### PR TITLE
Analytics: add `date_type` parameter to override date type option for revenue stats

### DIFF
--- a/plugins/woocommerce/changelog/add-date-type-param-to-revenue-stats-endpoint
+++ b/plugins/woocommerce/changelog/add-date-type-param-to-revenue-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add date_type parameter to analytics revenue stats endpoint

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -307,7 +307,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( isset( $query_args['date_type'] ) ) {
 			$date_type          = $query_args['date_type'];
 			$allowed_date_types = array( 'date_paid', 'date_created', 'date_completed' );
-			if ( in_array( $date_type, $allowed_date_types ) ) {
+			if ( in_array( $date_type, $allowed_date_types, true ) ) {
 				$this->date_column_name = $date_type;
 			}
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -305,11 +305,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$data      = $this->get_cached_data( $cache_key );
 
 		if ( isset( $query_args['date_type'] ) ) {
-			$date_type          = $query_args['date_type'];
-			$allowed_date_types = array( 'date_paid', 'date_created', 'date_completed' );
-			if ( in_array( $date_type, $allowed_date_types, true ) ) {
-				$this->date_column_name = $date_type;
-			}
+			$this->date_column_name = $query_args['date_type'];
 		}
 
 		if ( false === $data ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -304,6 +304,14 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$cache_key = $this->get_cache_key( $query_args );
 		$data      = $this->get_cached_data( $cache_key );
 
+		if (isset($query_args['date_type'])) {
+			$date_type = $query_args['date_type'];
+			$allowed_date_types = array('date_paid', 'date_created', 'date_completed');
+			if (in_array($date_type, $allowed_date_types)) {
+				$this->date_column_name = $date_type;
+			}
+		}
+
 		if ( false === $data ) {
 			$this->initialize_queries();
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -304,10 +304,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$cache_key = $this->get_cache_key( $query_args );
 		$data      = $this->get_cached_data( $cache_key );
 
-		if (isset($query_args['date_type'])) {
-			$date_type = $query_args['date_type'];
-			$allowed_date_types = array('date_paid', 'date_created', 'date_completed');
-			if (in_array($date_type, $allowed_date_types)) {
+		if ( isset( $query_args['date_type'] ) ) {
+			$date_type          = $query_args['date_type'];
+			$allowed_date_types = array( 'date_paid', 'date_created', 'date_completed' );
+			if ( in_array( $date_type, $allowed_date_types ) ) {
 				$this->date_column_name = $date_type;
 			}
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -54,7 +54,7 @@ class Controller extends GenericStatsController implements ExportableInterface {
 		$args['segmentby']           = $request['segmentby'];
 		$args['fields']              = $request['fields'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-		$args['date_type'] = $request['date_type'];
+		$args['date_type']           = $request['date_type'];
 
 		return $args;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -54,6 +54,7 @@ class Controller extends GenericStatsController implements ExportableInterface {
 		$args['segmentby']           = $request['segmentby'];
 		$args['fields']              = $request['fields'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
+		$args['date_type'] = $request['date_type'];
 
 		return $args;
 	}
@@ -265,6 +266,16 @@ class Controller extends GenericStatsController implements ExportableInterface {
 				'variation',
 				'coupon',
 				'customer_type', // new vs returning.
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['date_type']       = array(
+			'description'       => __( 'Override the "woocommerce_date_type" option that is used for the database date field considered for revenue reports.', 'woocommerce' ),
+			'type'              => 'string',
+			'enum'              => array(
+				'date_paid',
+				'date_created',
+				'date_completed',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-revenue-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-revenue-stats.php
@@ -134,4 +134,46 @@ class WC_Admin_Tests_API_Reports_Revenue_Stats extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'num_items_sold', $subtotals );
 		$this->assertArrayHasKey( 'segments', $subtotals );
 	}
+
+	/**
+	 * Test sending an invalid `date_type` parameter to fetch revenue stats.
+	 */
+	public function test_it_returns_400_error_when_date_type_param_is_invalid() {
+		// Given.
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'date_type' => 'random_type',
+			)
+		);
+
+		// When.
+		$response = rest_do_request( $request );
+
+		// Then.
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test sending a valid `date_type` parameter to fetch revenue stats.
+	 */
+	public function test_it_returns_200_when_date_type_param_is_valid() {
+		// Given.
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'date_type' => 'date_created',
+			)
+		);
+
+		// When.
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		// Then.
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $data ) );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-revenue-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-revenue-stats.php
@@ -161,19 +161,23 @@ class WC_Admin_Tests_API_Reports_Revenue_Stats extends WC_REST_Unit_Test_Case {
 	public function test_it_returns_200_when_date_type_param_is_valid() {
 		// Given.
 		wp_set_current_user( $this->user );
-		$request = new WP_REST_Request( 'GET', $this->endpoint );
-		$request->set_query_params(
-			array(
-				'date_type' => 'date_created',
-			)
-		);
+		$allowed_values = array( 'date_paid', 'date_created', 'date_completed' );
 
-		// When.
-		$response = rest_do_request( $request );
-		$data     = $response->get_data();
+		foreach ( $allowed_values as $allowed_value ) {
+			$request = new WP_REST_Request( 'GET', $this->endpoint );
+			$request->set_query_params(
+				array(
+					'date_type' => $allowed_value,
+				)
+			);
 
-		// Then.
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 2, count( $data ) );
+			// When.
+			$response = rest_do_request( $request );
+			$data     = $response->get_data();
+
+			// Then.
+			$this->assertEquals( 200, $response->get_status() );
+			$this->assertEquals( 2, count( $data ) );
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

API support for https://github.com/woocommerce/woocommerce-ios/issues/11496

#### Why

As described in pe5pgL-49w-p2, because mobile apps are displaying the revenue and product stats on the same analytics screen, when the revenue stats are fetched with the WC date type option (`date_paid` by default) that's different from the date column (`date_created`) used in product stats, the data could look inconsistent for orders completed on a different date from the creation date.

#### How

As the smallest backward-compatible change to make it work for mobile apps, we can add a new parameter `date_type` to the revenue stats endpoint to override `date_column_name` which is used for the query for date filters and [set to the WC option `woocommerce_date_type` by default](https://github.com/woocommerce/woocommerce/blob/ec9b7852f9ecfe98a0bce387eac7fb0c64eee61e/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php#L76) for order/revenue stats. This way, the client can always fetch the revenue stats with the same date column as for product stats `date_created`. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Prerequisite: in the store analytics settings `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fsettings`, `Date type` option is `Date paid`. The store has at least one order with at least one product, created on a different day, but the status is pending / not completed.

1. In core or mobile, mark the order in the prerequisite as paid (in core, you can go to the order page and update the order status to `Processing` or one of the statuses in the analytics settings > `Actionable statuses`. in mobile, tap `Collect Payment` > `Cash` > `Mark as paid`)
2. Make an API request to fetch revenue stats with the new `date_type=date_paid` parameter, e.g. `/wc-analytics/reports/revenue/stats?per_page=7&interval=day&after=2023-12-20T00:00:00&before=2023-12-20T23:59:59&force_cache_refresh=true&date_type=date_paid` --> it should include data from the fulfilled order, and the same as the response without the parameter `/wc-analytics/reports/revenue/stats?per_page=7&interval=day&after=2023-12-20T00:00:00&before=2023-12-20T23:59:59&force_cache_refresh=true`
3. Make an API request to fetch revenue stats with `date_type=date_created` parameter, e.g. `/wc-analytics/reports/revenue/stats?per_page=7&interval=day&after=2023-12-20T00:00:00&before=2023-12-20T23:59:59&force_cache_refresh=true&date_type=date_created` --> it should **not** include data from the fulfilled order
4. Make an API request to fetch revenue stats with `date_type=date_created` parameter, e.g. `/wc-analytics/reports/revenue/stats?per_page=7&interval=day&after=2023-12-01T00:00:00&before=2023-12-01T23:59:59&force_cache_refresh=true&date_type=date_created` assuming the order was created on Dec 1 --> it should include data from the fulfilled order

- [ ] @jaclync tests that the new parameter does not affect the response in a store without the PR changes

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>