### PR TITLE
Update to exception to throwable and pass additional data in store API

### DIFF
--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1289,7 +1289,7 @@ class WC_Checkout {
 					$this->process_order_without_payment( $order_id );
 				}
 			}
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			wc_add_notice( $e->getMessage(), 'error' );
 		}
 		$this->send_ajax_failure_response();

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -458,7 +458,7 @@ class WC_Form_Handler {
 								exit;
 							}
 						}
-					} catch ( Exception $e ) {
+					} catch ( Throwable $e ) {
 						wc_add_notice( $e->getMessage(), 'error' );
 					}
 				} else {

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -85,8 +85,9 @@ trait CheckoutTrait {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
 			}
 		} catch ( \Throwable $e ) {
+			$error_code = method_exists( $e, 'getErrorCode' ) ? $e->getErrorCode() : 'woocommerce_rest_checkout_process_payment_error';
 			$additional_data = method_exists( $e, 'getAdditionalData' ) ? $e->getAdditionalData() : [];
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 402, $additional_data );
+			throw new RouteException( $error_code, $e->getMessage(), 402, $additional_data );
 		}
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -84,8 +84,9 @@ trait CheckoutTrait {
 			if ( ! $payment_result instanceof PaymentResult ) {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
 			}
-		} catch ( \Exception $e ) {
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 402 );
+		} catch ( \Throwable $e ) {
+			$additional_data = method_exists( $e, 'getAdditionalData' ) ? $e->getAdditionalData() : [];
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 402, $additional_data );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR allows us to pass additional data to exceptions so we can see that data in the checkout endpoint response.

There might be backward compatibility issues.  If a merchant site is using an older version of WooCommerce and a newer version of WooPayments is using a custom exception, then errors will occur.



### How to test the changes in this Pull Request:

Test with https://github.com/Automattic/woocommerce-payments/pull/7873



### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>