### PR TITLE
Tweak Order Attribution meta data and Tracks data

### DIFF
--- a/plugins/woocommerce/changelog/add-order-attribution-changes
+++ b/plugins/woocommerce/changelog/add-order-attribution-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Tweaks to order attribution meta data and Tracks data.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -238,7 +238,7 @@ class Edit {
 		add_meta_box(
 			'woocommerce-order-source-data',
 			/* Translators: %s order type name. */
-			sprintf( __( '%s information', 'woocommerce' ), $title ),
+			sprintf( __( '%s attribution', 'woocommerce' ), $title ),
 			function( $post_or_order ) use ( $order_attribution_meta_box ) {
 				$order = $post_or_order instanceof WC_Order ? $post_or_order : wc_get_order( $post_or_order );
 				if ( $order instanceof WC_Order ) {

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -394,13 +394,14 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 * @return void
 	 */
 	private function send_order_tracks( array $source_data, WC_Order $order ) {
-		$origin_label  = $this->get_origin_label(
+		$origin_label        = $this->get_origin_label(
 			$source_data['type'] ?? '',
 			$source_data['utm_source'] ?? '',
 			false
 		);
-		$customer_info = $this->get_customer_history( $order->get_customer_id() ?: $order->get_billing_email() );
-		$tracks_data   = array(
+		$customer_identifier = $order->get_customer_id() ? $order->get_customer_id() : $order->get_billing_email();
+		$customer_info       = $this->get_customer_history( $customer_identifier );
+		$tracks_data         = array(
 			'order_id'             => $order->get_id(),
 			'type'                 => $source_data['type'] ?? '',
 			'medium'               => $source_data['utm_medium'] ?? '',

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -176,7 +176,6 @@ class OrderAttributionController implements RegisterHooksInterface {
 	private function maybe_set_admin_source( WC_Order $order ) {
 		if ( function_exists( 'is_admin' ) && is_admin() ) {
 			$order->add_meta_data( $this->get_meta_prefixed_field( 'type' ), 'admin' );
-			$order->add_meta_data( $this->get_meta_prefixed_field( 'origin' ), 'Web admin' );
 			$order->save();
 		}
 	}
@@ -300,7 +299,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Output the data for the Origin column in the orders table.
+	 * Output the translated origin label for the Origin column in the orders table.
 	 *
 	 * Default to "Unknown" if no origin is set.
 	 *
@@ -309,7 +308,9 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 * @return void
 	 */
 	private function output_origin_column( WC_Order $order ) {
-		$origin = $order->get_meta( $this->get_meta_prefixed_field( 'origin' ) );
+		$source_type = $order->get_meta( $this->get_meta_prefixed_field( 'type' ) );
+		$source      = $order->get_meta( $this->get_meta_prefixed_field( 'utm_source' ) );
+		$origin      = $this->get_origin_label( $source_type, $source );
 		if ( empty( $origin ) ) {
 			$origin = __( 'Unknown', 'woocommerce' );
 		}
@@ -398,7 +399,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 			$source_data['utm_source'] ?? '',
 			false
 		);
-		$tracks_data   = array(
+		$tracks_data  = array(
 			'order_id'             => $order->get_id(),
 			'type'                 => $source_data['type'] ?? '',
 			'medium'               => $source_data['utm_medium'] ?? '',

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -394,12 +394,13 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 * @return void
 	 */
 	private function send_order_tracks( array $source_data, WC_Order $order ) {
-		$origin_label = $this->get_origin_label(
+		$origin_label  = $this->get_origin_label(
 			$source_data['type'] ?? '',
 			$source_data['utm_source'] ?? '',
 			false
 		);
-		$tracks_data  = array(
+		$customer_info = $this->get_customer_history( $order->get_customer_id() ?: $order->get_billing_email() );
+		$tracks_data   = array(
 			'order_id'             => $order->get_id(),
 			'type'                 => $source_data['type'] ?? '',
 			'medium'               => $source_data['utm_medium'] ?? '',
@@ -409,7 +410,8 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'session_pages'        => $source_data['session_pages'] ?? 0,
 			'session_count'        => $source_data['session_count'] ?? 0,
 			'order_total'          => $order->get_total(),
-			'customer_order_count' => wc_get_customer_order_count( $order->get_customer_id() ),
+			'customer_order_count' => $customer_info['order_count'],
+			'customer_registered'  => $order->get_customer_id() ? 'yes' : 'no',
 		);
 		$this->proxy->call_static( WC_Tracks::class, 'record_event', 'order_attribution', $tracks_data );
 	}

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -155,6 +155,30 @@ class OrderAttributionController implements RegisterHooksInterface {
 				$this->register_order_origin_column();
 			}
 		);
+
+		add_action(
+			'woocommerce_new_order',
+			function( $order_id, $order ) {
+				$this->maybe_set_admin_source( $order );
+			},
+			2,
+			10
+		);
+	}
+
+	/**
+	 * If the order is created in the admin, set the source type and origin to admin/Web admin.
+	 *
+	 * @param WC_Order $order The recently created order object.
+	 *
+	 * @since 8.5.0
+	 */
+	private function maybe_set_admin_source( WC_Order $order ) {
+		if ( function_exists( 'is_admin' ) && is_admin() ) {
+			$order->add_meta_data( $this->get_meta_prefixed_field( 'type' ), 'admin' );
+			$order->add_meta_data( $this->get_meta_prefixed_field( 'origin' ), 'Web admin' );
+			$order->save();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -393,13 +393,18 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 * @return void
 	 */
 	private function send_order_tracks( array $source_data, WC_Order $order ) {
-		$tracks_data = array(
+		$origin_label = $this->get_origin_label(
+			$source_data['type'] ?? '',
+			$source_data['utm_source'] ?? '',
+			false
+		);
+		$tracks_data   = array(
 			'order_id'             => $order->get_id(),
 			'type'                 => $source_data['type'] ?? '',
 			'medium'               => $source_data['utm_medium'] ?? '',
 			'source'               => $source_data['utm_source'] ?? '',
-			'origin'               => strtolower( $source_data['origin'] ?? '' ),
 			'device_type'          => strtolower( $source_data['device_type'] ?? '(unknown)' ),
+			'origin_label'         => $origin_label,
 			'session_pages'        => $source_data['session_pages'] ?? 0,
 			'session_count'        => $source_data['session_count'] ?? 0,
 			'order_total'          => $order->get_total(),

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -405,7 +405,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'medium'               => $source_data['utm_medium'] ?? '',
 			'source'               => $source_data['utm_source'] ?? '',
 			'device_type'          => strtolower( $source_data['device_type'] ?? '(unknown)' ),
-			'origin_label'         => $origin_label,
+			'origin_label'         => strtolower( $origin_label ),
 			'session_pages'        => $source_data['session_pages'] ?? 0,
 			'session_count'        => $source_data['session_count'] ?? 0,
 			'order_total'          => $order->get_total(),

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -302,17 +302,18 @@ class OrderAttributionController implements RegisterHooksInterface {
 	/**
 	 * Output the data for the Origin column in the orders table.
 	 *
+	 * Default to "Unknown" if no origin is set.
+	 *
 	 * @param WC_Order $order The order object.
 	 *
 	 * @return void
 	 */
 	private function output_origin_column( WC_Order $order ) {
-		$source_type = $order->get_meta( $this->get_meta_prefixed_field( 'type' ) );
-		$source      = $order->get_meta( $this->get_meta_prefixed_field( 'utm_source' ) );
-		if ( ! $source ) {
-			$source = __( '(none)', 'woocommerce' );
+		$origin = $order->get_meta( $this->get_meta_prefixed_field( 'origin' ) );
+		if ( empty( $origin ) ) {
+			$origin = __( 'Unknown', 'woocommerce' );
 		}
-		echo esc_html( $this->get_origin_label( $source_type, $source ) );
+		echo esc_html( $origin );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -397,13 +397,13 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'type'                 => $source_data['type'] ?? '',
 			'medium'               => $source_data['utm_medium'] ?? '',
 			'source'               => $source_data['utm_source'] ?? '',
+			'origin'               => strtolower( $source_data['origin'] ?? '' ),
 			'device_type'          => strtolower( $source_data['device_type'] ?? '(unknown)' ),
 			'session_pages'        => $source_data['session_pages'] ?? 0,
 			'session_count'        => $source_data['session_count'] ?? 0,
 			'order_total'          => $order->get_total(),
 			'customer_order_count' => wc_get_customer_order_count( $order->get_customer_id() ),
 		);
-
 		$this->proxy->call_static( WC_Tracks::class, 'record_event', 'order_attribution', $tracks_data );
 	}
 

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -405,15 +405,10 @@ trait OrderAttributionMeta {
 		$orders = wc_get_orders( $args );
 
 		// Populate the order_count and total_spent variables with the valid orders.
-		$order_count = 0;
+		$order_count = count( $orders );
 		$total_spent = 0;
 		foreach ( $orders as $order ) {
-			$order_total = $order->get_total() - $order->get_total_refunded();
-			
-			if ( $order_total ) {
-				$order_count++;
-				$total_spent += $order_total;
-			}
+			$total_spent += $order->get_total() - $order->get_total_refunded();
 		}
 
 		return array(

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -108,7 +108,9 @@ trait OrderAttributionMeta {
 	}
 
 	/**
-	 * Filter the meta data to only the keys that we care about.
+	 * Filter an order's meta data to only the keys that we care about.
+	 *
+	 * Sets the origin value based on the source type.
 	 *
 	 * @param WC_Meta_Data[] $meta The meta data.
 	 *
@@ -142,6 +144,10 @@ trait OrderAttributionMeta {
 
 			case 'typein':
 				$origin = __( 'Direct', 'woocommerce' );
+				break;
+
+			case 'admin':
+				$origin = __( 'Web admin', 'woocommerce' );
 				break;
 
 			default:

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -316,12 +316,14 @@ trait OrderAttributionMeta {
 					: 'Referral: %s';
 				break;
 			case 'typein':
-				$label = $translated ?
+				$label  = '';
+				$source = $translated ?
 					__( 'Direct', 'woocommerce' )
 					: 'Direct';
 				break;
 			case 'admin':
-				$label = $translated ?
+				$label  = '';
+				$source = $translated ?
 					__( 'Web admin', 'woocommerce' )
 					: 'Web admin';
 				break;

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -308,7 +308,8 @@ trait OrderAttributionMeta {
 				break;
 
 			default:
-				$label = '';
+				$label  = '';
+				$source = __( 'Unknown', 'woocommerce' );
 				break;
 		}
 

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -281,11 +281,6 @@ trait OrderAttributionMeta {
 			$values['device_type'] = $this->get_device_type( $values );
 		}
 
-		// Set the origin label.
-		if ( array_key_exists( 'type', $values ) && array_key_exists( 'utm_source', $values ) ) {
-			$values['origin'] = $this->get_origin_label( $values['type'], $values['utm_source'] );
-		}
-
 		return $values;
 	}
 

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -389,7 +389,7 @@ trait OrderAttributionMeta {
 		$args = array(
 			'limit'  => - 1,
 			'return' => 'objects',
-			// Don't count cancelled, on-hold, or failed orders.
+			// Don't count cancelled or failed orders.
 			'status' => array( 'pending', 'processing', 'on-hold', 'completed', 'refunded' ),
 			'type'   => 'shop_order',
 		);

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -132,30 +132,9 @@ trait OrderAttributionMeta {
 		}
 
 		// Determine the origin based on source type and referrer.
-		$source_type = $return['type'] ?? '';
-		switch ( $source_type ) {
-			case 'organic':
-				$origin = __( 'Organic search', 'woocommerce' );
-				break;
-
-			case 'referral':
-				$origin = __( 'Referral', 'woocommerce' );
-				break;
-
-			case 'typein':
-				$origin = __( 'Direct', 'woocommerce' );
-				break;
-
-			case 'admin':
-				$origin = __( 'Web admin', 'woocommerce' );
-				break;
-
-			default:
-				$origin = __( 'Unknown', 'woocommerce' );
-				break;
-		}
-
-		$return['origin'] = $origin;
+		$source_type      = $return['type'] ?? '';
+		$source           = $return['utm_source'] ?? '';
+		$return['origin'] = $this->get_origin_label( $source_type, $source, true );
 
 		return $return;
 	}

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -429,12 +429,11 @@ trait OrderAttributionMeta {
 		$order_count = 0;
 		$total_spent = 0;
 		foreach ( $orders as $order ) {
-			$order_count ++;
-			$total_spent += $order->get_total();
-
-			// Remove any refunded amount from the total_spent.
-			foreach ( $order->get_refunds() as $refund ) {
-				$total_spent += $refund->get_total();
+			$order_total = $order->get_total() - $order->get_total_refunded();
+			
+			if ( $order_total ) {
+				$order_count++;
+				$total_spent += $order_total;
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -396,4 +396,52 @@ trait OrderAttributionMeta {
 		 */
 		return (string) apply_filters( 'wc_order_attribution_field_description', $description, $field );
 	}
+
+	/**
+	 * Get the order history for the customer (data matches Customers report).
+	 *
+	 * @param mixed $customer_identifier The customer ID or billing email.
+	 *
+	 * @return array Order count, total spend, and average spend per order.
+	 */
+	private function get_customer_history( $customer_identifier ): array {
+
+		// Get the valid customer orders.
+		$args = array(
+			'limit'  => - 1,
+			'return' => 'objects',
+			// Don't count cancelled, on-hold, or failed orders.
+			'status' => array( 'pending', 'processing', 'on-hold', 'completed', 'refunded' ),
+			'type'   => 'shop_order',
+		);
+
+		// If the customer_identifier is a valid ID, use it. Otherwise, use the billing email.
+		if ( is_numeric( $customer_identifier ) && $customer_identifier > 0 ) {
+			$args['customer_id'] = $customer_identifier;
+		} else {
+			$args['billing_email'] = $customer_identifier;
+			$args['customer_id']   = 0;
+		}
+
+		$orders = wc_get_orders( $args );
+
+		// Populate the order_count and total_spent variables with the valid orders.
+		$order_count = 0;
+		$total_spent = 0;
+		foreach ( $orders as $order ) {
+			$order_count ++;
+			$total_spent += $order->get_total();
+
+			// Remove any refunded amount from the total_spent.
+			foreach ( $order->get_refunds() as $refund ) {
+				$total_spent += $refund->get_total();
+			}
+		}
+
+		return array(
+			'order_count'   => $order_count,
+			'total_spent'   => $total_spent,
+			'average_spent' => $order_count ? $total_spent / $order_count : 0,
+		);
+	}
 }

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -290,27 +290,45 @@ trait OrderAttributionMeta {
 	}
 
 	/**
-	 * Get the label for the order origin
+	 * Get the label for the Order origin with placeholder where appropriate. Can be
+	 * translated (for DB / display) or untranslated (for Tracks).
 	 *
 	 * @param string $source_type The source type.
 	 * @param string $source      The source.
+	 * @param bool   $translated  Whether the label should be translated.
 	 *
 	 * @return string
 	 */
-	private function get_origin_label( string $source_type, string $source ): string {
+	private function get_origin_label( string $source_type, string $source, bool $translated = true ): string {
 		// Set up the label based on the source type.
 		switch ( $source_type ) {
 			case 'utm':
-				/* translators: %s is the source value */
-				$label = __( 'Source: %s', 'woocommerce' );
+				$label = $translated ?
+					/* translators: %s is the source value */
+					__( 'Source: %s', 'woocommerce' )
+					: 'Source: %s';
 				break;
 			case 'organic':
-				/* translators: %s is the source value */
-				$label = __( 'Organic: %s', 'woocommerce' );
+				$label = $translated ?
+					/* translators: %s is the source value */
+					__( 'Organic: %s', 'woocommerce' )
+					: 'Organic: %s';
 				break;
 			case 'referral':
-				/* translators: %s is the source value */
-				$label = __( 'Referral: %s', 'woocommerce' );
+				$label = $translated ?
+					/* translators: %s is the source value */
+					__( 'Referral: %s', 'woocommerce' )
+					: 'Referral: %s';
+				break;
+			case 'typein':
+				$label = $translated ?
+					__( 'Direct', 'woocommerce' )
+					: 'Direct';
+				break;
+			case 'admin':
+				$label = $translated ?
+					__( 'Web admin', 'woocommerce' )
+					: 'Web admin';
 				break;
 
 			default:

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
@@ -112,7 +112,7 @@ class OrderAttributionTest extends WP_UnitTestCase {
 		add_action(
 			'woocommerce_before_template_part',
 			function( $template_name, $template_path, $located, $args ) {
-				$this->assertEquals( 'Referral', $args['meta']['origin'] ?? '' );
+				$this->assertEquals( 'Referral: Woocommerce.com', $args['meta']['origin'] ?? '' );
 				$this->assertEquals( 'Desktop', $args['meta']['device_type'] ?? '' );
 				$this->assertEquals(
 					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderAttributionControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderAttributionControllerTest.php
@@ -85,7 +85,7 @@ class OrderAttributionControllerTest extends WP_UnitTestCase {
 			array(
 				'source_type'     => '',
 				'source'          => '',
-				'expected_output' => 'None',
+				'expected_output' => 'Unknown',
 			),
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR continues the work done in #39701 by making some modifications to the format of the meta data and Tracks data:
1. The `customer_order_count` Tracks value now matches number in the Customer report and Customer history metabox.
2. Tracks includes the `customer_registered` and `origin_label` fields as well.
3. Orders created from the Add Order admin page will have the Origin "Web admin" in the orders table and Order information box. 
4. Origin information is store in metadata untranslated, and then translated before display on the Orders table and Order information metabox.
5. The Origin label (`Referral: facebook.com`, `Organic: Google`, etc.) is no longer stored as a generated meta key because it isn't translatable. Instead, the value is generated on the fly for the Tracks event and for display on the Orders table and Edit Order pages.
6. Order table shows `Unknown` instead of `None` if no order attribution data was recorded.
7. Updates the title of the main Order meta box from "Order information" to "Order attribution"

_Translation_
![image](https://github.com/woocommerce/woocommerce/assets/228780/b0c5efb1-0963-4b4d-915a-ff9c044e63e5)

![image](https://github.com/woocommerce/woocommerce/assets/228780/99aaac7e-7b87-458c-94d3-57ab82225aa0)



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up the WooCommerce store in English. Add a debug line in `OrderAttributinController:send_order_tracks()` to capture the tracks sent.
2. Create several orders: typein, referral (dev tools to edit a URL on Facebook.com to point to the store), organic (ditto Google or Bing) and UTM (<https://utmbuilder.net/> works well). Some with an existing user, and some without registering. 
4. Confirm that the Tracks information looks correct:
    5. Correct values 
    8. Non-translated, lowercase values
    9. Correct order count and customer registration info
    10. Correct origin label
11. Create a new order from the WooCommerce admin.
12. Review order meta data to confirm that it's untranslated and lowercase 
    ```
    SELECT * FROM `wp_wc_orders_meta` WHERE meta_key like '_wc_order_attribution%';
    SELECT * FROM `wp_postmeta` WHERE meta_key like '_wc_order_attribution%';
    ```
4. Confirm that the values on the Orders table look correct (Referral: Facebook, Direct, etc).
5. Confirm that the values in the Edit Order meta box look correct.
6. Change the site language to Spanish, download the WooCommerce language file and add these lines to the file `wp-content/languages/plugins/woocommerce-es_ES.po`:

<details>
    <summary>Translations</summary>

```
msgid "Direct"
msgstr "Directo"

msgid "Referral: %s"
msgstr "Referencia: %s"

msgid "Organic: %s"
msgstr "Orgánico: %s"

msgid "Origin"
msgstr "Orígen"

msgid "Source: %s"
msgstr "Fuente: %s"

msgid "Web admin"
msgstr "Admon Web"

msgid "Session page views"
msgstr "Visitas en la sesión"

msgid "Customer history"
msgstr "Historial del Cliente"

msgid "%s attribution"
msgstr "Atribución del %s"

msgid "Device type"
msgstr "Dispositivo"

msgid "Source type"
msgstr "Tipo de fuente"

msgid "UTM campaign"
msgstr "Campaña UTM"

msgid "UTM source"
msgstr "Fuente UTM"

msgid "UTM medium"
msgstr "Medio UTM"

msgid "Desktop"
msgstr "Sobremesa"

msgid "Show details"
msgstr "Más detalle"

msgid "Hide details"
msgstr "Menos detalle"

msgid "Total orders"
msgstr "Nº pedidos"

msgid "Total revenue"
msgstr "Ingresos totales"

msgid "Average order value"
msgstr "Valor promedio de pedidos"
```

</details>

9. Update the `.mo` file by running `msgfmt -o woocommerce-es_ES.mo woocommerce-es_ES.po`.
8. Refresh the Orders Table and confirm that the translated values appear correctly (if any are missing, check to see if they're in the translations file).
9. Place a few more orders from different sources.
13. Confirm that the values in Tracks and metadata are untranslated.
14. Confirm that the values in Orders edit and Orders table are translated (both newly created and the old orders).
15. Revert site language to English, and check that Orders Edit and Orders table go back to English.

**Bonus** 
- Repeat with Checkout blocks.
- Repeat with HPOS disabled.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
