### PR TITLE
Add useProductMetadata hook

### DIFF
--- a/packages/js/product-editor/changelog/add-use-product-metadata
+++ b/packages/js/product-editor/changelog/add-use-product-metadata
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add useProductMetadata hook to perform update in multiple meta entries at same time

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useVariationsOrder as __experimentalUseVariationsOrder } from './use-va
 export { useCurrencyInputProps as __experimentalUseCurrencyInputProps } from './use-currency-input-props';
 export { useVariationSwitcher as __experimentalUseVariationSwitcher } from './use-variation-switcher';
 export { default as __experimentalUseProductEntityProp } from './use-product-entity-prop';
+export { default as __experimentalUseProductMetadata } from './use-product-metadata';

--- a/packages/js/product-editor/src/hooks/test/use-product-metadata.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-metadata.test.ts
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useProductMetadata from '../use-product-metadata';
+
+const mockFnMetadataProp = jest.fn();
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityProp: jest
+		.fn()
+		.mockImplementation( ( _postType, _product, property ) => {
+			return [
+				[
+					{
+						key: 'field1',
+						value: 'value1',
+					},
+					{
+						key: 'field2',
+						value: 'value1',
+					},
+					{
+						key: 'existing_field',
+						value: 'value1',
+					},
+				],
+				mockFnMetadataProp,
+			];
+		} ),
+} ) );
+
+describe( 'useProductMetadata', () => {
+	it( 'should update all the metadata with new values and not replace existing fields', async () => {
+		const { updateMetadata } = renderHook( () => useProductMetadata() )
+			.result.current;
+		updateMetadata( [
+			{
+				key: 'field1',
+				value: 'value2',
+			},
+			{
+				key: 'field2',
+				value: 'value2',
+			},
+		] );
+		expect( mockFnMetadataProp ).toHaveBeenCalledWith( [
+			{
+				key: 'existing_field',
+				value: 'value1',
+			},
+			{
+				key: 'field1',
+				value: 'value2',
+			},
+			{
+				key: 'field2',
+				value: 'value2',
+			},
+		] );
+	} );
+} );

--- a/packages/js/product-editor/src/hooks/test/use-product-metadata.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-metadata.test.ts
@@ -10,27 +10,25 @@ import useProductMetadata from '../use-product-metadata';
 
 const mockFnMetadataProp = jest.fn();
 jest.mock( '@wordpress/core-data', () => ( {
-	useEntityProp: jest
-		.fn()
-		.mockImplementation( ( _postType, _product, property ) => {
-			return [
-				[
-					{
-						key: 'field1',
-						value: 'value1',
-					},
-					{
-						key: 'field2',
-						value: 'value1',
-					},
-					{
-						key: 'existing_field',
-						value: 'value1',
-					},
-				],
-				mockFnMetadataProp,
-			];
-		} ),
+	useEntityProp: jest.fn().mockImplementation( () => {
+		return [
+			[
+				{
+					key: 'field1',
+					value: 'value1',
+				},
+				{
+					key: 'field2',
+					value: 'value1',
+				},
+				{
+					key: 'existing_field',
+					value: 'value1',
+				},
+			],
+			mockFnMetadataProp,
+		];
+	} ),
 } ) );
 
 describe( 'useProductMetadata', () => {

--- a/packages/js/product-editor/src/hooks/use-product-metadata.ts
+++ b/packages/js/product-editor/src/hooks/use-product-metadata.ts
@@ -8,14 +8,14 @@ import { useEntityProp } from '@wordpress/core-data';
 import { Metadata } from '../types';
 
 function useProductMetadata( postType?: string ) {
-	const [ metadata, setMetadata ] = useEntityProp< Metadata< never >[] >(
+	const [ metadata, setMetadata ] = useEntityProp< Metadata< string >[] >(
 		'postType',
 		postType || 'product',
 		'meta_data'
 	);
 
 	return {
-		updateMetadata: ( entries: Metadata< never >[] ) => {
+		updateMetadata: ( entries: Metadata< string >[] ) => {
 			setMetadata( [
 				...metadata.filter(
 					( item ) =>

--- a/packages/js/product-editor/src/hooks/use-product-metadata.ts
+++ b/packages/js/product-editor/src/hooks/use-product-metadata.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+/**
+ * Internal dependencies
+ */
+import { Metadata } from '../types';
+
+function useProductMetadata( postType?: string ) {
+	const [ metadata, setMetadata ] = useEntityProp< Metadata< never >[] >(
+		'postType',
+		postType || 'product',
+		'meta_data'
+	);
+
+	return {
+		updateMetadata: ( entries: Metadata< never >[] ) => {
+			setMetadata( [
+				...metadata.filter(
+					( item ) =>
+						entries.findIndex( ( e ) => e.key === item.key ) === -1
+				),
+				...entries,
+			] );
+		},
+	};
+}
+
+export default useProductMetadata;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I've came across a scenario while developing an extension where I need to update more than one metadata entry at the same time (in the same event). Due to the way the current API is structured (`useProductEntityProp` and the `meta_data` array), the last change was overwriting the previous change. So I created this hook, which allows me to batch update values.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

No manual tests are needed. I've added an automated test and this is still not used anywhere.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
