### PR TITLE
Fix the cp command for blocks so that the contents of build is copied into assets/client/blocks

### DIFF
--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -192,7 +192,7 @@
 	},
 	"wireit": {
 		"build:project": {
-			"command": "rm -rf assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build/* assets/client/blocks/ && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
+			"command": "rm -rf assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build/* assets/client/blocks && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
 			"clean": "if-file-deleted",
 			"files": [],
 			"output": [

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -192,7 +192,7 @@
 	},
 	"wireit": {
 		"build:project": {
-			"command": "rm -rf assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build/* assets/client/blocks && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
+			"command": "rm -rf assets/client/blocks assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build assets/client/blocks && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
 			"clean": "if-file-deleted",
 			"files": [],
 			"output": [

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -187,12 +187,12 @@
 			"node_modules/@woocommerce/block-library/blocks.ini",
 			"node_modules/@woocommerce/classic-assets/build",
 			"node_modules/@woocommerce/admin-library/build"
-		], 
+		],
 		"ignoreRoot": []
 	},
 	"wireit": {
 		"build:project": {
-			"command": "rm -rf assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build assets/client/blocks && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
+			"command": "rm -rf assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build/* assets/client/blocks/ && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
 			"clean": "if-file-deleted",
 			"files": [],
 			"output": [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is a bug with the current `cp` command, it moves the `build` folder into `assets/client/blocks/build`, due to cp behaviour we want to rm the existing directory first.

This fixes that issue.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I have been testing running blocks alongside the new project watch command:

1. Checkout this branch, run `pnpm i`
2. Build woocommerce plugin
3. Run `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build:project`
4. in the blocks plugin folder run `pnpm start`
5. Make a file change in JS
6. See that the file change is copied to the correct directory structure in assets/client/blocks.
7. Load the changed JS file in your WP environment and see the updated change is reflected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
