### PR TITLE
Interactive Price Filter: use `context` instead of `state`

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/components/price-slider.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/components/price-slider.tsx
@@ -52,7 +52,7 @@ export const PriceSlider = ( { attributes }: EditProps ) => {
 	);
 
 	return (
-		<>
+		<div>
 			<div className="range">
 				<div className="range-bar"></div>
 				<input
@@ -76,6 +76,6 @@ export const PriceSlider = ( { attributes }: EditProps ) => {
 				{ priceMin }
 				{ priceMax }
 			</div>
-		</>
+		</div>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/frontend.ts
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-import { store, navigate } from '@woocommerce/interactivity';
+import { store, navigate, getContext } from '@woocommerce/interactivity';
 import { formatPrice, getCurrency } from '@woocommerce/price-format';
 import { HTMLElementEvent } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
-import { PriceFilterState } from './types';
+import type { PriceFilterContext, PriceFilterStore } from './types';
 
-const getHrefWithFilters = ( state: PriceFilterState ) => {
-	const { minPrice = 0, maxPrice = 0, maxRange = 0 } = state;
+const getUrl = ( context: PriceFilterContext ) => {
+	const { minPrice, maxPrice, minRange, maxRange } = context;
 	const url = new URL( window.location.href );
 	const { searchParams } = url;
 
-	if ( minPrice > 0 ) {
+	if ( minPrice > minRange ) {
 		searchParams.set( 'min_price', minPrice.toString() );
 	} else {
 		searchParams.delete( 'min_price' );
@@ -34,80 +34,67 @@ const getHrefWithFilters = ( state: PriceFilterState ) => {
 	return url.href;
 };
 
-interface PriceFilterStore {
-	state: PriceFilterState;
-	actions: {
-		setMinPrice: ( event: HTMLElementEvent< HTMLInputElement > ) => void;
-		setMaxPrice: ( event: HTMLElementEvent< HTMLInputElement > ) => void;
-		updateProducts: () => void;
-		reset: () => void;
-	};
-}
+store< PriceFilterStore >( 'woocommerce/collection-price-filter', {
+	state: {
+		rangeStyle: () => {
+			const { minPrice, maxPrice, minRange, maxRange } =
+				getContext< PriceFilterContext >();
 
-const { state } = store< PriceFilterStore >(
-	'woocommerce/collection-price-filter',
-	{
-		state: {
-			get rangeStyle(): string {
-				const {
-					minPrice = 0,
-					maxPrice = 0,
-					minRange = 0,
-					maxRange = 0,
-				} = state;
-				return [
-					`--low: ${
-						( 100 * ( minPrice - minRange ) ) /
-						( maxRange - minRange )
-					}%`,
-					`--high: ${
-						( 100 * ( maxPrice - minRange ) ) /
-						( maxRange - minRange )
-					}%`,
-				].join( ';' );
-			},
-			get formattedMinPrice(): string {
-				const { minPrice = 0 } = state;
-				return formatPrice( minPrice, getCurrency( { minorUnit: 0 } ) );
-			},
-			get formattedMaxPrice(): string {
-				const { maxPrice = 0 } = state;
-				return formatPrice( maxPrice, getCurrency( { minorUnit: 0 } ) );
-			},
+			return [
+				`--low: ${
+					( 100 * ( minPrice - minRange ) ) / ( maxRange - minRange )
+				}%`,
+				`--high: ${
+					( 100 * ( maxPrice - minRange ) ) / ( maxRange - minRange )
+				}%`,
+			].join( ';' );
 		},
-		actions: {
-			setMinPrice: ( event: HTMLElementEvent< HTMLInputElement > ) => {
-				const { minRange = 0, maxPrice = 0, maxRange = 0 } = state;
-				const value = parseFloat( event.target.value );
-				state.minPrice = Math.min(
-					Number.isNaN( value ) ? minRange : value,
-					maxRange - 1
-				);
-				state.maxPrice = Math.max( maxPrice, state.minPrice + 1 );
-			},
-			setMaxPrice: ( event: HTMLElementEvent< HTMLInputElement > ) => {
-				const {
-					minRange = 0,
-					minPrice = 0,
-					maxPrice = 0,
-					maxRange = 0,
-				} = state;
-				const value = parseFloat( event.target.value );
-				state.maxPrice = Math.max(
-					Number.isNaN( value ) ? maxRange : value,
-					minRange + 1
-				);
-				state.minPrice = Math.min( minPrice, maxPrice - 1 );
-			},
-			updateProducts: () => {
-				navigate( getHrefWithFilters( state ) );
-			},
-			reset: () => {
-				const { maxRange = 0 } = state;
-				state.minPrice = 0;
-				state.maxPrice = maxRange;
-				navigate( getHrefWithFilters( state ) );
-			},
+		formattedMinPrice: () => {
+			const { minPrice } = getContext< PriceFilterContext >();
+			return formatPrice( minPrice, getCurrency( { minorUnit: 0 } ) );
 		},
-	}
-);
+		formattedMaxPrice: () => {
+			const { maxPrice } = getContext< PriceFilterContext >();
+			return formatPrice( maxPrice, getCurrency( { minorUnit: 0 } ) );
+		},
+	},
+	actions: {
+		updateProducts: ( event: HTMLElementEvent< HTMLInputElement > ) => {
+			const { minRange, minPrice, maxPrice, maxRange } =
+				getContext< PriceFilterContext >();
+			const type = event.target.name;
+			const value = parseFloat( event.target.value );
+
+			navigate(
+				getUrl( {
+					minRange,
+					maxRange,
+					minPrice:
+						type === 'min'
+							? Math.min(
+									Number.isNaN( value ) ? minRange : value,
+									maxRange - 1
+							  )
+							: minPrice,
+					maxPrice:
+						type === 'max'
+							? Math.max(
+									Number.isNaN( value ) ? maxRange : value,
+									minRange + 1
+							  )
+							: maxPrice,
+				} )
+			);
+		},
+		reset: () => {
+			navigate(
+				getUrl( {
+					minRange: 0,
+					maxRange: 0,
+					minPrice: 0,
+					maxPrice: 0,
+				} )
+			);
+		},
+	},
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/frontend.ts
@@ -60,29 +60,35 @@ store< PriceFilterStore >( 'woocommerce/collection-price-filter', {
 	},
 	actions: {
 		updateProducts: ( event: HTMLElementEvent< HTMLInputElement > ) => {
-			const { minRange, minPrice, maxPrice, maxRange } =
-				getContext< PriceFilterContext >();
+			const context = getContext< PriceFilterContext >();
+			const { minRange, minPrice, maxPrice, maxRange } = context;
 			const type = event.target.name;
 			const value = parseFloat( event.target.value );
+
+			const currentMinPrice =
+				type === 'min'
+					? Math.min(
+							Number.isNaN( value ) ? minRange : value,
+							maxRange - 1
+					  )
+					: minPrice;
+			const currentMaxPrice =
+				type === 'max'
+					? Math.max(
+							Number.isNaN( value ) ? maxRange : value,
+							minRange + 1
+					  )
+					: maxPrice;
+
+			context.minPrice = currentMinPrice;
+			context.maxPrice = currentMaxPrice;
 
 			navigate(
 				getUrl( {
 					minRange,
 					maxRange,
-					minPrice:
-						type === 'min'
-							? Math.min(
-									Number.isNaN( value ) ? minRange : value,
-									maxRange - 1
-							  )
-							: minPrice,
-					maxPrice:
-						type === 'max'
-							? Math.max(
-									Number.isNaN( value ) ? maxRange : value,
-									minRange + 1
-							  )
-							: maxPrice,
+					minPrice: currentMinPrice,
+					maxPrice: currentMaxPrice,
 				} )
 			);
 		},

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/types.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { BlockEditProps } from '@wordpress/blocks';
+import { HTMLElementEvent } from '@woocommerce/types';
 
 export type BlockAttributes = {
 	showInputFields: boolean;
@@ -11,11 +12,26 @@ export type BlockAttributes = {
 export type EditProps = BlockEditProps< BlockAttributes >;
 
 export type PriceFilterState = {
-	minPrice?: number;
-	maxPrice?: number;
-	minRange?: number;
-	maxRange?: number;
-	rangeStyle: string;
-	formattedMinPrice: string;
-	formattedMaxPrice: string;
+	rangeStyle: () => string;
+	formattedMinPrice: () => string;
+	formattedMaxPrice: () => string;
+};
+
+export type PriceFilterContext = {
+	minPrice: number;
+	maxPrice: number;
+	minRange: number;
+	maxRange: number;
+};
+
+export type FilterComponentProps = BlockEditProps< BlockAttributes > & {
+	collectionData: Partial< PriceFilterState >;
+};
+
+export type PriceFilterStore = {
+	state: PriceFilterState;
+	actions: {
+		updateProducts: ( event: HTMLElementEvent< HTMLInputElement > ) => void;
+		reset: () => void;
+	};
 };

--- a/plugins/woocommerce/changelog/42980-fix-42976-price-filter-convert-state-to-context
+++ b/plugins/woocommerce/changelog/42980-fix-42976-price-filter-convert-state-to-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Convert the Price Filter `state` to `context` to enhance its reactivity.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
@@ -156,12 +156,11 @@ final class CollectionPriceFilter extends AbstractBlock {
 		$__high      = 100 * ( $max_price - $min_range ) / ( $max_range - $min_range );
 		$range_style = "--low: $__low%; --high: $__high%";
 
-		$data_directive = wp_json_encode( array( 'namespace' => 'woocommerce/collection-price-filter' ) );
-
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
 				'class'               => $show_input_fields && $inline_input ? 'inline-input' : '',
-				'data-wc-interactive' => $data_directive,
+				'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-price-filter' ) ),
+				'data-wc-context'     => wp_json_encode( $data ),
 			)
 		);
 
@@ -171,8 +170,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 					class="min"
 					type="text"
 					value="%d"
-					data-wc-bind--value="state.minPrice"
-					data-wc-on--input="actions.setMinPrice"
+					data-wc-bind--value="context.minPrice"
 					data-wc-on--change="actions.updateProducts"
 				/>',
 				esc_attr( $min_price )
@@ -188,8 +186,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 					class="max"
 					type="text"
 					value="%d"
-					data-wc-bind--value="state.maxPrice"
-					data-wc-on--input="actions.setMaxPrice"
+					data-wc-bind--value="context.maxPrice"
 					data-wc-on--change="actions.updateProducts"
 				/>',
 				esc_attr( $max_price )
@@ -211,25 +208,25 @@ final class CollectionPriceFilter extends AbstractBlock {
 					<input
 						type="range"
 						class="min"
+						name="min"
 						min="<?php echo esc_attr( $min_range ); ?>"
 						max="<?php echo esc_attr( $max_range ); ?>"
 						value="<?php echo esc_attr( $min_price ); ?>"
-						data-wc-bind--max="state.maxRange"
-						data-wc-bind--value="state.minPrice"
-						data-wc-class--active="state.isMinActive"
-						data-wc-on--input="actions.setMinPrice"
+						data-wc-bind--min="context.minRange"
+						data-wc-bind--max="context.maxRange"
+						data-wc-bind--value="context.minPrice"
 						data-wc-on--change="actions.updateProducts"
 					>
 					<input
 						type="range"
 						class="max"
+						name="max"
 						min="<?php echo esc_attr( $min_range ); ?>"
 						max="<?php echo esc_attr( $max_range ); ?>"
 						value="<?php echo esc_attr( $max_price ); ?>"
-						data-wc-bind--max="state.maxRange"
-						data-wc-bind--value="state.maxPrice"
-						data-wc-class--active="state.isMaxActive"
-						data-wc-on--input="actions.setMaxPrice"
+						data-wc-bind--min="context.minRange"
+						data-wc-bind--max="context.maxRange"
+						data-wc-bind--value="context.maxPrice"
 						data-wc-on--change="actions.updateProducts"
 					>
 				</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
@@ -121,7 +121,6 @@ final class CollectionPriceFilter extends AbstractBlock {
 
 		$price_range = $block->context['collectionData']['price_range'];
 
-		$wrapper_attributes  = get_block_wrapper_attributes();
 		$min_range           = $price_range['min_price'] / 10 ** $price_range['currency_minor_unit'];
 		$max_range           = $price_range['max_price'] / 10 ** $price_range['currency_minor_unit'];
 		$min_price           = intval( get_query_var( self::MIN_PRICE_QUERY_VAR, $min_range ) );
@@ -160,7 +159,6 @@ final class CollectionPriceFilter extends AbstractBlock {
 			array(
 				'class'               => $show_input_fields && $inline_input ? 'inline-input' : '',
 				'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-price-filter' ) ),
-				'data-wc-context'     => wp_json_encode( $data ),
 			)
 		);
 
@@ -199,41 +197,43 @@ final class CollectionPriceFilter extends AbstractBlock {
 		ob_start();
 		?>
 			<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-				<div
-					class="range"
-					style="<?php echo esc_attr( $range_style ); ?>"
-					data-wc-bind--style="state.rangeStyle"
-				>
-					<div class="range-bar"></div>
-					<input
-						type="range"
-						class="min"
-						name="min"
-						min="<?php echo esc_attr( $min_range ); ?>"
-						max="<?php echo esc_attr( $max_range ); ?>"
-						value="<?php echo esc_attr( $min_price ); ?>"
-						data-wc-bind--min="context.minRange"
-						data-wc-bind--max="context.maxRange"
-						data-wc-bind--value="context.minPrice"
-						data-wc-on--change="actions.updateProducts"
+				<div data-wc-context="<?php echo esc_attr( wp_json_encode( $data ) ); ?>" >
+					<div
+						class="range"
+						style="<?php echo esc_attr( $range_style ); ?>"
+						data-wc-bind--style="state.rangeStyle"
 					>
-					<input
-						type="range"
-						class="max"
-						name="max"
-						min="<?php echo esc_attr( $min_range ); ?>"
-						max="<?php echo esc_attr( $max_range ); ?>"
-						value="<?php echo esc_attr( $max_price ); ?>"
-						data-wc-bind--min="context.minRange"
-						data-wc-bind--max="context.maxRange"
-						data-wc-bind--value="context.maxPrice"
-						data-wc-on--change="actions.updateProducts"
-					>
-				</div>
-				<div class="text">
-					<?php // $price_min and $price_max are escaped in the sprintf() calls above. ?>
-					<?php echo $price_min; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					<?php echo $price_max; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<div class="range-bar"></div>
+						<input
+							type="range"
+							class="min"
+							name="min"
+							min="<?php echo esc_attr( $min_range ); ?>"
+							max="<?php echo esc_attr( $max_range ); ?>"
+							value="<?php echo esc_attr( $min_price ); ?>"
+							data-wc-bind--min="context.minRange"
+							data-wc-bind--max="context.maxRange"
+							data-wc-bind--value="context.minPrice"
+							data-wc-on--change="actions.updateProducts"
+						>
+						<input
+							type="range"
+							class="max"
+							name="max"
+							min="<?php echo esc_attr( $min_range ); ?>"
+							max="<?php echo esc_attr( $max_range ); ?>"
+							value="<?php echo esc_attr( $max_price ); ?>"
+							data-wc-bind--min="context.minRange"
+							data-wc-bind--max="context.maxRange"
+							data-wc-bind--value="context.maxPrice"
+							data-wc-on--change="actions.updateProducts"
+						>
+					</div>
+					<div class="text">
+						<?php // $price_min and $price_max are escaped in the sprintf() calls above. ?>
+						<?php echo $price_min; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo $price_max; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</div>
 				</div>
 			</div>
 		<?php


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR updates the Price Filter block to use `context` instead of `state` to:
- makes the price filter react to changes from other blocks like `Active Filters`.
- enables merchant to add multiple price filter block on the same page. I'm not sure this is useful in reality, but by using context, we can ensure the block mutate and consume correct and up-to-date data, which is improve the reliability in general.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42976  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the Product Catalog in Dashboard > Themes > Editor > Templates > Product Catalog.
2. Update the product grid to use `Product Collection` block.
3. Add the `Collection Filters` block to the template, it should add a default set of new filters blocks including the Price Filter block.
4. View the catalog (the Shop page) on the frontend, change the price filter and other filter if available, see filter blocks and the product loop react to the changes.
5. Click the `Clear All` button of the `Active Filters` block, see all block reset to the initial state, including the Price Filter <= this doesn't happen previously when we use `state`.
6. Change the Price Filter again, see the corresponding price item in the `Active Filters` block.
7. Click on the remove button of that item, see it works as expected:
  - the `min_price` and/or `max_price` param is removed from the URL.
  - the `Price Filter` block is reset to its initial state.
  - the Products grid is updated accordingly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Convert the Price Filter `state` to `context` to enhance its reactivity.
</details>
