### PR TITLE
Performance: Log the performance metrics to codevitals

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -53,9 +53,9 @@ jobs:
                   path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
 
             - name: Publish performance results
-              if: github.event_name == 'pull_request'
+              if: github.event_name == 'push'
               env:
                   CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
               run: |
                   COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
-                  cd tools/compare-perf && pnpm run log $CODEVITALS_PROJECT_TOKEN trunk $GITHUB_SHA 2f6ca66e00b3666b2567877ae67cbfb5b6ce171a $COMMITTED_AT
+                  cd tools/compare-perf && pnpm run log $CODEVITALS_PROJECT_TOKEN trunk $GITHUB_SHA 19f3d0884617d7ecdcf37664f648a51e2987cada $COMMITTED_AT

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -51,3 +51,11 @@ jobs:
               with:
                   name: performance-results
                   path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
+
+            - name: Publish performance results
+              if: github.event_name == 'pull_request'
+              env:
+                  CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
+              run: |
+                  COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
+                  cd tools/compare-perf && pnpm run log $CODEVITALS_PROJECT_TOKEN trunk $GITHUB_SHA 2f6ca66e00b3666b2567877ae67cbfb5b6ce171a $COMMITTED_AT

--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -8,7 +8,7 @@ const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
 const resultsFiles = [
 	{
 		file: 'editor.performance-results.json',
-		metricsPrefix: 'editor',
+		metricsPrefix: 'editor-',
 	},
 ];
 

--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const https = require( 'https' );
+const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
+
+const resultsFiles = [
+	{
+		file: 'editor.performance-results.json',
+		metricsPrefix: 'editor',
+	},
+];
+
+const performanceResults = resultsFiles.map( ( { file } ) =>
+	JSON.parse(
+		fs.readFileSync(
+			path.join( process.env.WP_ARTIFACTS_PATH, file ),
+			'utf8'
+		)
+	)
+);
+
+const data = new TextEncoder().encode(
+	JSON.stringify( {
+		branch,
+		hash,
+		baseHash,
+		timestamp,
+		metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
+			return {
+				...result,
+				...Object.fromEntries(
+					Object.entries(
+						performanceResults[ index ][ hash ] ?? {}
+					).map( ( [ key, value ] ) => [
+						metricsPrefix + key,
+						value,
+					] )
+				),
+			};
+		}, {} ),
+		baseMetrics: resultsFiles.reduce(
+			( result, { metricsPrefix }, index ) => {
+				return {
+					...result,
+					...Object.fromEntries(
+						Object.entries(
+							performanceResults[ index ][ baseHash ] ?? {}
+						).map( ( [ key, value ] ) => [
+							metricsPrefix + key,
+							value,
+						] )
+					),
+				};
+			},
+			{}
+		),
+	} )
+);
+
+const options = {
+	hostname: 'codevitals.run',
+	port: 443,
+	path: '/api/log?token=' + token,
+	method: 'POST',
+	headers: {
+		'Content-Type': 'application/json',
+		'Content-Length': data.length,
+	},
+};
+
+const req = https.request( options, ( res ) => {
+	console.log( `statusCode: ${ res.statusCode }` );
+
+	res.on( 'data', ( d ) => {
+		process.stdout.write( d );
+	} );
+} );
+
+req.on( 'error', ( error ) => {
+	console.error( error );
+} );
+
+req.write( data );
+req.end();

--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -60,7 +60,7 @@ const data = new TextEncoder().encode(
 );
 
 const options = {
-	hostname: 'codevitals.run',
+	hostname: 'www.codevitals.run',
 	port: 443,
 	path: '/api/log?token=' + token,
 	method: 'POST',

--- a/tools/compare-perf/package.json
+++ b/tools/compare-perf/package.json
@@ -7,7 +7,8 @@
 	"license": "GPLv2",
 	"repository": "woocommerce/woocommerce",
 	"scripts": {
-		"compare": "node index.js"
+		"compare": "node index.js",
+		"log": "node log-to-codevitals.js"
 	},
 	"dependencies": {
 		"@wordpress/env": "^8.13.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Big Picture** My goal is to bring metrics tracking and performance dashboard to the tools WooCommerce use daily to avoid performance regressions and work on performance improvements similarly to the [Gutenberg project](https://www.codevitals.run/project/gutenberg) for instance. Actually the woo dashboard is already there now https://www.codevitals.run/project/woo

Implementing this require three complementary steps:

 1- First step is to have some test runner (e2e test here) that we can launch to compute the metrics.
 2- Second step is to be able to use the same test runner in two separate branches as part of the same CI job. The reason for this is that CI runners capacities are unstable and we can't rely on the absolute numbers. We have to compute relative numbers and compare each commit with a given "base commit".
 3- Third step is to send these values (base branch and commit) to the dashboard (codevitals) to log it and produce the graphs.

The current PR is the third and last step. It should just log the numbers generated by step 2 (running in trunk) to code vitals to produce beautiful graphs.

### How to test the changes in this Pull Request:

Nothing to check really, we just need to see some points appearing in the codevitals dashboard once the "metrics" job is done.

Temporarily in the PR, I'm running the logging in the "pull request" job but before merging, we should switch it to the "push" to only run it in the "trunk" jobs.