### PR TITLE
Revise excluded order statuses for order attribution customer history

### DIFF
--- a/plugins/woocommerce/changelog/tweak-customer-history-excluded-statuses
+++ b/plugins/woocommerce/changelog/tweak-customer-history-excluded-statuses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Revise excluded order statuses for customer history.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -411,7 +411,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'session_pages'        => $source_data['session_pages'] ?? 0,
 			'session_count'        => $source_data['session_count'] ?? 0,
 			'order_total'          => $order->get_total(),
-			// Add 1 to include the current order (which is currently still Pending.
+			// Add 1 to include the current order (which is currently still Pending when the event is sent).
 			'customer_order_count' => $customer_info['order_count'] + 1,
 			'customer_registered'  => $order->get_customer_id() ? 'yes' : 'no',
 		);

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -411,7 +411,8 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'session_pages'        => $source_data['session_pages'] ?? 0,
 			'session_count'        => $source_data['session_count'] ?? 0,
 			'order_total'          => $order->get_total(),
-			'customer_order_count' => $customer_info['order_count'],
+			// Add 1 to include the current order (which is currently still Pending.
+			'customer_order_count' => $customer_info['order_count'] + 1,
 			'customer_registered'  => $order->get_customer_id() ? 'yes' : 'no',
 		);
 		$this->proxy->call_static( WC_Tracks::class, 'record_event', 'order_attribution', $tracks_data );

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Traits;
 
 use Automattic\WooCommerce\Vendor\Detection\MobileDetect;
+use Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use Exception;
 use WC_Meta_Data;
 use WC_Order;
@@ -387,17 +388,17 @@ trait OrderAttributionMeta {
 	private function get_customer_history( $customer_identifier ): array {
 		/*
 		 * Exclude the statuses that aren't valid for the Customers report.
-		 * 'checkout-draft' is the checkout block's draft order status.
+		 * 'checkout-draft' is the checkout block's draft order status. `any` is added by V2 Orders REST.
 		 * @see /Automattic/WooCommerce/Admin/API/Report/DataStore::get_excluded_report_order_statuses()
 		 */
-		$all_statuses_no_prefix = str_replace( 'wc-', '', array_keys( wc_get_order_statuses() ) );
-		$excluded_statuses      = array( 'pending', 'failed', 'cancelled', 'auto-draft', 'trash', 'checkout-draft' );
+		$all_order_statuses = ReportsController::get_order_statuses();
+		$excluded_statuses  = array( 'pending', 'failed', 'cancelled', 'auto-draft', 'trash', 'checkout-draft', 'any' );
 
 		// Get the valid customer orders.
 		$args = array(
 			'limit'  => - 1,
 			'return' => 'objects',
-			'status' => array_diff( $all_statuses_no_prefix, $excluded_statuses ),
+			'status' => array_diff( $all_order_statuses, $excluded_statuses ),
 			'type'   => 'shop_order',
 		);
 

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -390,12 +390,7 @@ trait OrderAttributionMeta {
 		 * 'checkout-draft' is the checkout block's draft order status.
 		 * @see /Automattic/WooCommerce/Admin/API/Report/DataStore::get_excluded_report_order_statuses()
 		 */
-		$all_statuses_no_prefix = array_map(
-			function ( $status ) {
-				return str_replace( 'wc-', '', $status );
-			},
-			array_keys( wc_get_order_statuses() )
-		);
+		$all_statuses_no_prefix = str_replace( 'wc-', '', array_keys( wc_get_order_statuses() ) );
 		$excluded_statuses      = array( 'pending', 'failed', 'cancelled', 'auto-draft', 'trash', 'checkout-draft' );
 
 		// Get the valid customer orders.

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -385,13 +385,23 @@ trait OrderAttributionMeta {
 	 * @return array Order count, total spend, and average spend per order.
 	 */
 	private function get_customer_history( $customer_identifier ): array {
+		/*
+		 * Exclude the statuses that aren't valid for the Customers report.
+		 * @see /Automattic/WooCommerce/Admin/API/Report/DataStore::get_excluded_report_order_statuses()
+		 */
+		$all_statuses_no_prefix = array_map(
+			function ( $status ) {
+				return str_replace( 'wc-', '', $status );
+			},
+			array_keys( wc_get_order_statuses() )
+		);
+		$excluded_statuses      = array( 'pending', 'failed', 'cancelled', 'auto-draft', 'trash' );
 
 		// Get the valid customer orders.
 		$args = array(
 			'limit'  => - 1,
 			'return' => 'objects',
-			// Don't count cancelled or failed orders.
-			'status' => array( 'pending', 'processing', 'on-hold', 'completed', 'refunded' ),
+			'status' => array_diff( $all_statuses_no_prefix, $excluded_statuses ),
 			'type'   => 'shop_order',
 		);
 

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -387,6 +387,7 @@ trait OrderAttributionMeta {
 	private function get_customer_history( $customer_identifier ): array {
 		/*
 		 * Exclude the statuses that aren't valid for the Customers report.
+		 * 'checkout-draft' is the checkout block's draft order status.
 		 * @see /Automattic/WooCommerce/Admin/API/Report/DataStore::get_excluded_report_order_statuses()
 		 */
 		$all_statuses_no_prefix = array_map(
@@ -395,7 +396,7 @@ trait OrderAttributionMeta {
 			},
 			array_keys( wc_get_order_statuses() )
 		);
-		$excluded_statuses      = array( 'pending', 'failed', 'cancelled', 'auto-draft', 'trash' );
+		$excluded_statuses      = array( 'pending', 'failed', 'cancelled', 'auto-draft', 'trash', 'checkout-draft' );
 
 		// Get the valid customer orders.
 		$args = array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This just aligns the customer history data used in the Customer History metabox and for the Order Attribution Tracks even with the data visible in the WC Analytics Customers table. Previously only `cancelled` and `failed` orders were excluded. Now `pending`, `auto-draft`, and `trash` are also excluded statuses. This is taken from https://github.com/woocommerce/woocommerce/blob/50cc51bbc2007a657efd5ab4fd9352a425a34642/plugins/woocommerce/src/Admin/API/Reports/DataStore.php#L679-L683

It also excludes `checkout-draft`which is the block checkout / API draft status:
https://github.com/woocommerce/woocommerce/blob/0ba8f7848df7c6930924d33ee63d5a349d978069/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php#L17-L18

### How to test the changes in this Pull Request:

The main changes are to see that the data in the `Customer history` metabox on the Order Edit page, and `customer_order_count` in the OA Tracks event are aligned with the Customer report (`wp-admin/admin.php?page=wc-admin&path=/customers`)

1. Enable WC Analytics to have the Customers report available. Use the classic checkout (not checkout block).
2. Add a way to log or view the Tracks information sent on checkout:https://github.com/woocommerce/woocommerce/blob/ce92e43e01848331f5775d2d249e134d01f8f368/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php#L418
3. Place orders using several different payment methods (CC, COD, etc), and confirm that the `customer_order_count` is accurate both with and without an account (1 for first order, 2 for second order).
4. Check the Order Edit and see that the data for the customer matches the WooCommerce > Customer report:
![image](https://github.com/woocommerce/woocommerce/assets/228780/e971e9cd-3151-4d97-918e-be0fc60670f7)
![image](https://github.com/woocommerce/woocommerce/assets/228780/a2fd57ee-edf0-4c79-88e8-201cf608749d)
5. Toggle an order's status from `Processing` to `Pending Payment` and back, and see that the Customer history values change (the Customer report values will change too, but take longer to update).
6. Do the same for `Failed`, `Cancelled`, and `Draft` statuses - they should all remove the offer from the Customer history data.
7. `Refunded`, however, should just reduce the revenue numbers, but leave the total orders as is.
8. Test once with Checkout block. To ensure the order count in the Tracks event is accurate.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
