### PR TITLE
update woo-gutenberg-products-block text domain to woocommerce in patterns and templates folders

### DIFF
--- a/plugins/woocommerce/changelog/fix-41996-other
+++ b/plugins/woocommerce/changelog/fix-41996-other
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update woo-gutenberg-products-block text domain to woocommerce in patterns and templates folders

--- a/plugins/woocommerce/patterns/banner.php
+++ b/plugins/woocommerce/patterns/banner.php
@@ -47,7 +47,7 @@ $second_description = $content['descriptions'][1]['default'] ?? '';
 	<div class="wp-block-column is-vertically-aligned-center">
 		<!-- wp:image {"id":1,"sizeSlug":"full","linkDestination":"none"} -->
 		<figure class="wp-block-image size-full">
-			<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/music-needle-turntable-black-and-white-white-photography.jpg' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a banner.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1" />
+			<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/music-needle-turntable-black-and-white-white-photography.jpg' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a banner.', 'woocommerce' ); ?>" class="wp-image-1" />
 		</figure>
 		<!-- /wp:image -->
 	</div>

--- a/plugins/woocommerce/patterns/featured-category-focus.php
+++ b/plugins/woocommerce/patterns/featured-category-focus.php
@@ -16,7 +16,7 @@ $button = $content['buttons'][0]['default'] ?? '';
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)">
 	<!-- wp:image {"id":1,"width":"469px","height":"348px","sizeSlug":"full","linkDestination":"none", "scale":"cover"} -->
 	<figure class="wp-block-image size-full is-resized">
-		<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/white-black-black-and-white-photograph-monochrome-photography.jpg' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a featured category section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1"  style="object-fit:cover;width:469px;height:348px"/>
+		<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/white-black-black-and-white-photograph-monochrome-photography.jpg' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a featured category section.', 'woocommerce' ); ?>" class="wp-image-1"  style="object-fit:cover;width:469px;height:348px"/>
 	</figure>
 	<!-- /wp:image -->
 

--- a/plugins/woocommerce/patterns/featured-category-triple.php
+++ b/plugins/woocommerce/patterns/featured-category-triple.php
@@ -23,14 +23,14 @@ $third_title  = $content['titles'][2]['default'] ?? '';
 		<!-- wp:cover {"url":"<?php echo esc_url( $image1 ); ?>","id":1,"dimRatio":30,"overlayColor":"contrast","isUserOverlayColor":true,"contentPosition":"bottom center","style":{"spacing":{"padding":{"bottom":"56px"}}},"className":"has-white-color"} -->
 		<div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center has-white-color" style="padding-bottom:56px">
 			<span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim-30 has-background-dim"></span>
-			<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in featured categories banner. 1 out of 3.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( $image1 ); ?>" data-object-fit="cover"/>
+			<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in featured categories banner. 1 out of 3.', 'woocommerce' ); ?>" src="<?php echo esc_url( $image1 ); ?>" data-object-fit="cover"/>
 			<div class="wp-block-cover__inner-container">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"margin":{"bottom":"24px"}}}} -->
 				<h4 class="wp-block-heading has-text-align-center" style="margin-bottom:24px"><?php echo esc_html( $first_title ); ?></h4>
 				<!-- /wp:heading -->
 				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}}} -->
 				<p class="has-text-align-center has-link-color" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
-					<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" data-type="link" data-id="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php esc_html_e( 'Shop Now', 'woo-gutenberg-products-block' ); ?></a>
+					<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" data-type="link" data-id="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php esc_html_e( 'Shop Now', 'woocommerce' ); ?></a>
 				</p>
 				<!-- /wp:paragraph -->
 			</div>
@@ -44,14 +44,14 @@ $third_title  = $content['titles'][2]['default'] ?? '';
 		<!-- wp:cover {"url":"<?php echo esc_url( $image2 ); ?>","id":1,"dimRatio":30,"overlayColor":"contrast","isUserOverlayColor":true,"contentPosition":"bottom center","style":{"spacing":{"padding":{"bottom":"56px"}}},"className":"has-white-color"} -->
 		<div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center has-white-color" style="padding-bottom:56px">
 			<span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim-30 has-background-dim"></span>
-			<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in featured categories banner. 2 out of 3.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( $image2 ); ?>" data-object-fit="cover"/>
+			<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in featured categories banner. 2 out of 3.', 'woocommerce' ); ?>" src="<?php echo esc_url( $image2 ); ?>" data-object-fit="cover"/>
 			<div class="wp-block-cover__inner-container">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"margin":{"bottom":"24px"}}}} -->
 				<h4 class="wp-block-heading has-text-align-center" style="margin-bottom:24px"><?php echo esc_html( $second_title ); ?></h4>
 				<!-- /wp:heading -->
 				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}}} -->
 				<p class="has-text-align-center has-link-color" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
-					<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" data-type="link" data-id="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php esc_html_e( 'Shop Now', 'woo-gutenberg-products-block' ); ?></a>
+					<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" data-type="link" data-id="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php esc_html_e( 'Shop Now', 'woocommerce' ); ?></a>
 				</p>
 				<!-- /wp:paragraph -->
 			</div>
@@ -65,14 +65,14 @@ $third_title  = $content['titles'][2]['default'] ?? '';
 		<!-- wp:cover {"url":"<?php echo esc_url( $image3 ); ?>","id":1,"dimRatio":30,"overlayColor":"contrast","isUserOverlayColor":true,"contentPosition":"bottom center","style":{"spacing":{"padding":{"bottom":"56px"}}},"className":"has-white-color"} -->
 		<div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center has-white-color" style="padding-bottom:56px">
 			<span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim-30 has-background-dim"></span>
-			<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in featured categories banner. 3 out of 3', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( $image3 ); ?>" data-object-fit="cover"/>
+			<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in featured categories banner. 3 out of 3', 'woocommerce' ); ?>" src="<?php echo esc_url( $image3 ); ?>" data-object-fit="cover"/>
 			<div class="wp-block-cover__inner-container">
 				<!-- wp:heading {"textAlign":"center","level":4,"style":{"spacing":{"margin":{"bottom":"24px"}}}} -->
 				<h4 class="wp-block-heading has-text-align-center" style="margin-bottom:24px"><?php echo esc_html( $third_title ); ?></h4>
 				<!-- /wp:heading -->
 				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}}} -->
 				<p class="has-text-align-center has-link-color" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
-					<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" data-type="link" data-id="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php esc_html_e( 'Shop Now', 'woo-gutenberg-products-block' ); ?></a>
+					<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" data-type="link" data-id="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php esc_html_e( 'Shop Now', 'woocommerce' ); ?></a>
 				</p>
 				<!-- /wp:paragraph -->
 			</div>

--- a/plugins/woocommerce/patterns/featured-products-fresh-and-tasty.php
+++ b/plugins/woocommerce/patterns/featured-products-fresh-and-tasty.php
@@ -29,7 +29,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 	<div class="wp-block-column">
 		<!-- wp:image {"align":"full","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
 		<figure class="wp-block-image alignfull size-full">
-			<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 1 out of 4.', 'woo-gutenberg-products-block' ); ?>" />
+			<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 1 out of 4.', 'woocommerce' ); ?>" />
 		</figure>
 		<!-- /wp:image -->
 
@@ -46,7 +46,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 			<!-- wp:column {"width":"33%","layout":{"type":"constrained","justifyContent":"right"}} -->
 			<div class="wp-block-column" style="flex-basis:33%">
 				<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $1.99', 'woo-gutenberg-products-block' ); ?></p>
+				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $1.99', 'woocommerce' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:column -->
@@ -59,7 +59,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 	<div class="wp-block-column">
 		<!-- wp:image {"align":"full","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
 		<figure class="wp-block-image alignfull size-full">
-			<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 2 out of 4.', 'woo-gutenberg-products-block' ); ?>" />
+			<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 2 out of 4.', 'woocommerce' ); ?>" />
 		</figure>
 		<!-- /wp:image -->
 
@@ -76,7 +76,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 			<!-- wp:column {"width":"33%","layout":{"type":"constrained","justifyContent":"right"}} -->
 			<div class="wp-block-column" style="flex-basis:33%">
 				<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $2.99', 'woo-gutenberg-products-block' ); ?></p>
+				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $2.99', 'woocommerce' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:column -->
@@ -89,7 +89,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 	<div class="wp-block-column">
 		<!-- wp:image {"align":"full","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
 		<figure class="wp-block-image alignfull size-full">
-			<img src="<?php echo esc_url( $image3 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 3 out of 4.', 'woo-gutenberg-products-block' ); ?>" />
+			<img src="<?php echo esc_url( $image3 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 3 out of 4.', 'woocommerce' ); ?>" />
 		</figure>
 		<!-- /wp:image -->
 
@@ -106,7 +106,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 			<!-- wp:column {"width":"33%","layout":{"type":"constrained","justifyContent":"right"}} -->
 			<div class="wp-block-column" style="flex-basis:33%">
 				<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $0.99', 'woo-gutenberg-products-block' ); ?></p>
+				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $0.99', 'woocommerce' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:column -->
@@ -119,7 +119,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 	<div class="wp-block-column">
 		<!-- wp:image {"align":"full","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
 		<figure class="wp-block-image alignfull size-full">
-			<img src="<?php echo esc_url( $image4 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 4 out of 4.', 'woo-gutenberg-products-block' ); ?>" />
+			<img src="<?php echo esc_url( $image4 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in the featured products pattern. 4 out of 4.', 'woocommerce' ); ?>" />
 		</figure>
 		<!-- /wp:image -->
 
@@ -136,7 +136,7 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 			<!-- wp:column {"width":"33%","layout":{"type":"constrained","justifyContent":"right"}} -->
 			<div class="wp-block-column" style="flex-basis:33%">
 				<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $1.49', 'woo-gutenberg-products-block' ); ?></p>
+				<p class="has-text-align-left has-small-font-size"><?php esc_html_e( 'from $1.49', 'woocommerce' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:column -->

--- a/plugins/woocommerce/patterns/filters.php
+++ b/plugins/woocommerce/patterns/filters.php
@@ -9,7 +9,7 @@
 
 <!-- wp:woocommerce/filter-wrapper {"filterType":"active-filters"} -->
 <div class="wp-block-woocommerce-filter-wrapper"><!-- wp:heading {"level":3} -->
-<h3><?php esc_html_e( 'Active filters', 'woo-gutenberg-products-block' ); ?></h3>
+<h3><?php esc_html_e( 'Active filters', 'woocommerce' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:woocommerce/active-filters {"heading":"","lock":{"remove":true}} -->
@@ -19,7 +19,7 @@
 
 <!-- wp:woocommerce/filter-wrapper {"filterType":"price-filter"} -->
 <div class="wp-block-woocommerce-filter-wrapper"><!-- wp:heading {"level":3} -->
-<h3><?php esc_html_e( 'Filter by price', 'woo-gutenberg-products-block' ); ?></h3>
+<h3><?php esc_html_e( 'Filter by price', 'woocommerce' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:woocommerce/price-filter {"heading":"","lock":{"remove":true}} -->
@@ -29,7 +29,7 @@
 
 <!-- wp:woocommerce/filter-wrapper {"filterType":"stock-filter"} -->
 <div class="wp-block-woocommerce-filter-wrapper"><!-- wp:heading {"level":3} -->
-<h3><?php esc_html_e( 'Filter by stock status', 'woo-gutenberg-products-block' ); ?></h3>
+<h3><?php esc_html_e( 'Filter by stock status', 'woocommerce' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:woocommerce/stock-filter {"heading":"","lock":{"remove":true}} -->
@@ -39,7 +39,7 @@
 
 <!-- wp:woocommerce/filter-wrapper {"filterType":"attribute-filter"} -->
 <div class="wp-block-woocommerce-filter-wrapper"><!-- wp:heading {"level":3} -->
-<h3><?php esc_html_e( 'Filter by attribute', 'woo-gutenberg-products-block' ); ?></h3>
+<h3><?php esc_html_e( 'Filter by attribute', 'woocommerce' ); ?></h3>
 <!-- /wp:heading -->
 
 <?php
@@ -58,7 +58,7 @@ if ( ! empty( $attributes ) ) {
 
 <!-- wp:woocommerce/filter-wrapper {"filterType":"rating-filter"} -->
 <div class="wp-block-woocommerce-filter-wrapper"><!-- wp:heading {"level":3} -->
-<h3><?php esc_html_e( 'Filter by rating', 'woo-gutenberg-products-block' ); ?></h3>
+<h3><?php esc_html_e( 'Filter by rating', 'woocommerce' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:woocommerce/rating-filter {"lock":{"remove":true}} -->

--- a/plugins/woocommerce/patterns/footer-large-dark.php
+++ b/plugins/woocommerce/patterns/footer-large-dark.php
@@ -22,11 +22,11 @@
 				<!-- /wp:spacer -->
 
 				<!-- wp:heading {"level":5} -->
-				<h5><?php esc_html_e( 'Join the community', 'woo-gutenberg-products-block' ); ?></h5>
+				<h5><?php esc_html_e( 'Join the community', 'woocommerce' ); ?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph -->
-				<p><?php esc_html_e( 'Learn about new products and discounts!', 'woo-gutenberg-products-block' ); ?></p>
+				<p><?php esc_html_e( 'Learn about new products and discounts!', 'woocommerce' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:spacer {"height":"20px"} -->
@@ -80,7 +80,7 @@
 			<?php
 			echo sprintf(
 				/* translators: %s WooCommerce link */
-				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				esc_html__( 'Built with %s', 'woocommerce' ),
 				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>

--- a/plugins/woocommerce/patterns/footer-large.php
+++ b/plugins/woocommerce/patterns/footer-large.php
@@ -16,11 +16,11 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 			<div class="wp-block-group"><!-- wp:site-logo /-->
 				<!-- wp:heading {"level":5,"style":{"typography":{"textTransform":"none"},"spacing":{"margin":{"top":"40px"}}}} -->
-				<h5 class="wp-block-heading" style="margin-top:40px;text-transform:none"><?php esc_html_e( 'Join the community', 'woo-gutenberg-products-block' ); ?></h5>
+				<h5 class="wp-block-heading" style="margin-top:40px;text-transform:none"><?php esc_html_e( 'Join the community', 'woocommerce' ); ?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"40px"}}}} -->
-				<p style="margin-bottom:40px"><?php esc_html_e( 'Learn about new products and discounts', 'woo-gutenberg-products-block' ); ?></p>
+				<p style="margin-bottom:40px"><?php esc_html_e( 'Learn about new products and discounts', 'woocommerce' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:social-links {"size":"has-small-icon-size","style":{"spacing":{"blockGap":{"left":"16px"}}},"className":"is-style-logos-only"} -->
@@ -67,7 +67,7 @@
 			/* translators: Footer powered by text. %1$s being WordPress, %2$s being WooCommerce */
 				esc_html__(
 					'Powered by %1$s with %2$s',
-					'woo-gutenberg-products-block'
+					'woocommerce'
 				),
 				'<a href="https://wordpress.org" target="_blank" rel="noreferrer nofollow">WordPress</a>',
 				'<a href="https://woocommerce.com" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'

--- a/plugins/woocommerce/patterns/footer-simple-dark.php
+++ b/plugins/woocommerce/patterns/footer-simple-dark.php
@@ -54,7 +54,7 @@
 			<?php
 			echo sprintf(
 				/* translators: %s WooCommerce link */
-				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				esc_html__( 'Built with %s', 'woocommerce' ),
 				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>

--- a/plugins/woocommerce/patterns/footer-simple-menu.php
+++ b/plugins/woocommerce/patterns/footer-simple-menu.php
@@ -13,7 +13,7 @@
 	<div class="wp-block-group alignfull" style="padding-right:0;padding-left:0">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"24px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:search {"style":{"border":{"radius":"0px"}},"label":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%"} /-->
+			<!-- wp:search {"style":{"border":{"radius":"0px"}},"label":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%"} /-->
 		</div>
 		<!-- /wp:group -->
 
@@ -37,7 +37,7 @@
 		<p class="has-text-align-center">
 			<?php
 				/* translators: 1: WordPress link, 2: WooCommerce link */
-				echo sprintf( esc_html__( 'Powered by %1$s with %2$s', 'woo-gutenberg-products-block' ), '<a href="https://wordpress.org" target="_blank" rel="noreferrer nofollow">WordPress</a>', '<a href="https://woocommerce.com" target="_blank" rel="noreferrer nofollow">WooCommerce</a>' );
+				echo sprintf( esc_html__( 'Powered by %1$s with %2$s', 'woocommerce' ), '<a href="https://wordpress.org" target="_blank" rel="noreferrer nofollow">WordPress</a>', '<a href="https://woocommerce.com" target="_blank" rel="noreferrer nofollow">WooCommerce</a>' );
 			?>
 		</p>
 		<!-- /wp:paragraph -->

--- a/plugins/woocommerce/patterns/footer-simple.php
+++ b/plugins/woocommerce/patterns/footer-simple.php
@@ -54,7 +54,7 @@
 			<?php
 			echo sprintf(
 				/* translators: %s WooCommerce link */
-				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				esc_html__( 'Built with %s', 'woocommerce' ),
 				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>

--- a/plugins/woocommerce/patterns/footer-with-2-menus-dark.php
+++ b/plugins/woocommerce/patterns/footer-with-2-menus-dark.php
@@ -71,7 +71,7 @@
 			<?php
 			echo sprintf(
 					/* translators: %s WooCommerce link */
-				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				esc_html__( 'Built with %s', 'woocommerce' ),
 				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>

--- a/plugins/woocommerce/patterns/footer-with-2-menus.php
+++ b/plugins/woocommerce/patterns/footer-with-2-menus.php
@@ -70,7 +70,7 @@
 			<?php
 			echo sprintf(
 					/* translators: %s WooCommerce link */
-				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				esc_html__( 'Built with %s', 'woocommerce' ),
 				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>

--- a/plugins/woocommerce/patterns/footer-with-3-menus.php
+++ b/plugins/woocommerce/patterns/footer-with-3-menus.php
@@ -37,7 +37,7 @@
 
 		<!-- wp:column {"verticalAlignment":"stretch","width":"30%","style":{"spacing":{"blockGap":"60px"}},"layout":{"type":"default"}} -->
 		<div class="wp-block-column is-vertically-aligned-stretch" style="flex-basis:30%">
-			<!-- wp:search {"style":{"border":{"radius":"0px"}}, "label":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%"} /-->
+			<!-- wp:search {"style":{"border":{"radius":"0px"}}, "label":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%"} /-->
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"right":"0","left":"0"},"margin":{"top":"56px","bottom":"0"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
 			<div class="wp-block-group" style="margin-top:56px;margin-bottom:0;padding-right:0;padding-left:0">
 				<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
@@ -48,7 +48,7 @@
 					/* translators: Footer powered by text. %1$s being WordPress, %2$s being WooCommerce */
 						esc_html__(
 							'Powered by %1$s with %2$s',
-							'woo-gutenberg-products-block'
+							'woocommerce'
 						),
 						'<a href="https://wordpress.org" target="_blank" rel="noreferrer nofollow">WordPress</a>',
 						'<a href="https://woocommerce.com" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'

--- a/plugins/woocommerce/patterns/header-essential-dark.php
+++ b/plugins/woocommerce/patterns/header-essential-dark.php
@@ -11,7 +11,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"40px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 	<div class="wp-block-group">
 		<!-- wp:site-logo {"shouldSyncIcon":false} /-->
-		<!-- wp:search {"style":{"border":{"radius":"0px"}},"label":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%","backgroundColor":"contrast-2"} /-->
+		<!-- wp:search {"style":{"border":{"radius":"0px"}},"label":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%","backgroundColor":"contrast-2"} /-->
 		<!-- wp:navigation {"textColor":"background","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"center"}} /-->
 	</div>
 	<!-- /wp:group -->

--- a/plugins/woocommerce/patterns/header-large-dark.php
+++ b/plugins/woocommerce/patterns/header-large-dark.php
@@ -10,7 +10,7 @@
 <div class="wc-blocks-header-pattern wp-block-group alignfull has-background-color has-white-color has-black-background-color has-text-color has-background has-link-color" style="padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem">
 	<!-- wp:group {"style":{"spacing":{"blockGap":"1rem"}},"className":"has-small-font-size","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group has-small-font-size">
-		<!-- wp:search {"style":{"border":{"radius":"0px"}},"label":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%"} /-->
+		<!-- wp:search {"style":{"border":{"radius":"0px"}},"label":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%"} /-->
 		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
 			<!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","fontSize":"small","iconClass":"wc-block-customer-account__account-icon"} /-->

--- a/plugins/woocommerce/patterns/header-large.php
+++ b/plugins/woocommerce/patterns/header-large.php
@@ -47,7 +47,7 @@
 
 		<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="padding-right:0;padding-left:0">
-			<!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"style":{"border":{"radius":"0px"}}} /-->
+			<!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woocommerce' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"style":{"border":{"radius":"0px"}}} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/plugins/woocommerce/patterns/hero-product-3-split.php
+++ b/plugins/woocommerce/patterns/hero-product-3-split.php
@@ -26,7 +26,7 @@ $third_description  = $content['descriptions'][2]['default'] ?? '';
 			<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
 			<img
 				class="wp-block-cover__image-background"
-				alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased.', 'woo-gutenberg-products-block' ); ?>"
+				alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased.', 'woocommerce' ); ?>"
 				src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/drinkware-liquid-tableware-dishware-bottle-fluid.jpg' ) ); ?>"
 				data-object-fit="cover" />
 			<div class="wp-block-cover__inner-container">
@@ -98,7 +98,7 @@ $third_description  = $content['descriptions'][2]['default'] ?? '';
 			<!-- wp:buttons -->
 			<div class="wp-block-buttons"><!-- wp:button -->
 				<div class="wp-block-button">
-					<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
+					<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'woocommerce' ); ?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/plugins/woocommerce/patterns/hero-product-chessboard.php
+++ b/plugins/woocommerce/patterns/hero-product-chessboard.php
@@ -29,7 +29,7 @@ $button = $content['buttons'][0]['default'] ?? '';
 		<div class="wp-block-column">
 			<!-- wp:cover {"url":"<?php echo esc_url( $image1 ); ?>","dimRatio":0,"focalPoint":{"x":0.54,"y":0.52},"isDark":false,"style":{"color":{}}} -->
 			<div class="wp-block-cover is-light">
-				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section. 1 out of 2.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( $image1 ); ?>" style="object-position:54% 52%" data-object-fit="cover" data-object-position="54% 52%"/>
+				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section. 1 out of 2.', 'woocommerce' ); ?>" src="<?php echo esc_url( $image1 ); ?>" style="object-position:54% 52%" data-object-fit="cover" data-object-position="54% 52%"/>
 				<div class="wp-block-cover__inner-container">
 					<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
 						<p class="has-text-align-center has-large-font-size"> </p>
@@ -106,7 +106,7 @@ $button = $content['buttons'][0]['default'] ?? '';
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:cover {"url":"<?php echo esc_url( $image2 ); ?>","dimRatio":0,"focalPoint":{"x":0.33,"y":0.06},"style":{"color":{}}} -->
 			<div class="wp-block-cover">
-				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section. 2 out of 2.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( $image2 ); ?>" style="object-position:33% 6%" data-object-fit="cover" data-object-position="33% 6%"/>
+				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section. 2 out of 2.', 'woocommerce' ); ?>" src="<?php echo esc_url( $image2 ); ?>" style="object-position:33% 6%" data-object-fit="cover" data-object-position="33% 6%"/>
 				<div class="wp-block-cover__inner-container">
 					<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
 						<p class="has-text-align-center has-large-font-size"> </p>

--- a/plugins/woocommerce/patterns/hero-product-split.php
+++ b/plugins/woocommerce/patterns/hero-product-split.php
@@ -21,7 +21,7 @@ $hero_title = $content['titles'][0]['default'] ?? '';
 		<div class="wp-block-buttons" style="margin-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:button -->
 		<div class="wp-block-button">
-			<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop the sale', 'woo-gutenberg-products-block' ); ?></a>
+			<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop the sale', 'woocommerce' ); ?></a>
 		</div>
 		<!-- /wp:button -->
 		</div>
@@ -29,7 +29,7 @@ $hero_title = $content['titles'][0]['default'] ?? '';
 	</div>
 
 	<figure class="wp-block-media-text__media">
-		<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/man-person-winter-photography-statue-coat.png' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" />
+		<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/man-person-winter-photography-statue-coat.png' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woocommerce' ); ?>" />
 	</figure>
 </div>
 <!-- /wp:media-text -->

--- a/plugins/woocommerce/patterns/no-products-found.php
+++ b/plugins/woocommerce/patterns/no-products-found.php
@@ -8,6 +8,6 @@
 ?>
 <!-- wp:paragraph -->
 <p>
-	<?php echo esc_html_x( 'No products were found matching your selection.', 'Message explaining that there are no products returned from a search', 'woo-gutenberg-products-block' ); ?>
+	<?php echo esc_html_x( 'No products were found matching your selection.', 'Message explaining that there are no products returned from a search', 'woocommerce' ); ?>
 </p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/patterns/product-collection-featured-products-5-columns.php
+++ b/plugins/woocommerce/patterns/product-collection-featured-products-5-columns.php
@@ -35,7 +35,7 @@ $collection_title = $content['titles'][0]['default'] ?? '';
 		<!-- wp:button {"textAlign":"center"} -->
 		<div class="wp-block-button">
 			<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>">
-				<?php esc_html_e( 'Shop All', 'woo-gutenberg-products-block' ); ?>
+				<?php esc_html_e( 'Shop All', 'woocommerce' ); ?>
 			</a>
 		</div>
 		<!-- /wp:button -->

--- a/plugins/woocommerce/patterns/product-collections-featured-collections.php
+++ b/plugins/woocommerce/patterns/product-collections-featured-collections.php
@@ -40,13 +40,13 @@ $second_button = $content['buttons'][1]['default'] ?? '';
 		<div class="wp-block-group">
 			<!-- wp:image {"width":140,"sizeSlug":"full","linkDestination":"none"} -->
 			<figure class="wp-block-image size-full is-resized">
-				<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a left side of a banner. 1 out of 2.', 'woo-gutenberg-products-block' ); ?>" width="140" />
+				<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a left side of a banner. 1 out of 2.', 'woocommerce' ); ?>" width="140" />
 			</figure>
 			<!-- /wp:image -->
 
 			<!-- wp:image {"width":140,"height":100,"sizeSlug":"full","linkDestination":"none"} -->
 			<figure class="wp-block-image size-full is-resized">
-				<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a left side of a banner. 2 out of 2.', 'woo-gutenberg-products-block' ); ?>" width="140" height="100" />
+				<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a left side of a banner. 2 out of 2.', 'woocommerce' ); ?>" width="140" height="100" />
 			</figure>
 			<!-- /wp:image -->
 		</div>
@@ -74,13 +74,13 @@ $second_button = $content['buttons'][1]['default'] ?? '';
 		<div class="wp-block-group">
 			<!-- wp:image {"width":140,"height":100,"sizeSlug":"full","linkDestination":"none"} -->
 			<figure class="wp-block-image size-full is-resized">
-				<img src="<?php echo esc_url( $image3 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a right side of a banner. 1 out of 2.', 'woo-gutenberg-products-block' ); ?>" width="140" height="100" />
+				<img src="<?php echo esc_url( $image3 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a right side of a banner. 1 out of 2.', 'woocommerce' ); ?>" width="140" height="100" />
 			</figure>
 			<!-- /wp:image -->
 
 			<!-- wp:image {"width":140,"height":100,"sizeSlug":"full","linkDestination":"none"} -->
 			<figure class="wp-block-image size-full is-resized">
-				<img src="<?php echo esc_url( $image4 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a right side of a banner. 2 out of 2.', 'woo-gutenberg-products-block' ); ?>" width="140" height="100" />
+				<img src="<?php echo esc_url( $image4 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a right side of a banner. 2 out of 2.', 'woocommerce' ); ?>" width="140" height="100" />
 			</figure>
 			<!-- /wp:image -->
 		</div>

--- a/plugins/woocommerce/patterns/product-details-pattern.php
+++ b/plugins/woocommerce/patterns/product-details-pattern.php
@@ -11,7 +11,7 @@
 	<div class="wp-block-column" style="padding-top:0;padding-right:40px;padding-bottom:0;padding-left:0px">
 		<!-- wp:image {"id":1,"sizeSlug":"full","linkDestination":"none"} -->
 		<figure class="wp-block-image size-full">
-			<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-home-living-room-furniture-room.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product details banner. 1 out of 3.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1"/>
+			<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-home-living-room-furniture-room.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product details banner. 1 out of 3.', 'woocommerce' ); ?>" class="wp-image-1"/>
 		</figure>
 		<!-- /wp:image -->
 
@@ -21,7 +21,7 @@
 			<div class="wp-block-column" style="padding-top:0px;padding-right:5px;padding-bottom:0px;padding-left:0px;">
 				<!-- wp:image {"id":1,"sizeSlug":"full","linkDestination":"none"} -->
 				<figure class="wp-block-image size-full">
-					<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-white-chair-floor-shelf-lamp-square-lg.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product details banner. 2 out of 3.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1"/>
+					<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-white-chair-floor-shelf-lamp-square-lg.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product details banner. 2 out of 3.', 'woocommerce' ); ?>" class="wp-image-1"/>
 				</figure>
 				<!-- /wp:image --></div>
 			<!-- /wp:column -->
@@ -30,7 +30,7 @@
 			<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;">
 				<!-- wp:image {"id":1,"sizeSlug":"full","linkDestination":"none"} -->
 				<figure class="wp-block-image size-full">
-					<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-interior-atmosphere-living-room-furniture-square-lg.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product details banner. 3 out of 3.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1"/>
+					<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-interior-atmosphere-living-room-furniture-square-lg.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product details banner. 3 out of 3.', 'woocommerce' ); ?>" class="wp-image-1"/>
 				</figure>
 				<!-- /wp:image --></div>
 			<!-- /wp:column --></div>

--- a/plugins/woocommerce/patterns/product-hero-2-col-2-row.php
+++ b/plugins/woocommerce/patterns/product-hero-2-col-2-row.php
@@ -30,7 +30,7 @@ $button = $content['buttons'][0]['default'] ?? '';
 	<!-- wp:media-text {"align":"full","mediaType":"image","mediaId":1,"mediaLink":"<?php echo esc_url( $image1 ); ?>","mediaWidth":40} -->
 	<div class="wp-block-media-text alignfull is-stacked-on-mobile" style="grid-template-columns:40% auto">
 		<figure class="wp-block-media-text__media">
-			<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1 size-full" />
+			<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woocommerce' ); ?>" class="wp-image-1 size-full" />
 		</figure>
 		<div class="wp-block-media-text__content">
 			<!-- wp:group {"layout":{"contentSize":"760px","type":"constrained"}} -->
@@ -132,7 +132,7 @@ $button = $content['buttons'][0]['default'] ?? '';
 			<!-- /wp:columns -->
 		</div>
 		<figure class="wp-block-media-text__media">
-			<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1 size-full" />
+			<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woocommerce' ); ?>" class="wp-image-1 size-full" />
 		</figure>
 	</div>
 	<!-- /wp:media-text -->

--- a/plugins/woocommerce/patterns/product-listing-with-gallery-and-description.php
+++ b/plugins/woocommerce/patterns/product-listing-with-gallery-and-description.php
@@ -18,19 +18,19 @@
 				<div class="wp-block-group">
 					<!-- wp:image {"sizeSlug":"thumbnail","linkDestination":"none","style":{"border":{"color":"#dddddd","width":"1px","radius":"5px"}},"className":"is-resized"} -->
 					<figure class="wp-block-image size-thumbnail has-custom-border is-resized">
-						<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/desk-table-wood-chair-floor-home-square.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery. Secondary image - 1 out of 3.', 'woo-gutenberg-products-block' ); ?>" class="has-border-color" style="border-color:#dddddd;border-width:1px;border-radius:5px"/>
+						<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/desk-table-wood-chair-floor-home-square.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery. Secondary image - 1 out of 3.', 'woocommerce' ); ?>" class="has-border-color" style="border-color:#dddddd;border-width:1px;border-radius:5px"/>
 					</figure>
 					<!-- /wp:image -->
 
 					<!-- wp:image {"sizeSlug":"thumbnail","linkDestination":"none","style":{"border":{"color":"#dddddd","width":"1px","radius":"5px"}},"className":"is-resized"} -->
 					<figure class="wp-block-image size-thumbnail has-custom-border is-resized">
-						<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-interior-atmosphere-living-room-furniture-square.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery. Secondary image - 2 out of 3.', 'woo-gutenberg-products-block' ); ?>" class="has-border-color" style="border-color:#dddddd;border-width:1px;border-radius:5px"/>
+						<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-interior-atmosphere-living-room-furniture-square.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery. Secondary image - 2 out of 3.', 'woocommerce' ); ?>" class="has-border-color" style="border-color:#dddddd;border-width:1px;border-radius:5px"/>
 					</figure>
 					<!-- /wp:image -->
 
 					<!-- wp:image {"sizeSlug":"thumbnail","linkDestination":"none","style":{"border":{"color":"#dddddd","width":"1px","radius":"5px"}},"className":"is-resized"} -->
 					<figure class="wp-block-image size-thumbnail has-custom-border is-resized">
-						<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-home-living-room-furniture-room-square.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery. Secondary image - 3 out of 3.', 'woo-gutenberg-products-block' ); ?>" class="has-border-color" style="border-color:#dddddd;border-width:1px;border-radius:5px"/>
+						<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-floor-home-living-room-furniture-room-square.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery. Secondary image - 3 out of 3.', 'woocommerce' ); ?>" class="has-border-color" style="border-color:#dddddd;border-width:1px;border-radius:5px"/>
 					</figure>
 					<!-- /wp:image -->
 				</div>
@@ -42,7 +42,7 @@
 			<div class="wp-block-column" style="flex-basis:85%">
 				<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
 				<figure class="wp-block-image size-full">
-					<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-wood-chair-floor-living-room-furniture-vertical.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery as a main image', 'woo-gutenberg-products-block' ); ?>"/>
+					<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/table-wood-chair-floor-living-room-furniture-vertical.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a product gallery as a main image', 'woocommerce' ); ?>"/>
 				</figure>
 				<!-- /wp:image -->
 			</div>

--- a/plugins/woocommerce/patterns/product-search-form.php
+++ b/plugins/woocommerce/patterns/product-search-form.php
@@ -6,4 +6,4 @@
  * Categories: WooCommerce
  */
 ?>
-<!-- wp:search {"showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Search products…', 'placeholder for search field', 'woo-gutenberg-products-block' ); ?>","query":{"post_type":"product"}} /-->
+<!-- wp:search {"showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Search products…', 'placeholder for search field', 'woocommerce' ); ?>","query":{"post_type":"product"}} /-->

--- a/plugins/woocommerce/patterns/related-products.php
+++ b/plugins/woocommerce/patterns/related-products.php
@@ -16,7 +16,7 @@
 				<?php
 					echo esc_html__(
 						'Related products',
-						'woo-gutenberg-products-block'
+						'woocommerce'
 					)
 					?>
 			</h2>

--- a/plugins/woocommerce/patterns/social-follow-us-in-social-media.php
+++ b/plugins/woocommerce/patterns/social-follow-us-in-social-media.php
@@ -43,7 +43,7 @@ $social_title = $content['titles'][0]['default'] ?? '';
 		<div class="wp-block-column" style="flex-basis:25%">
 			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
 			<figure class="wp-block-image is-resized size-large">
-				<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 1 out of 4.', 'woo-gutenberg-products-block' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
+				<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 1 out of 4.', 'woocommerce' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
 			</figure>
 			<!-- /wp:image -->
 		</div>
@@ -53,7 +53,7 @@ $social_title = $content['titles'][0]['default'] ?? '';
 		<div class="wp-block-column" style="flex-basis:25%">
 			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
 			<figure class="wp-block-image is-resized size-large">
-				<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 2 out of 4.', 'woo-gutenberg-products-block' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
+				<img src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 2 out of 4.', 'woocommerce' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
 			</figure>
 			<!-- /wp:image -->
 		</div>
@@ -63,7 +63,7 @@ $social_title = $content['titles'][0]['default'] ?? '';
 		<div class="wp-block-column" style="flex-basis:25%">
 			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
 			<figure class="wp-block-image is-resized size-large">
-				<img src="<?php echo esc_url( $image3 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 3 out of 4.', 'woo-gutenberg-products-block' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
+				<img src="<?php echo esc_url( $image3 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 3 out of 4.', 'woocommerce' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
 			</figure>
 			<!-- /wp:image -->
 		</div>
@@ -73,7 +73,7 @@ $social_title = $content['titles'][0]['default'] ?? '';
 		<div class="wp-block-column" style="flex-basis:25%">
 			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
 			<figure class="wp-block-image is-resized size-large">
-				<img src="<?php echo esc_url( $image4 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 4 out of 4.', 'woo-gutenberg-products-block' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
+				<img src="<?php echo esc_url( $image4 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased under the social media icons. 4 out of 4.', 'woocommerce' ); ?>" style="aspect-ratio:1;object-fit:cover;"/>
 			</figure>
 			<!-- /wp:image -->
 		</div>

--- a/plugins/woocommerce/patterns/store-info-alt-image-and-text.php
+++ b/plugins/woocommerce/patterns/store-info-alt-image-and-text.php
@@ -34,7 +34,7 @@ $button = $content['buttons'][0]['default'] ?? '';
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
 			<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
 			<figure class="wp-block-image size-full">
-				<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used in the left column.', 'woo-gutenberg-products-block' ); ?>" />
+				<img src="<?php echo esc_url( $image1 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used in the left column.', 'woocommerce' ); ?>" />
 			</figure>
 			<!-- /wp:image -->
 		</div>
@@ -110,7 +110,7 @@ $button = $content['buttons'][0]['default'] ?? '';
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:52%">
 			<!-- wp:image {"sizeSlug":"full","linkDestination":"none", "height":"auto","aspectRatio":"1","scale":"cover", "className":"is-resized"} -->
 			<figure class="wp-block-image size-full is-resized">
-				<img style="aspect-ratio:1;object-fit:cover" src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used in the right column.', 'woo-gutenberg-products-block' ); ?>" />
+				<img style="aspect-ratio:1;object-fit:cover" src="<?php echo esc_url( $image2 ); ?>" alt="<?php esc_attr_e( 'Placeholder image used in the right column.', 'woocommerce' ); ?>" />
 			</figure>
 			<!-- /wp:image -->
 		</div>

--- a/plugins/woocommerce/patterns/testimonials-single.php
+++ b/plugins/woocommerce/patterns/testimonials-single.php
@@ -17,7 +17,7 @@ $description        = $content['descriptions'][0]['default'] ?? '';
 	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:160px">
 		<!-- wp:image {"width": "164px", "className":"is-style-rounded"} -->
 		<figure class="wp-block-image is-resized is-style-rounded">
-			<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/portrait.png' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image with the avatar of the user who is writing the testimonial.', 'woo-gutenberg-products-block' ); ?>" style="width:164px"/>
+			<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/portrait.png' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image with the avatar of the user who is writing the testimonial.', 'woocommerce' ); ?>" style="width:164px"/>
 		</figure>
 		<!-- /wp:image -->
 	</div>

--- a/plugins/woocommerce/templates/block-notices/error.php
+++ b/plugins/woocommerce/templates/block-notices/error.php
@@ -32,7 +32,7 @@ $multiple = count( $notices ) > 1;
 	</svg>
 	<div class="wc-block-components-notice-banner__content">
 		<?php if ( $multiple ) { ?>
-			<p class="wc-block-components-notice-banner__summary"><?php esc_html_e( 'The following problems were found:', 'woo-gutenberg-products-block' ); ?></p>
+			<p class="wc-block-components-notice-banner__summary"><?php esc_html_e( 'The following problems were found:', 'woocommerce' ); ?></p>
 			<ul>
 			<?php foreach ( $notices as $notice ) : ?>
 				<li<?php echo wc_get_notice_data_attr( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>

--- a/plugins/woocommerce/templates/emails/customer-new-account-blocks.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account-blocks.php
@@ -20,11 +20,11 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer username */ ?>
-<p><?php printf( esc_html__( 'Hello %s,', 'woo-gutenberg-products-block' ), esc_html( $user_login ) ); ?></p>
+<p><?php printf( esc_html__( 'Hello %s,', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
 <?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
-<p><?php printf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woo-gutenberg-products-block' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+<p><?php printf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
 <?php if ( $set_password_url ) : ?>
-	<p><a href="<?php echo esc_attr( $set_password_url ); ?>"><?php printf( esc_html__( 'Click here to set your new password.', 'woo-gutenberg-products-block' ) ); ?></a></p>
+	<p><a href="<?php echo esc_attr( $set_password_url ); ?>"><?php printf( esc_html__( 'Click here to set your new password.', 'woocommerce' ) ); ?></a></p>
 <?php endif; ?>
 
 <?php

--- a/plugins/woocommerce/templates/emails/plain/customer-new-account-blocks.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-new-account-blocks.php
@@ -16,12 +16,12 @@ echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Customer username */
-echo sprintf( esc_html__( 'Hi %s,', 'woo-gutenberg-products-block' ), esc_html( $user_login ) ) . "\n\n";
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
 /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */
-echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woo-gutenberg-products-block' ), esc_html( $blogname ), esc_html( $user_login ), esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
+echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), esc_html( $user_login ), esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
 
 if ( $set_password_url ) {
-	echo esc_html__( 'To set your password, visit the following address: ', 'woo-gutenberg-products-block' ) . "\n\n";
+	echo esc_html__( 'To set your password, visit the following address: ', 'woocommerce' ) . "\n\n";
 	echo esc_html( $set_password_url ) . "\n\n";
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the text domains in the `plugins/woocommerce/patterns|templates` folders from `woo-gutenberg-products-block` to `woocommerce`.

See #41996 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review text domain changes
2. Check that a string wasn't inadvertently changed
3. check locally that the blocks text domain isn't found in any files
```
cd patterns
grep -nR woo-gutenberg ./
cd ../templates
grep -nR woo-gutenberg ./
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
