### PR TITLE
Check store api draft order on short code for reserved stock

### DIFF
--- a/plugins/woocommerce/changelog/fix-42784-shortcode-reserve-stock
+++ b/plugins/woocommerce/changelog/fix-42784-shortcode-reserve-stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Shortcode cart checks for Store API reserved stock

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -759,7 +759,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function check_cart_item_stock() {
 		$error                    = new WP_Error();
 		$product_qty_in_cart      = $this->get_cart_item_quantities();
-		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ? absint( WC()->session->order_awaiting_payment ) : 0;
+		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ? absint( WC()->session->order_awaiting_payment ) : absint( WC()->session->get( 'store_api_draft_order', 0 ) );
 
 		foreach ( $this->get_cart() as $values ) {
 			$product = $values['data'];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR addresses an issue where a draft order is created through the Store API (for example using blocks checkout) and then visiting the shortcode cart. In those scenarios, when checking for the reserved stock, the order in the current session is not properly excluded from counting the reserved stock. This is due to the Store API tracking the draft order in `store_api_draft_order` and the shortcode cart tracking the draft order in `order_awaiting_payment`. This resulted in products being incorrectly marked as out of stock on the shortcode cart because it was not excluding the current shoppers current order.

There were two approaches to take when solving this:
- Either always add the current draft order to both `store_api_draft_order` and `order_awaiting_payment` at all times.
- Check both the `store_api_draft_order` and `order_awaiting_payment` when looking for the draft order.

I opted for the second option in this case as the exact issue was rather narrow. If it is more desirable to set both all the time, let me know in the review and I change the approach.

Closes #42784 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Preconditions**

- Have a product that tracks inventory and has an inventory of 1.
- Have a WooCommerce store setup that is using shortcode Cart and blocks Checkout pages.

**Steps**
1. As a shopper on the store, add the product with inventory of 1 to the cart.
2. Visit the shortcode cart page.
3. Confirm everything is working as expected and can proceed to checkout.
4. On the blocks checkout page enter a billing and/or shipping address, but do not place the order.
5. Hit the browser back button or use a navigation link to go back to the shortcode Cart page.
6. Before this PR you would be presented with an out of stock error message.
7. After this PR you are no longer presented with an out of stock error message.
8. Confirm you can successfully check out with the product and that the inventory is correctly adjusted.

Other flows to check:
- Confirm that as another shopper you still correctly get the out of stock error message if you visit the cart page with the product added to your cart.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
