### PR TITLE
Add select field type for custom checkout fields

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -26,6 +26,7 @@ import { AddressFormProps, FieldConfig, AddressFormFields } from './types';
 import prepareAddressFields from './prepare-address-fields';
 import validateShippingCountry from './validate-shipping-country';
 import customValidationHandler from './custom-validation-handler';
+import Combobox from '../../combobox';
 
 /**
  * Checkout address form.
@@ -159,6 +160,24 @@ const AddressForm = ( {
 									state: newValue,
 								} )
 							}
+						/>
+					);
+				}
+
+				if ( field.type === 'select' ) {
+					return (
+						<Combobox
+							key={ field.key }
+							{ ...fieldProps }
+							className="wc-block-components-select-input"
+							value={ values[ field.key ] }
+							onChange={ ( newValue: string ) => {
+								onChange( {
+									...values,
+									[ field.key ]: newValue,
+								} );
+							} }
+							options={ field.options }
 						/>
 					);
 				}

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -35,7 +35,7 @@ const AddressForm = ( {
 	fields,
 	fieldConfig = {} as FieldConfig,
 	onChange,
-	type = 'shipping',
+	addressType = 'shipping',
 	values,
 }: AddressFormProps ): JSX.Element => {
 	const instanceId = useInstanceId( AddressForm );
@@ -54,11 +54,11 @@ const AddressForm = ( {
 		);
 		return {
 			fields: preparedFields,
-			type,
+			addressType,
 			required: preparedFields.filter( ( field ) => field.required ),
 			hidden: preparedFields.filter( ( field ) => field.hidden ),
 		};
-	}, [ currentFields, currentFieldConfig, currentCountry, type ] );
+	}, [ currentFields, currentFieldConfig, currentCountry, addressType ] );
 
 	// Stores refs for rendered fields so we can access them later.
 	const fieldsRef = useRef<
@@ -80,10 +80,10 @@ const AddressForm = ( {
 
 	// Maybe validate country when other fields change so user is notified that it's required.
 	useEffect( () => {
-		if ( type === 'shipping' ) {
+		if ( addressType === 'shipping' ) {
 			validateShippingCountry( values );
 		}
-	}, [ values, type ] );
+	}, [ values, addressType ] );
 
 	// Changing country may change format for postcodes.
 	useEffect( () => {
@@ -101,7 +101,7 @@ const AddressForm = ( {
 
 				const fieldProps = {
 					id: `${ id }-${ field.key }`,
-					errorId: `${ type }_${ field.key }`,
+					errorId: `${ addressType }_${ field.key }`,
 					label: field.required ? field.label : field.optionalLabel,
 					autoCapitalize: field.autocapitalize,
 					autoComplete: field.autocomplete,
@@ -112,7 +112,7 @@ const AddressForm = ( {
 
 				if ( field.key === 'country' ) {
 					const Tag =
-						type === 'shipping'
+						addressType === 'shipping'
 							? ShippingCountryInput
 							: BillingCountryInput;
 					return (
@@ -144,7 +144,7 @@ const AddressForm = ( {
 
 				if ( field.key === 'state' ) {
 					const Tag =
-						type === 'shipping'
+						addressType === 'shipping'
 							? ShippingStateInput
 							: BillingStateInput;
 					return (

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -18,6 +18,7 @@ import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { useShallowEqual } from '@woocommerce/base-hooks';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -168,12 +169,15 @@ const AddressForm = ( {
 					if ( typeof field.options === 'undefined' ) {
 						return null;
 					}
-					
+
 					return (
 						<Combobox
 							key={ field.key }
 							{ ...fieldProps }
-							className="wc-block-components-select-input"
+							className={ classnames(
+								'wc-block-components-select-input',
+								`wc-block-components-select-input-${ field.key }`
+							) }
 							value={ values[ field.key ] }
 							onChange={ ( newValue: string ) => {
 								onChange( {

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -165,6 +165,9 @@ const AddressForm = ( {
 				}
 
 				if ( field.type === 'select' ) {
+					if ( typeof field.options === 'undefined' ) {
+						return null;
+					}
 					return (
 						<Combobox
 							key={ field.key }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -168,6 +168,7 @@ const AddressForm = ( {
 					if ( typeof field.options === 'undefined' ) {
 						return null;
 					}
+					
 					return (
 						<Combobox
 							key={ field.key }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/test/index.js
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/test/index.js
@@ -12,6 +12,15 @@ import { ADDRESS_FIELDS_KEYS } from '@woocommerce/block-settings';
  */
 import AddressForm from '../address-form';
 
+jest.mock( '@wordpress/element', () => {
+	return {
+		...jest.requireActual( '@wordpress/element' ),
+		useId: () => {
+			return 'mock-id';
+		},
+	};
+} );
+
 const renderInCheckoutProvider = ( ui, options = {} ) => {
 	const Wrapper = ( { children } ) => {
 		return <CheckoutProvider>{ children }</CheckoutProvider>;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/address-form/types.ts
@@ -18,7 +18,7 @@ export type FieldType = keyof AddressFields;
 
 export type AddressFormFields = {
 	fields: KeyedAddressField[];
-	type: AddressType;
+	addressType: AddressType;
 	required: KeyedAddressField[];
 	hidden: KeyedAddressField[];
 };
@@ -27,7 +27,7 @@ export interface AddressFormProps {
 	// Id for component.
 	id?: string;
 	// Type of form (billing or shipping).
-	type?: AddressType;
+	addressType?: AddressType;
 	// Array of fields in form.
 	fields: FieldType[];
 	// Field configuration for fields in form.

--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/index.tsx
@@ -3,8 +3,7 @@
  */
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
-import { withInstanceId } from '@wordpress/compose';
+import { useEffect, useId, useRef } from '@wordpress/element';
 import { ComboboxControl } from 'wordpress-components';
 import { ValidationInputError } from '@woocommerce/blocks-components';
 import { isObject } from '@woocommerce/types';
@@ -48,11 +47,11 @@ const Combobox = ( {
 	required = false,
 	errorMessage = __( 'Please select a value.', 'woocommerce' ),
 	errorId: incomingErrorId,
-	instanceId = '0',
 	autoComplete = 'off',
 }: ComboboxProps ): JSX.Element => {
 	const controlRef = useRef< HTMLDivElement >( null );
-	const controlId = id || 'control-' + instanceId;
+	const fallbackId = useId();
+	const controlId = id || 'control-' + fallbackId;
 	const errorId = incomingErrorId || controlId;
 
 	const { setValidationErrors, clearValidationError } =
@@ -154,4 +153,4 @@ const Combobox = ( {
 	);
 };
 
-export default withInstanceId( Combobox );
+export default Combobox;

--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
@@ -2,7 +2,6 @@
 .wc-block-components-select-input {
 	position: relative;
 	margin-top: $gap;
-	white-space: nowrap;
 }
 
 .wc-block-components-form .wc-block-components-combobox,

--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
@@ -1,3 +1,10 @@
+// For when the Combobox is being used as a select custom field.
+.wc-block-components-select-input {
+	position: relative;
+	margin-top: $gap;
+	white-space: nowrap;
+}
+
 .wc-block-components-form .wc-block-components-combobox,
 .wc-block-components-combobox {
 	.wc-block-components-combobox-control {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -21,7 +21,8 @@
 			gap: 0 calc(#{$gap-smaller} * 2); // Required for spacing especially when using flex-grow
 
 			.wc-block-components-text-input,
-			.wc-block-components-state-input {
+			.wc-block-components-state-input,
+			.wc-block-components-select-input {
 				flex: 1 0 calc(50% - #{$gap-smaller}); // "flex-grow = 1" allows the input to grow to fill the space
 				box-sizing: border-box;
 

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -20,7 +20,7 @@ export interface AddressField {
 	// Fields will be sorted and render in this order, lowest to highest.
 	index: number;
 	// The type of input to render. Defaults to text.
-	type?: 'text' | 'select';
+	type?: string;
 	// The options if this is a select field
 	options?: ComboboxControlOption[];
 }

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getSetting } from './utils';
+import { ComboboxControlOption } from '@woocommerce/base-components/combobox';
 
 export interface AddressField {
 	// The label for the field.
@@ -20,6 +21,8 @@ export interface AddressField {
 	index: number;
 	// The type of input to render. Defaults to text.
 	type?: 'text' | 'select';
+	// The options if this is a select field
+	options?: ComboboxControlOption[];
 }
 
 export interface LocaleSpecificAddressField extends Partial< AddressField > {

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -19,7 +19,7 @@ export interface AddressField {
 	// Fields will be sorted and render in this order, lowest to highest.
 	index: number;
 	// The type of input to render. Defaults to text.
-	type?: string;
+	type?: 'text' | 'select';
 }
 
 export interface LocaleSpecificAddressField extends Partial< AddressField > {

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import { ComboboxControlOption } from '@woocommerce/base-components/combobox';
+
+/**
  * Internal dependencies
  */
 import { getSetting } from './utils';
-import { ComboboxControlOption } from '@woocommerce/base-components/combobox';
 
 export interface AddressField {
 	// The label for the field.

--- a/plugins/woocommerce-blocks/changelog/42758-add-42133-custom-select-field
+++ b/plugins/woocommerce-blocks/changelog/42758-add-42133-custom-select-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for select fields in the experimental WooCommerce Blocks custom fields API.

--- a/plugins/woocommerce/changelog/42758-add-42133-custom-select-field
+++ b/plugins/woocommerce/changelog/42758-add-42133-custom-select-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for select fields in the experimental WooCommerce Blocks custom fields API.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -269,7 +269,17 @@ class CheckoutFields {
 		if ( ! empty( $options['type'] ) ) {
 			if ( ! in_array( $options['type'], $this->supported_field_types, true ) ) {
 				// translators: %1$s is the registered field type, %2$s is a list of supported field types (comma separated).
-				return new \WP_Error( 'woocommerce_blocks_checkout_field_type_unsupported', sprintf( __( 'Registering a field with type "%1$s" is not supported. The supported types are: %2$s.', 'woocommerce' ), esc_html( $options['type'] ), implode( ', ', $this->supported_field_types ) ) );
+				return new \WP_Error(
+					'woocommerce_blocks_checkout_field_type_unsupported',
+					sprintf(
+						__(
+							'Registering a field with type "%1$s" is not supported. The supported types are: %2$s.',
+							'woocommerce'
+						),
+						esc_html( $options['type'] ),
+						implode( ', ', $this->supported_field_types )
+					)
+				);
 			}
 			$type = $options['type'];
 		}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -449,7 +449,14 @@ class CheckoutFields {
 
 		if ( ! in_array( $key, $this->fields_locations[ $location ], true ) ) {
 			// translators: %1$s field key, %2$s location.
-			return new \WP_Error( 'woocommerce_blocks_checkout_field_invalid_location', \sprintf( __( 'The field %1$s is invalid for the location %2$s.', 'woocommerce' ), $key, $location ) );
+			return new \WP_Error(
+				'woocommerce_blocks_checkout_field_invalid_location',
+				\sprintf(
+					__( 'The field %1$s is invalid for the location %2$s.', 'woocommerce' ),
+					$key,
+					$location
+				)
+			);
 		}
 
 		$field = $this->additional_fields[ $key ];

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -451,10 +451,10 @@ class CheckoutFields {
 	 */
 	public function validate_field_for_location( $key, $value, $location ) {
 		if ( ! $this->is_field( $key ) ) {
-			// translators: %s field key.
 			return new \WP_Error(
 				'woocommerce_blocks_checkout_field_invalid',
 				\sprintf(
+					// translators: % is field key.
 					__( 'The field %s is invalid.', 'woocommerce' ),
 					$key
 				)
@@ -462,10 +462,10 @@ class CheckoutFields {
 		}
 
 		if ( ! in_array( $key, $this->fields_locations[ $location ], true ) ) {
-			// translators: %1$s field key, %2$s location.
 			return new \WP_Error(
 				'woocommerce_blocks_checkout_field_invalid_location',
 				\sprintf(
+					// translators: %1$s is field key, %2$s location.
 					__( 'The field %1$s is invalid for the location %2$s.', 'woocommerce' ),
 					$key,
 					$location
@@ -479,6 +479,7 @@ class CheckoutFields {
 			return new \WP_Error(
 				'woocommerce_blocks_checkout_field_required',
 				\sprintf(
+					// translators: %s is field key.
 					__( 'The field %s is required.', 'woocommerce' ),
 					$key
 				)

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -328,6 +328,14 @@ class CheckoutFields {
 				return;
 			}
 
+			// Select fields are always required. Log a warning if it's set explicitly as false.
+			$field_data['required'] = true;
+			if ( isset( $options['required'] ) && false === $options['required'] ) {
+				wc_get_logger()->warning(
+					sprintf( 'Registering select fields as optional is not supported. "%s" will be registered as required.', esc_html( $id ) )
+				);
+			}
+
 			$cleaned_options = array();
 			$added_values    = array();
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -264,6 +264,15 @@ class CheckoutFields {
 			return new \WP_Error( 'woocommerce_blocks_checkout_field_location_invalid', __( 'The field location is invalid.', 'woocommerce' ) );
 		}
 
+		$type = 'text';
+		if ( ! empty( $options['type'] ) ) {
+			if ( ! in_array( $options['type'], $this->supported_field_types, true ) ) {
+				// translators: %1$s is the registered field type, %2$s is a list of supported field types (comma separated).
+				return new \WP_Error( 'woocommerce_blocks_checkout_field_type_unsupported', sprintf( __( 'Registering a field with type "%1$s" is not supported. The supported types are: %2$s.', 'woo-gutenberg-products-block' ), esc_html( $options['type'] ), implode( ', ', $this->supported_field_types ) ) );
+			}
+			$type = $options['type'];
+		}
+
 		// At this point, the essentials fields and its location should be set.
 		$location = $options['location'];
 		$id       = $options['id'];
@@ -282,6 +291,7 @@ class CheckoutFields {
 		$this->additional_fields[ $id ] = array(
 			'label'          => $options['label'],
 			'hidden'         => false,
+			'type'           => $type,
 			'optionalLabel'  => empty( $options['optionalLabel'] ) ? '' : $options['optionalLabel'],
 			'required'       => empty( $options['required'] ) ? false : $options['required'],
 			'autocomplete'   => empty( $options['autocomplete'] ) ? '' : $options['autocomplete'],

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -301,17 +301,31 @@ class CheckoutFields {
 				return new \WP_Error( 'woocommerce_blocks_checkout_select_field_no_options_specified', __( 'Fields of type "select" must have an array of "options".', 'woo-gutenberg-products-block' ) );
 			}
 
+			$cleaned_options = array();
+			$added_values = array();
+
 			// Check all entries in $options['options'] has a key and value member.
 			foreach ( $options['options'] as $key => $option ) {
 				if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
 					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_invalid', __( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woo-gutenberg-products-block' ) );
 				}
 
-				$options[ $key ]['value'] = sanitize_text_field( $option['value'] );
-				$options[ $key ]['label'] = sanitize_text_field( $option['label'] );
+				$sanitized_value = sanitize_text_field( $option['value'] );
+				$sanitized_label = sanitize_text_field( $option['label'] );
+
+				if ( in_array( $sanitized_value, $added_values ) ) {
+					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_not_unique', sprintf( __( 'The value in each option of "select" fields must be unique. Duplicate value "%s" found.', 'woo-gutenberg-products-block' ), esc_html( $sanitized_value ) ) );
+				}
+
+				$added_values[] = $sanitized_value;
+
+				$cleaned_options[] = array(
+					'value' => $sanitized_value,
+					'label' => $sanitized_label,
+				);
 			}
 
-			$field_data['options'] = $options['options'];
+			$field_data['options'] = $cleaned_options;
 		}
 
 		// Insert new field into the correct location array.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -462,7 +462,13 @@ class CheckoutFields {
 		$field = $this->additional_fields[ $key ];
 		if ( ! empty( $field['required'] ) && empty( $value ) ) {
 			// translators: %s field key.
-			return new \WP_Error( 'woocommerce_blocks_checkout_field_required', \sprintf( __( 'The field %s is required.', 'woocommerce' ), $key ) );
+			return new \WP_Error(
+				'woocommerce_blocks_checkout_field_required',
+				\sprintf(
+					__( 'The field %s is required.', 'woocommerce' ),
+					$key
+				)
+			);
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -444,7 +444,13 @@ class CheckoutFields {
 	public function validate_field_for_location( $key, $value, $location ) {
 		if ( ! $this->is_field( $key ) ) {
 			// translators: %s field key.
-			return new \WP_Error( 'woocommerce_blocks_checkout_field_invalid', \sprintf( __( 'The field %s is invalid.', 'woocommerce' ), $key ) );
+			return new \WP_Error(
+				'woocommerce_blocks_checkout_field_invalid',
+				\sprintf(
+					__( 'The field %s is invalid.', 'woocommerce' ),
+					$key
+				)
+			);
 		}
 
 		if ( ! in_array( $key, $this->fields_locations[ $location ], true ) ) {

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -296,6 +296,24 @@ class CheckoutFields {
 			'autocapitalize' => empty( $options['autocapitalize'] ) ? '' : $options['autocapitalize'],
 		);
 
+		if ( 'select' === $type ) {
+			if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
+				return new \WP_Error( 'woocommerce_blocks_checkout_field_no_options_specified', __( 'Fields of type "select" must have an array of "options".', 'woo-gutenberg-products-block' ) );
+			}
+
+			// Check all entries in $options['options'] has a key and value member.
+			foreach ( $options['options'] as $key => $option ) {
+				if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
+					return new \WP_Error( 'woocommerce_blocks_checkout_field_options_invalid', __( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woo-gutenberg-products-block' ) );
+				}
+
+				$options[ $key ]['value'] = sanitize_text_field( $option['value'] );
+				$options[ $key ]['label'] = sanitize_text_field( $option['label'] );
+			}
+
+			$field_data['options'] = $options['options'];
+		}
+
 		// Insert new field into the correct location array.
 		$this->additional_fields[ $id ] = $field_data;
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -310,7 +310,10 @@ class CheckoutFields {
 
 		if ( 'select' === $type ) {
 			if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
-				return new \WP_Error( 'woocommerce_blocks_checkout_select_field_no_options_specified', __( 'Fields of type "select" must have an array of "options".', 'woocommerce' ) );
+				return new \WP_Error(
+					'woocommerce_blocks_checkout_select_field_no_options_specified',
+					__( 'Fields of type "select" must have an array of "options".', 'woocommerce' )
+				);
 			}
 
 			$cleaned_options = array();

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -33,6 +33,11 @@ class CheckoutFields {
 	private $fields_locations;
 
 	/**
+	 * Supported field types
+	 */
+	private $supported_field_types = [ 'text', 'select' ];
+
+	/**
 	 * Instance of the asset data registry.
 	 *
 	 * @var AssetDataRegistry

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -298,13 +298,13 @@ class CheckoutFields {
 
 		if ( 'select' === $type ) {
 			if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
-				return new \WP_Error( 'woocommerce_blocks_checkout_field_no_options_specified', __( 'Fields of type "select" must have an array of "options".', 'woo-gutenberg-products-block' ) );
+				return new \WP_Error( 'woocommerce_blocks_checkout_select_field_no_options_specified', __( 'Fields of type "select" must have an array of "options".', 'woo-gutenberg-products-block' ) );
 			}
 
 			// Check all entries in $options['options'] has a key and value member.
 			foreach ( $options['options'] as $key => $option ) {
 				if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
-					return new \WP_Error( 'woocommerce_blocks_checkout_field_options_invalid', __( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woo-gutenberg-products-block' ) );
+					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_invalid', __( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woo-gutenberg-products-block' ) );
 				}
 
 				$options[ $key ]['value'] = sanitize_text_field( $option['value'] );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -322,7 +322,10 @@ class CheckoutFields {
 			// Check all entries in $options['options'] has a key and value member.
 			foreach ( $options['options'] as $key => $option ) {
 				if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
-					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_invalid', __( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woocommerce' ) );
+					return new \WP_Error(
+						'woocommerce_blocks_checkout_select_field_options_invalid',
+						__( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woocommerce' )
+					);
 				}
 
 				$sanitized_value = sanitize_text_field( $option['value'] );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -10,7 +10,6 @@ use WC_Customer;
  */
 class CheckoutFields {
 
-
 	/**
 	 * Core checkout fields.
 	 *
@@ -287,8 +286,7 @@ class CheckoutFields {
 			trigger_error( sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', esc_html( $id ) ), E_USER_WARNING );
 		}
 
-		// Insert new field into the correct location array.
-		$this->additional_fields[ $id ] = array(
+		$field_data = array(
 			'label'          => $options['label'],
 			'hidden'         => false,
 			'type'           => $type,
@@ -297,6 +295,9 @@ class CheckoutFields {
 			'autocomplete'   => empty( $options['autocomplete'] ) ? '' : $options['autocomplete'],
 			'autocapitalize' => empty( $options['autocapitalize'] ) ? '' : $options['autocapitalize'],
 		);
+
+		// Insert new field into the correct location array.
+		$this->additional_fields[ $id ] = $field_data;
 
 		$this->fields_locations[ $location ][] = $id;
 	}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -243,34 +243,34 @@ class CheckoutFields {
 	 */
 	public function register_checkout_field( $options ) {
 		if ( empty( $options['id'] ) ) {
-			wc_get_logger()->debug( 'A checkout field cannot be registered without an id.' );
+			wc_get_logger()->warning( 'A checkout field cannot be registered without an id.' );
 			return;
 		}
 
 		// Having fewer than 2 after exploding around a / means there is no namespace.
 		if ( count( explode( '/', $options['id'] ) ) < 2 ) {
-			wc_get_logger()->debug(
+			wc_get_logger()->warning(
 				sprintf( 'Unable to register field with id: "%s". %s', esc_html( $options['id'] ), 'A checkout field id must consist of namespace/name.' )
 			);
 			return;
 		}
 
 		if ( empty( $options['label'] ) ) {
-			wc_get_logger()->debug(
+			wc_get_logger()->warning(
 				sprintf( 'Unable to register field with id: "%s". %s', esc_html( $options['id'] ), 'The field label is required.' )
 			);
 			return;
 		}
 
 		if ( empty( $options['location'] ) ) {
-			wc_get_logger()->debug(
+			wc_get_logger()->warning(
 				sprintf( 'Unable to register field with id: "%s". %s', esc_html( $options['id'] ), 'The field location is required.' )
 			);
 			return;
 		}
 
 		if ( ! in_array( $options['location'], array_keys( $this->fields_locations ), true ) ) {
-			wc_get_logger()->debug(
+			wc_get_logger()->warning(
 				sprintf( 'Unable to register field with id: "%s". %s', esc_html( $options['id'] ), 'The field location is invalid.' )
 			);
 			return;
@@ -279,7 +279,7 @@ class CheckoutFields {
 		$type = 'text';
 		if ( ! empty( $options['type'] ) ) {
 			if ( ! in_array( $options['type'], $this->supported_field_types, true ) ) {
-				wc_get_logger()->debug(
+				wc_get_logger()->warning(
 					sprintf(
 						'Unable to register field with id: "%s". Registering a field with type "%s" is not supported. The supported types are: %s.',
 						esc_html( $options['id'] ),
@@ -297,7 +297,7 @@ class CheckoutFields {
 		$id       = $options['id'];
 		// Check to see if field is already in the array.
 		if ( ! empty( $this->additional_fields[ $id ] ) || in_array( $id, $this->fields_locations[ $location ], true ) ) {
-			wc_get_logger()->debug(
+			wc_get_logger()->warning(
 				sprintf( 'Unable to register field with id: "%s". %s', esc_html( $id ), 'The field is already registered.' )
 			);
 			return;
@@ -305,7 +305,7 @@ class CheckoutFields {
 
 		// Hidden fields are not supported right now. They will be registered with hidden => false.
 		if ( ! empty( $options['hidden'] ) && true === $options['hidden'] ) {
-			wc_get_logger()->debug(
+			wc_get_logger()->warning(
 				sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', esc_html( $id ) )
 			);
 		}
@@ -320,9 +320,12 @@ class CheckoutFields {
 			'autocapitalize' => empty( $options['autocapitalize'] ) ? '' : $options['autocapitalize'],
 		);
 
+		/**
+		 * Handle Select fields.
+		 */
 		if ( 'select' === $type ) {
 			if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
-				wc_get_logger()->debug(
+				wc_get_logger()->warning(
 					sprintf( 'Unable to register field with id: "%s". %s', esc_html( $id ), 'Fields of type "select" must have an array of "options".' )
 				);
 				return;
@@ -340,9 +343,9 @@ class CheckoutFields {
 			$added_values    = array();
 
 			// Check all entries in $options['options'] has a key and value member.
-			foreach ( $options['options'] as $key => $option ) {
+			foreach ( $options['options'] as $option ) {
 				if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
-					wc_get_logger()->debug(
+					wc_get_logger()->warning(
 						sprintf( 'Unable to register field with id: "%s". %s', esc_html( $id ), 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.' )
 					);
 					return;
@@ -352,7 +355,7 @@ class CheckoutFields {
 				$sanitized_label = sanitize_text_field( $option['label'] );
 
 				if ( in_array( $sanitized_value, $added_values, true ) ) {
-					wc_get_logger()->debug(
+					wc_get_logger()->warning(
 						sprintf( 'Unable to register field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found.', esc_html( $id ), esc_html( $sanitized_value ) )
 					);
 					return;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -333,7 +333,13 @@ class CheckoutFields {
 
 				if ( in_array( $sanitized_value, $added_values, true ) ) {
 					// translators: %s is the duplicate value.
-					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_not_unique', sprintf( __( 'The value in each option of "select" fields must be unique. Duplicate value "%s" found.', 'woocommerce' ), esc_html( $sanitized_value ) ) );
+					return new \WP_Error(
+						'woocommerce_blocks_checkout_select_field_options_not_unique',
+						sprintf(
+							__( 'The value in each option of "select" fields must be unique. Duplicate value "%s" found.', 'woocommerce' ),
+							esc_html( $sanitized_value )
+						)
+					);
 				}
 
 				$added_values[] = $sanitized_value;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -22,7 +22,7 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $additional_fields = [];
+	private $additional_fields = array();
 
 	/**
 	 * Fields locations.
@@ -33,8 +33,10 @@ class CheckoutFields {
 
 	/**
 	 * Supported field types
+	 *
+	 * @var array
 	 */
-	private $supported_field_types = [ 'text', 'select' ];
+	private $supported_field_types = array( 'text', 'select' );
 
 	/**
 	 * Instance of the asset data registry.
@@ -267,7 +269,7 @@ class CheckoutFields {
 		if ( ! empty( $options['type'] ) ) {
 			if ( ! in_array( $options['type'], $this->supported_field_types, true ) ) {
 				// translators: %1$s is the registered field type, %2$s is a list of supported field types (comma separated).
-				return new \WP_Error( 'woocommerce_blocks_checkout_field_type_unsupported', sprintf( __( 'Registering a field with type "%1$s" is not supported. The supported types are: %2$s.', 'woo-gutenberg-products-block' ), esc_html( $options['type'] ), implode( ', ', $this->supported_field_types ) ) );
+				return new \WP_Error( 'woocommerce_blocks_checkout_field_type_unsupported', sprintf( __( 'Registering a field with type "%1$s" is not supported. The supported types are: %2$s.', 'woocommerce' ), esc_html( $options['type'] ), implode( ', ', $this->supported_field_types ) ) );
 			}
 			$type = $options['type'];
 		}
@@ -298,23 +300,24 @@ class CheckoutFields {
 
 		if ( 'select' === $type ) {
 			if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
-				return new \WP_Error( 'woocommerce_blocks_checkout_select_field_no_options_specified', __( 'Fields of type "select" must have an array of "options".', 'woo-gutenberg-products-block' ) );
+				return new \WP_Error( 'woocommerce_blocks_checkout_select_field_no_options_specified', __( 'Fields of type "select" must have an array of "options".', 'woocommerce' ) );
 			}
 
 			$cleaned_options = array();
-			$added_values = array();
+			$added_values    = array();
 
 			// Check all entries in $options['options'] has a key and value member.
 			foreach ( $options['options'] as $key => $option ) {
 				if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
-					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_invalid', __( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woo-gutenberg-products-block' ) );
+					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_invalid', __( 'Fields of type "select" must have an array of "options" with a "value" and "label" member.', 'woocommerce' ) );
 				}
 
 				$sanitized_value = sanitize_text_field( $option['value'] );
 				$sanitized_label = sanitize_text_field( $option['label'] );
 
-				if ( in_array( $sanitized_value, $added_values ) ) {
-					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_not_unique', sprintf( __( 'The value in each option of "select" fields must be unique. Duplicate value "%s" found.', 'woo-gutenberg-products-block' ), esc_html( $sanitized_value ) ) );
+				if ( in_array( $sanitized_value, $added_values, true ) ) {
+					// translators: %s is the duplicate value.
+					return new \WP_Error( 'woocommerce_blocks_checkout_select_field_options_not_unique', sprintf( __( 'The value in each option of "select" fields must be unique. Duplicate value "%s" found.', 'woocommerce' ), esc_html( $sanitized_value ) ) );
 				}
 
 				$added_values[] = $sanitized_value;
@@ -609,16 +612,16 @@ class CheckoutFields {
 	 */
 	public function get_all_fields_from_customer( $customer, $all = false ) {
 		$customer_id = $customer->get_id();
-		$meta_data   = [
-			'billing'    => [],
-			'shipping'   => [],
-			'additional' => [],
-		];
+		$meta_data   = array(
+			'billing'    => array(),
+			'shipping'   => array(),
+			'additional' => array(),
+		);
 		if ( ! $customer_id ) {
 			if ( isset( wc()->session ) ) {
-				$meta_data['billing']    = wc()->session->get( self::BILLING_FIELDS_KEY, [] );
-				$meta_data['shipping']   = wc()->session->get( self::SHIPPING_FIELDS_KEY, [] );
-				$meta_data['additional'] = wc()->session->get( self::ADDITIONAL_FIELDS_KEY, [] );
+				$meta_data['billing']    = wc()->session->get( self::BILLING_FIELDS_KEY, array() );
+				$meta_data['shipping']   = wc()->session->get( self::SHIPPING_FIELDS_KEY, array() );
+				$meta_data['additional'] = wc()->session->get( self::ADDITIONAL_FIELDS_KEY, array() );
 			}
 		} else {
 			$meta_data['billing']    = get_user_meta( $customer_id, self::BILLING_FIELDS_KEY, true );
@@ -638,11 +641,11 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	public function get_all_fields_from_order( $order, $all = false ) {
-		$meta_data = [
-			'billing'    => [],
-			'shipping'   => [],
-			'additional' => [],
-		];
+		$meta_data = array(
+			'billing'    => array(),
+			'shipping'   => array(),
+			'additional' => array(),
+		);
 		if ( $order instanceof \WC_Order ) {
 			$meta_data['billing']    = $order->get_meta( self::BILLING_FIELDS_KEY, true );
 			$meta_data['shipping']   = $order->get_meta( self::SHIPPING_FIELDS_KEY, true );
@@ -660,9 +663,9 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	private function format_meta_data( $meta, $all = false ) {
-		$billing_fields    = $meta['billing'] ?? [];
-		$shipping_fields   = $meta['shipping'] ?? [];
-		$additional_fields = $meta['additional'] ?? [];
+		$billing_fields    = $meta['billing'] ?? array();
+		$shipping_fields   = $meta['shipping'] ?? array();
+		$additional_fields = $meta['additional'] ?? array();
 
 		$fields = array();
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -356,9 +356,9 @@ class CheckoutFields {
 
 				if ( in_array( $sanitized_value, $added_values, true ) ) {
 					wc_get_logger()->warning(
-						sprintf( 'Unable to register field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found.', esc_html( $id ), esc_html( $sanitized_value ) )
+						sprintf( 'Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', esc_html( $id ), esc_html( $sanitized_value ) )
 					);
-					return;
+					continue;
 				}
 
 				$added_values[] = $sanitized_value;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -194,7 +194,18 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		}
 
 		foreach ( array_keys( $address ) as $key ) {
-			$result = rest_validate_value_from_schema( $address[ $key ], $this->get_properties()[ $key ], $key );
+
+			// Skip email here it will be validated in BillingAddressSchema.
+			if ( 'email' === $key ) {
+				continue;
+			}
+
+			$properties = $this->get_properties();
+			if ( empty( $properties[ $key ] ) ) {
+				continue;
+			}
+
+			$result = rest_validate_value_from_schema( $address[ $key ], $properties[ $key ], $key );
 			if ( is_wp_error( $result ) ) {
 				$errors->add( $result->get_error_code(), $result->get_error_message() );
 			}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -117,7 +117,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$address         = array_merge( array_fill_keys( array_keys( $this->get_properties() ), '' ), (array) $address );
 		$address         = array_reduce(
 			array_keys( $address ),
-			function( $carry, $key ) use ( $address, $validation_util ) {
+			function( $carry, $key ) use ( $address, $validation_util, $request ) {
 				switch ( $key ) {
 					case 'country':
 						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
@@ -129,7 +129,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
 						break;
 					default:
-						$carry[ $key ] = sanitize_text_field( wp_unslash( $address[ $key ] ) );
+						$carry[ $key ] = rest_sanitize_request_arg( wp_unslash( $address[ $key ] ), $request, $key );
 						break;
 				}
 				return $carry;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -201,7 +201,11 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			}
 
 			$properties = $this->get_properties();
-			if ( empty( $properties[ $key ] ) ) {
+
+			// Only run specific validation on properties that are defined in the schema and present in the address.
+			// This is for partial address pushes when only part of a customer address is sent.
+			// Full schema address validation still happens later, so empty, required values are disallowed.
+			if ( empty( $properties[ $key ] ) || empty( $address[ $key ] ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -204,7 +204,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 	protected function get_additional_address_fields_schema() {
 		$additional_fields_keys = $this->additional_fields_controller->get_address_fields_keys();
 
-		$fields = array_merge( $this->additional_fields_controller->get_core_fields(), $this->additional_fields_controller->get_additional_fields() );
+		$fields = $this->additional_fields_controller->get_additional_fields();
 
 		$address_fields = array_filter(
 			$fields,

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -232,14 +232,14 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			ARRAY_FILTER_USE_KEY
 		);
 
-		$schema = [];
+		$schema = array();
 		foreach ( $address_fields as $key => $field ) {
-			$field_schema = [
+			$field_schema = array(
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'required'    => true,
-			];
+			);
 
 			if ( 'select' === $field['type'] ) {
 				$field_schema['type'] = 'string';

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -223,12 +223,27 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 
 		$schema = [];
 		foreach ( $address_fields as $key => $field ) {
-			$schema[ $key ] = [
+			$field_schema = [
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'required'    => true,
 			];
+
+			if ( ! empty( $field['type'] ) && 'select' === $field['type'] ) {
+				$field_schema['type'] = 'string';
+				$field_schema['enum'] = array_map(
+					function( $option ) {
+						return $option['value'];
+					},
+					$field['options']
+				);
+				$field_schema['items'] = array(
+					'type' => 'string',
+				);
+			}
+
+			$schema[ $key ] = $field_schema;
 		}
 		return $schema;
 	}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -230,7 +230,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 				'required'    => true,
 			];
 
-			if ( ! empty( $field['type'] ) && 'select' === $field['type'] ) {
+			if ( 'select' === $field['type'] ) {
 				$field_schema['type'] = 'string';
 				$field_schema['enum'] = array_map(
 					function( $option ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -238,9 +238,6 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 					},
 					$field['options']
 				);
-				$field_schema['items'] = array(
-					'type' => 'string',
-				);
 			}
 
 			$schema[ $key ] = $field_schema;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -193,6 +193,13 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			);
 		}
 
+		foreach ( array_keys( $address ) as $key ) {
+			$result = rest_validate_value_from_schema( $address[ $key ], $this->get_properties()[ $key ], $key );
+			if ( is_wp_error( $result ) ) {
+				$errors->add( $result->get_error_code(), $result->get_error_message() );
+			}
+		}
+
 		return $errors->has_errors( $errors ) ? $errors : true;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -603,7 +603,7 @@ class Cart extends ControllerTestCase {
 					array(
 						'variation' => array( // order matters, alphabetical attribute order.
 							array(
-								'attribute' => 'color',
+								'attribute' => 'Color',
 								'value'     => 'red',
 							),
 							array(

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -603,7 +603,7 @@ class Cart extends ControllerTestCase {
 					array(
 						'variation' => array( // order matters, alphabetical attribute order.
 							array(
-								'attribute' => 'Color',
+								'attribute' => 'color',
 								'value'     => 'red',
 							),
 							array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- In `AddressForm`, renamed the `type` prop which was previously used to determine whether the address was `shipping` or `billing` to `addressType`. 
  - This is because fields will now have a type too (text, select, checkbox etc.)
- Add a case to handle the field type being `select` in the `AddressForm` this outputs a `Combobox`
- Update `Combobox` to use `useId` rather than `withInstanceId` hoc. This was done to reduce TS errors.
- Add additional checks to `register_checkout_field` to ensure valid configurations for select fields
- Updated `AbstractAddressSchema` so that it performs sanitization for the correct field type on the values preceived and so that it also validates each value against the schema.

Closes #42133.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Run your site in experimental mode: find `plugins/woocommerce-blocks/blocks.ini` and set the `woocommerce_blocks_phase` to 3.

Use this snippet for testing:

```php
add_action(
	'woocommerce_blocks_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id'             => 'plugin-namespace/vat-number',
				'label'          => __( 'VAT Number', 'woo-gutenberg-products-block' ),
				'optionalLabel'  => __( 'VAT Number (optional)', 'woo-gutenberg-products-block' ),
				'autocomplete'   => 'vat-number',
				'autocapitalize' => 'characters',
				'location'       => 'address',
				'type'           => 'text',
			)
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'             => 'plugin-namespace/road-type',
				'label'          => __( 'Road type', 'woo-gutenberg-products-block' ),
				'optionalLabel'  => __( 'Road type (optional)', 'woo-gutenberg-products-block' ),
				'autocomplete'   => 'road-type',
				'required'       => 'true',
				'autocapitalize' => 'characters',
				'location'       => 'address',
				'type'           => 'select',
				'options'        => array(
					array(
						'value' => 'alleyway',
						'label' => __( 'Alleyway', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'avenue',
						'label' => __( 'Avenue', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'boulevard',
						'label' => __( 'Boulevard', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'cul-de-sac',
						'label' => __( 'Cul-de-sac', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'street',
						'label' => __( 'Street', 'woo-gutenberg-products-block' ),
					),
				),
			)
		);
	}
);
```

### Happy path

1. Add the snippet somewhere on your site.
2. Add an item to your cart and go to the Checkout block.
3. In the address fields, you should have a text input for VAT and a combobox for road type.
4. Ensure road type is blank.
5. Fill in the rest of the checkout and try to place the order.
6. Ensure you get an error: Road type is required.
7. Click into the road type control.
8. Ensure the options for the road type match what is in the snippet (Alleyway, Avenue, Boulevard, Cul-de-sac, Street)
9. Ensure you can select each one and the value changes correctly.
10. With a value selected, ensure you can check out successfully.
11. Add an item to your cart again and revisit the checkout. Ensure your previously selected option is still selected.
12. Try to de-select it, it should not be possible.

### Testing incorrect configs

#### Duplicate keys

1. In the snippet, update the options to include an item with a non-unique value, e.g. add another entry with the value `alleyway`.
2. Load your site and ensure the field is registered without the duplicate key.
3. Check your WooCommerce logs, ensure a warning is shown about the duplicate keys.

#### No options

1. In the snippet, remove all options so it is just an empty array.
2. Load your site and ensure the field is not rendered.
3. Check your WooCommerce logs, ensure a warning is shown about the empty options array.
4. Change options to a non-array type, e.g. a string.
5. Load your site and ensure the field is not rendered.
6. Check your WooCommerce logs, ensure a warning is shown about the non-array options value.

#### Unsupported types

1. In the snippet, change the type from `select` to `password`
2. Load your site and ensure the field is not rendered.
3. Check your WooCommerce logs, ensure a warning is shown about the unsupported field type.

#### Invalid option shape

1. In the snippet, change one of the options. Change the `value` key to something else, e.g.
```php
array(
	'something_else' => 'street',
	'label' => __( 'Street', 'woo-gutenberg-products-block' ),
),
```

2. Load your site and ensure the field is not rendered.
3. Check your WooCommerce logs, ensure a warning is shown about the incorrect options shape.
4. Change it back, then change the `label` key to something else.
5. Load your site and ensure the field is not rendered.
6. Check your WooCommerce logs, ensure a warning is shown about the incorrect options shape.

### Store API

#### Required field

<details>
<summary>Example checkout payload</summary>

```json
{
  "shipping_address": {
    "first_name": "Jon",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": "",
    "plugin-namespace/vat-number": "12345",
    "plugin-namespace/road-type": ""
  },
  "billing_address": {
    "first_name": "Jon",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": "",
    "email": "jon@doe.com",
    "phone": "",
    "plugin-namespace/vat-number": "12345",
    "plugin-namespace/road-type": ""
  },
  "customer_note": "",
  "create_account": false,
  "payment_method": "bacs",
  "payment_data": [
    {
      "key": "wc-bacs-new-payment-method",
      "value": false
    }
  ]
}
```
</details>

1. Update the snippet so the road type field is required.
2. Using store API add an item to your cart.
3. Using store API Update the customer (post to `wc/store/v1/cart/update-customer`  - note the example snippet above for payload) and pass an empty string for the `plugin-namespace/road-type` value.
4. Ensure you get a 200 response.
5. Using store API Update the customer (post to `wc/store/v1/cart/update-customer`  - note the example snippet above for payload) and **remove** the `plugin-namespace/road-type` value for either billing or shipping address.
6. Ensure you get a 200 response.
7. Change the `plugin-namespace/road-type` value to `"freeway"` and post to `wc/store/v1/cart/update-customer` again. Expect a 400 error.
8. Check out (post to `wc/store/v1/cart/checkout` - note the example snippet above for payload) and ensure that `plugin-namespace/road-type` does not have a value.
9. Expect a 400 response with the error: `There was a problem with the provided shipping address: Road type is required`
10. Add a value for the one in the _shipping_ address and re-try.
11. Expect a 400 response with the error: `There was a problem with the provided billing address: Road type is required`
12. Add a value for the one in the billing address and re-try.
13. Expect a 200 response.

#### Value not in options

1. Using store API add an item to your cart
2. Check out (note the example snippet above) and ensure that `plugin-namespace/road-type` has a value that was not in the original list, e.g. `freeway`.
4. Expect a 400 error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add support for select fields in the experimental WooCommerce Blocks custom fields API.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
