### PR TITLE
[Product Block Editor]: do not use sub registry for the IFrame editor

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-access-to-editor-data-store
+++ b/packages/js/product-editor/changelog/update-product-editor-access-to-editor-data-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: do not use sub registry for the IFrame editor

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -139,7 +139,7 @@ export function IframeEditor( {
 						setTemporalBlocks( updatedBlocks );
 						onInput( updatedBlocks );
 					} }
-					useSubRegistry={ true }
+					useSubRegistry={ false }
 				>
 					<HeaderToolbar
 						onSave={ () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR sets the `useSubRegistry` to `false` to avoid using a sub-registry in the `<BlockEditorProvider>` instance of the IFrame editor, keeping in mind that both editor instances cannot coexist simultaneously. The goal is to be able to access to the data globally though the select helpers.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To access the Product Editor, follow these steps:

1. Open the dev console
2. Go to the Product Editor

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/e5461692-f920-4d17-a0a9-b9a09b1ae474">


3. From the store, select the current block instances of the editor

```js
wp.data.select( 'core/block-editor').getBlocks()
```

4. Confirm that the block instances are returned.

<img width="662" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/5a59fc7a-abf4-402f-901e-68589add7a38">

To edit the `description` field using the Modal editor (IFrame editor wrapper), do the following:

5. Open the Modal editor.

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/ea3991f9-8378-4aad-9522-7849bf63ff32">

6. Choose the block instances.
```js
wp.data.select( 'core/block-editor').getBlocks()
```

7. Make sure that the instances you see correspond to the Modal editor and not to the Product editor.

<img width="670" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/30e1cf6d-a5c1-443b-900c-97095db873ee">

8. Close the Modal editor
9. Confirm the app continues working as expected

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
