### PR TITLE
Ensure the gateway activation email does not depend on the gateway title being stored in the settings option

### DIFF
--- a/plugins/woocommerce/changelog/update-gateway-activation-mail-title
+++ b/plugins/woocommerce/changelog/update-gateway-activation-mail-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the gateway activation email does not depend on the gateway title being stored in the settings option

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -188,7 +188,7 @@ class WC_Payment_Gateways {
 		$admin_email          = get_option( 'admin_email' );
 		$user                 = get_user_by( 'email', $admin_email );
 		$username             = $user ? $user->user_login : $admin_email;
-		$gateway_title        = $gateway->get_title();
+		$gateway_title        = $gateway->get_method_title();
 		$gateway_settings_url = esc_url_raw( self_admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $gateway->id ) );
 		$site_name            = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 		$site_url             = home_url();

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -279,8 +279,7 @@ All at %6$s
 		// There was an old value, so this is an update.
 		if (
 			ArrayUtil::get_value_or_default( $value, 'enabled' ) === 'yes' &&
-			ArrayUtil::get_value_or_default( $old_value, 'enabled' ) !== 'yes' &&
-			isset( $value['title'] ) ) {
+			ArrayUtil::get_value_or_default( $old_value, 'enabled' ) !== 'yes' ) {
 			return true;
 		}
 		return false;

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -61,7 +61,7 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 		foreach ( $this->sut->payment_gateways() as $gateway ) {
 			// Disable the gateway and save the settings.
 			$gateway->settings['enabled'] = 'no';
-			$gateway->settings['title'] = null;
+			$gateway->settings['title']   = null;
 			update_option( $gateway->get_option_key(), $gateway->settings );
 
 			// Enable the gateway and save its settings; this should send the email and add a log entry.

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -61,6 +61,7 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 		foreach ( $this->sut->payment_gateways() as $gateway ) {
 			// Disable the gateway and save the settings.
 			$gateway->settings['enabled'] = 'no';
+			$gateway->settings['title'] = null;
 			update_option( $gateway->get_option_key(), $gateway->settings );
 
 			// Enable the gateway and save its settings; this should send the email and add a log entry.
@@ -68,13 +69,13 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 			update_option( $gateway->get_option_key(), $gateway->settings );
 
 			// Check that the log entry was created.
-			$this->assertEquals( 'Payment gateway enabled: "' . $gateway->get_title() . '"', end( $fake_logger->infos )['message'] );
+			$this->assertEquals( 'Payment gateway enabled: "' . $gateway->get_method_title() . '"', end( $fake_logger->infos )['message'] );
 
 			// Check that the email was sent correctly.
 			$this->assertStringContainsString( '@', $email_details['to'][0] );
 			$this->assertEquals( get_option( 'admin_email' ), $email_details['to'][0] );
-			$this->assertEquals( '[Test Blog] Payment gateway "' . $gateway->get_title() . '" enabled', $email_details['subject'] );
-			$this->assertStringContainsString( 'The payment gateway "' . $gateway->get_title() . '" was just enabled on this site', $email_details['message'] );
+			$this->assertEquals( '[Test Blog] Payment gateway "' . $gateway->get_method_title() . '" enabled', $email_details['subject'] );
+			$this->assertStringContainsString( 'The payment gateway "' . $gateway->get_method_title() . '" was just enabled on this site', $email_details['message'] );
 			$this->assertStringContainsString( 'If you did not enable this payment gateway, please log in to your site and consider disabling it here:', $email_details['message'] );
 			$this->assertStringContainsString( '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=' . $gateway->id, $email_details['message'] );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the gateway email notification introduced in #41645 to ignore the presence of the `title` property in the updated settings option so that it also works with Woo Payments (which does not include the `title` property when updating its settings option). We're fetching the title from the gateway object anyway. 

As part of this PR we're also updating the title that is used to the one more suited for admin contexts. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. checkout the branch locally and run `wp-env start` or spin up a JN site with this PR (the latter would work better for testing WooPayments in step 4)
2. configure the email system or install a plugin like "Mail Debug for WooCommerce"
3. activate and deactivate the existing payment gateways, ensure an email is sent to notify the admin (email from WordPress Settings / General) when a payment gateway is activated
4. install an additional payment gateway such as [WooPayments](https://wordpress.org/plugins/woocommerce-payments/) and ensure things work as expected for these
6. ensure the `add_option_` event works as well as the `update_option_` event (e.g., via the `wp option delete woocommerce_cod_settings` you proposed earlier)
7. ensure a sent email has a corresponding log entry under WooCommerce / Status / Logs

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
