### PR TITLE
Add HTML5 theme support to NO JS handling

### DIFF
--- a/plugins/woocommerce/changelog/Add HTML5 theme support to NO JS handling
+++ b/plugins/woocommerce/changelog/Add HTML5 theme support to NO JS handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+W3C validator shows a warning for using text/javascript on script tags. This adds a theme support check which is inline with Wordpress function _print_scripts in /wp-includes/script-loader.php

--- a/plugins/woocommerce/changelog/Add HTML5 theme support to NO JS handling
+++ b/plugins/woocommerce/changelog/Add HTML5 theme support to NO JS handling
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-W3C validator shows a warning for using text/javascript on script tags. This adds a theme support check which is inline with Wordpress function _print_scripts in /wp-includes/script-loader.php
+Fix the `wc_no_js` script so it avoids specifying its type unless necessary. This aligns it with core Wordpress functionality.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -363,8 +363,9 @@ function wc_body_class( $classes ) {
  * @since 3.4.0
  */
 function wc_no_js() {
+	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
 	?>
-	<script type="text/javascript">
+	<script<?php echo $type_attr; ?>>
 		(function () {
 			var c = document.body.className;
 			c = c.replace(/woocommerce-no-js/, 'woocommerce-js');

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -365,7 +365,7 @@ function wc_body_class( $classes ) {
 function wc_no_js() {
 	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
 	?>
-	<script<?php echo $type_attr; ?>>
+	<script<?php echo $type_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		(function () {
 			var c = document.body.className;
 			c = c.replace(/woocommerce-no-js/, 'woocommerce-js');


### PR DESCRIPTION
W3C validator shows a warning for using `text/javascript` on script tags. This adds a theme support check which is inline with Wordpress function `_print_scripts` in `/wp-includes/script-loader.php`

W3C validator on Storefont theme
https://validator.w3.org/nu/?doc=https%3A%2F%2Fthemes.woocommerce.com%2Fstorefront%2F

<img width="1216" alt="Screenshot 2023-12-13 at 10 33 39" src="https://github.com/woocommerce/woocommerce/assets/8536452/73f3c85b-2cd8-4fc4-8860-82da1f21a816">
