### PR TITLE
Logging: Render line breaks in log messages in the db log list table

### DIFF
--- a/plugins/woocommerce/changelog/update-db-log-line-breaks
+++ b/plugins/woocommerce/changelog/update-db-log-line-breaks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Render line breaks in messages in the database logger list table

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1567,6 +1567,13 @@ table.wc_status_table--tools {
 		}
 	}
 
+	.column-message {
+		pre {
+			margin: 0;
+			white-space: pre-wrap;
+		}
+	}
+
 	.column-context {
 		.button {
 			span {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
@@ -208,7 +208,10 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_message( $log ) {
-		return esc_html( $log['message'] );
+		return sprintf(
+			'<pre>%s</pre>',
+			esc_html( $log['message'] )
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Allow for line breaks within log messages so they can be easier to read when they contain a lot of content.

Based on a suggestion in #27758

### How to test the changes in this Pull Request:

#### Setup

1. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'WC_Log_Handler_DB' );`. This is what enables the DB log list table view.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.
3. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list.
4. On the Tools screen, run the tool to generate some log entries.
5. You may need to rebuild the stylesheet assets after checking out this branch. You can do so with `pnpm --filter=@woocommerce/classic-assets build`

#### Tests

1. On the Logs screen, you should see a list table containing log entries. There are two entries that have line breaks added.
    * One says, "Level 200. This is very informational." With this PR branch, there should be an empty line after that, followed by "Plugins have been loaded!"
    * The other says, "Level 300. This might be relevant." With this PR branch, there should be an empty line after that, followed by a stack trace summary.
2. Switching back to the trunk branch, and then refreshing the Logs screen, you should see that those log entries no longer show the line breaks.