### PR TITLE
Shipping Settings: Replace tables only for use in modals

### DIFF
--- a/plugins/woocommerce/changelog/42795-fix-shipping-settings-extension-tables
+++ b/plugins/woocommerce/changelog/42795-fix-shipping-settings-extension-tables
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Revert Shipping Settings change of replacing tables, replace only for use in JS powered modals.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -510,11 +510,13 @@
 					// `<table class="form-table" />` elements added by the Settings API need to be removed. 
 					// Modern browsers won't interpret other table elements like `td` not in a `table`, so 
 					// Removing the `table` is sufficient.
-					const htmlContent = $( html );
-					const tables = htmlContent.find( 'table.form-table' );
+					const originalTable = $( html );
+					const htmlContent = $( '<div class="wc-shipping-zone-method-fields" />' );
+					htmlContent.html( originalTable.html() );
 
-					tables.each( ( i ) => {
-						const table = $( tables[ i ] );
+					const innerTables = htmlContent.find( 'table.form-table' );
+					innerTables.each( ( i ) => {
+						const table = $( innerTables[ i ] );
 						const div = $( '<div class="wc-shipping-zone-method-fields" />' );
 						div.html( table.html() );
 						table.replaceWith( div );

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
@@ -460,7 +460,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 			$settings_html = $this->generate_settings_html( $this->get_form_fields(), false );
 		}
 
-		return '<table class="form-table">' . $settings_html . '</table>'; 
+		return '<table class="form-table">' . $settings_html . '</table>';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
@@ -460,7 +460,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 			$settings_html = $this->generate_settings_html( $this->get_form_fields(), false );
 		}
 
-		return '<div class="wc-shipping-zone-method-fields">' . $settings_html . '</div>';
+		return '<table class="form-table">' . $settings_html . '</table>'; 
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/woocommerce/issues/42759

In Shipping Settings a `table` html element was replaced with a `div` for the purposes of populating a new modal when creating and editing Shipping Zone methods. Unfortunately, the html was modified in all cases, including when a method is edited in its own dedicated page.

This PR reverts that change and only modifies the resulting Settings API html when rendering the modal. This isolates the change to only this specific use case.

### Examples of problems encountered

<img width="998" alt="image" src="https://github.com/woocommerce/woocommerce/assets/43415/c1a85e34-9018-4e0e-a9f9-ded1407cbb67">

![image (1)](https://github.com/woocommerce/woocommerce/assets/1922453/39a95a77-38a2-48a3-b828-06b9a477a49a)

![image (2)](https://github.com/woocommerce/woocommerce/assets/1922453/6b44fa3b-beb1-400a-a8f3-f1521895d6fa)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new Shipping Zone, `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new`
2. Create a new shipping method. See the modals rendered correctly.
3. Now edit a shipping method, but don't click on "Edit". Instead, right click to open in a new window or tab.
4. See the resulting page rendered correctly.
5. Now install and activate [USPS](https://github.com/woocommerce/woocommerce-shipping-usps/releases) and be sure to have a US address and USD currency.
6. Head to the USPS configuration screen, `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=usps`. It should render correctly.
7. Go back to your shipping zone and add a new shipping method, this time `USPS`
8. Now go to the configuration screen by clicking "Edit". This page should also render correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Revert Shipping Settings change of replacing tables, replace only for use in JS powered modals.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
