### PR TITLE
Add CLI tool to remove order data from legacy tables

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-41914
+++ b/plugins/woocommerce/changelog/enhancement-41914
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add CLI command `hpos cleanup` to cleanup postmeta data for migrated orders.

--- a/plugins/woocommerce/changelog/enhancement-41914
+++ b/plugins/woocommerce/changelog/enhancement-41914
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add CLI command `hpos cleanup` to cleanup postmeta data for migrated orders.
+Add CLI command `wc hpos cleanup` to cleanup post and post meta data for migrated orders.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -64,7 +64,6 @@ class CLIRunner {
 		WP_CLI::add_command( 'wc cot verify_cot_data', array( $this, 'verify_cot_data' ) );
 		WP_CLI::add_command( 'wc cot enable', array( $this, 'enable' ) );
 		WP_CLI::add_command( 'wc cot disable', array( $this, 'disable' ) );
-
 		WP_CLI::add_command( 'wc hpos cleanup', array( $this, 'cleanup_post_data' ) );
 	}
 

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -873,7 +873,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * <all|id|range>...
 	 * : ID or range of orders to clean up.
 	 *
- 	 * [--batch-size=<batch-size>]
+	 * [--batch-size=<batch-size>]
 	 * : Number of orders to process per batch. Applies only to cleaning up of 'all' orders.
 	 * ---
 	 * default: 500
@@ -893,8 +893,8 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 *    # Cleanup postmeta for all orders with a batch size of 200 (instead of the default 500).
 	 *    wp wc hpos cleanup all --batch-size=200
 	 *
-	 * @param array $args Positional arguments passed to the command.
-	 * @param array $assoc_args Associate arguments (options) passed to the command.
+	 * @param array $args       Positional arguments passed to the command.
+	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 * @return void
 	 */
 	public function cleanup_post_data( array $args = array(), array $assoc_args = array() ) {
@@ -913,9 +913,10 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			return;
 		}
 
-		$progress    = WP_CLI\Utils\make_progress_bar( __( 'HPOS cleanup', 'woocommerce' ), $order_count );
-		$count       = 0;
+		$progress = WP_CLI\Utils\make_progress_bar( __( 'HPOS cleanup', 'woocommerce' ), $order_count );
+		$count    = 0;
 
+		// translators: %d is the number of orders to clean up.
 		WP_CLI::log( sprintf( _n( 'Starting cleanup for %d order...', 'Starting cleanup for %d orders...', $order_count, 'woocommerce' ), $order_count ) );
 
 		do {
@@ -925,9 +926,12 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 				try {
 					$handler->cleanup_post_data( $order_id );
 					$count++;
+
+					// translators: %d is an order ID.
 					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ) );
 				} catch ( \Exception $e ) {
-					WP_CLI::error( sprintf( __( 'An error occurred while cleaning up order %d: %s', 'woocommerce' ), $order_id, $e->getMessage() ) );
+					// translators: %1$d is an order ID, %2$s is an error message.
+					WP_CLI::error( sprintf( __( 'An error occurred while cleaning up order %1$d: %2$s', 'woocommerce' ), $order_id, $e->getMessage() ) );
 				}
 
 				$progress->tick();
@@ -936,13 +940,13 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			if ( ! $all_orders ) {
 				break;
 			}
-
-		} while( $order_ids );
+		} while ( $order_ids );
 
 		$progress->finish();
 
 		WP_CLI::success(
 			sprintf(
+				// translators: %d is the number of orders that were cleaned up.
 				_n( 'Cleanup completed for %d order.', 'Cleanup completed for %d orders.', $count, 'woocommerce' ),
 				$count
 			)

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\Internal\DataStores\Orders\LegacyDataHandler;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use WP_CLI;
@@ -63,6 +64,8 @@ class CLIRunner {
 		WP_CLI::add_command( 'wc cot verify_cot_data', array( $this, 'verify_cot_data' ) );
 		WP_CLI::add_command( 'wc cot enable', array( $this, 'enable' ) );
 		WP_CLI::add_command( 'wc cot disable', array( $this, 'disable' ) );
+
+		WP_CLI::add_command( 'wc hpos cleanup', array( $this, 'cleanup_post_data' ) );
 	}
 
 	/**
@@ -860,6 +863,90 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 				WP_CLI::success( __( 'Sync disabled.', 'woocommerce' ) );
 			}
 		}
+	}
+
+	/**
+	 * When HPOS is enabled, this command lets you remove redundant data from the postmeta table for migrated orders.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <all|id|range>...
+	 * : ID or range of orders to clean up.
+	 *
+ 	 * [--batch-size=<batch-size>]
+	 * : Number of orders to process per batch. Applies only to cleaning up of 'all' orders.
+	 * ---
+	 * default: 500
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    # Cleanup post data for order 314.
+	 *    $ wp wc hpos cleanup 314
+	 *
+	 *    # Cleanup postmeta for orders with IDs betweeen 10 and 100 and order 314.
+	 *    $ wp wc hpos cleanup 10-100 314
+	 *
+	 *    # Cleanup postmeta for all orders.
+	 *    wp wc hpos cleanup all
+	 *
+	 *    # Cleanup postmeta for all orders with a batch size of 200 (instead of the default 500).
+	 *    wp wc hpos cleanup all --batch-size=200
+	 *
+	 * @param array $args Positional arguments passed to the command.
+	 * @param array $assoc_args Associate arguments (options) passed to the command.
+	 * @return void
+	 */
+	public function cleanup_post_data( array $args = array(), array $assoc_args = array() ) {
+		if ( ! $this->synchronizer->custom_orders_table_is_authoritative() || $this->synchronizer->data_sync_is_enabled() ) {
+			WP_CLI::error( __( 'Cleanup can only be performed when HPOS is active and compatibility mode is disabled.', 'woocommerce' ) );
+		}
+		$handler = wc_get_container()->get( LegacyDataHandler::class );
+
+		$all_orders  = 'all' === $args[0];
+		$q_order_ids = $all_orders ? array() : $args;
+		$q_limit     = $all_orders ? absint( $assoc_args['batch-size'] ?? 500 ) : 0; // Limit per batch.
+
+		$order_count = $handler->count_orders_for_cleanup( $q_order_ids );
+		if ( ! $order_count ) {
+			WP_CLI::warning( __( 'No orders to cleanup.', 'woocommerce' ) );
+			return;
+		}
+
+		$progress    = WP_CLI\Utils\make_progress_bar( __( 'HPOS cleanup', 'woocommerce' ), $order_count );
+		$count       = 0;
+
+		WP_CLI::log( sprintf( _n( 'Starting cleanup for %d order...', 'Starting cleanup for %d orders...', $order_count, 'woocommerce' ), $order_count ) );
+
+		do {
+			$order_ids = $handler->get_orders_for_cleanup( $q_order_ids, $q_limit );
+
+			foreach ( $order_ids as $order_id ) {
+				try {
+					$handler->cleanup_post_data( $order_id );
+					$count++;
+					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ) );
+				} catch ( \Exception $e ) {
+					WP_CLI::error( sprintf( __( 'An error occurred while cleaning up order %d: %s', 'woocommerce' ), $order_id, $e->getMessage() ) );
+				}
+
+				$progress->tick();
+			}
+
+			if ( ! $all_orders ) {
+				break;
+			}
+
+		} while( $order_ids );
+
+		$progress->finish();
+
+		WP_CLI::success(
+			sprintf(
+				_n( 'Cleanup completed for %d order.', 'Cleanup completed for %d orders.', $count, 'woocommerce' ),
+				$count
+			)
+		);
 	}
 
 }

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -879,6 +879,12 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * default: 500
 	 * ---
 	 *
+	 * [--force]
+	 * : Whether to skip checks before cleaning up.
+	 * ---
+	 * default: false
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *    # Cleanup post data for order 314.
@@ -904,6 +910,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 		$handler = wc_get_container()->get( LegacyDataHandler::class );
 
 		$all_orders  = 'all' === $args[0];
+		$force       = (bool) ( $assoc_args['force'] ?? false );
 		$q_order_ids = $all_orders ? array() : $args;
 		$q_limit     = $all_orders ? absint( $assoc_args['batch-size'] ?? 500 ) : 0; // Limit per batch.
 
@@ -924,7 +931,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 
 			foreach ( $order_ids as $order_id ) {
 				try {
-					$handler->cleanup_post_data( $order_id );
+					$handler->cleanup_post_data( $order_id, $force );
 					$count++;
 
 					// translators: %d is an order ID.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -931,7 +931,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ) );
 				} catch ( \Exception $e ) {
 					// translators: %1$d is an order ID, %2$s is an error message.
-					WP_CLI::error( sprintf( __( 'An error occurred while cleaning up order %1$d: %2$s', 'woocommerce' ), $order_id, $e->getMessage() ) );
+					WP_CLI::warning( sprintf( __( 'An error occurred while cleaning up order %1$d: %2$s', 'woocommerce' ), $order_id, $e->getMessage() ) );
 				}
 
 				$progress->tick();

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -879,7 +879,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * ---
 	 *
 	 * [--force]
-	 * : Whether to skip checks before cleaning up.
+	 * : When true, post meta will be cleaned up even if the post appears to have been updated more recently than the order.
 	 * ---
 	 * default: false
 	 * ---

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -104,7 +104,15 @@ class LegacyDataHandler {
 		}
 
 		$sql_where .= $sql_where ? ' AND ' : '';
+
+		// Post type handling.
+		$sql_where .= '(';
 		$sql_where .= "{$wpdb->posts}.post_type IN ('" . implode( "', '", esc_sql( wc_get_order_types( 'cot-migration' ) ) ) . "')";
+		$sql_where .= $wpdb->prepare(
+			" OR (post_type = %s AND EXISTS(SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID))",
+			$this->data_synchronizer::PLACEHOLDER_ORDER_POST_TYPE
+		);
+		$sql_where .= ')';
 
 		if ( 'count' === $result ) {
 			$sql_fields = 'COUNT(*)';

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -38,4 +38,82 @@ class LegacyDataHandler {
 		$this->data_store        = $data_store;
 		$this->data_synchronizer = $data_synchronizer;
 	}
+
+	/**
+	 * Returns the total number of orders for which legacy post data can be removed.
+	 *
+	 * @param array $order_ids If provided, total is computed only among IDs in this array, which can be either individual IDs or ranges like "100-200".
+	 * @return int Number of orders.
+	 */
+	public function count_orders_for_cleanup( $order_ids = array() ) : int {
+		global $wpdb;
+		return (int) $wpdb->get_var( $this->build_sql_query_for_cleanup( $order_ids, 'count' ) );
+	}
+
+	/**
+	 * Returns a set of orders for which legacy post data can be removed.
+	 *
+	 * @param array $order_ids If provided, result is a subset of the order IDs in this array, which can contain either individual order IDs or ranges like "100-200".
+	 * @param int   $limit     Limit the number of results.
+	 * @return array[int] Order IDs.
+	 */
+	public function get_orders_for_cleanup( $order_ids = array(), int $limit = 0 ): array {
+		global $wpdb;
+
+		return array_map(
+			'absint',
+			$wpdb->get_col( $this->build_sql_query_for_cleanup( $order_ids, 'ids', $limit ) )
+		);
+	}
+
+	/**
+	 * Builds a SQL statement to either count or obtain IDs for orders in need of cleanup.
+	 *
+	 * @param array   $order_ids If provided, the query will only include orders in this set of order IDs or ID ranges (like "10-100").
+	 * @param string  $result    Use 'count' to build a query that returns a count. Otherwise, the query will return order IDs.
+	 * @param integer $limit     If provided, the query will be limited to this number of results. Does not apply when $result is 'count'.
+	 * @return string SQL query.
+	 */
+	private function build_sql_query_for_cleanup( array $order_ids = array(), string $result = 'ids', int $limit = 0 ): string {
+		global $wpdb;
+
+		$order_types                 = wc_get_order_types( 'cot-migration' );
+		$sql_fields                  = 'count' === $result ? 'COUNT(*)' : 'ID as id';
+		$sql_order_types_placeholder = implode( ', ', array_fill( 0, count( $order_types ), '%s' ) );
+		$sql_limit_placeholder       = ( 'count' !== $result && $limit ) ? 'LIMIT %d' : '';
+
+		if ( $order_ids ) {
+			// Expand ranges in $order_ids as needed to build the WHERE clause.
+			$sql_ids    = '';
+			$sql_ranges = array();
+
+			foreach ( $order_ids as &$arg ) {
+				if ( is_numeric( $arg ) ) {
+					$sql_ids .= $wpdb->prepare( '%d,', absint( $arg ) );
+				} elseif ( preg_match( '/^(\d+)-(\d+)$/', $arg, $matches ) ) {
+					$sql_ranges[] = $wpdb->prepare( '(id >= %d AND id <= %d)', array( absint( $matches[1] ), absint( $matches[2] ) ) );
+				}
+			}
+
+			if ( $sql_ids ) {
+				$sql_ids = substr( $sql_ids, 0, -1 );
+				$sql_ids = "(id IN ({$sql_ids}))";
+			}
+
+			if ( ! $sql_ids && ! $sql_ranges ) {
+				$sql_where = '1=0';
+			} else {
+				$sql_where = implode( ' OR ', array_filter( array_merge( array( $sql_ids ), $sql_ranges ) ) );
+			}
+		} else {
+			$sql_where = '1=1';
+		}
+
+		$sql = $wpdb->prepare(
+			"SELECT {$sql_fields} FROM {$wpdb->posts} WHERE post_type IN ({$sql_order_types_placeholder}) AND ({$sql_where}) {$sql_limit_placeholder}",
+			array_merge( $order_types, $limit ? array( $limit ) : array() )
+		);
+
+		return $sql;
+	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * LegacyDataHandler class file.
+ */
+
+namespace Automattic\WooCommerce\Internal\DataStores\Orders;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class provides functionality to clean up post data from the posts table when HPOS is authoritative.
+ */
+class LegacyDataHandler {
+
+	/**
+	 * Instance of the HPOS datastore.
+	 *
+	 * @var OrdersTableDataStore
+	 */
+	private OrdersTableDataStore $data_store;
+
+	/**
+	 * Instance of the DataSynchronizer class.
+	 *
+	 * @var DataSynchronizer
+	 */
+	private DataSynchronizer $data_synchronizer;
+
+	/**
+	 * Class initialization, invoked by the DI container.
+	 *
+	 * @param OrdersTableDataStore $data_store HPOS datastore instance to use.
+	 * @param DataSynchronizer     $data_synchronizer DataSynchronizer instance to use.
+	 *
+	 * @internal
+	 */
+	final public function init( OrdersTableDataStore $data_store, DataSynchronizer $data_synchronizer ) {
+		$this->data_store        = $data_store;
+		$this->data_synchronizer = $data_synchronizer;
+	}
+}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -114,6 +114,9 @@ class LegacyDataHandler {
 		);
 		$sql_where .= ')';
 
+		// Exclude 'auto-draft' since those go away on their own.
+		$sql_where .= $wpdb->prepare( " AND {$wpdb->posts}.post_status != %s", 'auto-draft' );
+
 		if ( 'count' === $result ) {
 			$sql_fields = 'COUNT(*)';
 			$sql_limit  = '';

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableRefundDataStore
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\DataStores\Orders\LegacyDataHandler;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStoreMeta;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
@@ -42,6 +43,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 		OrdersTableRefundDataStore::class,
 		OrderCache::class,
 		OrderCacheController::class,
+		LegacyDataHandler::class,
 	);
 
 	/**
@@ -79,5 +81,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 		if ( Constants::is_defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->share( CLIRunner::class )->addArguments( array( CustomOrdersTableController::class, DataSynchronizer::class, PostsToOrdersMigrationController::class ) );
 		}
+
+		$this->share( LegacyDataHandler::class )->addArguments( array( OrdersTableDataStore::class, DataSynchronizer::class ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
@@ -1,0 +1,75 @@
+<?php
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+use Automattic\WooCommerce\Internal\DataStores\Orders\LegacyDataHandler;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+
+/**
+ * Class OrdersTableQueryTests.
+ */
+class LegacyDataHandlerTests extends WC_Unit_Test_Case {
+	use HPOSToggleTrait;
+
+	/**
+	 * @var LegacyDataHandler
+	 */
+	private $sut;
+
+	/**
+	 * Initializes system under test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+		$this->setup_cot();
+
+		$this->sut = wc_get_container()->get( LegacyDataHandler::class );
+	}
+
+	/**
+	 * Destroys system under test.
+	 */
+	public function tearDown(): void {
+		$this->clean_up_cot_setup();
+		remove_all_filters( 'wc_allow_changing_orders_storage_while_sync_is_pending' );
+	}
+
+	/**
+	 * Tests the cleanup of legacy data.
+	 */
+	public function test_post_data_cleanup() {
+		$this->enable_cot_sync();
+		$orders = array(
+			OrderHelper::create_complex_data_store_order(),
+			OrderHelper::create_order(),
+		);
+		$this->disable_cot_sync();
+
+		// Confirm orders have been synced up (i.e. are not placeholders) and contain metadata.
+		foreach ( $orders as $order ) {
+			$this->assertEquals( 'shop_order', get_post_type( $order->get_id() ) );
+			$this->assertNotEmpty( get_post_meta( $order->get_id() ) );
+		}
+
+		// Check that counts are working ok.
+		$this->assertEquals( 1, $this->sut->count_orders_for_cleanup( array( $orders[0]->get_id() ) ) );
+		$this->assertEquals( 2, $this->sut->count_orders_for_cleanup() );
+
+		// Cleanup one of the orders.
+		$this->sut->cleanup_post_data( $orders[0]->get_id() );
+
+		// Confirm metadata has been removed and post type has been reset to placeholder.
+		$this->assertEmpty( get_post_meta( $orders[0]->get_id() ) );
+		$this->assertEquals( 'shop_order_placehold', get_post_type( $orders[0]->get_id() ) );
+
+		// Check counts.
+		$this->assertEquals( 0, $this->sut->count_orders_for_cleanup( array( $orders[0]->get_id() ) ) );
+		$this->assertEquals( 1, $this->sut->count_orders_for_cleanup() );
+
+		// Confirm that we now have 1 unsynced order (due to the removal of the backup data).
+		$this->assertEquals( 1, wc_get_container()->get( DataSynchronizer::class )->get_current_orders_pending_sync_count() );
+	}
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
@@ -32,6 +32,7 @@ class LegacyDataHandlerTests extends WC_Unit_Test_Case {
 	 * Destroys system under test.
 	 */
 	public function tearDown(): void {
+		parent::tearDown();
 		$this->clean_up_cot_setup();
 		remove_all_filters( 'wc_allow_changing_orders_storage_while_sync_is_pending' );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a WP-CLI command (`wc hpos cleanup`) that allows cleaning up/removing metadata for orders after a migration to HPOS.

The command can work with individual order IDs or in bulk (by passing various IDs or ranges of IDs in the format "10-100") and can also remove data for _all_ orders. For example:

- `wp hpos cleanup 123` removes data for order with ID `123`.
- `wp hpos cleanup 123 456 700-800` removes data for orders 123, 456 and all orders between 700 and 800.
- `wp hpos cleanup all` removes data for all orders. It works in batches, their size being configurable with the `--batch-size` argument.

A few implementation decisions (which are obviously up for discussion):

- This tool introduces a new CLI namespace (`hpos`) instead of re-using `cot` (as the other HPOS-related tools do). I think it'd actually reduce confusion in the long term to move everything over to `hpos`, which is the name we're now using everywhere else. My plan (while working on the other CLI enhancements) is to move everything over from `cot` to `hpos`, keeping the former as sort of "alias" for backwards compat.
- Cleaning up of all orders has to be triggered explicitly by passing the `all` argument. This to prevent users from inadvertently wiping CPT data while trying to see how the command works.

Closes #41914.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with a site with a few orders (either in HPOS or CPT) and with everything synced up. If necessary, run `wp cot sync` on the site or wait until the scheduled job syncs orders.
2. Go to WC > Settings > Advanced > Features and make sure the legacy datastore is in use.
3. Confirm that the tool doesn't work when HPOS is not authoritative (as we don't want to remove data from posts when posts is authoritative):
   ```
   $ wp wc hpos cleanup all
   Error: Cleanup can only be performed when HPOS is active and compatibility mode is disabled.
   ```
4. Turn HPOS on in WC > Settings > Advanced > Features, as well as compatibility mode. Repeat step 3 and confirm that the tool doesn't work if compatibility mode is enabled (as there's no point in deleting data that will be re-created).
5. Turn compatibility mode off in WC > Settings > Advanced > Features.
6. Go to WC > Orders and take note of a few order IDs.
7. Run cleanup for one of those IDs and confirm that metadata for that post has been removed and the post has been changed to type `shop_order_placehold`:
   ```
   $ wp wc hpos cleanup ORDER_ID
   Success: Cleanup completed for 1 order.

   $ wp post meta list ORDER_ID
   +---------+----------+------------+
   | post_id | meta_key | meta_value |
   +---------+----------+------------+
   +---------+----------+------------+   

   $ wp post get ORDER_ID --field=post_type
   shop_order_placehold
   ```
9. Even though sync is disabled, if it were to be re-enabled this order would have to be synced again, so we can confirm that the sync tool is aware of this order:
   ```
   $ wp wc cot count_unmigrated
   There is 1 order to be synced.
   ```
10. Try a few variations of the command, such as passing it various order IDs (separated by space) or ranges of IDs, as described above and confirm that in all cases post meta is removed and the sync tool notices the difference.
11. Perform a cleanup for all orders by running `wp wc hpos cleanup all`.
12. Confirm that _all_ orders are marked as 'pending sync'.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
