### PR TITLE
Reviews by Product block: fix encoded in input aria-label

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -12,6 +12,7 @@ import {
 import { SearchListItem } from '@woocommerce/editor-components/search-list-control';
 import ProductControl from '@woocommerce/editor-components/product-control';
 import { commentContent, Icon } from '@wordpress/icons';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -60,7 +61,7 @@ const ReviewsByProductEditor = ( {
 						item.details.review_count,
 						'woocommerce'
 					),
-					item.name,
+					decodeEntities( item.name ),
 					item.details.review_count
 				) }
 			/>

--- a/plugins/woocommerce/changelog/42944-fix-reviews-by-product-encoded-entities-aria-label
+++ b/plugins/woocommerce/changelog/42944-fix-reviews-by-product-encoded-entities-aria-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reviews by Product block: decode the product name in the Product selector input aria-label


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While working on https://github.com/woocommerce/woocommerce/pull/42903 I noticed we weren't decoding the Product name when it's used in the Reviews by Products selector as the input `aria-label`. This small PR should handle that.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product with special characters in its name. Ie: `Fish & Chips`.
2. Create a new post or page and add the Reviews by Product block.
3. Verify there are no encoded characters in the input field `aria-label`. You can test that with a screen reader or directly with the browser devtools: press <kbd>F12</kbd> → _Inspector_ → and inspect the checkbox next to the product name.

Before | After
--- | ---
![Captura de pantalla de 2023-12-19 10-26-13](https://github.com/woocommerce/woocommerce/assets/3616980/10ec9310-754e-4e3b-ac40-eb908345d587) | ![Captura de pantalla de 2023-12-19 10-26-22](https://github.com/woocommerce/woocommerce/assets/3616980/a3391439-1089-4f44-b20c-e76390835e10)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Reviews by Product block: decode the product name in the Product selector input aria-label

#### Comment

</details>
