### PR TITLE
Enable WCCOM shipping partners API consumption

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
@@ -672,7 +672,7 @@ const ShippingWrapper = compose(
 
 		const shippingPartners = select(
 			SHIPPING_METHODS_STORE_NAME
-		).getShippingMethods( true );
+		).getShippingMethods();
 
 		const country = countryCode ? getCountry( countryCode ) : null;
 		const countryName = country ? country.name : null;

--- a/plugins/woocommerce/changelog/tweak-enable-shipping-partnes-api-use
+++ b/plugins/woocommerce/changelog/tweak-enable-shipping-partnes-api-use
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Enable shipping suggestions API consumption

--- a/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
+++ b/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
@@ -45,6 +45,7 @@ class DefaultShippingPartners {
 
 		return array(
 			array(
+				'id'                => 'woocommerce-shipstation-integration',
 				'name'              => 'ShipStation',
 				'slug'              => 'woocommerce-shipstation-integration',
 				'description'       => __( 'Powerful yet easy-to-use solution:', 'woocommerce' ),
@@ -90,6 +91,7 @@ class DefaultShippingPartners {
 				'available_layouts' => array( 'row', 'column' ),
 			),
 			array(
+				'id'                => 'skydropx-cotizador-y-envios',
 				'name'              => 'Skydropx',
 				'slug'              => 'skydropx-cotizador-y-envios',
 				'layout_column'     => array(
@@ -104,6 +106,7 @@ class DefaultShippingPartners {
 				'available_layouts' => array( 'column' ),
 			),
 			array(
+				'id'                => 'envia',
 				'name'              => 'Envia',
 				'slug'              => '',
 				'description'       => '',
@@ -118,6 +121,7 @@ class DefaultShippingPartners {
 				'available_layouts' => array( 'column' ),
 			),
 			array(
+				'id'                => 'easyship-woocommerce-shipping-rates',
 				'name'              => 'Easyship',
 				'slug'              => 'easyship-woocommerce-shipping-rates',
 				'description'       => __( 'Simplified shipping with: ', 'woocommerce' ),
@@ -160,6 +164,7 @@ class DefaultShippingPartners {
 				'available_layouts' => array( 'row', 'column' ),
 			),
 			array(
+				'id'                => 'sendcloud-shipping',
 				'name'              => 'Sendcloud',
 				'slug'              => 'sendcloud-shipping',
 				'description'       => __( 'All-in-one shipping tool:', 'woocommerce' ),
@@ -203,6 +208,7 @@ class DefaultShippingPartners {
 				'available_layouts' => array( 'row', 'column' ),
 			),
 			array(
+				'id'                => 'packlink-pro-shipping',
 				'name'              => 'Packlink',
 				'slug'              => 'packlink-pro-shipping',
 				'description'       => __( 'Optimize your full shipping process:', 'woocommerce' ),
@@ -251,6 +257,7 @@ class DefaultShippingPartners {
 				'available_layouts' => array( 'row', 'column' ),
 			),
 			array(
+				'id'                => 'woocommerce-services',
 				'name'              => 'WooCommerce Shipping',
 				'slug'              => 'woocommerce-services',
 				'description'       => __( 'Save time and money by printing your shipping labels right from your computer with WooCommerce Shipping. Try WooCommerce Shipping for free.', 'woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, shipping partners is utilising the defaults defined in core. This PR:

- Enables using the shipping partners API in woocommerce.com
- Adds `id` to all shipping partners to match the change in woocommerce.com

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

It's recommended to test after https://github.com/Automattic/woocommerce.com/pull/19020 is merged. Otherwise, you'll need to follow the instructions in that PR and point your shipping data poller endpoint to your local WCCOM environment.

1. In a fresh store, go through onboarding (allow tracks), select `United Kingdom` country in onboarding wizard
2. In homescreen, click on `Add shipping costs` task
3. Fill in the form with whatever and continue in step 1 and 2
4. In step 3, observe `ShipStation` and `sendcloud` is shown
5. Right click on ShipStation image, click on `open in a new tab`
6. Observe the URL is referring to woo.com, example: `https://woo.com/wp-content/plugins/wccom-plugins/shipping-partner-suggestions/images/shipstation-row.svg`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>