### PR TITLE
Fix Order Attribution device type in tracks.

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-attribution-device-type-in-tracks
+++ b/plugins/woocommerce/changelog/fix-order-attribution-device-type-in-tracks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Use non-translated device type in Order Attribution tracks event.
+Use non-translated device type in Order Attribution meta data and tracks event.

--- a/plugins/woocommerce/changelog/fix-order-attribution-device-type-in-tracks
+++ b/plugins/woocommerce/changelog/fix-order-attribution-device-type-in-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use non-translated device type in Order Attribution tracks event.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -23,6 +23,36 @@ class OrderAttribution {
 	}
 
 	/**
+	 * Format the meta data for display.
+	 *
+	 * @since 8.5.0
+	 *
+	 * @return void
+	 */
+	public function format_meta_data( array &$meta ) {
+		// Format the session pages.
+		if ( array_key_exists( 'device_type', $meta ) ) {
+
+			switch ( $meta['device_type'] ) {
+				case 'Mobile':
+					$meta['device_type'] = __( 'Mobile', 'woocommerce' );
+					break;
+				case 'Tablet':
+					$meta['device_type'] = __( 'Tablet', 'woocommerce' );
+					break;
+				case 'Desktop':
+					$meta['device_type'] = __( 'Desktop', 'woocommerce' );
+					break;
+
+				default:
+					$meta['device_type'] = __( 'Unknown', 'woocommerce' );
+					break;
+			}
+		}
+
+	}
+
+	/**
 	 * Output the attribution data metabox for the order.
 	 *
 	 * @since 8.5.0
@@ -39,6 +69,8 @@ class OrderAttribution {
 			esc_html_e( 'No order source data available.', 'woocommerce' );
 			return;
 		}
+
+		$this->format_meta_data( $meta );
 
 		$template_data = array(
 			'meta'             => $meta,

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -27,6 +27,8 @@ class OrderAttribution {
 	 *
 	 * @since 8.5.0
 	 *
+	 * @param array $meta The array of meta data to format.
+	 * 
 	 * @return void
 	 */
 	public function format_meta_data( array &$meta ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -30,7 +30,7 @@ class OrderAttribution {
 	 * @return void
 	 */
 	public function format_meta_data( array &$meta ) {
-		// Format the session pages.
+
 		if ( array_key_exists( 'device_type', $meta ) ) {
 
 			switch ( $meta['device_type'] ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -28,7 +28,7 @@ class OrderAttribution {
 	 * @since 8.5.0
 	 *
 	 * @param array $meta The array of meta data to format.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function format_meta_data( array &$meta ) {

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -57,11 +57,11 @@ trait OrderAttributionMeta {
 		$detector = new MobileDetect( array(), $values['user_agent'] );
 
 		if ( $detector->isMobile() ) {
-			return __( 'Mobile', 'woocommerce' );
+			return 'Mobile';
 		} elseif ( $detector->isTablet() ) {
-			return __( 'Tablet', 'woocommerce' );
+			return 'Tablet';
 		} else {
-			return __( 'Desktop', 'woocommerce' );
+			return 'Desktop';
 		}
 	}
 
@@ -281,7 +281,7 @@ trait OrderAttributionMeta {
 		}
 
 		return $values;
-	}
+		}
 
 	/**
 	 * Get the label for the order origin

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -281,7 +281,7 @@ trait OrderAttributionMeta {
 		}
 
 		return $values;
-		}
+	}
 
 	/**
 	 * Get the label for the order origin


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Send and store non-translated device type values for the Order Attribution feature. The device type names are translated for UI display only.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Simulate the customer and create an order.
2. As admin go to the order page.
3. Order information device type should be correctly displayed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
