### PR TITLE
update text domain in plugins/woocommerce-blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -56,7 +56,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 						>
 							{ __(
 								'Add to cart',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</button>
 					</Disabled>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/constants.tsx
@@ -5,11 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { cart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 
-export const BLOCK_TITLE = __( 'Add to Cart', 'woo-gutenberg-products-block' );
+export const BLOCK_TITLE = __( 'Add to Cart', 'woocommerce' );
 export const BLOCK_ICON = (
 	<Icon icon={ cart } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION = __(
 	'Displays an add to cart button. Optionally displays other add to cart form elements.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/edit.tsx
@@ -44,17 +44,17 @@ const Edit = ( { attributes, setAttributes }: EditProps ) => {
 			<EditProductLink productId={ product.id } />
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Layout', 'woocommerce' ) }
 				>
 					{ productSupportsAddToCartForm( product ) ? (
 						<ToggleControl
 							label={ __(
 								'Display form elements',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							help={ __(
 								'Depending on product type, allow customers to select a quantity, variations etc.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							checked={ showFormElements }
 							onChange={ () =>
@@ -71,7 +71,7 @@ const Edit = ( { attributes, setAttributes }: EditProps ) => {
 						>
 							{ __(
 								'This product does not support the block based add to cart form. A link to the product page will be shown instead.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</Notice>
 					) }
@@ -89,6 +89,6 @@ export default withProductSelector( {
 	label: BLOCK_TITLE,
 	description: __(
 		'Choose a product to display its add to cart form.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 } )( Edit );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/simple.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/simple.tsx
@@ -33,7 +33,7 @@ const Simple = () => {
 			<ProductUnavailable
 				reason={ __(
 					'This product is currently out of stock and cannot be purchased.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			/>
 		);

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/index.tsx
@@ -38,7 +38,7 @@ const Variable = () => {
 			<ProductUnavailable
 				reason={ __(
 					'This product is currently out of stock and cannot be purchased.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			/>
 		);

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/attribute-select-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/attribute-select-control.tsx
@@ -19,7 +19,7 @@ interface Props extends SelectControlType.Props< string > {
 // Default option for select boxes.
 const selectAnOption = {
 	value: '',
-	label: __( 'Select an option', 'woo-gutenberg-products-block' ),
+	label: __( 'Select an option', 'woocommerce' ),
 };
 
 /**
@@ -32,7 +32,7 @@ const AttributeSelectControl = ( {
 	onChange = () => void 0,
 	errorMessage = __(
 		'Please select a value.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 }: Props ) => {
 	const errorId = attributeName;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.tsx
@@ -75,11 +75,11 @@ const ButtonComponent = ( {
 							'%d in cart',
 							'%d in cart',
 							quantityInCart,
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						quantityInCart
 				  )
-				: __( 'Add to cart', 'woo-gutenberg-products-block' ) }
+				: __( 'Add to cart', 'woocommerce' ) }
 			{ !! isDone && <Icon icon={ check } /> }
 		</Button>
 	);
@@ -166,7 +166,7 @@ const AddToCartButton = () => {
 			href={ addToCartButtonData.url }
 			text={
 				addToCartButtonData.text ||
-				__( 'View Product', 'woo-gutenberg-products-block' )
+				__( 'View Product', 'woocommerce' )
 			}
 			onClick={ () => {
 				dispatchStoreEvent( 'product-view-link', {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/shared/product-unavailable.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart/shared/product-unavailable.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 const ProductUnavailable = ( {
 	reason = __(
 		'Sorry, this product cannot be purchased.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 } ) => {
 	return (

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/block.tsx
@@ -29,7 +29,7 @@ export const Block = ( props: ProductAverageRatingProps ): JSX.Element => {
 		<div className={ className } style={ styleProps.style }>
 			{ Number( product.average_rating ) > 0
 				? product.average_rating
-				: __( 'No ratings', 'woo-gutenberg-products-block' ) }
+				: __( 'No ratings', 'woocommerce' ) }
 		</div>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
@@ -55,13 +55,13 @@ const AddToCartButton = ( {
 					'%d in cart',
 					'%d in cart',
 					cartQuantity,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				cartQuantity
 		  )
 		: decodeEntities(
 				productCartDetails?.text ||
-					__( 'Add to cart', 'woo-gutenberg-products-block' )
+					__( 'Add to cart', 'woocommerce' )
 		  );
 
 	const ButtonTag = allowAddToCart ? 'button' : 'a';

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
@@ -42,12 +42,12 @@ function WidthPanel( {
 
 	return (
 		<PanelBody
-			title={ __( 'Width settings', 'woo-gutenberg-products-block' ) }
+			title={ __( 'Width settings', 'woocommerce' ) }
 		>
 			<ButtonGroup
 				aria-label={ __(
 					'Button width',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/block.tsx
@@ -135,7 +135,7 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	const ParentComponent = showProductLink ? 'a' : Fragment;
 	const anchorLabel = sprintf(
 		/* translators: %s is referring to the product name */
-		__( 'Link to %s', 'woo-gutenberg-products-block' ),
+		__( 'Link to %s', 'woocommerce' ),
 		product.name
 	);
 	const anchorProps = {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/constants.tsx
@@ -6,12 +6,12 @@ import { image, Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'Product Image',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon icon={ image } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Display the main product image.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
@@ -74,16 +74,16 @@ const Edit = ( {
 					setAttributes={ setAttributes }
 				/>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 				>
 					<ToggleControl
 						label={ __(
 							'Link to Product Page',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Links the image to the single product listing.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showProductLink }
 						onChange={ () =>
@@ -95,11 +95,11 @@ const Edit = ( {
 					<ToggleControl
 						label={ __(
 							'Show On-Sale Badge',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Display a “sale” badge if the product is on-sale.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showSaleBadge }
 						onChange={ () =>
@@ -112,7 +112,7 @@ const Edit = ( {
 						<ToggleGroupControl
 							label={ __(
 								'Sale Badge Alignment',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							value={ saleBadgeAlign }
 							onChange={ ( value: SaleBadgeAlignProps ) =>
@@ -123,21 +123,21 @@ const Edit = ( {
 								value="left"
 								label={ __(
 									'Left',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value="center"
 								label={ __(
 									'Center',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value="right"
 								label={ __(
 									'Right',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 						</ToggleGroupControl>
@@ -146,12 +146,12 @@ const Edit = ( {
 						<ToggleGroupControl
 							label={ __(
 								'Image Sizing',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							help={ createInterpolateElement(
 								__(
 									'Product image cropping can be modified in the <a>Customizer</a>.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								{
 									a: (
@@ -175,14 +175,14 @@ const Edit = ( {
 								value={ ImageSizing.SINGLE }
 								label={ __(
 									'Full Size',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value={ ImageSizing.THUMBNAIL }
 								label={ __(
 									'Cropped',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 						</ToggleGroupControl>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/image-size-settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/image-size-settings.tsx
@@ -31,15 +31,15 @@ interface ImageSizeSettingProps {
 const scaleHelp: Record< string, string > = {
 	cover: __(
 		'Image is scaled and cropped to fill the entire space without being distorted.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	contain: __(
 		'Image is scaled to fill the space without clipping nor distorting.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	fill: __(
 		'Image will be stretched and distorted to completely fill the space.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 
@@ -52,10 +52,10 @@ export const ImageSizeSettings = ( {
 	return (
 		<ToolsPanel
 			className="wc-block-product-image__tools-panel"
-			label={ __( 'Image size', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Image size', 'woocommerce' ) }
 		>
 			<UnitControl
-				label={ __( 'Height', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Height', 'woocommerce' ) }
 				onChange={ ( value: string ) => {
 					setAttributes( { height: value } );
 				} }
@@ -68,7 +68,7 @@ export const ImageSizeSettings = ( {
 				] }
 			/>
 			<UnitControl
-				label={ __( 'Width', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Width', 'woocommerce' ) }
 				onChange={ ( value: string ) => {
 					setAttributes( { width: value } );
 				} }
@@ -83,10 +83,10 @@ export const ImageSizeSettings = ( {
 			{ height && (
 				<ToolsPanelItem
 					hasValue={ () => true }
-					label={ __( 'Scale', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Scale', 'woocommerce' ) }
 				>
 					<ToggleGroupControl
-						label={ __( 'Scale', 'woo-gutenberg-products-block' ) }
+						label={ __( 'Scale', 'woocommerce' ) }
 						value={ scale }
 						help={ scaleHelp[ scale ] }
 						onChange={ ( value: string ) =>
@@ -101,21 +101,21 @@ export const ImageSizeSettings = ( {
 								value="cover"
 								label={ __(
 									'Cover',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value="contain"
 								label={ __(
 									'Contain',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value="fill"
 								label={ __(
 									'Fill',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 						</>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/index.ts
@@ -33,7 +33,7 @@ const blockConfig: BlockConfiguration = {
 		'core/post-template',
 		'woocommerce/product-template',
 	],
-	textdomain: 'woo-gutenberg-products-block',
+	textdomain: 'woocommerce',
 	attributes,
 	supports,
 	edit,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/constants.tsx
@@ -6,7 +6,7 @@ import { currencyDollar, Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'Product Price',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon
@@ -16,5 +16,5 @@ export const BLOCK_ICON: JSX.Element = (
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Display the price of a product.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.tsx
@@ -56,7 +56,7 @@ export const SingleProductDetails = () => {
 			active: true,
 			content: __(
 				'This block lists description, attributes and reviews for a single product.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 		},
 		{

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
@@ -31,7 +31,7 @@ const Edit = () => {
 					{
 						prefix: __(
 							'Category: ',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						term: 'product_cat',
 					},
@@ -39,7 +39,7 @@ const Edit = () => {
 				[
 					'core/post-terms',
 					{
-						prefix: __( 'Tags: ', 'woo-gutenberg-products-block' ),
+						prefix: __( 'Tags: ', 'woocommerce' ),
 						term: 'product_tag',
 					},
 				],

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-reviews/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-reviews/block.tsx
@@ -22,27 +22,27 @@ export const ProductReviews = () => {
 				<p>
 					{ __(
 						'The products reviews and the form to add a new review will be displayed here according to your theme. The look you see here is not representative of what is going to look like, this is just a placeholder.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</p>
 			</Notice>
 			<h2>
 				{ __(
 					'3 reviews for this product',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</h2>
 			<img
 				src={ `${ WC_BLOCKS_IMAGE_URL }block-placeholders/product-reviews.svg` }
 				alt="Placeholder"
 			/>
-			<h3>{ __( 'Add a review', 'woo-gutenberg-products-block' ) }</h3>
+			<h3>{ __( 'Add a review', 'woocommerce' ) }</h3>
 			<div className="wp-block-woocommerce-product-reviews__editor__form-container">
 				<div className="wp-block-woocommerce-product-reviews__editor__row">
 					<span>
 						{ __(
 							'Your rating *',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</span>
 					<p className="wp-block-woocommerce-product-reviews__editor__stars"></p>
@@ -51,7 +51,7 @@ export const ProductReviews = () => {
 					<span>
 						{ __(
 							'Your review *',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</span>
 					<textarea />
@@ -59,7 +59,7 @@ export const ProductReviews = () => {
 				<input
 					type="submit"
 					className="submit wp-block-button__link wp-element-button"
-					value={ __( 'Submit', 'woo-gutenberg-products-block' ) }
+					value={ __( 'Submit', 'woocommerce' ) }
 				/>
 			</div>
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/block.tsx
@@ -30,11 +30,11 @@ const ReviewsCount = ( props: { reviews: number } ): JSX.Element => {
 					'(%s customer review)',
 					'(%s customer reviews)',
 					reviews,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				reviews
 		  )
-		: __( '(X customer reviews)', 'woo-gutenberg-products-block' );
+		: __( '(X customer reviews)', 'woocommerce' );
 
 	return (
 		<span className="wc-block-components-product-rating-counter__reviews_count">

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/block.tsx
@@ -62,7 +62,7 @@ const NoRating = ( { parentClassName }: { parentClassName: string } ) => {
 			>
 				<span style={ starStyle } />
 			</div>
-			<span>{ __( 'No Reviews', 'woo-gutenberg-products-block' ) }</span>
+			<span>{ __( 'No Reviews', 'woocommerce' ) }</span>
 		</div>
 	);
 };
@@ -74,7 +74,7 @@ const Rating = ( props: RatingProps ): JSX.Element => {
 
 	const ratingText = sprintf(
 		/* translators: %f is referring to the average rating value */
-		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
+		__( 'Rated %f out of 5', 'woocommerce' ),
 		rating
 	);
 
@@ -85,7 +85,7 @@ const Rating = ( props: RatingProps ): JSX.Element => {
 				'Rated %1$s out of 5 based on %2$s customer rating',
 				'Rated %1$s out of 5 based on %2$s customer ratings',
 				reviews,
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			sprintf( '<strong class="rating">%f</strong>', rating ),
 			sprintf( '<span class="rating">%d</span>', reviews )

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/block.tsx
@@ -60,7 +60,7 @@ const NoRating = ( { parentClassName }: { parentClassName: string } ) => {
 			>
 				<span style={ starStyle } />
 			</div>
-			<span>{ __( 'No Reviews', 'woo-gutenberg-products-block' ) }</span>
+			<span>{ __( 'No Reviews', 'woocommerce' ) }</span>
 		</div>
 	);
 };
@@ -72,7 +72,7 @@ const Rating = ( props: RatingProps ): JSX.Element => {
 
 	const ratingText = sprintf(
 		/* translators: %f is referring to the average rating value */
-		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
+		__( 'Rated %f out of 5', 'woocommerce' ),
 		rating
 	);
 
@@ -83,7 +83,7 @@ const Rating = ( props: RatingProps ): JSX.Element => {
 				'Rated %1$s out of 5 based on %2$s customer rating',
 				'Rated %1$s out of 5 based on %2$s customer ratings',
 				reviews,
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			sprintf( '<strong class="rating">%f</strong>', rating ),
 			sprintf( '<span class="rating">%d</span>', reviews )
@@ -112,7 +112,7 @@ const ReviewsCount = ( props: { reviews: number } ): JSX.Element => {
 			'(%s customer review)',
 			'(%s customer reviews)',
 			reviews,
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		reviews
 	);

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/constants.tsx
@@ -6,7 +6,7 @@ import { starEmpty, Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'Product Rating',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon
@@ -16,5 +16,5 @@ export const BLOCK_ICON: JSX.Element = (
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Display the average rating of a product.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/related-products/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/related-products/edit.tsx
@@ -36,7 +36,7 @@ const Edit = () => {
 					<p>
 						{ __(
 							'These products will vary depending on the main product in the page',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 				</Notice>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/block.tsx
@@ -52,10 +52,10 @@ export const Block = ( props: Props ): JSX.Element | null => {
 			style={ styleProps.style }
 		>
 			<Label
-				label={ __( 'Sale', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Sale', 'woocommerce' ) }
 				screenReaderLabel={ __(
 					'Product on sale',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			/>
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/constants.tsx
@@ -6,12 +6,12 @@ import { percent, Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'On-Sale Badge',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon icon={ percent } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Displays an on-sale badge if the product is on-sale.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -16,7 +16,7 @@ import save from '../save';
  */
 const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	category: 'woocommerce-product-elements',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 	icon: {
 		src: (
 			<Icon

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/shared/product-selector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/shared/product-selector.tsx
@@ -51,7 +51,7 @@ export const ProductSelector = ( {
 								setIsEditing( false );
 							} }
 						>
-							{ __( 'Done', 'woo-gutenberg-products-block' ) }
+							{ __( 'Done', 'woocommerce' ) }
 						</Button>
 					</div>
 				</Placeholder>
@@ -64,7 +64,7 @@ export const ProductSelector = ( {
 							>
 								{ __(
 									'Switch product…',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</TextToolbarButton>
 						</ToolbarGroup>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
@@ -36,7 +36,7 @@ const Preview = ( {
 		} ) }
 		style={ style }
 	>
-		{ __( 'SKU:', 'woo-gutenberg-products-block' ) }{ ' ' }
+		{ __( 'SKU:', 'woocommerce' ) }{ ' ' }
 		<strong>{ sku }</strong>
 	</div>
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/constants.tsx
@@ -7,12 +7,12 @@ import { Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'Product SKU',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon icon={ barcode } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Display the SKU of a product.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
@@ -45,15 +45,15 @@ const getTextBasedOnStock = ( {
 	if ( isLowStock && lowStockAmount !== null ) {
 		return sprintf(
 			/* translators: %d stock amount (number of items in stock for product) */
-			__( '%d left in stock', 'woo-gutenberg-products-block' ),
+			__( '%d left in stock', 'woocommerce' ),
 			lowStockAmount
 		);
 	} else if ( isOnBackorder ) {
-		return __( 'Available on backorder', 'woo-gutenberg-products-block' );
+		return __( 'Available on backorder', 'woocommerce' );
 	} else if ( isInStock ) {
-		return __( 'In stock', 'woo-gutenberg-products-block' );
+		return __( 'In stock', 'woocommerce' );
 	}
-	return __( 'Out of stock', 'woo-gutenberg-products-block' );
+	return __( 'Out of stock', 'woocommerce' );
 };
 
 type Props = BlockAttributes & HTMLAttributes< HTMLDivElement >;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/constants.tsx
@@ -6,12 +6,12 @@ import { box, Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'Product Stock Indicator',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon icon={ box } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Display product stock status.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/constants.tsx
@@ -6,12 +6,12 @@ import { page, Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'Product Summary',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon icon={ page } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Display a short description about a product.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/constants.tsx
@@ -6,12 +6,12 @@ import { heading, Icon } from '@wordpress/icons';
 
 export const BLOCK_TITLE: string = __(
 	'Product Title',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const BLOCK_ICON: JSX.Element = (
 	<Icon icon={ heading } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION: string = __(
 	'Display the title of a product.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -55,13 +55,13 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 				<PanelBody
 					title={ __(
 						'Link settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleControl
 						label={ __(
 							'Make title a link',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showProductLink }
 						onChange={ () =>
@@ -75,7 +75,7 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 							<ToggleControl
 								label={ __(
 									'Open in new tab',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								onChange={ ( value ) =>
 									setAttributes( {
@@ -102,7 +102,7 @@ const Title = isFeaturePluginBuild()
 				label: BLOCK_TITLE,
 				description: __(
 					'Choose a product to display its title.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 			} ),
 	  ] )( TitleEdit )

--- a/plugins/woocommerce-blocks/assets/js/base/components/block-error-boundary/block-error.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/block-error-boundary/block-error.tsx
@@ -11,13 +11,13 @@ import type { BlockErrorProps } from './types';
 
 const BlockError = ( {
 	imageUrl = `${ WC_BLOCKS_IMAGE_URL }/block-error.svg`,
-	header = __( 'Oops!', 'woo-gutenberg-products-block' ),
+	header = __( 'Oops!', 'woocommerce' ),
 	text = __(
 		'There was an error loading the content.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	errorMessage,
-	errorMessagePrefix = __( 'Error:', 'woo-gutenberg-products-block' ),
+	errorMessagePrefix = __( 'Error:', 'woocommerce' ),
 	button,
 	showErrorBlock = true,
 }: BlockErrorProps ): JSX.Element | null => {

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/custom-validation-handler.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/custom-validation-handler.ts
@@ -30,7 +30,7 @@ const customValidationHandler = (
 		inputObject.setCustomValidity(
 			__(
 				'Please enter a valid postcode',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			)
 		);
 		return false;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/prepare-address-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/prepare-address-fields.ts
@@ -43,7 +43,7 @@ const getSupportedCoreLocaleProps = (
 	if ( localeField.label !== undefined && ! localeField.optionalLabel ) {
 		fields.optionalLabel = sprintf(
 			/* translators: %s Field label. */
-			__( '%s (optional)', 'woo-gutenberg-products-block' ),
+			__( '%s (optional)', 'woocommerce' ),
 			localeField.label
 		);
 	}

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/validate-shipping-country.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/validate-shipping-country.ts
@@ -25,7 +25,7 @@ const validateShippingCountry = ( values: ShippingAddress ): void => {
 				[ validationErrorId ]: {
 					message: __(
 						'Please select your country',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					hidden: false,
 				},

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -314,7 +314,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 										/* translators: %s refers to the item's name in the cart. */
 										__(
 											'Remove %s from cart',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 										),
 										name
 									) }
@@ -333,7 +333,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 												/* translators: %s refers to the item name in the cart. */
 												__(
 													'%s has been removed from your cart.',
-													'woo-gutenberg-products-block'
+													'woocommerce'
 												),
 												name
 											)
@@ -343,7 +343,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 								>
 									{ __(
 										'Remove item',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</button>
 							) }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
@@ -80,17 +80,17 @@ const CartLineItemsTable = ( {
 				<tr className="wc-block-cart-items__header">
 					<th className="wc-block-cart-items__header-image">
 						<span>
-							{ __( 'Product', 'woo-gutenberg-products-block' ) }
+							{ __( 'Product', 'woocommerce' ) }
 						</span>
 					</th>
 					<th className="wc-block-cart-items__header-product">
 						<span>
-							{ __( 'Details', 'woo-gutenberg-products-block' ) }
+							{ __( 'Details', 'woocommerce' ) }
 						</span>
 					</th>
 					<th className="wc-block-cart-items__header-total">
 						<span>
-							{ __( 'Total', 'woo-gutenberg-products-block' ) }
+							{ __( 'Total', 'woocommerce' ) }
 						</span>
 					</th>
 				</tr>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/index.tsx
@@ -32,7 +32,7 @@ const OrderSummary = ( {
 			hasBorder={ false }
 			title={
 				<span className="wc-block-components-order-summary__button-text">
-					{ __( 'Order summary', 'woo-gutenberg-products-block' ) }
+					{ __( 'Order summary', 'woocommerce' ) }
 				</span>
 			}
 		>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -139,7 +139,7 @@ const OrderSummaryItem = ( { cartItem }: OrderSummaryProps ): JSX.Element => {
 								'%d item',
 								'%d items',
 								quantity,
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							quantity
 						) }
@@ -188,7 +188,7 @@ const OrderSummaryItem = ( { cartItem }: OrderSummaryProps ): JSX.Element => {
 						'Total price for %1$d %2$s item: %3$s',
 						'Total price for %1$d %2$s items: %3$s',
 						quantity,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					quantity,
 					name,

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/pickup-location/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/pickup-location/index.tsx
@@ -60,7 +60,7 @@ const PickupLocation = (): JSX.Element | null => {
 		<span className="wc-block-components-shipping-address">
 			{ sprintf(
 				/* translators: %s: shipping method name, e.g. "Amazon Locker" */
-				__( 'Collection from %s', 'woo-gutenberg-products-block' ),
+				__( 'Collection from %s', 'woocommerce' ),
 				pickupAddress
 			) + ' ' }
 		</span>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/policies/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/policies/index.tsx
@@ -29,7 +29,7 @@ const Policies = (): JSX.Element => {
 							? decodeEntities( PRIVACY_PAGE_NAME )
 							: __(
 									'Privacy Policy',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 							  ) }
 					</a>
 				</li>
@@ -45,7 +45,7 @@ const Policies = (): JSX.Element => {
 							? decodeEntities( TERMS_PAGE_NAME )
 							: __(
 									'Terms and Conditions',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 							  ) }
 					</a>
 				</li>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/product-backorder-badge/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/product-backorder-badge/index.tsx
@@ -14,7 +14,7 @@ import ProductBadge from '../product-badge';
 const ProductBackorderBadge = (): JSX.Element => {
 	return (
 		<ProductBadge className="wc-block-components-product-backorder-badge">
-			{ __( 'Available on backorder', 'woo-gutenberg-products-block' ) }
+			{ __( 'Available on backorder', 'woocommerce' ) }
 		</ProductBadge>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/product-low-stock-badge/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/product-low-stock-badge/index.tsx
@@ -28,7 +28,7 @@ const ProductLowStockBadge = ( {
 		<ProductBadge className="wc-block-components-product-low-stock-badge">
 			{ sprintf(
 				/* translators: %d stock amount (number of items in stock for product) */
-				__( '%d left in stock', 'woo-gutenberg-products-block' ),
+				__( '%d left in stock', 'woocommerce' ),
 				lowStockRemaining
 			) }
 		</ProductBadge>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/product-sale-badge/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/product-sale-badge/index.tsx
@@ -41,7 +41,7 @@ const ProductSaleBadge = ( {
 
 	const formattedMessage = sprintf(
 		/* translators: %s will be replaced by the discount amount */
-		__( `Save %s`, 'woo-gutenberg-products-block' ),
+		__( `Save %s`, 'woocommerce' ),
 		format
 	);
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
@@ -27,7 +27,7 @@ const ReturnToCartButton = ( {
 			className="wc-block-components-checkout-return-to-cart-button"
 		>
 			<Icon icon={ arrowLeft } />
-			{ __( 'Return to Cart', 'woo-gutenberg-products-block' ) }
+			{ __( 'Return to Cart', 'woocommerce' ) }
 		</a>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
@@ -75,7 +75,7 @@ const ShippingCalculatorAddress = ( {
 				} }
 				type="submit"
 			>
-				{ __( 'Update', 'woo-gutenberg-products-block' ) }
+				{ __( 'Update', 'woocommerce' ) }
 			</Button>
 		</form>
 	);

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-location/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-location/index.tsx
@@ -19,7 +19,7 @@ const ShippingLocation = ( {
 		<span className="wc-block-components-shipping-address">
 			{ sprintf(
 				/* translators: %s location. */
-				__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
+				__( 'Shipping to %s', 'woocommerce' ),
 				formattedLocation
 			) + ' ' }
 		</span>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -72,7 +72,7 @@ export const ShippingRatesControlPackage = ( {
 											'%1$s (%2$d unit)',
 											'%1$s (%2$d units)',
 											quantity,
-											'woo-gutenberg-products-block'
+											'woocommerce'
 										),
 										name,
 										quantity

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -111,7 +111,7 @@ const ShippingRatesControl = ( {
 			isLoading={ isLoadingRates }
 			screenReaderLabel={ __(
 				'Loading shipping rates…',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			showSpinner={ true }
 		>
@@ -127,7 +127,7 @@ const ShippingRatesControl = ( {
 					>
 						{ __(
 							'Multiple shipments must have the same pickup location',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</NoticeBanner>
 				) }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/utils.ts
@@ -16,7 +16,7 @@ export const speakFoundShippingOptions = (
 					'%d shipping option was found.',
 					'%d shipping options were found.',
 					rateCount,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				rateCount
 			)
@@ -29,7 +29,7 @@ export const speakFoundShippingOptions = (
 					'Shipping option searched for %d package.',
 					'Shipping options searched for %d packages.',
 					packageCount,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				packageCount
 			) +
@@ -40,7 +40,7 @@ export const speakFoundShippingOptions = (
 						'%d shipping option was found',
 						'%d shipping options were found',
 						rateCount,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					rateCount
 				)

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -94,17 +94,17 @@ export const TotalsCoupon = ( {
 					className="wc-block-components-totals-coupon-link"
 					aria-label={ __(
 						'Add a coupon',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					onClick={ handleCouponAnchorClick }
 				>
-					{ __( 'Add a coupon', 'woo-gutenberg-products-block' ) }
+					{ __( 'Add a coupon', 'woocommerce' ) }
 				</a>
 			) : (
 				<LoadingMask
 					screenReaderLabel={ __(
 						'Applying coupon…',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					isLoading={ isLoading }
 					showSpinner={ false }
@@ -120,7 +120,7 @@ export const TotalsCoupon = ( {
 								className="wc-block-components-totals-coupon__input"
 								label={ __(
 									'Enter code',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								value={ couponValue }
 								ariaDescribedBy={ validationErrorId }
@@ -140,7 +140,7 @@ export const TotalsCoupon = ( {
 							>
 								{ __(
 									'Apply',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</Button>
 						</form>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
@@ -76,7 +76,7 @@ const TotalsDiscount = ( {
 					<LoadingMask
 						screenReaderLabel={ __(
 							'Removing coupon…',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						isLoading={ isRemovingCoupon }
 						showSpinner={ false }
@@ -92,7 +92,7 @@ const TotalsDiscount = ( {
 											/* translators: %s Coupon code. */
 											__(
 												'Coupon: %s',
-												'woo-gutenberg-products-block'
+												'woocommerce'
 											),
 											cartCoupon.label
 										) }
@@ -105,7 +105,7 @@ const TotalsDiscount = ( {
 											/* translators: %s is a coupon code. */
 											__(
 												'Remove coupon "%s"',
-												'woo-gutenberg-products-block'
+												'woocommerce'
 											),
 											cartCoupon.label
 										) }
@@ -118,8 +118,8 @@ const TotalsDiscount = ( {
 			}
 			label={
 				!! discountTotalValue
-					? __( 'Discount', 'woo-gutenberg-products-block' )
-					: __( 'Coupons', 'woo-gutenberg-products-block' )
+					? __( 'Discount', 'woocommerce' )
+					: __( 'Coupons', 'woocommerce' )
 			}
 			value={ discountTotalValue ? discountTotalValue * -1 : '-' }
 		/>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
@@ -66,7 +66,7 @@ const TotalsFooterItem = ( {
 	const { receiveCart, ...cart } = useStoreCart();
 	const label = applyCheckoutFilter( {
 		filterName: 'totalLabel',
-		defaultValue: __( 'Total', 'woo-gutenberg-products-block' ),
+		defaultValue: __( 'Total', 'woocommerce' ),
 		extensions: cart.extensions,
 		arg: { cart },
 	} );
@@ -76,7 +76,7 @@ const TotalsFooterItem = ( {
 		taxLines && taxLines.length > 0
 			? sprintf(
 					/* translators: %s is a list of tax rates */
-					__( 'Including %s', 'woo-gutenberg-products-block' ),
+					__( 'Including %s', 'woocommerce' ),
 					taxLines
 						.map( ( { name, price } ) => {
 							return `${ formatPrice(
@@ -88,7 +88,7 @@ const TotalsFooterItem = ( {
 			  )
 			: __(
 					'Including <TaxAmount/> in taxes',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 			  );
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/calculator-button.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/calculator-button.tsx
@@ -10,7 +10,7 @@ export interface CalculatorButtonProps {
 }
 
 export const CalculatorButton = ( {
-	label = __( 'Calculate', 'woo-gutenberg-products-block' ),
+	label = __( 'Calculate', 'woocommerce' ),
 	isShippingCalculatorOpen,
 	setIsShippingCalculatorOpen,
 }: CalculatorButtonProps ): JSX.Element => {

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -93,7 +93,7 @@ export const TotalsShipping = ( {
 			) }
 		>
 			<TotalsItem
-				label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Shipping', 'woocommerce' ) }
 				value={
 					! shippingMethodsMissing && cartHasCalculatedShipping
 						? // if address is not complete, display the link to add an address.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -53,7 +53,7 @@ export const ShippingAddress = ( {
 				<CalculatorButton
 					label={ __(
 						'Change address',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					isShippingCalculatorOpen={ isShippingCalculatorOpen }
 					setIsShippingCalculatorOpen={ setIsShippingCalculatorOpen }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-placeholder.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-placeholder.tsx
@@ -27,11 +27,11 @@ export const ShippingPlaceholder = ( {
 				{ isCheckout
 					? __(
 							'No shipping options available',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 					  )
 					: __(
 							'Calculated during checkout',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 					  ) }
 			</em>
 		);
@@ -41,7 +41,7 @@ export const ShippingPlaceholder = ( {
 		<CalculatorButton
 			label={ __(
 				'Add an address for shipping options',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			isShippingCalculatorOpen={ isShippingCalculatorOpen }
 			setIsShippingCalculatorOpen={ setIsShippingCalculatorOpen }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
@@ -24,8 +24,8 @@ export const ShippingRateSelector = ( {
 	isAddressComplete,
 }: ShippingRateSelectorProps ): JSX.Element => {
 	const legend = hasRates
-		? __( 'Shipping options', 'woo-gutenberg-products-block' )
-		: __( 'Choose a shipping option', 'woo-gutenberg-products-block' );
+		? __( 'Shipping options', 'woocommerce' )
+		: __( 'Choose a shipping option', 'woocommerce' );
 	return (
 		<fieldset className="wc-block-components-totals-shipping__fieldset">
 			<legend className="screen-reader-text">{ legend }</legend>
@@ -41,7 +41,7 @@ export const ShippingRateSelector = ( {
 							>
 								{ __(
 									'There are no shipping options available. Please check your shipping address.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</NoticeBanner>
 						) }

--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/index.tsx
@@ -48,7 +48,7 @@ const Combobox = ( {
 	required = false,
 	errorMessage = __(
 		'Please select a value.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	errorId: incomingErrorId,
 	instanceId = '0',

--- a/plugins/woocommerce-blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/country-input/country-input.tsx
@@ -25,7 +25,7 @@ export const CountryInput = ( {
 	errorId,
 	errorMessage = __(
 		'Please select a country',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 }: CountryInputWithCountriesProps ): JSX.Element => {
 	const options = useMemo(

--- a/plugins/woocommerce-blocks/assets/js/base/components/drawer/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/drawer/index.tsx
@@ -58,7 +58,7 @@ const CloseButtonPortal = ( {
 					className="wc-block-components-drawer__close"
 					icon={ close }
 					onClick={ onClick }
-					label={ __( 'Close', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Close', 'woocommerce' ) }
 					showTooltip={ false }
 				/>,
 				closeButtonWrapper

--- a/plugins/woocommerce-blocks/assets/js/base/components/filter-element-label/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/filter-element-label/index.tsx
@@ -36,7 +36,7 @@ const FilterElementLabel = ( {
 							'%s product',
 							'%s products',
 							count,
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						count
 					) }

--- a/plugins/woocommerce-blocks/assets/js/base/components/filter-reset-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/filter-reset-button/index.tsx
@@ -20,9 +20,9 @@ interface FilterResetButtonProps {
 const FilterResetButton = ( {
 	className,
 	/* translators: Reset button text for filters. */
-	label = __( 'Reset', 'woo-gutenberg-products-block' ),
+	label = __( 'Reset', 'woocommerce' ),
 	onClick,
-	screenReaderLabel = __( 'Reset filter', 'woo-gutenberg-products-block' ),
+	screenReaderLabel = __( 'Reset filter', 'woocommerce' ),
 }: FilterResetButtonProps ): JSX.Element => {
 	return (
 		<button

--- a/plugins/woocommerce-blocks/assets/js/base/components/filter-submit-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/filter-submit-button/index.tsx
@@ -24,9 +24,9 @@ const FilterSubmitButton = ( {
 	isLoading,
 	disabled,
 	/* translators: Submit button text for filters. */
-	label = __( 'Apply', 'woo-gutenberg-products-block' ),
+	label = __( 'Apply', 'woocommerce' ),
 	onClick,
-	screenReaderLabel = __( 'Apply filter', 'woo-gutenberg-products-block' ),
+	screenReaderLabel = __( 'Apply filter', 'woocommerce' ),
 }: FilterSubmitButtonProps ): JSX.Element => {
 	return (
 		<button

--- a/plugins/woocommerce-blocks/assets/js/base/components/load-more-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/load-more-button/index.tsx
@@ -18,8 +18,8 @@ interface LoadMoreButtonProps {
 
 export const LoadMoreButton = ( {
 	onClick,
-	label = __( 'Load more', 'woo-gutenberg-products-block' ),
-	screenReaderLabel = __( 'Load more', 'woo-gutenberg-products-block' ),
+	label = __( 'Load more', 'woocommerce' ),
+	screenReaderLabel = __( 'Load more', 'woocommerce' ),
 }: LoadMoreButtonProps ): JSX.Element => {
 	return (
 		<div className="wp-block-button wc-block-load-more wc-block-components-load-more">

--- a/plugins/woocommerce-blocks/assets/js/base/components/loading-mask/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/loading-mask/index.tsx
@@ -43,7 +43,7 @@ const LoadingMask = ( {
 			{ isLoading && (
 				<span className="screen-reader-text">
 					{ screenReaderLabel ||
-						__( 'Loading…', 'woo-gutenberg-products-block' ) }
+						__( 'Loading…', 'woocommerce' ) }
 				</span>
 			) }
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/index.tsx
@@ -77,7 +77,7 @@ const NoticeBanner = ( {
 					icon={ close }
 					label={ __(
 						'Dismiss this notice',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					onClick={ dismiss }
 					showTooltip={ false }

--- a/plugins/woocommerce-blocks/assets/js/base/components/pagination/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/pagination/index.tsx
@@ -83,7 +83,7 @@ const Pagination = ( {
 			<Label
 				screenReaderLabel={ __(
 					'Navigate to another page',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			/>
 			{ displayNextAndPreviousArrows && (
@@ -92,7 +92,7 @@ const Pagination = ( {
 					onClick={ () => onPageChange( currentPage - 1 ) }
 					title={ __(
 						'Previous page',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					disabled={ currentPage <= 1 }
 				>
@@ -100,7 +100,7 @@ const Pagination = ( {
 						label="&larr;"
 						screenReaderLabel={ __(
 							'Previous page',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 				</button>
@@ -124,7 +124,7 @@ const Pagination = ( {
 						label={ '1' }
 						screenReaderLabel={ sprintf(
 							/* translators: %d is the page number (1, 2, 3...). */
-							__( 'Page %d', 'woo-gutenberg-products-block' ),
+							__( 'Page %d', 'woocommerce' ),
 							1
 						) }
 					/>
@@ -135,7 +135,7 @@ const Pagination = ( {
 					className="wc-block-pagination-ellipsis wc-block-components-pagination__ellipsis"
 					aria-hidden="true"
 				>
-					{ __( '…', 'woo-gutenberg-products-block' ) }
+					{ __( '…', 'woocommerce' ) }
 				</span>
 			) }
 			{ pages.map( ( page ) => {
@@ -163,7 +163,7 @@ const Pagination = ( {
 							label={ page.toString() }
 							screenReaderLabel={ sprintf(
 								/* translators: %d is the page number (1, 2, 3...). */
-								__( 'Page %d', 'woo-gutenberg-products-block' ),
+								__( 'Page %d', 'woocommerce' ),
 								page
 							) }
 						/>
@@ -175,7 +175,7 @@ const Pagination = ( {
 					className="wc-block-pagination-ellipsis wc-block-components-pagination__ellipsis"
 					aria-hidden="true"
 				>
-					{ __( '…', 'woo-gutenberg-products-block' ) }
+					{ __( '…', 'woocommerce' ) }
 				</span>
 			) }
 			{ showLastPage && (
@@ -197,7 +197,7 @@ const Pagination = ( {
 						label={ totalPages.toString() }
 						screenReaderLabel={ sprintf(
 							/* translators: %d is the page number (1, 2, 3...). */
-							__( 'Page %d', 'woo-gutenberg-products-block' ),
+							__( 'Page %d', 'woocommerce' ),
 							totalPages
 						) }
 					/>
@@ -207,14 +207,14 @@ const Pagination = ( {
 				<button
 					className="wc-block-pagination-page wc-block-components-pagination__page wc-block-components-pagination-page--arrow"
 					onClick={ () => onPageChange( currentPage + 1 ) }
-					title={ __( 'Next page', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Next page', 'woocommerce' ) }
 					disabled={ currentPage >= totalPages }
 				>
 					<Label
 						label="&rarr;"
 						screenReaderLabel={ __(
 							'Next page',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 				</button>

--- a/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
@@ -351,7 +351,7 @@ const PriceSlider = ( {
 						className="wc-block-price-filter__range-input wc-block-price-filter__range-input--min wc-block-components-price-slider__range-input wc-block-components-price-slider__range-input--min"
 						aria-label={ __(
 							'Filter products by minimum price',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						aria-valuetext={ ariaReadableMinPrice }
 						value={
@@ -372,7 +372,7 @@ const PriceSlider = ( {
 						className="wc-block-price-filter__range-input wc-block-price-filter__range-input--max wc-block-components-price-slider__range-input wc-block-components-price-slider__range-input--max"
 						aria-label={ __(
 							'Filter products by maximum price',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						aria-valuetext={ ariaReadableMaxPrice }
 						value={
@@ -420,7 +420,7 @@ const PriceSlider = ( {
 							className={ getInputClassName( 'min' ) }
 							aria-label={ __(
 								'Filter products by minimum price',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							isAllowed={ isValidMinValue( {
 								minConstraint,
@@ -445,7 +445,7 @@ const PriceSlider = ( {
 							className={ getInputClassName( 'max' ) }
 							aria-label={ __(
 								'Filter products by maximum price',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							isAllowed={ isValidMaxValue( {
 								maxConstraint,
@@ -493,7 +493,7 @@ const PriceSlider = ( {
 							} }
 							screenReaderLabel={ __(
 								'Reset price filter',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					) }
@@ -505,7 +505,7 @@ const PriceSlider = ( {
 							onClick={ onSubmit }
 							screenReaderLabel={ __(
 								'Apply price filter',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					) }

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-list/no-matching-products.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-list/no-matching-products.tsx
@@ -22,16 +22,16 @@ const NoMatchingProducts = ( {
 				size={ 100 }
 			/>
 			<strong className={ `${ parentClassName }__no-products-title` }>
-				{ __( 'No products found', 'woo-gutenberg-products-block' ) }
+				{ __( 'No products found', 'woocommerce' ) }
 			</strong>
 			<p className={ `${ parentClassName }__no-products-description` }>
 				{ __(
 					'We were unable to find any results based on your search.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 			<button onClick={ resetCallback }>
-				{ __( 'Reset Search', 'woo-gutenberg-products-block' ) }
+				{ __( 'Reset Search', 'woocommerce' ) }
 			</button>
 		</div>
 	);

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-list/no-products.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-list/no-products.tsx
@@ -15,12 +15,12 @@ const NoProducts = (): JSX.Element => {
 				size={ 100 }
 			/>
 			<strong className={ `${ parentClassName }__no-products-title` }>
-				{ __( 'No products', 'woo-gutenberg-products-block' ) }
+				{ __( 'No products', 'woocommerce' ) }
 			</strong>
 			<p className={ `${ parentClassName }__no-products-description` }>
 				{ __(
 					'There are currently no products available to display.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-list/product-list.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-list/product-list.tsx
@@ -93,7 +93,7 @@ const announceLoadingCompletion = ( totalProducts: number ): void => {
 	}
 
 	if ( totalProducts === 0 ) {
-		speak( __( 'No products found', 'woo-gutenberg-products-block' ) );
+		speak( __( 'No products found', 'woocommerce' ) );
 	} else {
 		speak(
 			sprintf(
@@ -102,7 +102,7 @@ const announceLoadingCompletion = ( totalProducts: number ): void => {
 					'%d product found',
 					'%d products found',
 					totalProducts,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				totalProducts
 			)

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-list/product-sort-select/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-list/product-sort-select/index.tsx
@@ -23,42 +23,42 @@ const ProductSortSelect = ( {
 					key: 'menu_order',
 					label: __(
 						'Default sorting',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 				},
 				{
 					key: 'popularity',
-					label: __( 'Popularity', 'woo-gutenberg-products-block' ),
+					label: __( 'Popularity', 'woocommerce' ),
 				},
 				{
 					key: 'rating',
 					label: __(
 						'Average rating',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 				},
 				{
 					key: 'date',
-					label: __( 'Latest', 'woo-gutenberg-products-block' ),
+					label: __( 'Latest', 'woocommerce' ),
 				},
 				{
 					key: 'price',
 					label: __(
 						'Price: low to high',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 				},
 				{
 					key: 'price-desc',
 					label: __(
 						'Price: high to low',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 				},
 			] }
 			screenReaderLabel={ __(
 				'Order products by',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			value={ value }
 		/>

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-price/index.tsx
@@ -54,7 +54,7 @@ const PriceRange = ( {
 					/* translators: %1$s min price, %2$s max price */
 					__(
 						'Price between %1$s and %2$s',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					formatPrice( minPrice ),
 					formatPrice( maxPrice )
@@ -136,7 +136,7 @@ const SalePrice = ( {
 	return (
 		<>
 			<span className="screen-reader-text">
-				{ __( 'Previous price:', 'woo-gutenberg-products-block' ) }
+				{ __( 'Previous price:', 'woocommerce' ) }
 			</span>
 			<FormattedMonetaryAmount
 				currency={ currency }
@@ -154,7 +154,7 @@ const SalePrice = ( {
 				value={ regularPrice }
 			/>
 			<span className="screen-reader-text">
-				{ __( 'Discounted price:', 'woo-gutenberg-products-block' ) }
+				{ __( 'Discounted price:', 'woocommerce' ) }
 			</span>
 			<FormattedMonetaryAmount
 				currency={ currency }

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-rating/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-rating/index.tsx
@@ -25,14 +25,14 @@ const Rating = ( {
 
 	const ratingText = sprintf(
 		/* translators: %f is referring to the average rating value */
-		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
+		__( 'Rated %f out of 5', 'woocommerce' ),
 		rating
 	);
 
 	const ratingHTML = {
 		__html: sprintf(
 			/* translators: %s is the rating value wrapped in HTML strong tags. */
-			__( 'Rated %s out of 5', 'woo-gutenberg-products-block' ),
+			__( 'Rated %s out of 5', 'woocommerce' ),
 			sprintf( '<strong class="rating">%f</strong>', rating )
 		),
 	};

--- a/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/index.tsx
@@ -185,7 +185,7 @@ const QuantitySelector = ( {
 					/* translators: %s refers to the item name in the cart. */
 					__(
 						'Quantity of %s in your cart.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					itemName
 				) }
@@ -196,7 +196,7 @@ const QuantitySelector = ( {
 					/* translators: %s refers to the item name in the cart. */
 					__(
 						'Reduce quantity of %s',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					itemName
 				) }
@@ -210,7 +210,7 @@ const QuantitySelector = ( {
 							/* translators: %s refers to the item's new quantity in the cart. */
 							__(
 								'Quantity reduced to %s.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							newQuantity
 						)
@@ -226,7 +226,7 @@ const QuantitySelector = ( {
 					/* translators: %s refers to the item's name in the cart. */
 					__(
 						'Increase quantity of %s',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					itemName
 				) }
@@ -240,7 +240,7 @@ const QuantitySelector = ( {
 							/* translators: %s refers to the item's new quantity in the cart. */
 							__(
 								'Quantity increased to %s.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							newQuantity
 						)

--- a/plugins/woocommerce-blocks/assets/js/base/components/read-more/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/read-more/index.tsx
@@ -67,9 +67,9 @@ interface ReadMoreState {
 export const defaultProps = {
 	className: 'read-more-content',
 	ellipsis: '&hellip;',
-	lessText: __( 'Read less', 'woo-gutenberg-products-block' ),
+	lessText: __( 'Read less', 'woocommerce' ),
 	maxLines: 3,
-	moreText: __( 'Read more', 'woo-gutenberg-products-block' ),
+	moreText: __( 'Read more', 'woocommerce' ),
 };
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/base/components/reviews/review-list-item/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/reviews/review-list-item/index.tsx
@@ -46,10 +46,10 @@ function getReviewImage(
 					className="wc-block-review-list-item__verified wc-block-components-review-list-item__verified"
 					title={ __(
 						'Verified buyer',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
-					{ __( 'Verified buyer', 'woo-gutenberg-products-block' ) }
+					{ __( 'Verified buyer', 'woocommerce' ) }
 				</div>
 			) }
 		</div>
@@ -62,11 +62,11 @@ function getReviewContent( review: Review ): JSX.Element {
 			maxLines={ 10 }
 			moreText={ __(
 				'Read full review',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			lessText={ __(
 				'Hide full review',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			className="wc-block-review-list-item__text wc-block-components-review-list-item__text"
 		>
@@ -129,13 +129,13 @@ function getReviewRating( review: Review ): JSX.Element {
 	};
 	const ratingText = sprintf(
 		/* translators: %f is referring to the average rating value */
-		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
+		__( 'Rated %f out of 5', 'woocommerce' ),
 		rating
 	);
 	const ratingHTML = {
 		__html: sprintf(
 			/* translators: %s is referring to the average rating value */
-			__( 'Rated %s out of 5', 'woo-gutenberg-products-block' ),
+			__( 'Rated %s out of 5', 'woocommerce' ),
 			sprintf( '<strong class="rating">%f</strong>', rating )
 		),
 	};

--- a/plugins/woocommerce-blocks/assets/js/base/components/reviews/review-sort-select/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/reviews/review-sort-select/index.tsx
@@ -24,32 +24,32 @@ const ReviewSortSelect = ( {
 	return (
 		<SortSelect
 			className="wc-block-review-sort-select wc-block-components-review-sort-select"
-			label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Order by', 'woocommerce' ) }
 			onChange={ onChange }
 			options={ [
 				{
 					key: 'most-recent',
-					label: __( 'Most recent', 'woo-gutenberg-products-block' ),
+					label: __( 'Most recent', 'woocommerce' ),
 				},
 				{
 					key: 'highest-rating',
 					label: __(
 						'Highest rating',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 				},
 				{
 					key: 'lowest-rating',
 					label: __(
 						'Lowest rating',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 				},
 			] }
 			readOnly={ readOnly }
 			screenReaderLabel={ __(
 				'Order reviews by',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			value={ value }
 		/>

--- a/plugins/woocommerce-blocks/assets/js/base/components/state-input/state-input.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/state-input/state-input.tsx
@@ -103,7 +103,7 @@ const StateInput = ( {
 				value={ value }
 				errorMessage={ __(
 					'Please select a state.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				errorId={ errorId }
 				required={ required }

--- a/plugins/woocommerce-blocks/assets/js/base/components/tabs/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/tabs/index.tsx
@@ -59,7 +59,7 @@ export const __TabsWithoutInstanceId = ( {
 	tabs,
 	activeClass = 'is-active',
 	initialTabName,
-	ariaLabel = __( 'Tabbed Content', 'woo-gutenberg-products-block' ),
+	ariaLabel = __( 'Tabbed Content', 'woocommerce' ),
 	instanceId,
 	id,
 }: TabsProps ): JSX.Element | null => {

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -58,7 +58,7 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 							/* translators: %s coupon code. */
 							__(
 								'Coupon code "%s" has been applied to your cart.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							couponCode
 						),
@@ -98,7 +98,7 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 							/* translators: %s coupon code. */
 							__(
 								'Coupon code "%s" has been removed from your cart.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							couponCode
 						),

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
@@ -142,7 +142,7 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 		prepareTotalItems( cartTotals, needsShipping )
 	);
 	const currentCartTotal = useRef( {
-		label: __( 'Total', 'woo-gutenberg-products-block' ),
+		label: __( 'Total', 'woocommerce' ),
 		value: parseInt( cartTotals.total_price, 10 ),
 	} );
 
@@ -152,7 +152,7 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 			needsShipping
 		);
 		currentCartTotal.current = {
-			label: __( 'Total', 'woo-gutenberg-products-block' ),
+			label: __( 'Total', 'woocommerce' ),
 			value: parseInt( cartTotals.total_price, 10 ),
 		};
 	}, [ cartTotals, needsShipping ] );

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/utils.ts
@@ -49,25 +49,25 @@ export const prepareTotalItems = (
 
 	newTotals.push(
 		factory(
-			__( 'Subtotal:', 'woo-gutenberg-products-block' ),
+			__( 'Subtotal:', 'woocommerce' ),
 			'total_items'
 		)
 	);
 
 	newTotals.push(
-		factory( __( 'Fees:', 'woo-gutenberg-products-block' ), 'total_fees' )
+		factory( __( 'Fees:', 'woocommerce' ), 'total_fees' )
 	);
 
 	newTotals.push(
 		factory(
-			__( 'Discount:', 'woo-gutenberg-products-block' ),
+			__( 'Discount:', 'woocommerce' ),
 			'total_discount'
 		)
 	);
 
 	newTotals.push( {
 		key: 'total_tax',
-		label: __( 'Taxes:', 'woo-gutenberg-products-block' ),
+		label: __( 'Taxes:', 'woocommerce' ),
 		value: parseInt( totals.total_tax, 10 ),
 		valueWithTax: parseInt( totals.total_tax, 10 ),
 	} );
@@ -75,7 +75,7 @@ export const prepareTotalItems = (
 	if ( needsShipping ) {
 		newTotals.push(
 			factory(
-				__( 'Shipping:', 'woo-gutenberg-products-block' ),
+				__( 'Shipping:', 'woocommerce' ),
 				'total_shipping'
 			)
 		);

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -79,7 +79,7 @@ export const useShowShippingTotalWarning = () => {
 			createInfoNotice(
 				__(
 					'Totals will be recalculated when a valid shipping method is selected.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				{
 					id: 'wc-blocks-totals-shipping-warning',

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -171,7 +171,7 @@ const CheckoutProcessor = () => {
 				return {
 					errorMessage: __(
 						'Sorry, this order requires a shipping option.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 				};
 			}
@@ -181,7 +181,7 @@ const CheckoutProcessor = () => {
 			return {
 				errorMessage: __(
 					'There was a problem with your payment option.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				context: 'wc/checkout/payments',
 			};
@@ -190,7 +190,7 @@ const CheckoutProcessor = () => {
 			return {
 				errorMessage: __(
 					'There was a problem with your shipping option.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				context: 'wc/checkout/shipping-methods',
 			};
@@ -297,13 +297,13 @@ const CheckoutProcessor = () => {
 				} catch {
 					let errorMessage = __(
 						'Something went wrong when placing the order. Check your email for order updates before retrying.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					);
 
 					if ( customerId !== 0 ) {
 						errorMessage = __(
 							"Something went wrong when placing the order. Check your account's order history or your email for order updates before retrying.",
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						);
 					}
 					processErrorResponse( {

--- a/plugins/woocommerce-blocks/assets/js/base/utils/create-notice.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/create-notice.ts
@@ -12,7 +12,7 @@ import { noticeContexts } from '../context/event-emit/utils';
 
 export const DEFAULT_ERROR_MESSAGE = __(
 	'Something went wrong. Please contact us to get assistance.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -99,7 +99,7 @@ const ActiveAttributeFilters = ( {
 					if ( index > 0 && operator === 'and' ) {
 						prefix = (
 							<span className="wc-block-active-filters__list-item-operator">
-								{ __( 'All', 'woo-gutenberg-products-block' ) }
+								{ __( 'All', 'woocommerce' ) }
 							</span>
 						);
 					}

--- a/plugins/woocommerce-blocks/assets/js/blocks/active-filters/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/active-filters/attributes.ts
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export const blockAttributes = {
 	heading: {
 		type: 'string',
-		default: __( 'Active filters', 'woo-gutenberg-products-block' ),
+		default: __( 'Active filters', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/active-filters/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/active-filters/block.tsx
@@ -98,7 +98,7 @@ const ActiveFiltersBlock = ( {
 
 		const stockStatusLabel = __(
 			'Stock Status',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		);
 
 		return (
@@ -149,7 +149,7 @@ const ActiveFiltersBlock = ( {
 			return null;
 		}
 		return renderRemovableListItem( {
-			type: __( 'Price', 'woo-gutenberg-products-block' ),
+			type: __( 'Price', 'woocommerce' ),
 			name: formatPriceRange( minPrice, maxPrice ),
 			removeCallback: () => {
 				removeArgsFromFilterUrl( 'max_price', 'min_price' );
@@ -245,7 +245,7 @@ const ActiveFiltersBlock = ( {
 			return null;
 		}
 
-		const ratingLabel = __( 'Rating', 'woo-gutenberg-products-block' );
+		const ratingLabel = __( 'Rating', 'woocommerce' );
 
 		return (
 			<li>
@@ -260,7 +260,7 @@ const ActiveFiltersBlock = ( {
 								/* translators: %s is referring to the average rating value */
 								__(
 									'Rated %s out of 5',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								slug
 							),
@@ -351,22 +351,22 @@ const ActiveFiltersBlock = ( {
 							{ renderRemovableListItem( {
 								type: __(
 									'Size',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								name: __(
 									'Small',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								displayStyle: blockAttributes.displayStyle,
 							} ) }
 							{ renderRemovableListItem( {
 								type: __(
 									'Color',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								name: __(
 									'Blue',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								displayStyle: blockAttributes.displayStyle,
 							} ) }
@@ -403,11 +403,11 @@ const ActiveFiltersBlock = ( {
 						<Label
 							label={ __(
 								'Clear All',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							screenReaderLabel={ __(
 								'Clear All Filters',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</button>

--- a/plugins/woocommerce-blocks/assets/js/blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/active-filters/edit.tsx
@@ -40,13 +40,13 @@ const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Display Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleGroupControl
 						label={ __(
 							'Display Style',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ displayStyle }
 						onChange={ ( value: Attributes[ 'displayStyle' ] ) =>
@@ -60,14 +60,14 @@ const Edit = ( {
 							value="list"
 							label={ __(
 								'List',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="chips"
 							label={ __(
 								'Chips',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>

--- a/plugins/woocommerce-blocks/assets/js/blocks/active-filters/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/active-filters/utils.tsx
@@ -24,7 +24,7 @@ export const formatPriceRange = ( minPrice: number, maxPrice: number ) => {
 	if ( Number.isFinite( minPrice ) && Number.isFinite( maxPrice ) ) {
 		return sprintf(
 			/* translators: %1$s min price, %2$s max price */
-			__( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ),
+			__( 'Between %1$s and %2$s', 'woocommerce' ),
 			formatPrice( minPrice ),
 			formatPrice( maxPrice )
 		);
@@ -33,14 +33,14 @@ export const formatPriceRange = ( minPrice: number, maxPrice: number ) => {
 	if ( Number.isFinite( minPrice ) ) {
 		return sprintf(
 			/* translators: %s min price */
-			__( 'From %s', 'woo-gutenberg-products-block' ),
+			__( 'From %s', 'woocommerce' ),
 			formatPrice( minPrice )
 		);
 	}
 
 	return sprintf(
 		/* translators: %s max price */
-		__( 'Up to %s', 'woo-gutenberg-products-block' ),
+		__( 'Up to %s', 'woocommerce' ),
 		formatPrice( maxPrice )
 	);
 };
@@ -86,7 +86,7 @@ export const renderRemovableListItem = ( {
 	);
 	const removeText = sprintf(
 		/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
-		__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
+		__( 'Remove %s filter', 'woocommerce' ),
 		name
 	);
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/attributes.ts
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export const blockAttributes = {
 	heading: {
 		type: 'string',
-		default: __( 'Filter by attribute', 'woo-gutenberg-products-block' ),
+		default: __( 'Filter by attribute', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
@@ -557,7 +557,7 @@ const AttributeFilterBlock = ( {
 								/* translators: %s attribute name. */
 								__(
 									'Select %s',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								attributeObject.label
 							) }
@@ -611,7 +611,7 @@ const AttributeFilterBlock = ( {
 									/* translators: %s is the attribute label. */
 									__(
 										'%s filter added.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									attributeObject.label
 								),
@@ -619,7 +619,7 @@ const AttributeFilterBlock = ( {
 									/* translators: %s is the attribute label. */
 									__(
 										'%s filter removed.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									attributeObject.label
 								),
@@ -627,7 +627,7 @@ const AttributeFilterBlock = ( {
 									/* translators: %s is the attribute label. */
 									__(
 										'Remove %s filter.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									attributeObject.label.toLocaleLowerCase()
 								),
@@ -635,7 +635,7 @@ const AttributeFilterBlock = ( {
 									/* translators: %s is the attribute label. */
 									__(
 										'Invalid %s filter.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									attributeObject.label.toLocaleLowerCase()
 								),
@@ -668,7 +668,7 @@ const AttributeFilterBlock = ( {
 						} }
 						screenReaderLabel={ __(
 							'Reset attribute filter',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/edit.tsx
@@ -44,11 +44,11 @@ const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 const noticeContent = {
 	noAttributes: __(
 		'Please select an attribute to use this filter!',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	noProducts: __(
 		'There are no products with the selected attributes.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 
@@ -92,7 +92,7 @@ const Edit = ( {
 					controls={ [
 						{
 							icon: 'edit',
-							title: __( 'Edit', 'woo-gutenberg-products-block' ),
+							title: __( 'Edit', 'woocommerce' ),
 							onClick: () => setIsEditing( ! isEditing ),
 							isActive: isEditing,
 						},
@@ -129,16 +129,16 @@ const Edit = ( {
 		const messages = {
 			clear: __(
 				'Clear selected attribute',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
-			list: __( 'Product Attributes', 'woo-gutenberg-products-block' ),
+			list: __( 'Product Attributes', 'woocommerce' ),
 			noItems: __(
 				"Your store doesn't have any product attributes.",
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			search: __(
 				'Search for a product attribute:',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			selected: ( n: number ) =>
 				sprintf(
@@ -147,13 +147,13 @@ const Edit = ( {
 						'%d attribute selected',
 						'%d attributes selected',
 						n,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					n
 				),
 			updated: __(
 				'Product attribute search results updated.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 		};
 
@@ -185,13 +185,13 @@ const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Display Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleControl
 						label={ __(
 							'Display product count',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showCounts }
 						onChange={ () =>
@@ -203,7 +203,7 @@ const Edit = ( {
 					<ToggleGroupControl
 						label={ __(
 							'Allow selecting multiple options?',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ selectType || 'multiple' }
 						onChange={ ( value: string ) =>
@@ -217,14 +217,14 @@ const Edit = ( {
 							value="multiple"
 							label={ __(
 								'Multiple',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="single"
 							label={ __(
 								'Single',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
@@ -232,17 +232,17 @@ const Edit = ( {
 						<ToggleGroupControl
 							label={ __(
 								'Filter Conditions',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							help={
 								queryType === 'and'
 									? __(
 											'Choose to return filter results for all of the attributes selected.',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 									  )
 									: __(
 											'Choose to return filter results for any of the attributes selected.',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 									  )
 							}
 							value={ queryType }
@@ -257,14 +257,14 @@ const Edit = ( {
 								value="and"
 								label={ __(
 									'All',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value="or"
 								label={ __(
 									'Any',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 						</ToggleGroupControl>
@@ -272,7 +272,7 @@ const Edit = ( {
 					<ToggleGroupControl
 						label={ __(
 							'Display Style',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ displayStyle }
 						onChange={ ( value: string ) =>
@@ -286,25 +286,25 @@ const Edit = ( {
 							value="list"
 							label={ __(
 								'List',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="dropdown"
 							label={ __(
 								'Dropdown',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
 					<ToggleControl
 						label={ __(
 							"Show 'Apply filters' button",
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Products will update when the button is clicked.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showFilterButton }
 						onChange={ ( value ) =>
@@ -317,7 +317,7 @@ const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Content Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen={ false }
 				>
@@ -333,17 +333,17 @@ const Edit = ( {
 			icon={ <Icon icon={ category } /> }
 			label={ __(
 				'Filter by Attribute',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			instructions={ __(
 				'Display a list of filters based on the selected attributes.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		>
 			<p>
 				{ __(
 					"Attributes are needed for filtering your products. You haven't created any attributes yet.",
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 			<Button
@@ -354,7 +354,7 @@ const Edit = ( {
 				) }
 				target="_top"
 			>
-				{ __( 'Add new attribute', 'woo-gutenberg-products-block' ) +
+				{ __( 'Add new attribute', 'woocommerce' ) +
 					' ' }
 				<Icon icon={ external } />
 			</Button>
@@ -364,7 +364,7 @@ const Edit = ( {
 				href="https://docs.woocommerce.com/document/managing-product-taxonomies/"
 				target="_blank"
 			>
-				{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
+				{ __( 'Learn more', 'woocommerce' ) }
 			</Button>
 		</Placeholder>
 	);
@@ -374,7 +374,7 @@ const Edit = ( {
 		debouncedSpeak(
 			__(
 				'Now displaying a preview of the Filter Products by Attribute block.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			)
 		);
 	};
@@ -386,19 +386,19 @@ const Edit = ( {
 				icon={ <Icon icon={ category } /> }
 				label={ __(
 					'Filter by Attribute',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				<div className="wc-block-attribute-filter__instructions">
 					{ __(
 						'Display a list of filters based on the selected attributes.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</div>
 				<div className="wc-block-attribute-filter__selection">
 					{ renderAttributeControl( { isCompact: false } ) }
 					<Button variant="primary" onClick={ onDone }>
-						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+						{ __( 'Done', 'woocommerce' ) }
 					</Button>
 				</div>
 			</Placeholder>

--- a/plugins/woocommerce-blocks/assets/js/blocks/breadcrumbs/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/breadcrumbs/edit.tsx
@@ -18,9 +18,9 @@ const Edit = () => {
 		<div { ...blockProps }>
 			<Disabled>
 				<a href="/">
-					{ __( 'Breadcrumbs', 'woo-gutenberg-products-block' ) }
+					{ __( 'Breadcrumbs', 'woocommerce' ) }
 				</a>
-				{ __( ' / Navigation / Path', 'woo-gutenberg-products-block' ) }
+				{ __( ' / Navigation / Path', 'woocommerce' ) }
 			</Disabled>
 		</div>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/block-settings/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/block-settings/index.tsx
@@ -16,15 +16,15 @@ export const BlockSettings = ( {
 	const { hasDarkControls } = attributes;
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
+			<PanelBody title={ __( 'Style', 'woocommerce' ) }>
 				<ToggleControl
 					label={ __(
 						'Dark mode inputs',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					help={ __(
 						'Inputs styled specifically for use on dark background colors.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ hasDarkControls }
 					onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -50,7 +50,7 @@ const PaymentMethodCard = ( {
 					className="wc-block-components-payment-methods__save-card-info"
 					label={ __(
 						'Save payment information to my account for future purchases.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ shouldSavePaymentMethod }
 					onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.tsx
@@ -33,7 +33,7 @@ class PaymentMethodErrorBoundary extends Component< PaymentMethodErrorBoundaryPr
 		if ( hasError ) {
 			let errorText = __(
 				'We are experiencing difficulties with this payment method. Please contact us for assistance.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 			if ( isEditor || CURRENT_USER_IS_ADMIN ) {
 				if ( errorMessage ) {
@@ -41,7 +41,7 @@ class PaymentMethodErrorBoundary extends Component< PaymentMethodErrorBoundaryPr
 				} else {
 					errorText = __(
 						"There was an error with this payment method. Please verify it's configured correctly.",
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					);
 				}
 			}

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.tsx
@@ -37,7 +37,7 @@ const getCcOrEcheckLabel = ( {
 		/* translators: %1$s is referring to the payment method brand, %2$s is referring to the last 4 digits of the payment card, %3$s is referring to the expiry date.  */
 		__(
 			'%1$s ending in %2$s (expires %3$s)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		method.brand,
 		method.last4,
@@ -57,7 +57,7 @@ const getDefaultLabel = ( {
 	if ( method.brand && method.last4 ) {
 		return sprintf(
 			/* translators: %1$s is referring to the payment method brand, %2$s is referring to the last 4 digits of the payment card. */
-			__( '%1$s ending in %2$s', 'woo-gutenberg-products-block' ),
+			__( '%1$s ending in %2$s', 'woocommerce' ),
 			method.brand,
 			method.last4
 		);
@@ -66,7 +66,7 @@ const getDefaultLabel = ( {
 	/* For saved payment methods without brand & last 4 */
 	return sprintf(
 		/* translators: %s is the name of the payment method gateway. */
-		__( 'Saved token for %s', 'woo-gutenberg-products-block' ),
+		__( 'Saved token for %s', 'woocommerce' ),
 		method.gateway
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/view-switcher/switcher.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/view-switcher/switcher.tsx
@@ -89,7 +89,7 @@ export const Switcher = ( {
 				<ToolbarDropdownMenu
 					label={ __(
 						'Switch view',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					text={ currentViewLabel }
 					icon={

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-block/edit.tsx
@@ -15,7 +15,7 @@ export const Edit = (): JSX.Element => {
 			{
 				content: __(
 					'You may be interested in…',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				level: 2,
 				fontSize: 'large',

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
@@ -31,12 +31,12 @@ export const Edit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 		<div { ...blockProps }>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Settings', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Settings', 'woocommerce' ) }
 				>
 					<RangeControl
 						label={ __(
 							'Cross-Sells products to show',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ columns }
 						onChange={ ( value ) =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx
@@ -29,7 +29,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 		[
 			'woocommerce/cart-order-summary-heading-block',
 			{
-				content: __( 'Cart totals', 'woo-gutenberg-products-block' ),
+				content: __( 'Cart totals', 'woocommerce' ),
 			},
 			[],
 		],

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/attributes.ts
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 export default {
 	content: {
 		type: 'string',
-		default: __( 'Cart totals', 'woo-gutenberg-products-block' ),
+		default: __( 'Cart totals', 'woocommerce' ),
 	},
 	lock: {
 		type: 'object',

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/edit.tsx
@@ -34,13 +34,13 @@ export const Edit = ( {
 					<PanelBody
 						title={ __(
 							'Shipping Calculations',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					>
 						<p className="wc-block-checkout__controls-text">
 							{ __(
 								'Options that control shipping can be managed in your store settings.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</p>
 						<ExternalLink
@@ -48,7 +48,7 @@ export const Edit = ( {
 						>
 							{ __(
 								'Manage shipping options',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</ExternalLink>{ ' ' }
 					</PanelBody>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/edit.tsx
@@ -41,17 +41,17 @@ export const Edit = ( {
 						<PanelBody
 							title={ __(
 								'Taxes',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						>
 							<ToggleControl
 								label={ __(
 									'Show rate after tax name',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								help={ __(
 									'Show the percentage rate alongside each tax line in the summary.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								checked={ showRateAfterTaxName }
 								onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
@@ -25,7 +25,7 @@ const browseStoreTemplate = SHOP_URL
 					/* translators: %s is the link to the store product directory. */
 					__(
 						'<a href="%s">Browse store</a>',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					SHOP_URL
 				),
@@ -41,7 +41,7 @@ const defaultTemplate = [
 			textAlign: 'center',
 			content: __(
 				'Your cart is currently empty!',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			level: 2,
 			className: 'with-empty-cart-icon wc-block-cart__empty-cart__title',
@@ -58,7 +58,7 @@ const defaultTemplate = [
 		'core/heading',
 		{
 			textAlign: 'center',
-			content: __( 'New in store', 'woo-gutenberg-products-block' ),
+			content: __( 'New in store', 'woocommerce' ),
 			level: 2,
 		},
 	],

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/constants.tsx
@@ -5,5 +5,5 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultButtonLabel = __(
 	'Proceed to Checkout',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/edit.tsx
@@ -54,11 +54,11 @@ export const Edit = ( {
 						labels={ {
 							title: __(
 								'Proceed to Checkout button',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							default: __(
 								'WooCommerce Checkout Page',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 						} }
 					/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/catalog-sorting/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/catalog-sorting/edit.tsx
@@ -9,7 +9,7 @@ const CatalogSorting = () => {
 	return (
 		<select className="orderby">
 			<option>
-				{ __( 'Default sorting', 'woo-gutenberg-products-block' ) }
+				{ __( 'Default sorting', 'woocommerce' ) }
 			</option>
 		</select>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -65,14 +65,14 @@ const AddressCard = ( {
 					className="wc-block-components-address-card__edit"
 					aria-label={ __(
 						'Edit address',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					onClick={ ( e ) => {
 						onEdit();
 						e.preventDefault();
 					} }
 				>
-					{ __( 'Edit', 'woo-gutenberg-products-block' ) }
+					{ __( 'Edit', 'woocommerce' ) }
 				</a>
 			) }
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -36,12 +36,12 @@ const MustLoginPrompt = () => {
 		<div className="wc-block-must-login-prompt">
 			{ __(
 				'You must be logged in to checkout.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }{ ' ' }
 			<a href={ LOGIN_TO_CHECKOUT_URL }>
 				{ __(
 					'Click here to log in.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</a>
 		</div>
@@ -167,12 +167,12 @@ const Block = ( {
 		<BlockErrorBoundary
 			header={ __(
 				'Something went wrong. Please contact us for assistance.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			text={ createInterpolateElement(
 				__(
 					'The checkout has encountered an unexpected error. <button>Try reloading the page</button>. If the error persists, please get in touch with us so we can assist.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				{
 					button: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -101,16 +101,16 @@ export const Edit = ( {
 	const addressFieldControls = (): JSX.Element => (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Address Fields', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Address Fields', 'woocommerce' ) }
 			>
 				<p className="wc-block-checkout__controls-text">
 					{ __(
 						'Show or hide fields in the checkout address forms.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</p>
 				<ToggleControl
-					label={ __( 'Company', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Company', 'woocommerce' ) }
 					checked={ showCompanyField }
 					onChange={ () => toggleAttribute( 'showCompanyField' ) }
 				/>
@@ -118,7 +118,7 @@ export const Edit = ( {
 					<CheckboxControl
 						label={ __(
 							'Require company name?',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ requireCompanyField }
 						onChange={ () =>
@@ -130,13 +130,13 @@ export const Edit = ( {
 				<ToggleControl
 					label={ __(
 						'Apartment, suite, etc.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ showApartmentField }
 					onChange={ () => toggleAttribute( 'showApartmentField' ) }
 				/>
 				<ToggleControl
-					label={ __( 'Phone', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Phone', 'woocommerce' ) }
 					checked={ showPhoneField }
 					onChange={ () => toggleAttribute( 'showPhoneField' ) }
 				/>
@@ -144,7 +144,7 @@ export const Edit = ( {
 					<CheckboxControl
 						label={ __(
 							'Require phone number?',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ requirePhoneField }
 						onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/form-step/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/form-step/attributes.ts
@@ -4,10 +4,10 @@
 import { __ } from '@wordpress/i18n';
 
 const attributes = ( {
-	defaultTitle = __( 'Step', 'woo-gutenberg-products-block' ),
+	defaultTitle = __( 'Step', 'woocommerce' ),
 	defaultDescription = __(
 		'Step description text.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	defaultShowStepNumber = true,
 }: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/form-step/form-step-block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/form-step/form-step-block.tsx
@@ -44,13 +44,13 @@ export const FormStepBlock = ( {
 				<PanelBody
 					title={ __(
 						'Form Step Options',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleControl
 						label={ __(
 							'Show step number',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showStepNumber }
 						onChange={ () =>
@@ -80,7 +80,7 @@ export const FormStepBlock = ( {
 						value={ description }
 						placeholder={ __(
 							'Optional text for this form step.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						onChange={ ( value ) =>
 							setAttributes( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/constants.tsx
@@ -5,5 +5,5 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultPlaceOrderButtonLabel = __(
 	'Place Order',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -54,13 +54,13 @@ export const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Account options',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleControl
 						label={ __(
 							'Show a "Return to Cart" link',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showReturnToCart }
 						onChange={ () =>
@@ -83,11 +83,11 @@ export const Edit = ( {
 							labels={ {
 								title: __(
 									'Return to Cart button',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								default: __(
 									'WooCommerce Cart Page',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 							} }
 						/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/constants.tsx
@@ -5,18 +5,18 @@ import { __ } from '@wordpress/i18n';
 
 export const DEFAULT_TITLE = __(
 	'Billing address',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const DEFAULT_DESCRIPTION = __(
 	'Enter the billing address that matches your payment method.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 
 export const DEFAULT_FORCED_BILLING_TITLE = __(
 	'Billing and shipping address',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 export const DEFAULT_FORCED_BILLING_DESCRIPTION = __(
 	'Enter the billing and shipping address that matches your payment method.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/attributes.tsx
@@ -12,11 +12,11 @@ export default {
 	...formStepAttributes( {
 		defaultTitle: __(
 			'Contact information',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		defaultDescription: __(
 			"We'll use this email to send you details and updates about your order.",
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 	} ),
 	className: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
@@ -43,7 +43,7 @@ const Block = (): JSX.Element => {
 				className="wc-block-checkout__create-account"
 				label={ __(
 					'Create an account?',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				checked={ shouldCreateAccount }
 				onChange={ ( value ) =>
@@ -62,7 +62,7 @@ const Block = (): JSX.Element => {
 				type="email"
 				autoComplete="email"
 				errorId={ 'billing_email' }
-				label={ __( 'Email address', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Email address', 'woocommerce' ) }
 				value={ billingAddress.email }
 				required={ true }
 				onChange={ onChangeEmail }
@@ -71,7 +71,7 @@ const Block = (): JSX.Element => {
 						inputObject.setCustomValidity(
 							__(
 								'Please enter a valid email address',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							)
 						);
 						return false;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
@@ -44,13 +44,13 @@ export const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Account creation and guest checkout',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<p className="wc-block-checkout__controls-text">
 						{ __(
 							'Account creation and guest checkout settings can be managed in your store settings.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 					<ExternalLink
@@ -58,7 +58,7 @@ export const Edit = ( {
 					>
 						{ __(
 							'Manage account settings',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</ExternalLink>
 				</PanelBody>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.tsx
@@ -43,11 +43,11 @@ const Block = ( { className }: { className?: string } ): JSX.Element => {
 					needsShipping
 						? __(
 								'Notes about your order, e.g. special notes for delivery.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 						  )
 						: __(
 								'Notes about your order.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 						  )
 				}
 				value={ orderNotes }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/edit.tsx
@@ -41,17 +41,17 @@ export const Edit = ( {
 						<PanelBody
 							title={ __(
 								'Taxes',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						>
 							<ToggleControl
 								label={ __(
 									'Show rate after tax name',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								help={ __(
 									'Show the percentage rate alongside each tax line in the summary.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								checked={ showRateAfterTaxName }
 								onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/attributes.tsx
@@ -10,7 +10,7 @@ import formStepAttributes from '../../form-step/attributes';
 
 export default {
 	...formStepAttributes( {
-		defaultTitle: __( 'Payment options', 'woo-gutenberg-products-block' ),
+		defaultTitle: __( 'Payment options', 'woocommerce' ),
 		defaultDescription: '',
 	} ),
 	className: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/edit.tsx
@@ -49,7 +49,7 @@ export const Edit = ( {
 	}, [] );
 	const incompatiblePaymentMethodMessage = __(
 		'Incompatible with block-based checkout',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 	const wordCountType = blocksConfig.wordCountType;
 
@@ -67,13 +67,13 @@ export const Edit = ( {
 					<PanelBody
 						title={ __(
 							'Methods',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					>
 						<p className="wc-block-checkout__controls-text">
 							{ __(
 								'You currently have the following payment integrations active.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</p>
 						{ globalPaymentMethods.map( ( method ) => {
@@ -120,7 +120,7 @@ export const Edit = ( {
 						>
 							{ __(
 								'Manage payment methods',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</ExternalLink>
 					</PanelBody>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/attributes.tsx
@@ -10,7 +10,7 @@ import formStepAttributes from '../../form-step/attributes';
 
 export default {
 	...formStepAttributes( {
-		defaultTitle: __( 'Pickup options', 'woo-gutenberg-products-block' ),
+		defaultTitle: __( 'Pickup options', 'woocommerce' ),
 		defaultDescription: '',
 	} ),
 	className: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -79,7 +79,7 @@ const renderPickupLocation = (
 
 	// Default to showing "free" as the secondary label. Price checks below will update it if needed.
 	let secondaryLabel = (
-		<em>{ __( 'free', 'woo-gutenberg-products-block' ) }</em>
+		<em>{ __( 'free', 'woocommerce' ) }</em>
 	);
 
 	// If there is a cost for local pickup, show the cost per package.
@@ -99,7 +99,7 @@ const renderPickupLocation = (
 					'<price/> x <packageCount/> package',
 					'<price/> x <packageCount/> packages',
 					packageCount,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				{
 					price: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/attributes.tsx
@@ -10,10 +10,10 @@ import formStepAttributes from '../../form-step/attributes';
 
 export default {
 	...formStepAttributes( {
-		defaultTitle: __( 'Shipping address', 'woo-gutenberg-products-block' ),
+		defaultTitle: __( 'Shipping address', 'woocommerce' ),
 		defaultDescription: __(
 			'Enter the address where you want your order delivered.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 	} ),
 	className: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -129,7 +129,7 @@ const Block = ( {
 				className="wc-block-checkout__use-address-for-billing"
 				label={ __(
 					'Use same address for billing',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				checked={ useShippingAsBilling }
 				onChange={ ( checked: boolean ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/attributes.tsx
@@ -11,10 +11,10 @@ import { defaultShippingText, defaultLocalPickupText } from './constants';
 
 export default {
 	...formStepAttributes( {
-		defaultTitle: __( 'Shipping method', 'woo-gutenberg-products-block' ),
+		defaultTitle: __( 'Shipping method', 'woocommerce' ),
 		defaultDescription: __(
 			'Select how you would like to receive your order.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 	} ),
 	className: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
@@ -27,7 +27,7 @@ const SHIPPING_RATE_ERROR = {
 	hidden: true,
 	message: __(
 		'Shipping options are not available',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 
@@ -126,7 +126,7 @@ const ShippingSelector = ( {
 			<span className="wc-block-checkout__shipping-method-option-price">
 				{ __(
 					'calculated with an address',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</span>
 		) : (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/constants.tsx
@@ -5,10 +5,10 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultLocalPickupText = __(
 	'Local Pickup',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 
 export const defaultShippingText = __(
 	'Shipping',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -108,7 +108,7 @@ const ShippingSelector = ( {
 			<span className="wc-block-checkout__shipping-method-option-price">
 				{ __(
 					'calculated with an address',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</span>
 		) : (
@@ -211,18 +211,18 @@ export const Edit = ( {
 		>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Appearance', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Appearance', 'woocommerce' ) }
 				>
 					<p className="wc-block-checkout__controls-text">
 						{ __(
 							'Choose how this block is displayed to your customers.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 					<ToggleControl
 						label={ __(
 							'Show icon',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showIcon }
 						onChange={ () =>
@@ -234,7 +234,7 @@ export const Edit = ( {
 					<ToggleControl
 						label={ __(
 							'Show costs',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showPrice }
 						onChange={ () =>
@@ -247,13 +247,13 @@ export const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Shipping Methods',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<p className="wc-block-checkout__controls-text">
 						{ __(
 							'Methods can be made managed in your store settings.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 					<ExternalLinkCard
@@ -261,11 +261,11 @@ export const Edit = ( {
 						href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping` }
 						title={ __(
 							'Shipping',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						description={ __(
 							'Manage your shipping zones, methods, and rates.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 					<ExternalLinkCard
@@ -273,11 +273,11 @@ export const Edit = ( {
 						href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping&section=pickup_location` }
 						title={ __(
 							'Local Pickup',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						description={ __(
 							'Allow customers to choose a local pickup location during checkout.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 				</PanelBody>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
@@ -29,7 +29,7 @@ export const RatePrice = ( {
 		: parseInt( maxRate.price, 10 );
 	const priceElement =
 		minRatePrice === 0 ? (
-			<em>{ __( 'free', 'woo-gutenberg-products-block' ) }</em>
+			<em>{ __( 'free', 'woocommerce' ) }</em>
 		) : (
 			<FormattedMonetaryAmount
 				currency={ getCurrencyFromPriceResponse( minRate ) }
@@ -46,7 +46,7 @@ export const RatePrice = ( {
 							? '<price />'
 							: __(
 									'from <price />',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 							  ),
 						{
 							price: priceElement,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/attributes.tsx
@@ -10,7 +10,7 @@ import formStepAttributes from '../../form-step/attributes';
 
 export default {
 	...formStepAttributes( {
-		defaultTitle: __( 'Shipping options', 'woo-gutenberg-products-block' ),
+		defaultTitle: __( 'Shipping options', 'woocommerce' ),
 		defaultDescription: '',
 	} ),
 	className: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -91,7 +91,7 @@ const Block = ( { noShippingPlaceholder = null } ): ReactElement | null => {
 			<p>
 				{ __(
 					'Shipping options will be displayed here after entering your full shipping address.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 		);
@@ -117,13 +117,13 @@ const Block = ( { noShippingPlaceholder = null } ): ReactElement | null => {
 								>
 									{ __(
 										'There are no shipping options available. Please check your shipping address.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</NoticeBanner>
 							) : (
 								__(
 									'Add a shipping address to view shipping options.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								)
 							) }
 						</>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
@@ -67,13 +67,13 @@ export const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Shipping Calculations',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<p className="wc-block-checkout__controls-text">
 						{ __(
 							'Options that control shipping can be managed in your store settings.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 					<ExternalLink
@@ -81,7 +81,7 @@ export const Edit = ( {
 					>
 						{ __(
 							'Manage shipping options',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</ExternalLink>{ ' ' }
 				</PanelBody>
@@ -89,13 +89,13 @@ export const Edit = ( {
 					<PanelBody
 						title={ __(
 							'Methods',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					>
 						<p className="wc-block-checkout__controls-text">
 							{ __(
 								'The following shipping integrations are active on your store.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</p>
 						{ globalShippingMethods.map( ( method ) => {
@@ -113,7 +113,7 @@ export const Edit = ( {
 						>
 							{ __(
 								'Manage shipping methods',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</ExternalLink>
 					</PanelBody>
@@ -122,13 +122,13 @@ export const Edit = ( {
 					<PanelBody
 						title={ __(
 							'Shipping Zones',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					>
 						<p className="wc-block-checkout__controls-text">
 							{ __(
 								'Shipping Zones can be made managed in your store settings.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</p>
 						{ activeShippingZones.map( ( zone ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx
@@ -49,7 +49,7 @@ export const Edit = ( {
 					>
 						{ __(
 							"Link to your store's Terms and Conditions and Privacy Policy pages by creating pages for them.",
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						<br />
 						{ ! TERMS_URL && (
@@ -60,7 +60,7 @@ export const Edit = ( {
 								>
 									{ __(
 										'Setup a Terms and Conditions page',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</ExternalLink>
 							</>
@@ -73,7 +73,7 @@ export const Edit = ( {
 								>
 									{ __(
 										'Setup a Privacy Policy page',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</ExternalLink>
 							</>
@@ -97,7 +97,7 @@ export const Edit = ( {
 											{
 												label: __(
 													'Restore default text',
-													'woo-gutenberg-products-block'
+													'woocommerce'
 												),
 												onClick: () =>
 													setAttributes( {
@@ -111,7 +111,7 @@ export const Edit = ( {
 							<p>
 								{ __(
 									'Ensure you add links to your policy pages in this section.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</p>
 						</Notice>
@@ -119,13 +119,13 @@ export const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Display options',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleControl
 						label={ __(
 							'Require checkbox',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ checkbox }
 						onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx
@@ -53,7 +53,7 @@ const FrontendBlock = ( {
 				[ validationErrorId ]: {
 					message: __(
 						'Please read and accept the terms and conditions.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					hidden: true,
 				},

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/order-notes/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/order-notes/index.tsx
@@ -30,7 +30,7 @@ const CheckoutOrderNotes = ( {
 				disabled={ disabled }
 				label={ __(
 					'Add a note to your order',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				checked={ withOrderNotes }
 				onChange={ ( isChecked ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/phone-number/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/phone-number/index.tsx
@@ -29,8 +29,8 @@ const PhoneNumber = ( {
 			required={ isRequired }
 			label={
 				isRequired
-					? __( 'Phone', 'woo-gutenberg-products-block' )
-					: __( 'Phone (optional)', 'woo-gutenberg-products-block' )
+					? __( 'Phone', 'woocommerce' )
+					: __( 'Phone (optional)', 'woocommerce' )
 			}
 			value={ value }
 			onChange={ onChange }

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/cart.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/cart.tsx
@@ -14,7 +14,7 @@ const isConversionPossible = () => {
 };
 
 const getButtonLabel = () =>
-	__( 'Transform into blocks', 'woo-gutenberg-products-block' );
+	__( 'Transform into blocks', 'woocommerce' );
 
 const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 	[
@@ -53,7 +53,7 @@ const onClickCallback = ( {
  * Title shown within the block itself.
  */
 const getTitle = () => {
-	return __( 'Classic Cart', 'woo-gutenberg-products-block' );
+	return __( 'Classic Cart', 'woocommerce' );
 };
 
 /**
@@ -62,7 +62,7 @@ const getTitle = () => {
 const getDescription = () => {
 	return __(
 		'This block will render the classic cart shortcode. You can optionally transform it into blocks for more control over the cart experience.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/checkout.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/checkout.tsx
@@ -14,7 +14,7 @@ const isConversionPossible = () => {
 };
 
 const getButtonLabel = () =>
-	__( 'Transform into blocks', 'woo-gutenberg-products-block' );
+	__( 'Transform into blocks', 'woocommerce' );
 
 const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 	[
@@ -50,13 +50,13 @@ const onClickCallback = ( {
 };
 
 const getTitle = () => {
-	return __( 'Classic Checkout', 'woo-gutenberg-products-block' );
+	return __( 'Classic Checkout', 'woocommerce' );
 };
 
 const getDescription = () => {
 	return __(
 		'This block will render the classic checkout shortcode. You can optionally transform it into blocks for more control over the checkout experience.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/constants.ts
@@ -21,20 +21,20 @@ export const TEMPLATES: TemplateDetails = {
 	cart: {
 		type: TYPES.cart,
 		// Title shows up in the list view in the site editor.
-		title: __( 'Cart Shortcode', 'woo-gutenberg-products-block' ),
+		title: __( 'Cart Shortcode', 'woocommerce' ),
 		// Description in the site editor.
 		description: __(
 			'Renders the classic cart shortcode.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.cart,
 	},
 	checkout: {
 		type: TYPES.checkout,
-		title: __( 'Checkout Cart', 'woo-gutenberg-products-block' ),
+		title: __( 'Checkout Cart', 'woocommerce' ),
 		description: __(
 			'Renders the classic checkout shortcode.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.checkout,
 	},

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
@@ -88,14 +88,14 @@ const ConvertTemplate = ( { blockifyConfig, clientId, attributes } ) => {
 					createInfoNotice(
 						__(
 							'Classic shortcode transformed to blocks.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						{
 							actions: [
 								{
 									label: __(
 										'Undo',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									onClick: () => {
 										const targetBlocks = [
@@ -171,7 +171,7 @@ const ConvertTemplate = ( { blockifyConfig, clientId, attributes } ) => {
 				target="_blank"
 				tabIndex={ 0 }
 			>
-				{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
+				{ __( 'Learn more', 'woocommerce' ) }
 			</Button>
 		</TabbableContainer>
 	);
@@ -193,13 +193,13 @@ const Edit = ( { clientId, attributes }: BlockEditProps< Attributes > ) => {
 	const canConvert = isConversionPossible();
 	const placeholderTitle = getTitle
 		? getTitle()
-		: __( 'Classic Shortcode Placeholder', 'woo-gutenberg-products-block' );
+		: __( 'Classic Shortcode Placeholder', 'woocommerce' );
 	const placeholderDescription = getDescription( templateTitle, canConvert );
 
 	const learnMoreContent = createInterpolateElement(
 		__(
 			'You can learn more about the benefits of switching to blocks, compatibility with extensions, and how to switch back to shortcodes <a>in our documentation</a>.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		{
 			a: (
@@ -226,7 +226,7 @@ const Edit = ( { clientId, attributes }: BlockEditProps< Attributes > ) => {
 							<Icon icon={ woo } />{ ' ' }
 							{ __(
 								'WooCommerce',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</span>
 						<span>{ placeholderTitle }</span>
@@ -274,7 +274,7 @@ const settings = {
 	variations: [
 		{
 			name: 'checkout',
-			title: __( 'Classic Checkout', 'woo-gutenberg-products-block' ),
+			title: __( 'Classic Checkout', 'woocommerce' ),
 			attributes: {
 				shortcode: 'checkout',
 			},
@@ -284,7 +284,7 @@ const settings = {
 		},
 		{
 			name: 'cart',
-			title: __( 'Classic Cart', 'woo-gutenberg-products-block' ),
+			title: __( 'Classic Cart', 'woocommerce' ),
 			attributes: {
 				shortcode: 'cart',
 			},

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/archive-product.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/archive-product.ts
@@ -71,7 +71,7 @@ const getDescriptionAllowingConversion = ( templateTitle: string ) =>
 		/* translators: %s is the template title */
 		__(
 			'Transform this template into multiple blocks so you can add, remove, reorder, and customize your %s template.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		templateTitle
 	);
@@ -81,7 +81,7 @@ const getDescriptionDisallowingConversion = ( templateTitle: string ) =>
 		/* translators: %s is the template title */
 		__(
 			'This block serves as a placeholder for your %s. It will display the actual product image, title, price in your store. You can move this placeholder around and add more blocks around to customize the template.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		templateTitle
 	);
@@ -95,7 +95,7 @@ const getDescription = ( templateTitle: string, canConvert: boolean ) => {
 };
 
 const getButtonLabel = () =>
-	__( 'Transform into blocks', 'woo-gutenberg-products-block' );
+	__( 'Transform into blocks', 'woocommerce' );
 
 const onClickCallback = ( {
 	clientId,

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/constants.ts
@@ -29,7 +29,7 @@ export const TEMPLATES: TemplateDetails = {
 		type: TYPES.singleProduct,
 		title: __(
 			'WooCommerce Single Product Block',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.singleProduct,
 	},
@@ -37,7 +37,7 @@ export const TEMPLATES: TemplateDetails = {
 		type: TYPES.productCatalog,
 		title: __(
 			'WooCommerce Product Grid Block',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
@@ -45,7 +45,7 @@ export const TEMPLATES: TemplateDetails = {
 		type: TYPES.productTaxonomy,
 		title: __(
 			'WooCommerce Product Taxonomy Block',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
@@ -53,7 +53,7 @@ export const TEMPLATES: TemplateDetails = {
 		type: TYPES.productTaxonomy,
 		title: __(
 			'WooCommerce Product Tag Block',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
@@ -61,7 +61,7 @@ export const TEMPLATES: TemplateDetails = {
 		type: TYPES.productTaxonomy,
 		title: __(
 			'WooCommerce Product Attribute Block',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
@@ -70,7 +70,7 @@ export const TEMPLATES: TemplateDetails = {
 		type: TYPES.productTaxonomy,
 		title: __(
 			"WooCommerce Product's Custom Taxonomy Block",
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
@@ -78,18 +78,18 @@ export const TEMPLATES: TemplateDetails = {
 		type: TYPES.productSearchResults,
 		title: __(
 			'WooCommerce Product Search Results Block',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
 	'checkout-header': {
 		type: TYPES.checkoutHeader,
-		title: __( 'Checkout Header', 'woo-gutenberg-products-block' ),
+		title: __( 'Checkout Header', 'woocommerce' ),
 		placeholder: 'checkout-header',
 	},
 	'order-confirmation': {
 		type: TYPES.orderConfirmation,
-		title: __( 'Order Confirmation Block', 'woo-gutenberg-products-block' ),
+		title: __( 'Order Confirmation Block', 'woocommerce' ),
 		placeholder: PLACEHOLDERS.orderConfirmation,
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
@@ -115,14 +115,14 @@ const ConvertTemplate = ( { blockifyConfig, clientId, attributes } ) => {
 					createInfoNotice(
 						__(
 							'Template transformed into blocks!',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						{
 							actions: [
 								{
 									label: __(
 										'Undo',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									onClick: () => {
 										const clientIds = pickBlockClientIds(
@@ -264,13 +264,13 @@ const Edit = ( {
 							<Icon icon={ woo } />{ ' ' }
 							{ __(
 								'WooCommerce',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</span>
 						<span>
 							{ __(
 								'Classic Template Placeholder',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</span>
 					</div>
@@ -282,7 +282,7 @@ const Edit = ( {
 					<p>
 						{ __(
 							'You cannot edit the content of this block. However, you can move it and place other blocks around it.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 					{ canConvert && blockifyConfig && (
@@ -319,7 +319,7 @@ const registerClassicTemplateBlock = ( {
 				? TEMPLATES[ template ].title
 				: __(
 						'WooCommerce Classic Template',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 				  ),
 		icon: (
 			<Icon
@@ -329,10 +329,10 @@ const registerClassicTemplateBlock = ( {
 		),
 		category: 'woocommerce',
 		apiVersion: 2,
-		keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+		keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 		description: __(
 			'Renders classic WooCommerce PHP templates.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		supports: {
 			align: [ 'wide', 'full' ],

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -14,7 +14,7 @@ const isConversionPossible = () => {
 };
 
 const getButtonLabel = () =>
-	__( 'Transform into blocks', 'woo-gutenberg-products-block' );
+	__( 'Transform into blocks', 'woocommerce' );
 
 const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 	[
@@ -89,7 +89,7 @@ const onClickCallback = ( {
 const getDescription = () => {
 	return __(
 		'This block represents the classic template used to display the order confirmation. The actual rendered template may appear different from this placeholder.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 };
 
@@ -98,29 +98,29 @@ const getSkeleton = () => {
 		<div className="woocommerce-page">
 			<div className="woocommerce-order">
 				<h1>
-					{ __( 'Order received', 'woo-gutenberg-products-block' ) }
+					{ __( 'Order received', 'woocommerce' ) }
 				</h1>
 				<p className="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-confirmation">
 					{ __(
 						'Thank you. Your order has been received.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</p>
 				<ul className="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
 					<li className="woocommerce-order-overview__order order">
-						{ __( 'Order number', 'woo-gutenberg-products-block' ) }
+						{ __( 'Order number', 'woocommerce' ) }
 						: <strong>123</strong>
 					</li>
 					<li className="woocommerce-order-overview__date date">
-						{ __( 'Date', 'woo-gutenberg-products-block' ) }:{ ' ' }
+						{ __( 'Date', 'woocommerce' ) }:{ ' ' }
 						<strong>May 25, 2023</strong>
 					</li>
 					<li className="woocommerce-order-overview__email email">
-						{ __( 'Email', 'woo-gutenberg-products-block' ) }:{ ' ' }
+						{ __( 'Email', 'woocommerce' ) }:{ ' ' }
 						<strong>shopper@woo.com</strong>
 					</li>
 					<li className="woocommerce-order-overview__total total">
-						{ __( 'Total', 'woo-gutenberg-products-block' ) }:{ ' ' }
+						{ __( 'Total', 'woocommerce' ) }:{ ' ' }
 						<strong>$20.00</strong>
 					</li>
 				</ul>
@@ -129,7 +129,7 @@ const getSkeleton = () => {
 					<h2 className="woocommerce-order-details__title">
 						{ __(
 							'Order details',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</h2>
 					<table className="woocommerce-table woocommerce-table--order-details shop_table order_details">
@@ -138,13 +138,13 @@ const getSkeleton = () => {
 								<th className="woocommerce-table__product-name product-name">
 									{ __(
 										'Product',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</th>
 								<th className="woocommerce-table__product-table product-total">
 									{ __(
 										'Total',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</th>
 							</tr>
@@ -168,7 +168,7 @@ const getSkeleton = () => {
 								<th scope="row">
 									{ __(
 										'Subtotal',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 									:
 								</th>
@@ -178,7 +178,7 @@ const getSkeleton = () => {
 								<th scope="row">
 									{ __(
 										'Total',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 									:
 								</th>
@@ -194,7 +194,7 @@ const getSkeleton = () => {
 							<h2 className="woocommerce-column__title">
 								{ __(
 									'Billing address',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</h2>
 							<address>
@@ -210,7 +210,7 @@ const getSkeleton = () => {
 							<h2 className="woocommerce-column__title">
 								{ __(
 									'Shipping address',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</h2>
 							<address>

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/product-search-results.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/product-search-results.ts
@@ -25,17 +25,17 @@ const createNoResultsParagraph = () =>
 	createBlock( 'core/paragraph', {
 		content: __(
 			'No products were found matching your selection.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 	} );
 
 const createProductSearch = () =>
 	createBlock( 'core/search', {
 		buttonPosition: 'button-outside',
-		buttonText: __( 'Search', 'woo-gutenberg-products-block' ),
+		buttonText: __( 'Search', 'woocommerce' ),
 		buttonUseIcon: false,
 		showLabel: false,
-		placeholder: __( 'Search products…', 'woo-gutenberg-products-block' ),
+		placeholder: __( 'Search products…', 'woocommerce' ),
 		query: { post_type: 'product' },
 	} );
 
@@ -118,7 +118,7 @@ const getDescriptionAllowingConversion = ( templateTitle: string ) =>
 		/* translators: %s is the template title */
 		__(
 			'Transform this template into multiple blocks so you can add, remove, reorder, and customize your %s template.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		templateTitle
 	);
@@ -128,7 +128,7 @@ const getDescriptionDisallowingConversion = ( templateTitle: string ) =>
 		/* translators: %s is the template title */
 		__(
 			'This block serves as a placeholder for your %s. It will display the actual product image, title, price in your store. You can move this placeholder around and add more blocks around to customize the template.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		templateTitle
 	);
@@ -167,7 +167,7 @@ const onClickCallback = ( {
 };
 
 const getButtonLabel = () =>
-	__( 'Transform into blocks', 'woo-gutenberg-products-block' );
+	__( 'Transform into blocks', 'woocommerce' );
 
 const blockifyConfig = {
 	getButtonLabel,

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/single-product.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/single-product.ts
@@ -67,7 +67,7 @@ const getDescriptionAllowingConversion = ( templateTitle: string ) =>
 		/* translators: %s is the template title */
 		__(
 			'Transform this template into multiple blocks so you can add, remove, reorder, and customize your %s template.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		templateTitle
 	);
@@ -77,7 +77,7 @@ const getDescriptionDisallowingConversion = ( templateTitle: string ) =>
 		/* translators: %s is the template title */
 		__(
 			'This block serves as a placeholder for your %s. It will display the actual product image, title, price in your store. You can move this placeholder around and add more blocks around to customize the template.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		templateTitle
 	);
@@ -91,7 +91,7 @@ const getDescription = ( templateTitle: string, canConvert: boolean ) => {
 };
 
 const getButtonLabel = () =>
-	__( 'Transform into blocks', 'woo-gutenberg-products-block' );
+	__( 'Transform into blocks', 'woocommerce' );
 
 const onClickCallback = ( {
 	clientId,

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
@@ -12,7 +12,7 @@ const template = [
 	[
 		'core/heading',
 		{
-			content: __( 'Filter by Price', 'woo-gutenberg-products-block' ),
+			content: __( 'Filter by Price', 'woocommerce' ),
 			level: 3,
 		},
 	],
@@ -22,7 +22,7 @@ const template = [
 		{
 			content: __(
 				'Filter by Stock status',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			level: 3,
 		},
@@ -39,7 +39,7 @@ if ( firstAttribute ) {
 			{
 				content: sprintf(
 					// translators: %s is the attribute label.
-					__( 'Filter by %s', 'woo-gutenberg-products-block' ),
+					__( 'Filter by %s', 'woocommerce' ),
 					firstAttribute.attribute_label
 				),
 				level: 3,

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-dropdown.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-dropdown.tsx
@@ -14,7 +14,7 @@ export const AttributeDropdown = ( { label }: Props ) => (
 			suggestions={ [] }
 			placeholder={ sprintf(
 				/* translators: %s attribute name. */
-				__( 'Select %s', 'woo-gutenberg-products-block' ),
+				__( 'Select %s', 'woocommerce' ),
 				label
 			) }
 			onChange={ () => null }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-select-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-select-controls.tsx
@@ -22,15 +22,15 @@ export const AttributeSelectControls = ( {
 	attributeId,
 }: AttributeSelectControlsProps ) => {
 	const messages = {
-		clear: __( 'Clear selected attribute', 'woo-gutenberg-products-block' ),
-		list: __( 'Product Attributes', 'woo-gutenberg-products-block' ),
+		clear: __( 'Clear selected attribute', 'woocommerce' ),
+		list: __( 'Product Attributes', 'woocommerce' ),
 		noItems: __(
 			"Your store doesn't have any product attributes.",
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		search: __(
 			'Search for a product attribute:',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		selected: ( n: number ) =>
 			sprintf(
@@ -39,13 +39,13 @@ export const AttributeSelectControls = ( {
 					'%d attribute selected',
 					'%d attributes selected',
 					n,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				n
 			),
 		updated: __(
 			'Product attribute search results updated.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/inspector-controls.tsx
@@ -26,13 +26,13 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 			<PanelBody
 				title={ __(
 					'Display Settings',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				<ToggleControl
 					label={ __(
 						'Display product count',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ showCounts }
 					onChange={ () =>
@@ -44,7 +44,7 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				<ToggleGroupControl
 					label={ __(
 						'Allow selecting multiple options?',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ selectType || 'multiple' }
 					onChange={ ( value: string ) =>
@@ -58,29 +58,29 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 						value="multiple"
 						label={ __(
 							'Multiple',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 					<ToggleGroupControlOption
 						value="single"
-						label={ __( 'Single', 'woo-gutenberg-products-block' ) }
+						label={ __( 'Single', 'woocommerce' ) }
 					/>
 				</ToggleGroupControl>
 				{ selectType === 'multiple' && (
 					<ToggleGroupControl
 						label={ __(
 							'Filter Conditions',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={
 							queryType === 'and'
 								? __(
 										'Choose to return filter results for all of the attributes selected.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 								  )
 								: __(
 										'Choose to return filter results for any of the attributes selected.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 								  )
 						}
 						value={ queryType }
@@ -95,14 +95,14 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 							value="and"
 							label={ __(
 								'All',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="or"
 							label={ __(
 								'Any',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
@@ -110,7 +110,7 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				<ToggleGroupControl
 					label={ __(
 						'Display Style',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ displayStyle }
 					onChange={ ( value: string ) =>
@@ -122,13 +122,13 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				>
 					<ToggleGroupControlOption
 						value="list"
-						label={ __( 'List', 'woo-gutenberg-products-block' ) }
+						label={ __( 'List', 'woocommerce' ) }
 					/>
 					<ToggleGroupControlOption
 						value="dropdown"
 						label={ __(
 							'Dropdown',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 				</ToggleGroupControl>
@@ -136,7 +136,7 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 			<PanelBody
 				title={ __(
 					'Content Settings',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ false }
 			>

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/placeholder.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/placeholder.tsx
@@ -14,10 +14,10 @@ export const AttributesPlaceholder = ( {
 	<Placeholder
 		className="wc-block-attribute-filter"
 		icon={ <Icon icon={ category } /> }
-		label={ __( 'Filter by Attribute', 'woo-gutenberg-products-block' ) }
+		label={ __( 'Filter by Attribute', 'woocommerce' ) }
 		instructions={ __(
 			'Enable customers to filter the product grid by selecting one or more attributes, such as color.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
 	>
 		{ children }
@@ -29,7 +29,7 @@ export const NoAttributesPlaceholder = () => (
 		<p>
 			{ __(
 				"Attributes are needed for filtering your products. You haven't created any attributes yet.",
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</p>
 		<Button
@@ -40,7 +40,7 @@ export const NoAttributesPlaceholder = () => (
 			) }
 			target="_top"
 		>
-			{ __( 'Add new attribute', 'woo-gutenberg-products-block' ) + ' ' }
+			{ __( 'Add new attribute', 'woocommerce' ) + ' ' }
 			<Icon icon={ external } />
 		</Button>
 		<Button
@@ -49,7 +49,7 @@ export const NoAttributesPlaceholder = () => (
 			href="https://docs.woocommerce.com/document/managing-product-taxonomies/"
 			target="_blank"
 		>
-			{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
+			{ __( 'Learn more', 'woocommerce' ) }
 		</Button>
 	</AttributesPlaceholder>
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
@@ -134,7 +134,7 @@ const Edit = ( props: EditProps ) => {
 				controls={ [
 					{
 						icon: 'edit',
-						title: __( 'Edit', 'woo-gutenberg-products-block' ),
+						title: __( 'Edit', 'woocommerce' ),
 						onClick: () => setIsEditing( ! isEditing ),
 						isActive: isEditing,
 					},
@@ -162,12 +162,12 @@ const Edit = ( props: EditProps ) => {
 						debouncedSpeak(
 							__(
 								'Now displaying a preview of the Filter Products by Attribute block.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							)
 						);
 					} }
 				>
-					{ __( 'Done', 'woo-gutenberg-products-block' ) }
+					{ __( 'Done', 'woocommerce' ) }
 				</Button>
 			</div>
 		</AttributesPlaceholder>
@@ -202,7 +202,7 @@ const Edit = ( props: EditProps ) => {
 					<p>
 						{ __(
 							'Please select an attribute to use this filter!',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 				</Notice>
@@ -216,7 +216,7 @@ const Edit = ( props: EditProps ) => {
 					<p>
 						{ __(
 							'There are no products with the selected attributes.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</p>
 				</Notice>
@@ -231,7 +231,7 @@ const Edit = ( props: EditProps ) => {
 					<AttributeDropdown
 						label={
 							attributeObject.label ||
-							__( 'attribute', 'woo-gutenberg-products-block' )
+							__( 'attribute', 'woocommerce' )
 						}
 					/>
 				) : (

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/components/inspector.tsx
@@ -23,12 +23,12 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Settings', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Settings', 'woocommerce' ) }
 			>
 				<ToggleGroupControl
 					label={ __(
 						'Price Slider',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ showInputFields ? 'editable' : 'text' }
 					onChange={ ( value: string ) =>
@@ -42,19 +42,19 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 						value="editable"
 						label={ __(
 							'Editable',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 					<ToggleGroupControlOption
 						value="text"
-						label={ __( 'Text', 'woo-gutenberg-products-block' ) }
+						label={ __( 'Text', 'woocommerce' ) }
 					/>
 				</ToggleGroupControl>
 				{ showInputFields && (
 					<ToggleControl
 						label={ __(
 							'Inline input fields',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ inlineInput }
 						onChange={ () =>
@@ -64,7 +64,7 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 						}
 						help={ __(
 							'Show input fields inline with the slider.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/components/inspector.tsx
@@ -25,13 +25,13 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 			<PanelBody
 				title={ __(
 					'Display Settings',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				<ToggleControl
 					label={ __(
 						'Display product count',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ showCounts }
 					onChange={ () =>
@@ -43,7 +43,7 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				<ToggleGroupControl
 					label={ __(
 						'Allow selecting multiple options?',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ selectType || 'multiple' }
 					onChange={ ( value: string ) =>
@@ -57,18 +57,18 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 						value="multiple"
 						label={ __(
 							'Multiple',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 					<ToggleGroupControlOption
 						value="single"
-						label={ __( 'Single', 'woo-gutenberg-products-block' ) }
+						label={ __( 'Single', 'woocommerce' ) }
 					/>
 				</ToggleGroupControl>
 				<ToggleGroupControl
 					label={ __(
 						'Display Style',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ displayStyle }
 					onChange={ ( value ) =>
@@ -80,13 +80,13 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				>
 					<ToggleGroupControlOption
 						value="list"
-						label={ __( 'List', 'woo-gutenberg-products-block' ) }
+						label={ __( 'List', 'woocommerce' ) }
 					/>
 					<ToggleGroupControlOption
 						value="dropdown"
 						label={ __(
 							'Dropdown',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					/>
 				</ToggleGroupControl>

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
@@ -97,7 +97,7 @@ const Edit = ( props: BlockEditProps< BlockProps > ) => {
 										suggestions={ [] }
 										placeholder={ __(
 											'Select stock status',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 										) }
 										onChange={ () => null }
 										value={ [] }

--- a/plugins/woocommerce-blocks/assets/js/blocks/customer-account/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/customer-account/block.tsx
@@ -43,8 +43,8 @@ const Label = ( { displayStyle }: { displayStyle: DisplayStyle } ) => {
 	return (
 		<span className="label">
 			{ currentUserId
-				? __( 'My Account', 'woo-gutenberg-products-block' )
-				: __( 'Log in', 'woo-gutenberg-products-block' ) }
+				? __( 'My Account', 'woocommerce' )
+				: __( 'Log in', 'woocommerce' ) }
 		</span>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/customer-account/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/customer-account/index.tsx
@@ -38,7 +38,7 @@ registerBlockType( metadata, {
 // For more context, see https://github.com/woocommerce/woocommerce-blocks/pull/8594
 registerBlockVariation( 'woocommerce/customer-account', {
 	name: 'woocommerce/customer-account',
-	title: __( 'Customer account', 'woo-gutenberg-products-block' ),
+	title: __( 'Customer account', 'woocommerce' ),
 	isDefault: true,
 	attributes: {
 		...metadata.attributes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/customer-account/sidebar-settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/customer-account/sidebar-settings.tsx
@@ -40,7 +40,7 @@ const AccountSettingsLink = () => {
 	const linkText = createInterpolateElement(
 		`<a>${ __(
 			'Manage account settings',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }</a>`,
 		{
 			a: <ExternalLink href={ accountSettingsUrl } />,
@@ -72,14 +72,14 @@ export const BlockSettings = ( {
 			<PanelBody
 				title={ __(
 					'Display settings',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				<SelectControl
 					className="customer-account-display-style"
 					label={ __(
 						'Icon options',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ displayStyle }
 					onChange={ ( value: DisplayStyle ) => {
@@ -87,28 +87,28 @@ export const BlockSettings = ( {
 					} }
 					help={ __(
 						'Choose if you want to include an icon with the customer account link.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					options={ [
 						{
 							value: DisplayStyle.ICON_AND_TEXT,
 							label: __(
 								'Icon and text',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 						},
 						{
 							value: DisplayStyle.TEXT_ONLY,
 							label: __(
 								'Text-only',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 						},
 						{
 							value: DisplayStyle.ICON_ONLY,
 							label: __(
 								'Icon-only',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 						},
 					] }
@@ -117,7 +117,7 @@ export const BlockSettings = ( {
 					<ToggleGroupControl
 						label={ __(
 							'Display Style',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ iconStyle }
 						onChange={ ( value: IconStyle ) =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/block-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/block-controls.tsx
@@ -116,7 +116,7 @@ export const BlockControls = ( {
 							setAttributes( { mediaId: 0, mediaSrc: '' } )
 						}
 					>
-						{ __( 'Reset', 'woo-gutenberg-products-block' ) }
+						{ __( 'Reset', 'woocommerce' ) }
 					</ToolbarButton>
 				) : null }
 			</ToolbarGroup>

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/call-to-action.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/call-to-action.tsx
@@ -53,7 +53,7 @@ export const CallToAction = ( {
 							{
 								text: __(
 									'Shop now',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								url: permalink,
 							},

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/featured-category/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/featured-category/block.tsx
@@ -21,24 +21,24 @@ import { withUpdateButtonAttributes } from '../with-update-button-attributes';
 
 const GENERIC_CONFIG = {
 	icon: folderStarred,
-	label: __( 'Featured Category', 'woo-gutenberg-products-block' ),
+	label: __( 'Featured Category', 'woocommerce' ),
 };
 
 const BLOCK_CONTROL_CONFIG = {
 	...GENERIC_CONFIG,
-	cropLabel: __( 'Edit category image', 'woo-gutenberg-products-block' ),
-	editLabel: __( 'Edit selected category', 'woo-gutenberg-products-block' ),
+	cropLabel: __( 'Edit category image', 'woocommerce' ),
+	editLabel: __( 'Edit selected category', 'woocommerce' ),
 };
 
 const CONTENT_CONFIG = {
 	...GENERIC_CONFIG,
 	emptyMessage: __(
 		'No product category is selected.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	noSelectionButtonLabel: __(
 		'Select a category',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 
@@ -46,11 +46,11 @@ const EDIT_MODE_CONFIG = {
 	...GENERIC_CONFIG,
 	description: __(
 		'Visually highlight a product category and encourage prompt action.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	editLabel: __(
 		'Showing Featured Product block preview.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/featured-product/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/featured-product/block.tsx
@@ -21,24 +21,24 @@ import { withUpdateButtonAttributes } from '../with-update-button-attributes';
 
 const GENERIC_CONFIG = {
 	icon: starEmpty,
-	label: __( 'Featured Product', 'woo-gutenberg-products-block' ),
+	label: __( 'Featured Product', 'woocommerce' ),
 };
 
 const BLOCK_CONTROL_CONFIG = {
 	...GENERIC_CONFIG,
-	cropLabel: __( 'Edit product image', 'woo-gutenberg-products-block' ),
-	editLabel: __( 'Edit selected product', 'woo-gutenberg-products-block' ),
+	cropLabel: __( 'Edit product image', 'woocommerce' ),
+	editLabel: __( 'Edit selected product', 'woocommerce' ),
 };
 
 const CONTENT_CONFIG = {
 	...GENERIC_CONFIG,
 	emptyMessage: __(
 		'No product is selected.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	noSelectionButtonLabel: __(
 		'Select a product',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 
@@ -46,11 +46,11 @@ const EDIT_MODE_CONFIG = {
 	...GENERIC_CONFIG,
 	description: __(
 		'Highlight a product or variation.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	editLabel: __(
 		'Showing Featured Product block preview.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/inspector-controls.tsx
@@ -106,12 +106,12 @@ export const InspectorControls = ( {
 	return (
 		<GutenbergInspectorControls key="inspector">
 			<PanelBody
-				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Content', 'woocommerce' ) }
 			>
 				<ToggleControl
 					label={ __(
 						'Show description',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ showDesc }
 					onChange={ () => setAttributes( { showDesc: ! showDesc } ) }
@@ -124,13 +124,13 @@ export const InspectorControls = ( {
 						<PanelBody
 							title={ __(
 								'Media settings',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						>
 							<ToggleControl
 								label={ __(
 									'Fixed background',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								checked={ hasParallax }
 								onChange={ () => {
@@ -142,7 +142,7 @@ export const InspectorControls = ( {
 							<ToggleControl
 								label={ __(
 									'Repeated background',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								checked={ isRepeated }
 								onChange={ () => {
@@ -163,20 +163,20 @@ export const InspectorControls = ( {
 											>
 												{ __(
 													'Select “Cover” to have the image automatically fit its container.',
-													'woo-gutenberg-products-block'
+													'woocommerce'
 												) }
 											</span>
 											<span>
 												{ __(
 													'This may affect your ability to freely move the focal point of the image.',
-													'woo-gutenberg-products-block'
+													'woocommerce'
 												) }
 											</span>
 										</>
 									}
 									label={ __(
 										'Image fit',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 									value={ imageFit }
 									onChange={ ( value: ImageFit ) =>
@@ -188,7 +188,7 @@ export const InspectorControls = ( {
 									<ToggleGroupControlOption
 										label={ __(
 											'None',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 										) }
 										value="none"
 									/>
@@ -196,7 +196,7 @@ export const InspectorControls = ( {
 										/* translators: "Cover" is a verb that indicates an image covering the entire container. */
 										label={ __(
 											'Cover',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 										) }
 										value="cover"
 									/>
@@ -205,7 +205,7 @@ export const InspectorControls = ( {
 							<FocalPointPicker
 								label={ __(
 									'Focal Point Picker',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								url={ backgroundImageSrc }
 								value={ focalPoint }
@@ -219,7 +219,7 @@ export const InspectorControls = ( {
 								<TextareaControl
 									label={ __(
 										'Alt text (alternative text)',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 									value={ alt }
 									onChange={ ( value: string ) => {
@@ -230,7 +230,7 @@ export const InspectorControls = ( {
 											<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 												{ __(
 													'Describe the purpose of the image',
-													'woo-gutenberg-products-block'
+													'woocommerce'
 												) }
 											</ExternalLink>
 										</>
@@ -244,7 +244,7 @@ export const InspectorControls = ( {
 						__experimentalIsRenderedInSidebar
 						title={ __(
 							'Overlay',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						initialOpen={ true }
 						settings={ [
@@ -261,7 +261,7 @@ export const InspectorControls = ( {
 								},
 								label: __(
 									'Color',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 							},
 						] }
@@ -269,7 +269,7 @@ export const InspectorControls = ( {
 						<RangeControl
 							label={ __(
 								'Opacity',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							value={ dimRatio }
 							onChange={ ( value ) =>
@@ -325,7 +325,7 @@ export const withInspectorControls =
 		const contentPanel =
 			name === BLOCK_NAMES.featuredProduct ? (
 				<ToggleControl
-					label={ __( 'Show price', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Show price', 'woocommerce' ) }
 					checked={ showPrice }
 					onChange={ () =>
 						setAttributes( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/with-edit-mode.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/with-edit-mode.tsx
@@ -113,7 +113,7 @@ export const withEditMode =
 							/>
 						) }
 						<Button variant="primary" onClick={ onDone }>
-							{ __( 'Done', 'woo-gutenberg-products-block' ) }
+							{ __( 'Done', 'woocommerce' ) }
 						</Button>
 					</div>
 				</Placeholder>

--- a/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/index.tsx
@@ -24,22 +24,22 @@ const filterBlocksWidgets = [
 	{
 		widgetId: 'woocommerce_layered_nav_filters',
 		name: 'active-filters',
-		heading: __( 'Active filters', 'woo-gutenberg-products-block' ),
+		heading: __( 'Active filters', 'woocommerce' ),
 	},
 	{
 		widgetId: 'woocommerce_price_filter',
 		name: 'price-filter',
-		heading: __( 'Filter by price', 'woo-gutenberg-products-block' ),
+		heading: __( 'Filter by price', 'woocommerce' ),
 	},
 	{
 		widgetId: 'woocommerce_layered_nav',
 		name: 'attribute-filter',
-		heading: __( 'Filter by attribute', 'woo-gutenberg-products-block' ),
+		heading: __( 'Filter by attribute', 'woocommerce' ),
 	},
 	{
 		widgetId: 'woocommerce_rating_filter',
 		name: 'rating-filter',
-		heading: __( 'Filter by rating', 'woo-gutenberg-products-block' ),
+		heading: __( 'Filter by rating', 'woocommerce' ),
 	},
 ];
 
@@ -120,10 +120,10 @@ registerBlockType( metadata, {
 	variations: [
 		{
 			name: 'active-filters',
-			title: __( 'Active Filters', 'woo-gutenberg-products-block' ),
+			title: __( 'Active Filters', 'woocommerce' ),
 			description: __(
 				'Display the currently active filters.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			/**
 			 * We need to handle the isActive function differently for this
@@ -134,7 +134,7 @@ registerBlockType( metadata, {
 				attributes.filterType === 'active-filters' ||
 				! attributes.filterType,
 			attributes: {
-				heading: __( 'Active filters', 'woo-gutenberg-products-block' ),
+				heading: __( 'Active filters', 'woocommerce' ),
 				filterType: 'active-filters',
 			},
 			icon: {
@@ -149,10 +149,10 @@ registerBlockType( metadata, {
 		},
 		{
 			name: 'price-filter',
-			title: __( 'Filter by Price', 'woo-gutenberg-products-block' ),
+			title: __( 'Filter by Price', 'woocommerce' ),
 			description: __(
 				'Enable customers to filter the product grid by choosing a price range.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			isActive: ( attributes ) =>
 				attributes.filterType === 'price-filter',
@@ -160,7 +160,7 @@ registerBlockType( metadata, {
 				filterType: 'price-filter',
 				heading: __(
 					'Filter by price',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 			},
 			icon: {
@@ -174,10 +174,10 @@ registerBlockType( metadata, {
 		},
 		{
 			name: 'stock-filter',
-			title: __( 'Filter by Stock', 'woo-gutenberg-products-block' ),
+			title: __( 'Filter by Stock', 'woocommerce' ),
 			description: __(
 				'Enable customers to filter the product grid by stock status.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			isActive: ( attributes ) =>
 				attributes.filterType === 'stock-filter',
@@ -185,7 +185,7 @@ registerBlockType( metadata, {
 				filterType: 'stock-filter',
 				heading: __(
 					'Filter by stock status',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 			},
 			icon: {
@@ -199,10 +199,10 @@ registerBlockType( metadata, {
 		},
 		{
 			name: 'attribute-filter',
-			title: __( 'Filter by Attribute', 'woo-gutenberg-products-block' ),
+			title: __( 'Filter by Attribute', 'woocommerce' ),
 			description: __(
 				'Enable customers to filter the product grid by selecting one or more attributes, such as color.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			isActive: ( attributes ) =>
 				attributes.filterType === 'attribute-filter',
@@ -210,7 +210,7 @@ registerBlockType( metadata, {
 				filterType: 'attribute-filter',
 				heading: __(
 					'Filter by attribute',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 			},
 			icon: {
@@ -224,10 +224,10 @@ registerBlockType( metadata, {
 		},
 		{
 			name: 'rating-filter',
-			title: __( 'Filter by Rating', 'woo-gutenberg-products-block' ),
+			title: __( 'Filter by Rating', 'woocommerce' ),
 			description: __(
 				'Enable customers to filter the product grid by rating.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			isActive: ( attributes ) =>
 				attributes.filterType === 'rating-filter',
@@ -235,7 +235,7 @@ registerBlockType( metadata, {
 				filterType: 'rating-filter',
 				heading: __(
 					'Filter by rating',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 			},
 			icon: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/upgrade.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/upgrade.tsx
@@ -83,7 +83,7 @@ export const UpgradeNotice = ( {
 			onClick={ upgradeFilterBlockHandler }
 			variant="primary"
 		>
-			{ __( 'Upgrade block', 'woo-gutenberg-products-block' ) }
+			{ __( 'Upgrade block', 'woocommerce' ) }
 		</Button>,
 	];
 
@@ -91,7 +91,7 @@ export const UpgradeNotice = ( {
 		<Warning actions={ actions }>
 			{ __(
 				'Filter block: We have improved this block to make styling easier. Upgrade it using the button below.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</Warning>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/handpicked-products/edit-mode.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/handpicked-products/edit-mode.tsx
@@ -31,7 +31,7 @@ export const HandpickedProductsEditMode = (
 		debouncedSpeak(
 			__(
 				'Now displaying a preview of the Hand-picked Products block.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			)
 		);
 	};
@@ -41,13 +41,13 @@ export const HandpickedProductsEditMode = (
 			icon={ <Icon icon={ stack } /> }
 			label={ __(
 				'Hand-picked Products',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			className="wc-block-products-grid wc-block-handpicked-products"
 		>
 			{ __(
 				'Display a selection of hand-picked products in a grid.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			<div className="wc-block-handpicked-products__selection">
 				<ProductsControl
@@ -58,7 +58,7 @@ export const HandpickedProductsEditMode = (
 					} }
 				/>
 				<Button variant="primary" onClick={ onDone }>
-					{ __( 'Done', 'woo-gutenberg-products-block' ) }
+					{ __( 'Done', 'woocommerce' ) }
 				</Button>
 			</div>
 		</Placeholder>

--- a/plugins/woocommerce-blocks/assets/js/blocks/handpicked-products/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/handpicked-products/edit.tsx
@@ -36,7 +36,7 @@ export const EditBlock = ( props: Props ): JSX.Element => {
 							icon: 'edit',
 							title: __(
 								'Edit selected products',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							onClick: () => setIsEditing( ! isEditing ),
 							isActive: isEditing,

--- a/plugins/woocommerce-blocks/assets/js/blocks/handpicked-products/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/handpicked-products/inspector-controls.tsx
@@ -23,11 +23,11 @@ export const HandpickedProductsInspectorControls = (
 	return (
 		<InspectorControls key="inspector">
 			<PanelBody
-				title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Layout', 'woocommerce' ) }
 				initialOpen
 			>
 				<RangeControl
-					label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Columns', 'woocommerce' ) }
 					value={ columns }
 					onChange={ ( value ) =>
 						setAttributes( { columns: value } )
@@ -38,17 +38,17 @@ export const HandpickedProductsInspectorControls = (
 				<ToggleControl
 					label={ __(
 						'Align Buttons',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					help={
 						alignButtons
 							? __(
 									'Buttons are aligned vertically.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 							  )
 							: __(
 									'Buttons follow content.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 							  )
 					}
 					checked={ alignButtons }
@@ -58,7 +58,7 @@ export const HandpickedProductsInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Content', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridContentControl
@@ -69,7 +69,7 @@ export const HandpickedProductsInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Order By', 'woocommerce' ) }
 				initialOpen={ false }
 			>
 				<ProductOrderbyControl
@@ -78,7 +78,7 @@ export const HandpickedProductsInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Products', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Products', 'woocommerce' ) }
 				initialOpen={ false }
 			>
 				<ProductsControl

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/block.tsx
@@ -226,7 +226,7 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 					'%1$d item in cart',
 					'%1$d items in cart',
 					cartItemsCount,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				cartItemsCount
 		  )
@@ -236,7 +236,7 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 					'%1$d item in cart, total price of %2$s',
 					'%1$d items in cart, total price of %2$s',
 					cartItemsCount,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				cartItemsCount,
 				formatPrice(

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/edit.tsx
@@ -63,15 +63,15 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 
 	const miniCartColorAttributes = {
 		priceColor: {
-			label: __( 'Price', 'woo-gutenberg-products-block' ),
+			label: __( 'Price', 'woocommerce' ),
 			context: 'price-color',
 		},
 		iconColor: {
-			label: __( 'Icon', 'woo-gutenberg-products-block' ),
+			label: __( 'Icon', 'woocommerce' ),
 			context: 'icon-color',
 		},
 		productCountColor: {
-			label: __( 'Product Count', 'woo-gutenberg-products-block' ),
+			label: __( 'Product Count', 'woocommerce' ),
 			context: 'product-count-color',
 		},
 	};
@@ -93,14 +93,14 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 		<div { ...blockProps }>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Settings', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Settings', 'woocommerce' ) }
 				>
 					<ToggleGroupControl
 						className="wc-block-editor-mini-cart__cart-icon-toggle"
 						isBlock={ true }
 						label={ __(
 							'Cart Icon',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ miniCartIcon }
 						onChange={ ( value: 'cart' | 'bag' | 'bag-alt' ) => {
@@ -126,17 +126,17 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 						id="wc-block-mini-cart__display-toggle"
 						label={ __(
 							'Display',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					>
 						<ToggleControl
 							label={ __(
 								'Display total price',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							help={ __(
 								'Toggle to display the total price of products in the shopping cart. If no products have been added, the price will not display.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							checked={ ! hasHiddenPrice }
 							onChange={ () =>
@@ -151,7 +151,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							className="wc-block-editor-mini-cart__render-in-cart-and-checkout-toggle"
 							label={ __(
 								'Mini-Cart in cart and checkout pages',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							value={ cartAndCheckoutRenderStyle }
 							onChange={ ( value: boolean ) => {
@@ -161,21 +161,21 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							} }
 							help={ __(
 								'Select how the Mini-Cart behaves in the Cart and Checkout pages. This might affect the header layout.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						>
 							<ToggleGroupControlOption
 								value={ 'hidden' }
 								label={ __(
 									'Hide',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value={ 'removed' }
 								label={ __(
 									'Remove',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							/>
 						</ToggleGroupControl>
@@ -184,7 +184,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 				<PanelBody
 					title={ __(
 						'Cart Drawer',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					{ templatePartEditUri && (
@@ -201,14 +201,14 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							<p>
 								{ __(
 									'When opened, the Mini-Cart drawer gives shoppers quick access to view their selected products and checkout.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</p>
 							<p className="wc-block-editor-mini-cart__drawer-link">
 								<ExternalLink href={ templatePartEditUri }>
 									{ __(
 										'Edit Mini-Cart Drawer template',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</ExternalLink>
 							</p>
@@ -218,13 +218,13 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 						id="wc-block-mini-cart__add-to-cart-behaviour-toggle"
 						label={ __(
 							'Behavior',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					>
 						<ToggleControl
 							label={ __(
 								'Open drawer when adding',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							onChange={ ( value ) => {
 								setAttributes( {
@@ -235,7 +235,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							} }
 							help={ __(
 								'Toggle to open the Mini-Cart drawer when a shopper adds a product to their cart.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							checked={ addToCartBehaviour === 'open_drawer' }
 						/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/attributes.tsx
@@ -29,12 +29,12 @@ export const attributes = {
 		default: [
 			{
 				view: 'woocommerce/filled-mini-cart-contents-block',
-				label: __( 'Filled Mini-Cart', 'woo-gutenberg-products-block' ),
+				label: __( 'Filled Mini-Cart', 'woocommerce' ),
 				icon: <Icon icon={ filledCart } />,
 			},
 			{
 				view: 'woocommerce/empty-mini-cart-contents-block',
-				label: __( 'Empty Mini-Cart', 'woo-gutenberg-products-block' ),
+				label: __( 'Empty Mini-Cart', 'woocommerce' ),
 				icon: <Icon icon={ removeCart } />,
 			},
 		],

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -120,7 +120,7 @@ const Edit = ( {
 					<PanelBody
 						title={ __(
 							'Dimensions',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						initialOpen
 					>

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
@@ -17,7 +17,7 @@ import './inner-blocks';
 
 const settings: BlockConfiguration = {
 	apiVersion: 2,
-	title: __( 'Mini-Cart Contents', 'woo-gutenberg-products-block' ),
+	title: __( 'Mini-Cart Contents', 'woocommerce' ),
 	icon: {
 		src: (
 			<Icon
@@ -27,10 +27,10 @@ const settings: BlockConfiguration = {
 		),
 	},
 	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 	description: __(
 		'Display a Mini-Cart widget.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	supports: {
 		align: false,

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/constants.tsx
@@ -5,5 +5,5 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultCartButtonLabel = __(
 	'View my cart',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/constants.tsx
@@ -5,5 +5,5 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultCheckoutButtonLabel = __(
 	'Go to checkout',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -61,11 +61,11 @@ const Block = ( {
 			<TotalsItem
 				className="wc-block-mini-cart__footer-subtotal"
 				currency={ getCurrencyFromPriceResponse( cartTotals ) }
-				label={ __( 'Subtotal', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Subtotal', 'woocommerce' ) }
 				value={ subTotal }
 				description={ __(
 					'Shipping, taxes, and discounts calculated at checkout.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			/>
 			<div className="wc-block-mini-cart__footer-actions">

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/constants.ts
@@ -5,10 +5,10 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultCartButtonLabel = __(
 	'View my cart',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 
 export const defaultCheckoutButtonLabel = __(
 	'Go to checkout',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -47,11 +47,11 @@ export const Edit = (): JSX.Element => {
 				<TotalsItem
 					className="wc-block-mini-cart__footer-subtotal"
 					currency={ getCurrencyFromPriceResponse( cartTotals ) }
-					label={ __( 'Subtotal', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Subtotal', 'woocommerce' ) }
 					value={ subTotal }
 					description={ __(
 						'Shipping, taxes, and discounts calculated at checkout.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				/>
 				<div className="wc-block-mini-cart__footer-actions">

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/constants.tsx
@@ -5,5 +5,5 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultStartShoppingButtonLabel = __(
 	'Start shopping',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-items-counter-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-items-counter-block/block.tsx
@@ -25,7 +25,7 @@ const Block = ( props: Props ): JSX.Element => {
 					'(%d item)',
 					'(%d items)',
 					cartItemsCount,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				cartItemsCount
 			) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-items-counter-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-items-counter-block/edit.tsx
@@ -17,7 +17,7 @@ export const Edit = (): JSX.Element => {
 					'(%d item)',
 					'(%d items)',
 					cartItemsCount,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				cartItemsCount
 			) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-label-block/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-label-block/constants.ts
@@ -5,5 +5,5 @@ import { __ } from '@wordpress/i18n';
 
 export const defaultYourCartLabel = __(
 	'Your cart',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/utils/data.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/utils/data.ts
@@ -70,7 +70,7 @@ export const updateTotals = (
 							'%1$d item in cart',
 							'%1$d items in cart',
 							quantity,
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						quantity
 				  )
@@ -80,7 +80,7 @@ export const updateTotals = (
 							'%1$d item in cart, total price of %2$s',
 							'%1$d items in cart, total price of %2$s',
 							quantity,
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						quantity,
 						amount

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/billing-wrapper/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/billing-wrapper/attributes.tsx
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export default {
 	heading: {
 		type: 'string',
-		default: __( 'Billing address', 'woo-gutenberg-products-block' ),
+		default: __( 'Billing address', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/downloads-wrapper/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/downloads-wrapper/attributes.tsx
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export default {
 	heading: {
 		type: 'string',
-		default: __( 'Downloads', 'woo-gutenberg-products-block' ),
+		default: __( 'Downloads', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/downloads/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/downloads/edit.tsx
@@ -45,7 +45,7 @@ const Edit = (): JSX.Element => {
 								<span className="nobr">
 									{ __(
 										'Product',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</span>
 							</th>
@@ -53,7 +53,7 @@ const Edit = (): JSX.Element => {
 								<span className="nobr">
 									{ __(
 										'Downloads remaining',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</span>
 							</th>
@@ -61,7 +61,7 @@ const Edit = (): JSX.Element => {
 								<span className="nobr">
 									{ __(
 										'Expires',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</span>
 							</th>
@@ -69,7 +69,7 @@ const Edit = (): JSX.Element => {
 								<span className="nobr">
 									{ __(
 										'Download',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</span>
 							</th>
@@ -85,7 +85,7 @@ const Edit = (): JSX.Element => {
 									{ _x(
 										'Test Product',
 										'sample product name',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</a>
 							</td>
@@ -96,7 +96,7 @@ const Edit = (): JSX.Element => {
 								{ _x(
 									'∞',
 									'infinite downloads remaining',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</td>
 							<td
@@ -106,7 +106,7 @@ const Edit = (): JSX.Element => {
 								{ _x(
 									'Never',
 									'download expires',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</td>
 							<td className="download-file" data-title="Download">
@@ -117,7 +117,7 @@ const Edit = (): JSX.Element => {
 									{ _x(
 										'Test Download',
 										'sample download name',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</a>
 							</td>

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/shipping-wrapper/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/shipping-wrapper/attributes.tsx
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export default {
 	heading: {
 		type: 'string',
-		default: __( 'Shipping address', 'woo-gutenberg-products-block' ),
+		default: __( 'Shipping address', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/status/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/status/edit.tsx
@@ -19,7 +19,7 @@ const Edit = (): JSX.Element => {
 			<p>
 				{ __(
 					'Thank you. Your order has been received.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/summary/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/summary/edit.tsx
@@ -26,7 +26,7 @@ const Edit = (): JSX.Element => {
 						<span className="wc-block-order-confirmation-summary-list-item__key">
 							{ __(
 								'Order number:',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</span>{ ' ' }
 						<span className="wc-block-order-confirmation-summary-list-item__value">
@@ -35,7 +35,7 @@ const Edit = (): JSX.Element => {
 					</li>
 					<li className="wc-block-order-confirmation-summary-list-item">
 						<span className="wc-block-order-confirmation-summary-list-item__key">
-							{ __( 'Date:', 'woo-gutenberg-products-block' ) }
+							{ __( 'Date:', 'woocommerce' ) }
 						</span>{ ' ' }
 						<span className="wc-block-order-confirmation-summary-list-item__value">
 							{ date(
@@ -47,7 +47,7 @@ const Edit = (): JSX.Element => {
 					</li>
 					<li className="wc-block-order-confirmation-summary-list-item">
 						<span className="wc-block-order-confirmation-summary-list-item__key">
-							{ __( 'Total:', 'woo-gutenberg-products-block' ) }
+							{ __( 'Total:', 'woocommerce' ) }
 						</span>{ ' ' }
 						<span className="wc-block-order-confirmation-summary-list-item__value">
 							{ formatPrice( 4000 ) }
@@ -55,7 +55,7 @@ const Edit = (): JSX.Element => {
 					</li>
 					<li className="wc-block-order-confirmation-summary-list-item">
 						<span className="wc-block-order-confirmation-summary-list-item__key">
-							{ __( 'Email:', 'woo-gutenberg-products-block' ) }
+							{ __( 'Email:', 'woocommerce' ) }
 						</span>{ ' ' }
 						<span className="wc-block-order-confirmation-summary-list-item__value">
 							test@test.com
@@ -65,13 +65,13 @@ const Edit = (): JSX.Element => {
 						<span className="wc-block-order-confirmation-summary-list-item__key">
 							{ __(
 								'Payment method:',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</span>{ ' ' }
 						<span className="wc-block-order-confirmation-summary-list-item__value">
 							{ __(
 								'Credit Card',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</span>
 					</li>

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/totals-wrapper/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/totals-wrapper/attributes.tsx
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export default {
 	heading: {
 		type: 'string',
-		default: __( 'Order details', 'woo-gutenberg-products-block' ),
+		default: __( 'Order details', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/totals/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/totals/edit.tsx
@@ -45,13 +45,13 @@ const Edit = (): JSX.Element => {
 							<th className="wc-block-order-confirmation-totals__product">
 								{ __(
 									'Product',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</th>
 							<th className="wc-block-order-confirmation-totals__total">
 								{ __(
 									'Total',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</th>
 						</tr>
@@ -66,7 +66,7 @@ const Edit = (): JSX.Element => {
 									{ _x(
 										'Test Product',
 										'sample product name',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</a>
 								&nbsp;
@@ -87,7 +87,7 @@ const Edit = (): JSX.Element => {
 									{ _x(
 										'Test Product',
 										'sample product name',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</a>
 								&nbsp;
@@ -108,7 +108,7 @@ const Edit = (): JSX.Element => {
 							>
 								{ __(
 									'Total',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 							</th>
 							<td className="wc-block-order-confirmation-totals__total">

--- a/plugins/woocommerce-blocks/assets/js/blocks/page-content-wrapper/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/page-content-wrapper/index.tsx
@@ -68,7 +68,7 @@ registerBlockType( metadata, {
 	variations: [
 		{
 			name: 'checkout-page',
-			title: __( 'Checkout Page', 'woo-gutenberg-products-block' ),
+			title: __( 'Checkout Page', 'woocommerce' ),
 			attributes: {
 				page: 'checkout',
 			},
@@ -77,7 +77,7 @@ registerBlockType( metadata, {
 		},
 		{
 			name: 'cart-page',
-			title: __( 'Cart Page', 'woo-gutenberg-products-block' ),
+			title: __( 'Cart Page', 'woocommerce' ),
 			attributes: {
 				page: 'cart',
 			},

--- a/plugins/woocommerce-blocks/assets/js/blocks/price-filter/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/price-filter/attributes.ts
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export const blockAttributes = {
 	heading: {
 		type: 'string',
-		default: __( 'Filter by price', 'woo-gutenberg-products-block' ),
+		default: __( 'Filter by price', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/price-filter/edit.tsx
@@ -47,12 +47,12 @@ export default function ( {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
-					title={ __( 'Settings', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Settings', 'woocommerce' ) }
 				>
 					<ToggleGroupControl
 						label={ __(
 							'Price Range Selector',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ showInputFields ? 'editable' : 'text' }
 						onChange={ ( value: string ) =>
@@ -66,14 +66,14 @@ export default function ( {
 							value="editable"
 							label={ __(
 								'Editable',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="text"
 							label={ __(
 								'Text',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
@@ -81,7 +81,7 @@ export default function ( {
 						<ToggleControl
 							label={ __(
 								'Inline input fields',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							checked={ inlineInput }
 							onChange={ () =>
@@ -91,18 +91,18 @@ export default function ( {
 							}
 							help={ __(
 								'Show input fields inline with the slider.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					) }
 					<ToggleControl
 						label={ __(
 							"Show 'Apply filters' button",
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Products will update when the button is clicked.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showFilterButton }
 						onChange={ () =>
@@ -120,16 +120,16 @@ export default function ( {
 		<Placeholder
 			className="wc-block-price-slider"
 			icon={ <Icon icon={ currencyDollar } /> }
-			label={ __( 'Filter by Price', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Filter by Price', 'woocommerce' ) }
 			instructions={ __(
 				'Display a slider to filter products in your store by price.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		>
 			<p>
 				{ __(
 					'To filter your products by price you first need to assign prices to your products.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 			<Button
@@ -138,7 +138,7 @@ export default function ( {
 				href={ getAdminLink( 'post-new.php?post_type=product' ) }
 				target="_top"
 			>
-				{ __( 'Add new product', 'woo-gutenberg-products-block' ) +
+				{ __( 'Add new product', 'woocommerce' ) +
 					' ' }
 				<Icon icon={ external } />
 			</Button>
@@ -148,7 +148,7 @@ export default function ( {
 				href="https://docs.woocommerce.com/document/managing-products/"
 				target="_blank"
 			>
-				{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
+				{ __( 'Learn more', 'woocommerce' ) }
 			</Button>
 		</Placeholder>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-best-sellers/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-best-sellers/inspector-controls.tsx
@@ -30,7 +30,7 @@ export const ProductBestSellersInspectorControls = (
 	return (
 		<InspectorControls key="inspector">
 			<PanelBody
-				title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Layout', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridLayoutControl
@@ -45,7 +45,7 @@ export const ProductBestSellersInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Content', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridContentControl
@@ -58,7 +58,7 @@ export const ProductBestSellersInspectorControls = (
 			<PanelBody
 				title={ __(
 					'Filter by Product Category',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ false }
 			>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-categories/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-categories/block.tsx
@@ -27,13 +27,13 @@ const EmptyPlaceholder = () => (
 		icon={ <Icon icon={ listView } /> }
 		label={ __(
 			'Product Categories List',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
 		className="wc-block-product-categories"
 	>
 		{ __(
 			'This block displays the product categories for your store. To use it you first need to create a product and assign it to a category.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
 	</Placeholder>
 );
@@ -72,14 +72,14 @@ const ProductCategoriesBlock = ( {
 				<PanelBody
 					title={ __(
 						'List Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen
 				>
 					<ToggleGroupControl
 						label={ __(
 							'Display style',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ isDropdown ? 'dropdown' : 'list' }
 						onChange={ ( value: string ) =>
@@ -92,26 +92,26 @@ const ProductCategoriesBlock = ( {
 							value="list"
 							label={ __(
 								'List',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="dropdown"
 							label={ __(
 								'Dropdown',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 					initialOpen
 				>
 					<ToggleControl
 						label={ __(
 							'Show product count',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ hasCount }
 						onChange={ () =>
@@ -122,17 +122,17 @@ const ProductCategoriesBlock = ( {
 						<ToggleControl
 							label={ __(
 								'Show category images',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							help={
 								hasImage
 									? __(
 											'Category images are visible.',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 									  )
 									: __(
 											'Category images are hidden.',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 									  )
 							}
 							checked={ hasImage }
@@ -144,7 +144,7 @@ const ProductCategoriesBlock = ( {
 					<ToggleControl
 						label={ __(
 							'Show hierarchy',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ isHierarchical }
 						onChange={ () =>
@@ -156,7 +156,7 @@ const ProductCategoriesBlock = ( {
 					<ToggleControl
 						label={ __(
 							'Show empty categories',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ hasEmpty }
 						onChange={ () =>
@@ -167,11 +167,11 @@ const ProductCategoriesBlock = ( {
 						<ToggleControl
 							label={ __(
 								'Only show children of current category',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							help={ __(
 								'This will affect product category pages',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							checked={ showChildrenOnly }
 							onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-category/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-category/block.tsx
@@ -15,12 +15,12 @@ import { Props } from './types';
 const EmptyPlaceholder = () => (
 	<Placeholder
 		icon={ <Icon icon={ file } /> }
-		label={ __( 'Products by Category', 'woo-gutenberg-products-block' ) }
+		label={ __( 'Products by Category', 'woocommerce' ) }
 		className="wc-block-products-grid wc-block-products-category"
 	>
 		{ __(
 			'No products were found that matched your selection.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
 	</Placeholder>
 );
@@ -43,7 +43,7 @@ export const ProductByCategoryBlock = ( props: Props ): JSX.Element => {
 		<>
 			{ __(
 				'Select at least one category to display its products.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-category/edit-mode.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-category/edit-mode.tsx
@@ -48,7 +48,7 @@ export const ProductsByCategoryEditMode = (
 		debouncedSpeak(
 			__(
 				'Now displaying a preview of the reviews for the products in the selected categories.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			)
 		);
 	};
@@ -58,7 +58,7 @@ export const ProductsByCategoryEditMode = (
 		debouncedSpeak(
 			__(
 				'Now displaying a preview of the reviews for the products in the selected categories.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			)
 		);
 	};
@@ -68,13 +68,13 @@ export const ProductsByCategoryEditMode = (
 			icon={ <Icon icon={ file } /> }
 			label={ __(
 				'Products by Category',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			className="wc-block-products-grid wc-block-products-category"
 		>
 			{ __(
 				'Display a grid of products from your selected categories.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			<div className="wc-block-products-category__selection">
 				<ProductCategoryControl
@@ -89,14 +89,14 @@ export const ProductsByCategoryEditMode = (
 					}
 				/>
 				<Button variant="primary" onClick={ onDone }>
-					{ __( 'Done', 'woo-gutenberg-products-block' ) }
+					{ __( 'Done', 'woocommerce' ) }
 				</Button>
 				<Button
 					className="wc-block-products-category__cancel-button"
 					variant="tertiary"
 					onClick={ onCancel }
 				>
-					{ __( 'Cancel', 'woo-gutenberg-products-block' ) }
+					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>
 			</div>
 		</Placeholder>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-category/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-category/edit.tsx
@@ -40,7 +40,7 @@ const EditBlock = ( props: Props ): JSX.Element => {
 							icon: 'edit',
 							title: __(
 								'Edit selected categories',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							onClick: () => setIsEditing( ! isEditing ),
 							isActive: isEditing,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-category/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-category/inspector-controls.tsx
@@ -41,7 +41,7 @@ export const ProductsByCategoryInspectorControls = (
 			<PanelBody
 				title={ __(
 					'Product Category',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ ! attributes.categories.length && ! isEditing }
 			>
@@ -65,7 +65,7 @@ export const ProductsByCategoryInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Layout', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridLayoutControl
@@ -80,7 +80,7 @@ export const ProductsByCategoryInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Content', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridContentControl
@@ -91,7 +91,7 @@ export const ProductsByCategoryInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Order By', 'woocommerce' ) }
 				initialOpen={ false }
 			>
 				<ProductOrderbyControl
@@ -102,7 +102,7 @@ export const ProductsByCategoryInspectorControls = (
 			<PanelBody
 				title={ __(
 					'Filter by stock status',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ false }
 			>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/attributes-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/attributes-control.tsx
@@ -32,12 +32,12 @@ const AttributesControl = ( {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Product Attributes', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Product Attributes', 'woocommerce' ) }
 			hasValue={ () => !! woocommerceAttributes?.length }
 		>
 			<ProductAttributeTermControl
 				messages={ {
-					search: __( 'Attributes', 'woo-gutenberg-products-block' ),
+					search: __( 'Attributes', 'woocommerce' ),
 				} }
 				selected={ selectedAttributes || [] }
 				onChange={ ( searchListItems: SearchListItem[] ) => {
@@ -60,7 +60,7 @@ const AttributesControl = ( {
 				className="wc-block-editor-product-collection-panel__manage-attributes-link"
 				href={ EDIT_ATTRIBUTES_URL }
 			>
-				{ __( 'Manage attributes', 'woo-gutenberg-products-block' ) }
+				{ __( 'Manage attributes', 'woocommerce' ) }
 			</ExternalLink>
 		</ToolsPanelItem>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/columns-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/columns-control.tsx
@@ -16,11 +16,11 @@ import {
 import { DisplayLayoutToolbarProps } from '../../types';
 import { getDefaultDisplayLayout } from '../../constants';
 
-const columnsLabel = __( 'Columns', 'woo-gutenberg-products-block' );
-const toggleLabel = __( 'Responsive', 'woo-gutenberg-products-block' );
+const columnsLabel = __( 'Columns', 'woocommerce' );
+const toggleLabel = __( 'Responsive', 'woocommerce' );
 const toggleHelp = __(
 	'Automatically adjust the number of columns to better fit smaller screens.',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 
 const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/created-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/created-control.tsx
@@ -30,7 +30,7 @@ const CreatedControl = ( props: QueryControlProps ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Created', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Created', 'woocommerce' ) }
 			hasValue={ () => timeFrame?.operator && timeFrame?.value }
 			onDeselect={ () => {
 				setQueryAttribute( {
@@ -43,7 +43,7 @@ const CreatedControl = ( props: QueryControlProps ) => {
 					<ToggleGroupControl
 						label={ __(
 							'Created',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						isBlock
 						onChange={ ( value: ETimeFrameOperator ) => {
@@ -61,7 +61,7 @@ const CreatedControl = ( props: QueryControlProps ) => {
 							label={ _x(
 								'Within',
 								'Product Collection query operator',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
@@ -69,7 +69,7 @@ const CreatedControl = ( props: QueryControlProps ) => {
 							label={ _x(
 								'Before',
 								'Product Collection query operator',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/featured-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/featured-products-control.tsx
@@ -20,7 +20,7 @@ const FeaturedProductsControl = ( props: QueryControlProps ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Featured', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Featured', 'woocommerce' ) }
 			hasValue={ () => query.featured === true }
 			onDeselect={ () => {
 				setQueryAttribute( {
@@ -30,12 +30,12 @@ const FeaturedProductsControl = ( props: QueryControlProps ) => {
 		>
 			<BaseControl
 				id="product-collection-featured-products-control"
-				label={ __( 'Featured', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Featured', 'woocommerce' ) }
 			>
 				<ToggleControl
 					label={ __(
 						'Show only featured products',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ query.featured || false }
 					onChange={ ( featured ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
@@ -113,7 +113,7 @@ const HandPickedProductsControl = ( {
 		<ToolsPanelItem
 			label={ __(
 				'Hand-picked Products',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			hasValue={ () => !! selectedProductIds?.length }
 			onDeselect={ () => {
@@ -127,7 +127,7 @@ const HandPickedProductsControl = ( {
 				displayTransform={ transformTokenIntoProductName }
 				label={ __(
 					'Hand-picked Products',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				onChange={ onTokenChange }
 				suggestions={ suggestions }
@@ -137,7 +137,7 @@ const HandPickedProductsControl = ( {
 				}
 				value={
 					! productsMap.size
-						? [ __( 'Loading…', 'woo-gutenberg-products-block' ) ]
+						? [ __( 'Loading…', 'woocommerce' ) ]
 						: selectedProductIds || []
 				}
 				__experimentalExpandOnFocus={ true }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -67,7 +67,7 @@ const ProductCollectionInspectorControls = (
 	return (
 		<InspectorControls>
 			<ToolsPanel
-				label={ __( 'Settings', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Settings', 'woocommerce' ) }
 				resetAll={ () => {
 					const defaultSettings = getDefaultSettings(
 						props.attributes
@@ -85,7 +85,7 @@ const ProductCollectionInspectorControls = (
 
 			{ displayQueryControls ? (
 				<ToolsPanel
-					label={ __( 'Filters', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Filters', 'woocommerce' ) }
 					resetAll={ ( resetAllFilters: ( () => void )[] ) => {
 						setQueryAttribute( props, DEFAULT_FILTERS );
 						resetAllFilters.forEach( ( resetFilter ) =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/inherit-query-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/inherit-query-control.tsx
@@ -22,7 +22,7 @@ import { getDefaultValueOfInheritQueryFromTemplate } from '../../utils';
 
 const label = __(
 	'Inherit query from template',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 
 interface InheritQueryControlProps {
@@ -71,7 +71,7 @@ const InheritQueryControl = ( {
 				label={ label }
 				help={ __(
 					'Toggle to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				checked={ !! inherit }
 				onChange={ ( newInherit ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/keyword-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/keyword-control.tsx
@@ -36,12 +36,12 @@ const KeywordControl = ( props: QueryControlProps ) => {
 	return (
 		<ToolsPanelItem
 			hasValue={ () => !! querySearch }
-			label={ __( 'Keyword', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Keyword', 'woocommerce' ) }
 			onDeselect={ () => setQuerySearch( '' ) }
 			resetAllFilter={ () => setQuerySearch( '' ) }
 		>
 			<TextControl
-				label={ __( 'Keyword', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Keyword', 'woocommerce' ) }
 				value={ querySearch }
 				onChange={ setQuerySearch }
 			/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/layout-options-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/layout-options-control.tsx
@@ -26,12 +26,12 @@ const getHelpText = ( layoutOptions: LayoutOptions ) => {
 		case LayoutOptions.GRID:
 			return __(
 				'Display products using rows and columns.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		case LayoutOptions.STACK:
 			return __(
 				'Display products in a single column.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		default:
 			return '';
@@ -54,7 +54,7 @@ const LayoutOptionsControl = ( props: DisplayLayoutToolbarProps ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Layout', 'woocommerce' ) }
 			hasValue={ () => type !== DEFAULT_VALUE }
 			isShownByDefault
 			onDeselect={ () => {
@@ -62,7 +62,7 @@ const LayoutOptionsControl = ( props: DisplayLayoutToolbarProps ) => {
 			} }
 		>
 			<ToggleGroupControl
-				label={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Layout', 'woocommerce' ) }
 				isBlock
 				onChange={ ( value: LayoutOptions ) => {
 					setDisplayLayout( value );
@@ -72,11 +72,11 @@ const LayoutOptionsControl = ( props: DisplayLayoutToolbarProps ) => {
 			>
 				<ToggleGroupControlOption
 					value={ LayoutOptions.STACK }
-					label={ __( 'Stack', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Stack', 'woocommerce' ) }
 				/>
 				<ToggleGroupControlOption
 					value={ LayoutOptions.GRID }
-					label={ __( 'Grid', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Grid', 'woocommerce' ) }
 				/>
 			</ToggleGroupControl>
 		</ToolsPanelItem>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/on-sale-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/on-sale-control.tsx
@@ -19,7 +19,7 @@ const OnSaleControl = ( props: QueryControlProps ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'On Sale', 'woo-gutenberg-products-block' ) }
+			label={ __( 'On Sale', 'woocommerce' ) }
 			hasValue={ () => query.woocommerceOnSale === true }
 			isShownByDefault
 			onDeselect={ () => {
@@ -31,7 +31,7 @@ const OnSaleControl = ( props: QueryControlProps ) => {
 			<ToggleControl
 				label={ __(
 					'Show only products on sale',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				checked={ query.woocommerceOnSale || false }
 				onChange={ ( woocommerceOnSale ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
@@ -21,28 +21,28 @@ import { getDefaultQuery } from '../../constants';
 
 const orderOptions = [
 	{
-		label: __( 'A → Z', 'woo-gutenberg-products-block' ),
+		label: __( 'A → Z', 'woocommerce' ),
 		value: 'title/asc',
 	},
 	{
-		label: __( 'Z → A', 'woo-gutenberg-products-block' ),
+		label: __( 'Z → A', 'woocommerce' ),
 		value: 'title/desc',
 	},
 	{
-		label: __( 'Newest to oldest', 'woo-gutenberg-products-block' ),
+		label: __( 'Newest to oldest', 'woocommerce' ),
 		value: 'date/desc',
 	},
 	{
-		label: __( 'Oldest to newest', 'woo-gutenberg-products-block' ),
+		label: __( 'Oldest to newest', 'woocommerce' ),
 		value: 'date/asc',
 	},
 	{
 		value: 'popularity/desc',
-		label: __( 'Best Selling', 'woo-gutenberg-products-block' ),
+		label: __( 'Best Selling', 'woocommerce' ),
 	},
 	{
 		value: 'rating/desc',
-		label: __( 'Top Rated', 'woo-gutenberg-products-block' ),
+		label: __( 'Top Rated', 'woocommerce' ),
 	},
 ];
 
@@ -53,7 +53,7 @@ const OrderByControl = ( props: QueryControlProps ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Order by', 'woocommerce' ) }
 			hasValue={ () =>
 				order !== defaultQuery?.order ||
 				orderBy !== defaultQuery?.orderBy
@@ -66,7 +66,7 @@ const OrderByControl = ( props: QueryControlProps ) => {
 			<SelectControl
 				value={ `${ orderBy }/${ order }` }
 				options={ orderOptions }
-				label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Order by', 'woocommerce' ) }
 				onChange={ ( value ) => {
 					const [ newOrderBy, newOrder ] = value.split( '/' );
 					setQueryAttribute( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
@@ -38,7 +38,7 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Stock status', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Stock status', 'woocommerce' ) }
 			hasValue={ () =>
 				! fastDeepEqual(
 					query.woocommerceStockStatus,
@@ -53,7 +53,7 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 			isShownByDefault
 		>
 			<FormTokenField
-				label={ __( 'Stock status', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Stock status', 'woocommerce' ) }
 				onChange={ ( statusLabels ) => {
 					const woocommerceStockStatus = statusLabels
 						.map( getStockStatusIdByLabel )

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
@@ -51,7 +51,7 @@ function TaxonomyControls( {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Taxonomies', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Taxonomies', 'woocommerce' ) }
 			hasValue={ () =>
 				Object.values( taxQuery || {} ).some(
 					( terms ) => !! terms.length

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/upgrade-notice.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/upgrade-notice.tsx
@@ -18,12 +18,12 @@ import {
 const notice = createInterpolateElement(
 	__(
 		'Products (Beta) block was upgraded to <strongText />, an updated version with new features and simplified settings.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	{
 		strongText: (
 			<strong>
-				{ __( `Product Collection`, 'woo-gutenberg-products-block' ) }
+				{ __( `Product Collection`, 'woocommerce' ) }
 			</strong>
 		),
 	}
@@ -31,7 +31,7 @@ const notice = createInterpolateElement(
 
 const buttonLabel = __(
 	'Revert to Products (Beta)',
-	'woo-gutenberg-products-block'
+	'woocommerce'
 );
 
 type UpgradeNoticeProps = {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/display-layout-toolbar.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/display-layout-toolbar.tsx
@@ -25,7 +25,7 @@ const DisplayLayoutToolbar = ( props: DisplayLayoutToolbarProps ) => {
 	const displayLayoutControls = [
 		{
 			icon: list,
-			title: __( 'List view', 'woo-gutenberg-products-block' ),
+			title: __( 'List view', 'woocommerce' ),
 			onClick: () =>
 				setDisplayLayout( {
 					type: LayoutOptions.STACK,
@@ -36,7 +36,7 @@ const DisplayLayoutToolbar = ( props: DisplayLayoutToolbarProps ) => {
 		},
 		{
 			icon: grid,
-			title: __( 'Grid view', 'woo-gutenberg-products-block' ),
+			title: __( 'Grid view', 'woocommerce' ),
 			onClick: () =>
 				setDisplayLayout( {
 					type: LayoutOptions.GRID,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/display-settings-toolbar.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/display-settings-toolbar.tsx
@@ -30,7 +30,7 @@ interface ToggleButtonProps {
 const ToggleButton = ( { onToggle }: ToggleButtonProps ) => (
 	<ToolbarButton
 		icon={ settings }
-		label={ __( 'Display settings', 'woo-gutenberg-products-block' ) }
+		label={ __( 'Display settings', 'woocommerce' ) }
 		onClick={ onToggle }
 	/>
 );
@@ -88,7 +88,7 @@ const DisplaySettingsToolbar = ( {
 							{ ...numberControlProps }
 							label={ __(
 								'Items per Page',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							min={ 1 }
 							max={ 100 }
@@ -100,7 +100,7 @@ const DisplaySettingsToolbar = ( {
 							{ ...numberControlProps }
 							label={ __(
 								'Offset',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							min={ 0 }
 							max={ 100 }
@@ -111,7 +111,7 @@ const DisplaySettingsToolbar = ( {
 						<BaseControl
 							help={ __(
 								'Limit the pages you want to show, even if the query has more results. To show all pages use 0 (zero).',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							id="woocommerce-products-block__display-settings-pages"
 						>
@@ -119,7 +119,7 @@ const DisplaySettingsToolbar = ( {
 								{ ...numberControlProps }
 								label={ __(
 									'Max page to show',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								min={ 0 }
 								onChange={ handlePagesChange }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/pattern-chooser-toolbar.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/pattern-chooser-toolbar.tsx
@@ -10,7 +10,7 @@ const DisplayLayoutControl = ( props: {
 	return (
 		<ToolbarGroup>
 			<ToolbarButton onClick={ props.openPatternSelectionModal }>
-				{ __( 'Choose pattern', 'woo-gutenberg-products-block' ) }
+				{ __( 'Choose pattern', 'woocommerce' ) }
 			</ToolbarButton>
 		</ToolbarGroup>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/pattern-selection-modal.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/pattern-selection-modal.tsx
@@ -60,7 +60,7 @@ const DisplayLayoutControl = ( props: {
 	return (
 		<Modal
 			overlayClassName="wc-blocks-product-collection__selection-modal"
-			title={ __( 'Choose a pattern', 'woo-gutenberg-products-block' ) }
+			title={ __( 'Choose a pattern', 'woocommerce' ) }
 			onRequestClose={ props.closePatternSelectionModal }
 			isFullScreen={ true }
 		>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/inner-blocks/no-results/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/inner-blocks/no-results/edit.tsx
@@ -24,7 +24,7 @@ const TEMPLATE: Template[] = [
 					fontSize: 'medium',
 					content: `<strong>${ __(
 						'No results found',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }</strong>`,
 				},
 			],
@@ -33,16 +33,16 @@ const TEMPLATE: Template[] = [
 				{
 					content: `${ __(
 						'You can try',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) } <a href="#" class="wc-link-clear-any-filters">${ __(
 						'clearing any filters',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }</a> ${ __(
 						'or head to our',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) } <a href="#" class="wc-link-stores-home">${ __(
 						"store's home",
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }</a>`,
 				},
 			],

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/block-settings/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/block-settings/index.tsx
@@ -31,7 +31,7 @@ export const ProductGalleryBlockSettings = ( {
 			<PanelBody
 				title={ __(
 					'Gallery Navigation',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				<ProductGalleryPagerBlockSettings
@@ -52,16 +52,16 @@ export const ProductGalleryBlockSettings = ( {
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Media Settings', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Media Settings', 'woocommerce' ) }
 			>
 				<ToggleControl
 					label={ __(
 						'Crop images to fit',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					help={ __(
 						'Images will be cropped to fit within a square space.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ cropImages }
 					onChange={ () =>
@@ -74,11 +74,11 @@ export const ProductGalleryBlockSettings = ( {
 				<ToggleControl
 					label={ __(
 						'Zoom while hovering',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					help={ __(
 						'While hovering the large image will zoom in by 30%.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ hoverZoom }
 					onChange={ () =>
@@ -90,11 +90,11 @@ export const ProductGalleryBlockSettings = ( {
 				<ToggleControl
 					label={ __(
 						'Full-screen when clicked',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					help={ __(
 						'Clicking on the large image will open a full-screen gallery experience.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ fullScreenOnClick }
 					onChange={ () =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/settings.tsx
@@ -30,22 +30,22 @@ const getHelpText = ( buttonPosition: NextPreviousButtonSettingValues ) => {
 		case NextPreviousButtonSettingValues.insideTheImage:
 			return __(
 				'Next and previous buttons will appear inside the large image.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		case NextPreviousButtonSettingValues.outsideTheImage:
 			return __(
 				'Next and previous buttons will appear on outside the large image.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		case 'off':
 			return __(
 				'No next or previous button will be displayed.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		default:
 			return __(
 				'No next or previous button will be displayed.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 	}
 };
@@ -60,7 +60,7 @@ export const ProductGalleryNextPreviousBlockSettings = ( {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	return (
 		<ToggleGroupControl
-			label={ __( 'Next/Prev Buttons', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Next/Prev Buttons', 'woocommerce' ) }
 			className="wc-block-editor-product-gallery-large-image-next-previous-settings"
 			style={ {
 				width: '100%',
@@ -75,7 +75,7 @@ export const ProductGalleryNextPreviousBlockSettings = ( {
 		>
 			<ToggleGroupControlOption
 				value={ NextPreviousButtonSettingValues.off }
-				label={ __( 'Off', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Off', 'woocommerce' ) }
 			/>
 			<ToggleGroupControlOption
 				value={ NextPreviousButtonSettingValues.insideTheImage }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-pager/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-pager/settings.tsx
@@ -27,22 +27,22 @@ const getHelpText = ( pagerDisplayMode: PagerDisplayModes ) => {
 		case PagerDisplayModes.DIGITS:
 			return __(
 				'A list of numbers will show to indicate the number of items.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		case PagerDisplayModes.DOTS:
 			return __(
 				'A series of dots will show to indicate the number of items.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		case 'off':
 			return __(
 				'No pager will be displayed.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 		default:
 			return __(
 				'No pager will be displayed.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			);
 	}
 };
@@ -58,7 +58,7 @@ export const ProductGalleryPagerBlockSettings = ( {
 
 	return (
 		<ToggleGroupControl
-			label={ __( 'Pager', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Pager', 'woocommerce' ) }
 			style={ {
 				width: '100%',
 			} }
@@ -72,7 +72,7 @@ export const ProductGalleryPagerBlockSettings = ( {
 		>
 			<ToggleGroupControlOption
 				value={ PagerDisplayModes.OFF }
-				label={ __( 'Off', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Off', 'woocommerce' ) }
 			/>
 			<ToggleGroupControlOption
 				value={ PagerDisplayModes.DOTS }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/block-settings/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/block-settings/index.tsx
@@ -31,19 +31,19 @@ import type { ProductGalleryThumbnailsSettingsProps } from '../../../types';
 const positionHelp: Record< ThumbnailsPosition, string > = {
 	[ ThumbnailsPosition.OFF ]: __(
 		'No thumbnails will be displayed.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	[ ThumbnailsPosition.LEFT ]: __(
 		'A strip of small images will appear to the left of the main gallery image.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	[ ThumbnailsPosition.BOTTOM ]: __(
 		'A strip of small images will appear below the main gallery image.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	[ ThumbnailsPosition.RIGHT ]: __(
 		'A strip of small images will appear to the right of the main gallery image.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 
@@ -61,7 +61,7 @@ export const ProductGalleryThumbnailsBlockSettings = ( {
 			<ToggleGroupControl
 				className="wc-block-editor-product-gallery-thumbnails__position-toggle"
 				isBlock={ true }
-				label={ __( 'Thumbnails', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Thumbnails', 'woocommerce' ) }
 				value={ context.thumbnailsPosition }
 				help={
 					positionHelp[
@@ -76,7 +76,7 @@ export const ProductGalleryThumbnailsBlockSettings = ( {
 			>
 				<ToggleGroupControlOption
 					value={ ThumbnailsPosition.OFF }
-					label={ __( 'Off', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Off', 'woocommerce' ) }
 				/>
 				<ToggleGroupControlOption
 					value={ ThumbnailsPosition.LEFT }
@@ -101,7 +101,7 @@ export const ProductGalleryThumbnailsBlockSettings = ( {
 				<RangeControl
 					label={ __(
 						'Number of Thumbnails',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ context.thumbnailsNumberOfThumbnails }
 					onChange={ ( value: number ) =>
@@ -111,7 +111,7 @@ export const ProductGalleryThumbnailsBlockSettings = ( {
 					}
 					help={ __(
 						'Choose how many thumbnails (3-8) will display. If more images exist, a “View all” button will display.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					max={ maxNumberOfThumbnails }
 					min={ minNumberOfThumbnails }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-new/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-new/block.tsx
@@ -38,7 +38,7 @@ export const ProductNewestBlock = ( {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
-					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Layout', 'woocommerce' ) }
 					initialOpen
 				>
 					<GridLayoutControl
@@ -53,7 +53,7 @@ export const ProductNewestBlock = ( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 					initialOpen
 				>
 					<GridContentControl
@@ -66,7 +66,7 @@ export const ProductNewestBlock = ( {
 				<PanelBody
 					title={ __(
 						'Filter by stock status',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen={ false }
 				>
@@ -78,7 +78,7 @@ export const ProductNewestBlock = ( {
 				<PanelBody
 					title={ __(
 						'Filter by Product Category',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen={ false }
 				>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-new/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-new/index.tsx
@@ -16,7 +16,7 @@ import { Edit } from './edit';
 import metadata from './block.json';
 
 registerBlockType( metadata, {
-	title: __( 'Newest Products', 'woo-gutenberg-products-block' ),
+	title: __( 'Newest Products', 'woocommerce' ),
 	icon: {
 		src: (
 			<Icon

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-on-sale/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-on-sale/block.tsx
@@ -22,12 +22,12 @@ interface Props {
 const EmptyPlaceholder = () => (
 	<Placeholder
 		icon={ <Icon icon={ percent } /> }
-		label={ __( 'On Sale Products', 'woo-gutenberg-products-block' ) }
+		label={ __( 'On Sale Products', 'woocommerce' ) }
 		className="wc-block-product-on-sale"
 	>
 		{ __(
 			'This block shows on-sale products. There are currently no discounted products in your store.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
 	</Placeholder>
 );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-on-sale/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-on-sale/inspector-controls.tsx
@@ -39,7 +39,7 @@ export const ProductOnSaleInspectorControls = (
 	return (
 		<InspectorControls key="inspector">
 			<PanelBody
-				title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Layout', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridLayoutControl
@@ -54,7 +54,7 @@ export const ProductOnSaleInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Content', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridContentControl
@@ -65,7 +65,7 @@ export const ProductOnSaleInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Order By', 'woocommerce' ) }
 				initialOpen={ false }
 			>
 				<ProductOrderbyControl
@@ -76,7 +76,7 @@ export const ProductOnSaleInspectorControls = (
 			<PanelBody
 				title={ __(
 					'Filter by Product Category',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ false }
 			>
@@ -95,7 +95,7 @@ export const ProductOnSaleInspectorControls = (
 			<PanelBody
 				title={ __(
 					'Filter by stock status',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ false }
 			>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls.tsx
@@ -115,11 +115,11 @@ export const WooInheritToggleControl = (
 			className="woo-inherit-query-toggle"
 			label={ __(
 				'Inherit query from template',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			help={ __(
 				'Toggle to use the global query context that is set with the current template, such as variations of the product catalog or search. Disable to customize the filtering independently.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			checked={
 				isCustomInheritGlobalQueryImplementationEnabled
@@ -170,13 +170,13 @@ export const TOOLS_PANEL_CONTROLS = {
 
 		return (
 			<ToolsPanelItem
-				label={ __( 'Sale status', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Sale status', 'woocommerce' ) }
 				hasValue={ () => query.__woocommerceOnSale }
 			>
 				<ToggleControl
 					label={ __(
 						'Show only products on sale',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					checked={ query.__woocommerceOnSale || false }
 					onChange={ ( __woocommerceOnSale ) => {
@@ -194,13 +194,13 @@ export const TOOLS_PANEL_CONTROLS = {
 
 		return (
 			<ToolsPanelItem
-				label={ __( 'Stock status', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Stock status', 'woocommerce' ) }
 				hasValue={ () => query.__woocommerceStockStatus }
 			>
 				<FormTokenField
 					label={ __(
 						'Stock status',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					onChange={ ( statusLabels ) => {
 						const __woocommerceStockStatus = statusLabels
@@ -247,7 +247,7 @@ const ProductQueryControls = ( props: ProductQueryBlock ) => {
 					className="woocommerce-product-query-toolspanel"
 					label={ __(
 						'Advanced Filters',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					resetAll={ () => {
 						setQueryAttribute( props, defaultWooQueryParams );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/attributes-filter.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/attributes-filter.tsx
@@ -33,12 +33,12 @@ export const AttributesFilter = ( props: ProductQueryBlock ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Product Attributes', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Product Attributes', 'woocommerce' ) }
 			hasValue={ () => query.__woocommerceAttributes?.length }
 		>
 			<ProductAttributeTermControl
 				messages={ {
-					search: __( 'Attributes', 'woo-gutenberg-products-block' ),
+					search: __( 'Attributes', 'woocommerce' ),
 				} }
 				selected={ selected }
 				onChange={ ( attributes ) => {
@@ -62,7 +62,7 @@ export const AttributesFilter = ( props: ProductQueryBlock ) => {
 				className="woocommerce-product-query-panel__external-link"
 				href={ EDIT_ATTRIBUTES_URL }
 			>
-				{ __( 'Manage attributes', 'woo-gutenberg-products-block' ) }
+				{ __( 'Manage attributes', 'woocommerce' ) }
 			</ExternalLink>
 		</ToolsPanelItem>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
@@ -13,16 +13,16 @@ import { setQueryAttribute } from '../utils';
 const PRESETS = [
 	{
 		key: 'title/asc',
-		name: __( 'Sorted by title', 'woo-gutenberg-products-block' ),
+		name: __( 'Sorted by title', 'woocommerce' ),
 	},
-	{ key: 'date/desc', name: __( 'Newest', 'woo-gutenberg-products-block' ) },
+	{ key: 'date/desc', name: __( 'Newest', 'woocommerce' ) },
 	{
 		key: 'popularity/desc',
-		name: __( 'Best Selling', 'woo-gutenberg-products-block' ),
+		name: __( 'Best Selling', 'woocommerce' ),
 	},
 	{
 		key: 'rating/desc',
-		name: __( 'Top Rated', 'woo-gutenberg-products-block' ),
+		name: __( 'Top Rated', 'woocommerce' ),
 	},
 ];
 
@@ -32,20 +32,20 @@ export function PopularPresets( props: ProductQueryBlock ) {
 	return (
 		<PanelBody
 			className="woocommerce-product-query-panel__sort"
-			title={ __( 'Popular Filters', 'woo-gutenberg-products-block' ) }
+			title={ __( 'Popular Filters', 'woocommerce' ) }
 			initialOpen={ true }
 		>
 			<p>
 				{ __(
 					'Arrange products by popular pre-sets.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 			<CustomSelectControl
 				hideLabelFromVision={ true }
 				label={ __(
 					'Choose among these pre-sets',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				onChange={ ( option ) => {
 					if ( ! option.selectedItem?.key ) return;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/product-selector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/product-selector.tsx
@@ -74,7 +74,7 @@ export const ProductSelector = ( props: ProductQueryBlock ) => {
 		<ToolsPanelItem
 			label={ __(
 				'Hand-picked Products',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			hasValue={ () => query.include?.length }
 		>
@@ -89,7 +89,7 @@ export const ProductSelector = ( props: ProductQueryBlock ) => {
 				}
 				label={ __(
 					'Pick some products',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				onChange={ onTokenChange }
 				suggestions={ productsList.map( ( product ) => product.name ) }
@@ -98,7 +98,7 @@ export const ProductSelector = ( props: ProductQueryBlock ) => {
 				}
 				value={
 					! productsList.length
-						? [ __( 'Loading…', 'woo-gutenberg-products-block' ) ]
+						? [ __( 'Loading…', 'woocommerce' ) ]
 						: query?.include || []
 				}
 				__experimentalExpandOnFocus={ true }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/upgrade-notice.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/upgrade-notice.tsx
@@ -9,14 +9,14 @@ export const UpgradeNotice = ( props: { upgradeBlock: () => void } ) => {
 	const notice = createInterpolateElement(
 		__(
 			'Upgrade all Products (Beta) blocks on this page to <strongText /> for more features!',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		{
 			strongText: (
 				<strong>
 					{ __(
 						`Product Collection`,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</strong>
 			),
@@ -25,7 +25,7 @@ export const UpgradeNotice = ( props: { upgradeBlock: () => void } ) => {
 
 	const buttonLabel = __(
 		'Upgrade to Product Collection',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 
 	const handleClick = () => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/elements/product-template.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/elements/product-template.tsx
@@ -16,10 +16,10 @@ export const VARIATION_NAME = 'woocommerce/product-query/product-template';
 registerElementVariation( CORE_NAME, {
 	blockDescription: __(
 		'Contains the block elements used to render a product, like its name, featured image, rating, and more.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	blockIcon: <Icon icon={ layout } />,
-	blockTitle: __( 'Product template', 'woo-gutenberg-products-block' ),
+	blockTitle: __( 'Product template', 'woocommerce' ),
 	variationName: VARIATION_NAME,
 	scope: [ 'block', 'inserter' ],
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/product-query.tsx
@@ -40,11 +40,11 @@ const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
 	registerBlockVariation( QUERY_LOOP_ID, {
 		description: __(
 			'A block that displays a selection of products in your store.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		name: PRODUCT_QUERY_VARIATION_NAME,
 		/* translators: “Products“ is the name of the block. */
-		title: __( 'Products (Beta)', 'woo-gutenberg-products-block' ),
+		title: __( 'Products (Beta)', 'woocommerce' ),
 		isActive: ( blockAttributes ) =>
 			blockAttributes.namespace === PRODUCT_QUERY_VARIATION_NAME,
 		icon: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/related-products.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/related-products.tsx
@@ -56,7 +56,7 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		'core/heading',
 		{
 			level: 2,
-			content: __( 'Related products', 'woo-gutenberg-products-block' ),
+			content: __( 'Related products', 'woocommerce' ),
 			style: { spacing: { margin: { top: '1rem', bottom: '1rem' } } },
 		},
 	],
@@ -123,12 +123,12 @@ registerBlockSingleProductTemplate( {
 	blockSettings: {
 		description: __(
 			'Display related products.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		name: 'Related Products Controls',
 		title: __(
 			'Related Products Controls',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		// @ts-expect-error: `isActive` exists on Block Variation configuration
 		isActive: ( blockAttributes: BlockAttributes ) =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-results-count/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-results-count/edit.tsx
@@ -18,7 +18,7 @@ const Edit = () => {
 			<p className="woocommerce-result-count">
 				{ __(
 					'Showing 1-X of X results',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/block.tsx
@@ -70,7 +70,7 @@ const ProductSearchBlock = ( {
 						className="wc-block-product-search__button"
 						aria-label={ __(
 							'Search',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					>
 						<svg

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/edit.tsx
@@ -70,13 +70,13 @@ const Edit = ( {
 		<>
 			<InspectorControls key="inspector">
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 					initialOpen
 				>
 					<ToggleControl
 						label={ __(
 							'Show search field label',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ hasLabel }
 						onChange={ () =>
@@ -94,7 +94,7 @@ const Edit = ( {
 						>
 							{ __(
 								'Search Label',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</label>
 						<PlainText
@@ -114,7 +114,7 @@ const Edit = ( {
 						value={ placeholder }
 						placeholder={ __(
 							'Enter search placeholder text',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						onChange={ ( value ) =>
 							setAttributes( { placeholder: value } )
@@ -125,7 +125,7 @@ const Edit = ( {
 						className="wc-block-product-search__button"
 						aria-label={ __(
 							'Search',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						onClick={ ( e ) => e.preventDefault() }
 						tabIndex={ -1 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/index.tsx
@@ -44,7 +44,7 @@ const attributes = {
 	 */
 	label: {
 		type: 'string',
-		default: __( 'Search', 'woo-gutenberg-products-block' ),
+		default: __( 'Search', 'woocommerce' ),
 	},
 
 	/**
@@ -52,7 +52,7 @@ const attributes = {
 	 */
 	placeholder: {
 		type: 'string',
-		default: __( 'Search products…', 'woo-gutenberg-products-block' ),
+		default: __( 'Search products…', 'woocommerce' ),
 	},
 
 	/**
@@ -101,7 +101,7 @@ const DeprecatedBlockEdit = ( { clientId }: { clientId: string } ) => {
 
 	const actions = [
 		<Button key="update" onClick={ updateBlock } variant="primary">
-			{ __( 'Upgrade Block', 'woo-gutenberg-products-block' ) }
+			{ __( 'Upgrade Block', 'woocommerce' ) }
 		</Button>,
 	];
 
@@ -109,14 +109,14 @@ const DeprecatedBlockEdit = ( { clientId }: { clientId: string } ) => {
 		<Warning actions={ actions } className="wc-block-components-actions">
 			{ __(
 				'This version of the Product Search block is outdated. Upgrade to continue using.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</Warning>
 	);
 };
 
 registerBlockType( 'woocommerce/product-search', {
-	title: __( 'Product Search', 'woo-gutenberg-products-block' ),
+	title: __( 'Product Search', 'woocommerce' ),
 	icon: {
 		src: (
 			<Icon
@@ -126,10 +126,10 @@ registerBlockType( 'woocommerce/product-search', {
 		),
 	},
 	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 	description: __(
 		'A search box to allow customers to search for products by keyword.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
@@ -174,7 +174,7 @@ registerBlockType( 'woocommerce/product-search', {
 if ( isBlockVariationAvailable ) {
 	registerBlockVariation( 'core/search', {
 		name: 'woocommerce/product-search',
-		title: __( 'Product Search', 'woo-gutenberg-products-block' ),
+		title: __( 'Product Search', 'woocommerce' ),
 		icon: {
 			src: (
 				<Icon
@@ -191,10 +191,10 @@ if ( isBlockVariationAvailable ) {
 			);
 		},
 		category: 'woocommerce',
-		keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+		keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 		description: __(
 			'A search box to allow customers to search for products by keyword.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		attributes: PRODUCT_SEARCH_ATTRIBUTES,
 	} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-tag/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-tag/block.tsx
@@ -81,7 +81,7 @@ const ProductsByTagBlock = ( {
 				<PanelBody
 					title={ __(
 						'Product Tag',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen={ ! attributes.tags.length && ! isEditing }
 				>
@@ -99,7 +99,7 @@ const ProductsByTagBlock = ( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Layout', 'woocommerce' ) }
 					initialOpen
 				>
 					<GridLayoutControl
@@ -130,7 +130,7 @@ const ProductsByTagBlock = ( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 					initialOpen
 				>
 					<GridContentControl
@@ -141,7 +141,7 @@ const ProductsByTagBlock = ( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Order By', 'woocommerce' ) }
 					initialOpen={ false }
 				>
 					<ProductOrderbyControl
@@ -152,7 +152,7 @@ const ProductsByTagBlock = ( {
 				<PanelBody
 					title={ __(
 						'Filter by stock status',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen={ false }
 				>
@@ -172,7 +172,7 @@ const ProductsByTagBlock = ( {
 			debouncedSpeak(
 				__(
 					'Showing Products by Tag block preview.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				)
 			);
 		};
@@ -181,7 +181,7 @@ const ProductsByTagBlock = ( {
 			debouncedSpeak(
 				__(
 					'Showing Products by Tag block preview.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				)
 			);
 		};
@@ -193,13 +193,13 @@ const ProductsByTagBlock = ( {
 				}
 				label={ __(
 					'Products by Tag',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				className="wc-block-products-grid wc-block-product-tag"
 			>
 				{ __(
 					'Display a grid of products from your selected tags.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				<div className="wc-block-product-tag__selection">
 					<ProductTagControl
@@ -220,14 +220,14 @@ const ProductsByTagBlock = ( {
 						}
 					/>
 					<Button variant="primary" onClick={ onDone }>
-						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+						{ __( 'Done', 'woocommerce' ) }
 					</Button>
 					<Button
 						className="wc-block-product-tag__cancel-button"
 						variant="tertiary"
 						onClick={ onCancel }
 					>
-						{ __( 'Cancel', 'woo-gutenberg-products-block' ) }
+						{ __( 'Cancel', 'woocommerce' ) }
 					</Button>
 				</div>
 			</Placeholder>
@@ -253,13 +253,13 @@ const ProductsByTagBlock = ( {
 						}
 						label={ __(
 							'Products by Tag',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						className="wc-block-products-grid wc-block-product-tag"
 					>
 						{ __(
 							'This block displays products from selected tags. Select at least one tag to display its products.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</Placeholder>
 				) }
@@ -280,7 +280,7 @@ const ProductsByTagBlock = ( {
 							icon: 'edit',
 							title: __(
 								'Edit selected tags',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							onClick: () =>
 								isEditing ? stopEditing() : startEditing(),
@@ -295,12 +295,12 @@ const ProductsByTagBlock = ( {
 	) : (
 		<Placeholder
 			icon={ <Icon icon={ tag } className="block-editor-block-icon" /> }
-			label={ __( 'Products by Tag', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Products by Tag', 'woocommerce' ) }
 			className="wc-block-products-grid wc-block-product-tag"
 		>
 			{ __(
 				'This block displays products from selected tags. To use it you first need to create products and assign tags to them.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</Placeholder>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
@@ -229,7 +229,7 @@ const ProductTemplateEdit = ( {
 		return (
 			<p { ...blockProps }>
 				{ ' ' }
-				{ __( 'No results found.', 'woo-gutenberg-products-block' ) }
+				{ __( 'No results found.', 'woocommerce' ) }
 			</p>
 		);
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-top-rated/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-top-rated/block.tsx
@@ -39,7 +39,7 @@ export const ProductTopRatedBlock = ( {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
-					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Layout', 'woocommerce' ) }
 					initialOpen
 				>
 					<GridLayoutControl
@@ -54,7 +54,7 @@ export const ProductTopRatedBlock = ( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 					initialOpen
 				>
 					<GridContentControl
@@ -67,7 +67,7 @@ export const ProductTopRatedBlock = ( {
 				<PanelBody
 					title={ __(
 						'Filter by Product Category',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen={ false }
 				>
@@ -86,7 +86,7 @@ export const ProductTopRatedBlock = ( {
 				<PanelBody
 					title={ __(
 						'Filter by stock status',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					initialOpen={ false }
 				>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-top-rated/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-top-rated/index.tsx
@@ -25,10 +25,10 @@ registerBlockType( metadata, {
 		),
 	},
 	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 	description: __(
 		'Display a grid of your top rated products.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	attributes: {
 		...sharedAttributes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/edit-mode.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/edit-mode.tsx
@@ -32,7 +32,7 @@ export const ProductsByAttributeEditMode = (
 		debouncedSpeak(
 			__(
 				'Showing Products by Attribute block preview.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			)
 		);
 	};
@@ -42,13 +42,13 @@ export const ProductsByAttributeEditMode = (
 			icon={ <Icon icon={ category } /> }
 			label={ __(
 				'Products by Attribute',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			className="wc-block-products-grid wc-block-products-by-attribute"
 		>
 			{ __(
 				'Display a grid of products from your selected attributes.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 			<div className="wc-block-products-by-attribute__selection">
 				<ProductAttributeTermControl
@@ -68,7 +68,7 @@ export const ProductsByAttributeEditMode = (
 					}
 				/>
 				<Button variant="primary" onClick={ onDone }>
-					{ __( 'Done', 'woo-gutenberg-products-block' ) }
+					{ __( 'Done', 'woocommerce' ) }
 				</Button>
 			</div>
 		</Placeholder>

--- a/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/edit.tsx
@@ -37,7 +37,7 @@ export const EditBlock = ( props: Props ): JSX.Element => {
 							icon: 'edit',
 							title: __(
 								'Edit selected attribute',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							onClick: () => setIsEditing( ! isEditing ),
 							isActive: isEditing,

--- a/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/inspector-controls.tsx
@@ -34,7 +34,7 @@ export const ProductsByAttributeInspectorControls = (
 	return (
 		<InspectorControls key="inspector">
 			<PanelBody
-				title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Layout', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridLayoutControl
@@ -49,7 +49,7 @@ export const ProductsByAttributeInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Content', 'woocommerce' ) }
 				initialOpen
 			>
 				<GridContentControl
@@ -62,7 +62,7 @@ export const ProductsByAttributeInspectorControls = (
 			<PanelBody
 				title={ __(
 					'Filter by Product Attribute',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ false }
 			>
@@ -85,7 +85,7 @@ export const ProductsByAttributeInspectorControls = (
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+				title={ __( 'Order By', 'woocommerce' ) }
 				initialOpen={ false }
 			>
 				<ProductOrderbyControl
@@ -96,7 +96,7 @@ export const ProductsByAttributeInspectorControls = (
 			<PanelBody
 				title={ __(
 					'Filter by stock status',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				initialOpen={ false }
 			>

--- a/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/block.tsx
@@ -43,7 +43,7 @@ const translations = {
 			/* translators: %s is referring to the average rating value */
 			__(
 				'Rated %s out of 5 filter added.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			rating
 		),
@@ -52,7 +52,7 @@ const translations = {
 			/* translators: %s is referring to the average rating value */
 			__(
 				'Rated %s out of 5 filter added.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			rating
 		),
@@ -356,7 +356,7 @@ const RatingFilterBlock = ( {
 							disabled={ isLoading }
 							placeholder={ __(
 								'Select Rating',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							onChange={ ( tokens: string[] ) => {
 								if ( ! multiple && tokens.length > 1 ) {
@@ -441,19 +441,19 @@ const RatingFilterBlock = ( {
 							messages={ {
 								added: __(
 									'Rating filter added.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								removed: __(
 									'Rating filter removed.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								remove: __(
 									'Remove rating filter.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								__experimentalInvalid: __(
 									'Invalid rating filter.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 							} }
 						/>
@@ -485,7 +485,7 @@ const RatingFilterBlock = ( {
 							} }
 							screenReaderLabel={ __(
 								'Reset rating filter',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/edit.tsx
@@ -29,7 +29,7 @@ const noRatingsNotice = (
 		<p>
 			{ __(
 				"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</p>
 	</Notice>
@@ -57,13 +57,13 @@ const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Display Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleControl
 						label={ __(
 							'Display product count',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showCounts }
 						onChange={ () =>
@@ -75,7 +75,7 @@ const Edit = ( {
 					<ToggleGroupControl
 						label={ __(
 							'Allow selecting multiple options?',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ selectType || 'multiple' }
 						onChange={ ( value: string ) =>
@@ -89,21 +89,21 @@ const Edit = ( {
 							value="multiple"
 							label={ __(
 								'Multiple',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="single"
 							label={ __(
 								'Single',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
 					<ToggleGroupControl
 						label={ __(
 							'Display Style',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ displayStyle }
 						onChange={ ( value: string ) =>
@@ -117,25 +117,25 @@ const Edit = ( {
 							value="list"
 							label={ __(
 								'List',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="dropdown"
 							label={ __(
 								'Dropdown',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
 					<ToggleControl
 						label={ __(
 							"Show 'Apply filters' button",
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Products will update when the button is clicked.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showFilterButton }
 						onChange={ ( value ) =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/all-reviews/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/all-reviews/block.tsx
@@ -32,12 +32,12 @@ const AllReviewsEditor = ( {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 				>
 					<ToggleControl
 						label={ __(
 							'Product name',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ attributes.showProductName }
 						onChange={ () =>
@@ -54,7 +54,7 @@ const AllReviewsEditor = ( {
 				<PanelBody
 					title={ __(
 						'List Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					{ getSharedReviewListControls( attributes, setAttributes ) }
@@ -74,7 +74,7 @@ const AllReviewsEditor = ( {
 						className="block-editor-block-icon"
 					/>
 				}
-				name={ __( 'All Reviews', 'woo-gutenberg-products-block' ) }
+				name={ __( 'All Reviews', 'woocommerce' ) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
 		</>

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/all-reviews/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/all-reviews/index.tsx
@@ -21,7 +21,7 @@ import type { AllReviewsEditorProps } from './types';
  */
 registerBlockType( 'woocommerce/all-reviews', {
 	apiVersion: 2,
-	title: __( 'All Reviews', 'woo-gutenberg-products-block' ),
+	title: __( 'All Reviews', 'woocommerce' ),
 	icon: {
 		src: (
 			<Icon
@@ -31,10 +31,10 @@ registerBlockType( 'woocommerce/all-reviews', {
 		),
 	},
 	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 	description: __(
 		'Show a list of all product reviews.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	supports: {
 		html: false,

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/all-reviews/no-reviews-placeholder.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/all-reviews/no-reviews-placeholder.tsx
@@ -15,11 +15,11 @@ const NoCategoryReviewsPlaceholder = (): JSX.Element => {
 					className="block-editor-block-icon"
 				/>
 			}
-			label={ __( 'All Reviews', 'woo-gutenberg-products-block' ) }
+			label={ __( 'All Reviews', 'woocommerce' ) }
 		>
 			{ __(
 				'This block shows a list of all product reviews. Your store does not have any reviews yet, but they will show up here when it does.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</Placeholder>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/editor-container-block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/editor-container-block.tsx
@@ -48,7 +48,7 @@ const EditorContainerBlock = ( {
 			<Placeholder icon={ icon } label={ name }>
 				{ __(
 					'The content for this block is hidden due to block settings.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</Placeholder>
 		);

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/frontend-block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/frontend-block.tsx
@@ -57,7 +57,7 @@ const FrontendBlock = ( {
 					onClick={ onAppendReviews }
 					screenReaderLabel={ __(
 						'Load more reviews',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				/>
 			) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/frontend-container-block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/frontend-container-block.tsx
@@ -76,7 +76,7 @@ class FrontendContainerBlock extends Component<
 					'%d review loaded.',
 					'%d reviews loaded.',
 					newReviews.length,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				newReviews.length
 			)
@@ -84,14 +84,14 @@ class FrontendContainerBlock extends Component<
 	}
 
 	onReviewsReplaced() {
-		speak( __( 'Reviews list updated.', 'woo-gutenberg-products-block' ) );
+		speak( __( 'Reviews list updated.', 'woocommerce' ) );
 	}
 
 	onReviewsLoadError() {
 		speak(
 			__(
 				'There was an error loading the reviews.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			)
 		);
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
@@ -44,7 +44,7 @@ const ReviewsByCategoryEditor = ( {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
-					title={ __( 'Category', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Category', 'woocommerce' ) }
 					initialOpen={ false }
 				>
 					<ProductCategoryControl
@@ -58,12 +58,12 @@ const ReviewsByCategoryEditor = ( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 				>
 					<ToggleControl
 						label={ __(
 							'Product name',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ attributes.showProductName }
 						onChange={ () =>
@@ -80,7 +80,7 @@ const ReviewsByCategoryEditor = ( {
 				<PanelBody
 					title={ __(
 						'List Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					{ getSharedReviewListControls( attributes, setAttributes ) }
@@ -95,7 +95,7 @@ const ReviewsByCategoryEditor = ( {
 			debouncedSpeak(
 				__(
 					'Now displaying a preview of the reviews for the products in the selected categories.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				)
 			);
 		};
@@ -110,13 +110,13 @@ const ReviewsByCategoryEditor = ( {
 				}
 				label={ __(
 					'Reviews by Category',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				className="wc-block-reviews-by-category"
 			>
 				{ __(
 					'Show product reviews from specific categories.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				<div className="wc-block-reviews__selection">
 					<ProductCategoryControl
@@ -128,7 +128,7 @@ const ReviewsByCategoryEditor = ( {
 						showReviewCount={ true }
 					/>
 					<Button variant="primary" onClick={ onDone }>
-						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+						{ __( 'Done', 'woocommerce' ) }
 					</Button>
 				</div>
 			</Placeholder>
@@ -141,7 +141,7 @@ const ReviewsByCategoryEditor = ( {
 
 	const buttonTitle = __(
 		'Edit selected categories',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 
 	return (
@@ -158,7 +158,7 @@ const ReviewsByCategoryEditor = ( {
 				}
 				name={ __(
 					'Reviews by Category',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-category/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-category/index.tsx
@@ -18,7 +18,7 @@ import { example } from '../example.js';
  */
 registerBlockType( 'woocommerce/reviews-by-category', {
 	apiVersion: 2,
-	title: __( 'Reviews by Category', 'woo-gutenberg-products-block' ),
+	title: __( 'Reviews by Category', 'woocommerce' ),
 	icon: {
 		src: (
 			<Icon
@@ -28,10 +28,10 @@ registerBlockType( 'woocommerce/reviews-by-category', {
 		),
 	},
 	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
 	description: __(
 		'Show product reviews from specific categories.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	supports: {
 		html: false,

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-category/no-reviews-placeholder.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-category/no-reviews-placeholder.tsx
@@ -16,12 +16,12 @@ const NoReviewsPlaceholder = (): JSX.Element => {
 			}
 			label={ __(
 				'Reviews by Category',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		>
 			{ __(
 				'This block lists reviews for products from selected categories. The selected categories do not have any reviews yet, but they will show up here when they do.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</Placeholder>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -48,7 +48,7 @@ const ReviewsByProductEditor = ( {
 						'%d review',
 						'%d reviews',
 						item.details.review_count,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					item.details.review_count
 				) }
@@ -58,7 +58,7 @@ const ReviewsByProductEditor = ( {
 						'%1$s, has %2$d review',
 						'%1$s, has %2$d reviews',
 						item.details.review_count,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					item.name,
 					item.details.review_count
@@ -71,7 +71,7 @@ const ReviewsByProductEditor = ( {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
-					title={ __( 'Product', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Product', 'woocommerce' ) }
 					initialOpen={ false }
 				>
 					<ProductControl
@@ -85,7 +85,7 @@ const ReviewsByProductEditor = ( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __( 'Content', 'woocommerce' ) }
 				>
 					{ getSharedReviewContentControls(
 						attributes,
@@ -95,7 +95,7 @@ const ReviewsByProductEditor = ( {
 				<PanelBody
 					title={ __(
 						'List Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					{ getSharedReviewListControls( attributes, setAttributes ) }
@@ -110,7 +110,7 @@ const ReviewsByProductEditor = ( {
 			debouncedSpeak(
 				__(
 					'Showing Reviews by Product block preview.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				)
 			);
 		};
@@ -125,13 +125,13 @@ const ReviewsByProductEditor = ( {
 				}
 				label={ __(
 					'Reviews by Product',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				className="wc-block-reviews-by-product"
 			>
 				{ __(
 					'Show reviews of your product to build trust',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				<div className="wc-block-reviews__selection">
 					<ProductControl
@@ -147,7 +147,7 @@ const ReviewsByProductEditor = ( {
 						renderItem={ renderProductControlItem }
 					/>
 					<Button variant="primary" onClick={ onDone }>
-						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+						{ __( 'Done', 'woocommerce' ) }
 					</Button>
 				</div>
 			</Placeholder>
@@ -160,7 +160,7 @@ const ReviewsByProductEditor = ( {
 
 	const buttonTitle = __(
 		'Edit selected product',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 
 	return (
@@ -177,7 +177,7 @@ const ReviewsByProductEditor = ( {
 				}
 				name={ __(
 					'Reviews by Product',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/editor-block-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/editor-block-controls.tsx
@@ -22,7 +22,7 @@ const EditorBlockControls = ( {
 						icon: 'edit',
 						title: __(
 							'Edit selected product',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						onClick: () => setIsEditing( ! isEditing ),
 						isActive: isEditing,

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
@@ -95,7 +95,7 @@ const Editor = ( {
 			<BlockErrorBoundary
 				header={ __(
 					'Single Product Block Error',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			>
 				<EditorBlockControls
@@ -120,7 +120,7 @@ const Editor = ( {
 									setIsEditing( false );
 								} }
 							>
-								{ __( 'Done', 'woo-gutenberg-products-block' ) }
+								{ __( 'Done', 'woocommerce' ) }
 							</Button>
 						</div>
 					</Placeholder>
@@ -130,7 +130,7 @@ const Editor = ( {
 							<PanelBody
 								title={ __(
 									'Product',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								) }
 								initialOpen={ false }
 							>

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
@@ -60,13 +60,13 @@ const LayoutEditor = ( {
 			>
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+						title={ __( 'Layout', 'woocommerce' ) }
 						initialOpen={ true }
 					>
 						<Button
 							label={ __(
 								'Reset layout to default',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							onClick={ resetInnerBlocks }
 							variant="tertiary"
@@ -75,7 +75,7 @@ const LayoutEditor = ( {
 						>
 							{ __(
 								'Reset layout',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</Button>
 					</PanelBody>

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/attributes.ts
@@ -6,6 +6,6 @@ import { __ } from '@wordpress/i18n';
 export const blockAttributes = {
 	heading: {
 		type: 'string',
-		default: __( 'Filter by stock status', 'woo-gutenberg-products-block' ),
+		default: __( 'Filter by stock status', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/block.tsx
@@ -321,7 +321,7 @@ const StockStatusFilterBlock = ( {
 							/* translators: %s stock statuses (for example: 'instock'...) */
 							__(
 								'%s filter added.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							filterAddedName
 						)
@@ -332,7 +332,7 @@ const StockStatusFilterBlock = ( {
 							/* translators: %s stock statuses (for example:'instock'...) */
 							__(
 								'%s filter removed.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							filterRemovedName
 						)
@@ -469,7 +469,7 @@ const StockStatusFilterBlock = ( {
 							disabled={ isLoading }
 							placeholder={ __(
 								'Select stock status',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							onChange={ onDropdownChange }
 							value={ checked }
@@ -483,19 +483,19 @@ const StockStatusFilterBlock = ( {
 							messages={ {
 								added: __(
 									'Stock filter added.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								removed: __(
 									'Stock filter removed.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								remove: __(
 									'Remove stock filter.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								__experimentalInvalid: __(
 									'Invalid stock filter.',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 							} }
 						/>
@@ -524,7 +524,7 @@ const StockStatusFilterBlock = ( {
 							} }
 							screenReaderLabel={ __(
 								'Reset stock filter',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/edit.tsx
@@ -50,13 +50,13 @@ const Edit = ( {
 				<PanelBody
 					title={ __(
 						'Display Settings',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				>
 					<ToggleControl
 						label={ __(
 							'Display product count',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showCounts }
 						onChange={ () =>
@@ -68,7 +68,7 @@ const Edit = ( {
 					<ToggleGroupControl
 						label={ __(
 							'Allow selecting multiple options?',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ selectType || 'multiple' }
 						onChange={ ( value: string ) =>
@@ -82,21 +82,21 @@ const Edit = ( {
 							value="multiple"
 							label={ __(
 								'Multiple',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="single"
 							label={ __(
 								'Single',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
 					<ToggleGroupControl
 						label={ __(
 							'Display Style',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ displayStyle }
 						onChange={ ( value ) =>
@@ -110,25 +110,25 @@ const Edit = ( {
 							value="list"
 							label={ __(
 								'List',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 						<ToggleGroupControlOption
 							value="dropdown"
 							label={ __(
 								'Dropdown',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						/>
 					</ToggleGroupControl>
 					<ToggleControl
 						label={ __(
 							"Show 'Apply filters' button",
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Products will update when the button is clicked.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						checked={ showFilterButton }
 						onChange={ ( value ) =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/store-notices/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/store-notices/edit.tsx
@@ -20,7 +20,7 @@ const Edit = (): JSX.Element => {
 			<NoticeBanner status="info" isDismissible={ false }>
 				{ __(
 					'Notices added by WooCommerce or extensions will show up here.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</NoticeBanner>
 		</div>

--- a/plugins/woocommerce-blocks/assets/js/data/cart/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/constants.ts
@@ -8,7 +8,7 @@ export const CART_API_ERROR = {
 	code: 'cart_api_error',
 	message: __(
 		'Unable to get cart data from the API.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	data: {
 		status: 500,

--- a/plugins/woocommerce-blocks/assets/js/data/cart/notify-quantity-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/notify-quantity-changes.ts
@@ -62,7 +62,7 @@ const notifyIfQuantityLimitsChanged = ( oldCart: Cart, newCart: Cart ) => {
 					/* translators: %1$s is the name of the item, %2$d is the quantity of the item. %3$d is a number that the quantity must be a multiple of. */
 					__(
 						'The quantity of "%1$s" was changed to %2$d. You must purchase this product in groups of %3$d.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					cartItem.name,
 					// We round down to the nearest step value here. We need to do it this way because at this point we
@@ -89,7 +89,7 @@ const notifyIfQuantityLimitsChanged = ( oldCart: Cart, newCart: Cart ) => {
 					/* translators: %1$s is the name of the item, %2$d is the quantity of the item. */
 					__(
 						'The quantity of "%1$s" was increased to %2$d. This is the minimum required quantity.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					cartItem.name,
 					cartItem.quantity_limits.minimum
@@ -110,7 +110,7 @@ const notifyIfQuantityLimitsChanged = ( oldCart: Cart, newCart: Cart ) => {
 				/* translators: %1$s is the name of the item, %2$d is the quantity of the item. */
 				__(
 					'The quantity of "%1$s" was decreased to %2$d. This is the maximum allowed quantity.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				cartItem.name,
 				cartItem.quantity_limits.maximum
@@ -151,7 +151,7 @@ const notifyIfQuantityChanged = (
 						/* translators: %1$s is the name of the item, %2$d is the quantity of the item. */
 						__(
 							'The quantity of "%1$s" was changed to %2$d.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						cartItem.name,
 						cartItem.quantity
@@ -196,7 +196,7 @@ const notifyIfRemoved = (
 					/* translators: %s is the name of the item. */
 					__(
 						'"%s" was removed from your cart.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					oldCartItem.name
 				),

--- a/plugins/woocommerce-blocks/assets/js/data/checkout/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/checkout/utils.ts
@@ -102,7 +102,7 @@ export const runCheckoutFailObservers = ( {
 				data.processingResponse?.message ||
 				__(
 					'Something went wrong. Please contact us to get assistance.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				);
 			createErrorNotice( message, {
 				id: 'checkout',
@@ -214,7 +214,7 @@ export const getPaymentResultFromCheckoutResponse = (
 	) {
 		paymentResult.message = __(
 			'Something went wrong. Please contact us to get assistance.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		);
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/data/payment/utils/check-payment-methods.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/payment/utils/check-payment-methods.ts
@@ -141,7 +141,7 @@ const registrationErrorNotice = (
 		/* translators: %s the id of the payment method being registered (bank transfer, cheque...) */
 		__(
 			`There was an error registering the payment method with id '%s': `,
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		paymentMethod.paymentMethodId
 	);

--- a/plugins/woocommerce-blocks/assets/js/data/shared-controls.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/shared-controls.ts
@@ -19,7 +19,7 @@ const invalidJsonError = {
 	code: 'invalid_json',
 	message: __(
 		'The response is not a valid JSON response.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 

--- a/plugins/woocommerce-blocks/assets/js/editor-components/block-title/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/block-title/index.tsx
@@ -30,7 +30,7 @@ const BlockTitle = ( {
 				className="screen-reader-text"
 				htmlFor={ `block-title-${ instanceId }` }
 			>
-				{ __( 'Block title', 'woo-gutenberg-products-block' ) }
+				{ __( 'Block title', 'woocommerce' ) }
 			</label>
 			<PlainText
 				id={ `block-title-${ instanceId }` }

--- a/plugins/woocommerce-blocks/assets/js/editor-components/default-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/default-notice/index.tsx
@@ -104,7 +104,7 @@ export function DefaultNotice( { block }: { block: string } ) {
 		noticeContent = createInterpolateElement(
 			__(
 				'If you would like to use this block as your default checkout, <a>update your page settings</a>.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -112,7 +112,7 @@ export function DefaultNotice( { block }: { block: string } ) {
 					<a href="#" onClick={ updatePage }>
 						{ __(
 							'update your page settings',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</a>
 				),
@@ -122,7 +122,7 @@ export function DefaultNotice( { block }: { block: string } ) {
 		noticeContent = createInterpolateElement(
 			__(
 				'If you would like to use this block as your default cart, <a>update your page settings</a>.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -130,7 +130,7 @@ export function DefaultNotice( { block }: { block: string } ) {
 					<a href="#" onClick={ updatePage }>
 						{ __(
 							'update your page settings',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 					</a>
 				),
@@ -155,13 +155,13 @@ export function DefaultNotice( { block }: { block: string } ) {
 				settingStatus === 'updated'
 					? __(
 							'Page settings updated',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 					  )
 					: noticeContent
 			}
 		>
 			{ settingStatus === 'updated' ? (
-				__( 'Page settings updated', 'woo-gutenberg-products-block' )
+				__( 'Page settings updated', 'woocommerce' )
 			) : (
 				<>
 					<p>{ noticeContent }</p>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/edit-product-link/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/edit-product-link/index.tsx
@@ -37,7 +37,7 @@ const EditProductLink = ( props: EditProductLinkProps ): JSX.Element | null => {
 					>
 						{ __(
 							"Edit this product's details",
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						<Icon icon={ external } size={ 16 } />
 					</a>
@@ -45,7 +45,7 @@ const EditProductLink = ( props: EditProductLinkProps ): JSX.Element | null => {
 				<div className="wc-block-single-product__edit-card-description">
 					{ __(
 						'Edit details such as title, price, description and more.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</div>
 			</div>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/error-placeholder/error-message.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/error-placeholder/error-message.tsx
@@ -20,7 +20,7 @@ const getErrorMessage = ( { message, type }: ErrorObject ) => {
 	if ( ! message ) {
 		return __(
 			'An error has prevented the block from being updated.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		);
 	}
 
@@ -29,7 +29,7 @@ const getErrorMessage = ( { message, type }: ErrorObject ) => {
 			<span>
 				{ __(
 					'The following error was returned',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				<br />
 				<code>{ escapeHTML( message ) }</code>
@@ -42,7 +42,7 @@ const getErrorMessage = ( { message, type }: ErrorObject ) => {
 			<span>
 				{ __(
 					'The following error was returned from the API',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				<br />
 				<code>{ escapeHTML( message ) }</code>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/error-placeholder/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/error-placeholder/index.tsx
@@ -53,7 +53,7 @@ const ErrorPlaceholder = ( {
 		icon={ <Icon icon={ warning } /> }
 		label={ __(
 			'Sorry, an error occurred',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
 		className={ classNames( 'wc-block-api-error', className ) }
 	>
@@ -64,7 +64,7 @@ const ErrorPlaceholder = ( {
 					<Spinner />
 				) : (
 					<Button variant="secondary" onClick={ onRetry }>
-						{ __( 'Retry', 'woo-gutenberg-products-block' ) }
+						{ __( 'Retry', 'woocommerce' ) }
 					</Button>
 				) }
 			</>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/external-link-card/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/external-link-card/index.tsx
@@ -58,7 +58,7 @@ const ExternalLinkCard = ( {
 			<VisuallyHidden as="span">
 				{
 					/* translators: accessibility text */
-					__( '(opens in a new tab)', 'woo-gutenberg-products-block' )
+					__( '(opens in a new tab)', 'woocommerce' )
 				}
 			</VisuallyHidden>
 			<Icon

--- a/plugins/woocommerce-blocks/assets/js/editor-components/feedback-prompt/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/feedback-prompt/index.tsx
@@ -24,7 +24,7 @@ interface FeedbackPromptProps {
  */
 const FeedbackPrompt = ( {
 	text,
-	title = __( 'Feedback?', 'woo-gutenberg-products-block' ),
+	title = __( 'Feedback?', 'woocommerce' ),
 	url,
 }: FeedbackPromptProps ) => {
 	// By returning false we ensure that this component is not entered into the InspectorControls
@@ -53,7 +53,7 @@ const FeedbackPrompt = ( {
 					>
 						{ __(
 							'Give us your feedback.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						<Icon icon={ external } size={ 16 } />
 					</a>
@@ -69,7 +69,7 @@ export const CartCheckoutFeedbackPrompt = () => (
 	<FeedbackPrompt
 		text={ __(
 			'We are currently working on improving our cart and checkout blocks to provide merchants with the tools and customization options they need.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
 		url="https://github.com/woocommerce/woocommerce/discussions/new?category=checkout-flow&labels=type%3A+product%20feedback"
 	/>
@@ -79,9 +79,9 @@ export const ProductQueryFeedbackPrompt = () => (
 	<FeedbackPrompt
 		text={ __(
 			'Thanks for trying out the Products block! Help us make it better by sharing your feedback.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
-		title={ __( 'Share your feedback!', 'woo-gutenberg-products-block' ) }
+		title={ __( 'Share your feedback!', 'woocommerce' ) }
 		url={ 'https://airtable.com/shrFX5FAqmCY6hVYI' }
 	/>
 );
@@ -90,9 +90,9 @@ export const ProductCollectionFeedbackPrompt = () => (
 	<FeedbackPrompt
 		text={ __(
 			'Thanks for trying out the Product Collection block! Help us make it better by sharing your feedback.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		) }
-		title={ __( 'Share your feedback!', 'woo-gutenberg-products-block' ) }
+		title={ __( 'Share your feedback!', 'woocommerce' ) }
 		url={ 'https://airtable.com/shrqsMSDPvAKoY99u' }
 	/>
 );

--- a/plugins/woocommerce-blocks/assets/js/editor-components/grid-content-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/grid-content-control/index.tsx
@@ -34,31 +34,31 @@ const GridContentControl = ( {
 	return (
 		<>
 			<ToggleControl
-				label={ __( 'Product image', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Product image', 'woocommerce' ) }
 				checked={ imageIsVisible }
 				onChange={ () =>
 					onChange( { ...settings, image: ! imageIsVisible } )
 				}
 			/>
 			<ToggleControl
-				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Product title', 'woocommerce' ) }
 				checked={ title }
 				onChange={ () => onChange( { ...settings, title: ! title } ) }
 			/>
 			<ToggleControl
-				label={ __( 'Product price', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Product price', 'woocommerce' ) }
 				checked={ price }
 				onChange={ () => onChange( { ...settings, price: ! price } ) }
 			/>
 			<ToggleControl
-				label={ __( 'Product rating', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Product rating', 'woocommerce' ) }
 				checked={ rating }
 				onChange={ () => onChange( { ...settings, rating: ! rating } ) }
 			/>
 			<ToggleControl
 				label={ __(
 					'Add to Cart button',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				checked={ button }
 				onChange={ () => onChange( { ...settings, button: ! button } ) }

--- a/plugins/woocommerce-blocks/assets/js/editor-components/grid-layout-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/grid-layout-control/index.tsx
@@ -56,7 +56,7 @@ const GridLayoutControl = ( {
 	return (
 		<>
 			<RangeControl
-				label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Columns', 'woocommerce' ) }
 				value={ columns }
 				onChange={ ( value: number ) => {
 					const newValue = clamp( value, minColumns, maxColumns );
@@ -68,7 +68,7 @@ const GridLayoutControl = ( {
 				max={ maxColumns }
 			/>
 			<RangeControl
-				label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Rows', 'woocommerce' ) }
 				value={ rows }
 				onChange={ ( value: number ) => {
 					const newValue = clamp( value, minRows, maxRows );
@@ -82,17 +82,17 @@ const GridLayoutControl = ( {
 			<ToggleControl
 				label={ __(
 					'Align the last block to the bottom',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				help={
 					alignButtons
 						? __(
 								'Align the last block to the bottom.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 						  )
 						: __(
 								'The last inner block will follow other content.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 						  )
 				}
 				checked={ alignButtons }

--- a/plugins/woocommerce-blocks/assets/js/editor-components/incompatible-extension-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/incompatible-extension-notice/index.tsx
@@ -79,18 +79,18 @@ export function IncompatibleExtensionsNotice( {
 
 	const switchButtonLabel =
 		block === 'woocommerce/cart'
-			? __( 'Switch to classic cart', 'woo-gutenberg-products-block' )
+			? __( 'Switch to classic cart', 'woocommerce' )
 			: __(
 					'Switch to classic checkout',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 			  );
 
 	const snackbarLabel =
 		block === 'woocommerce/cart'
-			? __( 'Switched to classic cart.', 'woo-gutenberg-products-block' )
+			? __( 'Switched to classic cart.', 'woocommerce' )
 			: __(
 					'Switched to classic checkout.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 			  );
 
 	const noticeContent = (
@@ -99,7 +99,7 @@ export function IncompatibleExtensionsNotice( {
 				? createInterpolateElement(
 						__(
 							'Some active extensions do not yet support this block. This may impact the shopper experience. <a>Learn more</a>',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						{
 							a: (
@@ -112,7 +112,7 @@ export function IncompatibleExtensionsNotice( {
 							// translators: %s is the name of the extension.
 							__(
 								'<strong>%s</strong> does not yet support this block. This may impact the shopper experience. <a>Learn more</a>',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							Object.values( incompatibleExtensions )[ 0 ]
 						),
@@ -178,7 +178,7 @@ export function IncompatibleExtensionsNotice( {
 											'%s more incompatibility',
 											'%s more incompatibilites',
 											remainingEntries,
-											'woo-gutenberg-products-block'
+											'woocommerce'
 										),
 										remainingEntries
 									) }
@@ -254,7 +254,7 @@ export function IncompatibleExtensionsNotice( {
 												{
 													label: __(
 														'Undo',
-														'woo-gutenberg-products-block'
+														'woocommerce'
 													),
 													onClick: () => {
 														undo();
@@ -278,7 +278,7 @@ export function IncompatibleExtensionsNotice( {
 								>
 									{ __(
 										'Switch',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</Button>{ ' ' }
 								<Button
@@ -299,7 +299,7 @@ export function IncompatibleExtensionsNotice( {
 								>
 									{ __(
 										'Cancel',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</Button>
 							</TabbableContainer>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/incompatible-extension-notice/modal.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/incompatible-extension-notice/modal.tsx
@@ -13,7 +13,7 @@ export const ModalContent = ( {
 			<p>
 				{ __(
 					'If you continue, the cart block will be replaced with the classic experience powered by shortcodes. This means that you may lose customizations that you made to the cart block.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 		);
@@ -24,20 +24,20 @@ export const ModalContent = ( {
 			<p>
 				{ __(
 					'If you continue, the checkout block will be replaced with the classic experience powered by shortcodes. This means that you may lose:',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 			</p>
 			<ul className="cross-list">
 				<li>
 					{ __(
 						'Customizations and updates to the block',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</li>
 				<li>
 					{ __(
 						'Additional local pickup options created for the new checkout',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</li>
 			</ul>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/no-payment-methods-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/no-payment-methods-notice/index.tsx
@@ -13,7 +13,7 @@ import './editor.scss';
 export function NoPaymentMethodsNotice() {
 	const noticeContent = __(
 		'Your store does not have any payment methods that support the Checkout block. Once you have configured a compatible payment method it will be displayed here.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	);
 
 	return (
@@ -30,7 +30,7 @@ export function NoPaymentMethodsNotice() {
 				>
 					{ __(
 						'Configure Payment Methods',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				</ExternalLink>
 			</div>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/product-attribute-term-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/product-attribute-term-control/index.tsx
@@ -81,7 +81,7 @@ const ProductAttributeTermControl = ( {
 							'%d term',
 							'%d terms',
 							count,
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						count
 					) }
@@ -91,7 +91,7 @@ const ProductAttributeTermControl = ( {
 							'%1$s, has %2$d term',
 							'%1$s, has %2$d terms',
 							count,
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						item.name,
 						count
@@ -113,7 +113,7 @@ const ProductAttributeTermControl = ( {
 						'%d product',
 						'%d products',
 						count,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					count
 				) }
@@ -123,7 +123,7 @@ const ProductAttributeTermControl = ( {
 						'%1$s, has %2$d product',
 						'%1$s, has %2$d products',
 						count,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					itemName,
 					count
@@ -145,15 +145,15 @@ const ProductAttributeTermControl = ( {
 	messages = {
 		clear: __(
 			'Clear all product attributes',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		noItems: __(
 			"Your store doesn't have any product attributes.",
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		search: __(
 			'Search for product attributes',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		selected: ( n: number ) =>
 			sprintf(
@@ -162,13 +162,13 @@ const ProductAttributeTermControl = ( {
 					'%d attribute selected',
 					'%d attributes selected',
 					n,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				n
 			),
 		updated: __(
 			'Product attribute search results updated.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		...messages,
 	};
@@ -204,11 +204,11 @@ const ProductAttributeTermControl = ( {
 						className="woocommerce-product-attributes__operator"
 						label={ __(
 							'Display products matching',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Pick at least two attributes to use this setting.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ operator }
 						onChange={ onOperatorChange }
@@ -216,14 +216,14 @@ const ProductAttributeTermControl = ( {
 							{
 								label: __(
 									'Any selected attributes',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								value: 'any',
 							},
 							{
 								label: __(
 									'All selected attributes',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								value: 'all',
 							},

--- a/plugins/woocommerce-blocks/assets/js/editor-components/product-category-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/product-category-control/index.tsx
@@ -77,7 +77,7 @@ const ProductCategoryControl = ( {
 						'%1$s, has %2$d review',
 						'%1$s, has %2$d reviews',
 						item.details?.review_count || 0,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					accessibleName,
 					item.details?.review_count || 0
@@ -88,7 +88,7 @@ const ProductCategoryControl = ( {
 						'%1$s, has %2$d product',
 						'%1$s, has %2$d products',
 						item.details?.count || 0,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					accessibleName,
 					item.details?.count || 0
@@ -101,7 +101,7 @@ const ProductCategoryControl = ( {
 						'%d review',
 						'%d reviews',
 						item.details?.review_count || 0,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					item.details?.review_count || 0
 			  )
@@ -111,7 +111,7 @@ const ProductCategoryControl = ( {
 						'%d product',
 						'%d products',
 						item.details?.count || 0,
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					item.details?.count || 0
 			  );
@@ -136,16 +136,16 @@ const ProductCategoryControl = ( {
 	const messages = {
 		clear: __(
 			'Clear all product categories',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
-		list: __( 'Product Categories', 'woo-gutenberg-products-block' ),
+		list: __( 'Product Categories', 'woocommerce' ),
 		noItems: __(
 			"Your store doesn't have any product categories.",
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		search: __(
 			'Search for product categories',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		selected: ( n: number ) =>
 			sprintf(
@@ -154,13 +154,13 @@ const ProductCategoryControl = ( {
 					'%d category selected',
 					'%d categories selected',
 					n,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				n
 			),
 		updated: __(
 			'Category search results updated.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 	};
 
@@ -194,11 +194,11 @@ const ProductCategoryControl = ( {
 						className="woocommerce-product-categories__operator"
 						label={ __(
 							'Display products matching',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Pick at least two categories to use this setting.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ operator }
 						onChange={ onOperatorChange }
@@ -206,14 +206,14 @@ const ProductCategoryControl = ( {
 							{
 								label: __(
 									'Any selected categories',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								value: 'any',
 							},
 							{
 								label: __(
 									'All selected categories',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								value: 'all',
 							},

--- a/plugins/woocommerce-blocks/assets/js/editor-components/product-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/product-control/index.tsx
@@ -65,18 +65,18 @@ interface ProductControlProps {
 }
 
 const messages = {
-	list: __( 'Products', 'woo-gutenberg-products-block' ),
+	list: __( 'Products', 'woocommerce' ),
 	noItems: __(
 		"Your store doesn't have any products.",
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	search: __(
 		'Search for a product to display',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 	updated: __(
 		'Product search results updated.',
-		'woo-gutenberg-products-block'
+		'woocommerce'
 	),
 };
 
@@ -147,7 +147,7 @@ const ProductControl = (
 									/* translators: %1$d is the number of variations of a product product. */
 									__(
 										'%1$d variations',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									item.details?.variations.length
 							  )
@@ -163,7 +163,7 @@ const ProductControl = (
 										'%1$s, has %2$d variations',
 										item.details?.variations
 											?.length as number,
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									item.name,
 									item.details?.variations.length

--- a/plugins/woocommerce-blocks/assets/js/editor-components/product-orderby-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/product-orderby-control/index.tsx
@@ -22,53 +22,53 @@ const ProductOrderbyControl = ( {
 }: ProductOrderbyControlProps ) => {
 	return (
 		<SelectControl
-			label={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
+			label={ __( 'Order products by', 'woocommerce' ) }
 			value={ value }
 			options={ [
 				{
 					label: __(
 						'Newness - newest first',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					value: 'date',
 				},
 				{
 					label: __(
 						'Price - low to high',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					value: 'price_asc',
 				},
 				{
 					label: __(
 						'Price - high to low',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					value: 'price_desc',
 				},
 				{
 					label: __(
 						'Rating - highest first',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					value: 'rating',
 				},
 				{
 					label: __(
 						'Sales - most first',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					value: 'popularity',
 				},
 				{
 					label: __(
 						'Title - alphabetical',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					),
 					value: 'title',
 				},
 				{
-					label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
+					label: __( 'Menu Order', 'woocommerce' ),
 					value: 'menu_order',
 				},
 			] }

--- a/plugins/woocommerce-blocks/assets/js/editor-components/product-stock-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/product-stock-control/index.tsx
@@ -84,11 +84,11 @@ const ProductStockControl = ( {
 				const helpText = checkedOptions.includes( option.value )
 					? /* translators: %s stock status. */ __(
 							'Stock status "%s" visible.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 					  )
 					: /* translators: %s stock status. */ __(
 							'Stock status "%s" hidden.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 					  );
 				return (
 					<ToggleControl

--- a/plugins/woocommerce-blocks/assets/js/editor-components/product-tag-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/product-tag-control/index.tsx
@@ -63,13 +63,13 @@ const ProductTagControl = ( {
 	const debouncedOnSearch = useDebouncedCallback( onSearch, 400 );
 
 	const messages = {
-		clear: __( 'Clear all product tags', 'woo-gutenberg-products-block' ),
-		list: __( 'Product Tags', 'woo-gutenberg-products-block' ),
+		clear: __( 'Clear all product tags', 'woocommerce' ),
+		list: __( 'Product Tags', 'woocommerce' ),
 		noItems: __(
 			'You have not set up any product tags on your store.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
-		search: __( 'Search for product tags', 'woo-gutenberg-products-block' ),
+		search: __( 'Search for product tags', 'woocommerce' ),
 		selected: ( n: number ) =>
 			sprintf(
 				/* translators: %d is the count of selected tags. */
@@ -77,13 +77,13 @@ const ProductTagControl = ( {
 					'%d tag selected',
 					'%d tags selected',
 					n,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				n
 			),
 		updated: __(
 			'Tag search results updated.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 	};
 
@@ -108,11 +108,11 @@ const ProductTagControl = ( {
 						className="woocommerce-product-tags__operator"
 						label={ __(
 							'Display products matching',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						help={ __(
 							'Pick at least two tags to use this setting.',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						) }
 						value={ operator }
 						onChange={ onOperatorChange }
@@ -120,14 +120,14 @@ const ProductTagControl = ( {
 							{
 								label: __(
 									'Any selected tags',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								value: 'any',
 							},
 							{
 								label: __(
 									'All selected tags',
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								value: 'all',
 							},

--- a/plugins/woocommerce-blocks/assets/js/editor-components/product-tag-control/product-tag-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/product-tag-control/product-tag-item.tsx
@@ -40,7 +40,7 @@ export const ProductTagItem = ( {
 					'%1$d product tagged as %2$s',
 					'%1$d products tagged as %2$s',
 					item.count,
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				item.count,
 				accessibleName

--- a/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
@@ -127,7 +127,7 @@ const SelectedListItems = < T extends object = object >( {
 						onClick={ () => onChange( [] ) }
 						aria-label={ messages.clear }
 					>
-						{ __( 'Clear all', 'woo-gutenberg-products-block' ) }
+						{ __( 'Clear all', 'woocommerce' ) }
 					</Button>
 				) : null }
 			</div>
@@ -323,7 +323,7 @@ export const SearchListControl = < T extends object = object >(
 								? [
 										__(
 											'Loading…',
-											'woo-gutenberg-products-block'
+											'woocommerce'
 										),
 								  ]
 								: selected.map( ( token ) => ( {

--- a/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/utils.tsx
@@ -11,11 +11,11 @@ import { keyBy } from '@woocommerce/base-utils';
 import type { SearchListItem } from './types';
 
 export const defaultMessages = {
-	clear: __( 'Clear all selected items', 'woo-gutenberg-products-block' ),
-	noItems: __( 'No items found.', 'woo-gutenberg-products-block' ),
+	clear: __( 'Clear all selected items', 'woocommerce' ),
+	noItems: __( 'No items found.', 'woocommerce' ),
 	/* Translators: %s search term */
-	noResults: __( 'No results for %s', 'woo-gutenberg-products-block' ),
-	search: __( 'Search for items', 'woo-gutenberg-products-block' ),
+	noResults: __( 'No results for %s', 'woocommerce' ),
+	search: __( 'Search for items', 'woocommerce' ),
 	selected: ( n: number ): string =>
 		sprintf(
 			/* translators: Number of items selected from list. */
@@ -23,11 +23,11 @@ export const defaultMessages = {
 				'%d item selected',
 				'%d items selected',
 				n,
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			n
 		),
-	updated: __( 'Search results updated.', 'woo-gutenberg-products-block' ),
+	updated: __( 'Search results updated.', 'woocommerce' ),
 };
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/editor-components/sidebar-compatibility-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/sidebar-compatibility-notice/index.tsx
@@ -22,7 +22,7 @@ export const CartCheckoutSidebarCompatibilityNotice = ( {
 	const noticeText = createInterpolateElement(
 		__(
 			'The Cart & Checkout Blocks are built to optimize for faster checkout. To make sure this feature is right for your store, <a>review the list of compatible extensions</a>.',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		{
 			a: (

--- a/plugins/woocommerce-blocks/assets/js/editor-components/tag/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/tag/index.tsx
@@ -84,7 +84,7 @@ const Tag = ( {
 					onClick={ remove( id ) }
 					label={ sprintf(
 						// Translators: %s label.
-						__( 'Remove %s', 'woo-gutenberg-products-block' ),
+						__( 'Remove %s', 'woocommerce' ),
 						label
 					) }
 					aria-describedby={ labelId }

--- a/plugins/woocommerce-blocks/assets/js/editor-components/text-toolbar-button/README.md
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/text-toolbar-button/README.md
@@ -18,13 +18,13 @@ Example: two text buttons to select edit modes for cart block.
 			onClick={ toggleFullCartMode }
 			isToggled={ isFullCartMode }
 		>
-			{ __( 'Full Cart', 'woo-gutenberg-products-block' ) }
+			{ __( 'Full Cart', 'woocommerce' ) }
 		</TextToolbarButton>
 		<TextToolbarButton
 			onClick={ toggleFullCartMode }
 			isToggled={ ! isFullCartMode }
 		>
-			{ __( 'Empty Cart', 'woo-gutenberg-products-block' ) }
+			{ __( 'Empty Cart', 'woocommerce' ) }
 		</TextToolbarButton>
 	</Toolbar>
 </BlockControls>

--- a/plugins/woocommerce-blocks/assets/js/extensions/google-analytics/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/extensions/google-analytics/index.ts
@@ -61,7 +61,7 @@ addAction(
 	( { shippingRateId }: { shippingRateId: string } ): void => {
 		trackCheckoutOption( {
 			step: 4,
-			option: __( 'Shipping Method', 'woo-gutenberg-products-block' ),
+			option: __( 'Shipping Method', 'woocommerce' ),
 			value: shippingRateId,
 		} )();
 	}
@@ -79,7 +79,7 @@ addAction(
 	( { paymentMethodSlug }: { paymentMethodSlug: string } ): void => {
 		trackCheckoutOption( {
 			step: 5,
-			option: __( 'Payment Method', 'woo-gutenberg-products-block' ),
+			option: __( 'Payment Method', 'woocommerce' ),
 			value: paymentMethodSlug,
 		} )();
 	}
@@ -118,7 +118,7 @@ addAction(
 	} ): void => {
 		trackEvent( 'add_to_cart', {
 			event_category: 'ecommerce',
-			event_label: __( 'Add to Cart', 'woo-gutenberg-products-block' ),
+			event_label: __( 'Add to Cart', 'woocommerce' ),
 			items: [ getProductFieldObject( product, quantity ) ],
 		} );
 	}
@@ -144,7 +144,7 @@ addAction(
 			event_category: 'ecommerce',
 			event_label: __(
 				'Remove Cart Item',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			items: [ getProductFieldObject( product, quantity ) ],
 		} );
@@ -170,7 +170,7 @@ addAction(
 			event_category: 'ecommerce',
 			event_label: __(
 				'Change Cart Item Quantity',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			items: [ getProductFieldObject( product, quantity ) ],
 		} );
@@ -188,7 +188,7 @@ addAction(
 	namespace,
 	( {
 		products,
-		listName = __( 'Product List', 'woo-gutenberg-products-block' ),
+		listName = __( 'Product List', 'woocommerce' ),
 	}: {
 		products: Array< ProductResponseItem >;
 		listName: string;
@@ -200,7 +200,7 @@ addAction(
 			event_category: 'engagement',
 			event_label: __(
 				'Viewing products',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			items: products.map( ( product, index ) => ( {
 				...getProductImpressionObject( product, listName ),

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
@@ -47,7 +47,7 @@ const Form = ( {
 	return (
 		<form ref={ formRef }>
 			<TextControl
-				label={ __( 'Location name', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Location name', 'woocommerce' ) }
 				name={ 'location_name' }
 				value={ values.name }
 				onChange={ setLocationField( 'name' ) }
@@ -59,7 +59,7 @@ const Form = ( {
 					event.target.setCustomValidity(
 						__(
 							'A Location title is required',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						)
 					);
 				} }
@@ -68,29 +68,29 @@ const Form = ( {
 				} }
 			/>
 			<TextControl
-				label={ __( 'Address', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Address', 'woocommerce' ) }
 				name={ 'location_address' }
-				placeholder={ __( 'Address', 'woo-gutenberg-products-block' ) }
+				placeholder={ __( 'Address', 'woocommerce' ) }
 				value={ values.address.address_1 }
 				onChange={ setLocationAddressField( 'address_1' ) }
 				autoComplete="off"
 			/>
 			<TextControl
-				label={ __( 'City', 'woo-gutenberg-products-block' ) }
+				label={ __( 'City', 'woocommerce' ) }
 				name={ 'location_city' }
 				hideLabelFromVision={ true }
-				placeholder={ __( 'City', 'woo-gutenberg-products-block' ) }
+				placeholder={ __( 'City', 'woocommerce' ) }
 				value={ values.address.city }
 				onChange={ setLocationAddressField( 'city' ) }
 				autoComplete="off"
 			/>
 			<TextControl
-				label={ __( 'Postcode / ZIP', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Postcode / ZIP', 'woocommerce' ) }
 				name={ 'location_postcode' }
 				hideLabelFromVision={ true }
 				placeholder={ __(
 					'Postcode / ZIP',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				value={ values.address.postcode }
 				onChange={ setLocationAddressField( 'postcode' ) }
@@ -100,7 +100,7 @@ const Form = ( {
 				<TextControl
 					placeholder={ __(
 						'State',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ selectedState }
 					onChange={ setLocationAddressField( 'state' ) }
@@ -110,12 +110,12 @@ const Form = ( {
 				name="location_country_state"
 				label={ __(
 					'Country / State',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				hideLabelFromVision={ true }
 				placeholder={ __(
 					'Country / State',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				value={ ( () => {
 					if ( ! selectedState && countryHasStates ) {
@@ -168,7 +168,7 @@ const Form = ( {
 			</SelectControl>
 
 			<TextControl
-				label={ __( 'Pickup details', 'woo-gutenberg-products-block' ) }
+				label={ __( 'Pickup details', 'woocommerce' ) }
 				name={ 'pickup_details' }
 				value={ values.details }
 				onChange={ setLocationField( 'details' ) }

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
@@ -40,10 +40,10 @@ const EditLocation = ( {
 			onRequestClose={ onClose }
 			title={
 				editingLocation === 'new'
-					? __( 'Pickup location', 'woo-gutenberg-products-block' )
+					? __( 'Pickup location', 'woocommerce' )
 					: __(
 							'Edit pickup location',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 					  )
 			}
 			actions={
@@ -59,12 +59,12 @@ const EditLocation = ( {
 						>
 							{ __(
 								'Delete location',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</Button>
 					) }
 					<Button variant="secondary" onClick={ onClose }>
-						{ __( 'Cancel', 'woo-gutenberg-products-block' ) }
+						{ __( 'Cancel', 'woocommerce' ) }
 					</Button>
 					<Button
 						variant="primary"
@@ -77,7 +77,7 @@ const EditLocation = ( {
 							}
 						} }
 					>
-						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+						{ __( 'Done', 'woocommerce' ) }
 					</Button>
 				</>
 			}

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -22,17 +22,17 @@ import { useSettingsContext } from './settings-context';
 
 const GeneralSettingsDescription = () => (
 	<>
-		<h2>{ __( 'General', 'woo-gutenberg-products-block' ) }</h2>
+		<h2>{ __( 'General', 'woocommerce' ) }</h2>
 		<p>
 			{ __(
 				'Enable or disable local pickup on your store, and define costs. Local pickup is only available from the block checkout.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</p>
 		<ExternalLink
 			href={ `${ ADMIN_URL }post.php?post=${ CHECKOUT_PAGE_ID }&action=edit` }
 		>
-			{ __( 'View checkout page', 'woo-gutenberg-products-block' ) }
+			{ __( 'View checkout page', 'woocommerce' ) }
 		</ExternalLink>
 	</>
 );
@@ -60,7 +60,7 @@ const GeneralSettings = () => {
 						{ createInterpolateElement(
 							__(
 								'Enabling this will produce duplicate options at checkout. Remove the local pickup shipping method from your <a>shipping zones</a>.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							),
 							{
 								a: (
@@ -81,20 +81,20 @@ const GeneralSettings = () => {
 					onChange={ setSettingField( 'enabled' ) }
 					label={ __(
 						'Enable local pickup',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					help={
 						<span>
 							{ __(
 								'When enabled, local pickup will appear as an option on the block based checkout.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							{ shippingCostRequiresAddress ? (
 								<>
 									<br />
 									{ __(
 										'If local pickup is enabled, the "Hide shipping costs until an address is entered" setting will be ignored.',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									) }
 								</>
 							) : null }
@@ -102,15 +102,15 @@ const GeneralSettings = () => {
 					}
 				/>
 				<TextControl
-					label={ __( 'Title', 'woo-gutenberg-products-block' ) }
+					label={ __( 'Title', 'woocommerce' ) }
 					name="local_pickup_title"
 					help={ __(
 						'This is the shipping method title shown to customers.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					placeholder={ __(
 						'Local Pickup',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					value={ settings.title }
 					onChange={ setSettingField( 'title' ) }
@@ -123,7 +123,7 @@ const GeneralSettings = () => {
 						event.target.setCustomValidity(
 							__(
 								'Local pickup title is required',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							)
 						);
 					} }
@@ -141,11 +141,11 @@ const GeneralSettings = () => {
 					} }
 					label={ __(
 						'Add a price for customers who choose local pickup',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 					help={ __(
 						'By default, the local pickup shipping method is free.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					) }
 				/>
 				{ showCosts ? (
@@ -153,16 +153,16 @@ const GeneralSettings = () => {
 						<TextControl
 							label={ __(
 								'Cost',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							name="local_pickup_cost"
 							help={ __(
 								'Optional cost to charge for local pickup.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							placeholder={ __(
 								'Free',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							type="number"
 							pattern="[0-9]+\.?[0-9]*"
@@ -175,25 +175,25 @@ const GeneralSettings = () => {
 						<SelectControl
 							label={ __(
 								'Taxes',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							name="local_pickup_tax_status"
 							help={ __(
 								'If a cost is defined, this controls if taxes are applied to that cost.',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 							options={ [
 								{
 									label: __(
 										'Taxable',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									value: 'taxable',
 								},
 								{
 									label: __(
 										'Not taxable',
-										'woo-gutenberg-products-block'
+										'woocommerce'
 									),
 									value: 'none',
 								},

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/location-settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/location-settings.tsx
@@ -23,15 +23,15 @@ import { getUserFriendlyAddress } from './utils';
 
 const LocationSettingsDescription = () => (
 	<>
-		<h2>{ __( 'Pickup locations', 'woo-gutenberg-products-block' ) }</h2>
+		<h2>{ __( 'Pickup locations', 'woocommerce' ) }</h2>
 		<p>
 			{ __(
 				'Define pickup locations for your customers to choose from during checkout.',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			) }
 		</p>
 		<ExternalLink href="https://woocommerce.com/document/woocommerce-blocks-local-pickup/">
-			{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
+			{ __( 'Learn more', 'woocommerce' ) }
 		</ExternalLink>
 	</>
 );
@@ -57,7 +57,7 @@ const LocationSettings = () => {
 	const tableColumns = [
 		{
 			name: 'name',
-			label: __( 'Pickup location', 'woo-gutenberg-products-block' ),
+			label: __( 'Pickup location', 'woocommerce' ),
 			width: '50%',
 			renderCallback: ( row: SortableData ): JSX.Element => (
 				<>
@@ -70,7 +70,7 @@ const LocationSettings = () => {
 		},
 		{
 			name: 'enabled',
-			label: __( 'Enabled', 'woo-gutenberg-products-block' ),
+			label: __( 'Enabled', 'woocommerce' ),
 			align: 'right',
 			renderCallback: ( row: SortableData ): JSX.Element => (
 				<ToggleControl
@@ -92,7 +92,7 @@ const LocationSettings = () => {
 						setEditingLocation( row.id );
 					} }
 				>
-					{ __( 'Edit', 'woo-gutenberg-products-block' ) }
+					{ __( 'Edit', 'woocommerce' ) }
 				</button>
 			),
 		},
@@ -105,7 +105,7 @@ const LocationSettings = () => {
 				setEditingLocation( 'new' );
 			} }
 		>
-			{ __( 'Add pickup location', 'woo-gutenberg-products-block' ) }
+			{ __( 'Add pickup location', 'woocommerce' ) }
 		</Button>
 	);
 
@@ -120,7 +120,7 @@ const LocationSettings = () => {
 				} }
 				placeholder={ __(
 					'When you add a pickup location, it will appear here.',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				) }
 				footerContent={ FooterContent }
 			/>

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/save.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/save.tsx
@@ -37,7 +37,7 @@ const SaveSettings = () => {
 				} }
 				type="submit"
 			>
-				{ __( 'Save changes', 'woo-gutenberg-products-block' ) }
+				{ __( 'Save changes', 'woocommerce' ) }
 			</Button>
 		</SaveSectionWrapper>
 	);

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/settings-context.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/settings-context.tsx
@@ -151,7 +151,7 @@ export const SettingsProvider = ( {
 				dispatch( 'core/notices' ).createSuccessNotice(
 					__(
 						'Local Pickup settings have been saved.',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					)
 				);
 			}

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/utils.ts
@@ -27,7 +27,7 @@ export const indexLocationsById = (
 
 export const defaultSettings = {
 	enabled: false,
-	title: __( 'Local Pickup', 'woo-gutenberg-products-block' ),
+	title: __( 'Local Pickup', 'woocommerce' ),
 	tax_status: 'taxable',
 	cost: '',
 };

--- a/plugins/woocommerce-blocks/assets/js/previews/cart.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/cart.ts
@@ -42,11 +42,11 @@ export const previewCart: CartResponse = {
 			type: 'simple',
 			quantity: 2,
 			catalog_visibility: 'visible',
-			name: __( 'Beanie', 'woo-gutenberg-products-block' ),
-			summary: __( 'Beanie', 'woo-gutenberg-products-block' ),
+			name: __( 'Beanie', 'woocommerce' ),
+			summary: __( 'Beanie', 'woocommerce' ),
 			short_description: __(
 				'Warm hat for winter',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			description:
 				'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.',
@@ -75,12 +75,12 @@ export const previewCart: CartResponse = {
 			],
 			variation: [
 				{
-					attribute: __( 'Color', 'woo-gutenberg-products-block' ),
-					value: __( 'Yellow', 'woo-gutenberg-products-block' ),
+					attribute: __( 'Color', 'woocommerce' ),
+					value: __( 'Yellow', 'woocommerce' ),
 				},
 				{
-					attribute: __( 'Size', 'woo-gutenberg-products-block' ),
-					value: __( 'Small', 'woo-gutenberg-products-block' ),
+					attribute: __( 'Size', 'woocommerce' ),
+					value: __( 'Small', 'woocommerce' ),
 				},
 			],
 			prices: {
@@ -124,11 +124,11 @@ export const previewCart: CartResponse = {
 			type: 'simple',
 			quantity: 1,
 			catalog_visibility: 'visible',
-			name: __( 'Cap', 'woo-gutenberg-products-block' ),
-			summary: __( 'Cap', 'woo-gutenberg-products-block' ),
+			name: __( 'Cap', 'woocommerce' ),
+			summary: __( 'Cap', 'woocommerce' ),
 			short_description: __(
 				'Lightweight baseball cap',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			description:
 				'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.',
@@ -157,8 +157,8 @@ export const previewCart: CartResponse = {
 			],
 			variation: [
 				{
-					attribute: __( 'Color', 'woo-gutenberg-products-block' ),
-					value: __( 'Orange', 'woo-gutenberg-products-block' ),
+					attribute: __( 'Color', 'woocommerce' ),
+					value: __( 'Orange', 'woocommerce' ),
 				},
 			],
 			prices: {
@@ -200,14 +200,14 @@ export const previewCart: CartResponse = {
 	cross_sells: [
 		{
 			id: 1,
-			name: __( 'Polo', 'woo-gutenberg-products-block' ),
+			name: __( 'Polo', 'woocommerce' ),
 			parent: 0,
 			type: 'simple',
 			variation: '',
 			permalink: 'https://example.org',
 			sku: 'woo-polo',
-			short_description: __( 'Polo', 'woo-gutenberg-products-block' ),
-			description: __( 'Polo', 'woo-gutenberg-products-block' ),
+			short_description: __( 'Polo', 'woocommerce' ),
+			description: __( 'Polo', 'woocommerce' ),
 			on_sale: false,
 			prices: {
 				currency_code: 'USD',
@@ -257,7 +257,7 @@ export const previewCart: CartResponse = {
 		},
 		{
 			id: 2,
-			name: __( 'Long Sleeve Tee', 'woo-gutenberg-products-block' ),
+			name: __( 'Long Sleeve Tee', 'woocommerce' ),
 			parent: 0,
 			type: 'simple',
 			variation: '',
@@ -265,11 +265,11 @@ export const previewCart: CartResponse = {
 			sku: 'woo-long-sleeve-tee',
 			short_description: __(
 				'Long Sleeve Tee',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			description: __(
 				'Long Sleeve Tee',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			on_sale: false,
 			prices: {
@@ -321,7 +321,7 @@ export const previewCart: CartResponse = {
 		},
 		{
 			id: 3,
-			name: __( 'Hoodie with Zipper', 'woo-gutenberg-products-block' ),
+			name: __( 'Hoodie with Zipper', 'woocommerce' ),
 			parent: 0,
 			type: 'simple',
 			variation: '',
@@ -329,11 +329,11 @@ export const previewCart: CartResponse = {
 			sku: 'woo-hoodie-with-zipper',
 			short_description: __(
 				'Hoodie with Zipper',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			description: __(
 				'Hoodie with Zipper',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			on_sale: true,
 			prices: {
@@ -386,14 +386,14 @@ export const previewCart: CartResponse = {
 		},
 		{
 			id: 4,
-			name: __( 'Hoodie with Logo', 'woo-gutenberg-products-block' ),
+			name: __( 'Hoodie with Logo', 'woocommerce' ),
 			parent: 0,
 			type: 'simple',
 			variation: '',
 			permalink: 'https://example.org',
 			sku: 'woo-hoodie-with-logo',
-			short_description: __( 'Polo', 'woo-gutenberg-products-block' ),
-			description: __( 'Polo', 'woo-gutenberg-products-block' ),
+			short_description: __( 'Polo', 'woocommerce' ),
+			description: __( 'Polo', 'woocommerce' ),
 			on_sale: false,
 			prices: {
 				currency_code: 'USD',
@@ -444,7 +444,7 @@ export const previewCart: CartResponse = {
 		},
 		{
 			id: 5,
-			name: __( 'Hoodie with Pocket', 'woo-gutenberg-products-block' ),
+			name: __( 'Hoodie with Pocket', 'woocommerce' ),
 			parent: 0,
 			type: 'simple',
 			variation: '',
@@ -452,11 +452,11 @@ export const previewCart: CartResponse = {
 			sku: 'woo-hoodie-with-pocket',
 			short_description: __(
 				'Hoodie with Pocket',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			description: __(
 				'Hoodie with Pocket',
-				'woo-gutenberg-products-block'
+				'woocommerce'
 			),
 			on_sale: true,
 			prices: {
@@ -509,14 +509,14 @@ export const previewCart: CartResponse = {
 		},
 		{
 			id: 6,
-			name: __( 'T-Shirt', 'woo-gutenberg-products-block' ),
+			name: __( 'T-Shirt', 'woocommerce' ),
 			parent: 0,
 			type: 'simple',
 			variation: '',
 			permalink: 'https://example.org',
 			sku: 'woo-t-shirt',
-			short_description: __( 'T-Shirt', 'woo-gutenberg-products-block' ),
-			description: __( 'T-Shirt', 'woo-gutenberg-products-block' ),
+			short_description: __( 'T-Shirt', 'woocommerce' ),
+			description: __( 'T-Shirt', 'woocommerce' ),
 			on_sale: false,
 			prices: {
 				currency_code: 'USD',
@@ -568,7 +568,7 @@ export const previewCart: CartResponse = {
 	fees: [
 		{
 			id: 'fee',
-			name: __( 'Fee', 'woo-gutenberg-products-block' ),
+			name: __( 'Fee', 'woocommerce' ),
 			totals: {
 				currency_code: 'USD',
 				currency_symbol: '$',
@@ -632,7 +632,7 @@ export const previewCart: CartResponse = {
 		total_price: '4920',
 		tax_lines: [
 			{
-				name: __( 'Sales tax', 'woo-gutenberg-products-block' ),
+				name: __( 'Sales tax', 'woocommerce' ),
 				rate: '20%',
 				price: '820',
 			},

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -15,14 +15,14 @@ export const previewShippingRates: CartResponseShippingRate[] = [
 			country: '',
 		},
 		package_id: 0,
-		name: __( 'Shipping', 'woo-gutenberg-products-block' ),
+		name: __( 'Shipping', 'woocommerce' ),
 		items: [
 			{
 				key: '33e75ff09dd601bbe69f351039152189',
 				name: _x(
 					'Beanie with Logo',
 					'example product in Cart Block',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				quantity: 2,
 			},
@@ -31,7 +31,7 @@ export const previewShippingRates: CartResponseShippingRate[] = [
 				name: _x(
 					'Beanie',
 					'example product in Cart Block',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				quantity: 1,
 			},
@@ -47,7 +47,7 @@ export const previewShippingRates: CartResponseShippingRate[] = [
 				currency_suffix: '',
 				name: __(
 					'Flat rate shipping',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				description: '',
 				delivery_time: '',
@@ -67,7 +67,7 @@ export const previewShippingRates: CartResponseShippingRate[] = [
 				currency_thousand_separator: ',',
 				currency_prefix: '$',
 				currency_suffix: '',
-				name: __( 'Free shipping', 'woo-gutenberg-products-block' ),
+				name: __( 'Free shipping', 'woocommerce' ),
 				description: '',
 				delivery_time: '',
 				price: '0',
@@ -86,7 +86,7 @@ export const previewShippingRates: CartResponseShippingRate[] = [
 				currency_thousand_separator: ',',
 				currency_prefix: '$',
 				currency_suffix: '',
-				name: __( 'Local pickup', 'woo-gutenberg-products-block' ),
+				name: __( 'Local pickup', 'woocommerce' ),
 				description: '',
 				delivery_time: '',
 				price: '0',
@@ -114,7 +114,7 @@ export const previewShippingRates: CartResponseShippingRate[] = [
 				currency_thousand_separator: ',',
 				currency_prefix: '$',
 				currency_suffix: '',
-				name: __( 'Local pickup', 'woo-gutenberg-products-block' ),
+				name: __( 'Local pickup', 'woocommerce' ),
 				description: '',
 				delivery_time: '',
 				price: '0',

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-address-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-address-fields.ts
@@ -67,10 +67,10 @@ export type CountryAddressFields = Record< string, AddressFields >;
  */
 export const defaultAddressFields: AddressFields = {
 	first_name: {
-		label: __( 'First name', 'woo-gutenberg-products-block' ),
+		label: __( 'First name', 'woocommerce' ),
 		optionalLabel: __(
 			'First name (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'given-name',
 		autocapitalize: 'sentences',
@@ -79,10 +79,10 @@ export const defaultAddressFields: AddressFields = {
 		index: 10,
 	},
 	last_name: {
-		label: __( 'Last name', 'woo-gutenberg-products-block' ),
+		label: __( 'Last name', 'woocommerce' ),
 		optionalLabel: __(
 			'Last name (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'family-name',
 		autocapitalize: 'sentences',
@@ -91,10 +91,10 @@ export const defaultAddressFields: AddressFields = {
 		index: 20,
 	},
 	company: {
-		label: __( 'Company', 'woo-gutenberg-products-block' ),
+		label: __( 'Company', 'woocommerce' ),
 		optionalLabel: __(
 			'Company (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'organization',
 		autocapitalize: 'sentences',
@@ -103,10 +103,10 @@ export const defaultAddressFields: AddressFields = {
 		index: 30,
 	},
 	address_1: {
-		label: __( 'Address', 'woo-gutenberg-products-block' ),
+		label: __( 'Address', 'woocommerce' ),
 		optionalLabel: __(
 			'Address (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'address-line1',
 		autocapitalize: 'sentences',
@@ -115,10 +115,10 @@ export const defaultAddressFields: AddressFields = {
 		index: 40,
 	},
 	address_2: {
-		label: __( 'Apartment, suite, etc.', 'woo-gutenberg-products-block' ),
+		label: __( 'Apartment, suite, etc.', 'woocommerce' ),
 		optionalLabel: __(
 			'Apartment, suite, etc. (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'address-line2',
 		autocapitalize: 'sentences',
@@ -127,10 +127,10 @@ export const defaultAddressFields: AddressFields = {
 		index: 50,
 	},
 	country: {
-		label: __( 'Country/Region', 'woo-gutenberg-products-block' ),
+		label: __( 'Country/Region', 'woocommerce' ),
 		optionalLabel: __(
 			'Country/Region (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'country',
 		required: true,
@@ -138,8 +138,8 @@ export const defaultAddressFields: AddressFields = {
 		index: 60,
 	},
 	city: {
-		label: __( 'City', 'woo-gutenberg-products-block' ),
-		optionalLabel: __( 'City (optional)', 'woo-gutenberg-products-block' ),
+		label: __( 'City', 'woocommerce' ),
+		optionalLabel: __( 'City (optional)', 'woocommerce' ),
 		autocomplete: 'address-level2',
 		autocapitalize: 'sentences',
 		required: true,
@@ -147,10 +147,10 @@ export const defaultAddressFields: AddressFields = {
 		index: 70,
 	},
 	state: {
-		label: __( 'State/County', 'woo-gutenberg-products-block' ),
+		label: __( 'State/County', 'woocommerce' ),
 		optionalLabel: __(
 			'State/County (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'address-level1',
 		autocapitalize: 'sentences',
@@ -159,10 +159,10 @@ export const defaultAddressFields: AddressFields = {
 		index: 80,
 	},
 	postcode: {
-		label: __( 'Postal code', 'woo-gutenberg-products-block' ),
+		label: __( 'Postal code', 'woocommerce' ),
 		optionalLabel: __(
 			'Postal code (optional)',
-			'woo-gutenberg-products-block'
+			'woocommerce'
 		),
 		autocomplete: 'postal-code',
 		autocapitalize: 'characters',
@@ -171,8 +171,8 @@ export const defaultAddressFields: AddressFields = {
 		index: 90,
 	},
 	phone: {
-		label: __( 'Phone', 'woo-gutenberg-products-block' ),
-		optionalLabel: __( 'Phone (optional)', 'woo-gutenberg-products-block' ),
+		label: __( 'Phone', 'woocommerce' ),
+		optionalLabel: __( 'Phone (optional)', 'woocommerce' ),
 		autocomplete: 'tel',
 		type: 'tel',
 		required: true,

--- a/plugins/woocommerce-blocks/assets/js/templates/revert-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/templates/revert-button/index.tsx
@@ -99,14 +99,14 @@ const RevertClassicTemplateButton = () => {
 						>
 							{ __(
 								'Revert to Classic Product Template',
-								'woo-gutenberg-products-block'
+								'woocommerce'
 							) }
 						</Button>
 						<span>
 							{ createInterpolateElement(
 								__(
 									`The <strongText /> template doesn’t allow for reordering or customizing blocks, but might work better with your extensions`,
-									'woo-gutenberg-products-block'
+									'woocommerce'
 								),
 								{
 									strongText: (

--- a/plugins/woocommerce-blocks/changelog/fix-41996
+++ b/plugins/woocommerce-blocks/changelog/fix-41996
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update text domains in woocommerce-blocks folder


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the text domains in the `plugins/woocommerce-blocks/assets/js` folder to `woocommerce`.

See #41996 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review text domain changes
2. Check that a string wasn't inadvertently changed
3. check locally that the blocvks text domain isn't found in any files
```
cd assets
grep -nR woo-gutenberg ./
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
