### PR TITLE
Add: Active Filters block powered by Interactivity API

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/block.json
@@ -14,7 +14,8 @@
 		"reusable": false
 	},
 	"usesContext": [
-		"query"
+		"query",
+		"queryId"
 	],
 	"providesContext": {
 		"collectionData": "collectionData"

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
@@ -9,6 +9,7 @@ import type { AttributeSetting } from '@woocommerce/types';
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
 const template = [
+	[ 'woocommerce/collection-active-filters', {} ],
 	[
 		'core/heading',
 		{

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
@@ -8,7 +8,7 @@
 	"keywords": [
 		"WooCommerce"
 	],
-	"textdomain": "woo-gutenberg-products-block",
+	"textdomain": "woocommerce",
 	"apiVersion": 2,
 	"ancestor": [
 		"woocommerce/collection-filters"

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"name": "woocommerce/collection-active-filters",
+	"version": "1.0.0",
+	"title": "Collection Active Filters",
+	"description": "Display the currently active filters.",
+	"category": "woocommerce",
+	"keywords": [
+		"WooCommerce"
+	],
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2,
+	"ancestor": [
+		"woocommerce/collection-filters"
+	],
+	"supports": {
+		"interactivity": true
+	},
+	"usesContext": [
+		"queryId"
+	],
+	"attributes": {
+		"displayStyle": {
+			"type": "string",
+			"default": "list"
+		}
+	}
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import {
+	PanelBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { EditProps, BlockAttributes } from '../types';
+
+export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
+	const { displayStyle } = attributes;
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __(
+					'Display Settings',
+					'woo-gutenberg-products-block'
+				) }
+			>
+				<ToggleGroupControl
+					label={ __(
+						'Display Style',
+						'woo-gutenberg-products-block'
+					) }
+					value={ displayStyle }
+					onChange={ ( value: BlockAttributes[ 'displayStyle' ] ) =>
+						setAttributes( {
+							displayStyle: value,
+						} )
+					}
+					className="wc-block-active-filter__style-toggle"
+				>
+					<ToggleGroupControlOption
+						value="list"
+						label={ __( 'List', 'woo-gutenberg-products-block' ) }
+					/>
+					<ToggleGroupControlOption
+						value="chips"
+						label={ __( 'Chips', 'woo-gutenberg-products-block' ) }
+					/>
+				</ToggleGroupControl>
+			</PanelBody>
+		</InspectorControls>
+	);
+};

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
@@ -24,13 +24,13 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 			<PanelBody
 				title={ __(
 					'Display Settings',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				<ToggleGroupControl
 					label={ __(
 						'Display Style',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ displayStyle }
 					onChange={ ( value: BlockAttributes[ 'displayStyle' ] ) =>
@@ -42,11 +42,11 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				>
 					<ToggleGroupControlOption
 						value="list"
-						label={ __( 'List', 'woo-gutenberg-products-block' ) }
+						label={ __( 'List', 'woocommerce' ) }
 					/>
 					<ToggleGroupControlOption
 						value="chips"
-						label={ __( 'Chips', 'woo-gutenberg-products-block' ) }
+						label={ __( 'Chips', 'woocommerce' ) }
 					/>
 				</ToggleGroupControl>
 			</PanelBody>

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
@@ -21,17 +21,9 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 
 	return (
 		<InspectorControls>
-			<PanelBody
-				title={ __(
-					'Display Settings',
-					'woocommerce'
-				) }
-			>
+			<PanelBody title={ __( 'Display Settings', 'woocommerce' ) }>
 				<ToggleGroupControl
-					label={ __(
-						'Display Style',
-						'woocommerce'
-					) }
+					label={ __( 'Display Style', 'woocommerce' ) }
 					value={ displayStyle }
 					onChange={ ( value: BlockAttributes[ 'displayStyle' ] ) =>
 						setAttributes( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Label, RemovableChip } from '@woocommerce/blocks-components';
+import { Icon, closeSmall } from '@wordpress/icons';
+
+interface RemovableListItemProps {
+	type: string;
+	name: string;
+	prefix?: string | JSX.Element;
+	showLabel?: boolean;
+	isLoading?: boolean;
+	displayStyle: string;
+	removeCallback?: () => void;
+}
+
+export const RemovableListItem = ( {
+	type,
+	name,
+	prefix = '',
+	removeCallback = () => null,
+	showLabel = true,
+	displayStyle,
+}: RemovableListItemProps ) => {
+	const prefixedName = prefix ? (
+		<>
+			{ prefix }
+			&nbsp;
+			{ name }
+		</>
+	) : (
+		name
+	);
+	const removeText = sprintf(
+		/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
+		__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
+		name
+	);
+
+	return (
+		<li
+			className="wc-block-active-filters__list-item"
+			key={ type + ':' + name }
+		>
+			{ showLabel && (
+				<span className="wc-block-active-filters__list-item-type">
+					{ type + ': ' }
+				</span>
+			) }
+			{ displayStyle === 'chips' ? (
+				<RemovableChip
+					element="span"
+					text={ prefixedName }
+					onRemove={ removeCallback }
+					radius="large"
+					ariaLabel={ removeText }
+				/>
+			) : (
+				<span className="wc-block-active-filters__list-item-name">
+					<button
+						className="wc-block-active-filters__list-item-remove"
+						onClick={ removeCallback }
+					>
+						<Icon
+							className="wc-block-components-chip__remove-icon"
+							icon={ closeSmall }
+							size={ 16 }
+						/>
+						<Label screenReaderLabel={ removeText } />
+					</button>
+					{ prefixedName }
+				</span>
+			) }
+		</li>
+	);
+};

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
@@ -34,7 +34,7 @@ export const RemovableListItem = ( {
 	);
 	const removeText = sprintf(
 		/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
-		__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
+		__( 'Remove %s filter', 'woocommerce' ),
 		name
 	);
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
@@ -41,11 +41,11 @@ export const RemovableListItem = ( {
 	return (
 		<li
 			className="wc-block-active-filters__list-item"
-			key={ type + ':' + name }
+			key={ `${ type }: ${ name }` }
 		>
 			{ showLabel && (
 				<span className="wc-block-active-filters__list-item-type">
-					{ type + ': ' }
+					{ `${ type }: ` }
 				</span>
 			) }
 			{ displayStyle === 'chips' ? (

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
@@ -31,13 +31,13 @@ const Edit = ( props: EditProps ) => {
 					} ) }
 				>
 					<RemovableListItem
-						type={ __( 'Size', 'woo-gutenberg-products-block' ) }
-						name={ __( 'Small', 'woo-gutenberg-products-block' ) }
+						type={ __( 'Size', 'woocommerce' ) }
+						name={ __( 'Small', 'woocommerce' ) }
 						displayStyle={ displayStyle }
 					/>
 					<RemovableListItem
-						type={ __( 'Color', 'woo-gutenberg-products-block' ) }
-						name={ __( 'Blue', 'woo-gutenberg-products-block' ) }
+						type={ __( 'Color', 'woocommerce' ) }
+						name={ __( 'Blue', 'woocommerce' ) }
 						displayStyle={ displayStyle }
 					/>
 				</ul>

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+import { Disabled } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { EditProps } from './types';
+import { Inspector } from './components/inspector';
+import { RemovableListItem } from './components/removable-list-item';
+
+const Edit = ( props: EditProps ) => {
+	const { displayStyle } = props.attributes;
+
+	const blockProps = useBlockProps( {
+		className: 'wc-block-active-filters',
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<Inspector { ...props } />
+			<Disabled>
+				<ul
+					className={ classNames( 'wc-block-active-filters__list', {
+						'wc-block-active-filters__list--chips':
+							displayStyle === 'chips',
+					} ) }
+				>
+					<RemovableListItem
+						type={ __( 'Size', 'woo-gutenberg-products-block' ) }
+						name={ __( 'Small', 'woo-gutenberg-products-block' ) }
+						displayStyle={ displayStyle }
+					/>
+					<RemovableListItem
+						type={ __( 'Color', 'woo-gutenberg-products-block' ) }
+						name={ __( 'Blue', 'woo-gutenberg-products-block' ) }
+						displayStyle={ displayStyle }
+					/>
+				</ul>
+			</Disabled>
+		</div>
+	);
+};
+
+export default Edit;

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/frontend.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { store, navigate, getContext } from '@woocommerce/interactivity';
+
+type ActiveFiltersContext = {
+	queryId: number;
+	params: string[];
+};
+
+store( 'woocommerce/collection-active-filters', {
+	actions: {
+		clearAll: () => {
+			const { params } = getContext< ActiveFiltersContext >();
+			const url = new URL( window.location.href );
+			const { searchParams } = url;
+
+			params.forEach( ( param ) => searchParams.delete( param ) );
+			navigate( url.href );
+		},
+	},
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { Icon } from '@wordpress/icons';
+import { toggle } from '@woocommerce/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import './style.scss';
+
+registerBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				icon={ toggle }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
@@ -4,6 +4,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon } from '@wordpress/icons';
 import { toggle } from '@woocommerce/icons';
+import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -12,14 +13,16 @@ import metadata from './block.json';
 import Edit from './edit';
 import './style.scss';
 
-registerBlockType( metadata, {
-	icon: {
-		src: (
-			<Icon
-				icon={ toggle }
-				className="wc-block-editor-components-block-icon"
-			/>
-		),
-	},
-	edit: Edit,
-} );
+if ( isExperimentalBuild() ) {
+	registerBlockType( metadata, {
+		icon: {
+			src: (
+				<Icon
+					icon={ toggle }
+					className="wc-block-editor-components-block-icon"
+				/>
+			),
+		},
+		edit: Edit,
+	} );
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/style.scss
@@ -1,0 +1,179 @@
+.wc-block-active-filters {
+	margin-bottom: $gap-large;
+	overflow: hidden;
+
+	.wc-block-active-filters__clear-all {
+		@include filter-link-button();
+		@include font-size(small);
+		border: none;
+		margin-top: 15px;
+		padding: 0;
+		cursor: pointer;
+		float: right;
+
+		&,
+		&:hover,
+		&:focus,
+		&:active {
+			background: transparent;
+			color: inherit;
+		}
+	}
+
+	.wc-block-active-filters__clear-all-placeholder {
+		@include placeholder();
+		display: inline-block;
+		width: 80px;
+		height: 1em;
+		float: right;
+		border-radius: 0;
+	}
+
+	.wc-block-active-filters__list {
+		margin: 0 0 $gap-smallest;
+		padding: 0;
+		list-style: none outside;
+		clear: both;
+
+		&.wc-block-active-filters--loading {
+			margin-top: $gap-small;
+			display: flex;
+			flex-direction: column;
+			flex-wrap: nowrap;
+
+			&.wc-block-active-filters__list--chips {
+				flex-direction: row;
+				flex-wrap: wrap;
+				align-items: flex-end;
+				gap: 0 10px;
+			}
+		}
+
+		li {
+			margin: 9px 0 0;
+			padding: 0;
+			list-style: none outside;
+
+			ul {
+				margin: 0;
+				padding: 0;
+				list-style: none outside;
+			}
+
+			&:first-child {
+				.wc-block-active-filters__list-item-type {
+					margin: 0;
+				}
+			}
+		}
+		> li:first-child {
+			margin: 0;
+		}
+		li.show-loading-state-list {
+			display: inline-block;
+
+			> span {
+				@include placeholder();
+				display: inline-block;
+				box-shadow: none;
+				border-radius: 0;
+				height: 1em;
+				width: 100%;
+			}
+		}
+
+		li.show-loading-state-chips {
+			display: inline-block;
+
+			> span {
+				@include placeholder();
+				display: inline-block;
+				box-shadow: none;
+				border-radius: 13px;
+				height: 1em;
+				width: 100%;
+				min-width: 70px;
+				margin-right: 15px !important;
+			}
+
+			&:last-of-type > span {
+				margin-right: 0 !important;
+			}
+
+			&:nth-child(3) {
+				flex-grow: 1;
+				max-width: 200px;
+			}
+		}
+
+		> .wc-block-active-filters__list-item .wc-block-active-filters__list-item-name {
+			margin: 9px 0 0;
+		}
+	}
+
+	.wc-block-active-filters__list-item-type {
+		@include font-size(smaller);
+		font-weight: bold;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		margin: $gap 0 0;
+		display: block;
+	}
+
+	.wc-block-active-filters__list-item-operator {
+		font-weight: normal;
+		font-style: italic;
+	}
+
+	.wc-block-active-filters__list-item-name {
+		@include font-size(small);
+		display: flex;
+		align-items: center;
+		position: relative;
+		padding: 0;
+	}
+
+	.wc-block-active-filters__list-item-remove {
+		@include font-size(smaller);
+		background: $gray-200;
+		border: 0;
+		border-radius: 25px;
+		appearance: none;
+		padding: 0;
+		height: 16px;
+		width: 16px;
+		line-height: 16px;
+		margin: 0 0.5em 0 0;
+		color: currentColor;
+
+		&:hover,
+		&:focus {
+			background: $gray-600;
+
+			.wc-block-components-chip__remove-icon {
+				fill: #fff;
+			}
+		}
+
+		&:disabled {
+			color: $gray-200;
+			cursor: not-allowed;
+		}
+	}
+
+	.wc-block-active-filters__list--chips {
+		ul,
+		li {
+			display: inline;
+		}
+
+		.wc-block-active-filters__list-item-type {
+			display: none;
+		}
+
+		.wc-block-components-chip {
+			margin-top: em($gap-small * 0.25);
+			margin-bottom: em($gap-small * 0.25);
+		}
+	}
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/types.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { BlockEditProps } from '@wordpress/blocks';
+
+export type BlockAttributes = {
+	displayStyle: 'list' | 'chips';
+};
+
+export type EditProps = BlockEditProps< BlockAttributes >;

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-checkbox-list.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-checkbox-list.tsx
@@ -14,7 +14,7 @@ export const AttributeCheckboxList = ( {
 	showCounts,
 }: Props ) => (
 	<CheckboxList
-		className="attribute-checkbox-list"
+		className="wc-block-attribute-filter style-list"
 		onChange={ () => null }
 		options={ attributeTerms.map( ( term ) => ( {
 			label: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-dropdown.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-dropdown.tsx
@@ -9,7 +9,7 @@ type Props = {
 	label: string;
 };
 export const AttributeDropdown = ( { label }: Props ) => (
-	<div className="attribute-dropdown">
+	<div className="wc-block-attribute-filter style-dropdown">
 		<FormTokenField
 			suggestions={ [] }
 			placeholder={ sprintf(

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/frontend.ts
@@ -11,6 +11,10 @@ type AttributeFilterContext = {
 	selectType: 'single' | 'multiple';
 };
 
+interface ActiveAttributeFilterContext extends AttributeFilterContext {
+	value: string;
+}
+
 function getUrl(
 	selectedTerms: string[],
 	slug: string,
@@ -86,6 +90,16 @@ store( 'woocommerce/collection-attribute-filter', {
 					context.queryType
 				)
 			);
+		},
+		removeFilter: () => {
+			const { attributeSlug, queryType, value } =
+				getContext< ActiveAttributeFilterContext >();
+
+			let selectedTerms = getSelectedTermsFromUrl( attributeSlug );
+
+			selectedTerms = selectedTerms.filter( ( item ) => item !== value );
+
+			navigate( getUrl( selectedTerms, attributeSlug, queryType ) );
 		},
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -10,6 +11,8 @@ import './style.scss';
 import metadata from './block.json';
 import Edit from './edit';
 
-registerBlockType( metadata, {
-	edit: Edit,
-} );
+if ( isExperimentalBuild() ) {
+	registerBlockType( metadata, {
+		edit: Edit,
+	} );
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/style.scss
@@ -3,7 +3,7 @@
 @import "../../../../../../packages/components/checkbox-control/style";
 
 .wp-block-woocommerce-collection-attribute-filter {
-	.attribute-dropdown {
+	.style-dropdown {
 		position: relative;
 
 		> svg {

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/index.tsx
@@ -3,6 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, currencyDollar } from '@wordpress/icons';
+import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -11,14 +12,16 @@ import './style.scss';
 import metadata from './block.json';
 import Edit from './edit';
 
-registerBlockType( metadata, {
-	icon: {
-		src: (
-			<Icon
-				icon={ currencyDollar }
-				className="wc-block-editor-components-block-icon"
-			/>
-		),
-	},
-	edit: Edit,
-} );
+if ( isExperimentalBuild() ) {
+	registerBlockType( metadata, {
+		icon: {
+			src: (
+				<Icon
+					icon={ currencyDollar }
+					className="wc-block-editor-components-block-icon"
+				/>
+			),
+		},
+		edit: Edit,
+	} );
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/frontend.ts
@@ -17,7 +17,7 @@ function getUrl( filters: Array< string | null > ) {
 		url.searchParams.delete( 'rating_filter' );
 	}
 
-	return url;
+	return url.href;
 }
 
 store( 'woocommerce/collection-rating-filter', {

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/frontend.ts
@@ -5,6 +5,21 @@ import { getContext, navigate, store } from '@woocommerce/interactivity';
 import { CheckboxListContext } from '@woocommerce/interactivity-components/checkbox-list';
 import { DropdownContext } from '@woocommerce/interactivity-components/dropdown';
 
+function getUrl( filters: Array< string | null > ) {
+	filters = filters.filter( Boolean );
+	const url = new URL( window.location.href );
+
+	if ( filters.length ) {
+		// add filters to url
+		url.searchParams.set( 'rating_filter', filters.join( ',' ) );
+	} else {
+		// remove filters from url
+		url.searchParams.delete( 'rating_filter' );
+	}
+
+	return url;
+}
+
 store( 'woocommerce/collection-rating-filter', {
 	actions: {
 		onCheckboxChange: () => {
@@ -20,17 +35,7 @@ store( 'woocommerce/collection-rating-filter', {
 					return item.value;
 				} );
 
-			const url = new URL( window.location.href );
-
-			if ( filters.length ) {
-				// add filters to url
-				url.searchParams.set( 'rating_filter', filters.join( ',' ) );
-			} else {
-				// remove filters from url
-				url.searchParams.delete( 'rating_filter' );
-			}
-
-			navigate( url );
+			navigate( getUrl( filters ) );
 		},
 		onDropdownChange: () => {
 			const dropdownContext = getContext< DropdownContext >(
@@ -38,17 +43,27 @@ store( 'woocommerce/collection-rating-filter', {
 			);
 
 			const filter = dropdownContext.selectedItem?.value;
-			const url = new URL( window.location.href );
 
-			if ( filter ) {
-				// add filter to url
-				url.searchParams.set( 'rating_filter', filter );
-			} else {
-				// remove filter from url
-				url.searchParams.delete( 'rating_filter' );
+			navigate( getUrl( [ filter ] ) );
+		},
+		removeFilter: () => {
+			const { value } = getContext< { value: string } >();
+			// get the active filters from the url:
+			const url = new URL( window.location.href );
+			const currentFilters =
+				url.searchParams.get( 'rating_filter' ) || '';
+
+			// split out the active filters into an array.
+			const filtersArr =
+				currentFilters === '' ? [] : currentFilters.split( ',' );
+
+			const index = filtersArr.indexOf( value );
+
+			if ( index > -1 ) {
+				filtersArr.splice( index, 1 );
 			}
 
-			navigate( url );
+			navigate( getUrl( filtersArr ) );
 		},
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/frontend.ts
@@ -53,5 +53,24 @@ store( 'woocommerce/collection-stock-filter', {
 
 			navigate( getUrl( filtersArr.join( ',' ) ) );
 		},
+		removeFilter: () => {
+			const { value } = getContext< { value: string } >();
+			// get the active filters from the url:
+			const url = new URL( window.location.href );
+			const currentFilters =
+				url.searchParams.get( 'filter_stock_status' ) || '';
+
+			// split out the active filters into an array.
+			const filtersArr =
+				currentFilters === '' ? [] : currentFilters.split( ',' );
+
+			const index = filtersArr.indexOf( value );
+
+			if ( index > -1 ) {
+				filtersArr.splice( index, 1 );
+			}
+
+			navigate( getUrl( filtersArr.join( ',' ) ) );
+		},
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/save.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/save.tsx
@@ -1,11 +1,8 @@
 /**
  * External dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 export default function save() {
-	const blockProps = useBlockProps.save();
-	const innerBlockProps = useInnerBlocksProps.save( blockProps );
-
-	return <nav { ...innerBlockProps } />;
+	return <InnerBlocks.Content />;
 }

--- a/plugins/woocommerce-blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce-blocks/bin/webpack-entries.js
@@ -113,6 +113,10 @@ const blocks = {
 		customDir: 'collection-filters/inner-blocks/rating-filter',
 		isExperimental: true,
 	},
+	'collection-active-filters': {
+		customDir: 'collection-filters/inner-blocks/active-filters',
+		isExperimental: true,
+	},
 	'order-confirmation-summary': {
 		customDir: 'order-confirmation/summary',
 	},

--- a/plugins/woocommerce-blocks/changelog/42008-add-interactive-active-filters-block
+++ b/plugins/woocommerce-blocks/changelog/42008-add-interactive-active-filters-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Add new Active Filters block powered by Interactivity API.
+

--- a/plugins/woocommerce/changelog/42008-add-interactive-active-filters-block
+++ b/plugins/woocommerce/changelog/42008-add-interactive-active-filters-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Add new Active Filters block powered by Interactivity API.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
@@ -192,12 +192,13 @@ final class CollectionActiveFilters extends AbstractBlock {
 
 	/**
 	 * Parse the filter parameters from the URL.
+	 * For now we only get the global query params from the URL. In the future,
+	 * we should get the query params based on $query_id.
 	 *
 	 * @param int $query_id Query ID.
 	 * @return array Parsed filter params.
 	 */
 	private function get_filter_query_params( $query_id ) {
-		// @todo Get the query params based on $query_id
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
@@ -1,0 +1,232 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * CollectionAttributeFilter class.
+ */
+final class CollectionActiveFilters extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'collection-active-filters';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$query_id = $block->context['queryId'] ?? 0;
+
+		/**
+		 * Filters the active filter data provided by filter blocks.
+		 *
+		 * $data = array(
+		 *     <id> => array(
+		 *         'type' => string,
+		 *         'items' => array(
+		 *             array(
+		 *                 'title' => string,
+		 *                 'attributes' => array(
+		 *                     <key> => string
+		 *                 )
+		 *             )
+		 *         )
+		 *     ),
+		 * );
+		 *
+		 * @since 11.7.0
+		 *
+		 * @param array $data   The active filters data
+		 * @param array $params The query param parsed from the URL.
+		 * @return array Active filters data.
+		 */
+		$active_filters = apply_filters( 'collection_active_filters_data', array(), $this->get_filter_query_params( $query_id ) );
+
+		if ( empty( $active_filters ) ) {
+			return $content;
+		}
+
+		$context = array(
+			'queryId' => $query_id,
+			'params'  => array_keys( $this->get_filter_query_params( $query_id ) ),
+		);
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class'               => 'wc-block-active-filters',
+				'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-active-filters' ) ),
+				'data-wc-context'     => wp_json_encode( $context ),
+			)
+		);
+
+		ob_start();
+		?>
+
+		<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<div <?php echo $wrapper_attributes; ?>>
+			<ul class="wc-block-active-filters__list %3$s">
+				<?php foreach ( $active_filters as $filter ) : ?>
+				<li>
+					<span class="wc-block-active-filters__list-item-type"><?php echo esc_html( $filter['type'] ); ?>: </span>
+					<ul>
+						<?php $this->render_items( $filter['items'], $attributes['displayStyle'] ); ?>
+					</ul>
+				</li>
+				<?php endforeach; ?>
+			</ul>
+			<button class="wc-block-active-filters__clear-all" data-wc-on--click="actions.clearAll">
+				<span aria-hidden="true"><?php echo esc_html__( 'Clear All', 'woo-gutenberg-products-block' ); ?></span>
+				<span class="screen-reader-text"><?php echo esc_html__( 'Clear All Filters', 'woo-gutenberg-products-block' ); ?></span>
+			</button>
+		</div>
+
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render the list items.
+	 *
+	 * @param array  $items Items data.
+	 * @param string $style Display style: list | chips.
+	 */
+	private function render_items( $items, $style ) {
+		foreach ( $items as $item ) {
+			if ( 'chips' === $style ) {
+				$this->render_chip_item( $item );
+			} else {
+				$this->render_list_item( $item );
+			}
+		}
+	}
+
+	/**
+	 * Render the list item of an active filter.
+	 *
+	 * @param array $args Item data.
+	 * @return string Item HTML.
+	 */
+	private function render_list_item( $args ) {
+		list ( 'title' => $title, 'attributes' => $attributes ) = wp_parse_args(
+			$args,
+			array(
+				'title'      => '',
+				'attributes' => array(),
+			)
+		);
+
+		if ( ! $title || empty( $attributes ) ) {
+			return;
+		}
+
+		$remove_label = sprintf( 'Remove %s filter', wp_strip_all_tags( $title ) );
+		?>
+		<li class="wc-block-active-filters__list-item">
+			<span class="wc-block-active-filters__list-item-name">
+				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<button class="wc-block-active-filters__list-item-remove"  <?php echo $this->get_html_attributes( $attributes ); ?>>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" class="wc-block-components-chip__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
+					<span class="screen-reader-text"><?php echo esc_html( $remove_label ); ?></span>
+				</button>
+				<?php echo wp_kses_post( $title ); ?>
+			</span>
+		</li>
+		<?php
+	}
+
+	/**
+	 * Render the chip item of an active filter.
+	 *
+	 * @param array $args Item data.
+	 * @return string Item HTML.
+	 */
+	private function render_chip_item( $args ) {
+		list ( 'title' => $title, 'attributes' => $attributes ) = wp_parse_args(
+			$args,
+			array(
+				'title'      => '',
+				'attributes' => array(),
+			)
+		);
+
+		if ( ! $title || empty( $attributes ) ) {
+			return;
+		}
+
+		$remove_label = sprintf( 'Remove %s filter', wp_strip_all_tags( $title ) );
+		?>
+		<li class="wc-block-active-filters__list-item">
+			<span class="is-removable wc-block-components-chip wc-block-components-chip--radius-large">
+				<span aria-hidden="false" class="wc-block-components-chip__text"><?php echo wp_kses_post( $title ); ?></span>
+				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<button class="wc-block-components-chip__remove" aria-label="<?php echo esc_attr( $remove_label ); ?>" <?php echo $this->get_html_attributes( $attributes ); ?>>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" role="img" class="wc-block-components-chip__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
+				</button>
+			</span>
+		</li>
+		<?php
+	}
+
+	/**
+	 * Build HTML attributes string from assoc array.
+	 *
+	 * @param array $attributes Attributes data as an assoc array.
+	 * @return string Escaped HTML attributes string.
+	 */
+	private function get_html_attributes( $attributes ) {
+		return array_reduce(
+			array_keys( $attributes ),
+			function( $acc, $key ) use ( $attributes ) {
+				$acc .= sprintf( ' %1$s="%2$s"', esc_attr( $key ), esc_attr( $attributes[ $key ] ) );
+				return $acc;
+			},
+			''
+		);
+	}
+
+	/**
+	 * Parse the filter parameters from the URL.
+	 *
+	 * @param int $query_id Query ID.
+	 * @return array Parsed filter params.
+	 */
+	private function get_filter_query_params( $query_id ) {
+		// @todo Get the query params based on $query_id
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+
+		$parsed_url = wp_parse_url( esc_url_raw( $request_uri ) );
+
+		if ( empty( $parsed_url['query'] ) ) {
+			return array();
+		}
+
+		parse_str( $parsed_url['query'], $url_query_params );
+
+		/**
+		 * Filters the active filter data provided by filter blocks.
+		 *
+		 * @since 11.7.0
+		 *
+		 * @param array $filter_param_keys The active filters data
+		 * @param array $url_param_keys    The query param parsed from the URL.
+		 *
+		 * @return array Active filters params.
+		 */
+		$filter_param_keys = array_unique( apply_filters( 'collection_filter_query_param_keys', array(), array_keys( $url_query_params ) ) );
+
+		return array_filter(
+			$url_query_params,
+			function( $key ) use ( $filter_param_keys ) {
+				return in_array( $key, $filter_param_keys, true );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
@@ -81,8 +81,8 @@ final class CollectionActiveFilters extends AbstractBlock {
 				<?php endforeach; ?>
 			</ul>
 			<button class="wc-block-active-filters__clear-all" data-wc-on--click="actions.clearAll">
-				<span aria-hidden="true"><?php echo esc_html__( 'Clear All', 'woo-gutenberg-products-block' ); ?></span>
-				<span class="screen-reader-text"><?php echo esc_html__( 'Clear All Filters', 'woo-gutenberg-products-block' ); ?></span>
+				<span aria-hidden="true"><?php echo esc_html__( 'Clear All', 'woocommerce' ); ?></span>
+				<span class="screen-reader-text"><?php echo esc_html__( 'Clear All Filters', 'woocommerce' ); ?></span>
 			</button>
 		</div>
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
@@ -16,6 +16,109 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	protected $block_name = 'collection-attribute-filter';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
+		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $filter_param_keys The active filters data.
+	 * @param array $url_param_keys    The query param parsed from the URL.
+	 *
+	 * @return array Active filters param keys.
+	 */
+	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
+		$attribute_param_keys = array_filter(
+			$url_param_keys,
+			function( $param ) {
+				return strpos( $param, 'filter_' ) === 0 || strpos( $param, 'query_type_' ) === 0;
+			}
+		);
+
+		return array_merge(
+			$filter_param_keys,
+			$attribute_param_keys
+		);
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $data   The active filters data.
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters data.
+	 */
+	public function register_active_filters_data( $data, $params ) {
+		$product_attributes_map = array_reduce(
+			wc_get_attribute_taxonomies(),
+			function( $acc, $attribute_object ) {
+				$acc[ $attribute_object->attribute_name ] = $attribute_object->attribute_label;
+				return $acc;
+			},
+			array()
+		);
+
+		$active_product_attributes = array_reduce(
+			array_keys( $params ),
+			function( $acc, $attribute ) {
+				if ( strpos( $attribute, 'filter_' ) === 0 ) {
+					$acc[] = str_replace( 'filter_', '', $attribute );
+				}
+				return $acc;
+			},
+			array()
+		);
+
+		$active_product_attributes = array_filter(
+			$active_product_attributes,
+			function( $item ) use ( $product_attributes_map ) {
+				return in_array( $item, array_keys( $product_attributes_map ), true );
+			}
+		);
+
+		foreach ( $active_product_attributes as $product_attribute ) {
+			$terms = explode( ',', get_query_var( "filter_{$product_attribute}" ) );
+
+			// Get attribute term by slug.
+			$terms = array_map(
+				function( $term ) use ( $product_attribute ) {
+					$term_object = get_term_by( 'slug', $term, "pa_{$product_attribute}" );
+					return array(
+						'title'      => $term_object->name,
+						'attributes' => array(
+							'data-wc-on--click' => 'woocommerce/collection-attribute-filter::actions.removeFilter',
+							'data-wc-context'   => 'woocommerce/collection-attribute-filter::' . wp_json_encode(
+								array(
+									'value'         => $term,
+									'attributeSlug' => $product_attribute,
+									'queryType'     => get_query_var( "query_type_{$product_attribute}" ),
+								)
+							),
+						),
+					);
+				},
+				$terms
+			);
+
+			$data[ $product_attribute ] = array(
+				'type'  => $product_attributes_map[ $product_attribute ],
+				'items' => $terms,
+			);
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
@@ -29,7 +29,7 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	}
 
 	/**
-	 * Register the active filters data.
+	 * Register the query param keys.
 	 *
 	 * @param array $filter_param_keys The active filters data.
 	 * @param array $url_param_keys    The query param parsed from the URL.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
@@ -73,6 +73,31 @@ final class CollectionFilters extends AbstractBlock {
 	}
 
 	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$attributes_data = array(
+			'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-filters' ) ),
+			'class'               => 'wc-block-collection-filters',
+		);
+
+		if ( ! isset( $block->context['queryId'] ) ) {
+			$attributes_data['data-wc-navigation-id'] = 'wc-collection-filters';
+		}
+
+		return sprintf(
+			'<nav %1$s>%2$s</nav>',
+			get_block_wrapper_attributes( $attributes_data ),
+			$content
+		);
+	}
+
+	/**
 	 * Modify the context of inner blocks.
 	 *
 	 * @param array    $context The block context.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
@@ -87,7 +87,10 @@ final class CollectionFilters extends AbstractBlock {
 		);
 
 		if ( ! isset( $block->context['queryId'] ) ) {
-			$attributes_data['data-wc-navigation-id'] = 'wc-collection-filters';
+			$attributes_data['data-wc-navigation-id'] = sprintf(
+				'wc-collection-filters-%s',
+				md5( wp_json_encode( $block->parsed_block['innerBlocks'] ) )
+			);
 		}
 
 		return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
@@ -30,7 +30,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 	}
 
 	/**
-	 * Register the active filters data.
+	 * Register the query param keys.
 	 *
 	 * @param array $filter_param_keys The active filters data.
 	 * @param array $url_param_keys    The query param parsed from the URL.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
@@ -71,7 +71,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 		if ( $formatted_min_price && $formatted_max_price ) {
 			$title = sprintf(
 				/* translators: %1$s and %2$s are the formatted minimum and maximum prices respectively. */
-				__( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ),
+				__( 'Between %1$s and %2$s', 'woocommerce' ),
 				$formatted_min_price,
 				$formatted_max_price
 			);
@@ -79,16 +79,16 @@ final class CollectionPriceFilter extends AbstractBlock {
 
 		if ( ! $formatted_min_price ) {
 			/* translators: %s is the formatted maximum price. */
-			$title = sprintf( __( 'Up to %s', 'woo-gutenberg-products-block' ), $formatted_max_price );
+			$title = sprintf( __( 'Up to %s', 'woocommerce' ), $formatted_max_price );
 		}
 
 		if ( ! $formatted_max_price ) {
 			/* translators: %s is the formatted minimum price. */
-			$title = sprintf( __( 'From %s', 'woo-gutenberg-products-block' ), $formatted_min_price );
+			$title = sprintf( __( 'From %s', 'woocommerce' ), $formatted_min_price );
 		}
 
 		$data['price'] = array(
-			'type'  => __( 'Price', 'woo-gutenberg-products-block' ),
+			'type'  => __( 'Price', 'woocommerce' ),
 			'items' => array(
 				array(
 					'title'      => $title,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
@@ -17,6 +17,92 @@ final class CollectionPriceFilter extends AbstractBlock {
 	const MAX_PRICE_QUERY_VAR = 'max_price';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
+		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $filter_param_keys The active filters data.
+	 * @param array $url_param_keys    The query param parsed from the URL.
+	 *
+	 * @return array Active filters param keys.
+	 */
+	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
+		$price_param_keys = array_filter(
+			$url_param_keys,
+			function( $param ) {
+				return self::MIN_PRICE_QUERY_VAR === $param || self::MAX_PRICE_QUERY_VAR === $param;
+			}
+		);
+
+		return array_merge(
+			$filter_param_keys,
+			$price_param_keys
+		);
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $data   The active filters data.
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters data.
+	 */
+	public function register_active_filters_data( $data, $params ) {
+		$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
+		$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
+		$formatted_min_price = $min_price ? wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ) : null;
+		$formatted_max_price = $max_price ? wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ) : null;
+
+		if ( ! $formatted_min_price && ! $formatted_max_price ) {
+			return $data;
+		}
+
+		if ( $formatted_min_price && $formatted_max_price ) {
+			$title = sprintf(
+				/* translators: %1$s and %2$s are the formatted minimum and maximum prices respectively. */
+				__( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ),
+				$formatted_min_price,
+				$formatted_max_price
+			);
+		}
+
+		if ( ! $formatted_min_price ) {
+			/* translators: %s is the formatted maximum price. */
+			$title = sprintf( __( 'Up to %s', 'woo-gutenberg-products-block' ), $formatted_max_price );
+		}
+
+		if ( ! $formatted_max_price ) {
+			/* translators: %s is the formatted minimum price. */
+			$title = sprintf( __( 'From %s', 'woo-gutenberg-products-block' ), $formatted_min_price );
+		}
+
+		$data['price'] = array(
+			'type'  => __( 'Price', 'woo-gutenberg-products-block' ),
+			'items' => array(
+				array(
+					'title'      => $title,
+					'attributes' => array(
+						'data-wc-on--click' => 'woocommerce/collection-price-filter::actions.reset',
+					),
+				),
+			),
+		);
+
+		return $data;
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
@@ -20,6 +20,83 @@ final class CollectionRatingFilter extends AbstractBlock {
 	const RATING_FILTER_QUERY_VAR = 'rating_filter';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
+		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
+
+	/**
+	 * Register the query param keys.
+	 *
+	 * @param array $filter_param_keys The active filters data.
+	 * @param array $url_param_keys    The query param parsed from the URL.
+	 *
+	 * @return array Active filters param keys.
+	 */
+	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
+		$price_param_keys = array_filter(
+			$url_param_keys,
+			function( $param ) {
+				return self::RATING_FILTER_QUERY_VAR === $param;
+			}
+		);
+
+		return array_merge(
+			$filter_param_keys,
+			$price_param_keys
+		);
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $data   The active filters data.
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters data.
+	 */
+	public function register_active_filters_data( $data, $params ) {
+		if ( empty( $params[ self::RATING_FILTER_QUERY_VAR ] ) ) {
+			return $data;
+		}
+
+		$active_ratings = array_filter(
+			explode( ',', $params[ self::RATING_FILTER_QUERY_VAR ] )
+		);
+
+		if ( empty( $active_ratings ) ) {
+			return $data;
+		}
+
+		$active_ratings = array_map(
+			function( $rating ) {
+				return array(
+					/* translators: %d is the rating value. */
+					'title'      => sprintf( __('Rated %d out of 5', 'woocommerce' ), $rating ),
+					'attributes' => array(
+						'data-wc-on--click' => 'woocommerce/collection-rating-filter::actions.removeFilter',
+						'data-wc-context'   => 'woocommerce/collection-rating-filter::' . wp_json_encode( array( 'value' => $rating ) ),
+					),
+				);
+			},
+			$active_ratings
+		);
+
+		$data['stock'] = array(
+			'type'  => __( 'Rating', 'woocommerce' ),
+			'items' => $active_ratings,
+		);
+
+		return $data;
+	}
+
+	/**
 	 * Include and render the block.
 	 *
 	 * @param array    $attributes Block attributes. Default empty array.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
@@ -88,7 +88,7 @@ final class CollectionRatingFilter extends AbstractBlock {
 			$active_ratings
 		);
 
-		$data['stock'] = array(
+		$data['rating'] = array(
 			'type'  => __( 'Rating', 'woocommerce' ),
 			'items' => $active_ratings,
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
@@ -78,7 +78,7 @@ final class CollectionRatingFilter extends AbstractBlock {
 			function( $rating ) {
 				return array(
 					/* translators: %d is the rating value. */
-					'title'      => sprintf( __('Rated %d out of 5', 'woocommerce' ), $rating ),
+					'title'      => sprintf( __( 'Rated %d out of 5', 'woocommerce' ), $rating ),
 					'attributes' => array(
 						'data-wc-on--click' => 'woocommerce/collection-rating-filter::actions.removeFilter',
 						'data-wc-context'   => 'woocommerce/collection-rating-filter::' . wp_json_encode( array( 'value' => $rating ) ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
@@ -18,6 +18,84 @@ final class CollectionStockFilter extends AbstractBlock {
 	const STOCK_STATUS_QUERY_VAR = 'filter_stock_status';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
+		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $filter_param_keys The active filters data.
+	 * @param array $url_param_keys    The query param parsed from the URL.
+	 *
+	 * @return array Active filters param keys.
+	 */
+	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
+		$stock_param_keys = array_filter(
+			$url_param_keys,
+			function( $param ) {
+				return self::STOCK_STATUS_QUERY_VAR === $param;
+			}
+		);
+
+		return array_merge(
+			$filter_param_keys,
+			$stock_param_keys
+		);
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $data   The active filters data.
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters data.
+	 */
+	public function register_active_filters_data( $data, $params ) {
+		$stock_status_options = wc_get_product_stock_status_options();
+
+		if ( empty( $params[ self::STOCK_STATUS_QUERY_VAR ] ) ) {
+			return $data;
+		}
+
+		$active_stock_statuses = array_filter(
+			explode( ',', $params[ self::STOCK_STATUS_QUERY_VAR ] )
+		);
+
+		if ( empty( $active_stock_statuses ) ) {
+			return $data;
+		}
+
+		$active_stock_statuses = array_map(
+			function( $status ) use ( $stock_status_options ) {
+				return array(
+					'title'      => $stock_status_options[ $status ],
+					'attributes' => array(
+						'data-wc-on--click' => 'woocommerce/collection-stock-filter::actions.removeFilter',
+						'data-wc-context'   => 'woocommerce/collection-stock-filter::' . wp_json_encode( array( 'value' => $status ) ),
+					),
+				);
+			},
+			$active_stock_statuses
+		);
+
+		$data['stock'] = array(
+			'type'  => __( 'Stock Status', 'woo-gutenberg-products-block' ),
+			'items' => $active_stock_statuses,
+		);
+
+		return $data;
+	}
+
+	/**
 	 * Extra data passed through from server to client for block.
 	 *
 	 * @param array $stock_statuses  Any stock statuses that currently are available from the block.
@@ -112,12 +190,12 @@ final class CollectionStockFilter extends AbstractBlock {
 							<li>
 								<div class="wc-block-components-checkbox wc-block-checkbox-list__checkbox">
 									<label for="<?php echo esc_attr( $stock_count['status'] ); ?>">
-										<input 
-											id="<?php echo esc_attr( $stock_count['status'] ); ?>" 
-											class="wc-block-components-checkbox__input" 
-											type="checkbox" 
-											aria-invalid="false" 
-											data-wc-on--change="actions.updateProducts" 
+										<input
+											id="<?php echo esc_attr( $stock_count['status'] ); ?>"
+											class="wc-block-components-checkbox__input"
+											type="checkbox"
+											aria-invalid="false"
+											data-wc-on--change="actions.updateProducts"
 											value="<?php echo esc_attr( $stock_count['status'] ); ?>"
 											<?php checked( strpos( $selected_stock_status, $stock_count['status'] ) !== false, 1 ); ?>
 										>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
@@ -88,7 +88,7 @@ final class CollectionStockFilter extends AbstractBlock {
 		);
 
 		$data['stock'] = array(
-			'type'  => __( 'Stock Status', 'woo-gutenberg-products-block' ),
+			'type'  => __( 'Stock Status', 'woocommerce' ),
 			'items' => $active_stock_statuses,
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
@@ -31,7 +31,7 @@ final class CollectionStockFilter extends AbstractBlock {
 	}
 
 	/**
-	 * Register the active filters data.
+	 * Register the query param keys.
 	 *
 	 * @param array $filter_param_keys The active filters data.
 	 * @param array $url_param_keys    The query param parsed from the URL.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -301,6 +301,7 @@ final class BlockTypesController {
 			$block_types[] = 'CollectionPriceFilter';
 			$block_types[] = 'CollectionAttributeFilter';
 			$block_types[] = 'CollectionRatingFilter';
+			$block_types[] = 'CollectionActiveFilters';
 		}
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42179  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the `Collection Filters` block into a `Product Collection` block.
2. See the `Collection Active Filters` and other filter blocks added along with the `Collection Filters` block.
3. Toggle the display style, see the editor reacts.
4. Save and test the block on the frontend:
  - It's hidden when no filter applied.
  - It's visible when a filter is applied.
  - Clicking on the remove button of each active filter removes that filter from the URL and update the products grid as well as the corresponding filter block.
  - Clicking on the `Clear All` button remove all filters.
  - Removing a filter from the filter block also remove the corresponding one from the active filter block.
  - See chip and list style work as expected.

Note that the price filter nêd to be updated to use `context` instead of `state` to make it work properly with `Clear All` button.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Add new Active Filters block powered by Interactivity API.
</details>
