### PR TITLE
Navigation: Change error_log call to doing_it_wrong

### DIFF
--- a/plugins/woocommerce/changelog/update-navigation-unit-test-error
+++ b/plugins/woocommerce/changelog/update-navigation-unit-test-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: All this does is fix an error message output during unit testing
+
+

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Menu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Menu.php
@@ -223,13 +223,16 @@ class Menu {
 		}
 
 		if ( isset( self::$menu_items[ $args['id'] ] ) ) {
-			error_log(  // phpcs:ignore
+			wc_doing_it_wrong(
+				__METHOD__,
 				sprintf(
 					/* translators: 1: Duplicate menu item path. */
 					esc_html__( 'You have attempted to register a duplicate item with WooCommerce Navigation: %1$s', 'woocommerce' ),
 					'`' . $args['id'] . '`'
-				)
+				),
+				'6.5.0'
 			);
+
 			return;
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/navigation/class-wc-menu.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/navigation/class-wc-menu.php
@@ -99,7 +99,7 @@ class WC_Admin_Tests_Navigation_Menu extends WC_Unit_Test_Case {
 	/**
 	 * Test adding an existing menu ID.
 	 */
-	public function test_add_dupliacte_plugin_items() {
+	public function test_add_duplicate_plugin_items() {
 		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item' );
 
 		$item = array(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/navigation/class-wc-menu.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/navigation/class-wc-menu.php
@@ -100,6 +100,8 @@ class WC_Admin_Tests_Navigation_Menu extends WC_Unit_Test_Case {
 	 * Test adding an existing menu ID.
 	 */
 	public function test_add_dupliacte_plugin_items() {
+		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item' );
+
 		$item = array(
 			'id'         => 'test-duplicate-item',
 			'title'      => 'Test Duplicate Item',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There's a unit test that specifically creates the conditions that cause this particular error to get triggered. Unfortunately, this makes the error message get output in the middle of the unit tests, like this:

```php
 ............................................................. 1952 / 3898 ( 50%)
[16-Dec-2023 00:36:53 UTC] You have attempted to register a duplicate item with WooCommerce Navigation: `test-duplicate-item`
.....................................S....................... 2013 / 3898 ( 51%)
```

This changes the `error_log` call to `wc_doing_it_wrong`, which uses WP Core's `_doing_it_wrong` function, which makes it so that the error only gets output when WP_DEBUG is enabled. It also updates the unit test to expect that `doing_it_wrong` will be called.

### How to test the changes in this Pull Request:

Check and see if the error message is still happening in the unit test output during the CI run.
