### PR TITLE
Display update quantity notice on classic cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-42747-update-quantity-notice-on-classic-cart
+++ b/plugins/woocommerce/changelog/fix-42747-update-quantity-notice-on-classic-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Display update quantity notice when using the cart shortcode.

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -1,6 +1,5 @@
 /* global wc_cart_params */
-jQuery( function( $ ) {
-
+jQuery( function ( $ ) {
 	// wc_cart_params is required to continue, ensure the object exists
 	if ( typeof wc_cart_params === 'undefined' ) {
 		return false;
@@ -14,11 +13,10 @@ jQuery( function( $ ) {
 	 * @param {String} endpoint The AJAX Endpoint
 	 * @return {String} The URL to use for the request
 	 */
-	var get_url = function( endpoint ) {
-		return wc_cart_params.wc_ajax_url.toString().replace(
-			'%%endpoint%%',
-			endpoint
-		);
+	var get_url = function ( endpoint ) {
+		return wc_cart_params.wc_ajax_url
+			.toString()
+			.replace( '%%endpoint%%', endpoint );
 	};
 
 	/**
@@ -27,8 +25,10 @@ jQuery( function( $ ) {
 	 * @param {JQuery Object} $node
 	 * @return {bool} True if the DOM Element is UI Blocked, false if not.
 	 */
-	var is_blocked = function( $node ) {
-		return $node.is( '.processing' ) || $node.parents( '.processing' ).length;
+	var is_blocked = function ( $node ) {
+		return (
+			$node.is( '.processing' ) || $node.parents( '.processing' ).length
+		);
 	};
 
 	/**
@@ -36,14 +36,14 @@ jQuery( function( $ ) {
 	 *
 	 * @param {JQuery Object} $node
 	 */
-	var block = function( $node ) {
+	var block = function ( $node ) {
 		if ( ! is_blocked( $node ) ) {
 			$node.addClass( 'processing' ).block( {
 				message: null,
 				overlayCSS: {
 					background: '#fff',
-					opacity: 0.6
-				}
+					opacity: 0.6,
+				},
 			} );
 		}
 	};
@@ -53,7 +53,7 @@ jQuery( function( $ ) {
 	 *
 	 * @param {JQuery Object} $node
 	 */
-	var unblock = function( $node ) {
+	var unblock = function ( $node ) {
 		$node.removeClass( 'processing' ).unblock();
 	};
 
@@ -62,11 +62,11 @@ jQuery( function( $ ) {
 	 *
 	 * @param {JQuery Object} $notices
 	 */
-	var remove_duplicate_notices = function( $notices ) {
-		var seen                 = new Set();
+	var remove_duplicate_notices = function ( $notices ) {
+		var seen = new Set();
 		var deduplicated_notices = [];
 
-		$notices.each( function() {
+		$notices.each( function () {
 			const text = $( this ).text();
 
 			if ( ! seen.has( text ) ) {
@@ -84,11 +84,16 @@ jQuery( function( $ ) {
 	 * @param {String} html_str The HTML string with which to replace the div.
 	 * @param {bool} preserve_notices Should notices be kept? False by default.
 	 */
-	var update_wc_div = function( html_str, preserve_notices ) {
-		var $html       = $.parseHTML( html_str );
-		var $new_form   = $( '.woocommerce-cart-form', $html );
+	var update_wc_div = function ( html_str, preserve_notices ) {
+		var $html = $.parseHTML( html_str );
+		var $new_form = $( '.woocommerce-cart-form', $html );
 		var $new_totals = $( '.cart_totals', $html );
-		var $notices    = remove_duplicate_notices( $( '.woocommerce-error, .woocommerce-message, .woocommerce-info', $html ) );
+		var $notices = remove_duplicate_notices(
+			$(
+				'.woocommerce-error, .woocommerce-message, .woocommerce-info, .is-error, .is-notice, .is-success',
+				$html
+			)
+		);
 
 		// No form, cannot do this.
 		if ( $( '.woocommerce-cart-form' ).length === 0 ) {
@@ -98,7 +103,9 @@ jQuery( function( $ ) {
 
 		// Remove errors
 		if ( ! preserve_notices ) {
-			$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
+			$(
+				'.woocommerce-error, .woocommerce-message, .woocommerce-info'
+			).remove();
 		}
 
 		if ( $new_form.length === 0 ) {
@@ -109,8 +116,12 @@ jQuery( function( $ ) {
 			}
 
 			// No items to display now! Replace all cart content.
-			var $cart_html = $( '.wc-empty-cart-message', $html ).closest( '.woocommerce' );
-			$( '.woocommerce-cart-form__contents' ).closest( '.woocommerce' ).replaceWith( $cart_html );
+			var $cart_html = $( '.wc-empty-cart-message', $html ).closest(
+				'.woocommerce'
+			);
+			$( '.woocommerce-cart-form__contents' )
+				.closest( '.woocommerce' )
+				.replaceWith( $cart_html );
 
 			// Display errors
 			if ( $notices.length > 0 ) {
@@ -126,7 +137,9 @@ jQuery( function( $ ) {
 			}
 
 			$( '.woocommerce-cart-form' ).replaceWith( $new_form );
-			$( '.woocommerce-cart-form' ).find( ':input[name="update_cart"]' ).prop( 'disabled', true );
+			$( '.woocommerce-cart-form' )
+				.find( ':input[name="update_cart"]' )
+				.prop( 'disabled', true );
 
 			if ( $notices.length > 0 ) {
 				show_notice( $notices );
@@ -143,7 +156,7 @@ jQuery( function( $ ) {
 	 *
 	 * @param {String} html_str The HTML string with which to replace the div.
 	 */
-	var update_cart_totals_div = function( html_str ) {
+	var update_cart_totals_div = function ( html_str ) {
 		$( '.cart_totals' ).replaceWith( html_str );
 		$( document.body ).trigger( 'updated_cart_totals' );
 	};
@@ -153,29 +166,30 @@ jQuery( function( $ ) {
 	 *
 	 * @param {Object} The Notice HTML Element in string or object form.
 	 */
-	var show_notice = function( html_element, $target ) {
+	var show_notice = function ( html_element, $target ) {
 		if ( ! $target ) {
-			$target = $( '.woocommerce-notices-wrapper:first' ) ||
+			$target =
+				$( '.woocommerce-notices-wrapper:first' ) ||
 				$( '.wc-empty-cart-message' ).closest( '.woocommerce' ) ||
 				$( '.woocommerce-cart-form' );
 		}
 		$target.prepend( html_element );
 	};
 
-
 	/**
 	 * Object to handle AJAX calls for cart shipping changes.
 	 */
 	var cart_shipping = {
-
 		/**
 		 * Initialize event handlers and UI state.
 		 */
-		init: function( cart ) {
-			this.cart                       = cart;
-			this.toggle_shipping            = this.toggle_shipping.bind( this );
-			this.shipping_method_selected   = this.shipping_method_selected.bind( this );
-			this.shipping_calculator_submit = this.shipping_calculator_submit.bind( this );
+		init: function ( cart ) {
+			this.cart = cart;
+			this.toggle_shipping = this.toggle_shipping.bind( this );
+			this.shipping_method_selected =
+				this.shipping_method_selected.bind( this );
+			this.shipping_calculator_submit =
+				this.shipping_calculator_submit.bind( this );
 
 			$( document ).on(
 				'click',
@@ -199,9 +213,11 @@ jQuery( function( $ ) {
 		/**
 		 * Toggle Shipping Calculator panel
 		 */
-		toggle_shipping: function() {
+		toggle_shipping: function () {
 			$( '.shipping-calculator-form' ).slideToggle( 'slow' );
-			$( 'select.country_to_state, input.country_to_state' ).trigger( 'change' );
+			$( 'select.country_to_state, input.country_to_state' ).trigger(
+				'change'
+			);
 			$( document.body ).trigger( 'country_to_state_changed' ); // Trigger select2 to load.
 			return false;
 		},
@@ -209,11 +225,13 @@ jQuery( function( $ ) {
 		/**
 		 * Handles when a shipping method is selected.
 		 */
-		shipping_method_selected: function() {
+		shipping_method_selected: function () {
 			var shipping_methods = {};
 
 			// eslint-disable-next-line max-len
-			$( 'select.shipping_method, :input[name^=shipping_method][type=radio]:checked, :input[name^=shipping_method][type=hidden]' ).each( function() {
+			$(
+				'select.shipping_method, :input[name^=shipping_method][type=radio]:checked, :input[name^=shipping_method][type=hidden]'
+			).each( function () {
 				shipping_methods[ $( this ).data( 'index' ) ] = $( this ).val();
 			} );
 
@@ -221,21 +239,21 @@ jQuery( function( $ ) {
 
 			var data = {
 				security: wc_cart_params.update_shipping_method_nonce,
-				shipping_method: shipping_methods
+				shipping_method: shipping_methods,
 			};
 
 			$.ajax( {
-				type:     'post',
-				url:      get_url( 'update_shipping_method' ),
-				data:     data,
+				type: 'post',
+				url: get_url( 'update_shipping_method' ),
+				data: data,
 				dataType: 'html',
-				success:  function( response ) {
+				success: function ( response ) {
 					update_cart_totals_div( response );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $( 'div.cart_totals' ) );
 					$( document.body ).trigger( 'updated_shipping_method' );
-				}
+				},
 			} );
 		},
 
@@ -244,7 +262,7 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event.
 		 */
-		shipping_calculator_submit: function( evt ) {
+		shipping_calculator_submit: function ( evt ) {
 			evt.preventDefault();
 
 			var $form = $( evt.currentTarget );
@@ -253,26 +271,27 @@ jQuery( function( $ ) {
 			block( $form );
 
 			// Provide the submit button value because wc-form-handler expects it.
-			$( '<input />' ).attr( 'type', 'hidden' )
-							.attr( 'name', 'calc_shipping' )
-							.attr( 'value', 'x' )
-							.appendTo( $form );
+			$( '<input />' )
+				.attr( 'type', 'hidden' )
+				.attr( 'name', 'calc_shipping' )
+				.attr( 'value', 'x' )
+				.appendTo( $form );
 
 			// Make call to actual form post URL.
 			$.ajax( {
-				type:     $form.attr( 'method' ),
-				url:      $form.attr( 'action' ),
-				data:     $form.serialize(),
+				type: $form.attr( 'method' ),
+				url: $form.attr( 'action' ),
+				data: $form.serialize(),
 				dataType: 'html',
-				success:  function( response ) {
+				success: function ( response ) {
 					update_wc_div( response );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
-				}
+				},
 			} );
-		}
+		},
 	};
 
 	/**
@@ -282,64 +301,78 @@ jQuery( function( $ ) {
 		/**
 		 * Initialize cart UI events.
 		 */
-		init: function() {
-			this.update_cart_totals    = this.update_cart_totals.bind( this );
-			this.input_keypress        = this.input_keypress.bind( this );
-			this.cart_submit           = this.cart_submit.bind( this );
-			this.submit_click          = this.submit_click.bind( this );
-			this.apply_coupon          = this.apply_coupon.bind( this );
-			this.remove_coupon_clicked = this.remove_coupon_clicked.bind( this );
-			this.quantity_update       = this.quantity_update.bind( this );
-			this.item_remove_clicked   = this.item_remove_clicked.bind( this );
-			this.item_restore_clicked  = this.item_restore_clicked.bind( this );
-			this.update_cart           = this.update_cart.bind( this );
+		init: function () {
+			this.update_cart_totals = this.update_cart_totals.bind( this );
+			this.input_keypress = this.input_keypress.bind( this );
+			this.cart_submit = this.cart_submit.bind( this );
+			this.submit_click = this.submit_click.bind( this );
+			this.apply_coupon = this.apply_coupon.bind( this );
+			this.remove_coupon_clicked =
+				this.remove_coupon_clicked.bind( this );
+			this.quantity_update = this.quantity_update.bind( this );
+			this.item_remove_clicked = this.item_remove_clicked.bind( this );
+			this.item_restore_clicked = this.item_restore_clicked.bind( this );
+			this.update_cart = this.update_cart.bind( this );
 
-			$( document ).on(
-				'wc_update_cart added_to_cart',
-				function() { cart.update_cart.apply( cart, [].slice.call( arguments, 1 ) ); } );
+			$( document ).on( 'wc_update_cart added_to_cart', function () {
+				cart.update_cart.apply( cart, [].slice.call( arguments, 1 ) );
+			} );
 			$( document ).on(
 				'click',
 				'.woocommerce-cart-form :input[type=submit]',
-				this.submit_click );
+				this.submit_click
+			);
 			$( document ).on(
 				'keypress',
 				'.woocommerce-cart-form :input[type=number]',
-				this.input_keypress );
+				this.input_keypress
+			);
 			$( document ).on(
 				'submit',
 				'.woocommerce-cart-form',
-				this.cart_submit );
+				this.cart_submit
+			);
 			$( document ).on(
 				'click',
 				'a.woocommerce-remove-coupon',
-				this.remove_coupon_clicked );
+				this.remove_coupon_clicked
+			);
 			$( document ).on(
 				'click',
 				'.woocommerce-cart-form .product-remove > a',
-				this.item_remove_clicked );
+				this.item_remove_clicked
+			);
 			$( document ).on(
 				'click',
 				'.woocommerce-cart .restore-item',
-				this.item_restore_clicked );
+				this.item_restore_clicked
+			);
 			$( document ).on(
 				'change input',
 				'.woocommerce-cart-form .cart_item :input',
-				this.input_changed );
+				this.input_changed
+			);
 
-			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', true );
+			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop(
+				'disabled',
+				true
+			);
 		},
 
 		/**
 		 * After an input is changed, enable the update cart button.
 		 */
-		input_changed: function() {
-			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', false );
+		input_changed: function () {
+			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop(
+				'disabled',
+				false
+			);
 		},
 
 		/**
 		 * Update entire cart via ajax.
 		 */
-		update_cart: function( preserve_notices ) {
+		update_cart: function ( preserve_notices ) {
 			var $form = $( '.woocommerce-cart-form' );
 
 			block( $form );
@@ -347,36 +380,36 @@ jQuery( function( $ ) {
 
 			// Make call to actual form post URL.
 			$.ajax( {
-				type:     $form.attr( 'method' ),
-				url:      $form.attr( 'action' ),
-				data:     $form.serialize(),
+				type: $form.attr( 'method' ),
+				url: $form.attr( 'action' ),
+				data: $form.serialize(),
 				dataType: 'html',
-				success:  function( response ) {
+				success: function ( response ) {
 					update_wc_div( response, preserve_notices );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
 					$.scroll_to_notices( $( '[role="alert"]' ) );
-				}
+				},
 			} );
 		},
 
 		/**
 		 * Update the cart after something has changed.
 		 */
-		update_cart_totals: function() {
+		update_cart_totals: function () {
 			block( $( 'div.cart_totals' ) );
 
 			$.ajax( {
-				url:      get_url( 'get_cart_totals' ),
+				url: get_url( 'get_cart_totals' ),
 				dataType: 'html',
-				success:  function( response ) {
+				success: function ( response ) {
 					update_cart_totals_div( response );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $( 'div.cart_totals' ) );
-				}
+				},
 			} );
 		},
 
@@ -390,19 +423,18 @@ jQuery( function( $ ) {
 		 * For us, that is the Apply Coupon button. This is required
 		 * to catch the event before that happens.
 		 */
-		input_keypress: function( evt ) {
-
+		input_keypress: function ( evt ) {
 			// Catch the enter key and don't let it submit the form.
 			if ( 13 === evt.keyCode ) {
 				var $form = $( evt.currentTarget ).parents( 'form' );
 
 				try {
 					// If there are no validation errors, handle the submit.
-					if ( $form[0].checkValidity() ) {
+					if ( $form[ 0 ].checkValidity() ) {
 						evt.preventDefault();
 						this.cart_submit( evt );
 					}
-				} catch( err ) {
+				} catch ( err ) {
 					evt.preventDefault();
 					this.cart_submit( evt );
 				}
@@ -414,10 +446,10 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		cart_submit: function( evt ) {
-			var $submit  = $( document.activeElement ),
+		cart_submit: function ( evt ) {
+			var $submit = $( document.activeElement ),
 				$clicked = $( ':input[type=submit][clicked=true]' ),
-				$form    = $( evt.currentTarget );
+				$form = $( evt.currentTarget );
 
 			// For submit events, currentTarget is form.
 			// For keypress events, currentTarget is input.
@@ -425,7 +457,9 @@ jQuery( function( $ ) {
 				$form = $( evt.currentTarget ).parents( 'form' );
 			}
 
-			if ( 0 === $form.find( '.woocommerce-cart-form__contents' ).length ) {
+			if (
+				0 === $form.find( '.woocommerce-cart-form__contents' ).length
+			) {
 				return;
 			}
 
@@ -433,11 +467,16 @@ jQuery( function( $ ) {
 				return false;
 			}
 
-			if ( $clicked.is( ':input[name="update_cart"]' ) || $submit.is( 'input.qty' ) ) {
+			if (
+				$clicked.is( ':input[name="update_cart"]' ) ||
+				$submit.is( 'input.qty' )
+			) {
 				evt.preventDefault();
 				this.quantity_update( $form );
-
-			} else if ( $clicked.is( ':input[name="apply_coupon"]' ) || $submit.is( '#coupon_code' ) ) {
+			} else if (
+				$clicked.is( ':input[name="apply_coupon"]' ) ||
+				$submit.is( '#coupon_code' )
+			) {
 				evt.preventDefault();
 				this.apply_coupon( $form );
 			}
@@ -448,8 +487,11 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		submit_click: function( evt ) {
-			$( ':input[type=submit]', $( evt.target ).parents( 'form' ) ).removeAttr( 'clicked' );
+		submit_click: function ( evt ) {
+			$(
+				':input[type=submit]',
+				$( evt.target ).parents( 'form' )
+			).removeAttr( 'clicked' );
 			$( evt.target ).attr( 'clicked', 'true' );
 		},
 
@@ -458,7 +500,7 @@ jQuery( function( $ ) {
 		 *
 		 * @param {JQuery Object} $form The cart form.
 		 */
-		apply_coupon: function( $form ) {
+		apply_coupon: function ( $form ) {
 			block( $form );
 
 			var cart = this;
@@ -467,24 +509,28 @@ jQuery( function( $ ) {
 
 			var data = {
 				security: wc_cart_params.apply_coupon_nonce,
-				coupon_code: coupon_code
+				coupon_code: coupon_code,
 			};
 
 			$.ajax( {
-				type:     'POST',
-				url:      get_url( 'apply_coupon' ),
-				data:     data,
+				type: 'POST',
+				url: get_url( 'apply_coupon' ),
+				data: data,
 				dataType: 'html',
-				success: function( response ) {
-					$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
+				success: function ( response ) {
+					$(
+						'.woocommerce-error, .woocommerce-message, .woocommerce-info'
+					).remove();
 					show_notice( response );
-					$( document.body ).trigger( 'applied_coupon', [ coupon_code ] );
+					$( document.body ).trigger( 'applied_coupon', [
+						coupon_code,
+					] );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $form );
 					$text_field.val( '' );
 					cart.update_cart( true );
-				}
+				},
 			} );
 		},
 
@@ -493,34 +539,36 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		remove_coupon_clicked: function( evt ) {
+		remove_coupon_clicked: function ( evt ) {
 			evt.preventDefault();
 
-			var cart     = this;
+			var cart = this;
 			var $wrapper = $( evt.currentTarget ).closest( '.cart_totals' );
-			var coupon   = $( evt.currentTarget ).attr( 'data-coupon' );
+			var coupon = $( evt.currentTarget ).attr( 'data-coupon' );
 
 			block( $wrapper );
 
 			var data = {
 				security: wc_cart_params.remove_coupon_nonce,
-				coupon: coupon
+				coupon: coupon,
 			};
 
 			$.ajax( {
-				type:    'POST',
-				url:      get_url( 'remove_coupon' ),
-				data:     data,
+				type: 'POST',
+				url: get_url( 'remove_coupon' ),
+				data: data,
 				dataType: 'html',
-				success: function( response ) {
-					$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
+				success: function ( response ) {
+					$(
+						'.woocommerce-error, .woocommerce-message, .woocommerce-info'
+					).remove();
 					show_notice( response );
 					$( document.body ).trigger( 'removed_coupon', [ coupon ] );
 					unblock( $wrapper );
 				},
-				complete: function() {
+				complete: function () {
 					cart.update_cart( true );
-				}
+				},
 			} );
 		},
 
@@ -529,30 +577,31 @@ jQuery( function( $ ) {
 		 *
 		 * @param {JQuery Object} $form The cart form.
 		 */
-		quantity_update: function( $form ) {
+		quantity_update: function ( $form ) {
 			block( $form );
 			block( $( 'div.cart_totals' ) );
 
 			// Provide the submit button value because wc-form-handler expects it.
-			$( '<input />' ).attr( 'type', 'hidden' )
-							.attr( 'name', 'update_cart' )
-							.attr( 'value', 'Update Cart' )
-							.appendTo( $form );
+			$( '<input />' )
+				.attr( 'type', 'hidden' )
+				.attr( 'name', 'update_cart' )
+				.attr( 'value', 'Update Cart' )
+				.appendTo( $form );
 
 			// Make call to actual form post URL.
 			$.ajax( {
-				type:     $form.attr( 'method' ),
-				url:      $form.attr( 'action' ),
-				data:     $form.serialize(),
+				type: $form.attr( 'method' ),
+				url: $form.attr( 'action' ),
+				data: $form.serialize(),
 				dataType: 'html',
-				success:  function( response ) {
+				success: function ( response ) {
 					update_wc_div( response );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
 					$.scroll_to_notices( $( '[role="alert"]' ) );
-				}
+				},
 			} );
 		},
 
@@ -561,7 +610,7 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		item_remove_clicked: function( evt ) {
+		item_remove_clicked: function ( evt ) {
 			evt.preventDefault();
 
 			var $a = $( evt.currentTarget );
@@ -571,17 +620,17 @@ jQuery( function( $ ) {
 			block( $( 'div.cart_totals' ) );
 
 			$.ajax( {
-				type:     'GET',
-				url:      $a.attr( 'href' ),
+				type: 'GET',
+				url: $a.attr( 'href' ),
 				dataType: 'html',
-				success:  function( response ) {
+				success: function ( response ) {
 					update_wc_div( response );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
 					$.scroll_to_notices( $( '[role="alert"]' ) );
-				}
+				},
 			} );
 		},
 
@@ -590,7 +639,7 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		item_restore_clicked: function( evt ) {
+		item_restore_clicked: function ( evt ) {
 			evt.preventDefault();
 
 			var $a = $( evt.currentTarget );
@@ -600,18 +649,18 @@ jQuery( function( $ ) {
 			block( $( 'div.cart_totals' ) );
 
 			$.ajax( {
-				type:     'GET',
-				url:      $a.attr( 'href' ),
+				type: 'GET',
+				url: $a.attr( 'href' ),
 				dataType: 'html',
-				success:  function( response ) {
+				success: function ( response ) {
 					update_wc_div( response );
 				},
-				complete: function() {
+				complete: function () {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
-				}
+				},
 			} );
-		}
+		},
 	};
 
 	cart_shipping.init( cart );

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -1,5 +1,6 @@
 /* global wc_cart_params */
-jQuery( function ( $ ) {
+jQuery( function( $ ) {
+
 	// wc_cart_params is required to continue, ensure the object exists
 	if ( typeof wc_cart_params === 'undefined' ) {
 		return false;
@@ -13,10 +14,11 @@ jQuery( function ( $ ) {
 	 * @param {String} endpoint The AJAX Endpoint
 	 * @return {String} The URL to use for the request
 	 */
-	var get_url = function ( endpoint ) {
-		return wc_cart_params.wc_ajax_url
-			.toString()
-			.replace( '%%endpoint%%', endpoint );
+	var get_url = function( endpoint ) {
+		return wc_cart_params.wc_ajax_url.toString().replace(
+			'%%endpoint%%',
+			endpoint
+		);
 	};
 
 	/**
@@ -25,10 +27,8 @@ jQuery( function ( $ ) {
 	 * @param {JQuery Object} $node
 	 * @return {bool} True if the DOM Element is UI Blocked, false if not.
 	 */
-	var is_blocked = function ( $node ) {
-		return (
-			$node.is( '.processing' ) || $node.parents( '.processing' ).length
-		);
+	var is_blocked = function( $node ) {
+		return $node.is( '.processing' ) || $node.parents( '.processing' ).length;
 	};
 
 	/**
@@ -36,14 +36,14 @@ jQuery( function ( $ ) {
 	 *
 	 * @param {JQuery Object} $node
 	 */
-	var block = function ( $node ) {
+	var block = function( $node ) {
 		if ( ! is_blocked( $node ) ) {
 			$node.addClass( 'processing' ).block( {
 				message: null,
 				overlayCSS: {
 					background: '#fff',
-					opacity: 0.6,
-				},
+					opacity: 0.6
+				}
 			} );
 		}
 	};
@@ -53,7 +53,7 @@ jQuery( function ( $ ) {
 	 *
 	 * @param {JQuery Object} $node
 	 */
-	var unblock = function ( $node ) {
+	var unblock = function( $node ) {
 		$node.removeClass( 'processing' ).unblock();
 	};
 
@@ -62,11 +62,11 @@ jQuery( function ( $ ) {
 	 *
 	 * @param {JQuery Object} $notices
 	 */
-	var remove_duplicate_notices = function ( $notices ) {
-		var seen = new Set();
+	var remove_duplicate_notices = function( $notices ) {
+		var seen                 = new Set();
 		var deduplicated_notices = [];
 
-		$notices.each( function () {
+		$notices.each( function() {
 			const text = $( this ).text();
 
 			if ( ! seen.has( text ) ) {
@@ -84,16 +84,11 @@ jQuery( function ( $ ) {
 	 * @param {String} html_str The HTML string with which to replace the div.
 	 * @param {bool} preserve_notices Should notices be kept? False by default.
 	 */
-	var update_wc_div = function ( html_str, preserve_notices ) {
-		var $html = $.parseHTML( html_str );
-		var $new_form = $( '.woocommerce-cart-form', $html );
+	var update_wc_div = function( html_str, preserve_notices ) {
+		var $html       = $.parseHTML( html_str );
+		var $new_form   = $( '.woocommerce-cart-form', $html );
 		var $new_totals = $( '.cart_totals', $html );
-		var $notices = remove_duplicate_notices(
-			$(
-				'.woocommerce-error, .woocommerce-message, .woocommerce-info, .is-error, .is-notice, .is-success',
-				$html
-			)
-		);
+		var $notices    = remove_duplicate_notices( $( '.woocommerce-error, .woocommerce-message, .woocommerce-info, .is-error, .is-notice, .is-success', $html ) );
 
 		// No form, cannot do this.
 		if ( $( '.woocommerce-cart-form' ).length === 0 ) {
@@ -103,9 +98,7 @@ jQuery( function ( $ ) {
 
 		// Remove errors
 		if ( ! preserve_notices ) {
-			$(
-				'.woocommerce-error, .woocommerce-message, .woocommerce-info'
-			).remove();
+			$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
 		}
 
 		if ( $new_form.length === 0 ) {
@@ -116,12 +109,8 @@ jQuery( function ( $ ) {
 			}
 
 			// No items to display now! Replace all cart content.
-			var $cart_html = $( '.wc-empty-cart-message', $html ).closest(
-				'.woocommerce'
-			);
-			$( '.woocommerce-cart-form__contents' )
-				.closest( '.woocommerce' )
-				.replaceWith( $cart_html );
+			var $cart_html = $( '.wc-empty-cart-message', $html ).closest( '.woocommerce' );
+			$( '.woocommerce-cart-form__contents' ).closest( '.woocommerce' ).replaceWith( $cart_html );
 
 			// Display errors
 			if ( $notices.length > 0 ) {
@@ -137,9 +126,7 @@ jQuery( function ( $ ) {
 			}
 
 			$( '.woocommerce-cart-form' ).replaceWith( $new_form );
-			$( '.woocommerce-cart-form' )
-				.find( ':input[name="update_cart"]' )
-				.prop( 'disabled', true );
+			$( '.woocommerce-cart-form' ).find( ':input[name="update_cart"]' ).prop( 'disabled', true );
 
 			if ( $notices.length > 0 ) {
 				show_notice( $notices );
@@ -156,7 +143,7 @@ jQuery( function ( $ ) {
 	 *
 	 * @param {String} html_str The HTML string with which to replace the div.
 	 */
-	var update_cart_totals_div = function ( html_str ) {
+	var update_cart_totals_div = function( html_str ) {
 		$( '.cart_totals' ).replaceWith( html_str );
 		$( document.body ).trigger( 'updated_cart_totals' );
 	};
@@ -166,30 +153,29 @@ jQuery( function ( $ ) {
 	 *
 	 * @param {Object} The Notice HTML Element in string or object form.
 	 */
-	var show_notice = function ( html_element, $target ) {
+	var show_notice = function( html_element, $target ) {
 		if ( ! $target ) {
-			$target =
-				$( '.woocommerce-notices-wrapper:first' ) ||
+			$target = $( '.woocommerce-notices-wrapper:first' ) ||
 				$( '.wc-empty-cart-message' ).closest( '.woocommerce' ) ||
 				$( '.woocommerce-cart-form' );
 		}
 		$target.prepend( html_element );
 	};
 
+
 	/**
 	 * Object to handle AJAX calls for cart shipping changes.
 	 */
 	var cart_shipping = {
+
 		/**
 		 * Initialize event handlers and UI state.
 		 */
-		init: function ( cart ) {
-			this.cart = cart;
-			this.toggle_shipping = this.toggle_shipping.bind( this );
-			this.shipping_method_selected =
-				this.shipping_method_selected.bind( this );
-			this.shipping_calculator_submit =
-				this.shipping_calculator_submit.bind( this );
+		init: function( cart ) {
+			this.cart                       = cart;
+			this.toggle_shipping            = this.toggle_shipping.bind( this );
+			this.shipping_method_selected   = this.shipping_method_selected.bind( this );
+			this.shipping_calculator_submit = this.shipping_calculator_submit.bind( this );
 
 			$( document ).on(
 				'click',
@@ -213,11 +199,9 @@ jQuery( function ( $ ) {
 		/**
 		 * Toggle Shipping Calculator panel
 		 */
-		toggle_shipping: function () {
+		toggle_shipping: function() {
 			$( '.shipping-calculator-form' ).slideToggle( 'slow' );
-			$( 'select.country_to_state, input.country_to_state' ).trigger(
-				'change'
-			);
+			$( 'select.country_to_state, input.country_to_state' ).trigger( 'change' );
 			$( document.body ).trigger( 'country_to_state_changed' ); // Trigger select2 to load.
 			return false;
 		},
@@ -225,13 +209,11 @@ jQuery( function ( $ ) {
 		/**
 		 * Handles when a shipping method is selected.
 		 */
-		shipping_method_selected: function () {
+		shipping_method_selected: function() {
 			var shipping_methods = {};
 
 			// eslint-disable-next-line max-len
-			$(
-				'select.shipping_method, :input[name^=shipping_method][type=radio]:checked, :input[name^=shipping_method][type=hidden]'
-			).each( function () {
+			$( 'select.shipping_method, :input[name^=shipping_method][type=radio]:checked, :input[name^=shipping_method][type=hidden]' ).each( function() {
 				shipping_methods[ $( this ).data( 'index' ) ] = $( this ).val();
 			} );
 
@@ -239,21 +221,21 @@ jQuery( function ( $ ) {
 
 			var data = {
 				security: wc_cart_params.update_shipping_method_nonce,
-				shipping_method: shipping_methods,
+				shipping_method: shipping_methods
 			};
 
 			$.ajax( {
-				type: 'post',
-				url: get_url( 'update_shipping_method' ),
-				data: data,
+				type:     'post',
+				url:      get_url( 'update_shipping_method' ),
+				data:     data,
 				dataType: 'html',
-				success: function ( response ) {
+				success:  function( response ) {
 					update_cart_totals_div( response );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $( 'div.cart_totals' ) );
 					$( document.body ).trigger( 'updated_shipping_method' );
-				},
+				}
 			} );
 		},
 
@@ -262,7 +244,7 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event.
 		 */
-		shipping_calculator_submit: function ( evt ) {
+		shipping_calculator_submit: function( evt ) {
 			evt.preventDefault();
 
 			var $form = $( evt.currentTarget );
@@ -271,27 +253,26 @@ jQuery( function ( $ ) {
 			block( $form );
 
 			// Provide the submit button value because wc-form-handler expects it.
-			$( '<input />' )
-				.attr( 'type', 'hidden' )
-				.attr( 'name', 'calc_shipping' )
-				.attr( 'value', 'x' )
-				.appendTo( $form );
+			$( '<input />' ).attr( 'type', 'hidden' )
+							.attr( 'name', 'calc_shipping' )
+							.attr( 'value', 'x' )
+							.appendTo( $form );
 
 			// Make call to actual form post URL.
 			$.ajax( {
-				type: $form.attr( 'method' ),
-				url: $form.attr( 'action' ),
-				data: $form.serialize(),
+				type:     $form.attr( 'method' ),
+				url:      $form.attr( 'action' ),
+				data:     $form.serialize(),
 				dataType: 'html',
-				success: function ( response ) {
+				success:  function( response ) {
 					update_wc_div( response );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
-				},
+				}
 			} );
-		},
+		}
 	};
 
 	/**
@@ -301,78 +282,64 @@ jQuery( function ( $ ) {
 		/**
 		 * Initialize cart UI events.
 		 */
-		init: function () {
-			this.update_cart_totals = this.update_cart_totals.bind( this );
-			this.input_keypress = this.input_keypress.bind( this );
-			this.cart_submit = this.cart_submit.bind( this );
-			this.submit_click = this.submit_click.bind( this );
-			this.apply_coupon = this.apply_coupon.bind( this );
-			this.remove_coupon_clicked =
-				this.remove_coupon_clicked.bind( this );
-			this.quantity_update = this.quantity_update.bind( this );
-			this.item_remove_clicked = this.item_remove_clicked.bind( this );
-			this.item_restore_clicked = this.item_restore_clicked.bind( this );
-			this.update_cart = this.update_cart.bind( this );
+		init: function() {
+			this.update_cart_totals    = this.update_cart_totals.bind( this );
+			this.input_keypress        = this.input_keypress.bind( this );
+			this.cart_submit           = this.cart_submit.bind( this );
+			this.submit_click          = this.submit_click.bind( this );
+			this.apply_coupon          = this.apply_coupon.bind( this );
+			this.remove_coupon_clicked = this.remove_coupon_clicked.bind( this );
+			this.quantity_update       = this.quantity_update.bind( this );
+			this.item_remove_clicked   = this.item_remove_clicked.bind( this );
+			this.item_restore_clicked  = this.item_restore_clicked.bind( this );
+			this.update_cart           = this.update_cart.bind( this );
 
-			$( document ).on( 'wc_update_cart added_to_cart', function () {
-				cart.update_cart.apply( cart, [].slice.call( arguments, 1 ) );
-			} );
+			$( document ).on(
+				'wc_update_cart added_to_cart',
+				function() { cart.update_cart.apply( cart, [].slice.call( arguments, 1 ) ); } );
 			$( document ).on(
 				'click',
 				'.woocommerce-cart-form :input[type=submit]',
-				this.submit_click
-			);
+				this.submit_click );
 			$( document ).on(
 				'keypress',
 				'.woocommerce-cart-form :input[type=number]',
-				this.input_keypress
-			);
+				this.input_keypress );
 			$( document ).on(
 				'submit',
 				'.woocommerce-cart-form',
-				this.cart_submit
-			);
+				this.cart_submit );
 			$( document ).on(
 				'click',
 				'a.woocommerce-remove-coupon',
-				this.remove_coupon_clicked
-			);
+				this.remove_coupon_clicked );
 			$( document ).on(
 				'click',
 				'.woocommerce-cart-form .product-remove > a',
-				this.item_remove_clicked
-			);
+				this.item_remove_clicked );
 			$( document ).on(
 				'click',
 				'.woocommerce-cart .restore-item',
-				this.item_restore_clicked
-			);
+				this.item_restore_clicked );
 			$( document ).on(
 				'change input',
 				'.woocommerce-cart-form .cart_item :input',
-				this.input_changed
-			);
+				this.input_changed );
 
-			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop(
-				'disabled',
-				true
-			);
+			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', true );
 		},
 
 		/**
 		 * After an input is changed, enable the update cart button.
 		 */
-		input_changed: function () {
-			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop(
-				'disabled',
-				false
-			);
+		input_changed: function() {
+			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', false );
 		},
 
 		/**
 		 * Update entire cart via ajax.
 		 */
-		update_cart: function ( preserve_notices ) {
+		update_cart: function( preserve_notices ) {
 			var $form = $( '.woocommerce-cart-form' );
 
 			block( $form );
@@ -380,36 +347,36 @@ jQuery( function ( $ ) {
 
 			// Make call to actual form post URL.
 			$.ajax( {
-				type: $form.attr( 'method' ),
-				url: $form.attr( 'action' ),
-				data: $form.serialize(),
+				type:     $form.attr( 'method' ),
+				url:      $form.attr( 'action' ),
+				data:     $form.serialize(),
 				dataType: 'html',
-				success: function ( response ) {
+				success:  function( response ) {
 					update_wc_div( response, preserve_notices );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
 					$.scroll_to_notices( $( '[role="alert"]' ) );
-				},
+				}
 			} );
 		},
 
 		/**
 		 * Update the cart after something has changed.
 		 */
-		update_cart_totals: function () {
+		update_cart_totals: function() {
 			block( $( 'div.cart_totals' ) );
 
 			$.ajax( {
-				url: get_url( 'get_cart_totals' ),
+				url:      get_url( 'get_cart_totals' ),
 				dataType: 'html',
-				success: function ( response ) {
+				success:  function( response ) {
 					update_cart_totals_div( response );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $( 'div.cart_totals' ) );
-				},
+				}
 			} );
 		},
 
@@ -423,18 +390,19 @@ jQuery( function ( $ ) {
 		 * For us, that is the Apply Coupon button. This is required
 		 * to catch the event before that happens.
 		 */
-		input_keypress: function ( evt ) {
+		input_keypress: function( evt ) {
+
 			// Catch the enter key and don't let it submit the form.
 			if ( 13 === evt.keyCode ) {
 				var $form = $( evt.currentTarget ).parents( 'form' );
 
 				try {
 					// If there are no validation errors, handle the submit.
-					if ( $form[ 0 ].checkValidity() ) {
+					if ( $form[0].checkValidity() ) {
 						evt.preventDefault();
 						this.cart_submit( evt );
 					}
-				} catch ( err ) {
+				} catch( err ) {
 					evt.preventDefault();
 					this.cart_submit( evt );
 				}
@@ -446,10 +414,10 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		cart_submit: function ( evt ) {
-			var $submit = $( document.activeElement ),
+		cart_submit: function( evt ) {
+			var $submit  = $( document.activeElement ),
 				$clicked = $( ':input[type=submit][clicked=true]' ),
-				$form = $( evt.currentTarget );
+				$form    = $( evt.currentTarget );
 
 			// For submit events, currentTarget is form.
 			// For keypress events, currentTarget is input.
@@ -457,9 +425,7 @@ jQuery( function ( $ ) {
 				$form = $( evt.currentTarget ).parents( 'form' );
 			}
 
-			if (
-				0 === $form.find( '.woocommerce-cart-form__contents' ).length
-			) {
+			if ( 0 === $form.find( '.woocommerce-cart-form__contents' ).length ) {
 				return;
 			}
 
@@ -467,16 +433,11 @@ jQuery( function ( $ ) {
 				return false;
 			}
 
-			if (
-				$clicked.is( ':input[name="update_cart"]' ) ||
-				$submit.is( 'input.qty' )
-			) {
+			if ( $clicked.is( ':input[name="update_cart"]' ) || $submit.is( 'input.qty' ) ) {
 				evt.preventDefault();
 				this.quantity_update( $form );
-			} else if (
-				$clicked.is( ':input[name="apply_coupon"]' ) ||
-				$submit.is( '#coupon_code' )
-			) {
+
+			} else if ( $clicked.is( ':input[name="apply_coupon"]' ) || $submit.is( '#coupon_code' ) ) {
 				evt.preventDefault();
 				this.apply_coupon( $form );
 			}
@@ -487,11 +448,8 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		submit_click: function ( evt ) {
-			$(
-				':input[type=submit]',
-				$( evt.target ).parents( 'form' )
-			).removeAttr( 'clicked' );
+		submit_click: function( evt ) {
+			$( ':input[type=submit]', $( evt.target ).parents( 'form' ) ).removeAttr( 'clicked' );
 			$( evt.target ).attr( 'clicked', 'true' );
 		},
 
@@ -500,7 +458,7 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {JQuery Object} $form The cart form.
 		 */
-		apply_coupon: function ( $form ) {
+		apply_coupon: function( $form ) {
 			block( $form );
 
 			var cart = this;
@@ -509,28 +467,24 @@ jQuery( function ( $ ) {
 
 			var data = {
 				security: wc_cart_params.apply_coupon_nonce,
-				coupon_code: coupon_code,
+				coupon_code: coupon_code
 			};
 
 			$.ajax( {
-				type: 'POST',
-				url: get_url( 'apply_coupon' ),
-				data: data,
+				type:     'POST',
+				url:      get_url( 'apply_coupon' ),
+				data:     data,
 				dataType: 'html',
-				success: function ( response ) {
-					$(
-						'.woocommerce-error, .woocommerce-message, .woocommerce-info'
-					).remove();
+				success: function( response ) {
+					$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
 					show_notice( response );
-					$( document.body ).trigger( 'applied_coupon', [
-						coupon_code,
-					] );
+					$( document.body ).trigger( 'applied_coupon', [ coupon_code ] );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $form );
 					$text_field.val( '' );
 					cart.update_cart( true );
-				},
+				}
 			} );
 		},
 
@@ -539,36 +493,34 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		remove_coupon_clicked: function ( evt ) {
+		remove_coupon_clicked: function( evt ) {
 			evt.preventDefault();
 
-			var cart = this;
+			var cart     = this;
 			var $wrapper = $( evt.currentTarget ).closest( '.cart_totals' );
-			var coupon = $( evt.currentTarget ).attr( 'data-coupon' );
+			var coupon   = $( evt.currentTarget ).attr( 'data-coupon' );
 
 			block( $wrapper );
 
 			var data = {
 				security: wc_cart_params.remove_coupon_nonce,
-				coupon: coupon,
+				coupon: coupon
 			};
 
 			$.ajax( {
-				type: 'POST',
-				url: get_url( 'remove_coupon' ),
-				data: data,
+				type:    'POST',
+				url:      get_url( 'remove_coupon' ),
+				data:     data,
 				dataType: 'html',
-				success: function ( response ) {
-					$(
-						'.woocommerce-error, .woocommerce-message, .woocommerce-info'
-					).remove();
+				success: function( response ) {
+					$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
 					show_notice( response );
 					$( document.body ).trigger( 'removed_coupon', [ coupon ] );
 					unblock( $wrapper );
 				},
-				complete: function () {
+				complete: function() {
 					cart.update_cart( true );
-				},
+				}
 			} );
 		},
 
@@ -577,31 +529,30 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {JQuery Object} $form The cart form.
 		 */
-		quantity_update: function ( $form ) {
+		quantity_update: function( $form ) {
 			block( $form );
 			block( $( 'div.cart_totals' ) );
 
 			// Provide the submit button value because wc-form-handler expects it.
-			$( '<input />' )
-				.attr( 'type', 'hidden' )
-				.attr( 'name', 'update_cart' )
-				.attr( 'value', 'Update Cart' )
-				.appendTo( $form );
+			$( '<input />' ).attr( 'type', 'hidden' )
+							.attr( 'name', 'update_cart' )
+							.attr( 'value', 'Update Cart' )
+							.appendTo( $form );
 
 			// Make call to actual form post URL.
 			$.ajax( {
-				type: $form.attr( 'method' ),
-				url: $form.attr( 'action' ),
-				data: $form.serialize(),
+				type:     $form.attr( 'method' ),
+				url:      $form.attr( 'action' ),
+				data:     $form.serialize(),
 				dataType: 'html',
-				success: function ( response ) {
+				success:  function( response ) {
 					update_wc_div( response );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
 					$.scroll_to_notices( $( '[role="alert"]' ) );
-				},
+				}
 			} );
 		},
 
@@ -610,7 +561,7 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		item_remove_clicked: function ( evt ) {
+		item_remove_clicked: function( evt ) {
 			evt.preventDefault();
 
 			var $a = $( evt.currentTarget );
@@ -620,17 +571,17 @@ jQuery( function ( $ ) {
 			block( $( 'div.cart_totals' ) );
 
 			$.ajax( {
-				type: 'GET',
-				url: $a.attr( 'href' ),
+				type:     'GET',
+				url:      $a.attr( 'href' ),
 				dataType: 'html',
-				success: function ( response ) {
+				success:  function( response ) {
 					update_wc_div( response );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
 					$.scroll_to_notices( $( '[role="alert"]' ) );
-				},
+				}
 			} );
 		},
 
@@ -639,7 +590,7 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} evt The JQuery event
 		 */
-		item_restore_clicked: function ( evt ) {
+		item_restore_clicked: function( evt ) {
 			evt.preventDefault();
 
 			var $a = $( evt.currentTarget );
@@ -649,18 +600,18 @@ jQuery( function ( $ ) {
 			block( $( 'div.cart_totals' ) );
 
 			$.ajax( {
-				type: 'GET',
-				url: $a.attr( 'href' ),
+				type:     'GET',
+				url:      $a.attr( 'href' ),
 				dataType: 'html',
-				success: function ( response ) {
+				success:  function( response ) {
 					update_wc_div( response );
 				},
-				complete: function () {
+				complete: function() {
 					unblock( $form );
 					unblock( $( 'div.cart_totals' ) );
-				},
+				}
 			} );
-		},
+		}
 	};
 
 	cart_shipping.init( cart );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42747.

In https://github.com/woocommerce/woocommerce-blocks/pull/12043, we replaced the old notice styles with the new ones. Due to this change, the update quantity notice on the classic cart stopped working. The notices to display are fetched in https://github.com/woocommerce/woocommerce/blob/be290984b9e0d7228b2985022ceb7e7362094493/plugins/woocommerce/client/legacy/js/frontend/cart.js#L91

When introducing the new notice styles, we also introduced new CSS classes for the notices.

**Old class names:**

```css
.woocommerce-error
.woocommerce-message
.woocommerce-info
```

**New class names:**

```css
.is-error
.is-success
.is-notice
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a test page and add the following shortcode to it:
```
[woocommerce_cart]
```
2. Go to the frontend and add a product to the cart.
3. Go to the created test page with the cart shortcode.
4. Adjust the product quantity and click the `Update cart` button.
5. Verify that the notice `Cart updated.` is displayed.

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1278" alt="Screenshot 2023-12-13 at 17 03 40" src="https://github.com/woocommerce/woocommerce/assets/3323310/04ce8f05-e9c5-4e7e-b6dd-e81e910e4e8d">
</td>
<td valign="top">After:
<br><br>
<img width="1279" alt="Screenshot 2023-12-13 at 17 02 54" src="https://github.com/woocommerce/woocommerce/assets/3323310/6fc9f335-921a-4afe-836b-7110c3808945">
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix: Display update quantity notice when using the cart shortcode.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
