### PR TITLE
Move action button ( reorder and add products ) inline with the section header

### DIFF
--- a/packages/js/product-editor/changelog/add-42849
+++ b/packages/js/product-editor/changelog/add-42849
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Move action button ( reorder and add products ) inline with the section header

--- a/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
@@ -23,6 +23,7 @@ export function SectionDescriptionBlockEdit( {
 			{ ...blockProps }
 			name="section-description"
 			clientId={ clientId }
+			slotContainerBlockName="woocommerce/product-section"
 		>
 			<div>{ content }</div>
 		</BlockFill>

--- a/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { Fill } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
+import { BlockFill } from '../../../components/block-slot-fill';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { SectionDescriptionBlockAttributes } from './types';
 
@@ -19,19 +18,13 @@ export function SectionDescriptionBlockEdit( {
 	const { content } = attributes;
 	const blockProps = useWooBlockProps( attributes );
 
-	const rootClientId = useSelect(
-		( select ) => {
-			const { getBlockRootClientId } = select( 'core/block-editor' );
-			return getBlockRootClientId( clientId );
-		},
-		[ clientId ]
-	);
-
-	if ( ! rootClientId ) return;
-
 	return (
-		<Fill { ...blockProps } name={ rootClientId }>
+		<BlockFill
+			{ ...blockProps }
+			name="section-description"
+			clientId={ clientId }
+		>
 			<div>{ content }</div>
-		</Fill>
+		</BlockFill>
 	);
 }

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -15,6 +15,7 @@ import {
 /**
  * Internal dependencies
  */
+import { BlockSlot } from '../../../components/block-slot-fill';
 import { sanitizeHTML } from '../../../utils/sanitize-html';
 import { SectionBlockAttributes } from './types';
 import { ProductEditorBlockEditProps } from '../../../types';
@@ -43,27 +44,34 @@ export function SectionBlockEdit( {
 		<SectionTagName { ...blockProps }>
 			{ title && (
 				<HeadingTagName className="wp-block-woocommerce-product-section__heading">
-					<h2 className="wp-block-woocommerce-product-section__heading-title">
-						{ title }
-						{ description && (
-							<Tooltip
-								className={ tooltipClassName }
-								text={
-									<p
-										className="wp-block-woocommerce-product-section__heading-description"
-										dangerouslySetInnerHTML={ sanitizeHTML(
-											description
-										) }
-									/>
-								}
-								position={ 'bottom center' }
-								helperText={ __(
-									'View helper text',
-									'woocommerce'
-								) }
-							/>
-						) }
-					</h2>
+					<div className="wp-block-woocommerce-product-section__heading-title-wrapper">
+						<h2 className="wp-block-woocommerce-product-section__heading-title">
+							{ title }
+							{ description && (
+								<Tooltip
+									className={ tooltipClassName }
+									text={
+										<p
+											className="wp-block-woocommerce-product-section__heading-description"
+											dangerouslySetInnerHTML={ sanitizeHTML(
+												description
+											) }
+										/>
+									}
+									position={ 'bottom center' }
+									helperText={ __(
+										'View helper text',
+										'woocommerce'
+									) }
+								/>
+							) }
+						</h2>
+
+						<BlockSlot
+							name="section-actions"
+							clientId={ clientId }
+						/>
+					</div>
 
 					<Slot name={ clientId } />
 				</HeadingTagName>

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { Slot } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useWooBlockProps } from '@woocommerce/block-templates';
@@ -73,7 +72,10 @@ export function SectionBlockEdit( {
 						/>
 					</div>
 
-					<Slot name={ clientId } />
+					<BlockSlot
+						name="section-description"
+						clientId={ clientId }
+					/>
 				</HeadingTagName>
 			) }
 

--- a/packages/js/product-editor/src/blocks/generic/section/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/section/editor.scss
@@ -16,7 +16,14 @@
 		margin: 0 0 calc(2 * $gap) 0;
 		width: 100%;
 
-		.wp-block-woocommerce-product-section__heading-title {
+		&-title-wrapper {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: $grid-unit-20;
+		}
+
+		&-title {
 			margin: 0;
 			font-size: 20px;
 			font-weight: 500;

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
@@ -26,6 +26,7 @@ import {
 	getProductImageStyle,
 	ReorderProductsModal,
 } from '../../../components/add-products-modal';
+import { BlockFill } from '../../../components/block-slot-fill';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { Shirt, Pants, Glasses } from './images';
 import { UploadsBlockAttributes } from './types';
@@ -37,6 +38,7 @@ import {
 export function Edit( {
 	attributes,
 	context: { postType },
+	clientId,
 }: ProductEditorBlockEditProps< UploadsBlockAttributes > ) {
 	const { property } = attributes;
 	const blockProps = useWooBlockProps( attributes );
@@ -120,22 +122,24 @@ export function Edit( {
 
 	return (
 		<div { ...blockProps }>
-			<div className="wp-block-woocommerce-product-list-field__header">
-				{ ! isLoading && groupedProducts.length > 0 && (
+			<BlockFill name="section-actions" clientId={ clientId }>
+				<div className="wp-block-woocommerce-product-list-field__header">
+					{ ! isLoading && groupedProducts.length > 0 && (
+						<Button
+							onClick={ handleReorderProductsButtonClick }
+							variant="tertiary"
+						>
+							{ __( 'Reorder', 'woocommerce' ) }
+						</Button>
+					) }
 					<Button
-						onClick={ handleReorderProductsButtonClick }
-						variant="tertiary"
+						onClick={ handleAddProductsButtonClick }
+						variant="secondary"
 					>
-						{ __( 'Reorder', 'woocommerce' ) }
+						{ __( 'Add products', 'woocommerce' ) }
 					</Button>
-				) }
-				<Button
-					onClick={ handleAddProductsButtonClick }
-					variant="secondary"
-				>
-					{ __( 'Add products', 'woocommerce' ) }
-				</Button>
-			</div>
+				</div>
+			</BlockFill>
 
 			<div className="wp-block-woocommerce-product-list-field__body">
 				{ ! isLoading && groupedProducts.length === 0 && (

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
@@ -122,7 +122,11 @@ export function Edit( {
 
 	return (
 		<div { ...blockProps }>
-			<BlockFill name="section-actions" clientId={ clientId }>
+			<BlockFill
+				name="section-actions"
+				clientId={ clientId }
+				slotContainerBlockName="woocommerce/product-section"
+			>
 				<div className="wp-block-woocommerce-product-list-field__header">
 					{ ! isLoading && groupedProducts.length > 0 && (
 						<Button

--- a/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { Fill } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getName } from './utils/get-name';
+import { BlockFillProps } from './types';
+
+export function BlockFill( { name, clientId, ...props }: BlockFillProps ) {
+	const rootClientId = useSelect(
+		( select ) => {
+			const { getBlockRootClientId } = select( 'core/block-editor' );
+			return getBlockRootClientId( clientId );
+		},
+		[ clientId ]
+	);
+
+	if ( ! rootClientId ) return null;
+
+	return <Fill { ...props } name={ getName( name, rootClientId ) } />;
+}

--- a/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
@@ -11,16 +11,32 @@ import { createElement } from '@wordpress/element';
 import { getName } from './utils/get-name';
 import { BlockFillProps } from './types';
 
-export function BlockFill( { name, clientId, ...props }: BlockFillProps ) {
-	const rootClientId = useSelect(
+export function BlockFill( {
+	name,
+	clientId,
+	slotContainerBlockName,
+	...props
+}: BlockFillProps ) {
+	const closestAncestorClientId = useSelect(
 		( select ) => {
-			const { getBlockRootClientId } = select( 'core/block-editor' );
-			return getBlockRootClientId( clientId );
+			// @ts-expect-error Outdated type definition.
+			const { getBlockParentsByBlockName } =
+				select( 'core/block-editor' );
+
+			const [ closestParentClientId ] = getBlockParentsByBlockName(
+				clientId,
+				slotContainerBlockName,
+				true
+			);
+
+			return closestParentClientId;
 		},
-		[ clientId ]
+		[ clientId, slotContainerBlockName ]
 	);
 
-	if ( ! rootClientId ) return null;
+	if ( ! closestAncestorClientId ) return null;
 
-	return <Fill { ...props } name={ getName( name, rootClientId ) } />;
+	return (
+		<Fill { ...props } name={ getName( name, closestAncestorClientId ) } />
+	);
 }

--- a/packages/js/product-editor/src/components/block-slot-fill/block-slot.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-slot.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { Slot } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getName } from './utils/get-name';
+import { BlockSlotProps } from './types';
+
+export function BlockSlot( { name, clientId, ...props }: BlockSlotProps ) {
+	return <Slot { ...props } name={ getName( name, clientId ) } />;
+}

--- a/packages/js/product-editor/src/components/block-slot-fill/index.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/index.ts
@@ -1,0 +1,3 @@
+export * from './block-fill';
+export * from './block-slot';
+export * from './types';

--- a/packages/js/product-editor/src/components/block-slot-fill/types.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/types.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { Fill, Slot } from '@wordpress/components';
+
+export type BlockSlotFillProps = {
+	clientId: string;
+	name: string;
+};
+
+export type BlockSlotProps = BlockSlotFillProps & Slot.Props;
+
+export type BlockFillProps = BlockSlotFillProps & Fill.Props;

--- a/packages/js/product-editor/src/components/block-slot-fill/types.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/types.ts
@@ -10,4 +10,7 @@ export type BlockSlotFillProps = {
 
 export type BlockSlotProps = BlockSlotFillProps & Slot.Props;
 
-export type BlockFillProps = BlockSlotFillProps & Fill.Props;
+export type BlockFillProps = BlockSlotFillProps &
+	Fill.Props & {
+		slotContainerBlockName: string;
+	};

--- a/packages/js/product-editor/src/components/block-slot-fill/utils/get-name.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/utils/get-name.ts
@@ -1,0 +1,3 @@
+export function getName( name: string, clientId: string ) {
+	return `${ name }-${ clientId }`;
+}

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -56,3 +56,10 @@ export {
 	AddProductsModal as __experimentalAddProductsModal,
 	AddProductsModalProps,
 } from './add-products-modal';
+
+export {
+	BlockFill as __experimentalBlockFill,
+	BlockSlot as __experimentalBlockSlot,
+	BlockFillProps,
+	BlockSlotProps,
+} from './block-slot-fill';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42849

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a `Grouped` product from the classic editor
2. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Make sure feature `product-grouped` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
4. If you try to edit the product created in point 1 you should be redirected to the new product editor.
5. From there under the `General` tab, a new `Products in this group` section the action buttons should be shown to the right of the section title and not below. 
<img width="675" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/09b4b20e-5ae3-4749-9dd3-9703ad37843a">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
