### PR TITLE
Perfomance: Fix the metrics job on trunk

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -31,19 +31,19 @@ jobs:
 
             - name: Compare performance with trunk
               if: github.event_name == 'pull_request'
-              run: cd tools/compare-perf && pnpm run test perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+              run: cd tools/compare-perf && pnpm run compare perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
             - name: Compare performance with base branch
               if: github.event_name == 'push'
               # The base hash used here need to be a commit that is compatible with the current WP version
-              # The current one is 2f6ca66e00b3666b2567877ae67cbfb5b6ce171a 
+              # The current one is 19f3d0884617d7ecdcf37664f648a51e2987cada
               # it needs to be updated every time it becomes unsupported by the current wp-env (WP version).
               # It is used as a base comparison point to avoid fluctuation in the performance metrics.
               run: |
-                  WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)
+                  WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' plugins/woocommerce/readme.txt)
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  cd tools/compare-perf && pnpm run test perf $GITHUB_SHA 2f6ca66e00b3666b2567877ae67cbfb5b6ce171a --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
+                  cd tools/compare-perf && pnpm run compare perf $GITHUB_SHA 19f3d0884617d7ecdcf37664f648a51e2987cada --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
 
             - name: Archive performance results
               if: success()

--- a/tools/compare-perf/package.json
+++ b/tools/compare-perf/package.json
@@ -7,7 +7,7 @@
 	"license": "GPLv2",
 	"repository": "woocommerce/woocommerce",
 	"scripts": {
-		"test": "node index.js"
+		"compare": "node index.js"
 	},
 	"dependencies": {
 		"@wordpress/env": "^8.13.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/42693 we added a new metrics job to track some performance metrics. The job passed properly on the PR but failed on trunk because of a wrong file path. This PR is fixing it. 

I changed the conditions in the workflow temporarily to verify the fix and will restore the conditions before merging.

