### PR TITLE
Delete trashed orders after `EMPTY_TRASH_DAYS` as defined by WordPress (HPOS)

### DIFF
--- a/plugins/woocommerce/changelog/fix-41249
+++ b/plugins/woocommerce/changelog/fix-41249
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Delete trashed orders after `EMPTY_TRASH_DAYS` as defined by WordPress (HPOS)

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -110,7 +110,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		self::add_action( 'woocommerce_refund_created', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'wp_scheduled_auto_draft_delete', array( $this, 'delete_auto_draft_orders' ), 9 );
-		self::add_action( 'wp_scheduled_delete', array( $this, 'delete_trashed_orders' ) );
+		self::add_action( 'wp_scheduled_delete', array( $this, 'delete_trashed_orders' ), 9 );
 		self::add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );
 		self::add_filter( 'added_option', array( $this, 'process_added_option' ), 999, 2 );
 		self::add_filter( 'deleted_option', array( $this, 'process_deleted_option' ), 999 );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -983,8 +983,11 @@ ORDER BY orders.id ASC
 	 * @return void
 	 */
 	private function delete_trashed_orders() {
-		$delete_timestamp = $this->legacy_proxy->call_function( 'time' ) - ( DAY_IN_SECONDS * EMPTY_TRASH_DAYS );
+		if ( ! $this->custom_orders_table_is_authoritative() ) {
+			return;
+		}
 
+		$delete_timestamp = $this->legacy_proxy->call_function( 'time' ) - ( DAY_IN_SECONDS * EMPTY_TRASH_DAYS );
 		$args = array(
 			'status'        => 'trash',
 			'limit'         => self::ORDERS_SYNC_BATCH_SIZE,

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -81,6 +81,13 @@ class DataSynchronizer implements BatchProcessorInterface {
 	private $error_logger;
 
 	/**
+	 * The instance of the LegacyProxy object to use.
+	 *
+	 * @var LegacyProxy
+	 */
+	private $legacy_proxy;
+
+	/**
 	 * The order cache controller.
 	 *
 	 * @var OrderCacheController
@@ -103,6 +110,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		self::add_action( 'woocommerce_refund_created', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'wp_scheduled_auto_draft_delete', array( $this, 'delete_auto_draft_orders' ), 9 );
+		self::add_action( 'wp_scheduled_delete', array( $this, 'delete_trashed_orders' ) );
 		self::add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );
 		self::add_filter( 'added_option', array( $this, 'process_added_option' ), 999, 2 );
 		self::add_filter( 'deleted_option', array( $this, 'process_deleted_option' ), 999 );
@@ -136,6 +144,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		$this->data_store                  = $data_store;
 		$this->database_util               = $database_util;
 		$this->posts_to_cot_migrator       = $posts_to_cot_migrator;
+		$this->legacy_proxy                = $legacy_proxy;
 		$this->error_logger                = $legacy_proxy->call_function( 'wc_get_logger' );
 		$this->order_cache_controller      = $order_cache_controller;
 		$this->batch_processing_controller = $batch_processing_controller;
@@ -964,6 +973,38 @@ ORDER BY orders.id ASC
 		 * @since 7.7.0
 		 */
 		do_action( 'woocommerce_scheduled_auto_draft_delete' );
+	}
+
+	/**
+	 * Handles deletion of trashed orders after `EMPTY_TRASH_DAYS` as defined by WordPress.
+	 *
+	 * @since 8.5.0
+	 *
+	 * @return void
+	 */
+	private function delete_trashed_orders() {
+		$delete_timestamp = $this->legacy_proxy->call_function( 'time' ) - ( DAY_IN_SECONDS * EMPTY_TRASH_DAYS );
+
+		$args = array(
+			'status' => 'trash',
+			'limit'  => self::ORDERS_SYNC_BATCH_SIZE,
+			'date_modified' => '<' . $delete_timestamp,
+		);
+
+		$orders = wc_get_orders( $args );
+		if ( ! $orders || ! is_array( $orders ) ) {
+			return;
+		}
+
+		foreach ( $orders as $order ) {
+			if ( $order->get_status() !== 'trash' ) {
+				continue;
+			}
+			if ($order->get_date_modified()->getTimestamp() >= $delete_timestamp ) {
+				continue;
+			}
+			$order->delete( true );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -986,8 +986,8 @@ ORDER BY orders.id ASC
 		$delete_timestamp = $this->legacy_proxy->call_function( 'time' ) - ( DAY_IN_SECONDS * EMPTY_TRASH_DAYS );
 
 		$args = array(
-			'status' => 'trash',
-			'limit'  => self::ORDERS_SYNC_BATCH_SIZE,
+			'status'        => 'trash',
+			'limit'         => self::ORDERS_SYNC_BATCH_SIZE,
 			'date_modified' => '<' . $delete_timestamp,
 		);
 
@@ -1000,7 +1000,7 @@ ORDER BY orders.id ASC
 			if ( $order->get_status() !== 'trash' ) {
 				continue;
 			}
-			if ($order->get_date_modified()->getTimestamp() >= $delete_timestamp ) {
+			if ( $order->get_date_modified()->getTimestamp() >= $delete_timestamp ) {
 				continue;
 			}
 			$order->delete( true );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -988,7 +988,7 @@ ORDER BY orders.id ASC
 		}
 
 		$delete_timestamp = $this->legacy_proxy->call_function( 'time' ) - ( DAY_IN_SECONDS * EMPTY_TRASH_DAYS );
-		$args = array(
+		$args             = array(
 			'status'        => 'trash',
 			'limit'         => self::ORDERS_SYNC_BATCH_SIZE,
 			'date_modified' => '<' . $delete_timestamp,

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -555,7 +555,7 @@ class DataSynchronizerTests extends HposTestCase {
 		$order->save();
 
 		// Run scheduled deletion.
-		do_action( 'wp_scheduled_delete' );
+		do_action( 'wp_scheduled_delete' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
 
 		// Refresh order and ensure it's *not* gone.
 		$order = wc_get_order( $order->get_id() );
@@ -571,7 +571,7 @@ class DataSynchronizerTests extends HposTestCase {
 		);
 
 		// Run scheduled deletion.
-		do_action( 'wp_scheduled_delete' );
+		do_action( 'wp_scheduled_delete' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
 
 		// Ensure the placeholder post is gone.
 		$placeholder = get_post( $order->get_id() );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -25,13 +25,18 @@ class DataSynchronizerTests extends HposTestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->reset_legacy_proxy_mocks();
+		$container = wc_get_container();
+		$container->reset_all_resolved();
+
 		// Remove the Test Suite’s use of temporary tables https://wordpress.stackexchange.com/a/220308.
 		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 		OrderHelper::delete_order_custom_tables(); // We need this since non-temporary tables won't drop automatically.
 		OrderHelper::create_order_custom_table_if_not_exist();
 		OrderHelper::toggle_cot_feature_and_usage( false );
-		$this->sut = wc_get_container()->get( DataSynchronizer::class );
+		$this->sut = $container->get( DataSynchronizer::class );
 	}
 
 	/**
@@ -528,6 +533,53 @@ class DataSynchronizerTests extends HposTestCase {
 		$this->assertContains( $order2->get_id(), $orders );
 		$this->assertContains( $order3->get_id(), $orders );
 		$this->assertNotContains( $order1->get_id(), $orders );
+	}
+
+	/**
+	 * Test that trashed orders are deleted after the time set in `EMPTY_TRASH_DAYS`.
+	 */
+	public function test_trashed_order_deletion(): void {
+		$this->toggle_cot_authoritative( true );
+		$this->disable_cot_sync();
+
+		$order = new WC_Order();
+		$order->save();
+
+		// Ensure the placeholder post is there.
+		$placeholder = get_post( $order->get_id() );
+		$this->assertEquals( $order->get_id(), $placeholder->ID );
+
+		// Trashed orders should be deleted by the collection mechanism.
+		$order->get_data_store()->delete( $order );
+		$this->assertEquals( $order->get_status(), 'trash' );
+		$order->save();
+
+		// Run scheduled deletion.
+		do_action( 'wp_scheduled_delete' );
+
+		// Refresh order and ensure it's *not* gone.
+		$order = wc_get_order( $order->get_id() );
+		$this->assertNotNull( $order );
+
+		// Time-travel into the future so that the time required to delete a trashed order has passed.
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'time' => function() {
+					return time() + DAY_IN_SECONDS * EMPTY_TRASH_DAYS + 1;
+				},
+			)
+		);
+
+		// Run scheduled deletion.
+		do_action( 'wp_scheduled_delete' );
+
+		// Ensure the placeholder post is gone.
+		$placeholder = get_post( $order->get_id() );
+		$this->assertNull( $placeholder );
+
+		// Refresh order and ensure it's gone.
+		$order = wc_get_order( $order->get_id() );
+		$this->assertFalse( $order );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41249.

Note / up for discussion: so far this doesn't yet do any batching and hooks into the WordPress-native `wp_scheduled_delete` hook. If we wanted to add batching we should probably go with an Action Scheduler job instead ([example from Blocks deleting draft orders here](https://github.com/woocommerce/woocommerce-blocks/blob/22793eb4ae5f8c2fbf19538e708d4b4489c725d2/src/Domain/Services/DraftOrders.php#L158-L186)). 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. the first commit contains a failing test -- review it for completeness and then check out this branch but walk back the HEAD ref so only the first commit is applied. 
2. run `pnpm --filter=woocommerce test:unit:env --filter=DataSynchronizerTests` to see the test fail
3. apply the reset of the commits from this branch
4. run `pnpm --filter=woocommerce test:unit:env --filter=DataSynchronizerTests` again and see the test succeed
5. alternatively trash an order under HPOS, change your server's time at least 30 days into the future, and ensure that the trashed order is being deleted by the respective job

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
