### PR TITLE
Shipping Settings: Handle multiple tables in modal html

### DIFF
--- a/plugins/woocommerce/changelog/42847-fix-shipping-settings-table-modal-html
+++ b/plugins/woocommerce/changelog/42847-fix-shipping-settings-table-modal-html
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Updates a previously unreleased fix
+

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -516,13 +516,12 @@
 					return htmlContent.prop( 'outerHTML' );
 				},
 				replaceHTMLTables: function ( html ) {
+					// Wrap the html content in a div
+					const htmlContent = $( '<div>' + html + '</div>' );
+
 					// `<table class="form-table" />` elements added by the Settings API need to be removed. 
 					// Modern browsers won't interpret other table elements like `td` not in a `table`, so 
 					// Removing the `table` is sufficient.
-					const originalTable = $( html );
-					const htmlContent = $( '<div class="wc-shipping-zone-method-fields" />' );
-					htmlContent.html( originalTable.html() );
-
 					const innerTables = htmlContent.find( 'table.form-table' );
 					innerTables.each( ( i ) => {
 						const table = $( innerTables[ i ] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Previously merged changes in https://github.com/woocommerce/woocommerce/pull/42795 to handle html transformation of Settings API HTML output for rendering in Shipping Zone method modals did not account for multiple table elements. 

In most cases, only a single table was to be rendered, but in the case of Flat rate methods when there are also shipping classes available, multiple tables are included. This PR changes the logic such that all the html is preserved. You can reproduce the problem on `trunk` by seeing flat rate method modals not include shipping class inputs when they should.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new Shipping Zone, `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new`
2. Add a Flat Rate method, see the input fields only include Name, Tax status, and Cost.
3. Now add a Shipping Class, `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=classes`
4. Go back to your Shipping Zone and now add another Flat rate method. You should now see input fields relating to the class you added in the previous step. Note, these fields are missing on `trunk` if you want to quickly switch branches to confirm.
5. Check out several other methods to make sure contents are rendered correctly.

Note, there is an asset problem, likely having to do with the new build process, where an icon is missing. To be addressed in a follow up.

<img width="117" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/23bacb5d-dd9c-4165-bbab-d0c42a91be40">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Updates a previously unreleased fix

</details>
