### PR TITLE
Enhance Build Watching

### DIFF
--- a/packages/js/admin-e2e-tests/package.json
+++ b/packages/js/admin-e2e-tests/package.json
@@ -26,7 +26,7 @@
 	],
 	"sideEffects": false,
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:typescript": "wireit",
 		"changelog": "composer install && composer exec -- changelogger",
@@ -35,7 +35,8 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -76,6 +77,7 @@
 	"wireit": {
 		"build:project:typescript": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/admin-e2e-tests/package.json
+++ b/packages/js/admin-e2e-tests/package.json
@@ -36,7 +36,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:typescript": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -89,6 +90,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:typescript": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"dependencyOutputs": {
 			"allowUsuallyExcludedPaths": true,

--- a/packages/js/admin-layout/package.json
+++ b/packages/js/admin-layout/package.json
@@ -34,7 +34,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -45,7 +45,7 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {

--- a/packages/js/admin-layout/package.json
+++ b/packages/js/admin-layout/package.json
@@ -46,7 +46,10 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"dependencies": {
 		"@woocommerce/components": "workspace:*",
@@ -95,6 +98,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -109,6 +116,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -125,6 +136,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"dependencyOutputs": {
 			"allowUsuallyExcludedPaths": true,

--- a/packages/js/admin-layout/package.json
+++ b/packages/js/admin-layout/package.json
@@ -45,7 +45,8 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {
 		"@woocommerce/components": "workspace:*",
@@ -82,6 +83,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -95,6 +97,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -109,6 +112,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/ai/package.json
+++ b/packages/js/ai/package.json
@@ -44,7 +44,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "wp-6.0",
@@ -104,6 +105,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -117,6 +119,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -131,6 +134,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/ai/package.json
+++ b/packages/js/ai/package.json
@@ -45,7 +45,10 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "wp-6.0",
@@ -117,6 +120,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -131,6 +138,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -147,6 +158,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/ai/package.json
+++ b/packages/js/ai/package.json
@@ -32,7 +32,7 @@
 	],
 	"private": true,
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -44,7 +44,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {

--- a/packages/js/api/package.json
+++ b/packages/js/api/package.json
@@ -40,7 +40,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -72,6 +73,7 @@
 	"wireit": {
 		"build:project:typescript": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/api/package.json
+++ b/packages/js/api/package.json
@@ -30,7 +30,7 @@
 	],
 	"sideEffects": false,
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:typescript": "wireit",
 		"changelog": "composer install && composer exec -- changelogger",
@@ -40,7 +40,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -44,7 +44,10 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"dependencies": {
 		"@woocommerce/expression-evaluation": "workspace:*",
@@ -107,6 +110,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -121,6 +128,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -137,6 +148,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -31,7 +31,7 @@
 		"src/**/*.scss"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -43,7 +43,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -43,7 +43,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {
 		"@woocommerce/expression-evaluation": "workspace:*",
@@ -94,6 +95,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -107,6 +109,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -121,6 +124,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -36,7 +36,7 @@
 	],
 	"types": "build-types",
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -48,7 +48,7 @@
 		"lint:lang:js": "eslint --ext=js,ts,tsx src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -48,7 +48,8 @@
 		"lint:lang:js": "eslint --ext=js,ts,tsx src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -178,6 +179,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -191,6 +193,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -205,6 +208,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -49,7 +49,10 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -191,6 +194,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -205,6 +212,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -221,6 +232,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/csv-export/package.json
+++ b/packages/js/csv-export/package.json
@@ -31,7 +31,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -42,7 +42,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {

--- a/packages/js/csv-export/package.json
+++ b/packages/js/csv-export/package.json
@@ -43,7 +43,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"dependencies": {
 		"@types/node": "^16.18.68",
@@ -89,6 +91,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -104,6 +110,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/csv-export/package.json
+++ b/packages/js/csv-export/package.json
@@ -42,7 +42,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {
 		"@types/node": "^16.18.68",
@@ -75,6 +76,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -89,6 +91,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/currency/package.json
+++ b/packages/js/currency/package.json
@@ -43,7 +43,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -92,6 +94,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -107,6 +113,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/currency/package.json
+++ b/packages/js/currency/package.json
@@ -31,7 +31,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -42,7 +42,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/currency/package.json
+++ b/packages/js/currency/package.json
@@ -42,7 +42,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -78,6 +79,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -92,6 +94,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -43,7 +43,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -103,6 +104,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -116,6 +118,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -130,6 +133,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -44,7 +44,10 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -116,6 +119,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -130,6 +137,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -146,6 +157,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -31,7 +31,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -43,7 +43,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -42,7 +42,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -121,6 +123,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -136,6 +142,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -41,7 +41,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -107,6 +108,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -121,6 +123,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -30,7 +30,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -41,7 +41,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -63,7 +63,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -74,7 +74,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -74,7 +74,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -85,6 +86,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -99,6 +101,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -75,7 +75,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -99,6 +101,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -114,6 +120,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -103,7 +103,10 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -126,6 +129,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -140,6 +147,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -156,6 +167,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -90,7 +90,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -102,7 +102,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -102,7 +102,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -113,6 +114,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -126,6 +128,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -140,6 +143,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -42,7 +42,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -82,6 +83,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -96,6 +98,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -31,7 +31,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -42,7 +42,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -43,7 +43,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -96,6 +98,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -111,6 +117,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/expression-evaluation/package.json
+++ b/packages/js/expression-evaluation/package.json
@@ -39,7 +39,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -49,7 +49,7 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {

--- a/packages/js/expression-evaluation/package.json
+++ b/packages/js/expression-evaluation/package.json
@@ -49,7 +49,8 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.5",
@@ -74,6 +75,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -88,6 +90,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/expression-evaluation/package.json
+++ b/packages/js/expression-evaluation/package.json
@@ -50,7 +50,9 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.5",
@@ -88,6 +90,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -103,6 +109,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"dependencyOutputs": {
 			"allowUsuallyExcludedPaths": true,

--- a/packages/js/integrate-plugin/package.json
+++ b/packages/js/integrate-plugin/package.json
@@ -28,7 +28,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -39,7 +39,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {

--- a/packages/js/integrate-plugin/package.json
+++ b/packages/js/integrate-plugin/package.json
@@ -40,7 +40,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"dependencies": {
 		"@wordpress/create-block": "wp-6.0",
@@ -93,6 +95,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -108,6 +114,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/integrate-plugin/package.json
+++ b/packages/js/integrate-plugin/package.json
@@ -39,7 +39,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {
 		"@wordpress/create-block": "wp-6.0",
@@ -79,6 +80,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -93,6 +95,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/internal-js-tests/package.json
+++ b/packages/js/internal-js-tests/package.json
@@ -26,7 +26,7 @@
 		"jest-preset.js"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -36,7 +36,7 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {

--- a/packages/js/internal-js-tests/package.json
+++ b/packages/js/internal-js-tests/package.json
@@ -37,7 +37,9 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"dependencies": {
 		"@testing-library/jest-dom": "5.16.2",
@@ -81,6 +83,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -95,6 +101,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"dependencyOutputs": {
 			"allowUsuallyExcludedPaths": true,

--- a/packages/js/internal-js-tests/package.json
+++ b/packages/js/internal-js-tests/package.json
@@ -36,7 +36,8 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"dependencies": {
 		"@testing-library/jest-dom": "5.16.2",
@@ -67,6 +68,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -81,6 +83,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -42,7 +42,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -88,6 +89,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -102,6 +104,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -31,7 +31,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -42,7 +42,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -43,7 +43,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -102,6 +104,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -117,6 +123,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/notices/package.json
+++ b/packages/js/notices/package.json
@@ -42,7 +42,8 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -83,6 +84,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -97,6 +99,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/notices/package.json
+++ b/packages/js/notices/package.json
@@ -32,7 +32,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -42,7 +42,7 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/notices/package.json
+++ b/packages/js/notices/package.json
@@ -43,7 +43,9 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -97,6 +99,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -112,6 +118,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"dependencyOutputs": {
 			"allowUsuallyExcludedPaths": true,

--- a/packages/js/number/package.json
+++ b/packages/js/number/package.json
@@ -36,7 +36,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -47,7 +47,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {

--- a/packages/js/number/package.json
+++ b/packages/js/number/package.json
@@ -48,7 +48,9 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.5",
@@ -88,6 +90,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -103,6 +109,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/number/package.json
+++ b/packages/js/number/package.json
@@ -47,7 +47,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.5",
@@ -74,6 +75,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -88,6 +90,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -32,7 +32,7 @@
 		"build-types"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -44,7 +44,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -45,7 +45,10 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -112,6 +115,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -126,6 +133,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -142,6 +153,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -44,7 +44,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.(t|j)s?(x)": [
@@ -99,6 +100,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -112,6 +114,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -126,6 +129,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -128,7 +128,7 @@
 		"wireit": "0.14.1"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:cjs": "wireit",
@@ -140,7 +140,7 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"peerDependencies": {

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -140,7 +140,8 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"peerDependencies": {
 		"@types/react": "^17.0.71",
@@ -151,6 +152,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"
@@ -164,6 +166,7 @@
 		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -178,6 +181,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -141,7 +141,10 @@
 		"prepack": "pnpm build",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"peerDependencies": {
 		"@types/react": "^17.0.71",
@@ -164,6 +167,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
+		},
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
 			"clean": "if-file-deleted",
@@ -178,6 +185,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
@@ -194,6 +205,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config ./jest.config.json --passWithNoTests",

--- a/packages/js/tracks/package.json
+++ b/packages/js/tracks/package.json
@@ -47,7 +47,8 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.5",
@@ -70,6 +71,7 @@
 	"wireit": {
 		"build:project:cjs": {
 			"command": "tsc --project tsconfig-cjs.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig-cjs.json",
 				"src/**/*.{js,jsx,ts,tsx}",
@@ -84,6 +86,7 @@
 		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
+			"clean": "if-file-deleted",
 			"files": [
 				"tsconfig.json",
 				"src/**/*.{js,jsx,ts,tsx}",

--- a/packages/js/tracks/package.json
+++ b/packages/js/tracks/package.json
@@ -48,7 +48,9 @@
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:cjs": "wireit",
+		"watch:build:project:esm": "wireit"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.5",
@@ -84,6 +86,10 @@
 				"dependencyOutputs"
 			]
 		},
+		"watch:build:project:cjs": {
+			"command": "tsc --project tsconfig-cjs.json --watch",
+			"service": true
+		},
 		"build:project:esm": {
 			"command": "tsc --project tsconfig.json",
 			"clean": "if-file-deleted",
@@ -99,6 +105,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:esm": {
+			"command": "tsc --project tsconfig.json --watch",
+			"service": true
 		},
 		"dependencyOutputs": {
 			"allowUsuallyExcludedPaths": true,

--- a/packages/js/tracks/package.json
+++ b/packages/js/tracks/package.json
@@ -37,7 +37,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:cjs": "wireit",
 		"build:project:esm": "wireit",
@@ -47,7 +47,7 @@
 		"lint:fix:lang:js": "eslint src --fix",
 		"lint:lang:js": "eslint src",
 		"prepack": "pnpm build",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -26,7 +26,7 @@
 		"lint:lang:js": "eslint ./client --ext=js,ts,tsx",
 		"test:js": "wireit",
 		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "webpack --watch"
 	},
 	"lint-staged": {
 		"*.scss": [

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -26,7 +26,8 @@
 		"lint:lang:js": "eslint ./client --ext=js,ts,tsx",
 		"test:js": "wireit",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "webpack --watch"
+		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
+		"watch:build:project:bundle": "wireit"
 	},
 	"lint-staged": {
 		"*.scss": [
@@ -255,6 +256,10 @@
 			"dependencies": [
 				"dependencyOutputs"
 			]
+		},
+		"watch:build:project:bundle": {
+			"command": "webpack --watch",
+			"service": true
 		},
 		"test:js": {
 			"command": "jest --config client/jest.config.js",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -13,7 +13,7 @@
 		"build"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:project:feature-config": "php ../woocommerce/bin/generate-feature-config.php",
@@ -25,7 +25,7 @@
 		"lint:lang:css": "stylelint '**/*.scss'",
 		"lint:lang:js": "eslint ./client --ext=js,ts,tsx",
 		"test:js": "wireit",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "webpack --watch"
 	},
 	"lint-staged": {

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -25,7 +25,8 @@
 		"lint:lang:css": "stylelint '**/*.scss'",
 		"lint:lang:js": "eslint ./client --ext=js,ts,tsx",
 		"test:js": "wireit",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.scss": [
@@ -237,6 +238,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"env": {
 				"NODE_ENV": "production",
 				"WC_ADMIN_PHASE": "core"

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -110,7 +110,8 @@
 		"ts:log-errors": "npm --silent run ts:check | npx -y @bartekbp/typescript-checkstyle > checkstyle.xml",
 		"wp-env": "wp-env",
 		"wp-env:config": "./bin/wp-env-pre-config.sh",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {
 		"@actions/core": "1.10.0",
@@ -359,6 +360,7 @@
 	"wireit": {
 		"build:project:bundle": {
 			"command": "webpack",
+			"clean": "if-file-deleted",
 			"env": {
 				"NODE_ENV": {
 					"external": true

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -111,7 +111,7 @@
 		"wp-env": "wp-env",
 		"wp-env:config": "./bin/wp-env-pre-config.sh",
 		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:project": "webpack --watch"
 	},
 	"devDependencies": {
 		"@actions/core": "1.10.0",

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -44,7 +44,7 @@
 	"scripts": {
 		"analyze-bundles": "cross-env WP_BUNDLE_ANALYZER=1 pnpm run build",
 		"changelog": "composer install && composer exec -- changelogger",
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:bundle": "wireit",
 		"build:check-assets": "rimraf build/* && cross-env ASSET_CHECK=true BABEL_ENV=default NODE_ENV=production webpack",
@@ -110,7 +110,7 @@
 		"ts:log-errors": "npm --silent run ts:check | npx -y @bartekbp/typescript-checkstyle > checkstyle.xml",
 		"wp-env": "wp-env",
 		"wp-env:config": "./bin/wp-env-pre-config.sh",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "webpack --watch"
 	},
 	"devDependencies": {

--- a/plugins/woocommerce/client/legacy/package.json
+++ b/plugins/woocommerce/client/legacy/package.json
@@ -9,12 +9,12 @@
 		"build"
 	],
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "pnpm --if-present /^build:project:.*$/",
 		"build:project:assets": "wireit",
 		"lint": "pnpm --if-present '/^lint:lang:.*$/'",
 		"lint:fix": "pnpm --if-present '/^lint:fix:lang:.*$/'",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {

--- a/plugins/woocommerce/client/legacy/package.json
+++ b/plugins/woocommerce/client/legacy/package.json
@@ -14,7 +14,8 @@
 		"build:project:assets": "wireit",
 		"lint": "pnpm --if-present '/^lint:lang:.*$/'",
 		"lint:fix": "pnpm --if-present '/^lint:fix:lang:.*$/'",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"devDependencies": {
 		"@types/node": "^16.18.68",
@@ -48,6 +49,7 @@
 	"wireit": {
 		"build:project:assets": {
 			"command": "grunt assets",
+			"clean": "if-file-deleted",
 			"files": [
 				"Gruntfile.js",
 				"js/**/*.js",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -53,7 +53,8 @@
 		"test:unit": "pnpm test:php",
 		"test:unit:env": "pnpm test:php:env",
 		"update-wp-env": "php ./tests/e2e-pw/bin/update-wp-env.php",
-		"watch:build": "pnpm build:project --watch"
+		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {
 		"*.php": [
@@ -181,6 +182,7 @@
 	"wireit": {
 		"build:project": {
 			"command": "rm -rf assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build assets/client/blocks && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
+			"clean": "if-file-deleted",
 			"files": [],
 			"output": [
 				"assets/client/admin",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -10,7 +10,7 @@
 	},
 	"license": "GPL-3.0+",
 	"scripts": {
-		"build": "pnpm --if-present --filter=\"$npm_package_name...\" build:project",
+		"build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" build:project",
 		"build:project": "wireit",
 		"build:zip": "./bin/build-zip.sh",
 		"changelog": "composer exec -- changelogger",
@@ -53,7 +53,7 @@
 		"test:unit": "pnpm test:php",
 		"test:unit:env": "pnpm test:php:env",
 		"update-wp-env": "php ./tests/e2e-pw/bin/update-wp-env.php",
-		"watch:build": "pnpm --if-present --filter=\"$npm_package_name...\" --parallel watch:build:project",
+		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
 		"watch:build:project": "pnpm build:project --watch"
 	},
 	"lint-staged": {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request adds a new `watch:build:project` script that is intended to mirror the behavior of `build:project` except for watching. This allows us to set up project-specific watch commands, such as those taking better advantage of `webpack --watch`. The `watch:build` command has been updated to replicate the `build` command and cascades through children.

Closes #42012.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter='@woocommerce/plugin-woocommerce' build` to populate any caches
2. Run `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build`
3. Make changes to any of WooCommerce's dependent packages and watch that it cascades properly.
4. Ensure that any changes are reflected in updates to code in the development environment.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
