### PR TITLE
Interactivity API: Fix `wc-each-key` to allow paths as value

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/interactivity/directives.js
+++ b/plugins/woocommerce-blocks/assets/js/interactivity/directives.js
@@ -17,7 +17,7 @@ import { deepSignal, peek } from 'deepsignal';
  */
 import { createPortal } from './portals';
 import { useSignalEffect } from './utils';
-import { directive } from './hooks';
+import { directive, getScope, getEvaluate } from './hooks';
 import { SlotProvider, Slot, Fill } from './slots';
 import { navigate } from './router';
 
@@ -443,7 +443,8 @@ export default () => {
 					return currentValue.current;
 				}, [ inheritedValue, entry ] );
 
-				const key = eachKey?.value;
+				const scope = { ...getScope(), context: currentValue.current };
+				const key = getEvaluate( { scope } )( eachKey );
 
 				return (
 					<Provider value={ currentValue.current } key={ key }>
@@ -451,7 +452,8 @@ export default () => {
 					</Provider>
 				);
 			} );
-		}
+		},
+		{ priority: 20 }
 	);
 
 	directive( 'each-child', () => null );

--- a/plugins/woocommerce-blocks/assets/js/interactivity/hooks.tsx
+++ b/plugins/woocommerce-blocks/assets/js/interactivity/hooks.tsx
@@ -65,8 +65,8 @@ const deepImmutable = < T extends Object = {} >( target: T ): T => {
 
 // Store stacks for the current scope and the default namespaces and export APIs
 // to interact with them.
-let scopeStack: any[] = [];
-let namespaceStack: string[] = [];
+const scopeStack: any[] = [];
+const namespaceStack: string[] = [];
 
 export const getContext = < T extends object >( namespace?: string ): T =>
 	getScope()?.context[ namespace || namespaceStack.slice( -1 ) ];
@@ -80,7 +80,7 @@ export const getElement = () => {
 	const { ref, state, props } = getScope();
 	return Object.freeze( {
 		ref: ref.current,
-		state: state,
+		state,
 		props: deepImmutable( props ),
 	} );
 };
@@ -186,7 +186,7 @@ const resolve = ( path, namespace ) => {
 };
 
 // Generate the evaluate function.
-const getEvaluate =
+export const getEvaluate =
 	( { scope } = {} ) =>
 	( entry, ...args ) => {
 		let { value: path, namespace } = entry;

--- a/plugins/woocommerce/src/Blocks/InteractivityComponents/Dropdown.php
+++ b/plugins/woocommerce/src/Blocks/InteractivityComponents/Dropdown.php
@@ -30,7 +30,6 @@ class Dropdown {
 			'selectedItems' => $selected_items,
 			'isOpen'        => false,
 			'selectType'    => $select_type,
-			'items'         => $items,
 		);
 
 		$action = $props['action'] ?? '';
@@ -53,7 +52,7 @@ class Dropdown {
 							<?php if ( 'multiple' === $select_type ) { ?>
 								<template
 									data-wc-each="context.selectedItems"
-									data-wc-each-key="value"
+									data-wc-each-key="context.item.value"
 								>
 									<span class="components-form-token-field__token">
 										<span
@@ -94,29 +93,18 @@ class Dropdown {
 							<?php } ?>
 							<input id="components-form-token-input-1" type="text" autocomplete="off" data-wc-bind--placeholder="state.placeholderText" class="components-form-token-field__input" role="combobox" aria-expanded="false" aria-autocomplete="list" aria-describedby="components-form-token-suggestions-howto-1" value="" data-wc-key="input">
 							<ul hidden data-wc-bind--hidden="!context.isOpen" class="components-form-token-field__suggestions-list" id="components-form-token-suggestions-1" role="listbox"  data-wc-key="ul">
-								<template data-wc-each="context.items" data-wc-each-key="value">
+								<?php
+								foreach ( $items as $item ) :
+									$context = array( 'item' => $item );
+									?>
 									<li
 										role="option"
-										data-wc-text="context.item.label"
 										data-wc-on--click--select-item="actions.selectDropdownItem"
 										data-wc-on--click--parent-action="<?php echo esc_attr( $action ); ?>"
 										data-wc-class--is-selected="state.isSelected"
 										class="components-form-token-field__suggestion"
 										data-wc-bind--aria-selected="state.isSelected"
-									>
-									</li>
-								</template>
-								<?php
-								foreach ( $items as $item ) :
-									$context = array(
-										'currentItem' => $item,
-									);
-									?>
-									<li
-										role="option"
-										class="components-form-token-field__suggestion"
-										aria-selected="false"
-										data-wc-each-child
+										data-wc-context='<?php echo wp_json_encode( $context ); ?>'
 									>
 									<?php // This attribute supports HTML so should be sanitized by caller. ?>
 									<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The directive `data-wc-each-key` was intended to accept a variable name to extract a unique ID from each item. This doesn't work well for string or number items instead of objects. Also, there was a bug in the implementation. 🐛

With these changes, `data-wc-each-key` can receive a path to retrieve the key, so neither the type of the item nor the ID location is a problem.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
