### PR TITLE
Remove duplicate cookie headers from the response

### DIFF
--- a/plugins/woocommerce/changelog/42828-fix-duplicate-cookies-39670
+++ b/plugins/woocommerce/changelog/42828-fix-duplicate-cookies-39670
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove duplicate cookie headers from the response when adding multiple items to the cart programmatically.

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -82,7 +82,7 @@ final class WC_Cart_Session {
 
 		// Cookie events - cart cookies need to be set before headers are sent.
 		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
-		add_action( 'send_headers', array( $this, 'maybe_set_cart_cookies' ), 99 );
+		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
 		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 	}
 
@@ -256,7 +256,7 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function maybe_set_cart_cookies() {
-		if ( headers_sent() || ! did_action( 'send_headers' ) ) {
+		if ( headers_sent() || ! did_action( 'wp_loaded' ) ) {
 			return;
 		}
 		if ( ! $this->cart->is_empty() ) {

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -82,7 +82,7 @@ final class WC_Cart_Session {
 
 		// Cookie events - cart cookies need to be set before headers are sent.
 		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
-		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
+		add_action( 'send_headers', array( $this, 'maybe_set_cart_cookies' ), 99 );
 		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 	}
 
@@ -161,16 +161,16 @@ final class WC_Cart_Session {
 				 */
 				do_action( 'woocommerce_remove_cart_item_from_session', $key, $values, $product );
 
-			/**
-			 * Allow 3rd parties to override this item's is_purchasable() result with cart item data.
-			 *
-			 * @param bool       $is_purchasable If false, the item will not be added to the cart. Default: product's is_purchasable() status.
-			 * @param string     $key Cart item key.
-			 * @param array      $values Cart item values e.g. quantity and product_id.
-			 * @param WC_Product $product The product being added to the cart.
-			 *
-			 * @since 7.0.0
-			 */
+				/**
+				 * Allow 3rd parties to override this item's is_purchasable() result with cart item data.
+				 *
+				 * @param bool       $is_purchasable If false, the item will not be added to the cart. Default: product's is_purchasable() status.
+				 * @param string     $key Cart item key.
+				 * @param array      $values Cart item values e.g. quantity and product_id.
+				 * @param WC_Product $product The product being added to the cart.
+				 *
+				 * @since 7.0.0
+				 */
 			} elseif ( ! apply_filters( 'woocommerce_cart_item_is_purchasable', $product->is_purchasable(), $key, $values, $product ) ) {
 				$update_cart_session = true;
 				/* translators: %s: product name */
@@ -251,14 +251,45 @@ final class WC_Cart_Session {
 	/**
 	 * Will set cart cookies if needed and when possible.
 	 *
+	 * Headers are only updated if headers have not yet been sent.
+	 *
 	 * @since 3.2.0
 	 */
 	public function maybe_set_cart_cookies() {
-		if ( ! headers_sent() && did_action( 'wp_loaded' ) ) {
-			if ( ! $this->cart->is_empty() ) {
-				$this->set_cart_cookies( true );
-			} elseif ( isset( $_COOKIE['woocommerce_items_in_cart'] ) ) { // WPCS: input var ok.
-				$this->set_cart_cookies( false );
+		if ( headers_sent() || ! did_action( 'send_headers' ) ) {
+			return;
+		}
+		if ( ! $this->cart->is_empty() ) {
+			$this->set_cart_cookies( true );
+		} elseif ( isset( $_COOKIE['woocommerce_items_in_cart'] ) ) { // WPCS: input var ok.
+			$this->set_cart_cookies( false );
+		}
+		$this->dedupe_cookies();
+	}
+
+	/**
+	 * Remove duplicate cookies from the response.
+	 */
+	private function dedupe_cookies() {
+		$final_cookies  = array();
+		$update_cookies = false;
+
+		foreach ( headers_list() as $header ) {
+			if ( stripos( $header, 'Set-Cookie:' ) === false ) {
+				continue;
+			}
+			list(, $cookie_value)             = explode( ':', $header, 2 );
+			list($cookie_name, $cookie_value) = explode( '=', trim( $cookie_value ), 2 );
+			if ( array_key_exists( $cookie_name, $final_cookies ) ) {
+				$update_cookies = true;
+			}
+			$final_cookies[ $cookie_name ] = $cookie_value;
+		}
+		if ( $update_cookies ) {
+			header_remove( 'Set-Cookie' );
+			foreach ( $final_cookies as $cookie_name => $cookie_value ) {
+				// Using header here preserves previous cookie args.
+				header( "Set-Cookie: {$cookie_name}={$cookie_value}", false );
 			}
 		}
 	}
@@ -331,6 +362,7 @@ final class WC_Cart_Session {
 			foreach ( $setcookies as $name => $value ) {
 				if ( ! isset( $_COOKIE[ $name ] ) || $_COOKIE[ $name ] !== $value ) {
 					wc_setcookie( $name, $value );
+					$_COOKIE[ $name ] = $value;
 				}
 			}
 		} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When adding multiple products to the cart programmatically, 2 headers are added per item. This PR ensures that duplicate headers are removed to prevent this occuring.

Closes #39670

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Developers:** 

To test this you can add the following code to your site somewhere. This will add 5 products to your cart when you visit any page, then redirect to the homepage.

```php
add_action(
	'template_redirect',
	function() {
		if ( is_front_page() ) {
			return;
		}

		if ( is_page() ) {
			$products = wc_get_products(
				array(
					'posts_per_page' => 5,
					'status'         => 'publish',
					'type'           => 'simple',
				)
			);
			wc_empty_cart();
			foreach ( $products as $product ) {
				WC()->cart->add_to_cart( $product->get_id(), 1 );
			}
			wp_redirect( get_site_url() );
			exit;
		}
	},
	20
);
```

After this you can use browser tools to see what headers came back in the response:

![Screenshot 2023-12-14 at 15 21 34](https://github.com/woocommerce/woocommerce/assets/90977/336f8863-40cd-40ea-a3da-3c7590788c87)

1. With the above code in place, go to a page. Wait for the redirect then open network console and view the response of the page with the 302 redirect.
2. With this PR you'll see 2 headers (cart hash and cart items)
3. Without this PR you'll see ~10 headers, with duplicates of the above.

**Non-developers:**

1. Please smoke test adding items to the cart to test for regressions.
2. Add items to cart from the shop page.
3. Add items to the cart from the product pages.
4. View the cart and ensure results are correct.
5. Test the above as a logged in user, and as a guest.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Remove duplicate cookie headers from the response when adding multiple items to the cart programmatically. 

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
