### PR TITLE
Fix explanations not showing on incompatible plugin list page

### DIFF
--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1073,7 +1073,7 @@ class FeaturesController {
 		}
 
 		$features                   = $this->get_feature_definitions();
-		$feature_compatibility_info = $this->get_compatible_features_for_plugin( $plugin_file, true );
+		$feature_compatibility_info = $this->get_compatible_features_for_plugin( $plugin_file );
 		$incompatible_features      = array_merge( $feature_compatibility_info['incompatible'], $feature_compatibility_info['uncertain'] );
 		$incompatible_features      = array_values(
 			array_filter(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, when reviewing the list of plugins that are incompatible with some WooCommerce features (`/wp-admin/plugins.php?plugin_status=incompatible_with_feature`), plugins will appear in this list if they are incompatible with either active *or* inactive features. 

However, the explanation of why the plugin is included in the list is hidden if the feature is not active. This PR resolves that. 

### How to test the changes in this Pull Request:

Take a "WooCommerce" plugin, and ensure that it does *not* declare compatibility with an inactive WooCommerce feature (e.g. cart checkout blocks). Visit `example.com/wp-admin/plugins.php?plugin_status=incompatible_with_feature` and verify that:
a) The plugin is included in the list
b) The plugin does not explain *which* feature it is incompatible with

For example:
![Screenshot 2023-12-08 at 15 27 38](https://github.com/woocommerce/woocommerce/assets/1097338/34b85981-ce1d-46b3-a4ea-9a28ce01844f)

After this PR, the plugin listing correctly indicates why it is in the list:
![Screenshot 2023-12-08 at 15 28 25](https://github.com/woocommerce/woocommerce/assets/1097338/fe5c3801-0ce2-44af-bd8f-d236a7a29406)

#### Significance
Minor

#### Type

-   [ ] Fix - Fixes an existing bug
