### PR TITLE
Admin.scss: Provide image-mask for Chrome

### DIFF
--- a/plugins/woocommerce/changelog/42853-fix-shipping-settings-mask-css-svg
+++ b/plugins/woocommerce/changelog/42853-fix-shipping-settings-mask-css-svg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: No functionality changed, just minor CSS fix no changelog required.
+

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4624,6 +4624,8 @@ table.wc-shipping-classes {
 		&::before {
 			content: "";
 			mask: url(../images/icons/move-icon.svg);
+			mask-image: url(../images/icons/move-icon.svg);
+			-webkit-mask-image: url(../images/icons/move-icon.svg);
 			background-color: #1E1E1E;
 			display: block;
 			width: 17px;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I'm not sure what changed in Chrome, but `mask` CSS property stopped working. This only affected Chrome.

#### Before
<img width="107" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/5a5217eb-800f-4e0a-9ee0-cf814fc9abea">


#### After
<img width="96" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/343a9d8a-0d0b-4cb9-a4a0-645a0ac966b8">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using Chrome, create a new Shipping Zone, `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new`
2. Now return to the main tab, `/wp-admin/admin.php?page=wc-settings&tab=shipping` and see the move icon rendered correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

No functionality changed, just minor CSS fix no changelog required.

</details>
