### PR TITLE
Fix sizing of `<SelectControl>` & UI bug for `<ReportFilters>`

### DIFF
--- a/packages/js/components/changelog/42969-fix-select-style
+++ b/packages/js/components/changelog/42969-fix-select-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix sizing of `<SelectControl>`.

--- a/packages/js/components/src/select-control/style.scss
+++ b/packages/js/components/src/select-control/style.scss
@@ -4,6 +4,7 @@
 	.components-base-control {
 		height: 56px;
 		display: flex;
+		box-sizing: border-box;
 		align-items: center;
 		border: 1px solid $studio-gray-20;
 		border-radius: 3px;


### PR DESCRIPTION


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Set `box-sizing` to `border-box`, to prevent `<SelectControl>` from being wider than its container.

Fixes https://github.com/woocommerce/google-listings-and-ads/issues/2186

#### Before
![image](https://github.com/woocommerce/woocommerce/assets/17435/41223eed-76a0-440a-bb8d-16939bb3ee75)
#### After
![image](https://github.com/woocommerce/woocommerce/assets/17435/bbc999f0-2992-47d2-9828-992b6414ce12)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Customers** `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomers`
2. Use a filter to show "Single Customer"
3. Check the size of input field in the popover

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix sizing of `<SelectControl>`.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
