### PR TITLE
Allow built in payment method descriptions to contain HTML when rendered on the block checkout

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/bacs/index.js
+++ b/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/bacs/index.js
@@ -5,6 +5,8 @@ import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { getPaymentMethodData } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
+import { sanitizeHTML } from '@woocommerce/utils';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,7 +21,7 @@ const label = decodeEntities( settings?.title || '' ) || defaultLabel;
  * Content component
  */
 const Content = () => {
-	return decodeEntities( settings.description || '' );
+	return <RawHTML>{ sanitizeHTML( settings.description || '' ) }</RawHTML>;
 };
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/cheque/index.js
+++ b/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/cheque/index.js
@@ -5,6 +5,8 @@ import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { getPaymentMethodData } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
+import { sanitizeHTML } from '@woocommerce/utils';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,7 +21,7 @@ const label = decodeEntities( settings?.title || '' ) || defaultLabel;
  * Content component
  */
 const Content = () => {
-	return decodeEntities( settings.description || '' );
+	return <RawHTML>{ sanitizeHTML( settings.description || '' ) }</RawHTML>;
 };
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/cod/index.js
+++ b/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/cod/index.js
@@ -5,6 +5,8 @@ import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { getPaymentMethodData } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
+import { sanitizeHTML } from '@woocommerce/utils';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,7 +21,7 @@ const label = decodeEntities( settings?.title || '' ) || defaultLabel;
  * Content component
  */
 const Content = () => {
-	return decodeEntities( settings.description || '' );
+	return <RawHTML>{ sanitizeHTML( settings.description || '' ) }</RawHTML>;
 };
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/paypal/index.js
+++ b/plugins/woocommerce-blocks/assets/js/extensions/payment-methods/paypal/index.js
@@ -5,6 +5,8 @@ import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { getPaymentMethodData, WC_ASSET_URL } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
+import { sanitizeHTML } from '@woocommerce/utils';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,7 +19,7 @@ const settings = getPaymentMethodData( 'paypal', {} );
  * Content component
  */
 const Content = () => {
-	return decodeEntities( settings.description || '' );
+	return <RawHTML>{ sanitizeHTML( settings.description || '' ) }</RawHTML>;
 };
 
 const paypalPaymentMethod = {

--- a/plugins/woocommerce-blocks/changelog/fix-html-tags-for-payment-description-42123
+++ b/plugins/woocommerce-blocks/changelog/fix-html-tags-for-payment-description-42123
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Allow built in payment method descriptions to contain HTML when rendered on the block checkout.

--- a/plugins/woocommerce/changelog/fix-html-tags-for-payment-description-42123
+++ b/plugins/woocommerce/changelog/fix-html-tags-for-payment-description-42123
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Allow built in payment method descriptions to contain HTML when rendered on the block checkout.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the content elements of built in payment method integrations (bacs, cheque, cod) to support HTML. This requires the use of `RawHTML` and sanitises allowed tags. This is inline with classic checkout which allowed HTML also.

Closes #42123

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Payments > Bacs and edit the description to include some HTML, e.g. `<strong>Test</strong>`.
2.  Save the payment method.
3. Add something to your cart and go to block checkout.
4. Select Bacs payment method. Confirm the description is rendered as HTML not text.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Allow built in payment method descriptions to contain HTML when rendered on the block checkout.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
