### PR TITLE
Prevent "Use same address for billing" being checked by default if addresses differ

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/utils/address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/address.ts
@@ -22,7 +22,7 @@ export const isSameAddress = < T extends ShippingAddress | BillingAddress >(
 	address1: T,
 	address2: T
 ): boolean => {
-	return Object.keys( ADDRESS_FIELDS_KEYS ).every( ( field: string ) => {
+	return ADDRESS_FIELDS_KEYS.every( ( field: string ) => {
 		return address1[ field as keyof T ] === address2[ field as keyof T ];
 	} );
 };

--- a/plugins/woocommerce/changelog/42967-fix-same-address-blocks
+++ b/plugins/woocommerce/changelog/42967-fix-same-address-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update the check used to determine if the "Use same address for billing" box should be checked on the Checkout block.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/42695 we changed how address keys were stored, in `plugins/woocommerce-blocks/assets/js/base/utils/address.ts` we checked the `ADDRESS_FIELDS_KEYS` as if it were an object, but it is now an array. This resulted in comparison of `address1[ undefined ]` to `address2[ undefined ]` which was always true, therefore we determined the addresses were the same and that the checkbox should be checked.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an item to your cart, go to the Checkout block and check out with a different shipping and billing address.
2. Re-add an item to the cart and go back to the Checkout block. The "Use same address for billing" box should be unchecked.
3. Check out without changing anything.
4. Re-add an item to the cart and go back to the Checkout block. The "Use same address for billing" box should still be unchecked. Change the addresses so they're the same (use the checkbox if you like, or do it manually), then check out.
5. Re-add an item to the cart and go back to the Checkout block. Ensure the "Use same address for billing" box is now checked.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update the check used to determine if the "Use same address for billing" box should be checked on the Checkout block.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
