### PR TITLE
Disable `DisallowShortArraySyntax` and `InternalInjectionMethod` sniffs for blocks files.

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpcs-blocks
+++ b/plugins/woocommerce/changelog/fix-phpcs-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add InternalInjection sniff and DisallowShortArraySyntax exceptions for blocks

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -102,4 +102,22 @@
 	<rule ref="Squiz.Commenting.FileComment.Missing">
 		<exclude-pattern>tests/php/</exclude-pattern>
 	</rule>
+
+	<!-- Temporary -->
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+		<exclude-pattern>src/Blocks/</exclude-pattern>
+		<exclude-pattern>src/StoreApi/</exclude-pattern>
+	</rule>
+
+	<!-- Temporary -->
+	<rule ref="WooCommerce.Functions.InternalInjectionMethod.MissingFinal">
+		<exclude-pattern>src/Blocks/</exclude-pattern>
+		<exclude-pattern>src/StoreApi/</exclude-pattern>
+	</rule>
+
+	<!-- Temporary -->
+	<rule ref="WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag">
+		<exclude-pattern>src/Blocks/</exclude-pattern>
+		<exclude-pattern>src/StoreApi/</exclude-pattern>
+	</rule>
 </ruleset>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds `WooCommerce.Functions.InternalInjectionMethod` and `Generic.Arrays.DisallowShortArraySyntax` exceptions for the two blocks folders under `src`. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review configuration change
2. Run `pnpm --filter="@woocommerce/plugin-woocommerce" lint:php -- src/StoreApi`
3. Ensure no errors about `DisallowShortArraySyntax` or `InternalInjectionMethod` are output. (Other errors will be, but they are OK and should be fixed)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
