### PR TITLE
Update tracks events hooks for HPOS

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
@@ -11,9 +11,9 @@ import { staticFormDataToObject } from '~/utils/static-form-helper';
 type FormElements = {
 	post?: HTMLFormElement;
 	order?: HTMLFormElement;
-} & HTMLCollectionOf<HTMLFormElement>;
+} & HTMLCollectionOf< HTMLFormElement >;
 const forms: FormElements = document.forms;
-if ( forms?.order || forms?.post ) {
+if ( forms?.post || forms?.order ) {
 	let triggeredSaveOrDeleteButton = false;
 	const saveButton = document.querySelector( '.save_order' );
 	const deleteButton = document.querySelector( '.submitdelete' );
@@ -28,14 +28,19 @@ if ( forms?.order || forms?.post ) {
 			triggeredSaveOrDeleteButton = true;
 		} );
 	}
-	const formData = staticFormDataToObject( ( forms?.post || forms?.order ) as HTMLFormElement );
+	const formData = staticFormDataToObject(
+		( forms?.post || forms?.order ) as HTMLFormElement
+	);
 	addCustomerEffortScoreExitPageListener( 'shop_order_update', () => {
 		if ( triggeredSaveOrDeleteButton ) {
 			return false;
 		}
-		const newFormData = ( forms?.post || forms?.order )
-			? staticFormDataToObject( ( forms?.post || forms?.order ) as HTMLFormElement )
-			: {};
+		const newFormData =
+			forms?.post || forms?.order
+				? staticFormDataToObject(
+						( forms?.post || forms?.order ) as HTMLFormElement
+				  )
+				: {};
 		for ( const key of Object.keys( formData ) ) {
 			const value =
 				typeof formData[ key ] === 'object'

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
@@ -10,9 +10,10 @@ import { staticFormDataToObject } from '~/utils/static-form-helper';
 
 type FormElements = {
 	post?: HTMLFormElement;
-} & HTMLCollectionOf< HTMLFormElement >;
+	order?: HTMLFormElement;
+} & HTMLCollectionOf<HTMLFormElement>;
 const forms: FormElements = document.forms;
-if ( forms?.post ) {
+if ( forms?.order || forms?.post ) {
 	let triggeredSaveOrDeleteButton = false;
 	const saveButton = document.querySelector( '.save_order' );
 	const deleteButton = document.querySelector( '.submitdelete' );
@@ -27,13 +28,13 @@ if ( forms?.post ) {
 			triggeredSaveOrDeleteButton = true;
 		} );
 	}
-	const formData = staticFormDataToObject( forms.post );
+	const formData = staticFormDataToObject( ( forms?.post || forms?.order ) as HTMLFormElement );
 	addCustomerEffortScoreExitPageListener( 'shop_order_update', () => {
 		if ( triggeredSaveOrDeleteButton ) {
 			return false;
 		}
-		const newFormData = forms.post
-			? staticFormDataToObject( forms.post )
+		const newFormData = ( forms?.post || forms?.order )
+			? staticFormDataToObject( ( forms?.post || forms?.order ) as HTMLFormElement )
 			: {};
 		for ( const key of Object.keys( formData ) ) {
 			const value =

--- a/plugins/woocommerce/changelog/fix-38886
+++ b/plugins/woocommerce/changelog/fix-38886
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update a few Tracks events to be HPOS compatible.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -188,14 +188,11 @@ class WC_Orders_Tracking {
 	 *
 	 * @param string $hook Page hook.
 	 */
-	public function possibly_add_order_tracking_scripts( $hook ) {
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
-		if (
-			( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) ||
-			( 'post.php' === $hook && isset( $_GET['post'] ) && 'shop_order' === get_post_type( intval( $_GET['post'] ) ) )
-		) {
-			WCAdminAssets::register_script( 'wp-admin-scripts', 'order-tracking', false );
+	public function possibly_add_order_tracking_scripts() {
+		if ( ! OrderUtil::is_new_order_screen() && ! OrderUtil::is_order_edit_screen() && ! OrderUtil::is_order_list_table_screen() ) {
+			return;
 		}
-		// phpcs:enable
+
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'order-tracking', false );
 	}
 }

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -205,7 +205,7 @@ class WC_Orders_Tracking {
 
 		if (
 			( $post_edit_page['path'] === $referring_page['path'] ) &&
-			( isset( $post_edit_page['query'] ) || false !== strpos( $referring_page['query'], $post_edit_page['query'] ) ) &&
+			( ! isset( $post_edit_page['query'] ) || false !== strpos( $referring_page['query'], $post_edit_page['query'] ) ) &&
 			( isset( $referring_args['action'] ) && 'edit' === $referring_args['action'] ) &&
 			'shop_order' === OrderUtil::get_order_type( $order_id )
 		) {

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -25,8 +25,11 @@ class WC_Orders_Tracking {
 		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_orders_view' ), 10 ); // HPOS.
 		add_action( 'load-post-new.php', array( $this, 'track_add_order_from_edit' ), 10 );
 
+		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_created_date_change' ), 10 );
+
 		add_filter( 'load-edit.php', array( $this, 'track_order_search' ) );
 		add_filter( 'load-woocommerce_page_wc-orders', array( $this, 'track_order_search' ) ); // HPOS.
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_order_tracking_scripts' ) );
 	}
 
@@ -90,15 +93,15 @@ class WC_Orders_Tracking {
 			return;
 		}
 
-		if ( 'auto-draft' === get_post_status( $id ) ) {
+		$order = wc_get_order( $id );
+		if ( ! $order || 'auto-draft' === $order->get_status() ) {
 			return;
 		}
 
-		$order        = wc_get_order( $id );
 		$date_created = $order->get_date_created() ? $order->get_date_created()->date( 'Y-m-d H:i:s' ) : '';
 		// phpcs:disable WordPress.Security.NonceVerification
 		$new_date = sprintf(
-			'%s %2d:%2d:%2d',
+			'%s %2d:%02d:%02d',
 			isset( $_POST['order_date'] ) ? wc_clean( wp_unslash( $_POST['order_date'] ) ) : '',
 			isset( $_POST['order_date_hour'] ) ? wc_clean( wp_unslash( $_POST['order_date_hour'] ) ) : '',
 			isset( $_POST['order_date_minute'] ) ? wc_clean( wp_unslash( $_POST['order_date_minute'] ) ) : '',

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -24,32 +24,21 @@ class WC_Orders_Tracking {
 		add_action( 'load-edit.php', array( $this, 'track_orders_view' ), 10 );
 		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_orders_view' ), 10 ); // HPOS.
 		add_action( 'load-post-new.php', array( $this, 'track_add_order_from_edit' ), 10 );
-		add_filter( 'woocommerce_shop_order_search_results', array( $this, 'track_order_search' ), 10, 3 );
+
+		add_filter( 'load-edit.php', array( $this, 'track_order_search' ) );
+		add_filter( 'load-woocommerce_page_wc-orders', array( $this, 'track_order_search' ) ); // HPOS.
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_order_tracking_scripts' ) );
 	}
 
 	/**
 	 * Send a track event when on the Order Listing page, and search results are being displayed.
-	 *
-	 * @param array  $order_ids Array of order_ids that are matches for the search.
-	 * @param string $term The string that was used in the search.
-	 * @param array  $search_fields Fields that were used in the original search.
 	 */
-	public function track_order_search( $order_ids, $term, $search_fields ) {
-		// Since `woocommerce_shop_order_search_results` can run in the front-end context, exit if get_current_screen isn't defined.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return $order_ids;
+	public function track_order_search() {
+		if ( ! OrderUtil::is_order_list_table_screen() || empty( $_REQUEST['s'] ) ) {
+			return;
 		}
 
-		$screen = get_current_screen();
-
-		// We only want to record this track when the filter is executed on the order listing page.
-		if ( 'edit-shop_order' === $screen->id ) {
-			// we are on the order listing page, and query results are being shown.
-			WC_Tracks::record_event( 'orders_view_search' );
-		}
-
-		return $order_ids;
+		WC_Tracks::record_event( 'orders_view_search' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -30,8 +30,8 @@ class WC_Orders_Tracking {
 
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_created_date_change' ), 10 );
 
-		add_filter( 'load-edit.php', array( $this, 'track_order_search' ) );
-		add_filter( 'load-woocommerce_page_wc-orders', array( $this, 'track_order_search' ) ); // HPOS.
+		add_action( 'load-edit.php', array( $this, 'track_order_search' ) );
+		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_order_search' ) ); // HPOS.
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_order_tracking_scripts' ) );
 	}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -40,7 +40,7 @@ class WC_Orders_Tracking {
 	 * Send a track event when on the Order Listing page, and search results are being displayed.
 	 */
 	public function track_order_search() {
-		if ( ! OrderUtil::is_order_list_table_screen() || empty( $_REQUEST['s'] ) ) {
+		if ( ! OrderUtil::is_order_list_table_screen() || empty( $_REQUEST['s'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
@@ -185,8 +185,6 @@ class WC_Orders_Tracking {
 
 	/**
 	 * Adds the tracking scripts for product setting pages.
-	 *
-	 * @param string $hook Page hook.
 	 */
 	public function possibly_add_order_tracking_scripts() {
 		if ( ! OrderUtil::is_new_order_screen() && ! OrderUtil::is_order_edit_screen() && ! OrderUtil::is_order_list_table_screen() ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
@@ -1,24 +1,15 @@
 <?php
 
-// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
-if ( ! class_exists( 'CurrentScreenMock' ) ) {
-	/**
-	 * Class CurrentScreenMock
-	 */
-	class CurrentScreenMock {
-		/**
-		 * CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
-		 */
-		public function in_admin() {
-			return true;
-		}
-	}
-}
+use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
  * Class WC_Orders_Tracking_Test.
  */
 class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
+
+	use HPOSToggleTrait;
 
 	/**
 	 * @var object Backup object of $GLOBALS['current_screen'];
@@ -33,14 +24,21 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-orders-tracking.php';
 		update_option( 'woocommerce_allow_tracking', 'yes' );
-		if ( isset( $GLOBALS['current_screen'] ) ) {
-			$this->current_screen_backup = $GLOBALS['current_screen'];
+
+		// Mock screen.
+		$this->current_screen_backup = $GLOBALS['current_screen'] ?? null;
+		$GLOBALS['current_screen']   = $this->get_screen_mock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		if ( ! did_action( 'current_screen' ) ) {
+			do_action( 'current_screen', $GLOBALS['current_screen'] ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		}
-		$GLOBALS['current_screen'] = new CurrentScreenMock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$orders_tracking           = new WC_Orders_Tracking();
+
+		$orders_tracking = new WC_Orders_Tracking();
 		$orders_tracking->init();
 		parent::setUp();
+
+		$this->setup_cot();
 	}
+
 	/**
 	 * Teardown test
 	 *
@@ -52,39 +50,109 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 			$GLOBALS['current_screen'] = $this->current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 		parent::tearDown();
+		$this->clean_up_cot_setup();
+		remove_all_filters( 'wc_allow_changing_orders_storage_while_sync_is_pending' );
 	}
 
 	/**
-	 * Test wcadmin_orders_edit_status_change Tracks event
+	 * Test wcadmin_orders_edit_status_change Tracks event.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $hpos_enabled Whether to test with HPOS enabled or not.
 	 */
-	public function test_orders_view_search() {
+	public function test_orders_status_change( $hpos_enabled ) {
+		$this->toggle_cot_authoritative( $hpos_enabled );
 		$order = wc_create_order();
 		$order->save();
+
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'woocommerce_order_status_changed', $order->get_id(), 'pending', 'finished' );
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_edit_status_change' );
 	}
 
 	/**
-	 * Test wcadmin_orders_view Tracks event
+	 * Test wcadmin_orders_view Tracks event.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $hpos_enabled Whether to test with HPOS enabled or not.
 	 */
-	public function test_orders_view() {
-		$_GET['post_type'] = 'shop_order';
+	public function test_orders_view( $hpos_enabled ) {
+		$this->toggle_cot_authoritative( $hpos_enabled );
+		$this->setup_screen( 'list' );
+
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
-		do_action( 'load-edit.php' );
+		do_action( $hpos_enabled ? 'load-woocommerce_page_wc-orders' : 'load-edit.php' );
+
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_view' );
 	}
 
 	/**
-	 * Test wcadmin_orders_view_search Tracks event
+	 * Test wcadmin_orders_view_search Tracks event.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $hpos_enabled Whether to test with HPOS enabled or not.
 	 */
-	public function test_orders_search() {
-		$GLOBALS['current_screen']->id = 'edit-shop_order';
-		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
-		apply_filters( 'woocommerce_shop_order_search_results', array( 'order_id1' ), 'term', array() );
+	public function test_orders_search( $hpos_enabled ) {
+		$this->toggle_cot_authoritative( $hpos_enabled );
+
+		$_REQUEST['s'] = 'term';
+		$this->setup_screen( 'list' );
+
+		do_action( 'load-edit.php' );
 
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_view_search' );
+	}
+
+	/**
+	 * Configure the screen as if it were the "list" orders screen.
+	 */
+	private function setup_screen() {
+		$GLOBALS['current_screen']->post_type = 'shop_order';
+		$GLOBALS['current_screen']->base      = 'edit';
+		$_GET['action']                       = '';
+
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$GLOBALS['pagenow']     = 'admin.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$GLOBALS['plugin_page'] = 'wc-orders'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+			add_filter( 'map_meta_cap', array( $this, 'allow_edit_shop_orders' ), 10, 3 );
+			wc_get_container()->get( PageController::class )->setup();
+			remove_filter( 'map_meta_cap', array( $this, 'allow_edit_shop_orders' ), 10 );
+		}
+	}
+
+	/**
+	 * Returns an object mocking what we need from `\WP_Screen`.
+	 *
+	 * @return object
+	 */
+	private function get_screen_mock() {
+		$screen_mock = $this->getMockBuilder( stdClass::class )->setMethods( array( 'in_admin', 'add_option' ) )->getMock();
+		$screen_mock->method( 'in_admin' )->willReturn( true );
+		foreach ( array( 'id', 'base', 'action', 'post_type' ) as $key ) {
+			$screen_mock->{$key} = '';
+		}
+
+		return $screen_mock;
+	}
+
+	/**
+	 * Used to temporarily grant the current user the 'edit_shop_orders' permission.
+	 *
+	 * @param string[] $caps     Primitive capabilities required for the user.
+	 * @param string   $cap      Capability being checked.
+	 * @param int      $user_id  The user ID.
+	 * @return array
+	 */
+	public function allow_edit_shop_orders( $caps, $cap, $user_id ) {
+		return ( 0 === $user_id && 'edit_shop_orders' === $cap ) ? array() : $caps;
 	}
 
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR updates tracking code that was still relying only on screen IDs or hooks that are only available when we're using the posts datastore for orders.

It also reworks some of the unit tests to run with HPOS enabled and disabled.

Closes #38886.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Drop [this snippet](https://gist.githubusercontent.com/jorgeatorres/cd450223c16321b54ac752f0d6891dd7/raw/65671d942df949259dde3b0c6b14d8b58f001c26/capture-tracks.php) in `wp-content/mu-plugins`. It's designed to help us test that Tracks events are correctly being registered without actually contacting the Tracks endpoint. It'll dump any Tracks event to a `tracks-events` log file.
2. Go to WC > Settings > Advanced > Woo.com and make sure that "Allow usage of WooCommerce to be tracked" is checked.
3. Go to WC > Settings > Advanced > Features and make sure HPOS is chosen as datastore.
   I'd suggest sync is enabled too as that would make testing easier when datastores need to be switched.
4. Make sure your site has a few orders (or create some if necessary).
5. Perform each of the actions in the table below and for each one, confirm that the log file in `tracks-events-<date>-...` in WC > Status > Logs includes an entry with the Tracks event name.

   |Action|Tracks Event|
   |------|------------|
   |Visit WC > Orders|`wcadmin_orders_view`|
   |Perform a search on WC > Orders|`wcadmin_orders_view_search`|
   |Change the status of an order|`wcadmin_orders_edit_status_change`|
   |Change "date created" on an order|`wcadmin_order_edit_date_created`|
   |Perform an "order action" from the order actions metabox (order edit screen)|`wcadmin_order_edit_order_action`|
   |While editing an existing order, click "Add Order" at the top of the page|`wc_adminorder_edit_add_order`|

   These are not the only events captured, so you might need to do a search to find the ones you need.
   For example, after using the "Resend new order notification" action on an order, you might find an entry like this in the log file:
  
   > 12-20-2023 @ 16:30:09 - **wcadmin_order_edit_order_action** {"order_id":"8434","status":"completed","action":"send_order_details_admin" ...
6. Go to WC > Settings > Advanced > Features and switch the datastore to posts.
7. Repeat step 5.
8. Don't forget to remove the mu-plugin and disable tracking if you had it disabled.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
