### PR TITLE
Add hooks around HPOS orders being synced from/to posts on read/write

### DIFF
--- a/plugins/woocommerce/changelog/fix-37721
+++ b/plugins/woocommerce/changelog/fix-37721
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Trigger a hook when an order is updated on read from a post record or the post record backfilled.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -610,6 +610,13 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		}
 		self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
 
+		/**
+		 * Fired when the backing post record for an HPOS order is backfilled after an order update.
+		 *
+		 * @since 8.5.0
+		 *
+		 * @param \WC_Order $order The order object.
+		 */
 		do_action( 'woocommerce_hpos_post_record_backfilled', $order );
 	}
 
@@ -1432,6 +1439,14 @@ WHERE
 		}
 		$this->persist_updates( $order, false );
 
+		/**
+		 * Fired when an HPOS order is updated from its corresponding post record on read due to a difference in the data.
+		 *
+		 * @since 8.5.0
+		 *
+		 * @param \WC_Order $order The order object.
+		 * @param array     $diff  Difference between HPOS data and post data.
+		 */
 		do_action( 'woocommerce_hpos_post_record_migrated_on_read', $order, $diff );
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -609,6 +609,8 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 			}
 		}
 		self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
+
+		do_action( 'woocommerce_hpos_post_record_backfilled', $order );
 	}
 
 	/**
@@ -1423,12 +1425,14 @@ WHERE
 	 * @return void
 	 */
 	private function migrate_post_record( \WC_Abstract_Order &$order, \WC_Abstract_Order $post_order ): void {
-		$this->migrate_meta_data_from_post_order( $order, $post_order );
+		$diff                 = $this->migrate_meta_data_from_post_order( $order, $post_order );
 		$post_order_base_data = $post_order->get_base_data();
 		foreach ( $post_order_base_data as $key => $value ) {
 			$this->set_order_prop( $order, $key, $value );
 		}
 		$this->persist_updates( $order, false );
+
+		do_action( 'woocommerce_hpos_post_record_migrated_on_read', $order, $diff );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -26,7 +26,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	/**
 	 * Order IDs for which we are checking sync on read in the current request. In WooCommerce, using wc_get_order is a very common pattern, to avoid performance issues, we only sync on read once per request per order. This works because we consider out of sync orders to be an anomaly, so we don't recommend running HPOS with incompatible plugins.
 	 *
-	 * @var array.
+	 * @var array
 	 */
 	private static $reading_order_ids = array();
 
@@ -1412,17 +1412,6 @@ WHERE
 			$diff[ $key ] = $order2_values;
 		}
 		return $diff;
-	}
-
-	/**
-	 * Log difference between post and COT data for an order.
-	 *
-	 * @param array $diff Difference between post and COT data.
-	 *
-	 * @return void
-	 */
-	private function log_diff( array $diff ): void {
-		$this->error_logger->notice( 'Diff found: ' . wp_json_encode( $diff, JSON_PRETTY_PRINT ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a couple of hooks that can be used to "listen" on a couple of events related to 'on read' and 'on write' sync of HPOS and post objects:

- `woocommerce_hpos_post_record_migrated_on_read` which gets fired when an HPOS order is updated from post data while being read. This happens when there's a mismatch between HPOS and post and post data is more recent.
- `woocommerce_hpos_post_record_backfilled`, triggered when an HPOS order is persisted and the backup post record is updated.

Closes #37721.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Settings > Advanced > Features and make sure that HPOS and compatibility mode are both enabled.
2. Make sure your site has some orders. If necessary, create a few first.
3. Drop the following code in a .php file inside `wp-content/mu-plugins`. This code will hook onto the new actions and log some info to the error log.
   ```php
   <?php
   add_action(
	   'woocommerce_hpos_post_record_migrated_on_read',
	   function( $order, $diff ) {
		   error_log( sprintf( 'HPOS order %d updated from post on read. Diff: %s.', $order->get_id(), wp_json_encode( $diff, JSON_PRETTY_PRINT ) ) );
	   },
	   10,
	   2
   );
   
   add_action(
	   'woocommerce_hpos_post_record_backfilled',
	   function( $order ) {
		   error_log( sprintf( 'Post was backfilled for HPOS order %d.', $order->get_id() ) );
	   }
   );
   ```
5. Go to WC > Orders and edit any order. Click "Update".
6. Confirm that the error log now contains an entry like the following:
   > [15-Dec-2023 11:58:16 UTC] Post was backfilled for HPOS order 5006.
7. Choose any order ID (from your orders in WC > Orders) and use WP-CLI to update the post independently of HPOS:
   ```
   wp post meta add ORDER_ID 'some_new_meta' 1
   ```
9. Go to WC > Orders and click on the order corresponding to the order ID you chose.
10. Confirm that the error log now contains an entry like this one:
    ```
    [15-Dec-2023 11:40:16 UTC] HPOS order 5006 updated from post on read. Diff: {
       "some_new_meta": [
           "1"
       ]
    }.
    ```
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
