### PR TITLE
Fixed `watch:build` Race Conditions & Added Convenience Watch Commands

### DIFF
--- a/packages/js/ai/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/ai/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/ai/package.json
+++ b/packages/js/ai/package.json
@@ -176,6 +176,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/block-templates/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/block-templates/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -166,6 +166,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/components/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/components/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -250,6 +250,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/csv-export/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/csv-export/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/csv-export/package.json
+++ b/packages/js/csv-export/package.json
@@ -126,6 +126,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/currency/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/currency/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/currency/package.json
+++ b/packages/js/currency/package.json
@@ -129,6 +129,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/customer-effort-score/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/customer-effort-score/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -181,6 +181,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/data/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/data/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -158,6 +158,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/date/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/date/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -136,6 +136,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/experimental/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/experimental/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -185,6 +185,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/explat/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/explat/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -133,6 +133,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/expression-evaluation/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/expression-evaluation/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/expression-evaluation/package.json
+++ b/packages/js/expression-evaluation/package.json
@@ -119,6 +119,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/integrate-plugin/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/integrate-plugin/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/integrate-plugin/package.json
+++ b/packages/js/integrate-plugin/package.json
@@ -130,6 +130,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/navigation/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/navigation/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -139,6 +139,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/number/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/number/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/number/package.json
+++ b/packages/js/number/package.json
@@ -125,6 +125,7 @@
 			"files": [
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/onboarding/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/onboarding/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -171,6 +171,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/packages/js/product-editor/changelog/42802-fix-watch-build-race-condition
+++ b/packages/js/product-editor/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -223,6 +223,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/eslint-plugin/configs",
 				"node_modules/@woocommerce/eslint-plugin/rules",
 				"node_modules/@woocommerce/eslint-plugin/index.js",

--- a/plugins/woocommerce-admin/changelog/42802-fix-watch-build-race-condition
+++ b/plugins/woocommerce-admin/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+
+

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -294,6 +294,7 @@
 				"node_modules/@woocommerce/internal-style-build/abstracts",
 				"node_modules/@woocommerce/internal-js-tests/build",
 				"node_modules/@woocommerce/internal-js-tests/build-module",
+				"node_modules/@woocommerce/internal-js-tests/jest-preset.js",
 				"node_modules/@woocommerce/explat/build",
 				"node_modules/@woocommerce/explat/build-module",
 				"node_modules/@woocommerce/explat/build-types",

--- a/plugins/woocommerce/changelog/42802-fix-watch-build-race-condition
+++ b/plugins/woocommerce/changelog/42802-fix-watch-build-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Only a change to development tooling.
+

--- a/plugins/woocommerce/changelog/fix-watch-build-race-condition
+++ b/plugins/woocommerce/changelog/fix-watch-build-race-condition
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just making a change to some commands
+
+

--- a/plugins/woocommerce/changelog/fix-watch-build-race-condition
+++ b/plugins/woocommerce/changelog/fix-watch-build-race-condition
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Just making a change to some commands
-
-

--- a/plugins/woocommerce/client/legacy/package.json
+++ b/plugins/woocommerce/client/legacy/package.json
@@ -38,7 +38,6 @@
 		"grunt-sass": "3.1.0",
 		"grunt-stylelint": "0.16.0",
 		"gruntify-eslint": "5.0.0",
-		"nodemon": "^2.0.22",
 		"sass": "^1.69.5",
 		"stylelint": "13.8.0",
 		"wireit": "0.14.1"

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -183,7 +183,6 @@
 		"@wordpress/browserslist-config": "wp-6.0"
 	},
 	"nodemonConfig": {
-		"command": "pnpm run build:project",
 		"delay": 2500,
 		"watch": [
 			"node_modules/@woocommerce/block-library/build",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -54,7 +54,9 @@
 		"test:unit:env": "pnpm test:php:env",
 		"update-wp-env": "php ./tests/e2e-pw/bin/update-wp-env.php",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:project": "pnpm build:project --watch"
+		"watch:build:admin": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"@woocommerce/admin-library...\" --filter=\"$npm_package_name\" --parallel watch:build:project",
+		"watch:build:blocks": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"@woocommerce/block-library...\" --filter=\"$npm_package_name\" --parallel watch:build:project",
+		"watch:build:project": "nodemon --exec \"pnpm run\" build:project"
 	},
 	"lint-staged": {
 		"*.php": [
@@ -179,6 +181,17 @@
 		"@woocommerce/block-library": "workspace:*",
 		"@woocommerce/classic-assets": "workspace:*",
 		"@wordpress/browserslist-config": "wp-6.0"
+	},
+	"nodemonConfig": {
+		"command": "pnpm run build:project",
+		"delay": 2500,
+		"watch": [
+			"node_modules/@woocommerce/block-library/build",
+			"node_modules/@woocommerce/block-library/blocks.ini",
+			"node_modules/@woocommerce/classic-assets/build",
+			"node_modules/@woocommerce/admin-library/build"
+		], 
+		"ignoreRoot": []
 	},
 	"wireit": {
 		"build:project": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -54,8 +54,6 @@
 		"test:unit:env": "pnpm test:php:env",
 		"update-wp-env": "php ./tests/e2e-pw/bin/update-wp-env.php",
 		"watch:build": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel watch:build:project",
-		"watch:build:admin": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"@woocommerce/admin-library...\" --filter=\"$npm_package_name\" --parallel watch:build:project",
-		"watch:build:blocks": "WIREIT_LOGGER='quiet-ci' pnpm --if-present --workspace-concurrency=Infinity --filter=\"@woocommerce/block-library...\" --filter=\"$npm_package_name\" --parallel watch:build:project",
 		"watch:build:project": "nodemon --exec \"pnpm run\" build:project"
 	},
 	"lint-staged": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -155,6 +155,7 @@
 		"istanbul": "1.0.0-alpha.2",
 		"jest": "~27.5.1",
 		"mocha": "7.2.0",
+		"nodemon": "^3.0.2",
 		"prettier": "npm:wp-prettier@^2.8.5",
 		"stylelint": "^13.13.1",
 		"typescript": "^5.3.3",
@@ -174,10 +175,10 @@
 		"ie 9"
 	],
 	"dependencies": {
-		"@wordpress/browserslist-config": "wp-6.0",
 		"@woocommerce/admin-library": "workspace:*",
+		"@woocommerce/block-library": "workspace:*",
 		"@woocommerce/classic-assets": "workspace:*",
-		"@woocommerce/block-library": "workspace:*"
+		"@wordpress/browserslist-config": "wp-6.0"
 	},
 	"wireit": {
 		"build:project": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1421,7 +1421,7 @@ importers:
         version: 0.2.0
       '@woocommerce/e2e-utils':
         specifier: ^0.1.6
-        version: 0.1.6(@woocommerce/api@0.2.0)(jest@29.7.0)(puppeteer@21.6.0)(react-native@0.73.0)
+        version: 0.1.6(@woocommerce/api@0.2.0)(jest@29.7.0)(puppeteer@2.1.1)(react-native@0.73.0)
       '@wordpress/deprecated':
         specifier: wp-6.0
         version: 3.6.1
@@ -2095,7 +2095,7 @@ importers:
         version: 5.16.2
       '@testing-library/react':
         specifier: 12.1.3
-        version: 12.1.3(react-dom@18.2.0)(react@17.0.2)
+        version: 12.1.3(react-dom@17.0.2)(react@17.0.2)
       '@wordpress/data':
         specifier: wp-6.0
         version: 6.6.1(react@17.0.2)
@@ -2443,7 +2443,7 @@ importers:
         version: 7.23.5
       '@storybook/addon-knobs':
         specifier: ^7.0.2
-        version: 7.0.2(@storybook/addons@7.6.4)(@storybook/api@7.6.4)(@storybook/components@7.6.4)(@storybook/core-events@7.6.4)(@storybook/theming@7.6.4)(@types/react@17.0.71)(react-dom@16.14.0)(react@17.0.2)
+        version: 7.0.2(@storybook/addons@7.5.2)(@storybook/api@7.6.4)(@storybook/components@7.6.4)(@storybook/core-events@7.6.4)(@storybook/theming@7.6.4)(@types/react@17.0.71)(react-dom@16.14.0)(react@17.0.2)
       '@testing-library/react':
         specifier: 12.1.3
         version: 12.1.3(react-dom@16.14.0)(react@17.0.2)
@@ -3069,6 +3069,9 @@ importers:
       mocha:
         specifier: 7.2.0
         version: 7.2.0
+      nodemon:
+        specifier: ^3.0.2
+        version: 3.0.2
       prettier:
         specifier: npm:wp-prettier@^2.8.5
         version: /wp-prettier@2.8.5
@@ -4530,9 +4533,6 @@ importers:
       gruntify-eslint:
         specifier: 5.0.0
         version: 5.0.0(grunt@1.3.0)
-      nodemon:
-        specifier: ^2.0.22
-        version: 2.0.22
       sass:
         specifier: ^1.69.5
         version: 1.69.5
@@ -14251,7 +14251,7 @@ packages:
       '@react-native-community/cli-tools': 12.1.1
       chalk: 4.1.2
       execa: 5.1.1
-      fast-xml-parser: 4.3.2
+      fast-xml-parser: 4.2.4
       glob: 7.2.3
       logkitty: 0.7.1
     transitivePeerDependencies:
@@ -14263,7 +14263,7 @@ packages:
       '@react-native-community/cli-tools': 12.1.1
       chalk: 4.1.2
       execa: 5.1.1
-      fast-xml-parser: 4.3.2
+      fast-xml-parser: 4.2.4
       glob: 7.2.3
       ora: 5.4.1
     transitivePeerDependencies:
@@ -15250,7 +15250,7 @@ packages:
       react-select: 3.2.0(react-dom@17.0.2)(react@17.0.2)
     dev: true
 
-  /@storybook/addon-knobs@7.0.2(@storybook/addons@7.6.4)(@storybook/api@7.6.4)(@storybook/components@7.6.4)(@storybook/core-events@7.6.4)(@storybook/theming@7.6.4)(@types/react@17.0.71)(react-dom@16.14.0)(react@17.0.2):
+  /@storybook/addon-knobs@7.0.2(@storybook/addons@7.5.2)(@storybook/api@7.6.4)(@storybook/components@7.6.4)(@storybook/core-events@7.6.4)(@storybook/theming@7.6.4)(@types/react@17.0.71)(react-dom@16.14.0)(react@17.0.2):
     resolution: {integrity: sha512-PzKuscxcBPhA2jpDxJ/F+BvBRqHJ8qBki1kS1IOjmJbAfE96WFnweXZ73ImyAJnRtmtReCL6p0ZmFkrNDMDpUw==}
     peerDependencies:
       '@storybook/addons': ^7.0.0
@@ -15266,7 +15266,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 7.6.4(react-dom@16.14.0)(react@17.0.2)
+      '@storybook/addons': 7.5.2(react-dom@16.14.0)(react@17.0.2)
       '@storybook/api': 7.6.4(react-dom@16.14.0)(react@17.0.2)
       '@storybook/components': 7.6.4(@types/react@17.0.71)(react-dom@16.14.0)(react@17.0.2)
       '@storybook/core-events': 7.6.4
@@ -15555,6 +15555,19 @@ packages:
       regenerator-runtime: 0.13.11
     dev: true
 
+  /@storybook/addons@7.5.2(react-dom@16.14.0)(react@17.0.2):
+    resolution: {integrity: sha512-hRiy56zQbz72Pwa4F40srUWXKGNIriNkZ1R0j5KPd8ZqoMk1hIeW0S8E7s1vuM/MplnUE/jFJZqu6HQCvbqmGg==}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/manager-api': 7.5.2(react-dom@16.14.0)(react@17.0.2)
+      '@storybook/preview-api': 7.5.2
+      '@storybook/types': 7.5.2
+      react: 17.0.2
+      react-dom: 16.14.0(react@17.0.2)
+    dev: true
+
   /@storybook/addons@7.5.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-hRiy56zQbz72Pwa4F40srUWXKGNIriNkZ1R0j5KPd8ZqoMk1hIeW0S8E7s1vuM/MplnUE/jFJZqu6HQCvbqmGg==}
     peerDependencies:
@@ -15566,17 +15579,6 @@ packages:
       '@storybook/types': 7.5.2
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: true
-
-  /@storybook/addons@7.6.4(react-dom@16.14.0)(react@17.0.2):
-    resolution: {integrity: sha512-YnmLyR/ciALtzoi9HEu+Y+NJWeOVEBo9PRgQaG7zGiNDvOrLY69uU3Ej0+TZlrTqBqce42bRCrDINJfnk0Mfsg==}
-    dependencies:
-      '@storybook/manager-api': 7.6.4(react-dom@16.14.0)(react@17.0.2)
-      '@storybook/preview-api': 7.6.4
-      '@storybook/types': 7.6.4
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: true
 
   /@storybook/api@6.5.17-alpha.0(react-dom@17.0.2)(react@17.0.2):
@@ -16850,6 +16852,31 @@ packages:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
     dev: true
 
+  /@storybook/manager-api@7.5.2(react-dom@16.14.0)(react@17.0.2):
+    resolution: {integrity: sha512-WX8GjBkITRQzhQ08WEAVjdDW8QqqIQhWOpFzXUYCxCNzt1eSALI31QQ+M1/MYymw+TOkotC/SMcn/puIAm4rdA==}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/channels': 7.5.2
+      '@storybook/client-logger': 7.5.2
+      '@storybook/core-events': 7.5.2
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      '@storybook/router': 7.5.2(react-dom@16.14.0)(react@17.0.2)
+      '@storybook/theming': 7.5.2(react-dom@16.14.0)(react@17.0.2)
+      '@storybook/types': 7.5.2
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 16.14.0(react@17.0.2)
+      semver: 7.5.4
+      store2: 2.14.2
+      telejson: 7.2.0
+      ts-dedent: 2.2.0
+    dev: true
+
   /@storybook/manager-api@7.5.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-WX8GjBkITRQzhQ08WEAVjdDW8QqqIQhWOpFzXUYCxCNzt1eSALI31QQ+M1/MYymw+TOkotC/SMcn/puIAm4rdA==}
     peerDependencies:
@@ -17605,6 +17632,19 @@ packages:
       regenerator-runtime: 0.13.11
     dev: true
 
+  /@storybook/router@7.5.2(react-dom@16.14.0)(react@17.0.2):
+    resolution: {integrity: sha512-jlh48TVUlqvGkU8MnkVp9SrCHomWGtQGx1WMK94NMyOPVPTLWzM6LjIybgmHz0MTe4lpzmbiIOfSlU3pPX054w==}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 7.5.2
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      react: 17.0.2
+      react-dom: 16.14.0(react@17.0.2)
+    dev: true
+
   /@storybook/router@7.5.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-jlh48TVUlqvGkU8MnkVp9SrCHomWGtQGx1WMK94NMyOPVPTLWzM6LjIybgmHz0MTe4lpzmbiIOfSlU3pPX054w==}
     peerDependencies:
@@ -17750,6 +17790,20 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
+    dev: true
+
+  /@storybook/theming@7.5.2(react-dom@16.14.0)(react@17.0.2):
+    resolution: {integrity: sha512-DZBTcYErSYvmTYsGz7lKtiIcBe8flBw5Ojp52r3O4GcRYG4AbuUwwVvehz+O1cWaS+UW3HavrcgapERH7ZHd1A==}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@17.0.2)
+      '@storybook/client-logger': 7.5.2
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 16.14.0(react@17.0.2)
     dev: true
 
   /@storybook/theming@7.5.2(react-dom@17.0.2)(react@17.0.2):
@@ -18541,21 +18595,6 @@ packages:
       '@types/react-dom': 18.0.10
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: true
-
-  /@testing-library/react@12.1.3(react-dom@18.2.0)(react@17.0.2):
-    resolution: {integrity: sha512-oCULRXWRrBtC9m6G/WohPo1GLcLesH7T4fuKzRAKn1CWVu9BzXtqLXDDTA6KhFNNtRwLtfSMr20HFl+Qrdrvmg==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: ^17.0.2
-      react-dom: '*'
-    dependencies:
-      '@babel/runtime': 7.23.5
-      '@testing-library/dom': 8.11.3
-      '@types/react-dom': 18.0.10
-      react: 17.0.2
-      react-dom: 18.2.0(react@17.0.2)
-    dev: false
 
   /@testing-library/react@12.1.5(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==}
@@ -19392,6 +19431,7 @@ packages:
     dependencies:
       '@types/react': 17.0.71
       '@types/tinycolor2': 1.4.6
+      '@types/wordpress__components': 23.0.10(react-dom@16.14.0)(react@17.0.2)
       '@types/wordpress__notices': 3.27.6(react@17.0.2)
       '@types/wordpress__rich-text': 3.4.6
       '@wordpress/element': 4.4.1
@@ -19407,6 +19447,7 @@ packages:
     dependencies:
       '@types/react': 17.0.71
       '@types/tinycolor2': 1.4.6
+      '@types/wordpress__components': 23.0.10(react-dom@17.0.2)(react@17.0.2)
       '@types/wordpress__notices': 3.27.6(react@17.0.2)
       '@types/wordpress__rich-text': 3.4.6
       '@wordpress/element': 4.4.1
@@ -19415,6 +19456,21 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
+
+  /@types/wordpress__components@23.0.10(react-dom@16.14.0)(react@17.0.2):
+    resolution: {integrity: sha512-dI1wP88AkEjhZAdqfz6Pz3lK0EMUEfpXH0omgb6IZ/toz6qpXOG/aemlLskNtPFuNkYYHvD+bwFkLPqKWo9ATA==}
+    dependencies:
+      '@types/react': 17.0.71
+      '@types/tinycolor2': 1.4.6
+      '@types/wordpress__notices': 3.27.6(react@17.0.2)
+      '@types/wordpress__rich-text': 3.4.6
+      '@wordpress/element': 5.22.0
+      downshift: 6.1.12(react@17.0.2)
+      re-resizable: 6.9.11(react-dom@16.14.0)(react@17.0.2)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+    dev: true
 
   /@types/wordpress__components@23.0.10(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-dI1wP88AkEjhZAdqfz6Pz3lK0EMUEfpXH0omgb6IZ/toz6qpXOG/aemlLskNtPFuNkYYHvD+bwFkLPqKWo9ATA==}
@@ -19429,7 +19485,6 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
-    dev: true
 
   /@types/wordpress__compose@4.0.1:
     resolution: {integrity: sha512-2Czdu9Nyhxn0R7lSl+LwVyzHF+xgP6nuikRDt26VJPLAZhmgE9c/lmB8v8xiby8UGVWj6oKGQDmKda8kvoBWBQ==}
@@ -20791,14 +20846,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@woocommerce/e2e-utils@0.1.6(@woocommerce/api@0.2.0)(jest@29.7.0)(puppeteer@21.6.0)(react-native@0.73.0):
+  /@woocommerce/e2e-utils@0.1.6(@woocommerce/api@0.2.0)(jest@29.7.0)(puppeteer@2.1.1)(react-native@0.73.0):
     resolution: {integrity: sha512-gWSEgFIjMqaqiiIyrpa1epIHkmBBAfk6WfRojva1f5ZmffSJCc0VbX2jQQRdFm1BuEYr8KGCCYo+q8NIjlMZ7g==}
     peerDependencies:
       '@woocommerce/api': ^0.2.0
     dependencies:
       '@woocommerce/api': 0.2.0
       '@wordpress/deprecated': 2.12.3
-      '@wordpress/e2e-test-utils': 4.16.1(jest@29.7.0)(puppeteer@21.6.0)(react-native@0.73.0)
+      '@wordpress/e2e-test-utils': 4.16.1(jest@29.7.0)(puppeteer@2.1.1)(react-native@0.73.0)
       config: 3.3.3
       faker: 5.5.3
       fishery: 1.4.0
@@ -22740,7 +22795,7 @@ packages:
       - react-native
     dev: false
 
-  /@wordpress/e2e-test-utils@4.16.1(jest@29.7.0)(puppeteer@21.6.0)(react-native@0.73.0):
+  /@wordpress/e2e-test-utils@4.16.1(jest@29.7.0)(puppeteer@2.1.1)(react-native@0.73.0):
     resolution: {integrity: sha512-Dpsq5m0VSvjIhro2MjACSzkOkOf1jGEryzgEMW1ikbT6YI+motspHfGtisKXgYhZJOnjV4PwuEg+9lPVnd971g==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -22753,7 +22808,7 @@ packages:
       jest: 29.7.0(@types/node@16.18.68)(ts-node@10.9.2)
       lodash: 4.17.21
       node-fetch: 2.7.0
-      puppeteer: 21.6.0(typescript@5.3.3)
+      puppeteer: 2.1.1
     transitivePeerDependencies:
       - encoding
       - react-native
@@ -27130,7 +27185,7 @@ packages:
       '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.5)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.5)
       '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.5)
-      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.5)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.5)
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.5)
       '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.23.5)
       '@babel/plugin-transform-block-scoped-functions': 7.23.3(@babel/core@7.23.5)
@@ -29290,6 +29345,7 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       typescript: 5.3.3
+    dev: true
 
   /cp-file@7.0.0:
     resolution: {integrity: sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==}
@@ -29485,7 +29541,7 @@ packages:
     dependencies:
       balanced-match: 0.1.0
       color: 0.11.4
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       rgb: 0.1.0
     transitivePeerDependencies:
       - supports-color
@@ -30100,7 +30156,7 @@ packages:
       supports-color: 6.0.0
     dev: true
 
-  /debug@3.2.7(supports-color@5.5.0):
+  /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
       supports-color: '*'
@@ -30109,7 +30165,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-      supports-color: 5.5.0
 
   /debug@4.1.1:
     resolution: {integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==}
@@ -30146,6 +30201,19 @@ packages:
     dependencies:
       ms: 2.1.2
     dev: false
+
+  /debug@4.3.4(supports-color@5.5.0):
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+      supports-color: 5.5.0
+    dev: true
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -31473,7 +31541,7 @@ packages:
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -31524,7 +31592,7 @@ packages:
       webpack: '>=1.11.0'
     dependencies:
       array-find: 1.0.0
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       enhanced-resolve: 0.9.1
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.56.0)(eslint-import-resolver-typescript@3.2.4)(eslint-import-resolver-webpack@0.13.2)(eslint@8.55.0)
       find-root: 1.1.0
@@ -31548,7 +31616,7 @@ packages:
       webpack: '>=1.11.0'
     dependencies:
       array.prototype.find: 2.2.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       enhanced-resolve: 0.9.1
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint-import-resolver-webpack@0.13.8)(eslint@8.55.0)
       find-root: 1.1.0
@@ -31585,7 +31653,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 4.33.0(eslint@8.55.0)(typescript@5.3.3)
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -31614,7 +31682,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.55.0)(typescript@5.3.2)
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.2.4(eslint-plugin-import@2.28.1)(eslint@8.55.0)
@@ -31645,7 +31713,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.55.0)(typescript@5.3.3)
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.29.0)(eslint@8.55.0)
@@ -31675,7 +31743,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.55.0)(typescript@5.3.2)
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.2.4(eslint-plugin-import@2.28.1)(eslint@8.55.0)
@@ -31706,7 +31774,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 6.13.2(eslint@8.55.0)(typescript@5.3.3)
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -31728,7 +31796,7 @@ packages:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
@@ -31763,7 +31831,7 @@ packages:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
@@ -31798,7 +31866,7 @@ packages:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
@@ -31832,7 +31900,7 @@ packages:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
@@ -31867,7 +31935,7 @@ packages:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
@@ -33203,13 +33271,6 @@ packages:
     hasBin: true
     dependencies:
       strnum: 1.0.5
-    dev: true
-
-  /fast-xml-parser@4.3.2:
-    resolution: {integrity: sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==}
-    hasBin: true
-    dependencies:
-      strnum: 1.0.5
 
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -33646,7 +33707,6 @@ packages:
   /flow-parser@0.223.3:
     resolution: {integrity: sha512-9KxxDKSB22ovMpSULbOL/QAQGPN6M0YMS3PubQvB0jVc4W7QP6VhasIVic7MzKcJSh0BAVs4J6SZjoH0lDDNlg==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /flush-write-stream@1.1.1:
     resolution: {integrity: sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==}
@@ -34434,7 +34494,7 @@ packages:
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.8
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -34456,7 +34516,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.8
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -35676,7 +35736,7 @@ packages:
     engines: {node: '>= 4.5.0'}
     dependencies:
       agent-base: 4.3.0
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
     transitivePeerDependencies:
       - supports-color
 
@@ -36904,7 +36964,7 @@ packages:
   /istanbul-lib-source-maps@1.2.6:
     resolution: {integrity: sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==}
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       istanbul-lib-coverage: 1.2.1
       mkdirp: 0.5.6
       rimraf: 2.7.1
@@ -39435,7 +39495,7 @@ packages:
       '@babel/register': 7.22.15(@babel/core@7.23.6)
       babel-core: 7.0.0-bridge.0(@babel/core@7.23.6)
       chalk: 4.1.2
-      flow-parser: 0.206.0
+      flow-parser: 0.223.3
       graceful-fs: 4.2.11
       micromatch: 4.0.5
       neo-async: 2.6.2
@@ -42268,18 +42328,18 @@ packages:
       hasown: 2.0.0
       is: 3.3.0
 
-  /nodemon@2.0.22:
-    resolution: {integrity: sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==}
-    engines: {node: '>=8.10.0'}
+  /nodemon@3.0.2:
+    resolution: {integrity: sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==}
+    engines: {node: '>=10'}
     hasBin: true
     dependencies:
       chokidar: 3.5.3
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@5.5.0)
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
-      semver: 5.7.2
-      simple-update-notifier: 1.1.0
+      semver: 7.5.4
+      simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.0
       undefsafe: 2.0.5
@@ -43799,7 +43859,7 @@ packages:
     engines: {node: '>= 0.12.0'}
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color
@@ -45584,23 +45644,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  /puppeteer@21.6.0(typescript@5.3.3):
-    resolution: {integrity: sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==}
-    engines: {node: '>=16.13.2'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@puppeteer/browsers': 1.9.0
-      cosmiconfig: 8.3.6(typescript@5.3.3)
-      puppeteer-core: 21.6.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-    dev: false
 
   /pure-rand@6.0.4:
     resolution: {integrity: sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==}
@@ -48058,11 +48101,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  /semver@7.0.0:
-    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
-    hasBin: true
-    dev: true
-
   /semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -48333,13 +48371,6 @@ packages:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
-
-  /simple-update-notifier@1.1.0:
-    resolution: {integrity: sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==}
-    engines: {node: '>=8.10.0'}
-    dependencies:
-      semver: 7.0.0
-    dev: true
 
   /simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
@@ -50391,7 +50422,7 @@ packages:
     resolution: {integrity: sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==}
     dependencies:
       body: 5.1.0
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       faye-websocket: 0.10.0
       livereload-js: 2.4.0
       object-assign: 4.1.1
@@ -52693,7 +52724,7 @@ packages:
   /webpack-virtual-modules@0.2.2:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There is currently a bug in `wireit` that prevents us from using it to `--watch` a task when using tool-specific commands like `webpack --watch` on other projects. While we wait for an upstream fix to land, this switches it out with `nodemon` for watching the files that change as a result of builds.

I've also added two `watch:build` commands for convenience to `@woocommerce/plugin-woocommerce`. There is `watch:build:blocks` and `watch:build:admin` that limit what they watch to what is related. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build`
2. After the build finishes, make arbitrary changes and make sure that no matter what the watch doesn't stop.
3. Run `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build:blocks` and confirm it limits the scope of watching.
4. Run `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build:admin` and confirm it limits the scope of watching.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Only a change to development tooling.


</details>
