### PR TITLE
Marketplace: refresh subscriptions if "install" parameter exists

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/contexts/subscriptions-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/subscriptions-context.tsx
@@ -2,13 +2,15 @@
  * External dependencies
  */
 import { useState, createContext, useEffect } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { SubscriptionsContextType } from './types';
+import { SubscriptionsContextType, NoticeStatus } from './types';
 import { Subscription } from '../components/my-subscriptions/types';
 import {
+	addNotice,
 	fetchSubscriptions,
 	refreshSubscriptions as fetchSubscriptionsFromWooCom,
 } from '../utils/functions';
@@ -46,12 +48,20 @@ export function SubscriptionsContextProvider( props: {
 			} );
 	};
 
-	const refreshSubscriptions = () => {
-		return fetchSubscriptionsFromWooCom().then(
-			( subscriptionResponse ) => {
+	const refreshSubscriptions = ( toggleLoading?: boolean ) => {
+		if ( toggleLoading ) {
+			setIsLoading( true );
+		}
+
+		return fetchSubscriptionsFromWooCom()
+			.then( ( subscriptionResponse ) => {
 				setSubscriptions( subscriptionResponse );
-			}
-		);
+			} )
+			.finally( () => {
+				if ( toggleLoading ) {
+					setIsLoading( false );
+				}
+			} );
 	};
 
 	useEffect( () => {
@@ -63,14 +73,35 @@ export function SubscriptionsContextProvider( props: {
 		const installKey = urlParams.get( 'install' );
 
 		if ( installKey ) {
-			refreshSubscriptions().finally( () => {
-				setIsLoading( false );
+			refreshSubscriptions( true ).catch( ( error ) => {
+				addNotice(
+					'woocommerce-marketplace-refresh-subscriptions',
+					sprintf(
+						// translators: %s is the error message.
+						__(
+							'Error refreshing subscriptions: %s',
+							'woocommerce'
+						),
+						error.message
+					),
+					NoticeStatus.Error
+				);
 			} );
 
 			return;
 		}
 
-		loadSubscriptions( true );
+		loadSubscriptions( true ).catch( ( error ) => {
+			addNotice(
+				'woocommerce-marketplace-load-subscriptions',
+				sprintf(
+					// translators: %s is the error message.
+					__( 'Error loading subscriptions: %s', 'woocommerce' ),
+					error.message
+				),
+				NoticeStatus.Error
+			);
+		} );
 	}, [] );
 
 	const contextValue = {

--- a/plugins/woocommerce-admin/client/marketplace/contexts/subscriptions-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/subscriptions-context.tsx
@@ -55,6 +55,21 @@ export function SubscriptionsContextProvider( props: {
 	};
 
 	useEffect( () => {
+		/**
+		 * Check if we have &install=PRODUCT_KEY in the URL. This means we have just
+		 * installed a new product and nwe need to refresh the list.
+		 */
+		const urlParams = new URLSearchParams( window.location.search );
+		const installKey = urlParams.get( 'install' );
+
+		if ( installKey ) {
+			refreshSubscriptions().finally( () => {
+				setIsLoading( false );
+			} );
+
+			return;
+		}
+
 		loadSubscriptions( true );
 	}, [] );
 

--- a/plugins/woocommerce/changelog/42704-add-18947-bust-subscription-cache-query-param
+++ b/plugins/woocommerce/changelog/42704-add-18947-bust-subscription-cache-query-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+Comment: Marketplace: refresh subscriptions in if "install" query parameter exists
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Refresh subscriptions in if "install" parameter exists


### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build assets
2. Visit the marketplace make sure you load the subscriptions. This means it's now cached. 
3. Now add `&install=some-string` to the URL and load the page. It should take a second to fetch the new list from WooCommerce.com.
4. Please test around this issue.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment Marketplace: refresh subscriptions in if "install" query parameter exists

</details>
