### PR TITLE
Trigger event `experimental__woocommerce_blocks-cart-add-item` in the SSR Product Button vis Interactivity API

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -146,9 +146,10 @@ const { state } = store< Store >( 'woocommerce/product-button', {
 					quantityToAdd
 				);
 
-				// Add a manual trigger of the event for backward compatibility
-				// and symmetry (remove event is triggered properly from Cart and Mini Cart).
-				// We'll try to unify the events in future.
+				// Adding a manual trigger of the event for backward compatibility
+				// and symmetry ("remove" event is triggered properly from Cart and Mini Cart).
+				// The events will be revisited and unified in scope of:
+				// https://github.com/woocommerce/woocommerce/pull/42946
 				yield doAction(
 					`experimental__woocommerce_blocks-cart-add-item`,
 					product

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -7,6 +7,7 @@ import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { Cart } from '@woocommerce/type-defs/cart';
 import { createRoot } from '@wordpress/element';
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
+import { doAction } from '@wordpress/hooks';
 
 interface Context {
 	isLoading: boolean;
@@ -135,6 +136,7 @@ const { state } = store< Store >( 'woocommerce/product-button', {
 		*addToCart() {
 			const context = getContext();
 			const { productId, quantityToAdd } = context;
+			const product = getProductById( state.cart, productId );
 
 			context.isLoading = true;
 
@@ -142,6 +144,14 @@ const { state } = store< Store >( 'woocommerce/product-button', {
 				yield dispatch( storeKey ).addItemToCart(
 					productId,
 					quantityToAdd
+				);
+
+				// Add a manual trigger of the event for backward compatibility
+				// and symmetry (remove event is triggered properly from Cart and Mini Cart).
+				// We'll try to unify the events in future.
+				yield doAction(
+					`experimental__woocommerce_blocks-cart-add-item`,
+					product
 				);
 
 				// After the cart is updated, sync the temporary number of items again.

--- a/plugins/woocommerce/changelog/42946-add-42924-fire-legacy-add-to-cart-event
+++ b/plugins/woocommerce/changelog/42946-add-42924-fire-legacy-add-to-cart-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Button: Trigger event `experimental__woocommerce_blocks-cart-add-item` in Products and Product Collection blocks.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In [usages of experimental prefix docs](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md#usages-of-experimental-prefix) we describe the `experimental__woocommerce_blocks-cart-add-item` which is not fired in Products or Product Collection blocks.

The implementation of these events is in JS so they're fired from client-side rendered blocks (e.g. All Products block). However, with many blocks being server-side rendered that functionality is not covered. 

There's another set of actions like `woocommerce_add_to_cart` ([documentation](https://wp-kama.com/plugin/woocommerce/hook/woocommerce_add_to_cart)) which should be used, however, for backward compatibility, in this PR I'm adding `experimental__woocommerce_blocks-cart-add-item` to Products and Product Collection blocks until we take action to clean up and unify events.

There's no specific contract in terms of payload of the event. The `product` is passed as an event's payload in [JS code](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/block.tsx#L76). I'm passing `product` in its shape from Product Button's store.

Closes https://github.com/woocommerce/woocommerce/issues/42924

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Note:** this PR can no longer be tested in releases, as it was reverted in https://github.com/woocommerce/woocommerce/pull/43177.

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Editor
2. Add Products (Beta) and Product Collection block
3. Save and go to frontend
4. Open developer tools in your browser
5. In console add:

```
wp.hooks.addAction(
  'experimental__woocommerce_blocks-cart-add-item',
  'my-namespace',
  ( product ) => { console.log( 'Item added to cart: ' + product.name ); }
)
```

6. Add a product to a cart using Products (Beta) and Product Collection blocks
7. Expected: In both cases you should get `Item added to cart: <<PRODUCT NAME>>` in the console

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Product Button: Trigger event `experimental__woocommerce_blocks-cart-add-item` in Products and Product Collection blocks.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
