### PR TITLE
Interactivity API: Fix context merge

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/interactivity/directives.js
+++ b/plugins/woocommerce-blocks/assets/js/interactivity/directives.js
@@ -40,6 +40,17 @@ const mergeDeepSignals = ( target, source, overwrite ) => {
 	}
 };
 
+const deepClone = ( o ) => {
+	if ( isObject( o ) )
+		return Object.fromEntries(
+			Object.entries( o ).map( ( [ k, v ] ) => [ k, deepClone( v ) ] )
+		);
+	if ( Array.isArray( o ) ) {
+		return [ ...o.map( ( i ) => deepClone( i ) ) ];
+	}
+	return o;
+};
+
 export default () => {
 	// data-wc-context
 	directive(
@@ -56,7 +67,9 @@ export default () => {
 
 			currentValue.current = useMemo( () => {
 				const newValue = context
-					.map( ( c ) => deepSignal( { [ c.namespace ]: c.value } ) )
+					.map( ( c ) =>
+						deepSignal( { [ c.namespace ]: deepClone( c.value ) } )
+					)
 					.reduceRight( mergeDeepSignals );
 
 				mergeDeepSignals( newValue, inheritedValue );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes issues with merging inherited contexts declared with the `data-wc-context` directive.

1. Do not replace signals with new ones when the context value changes. This prevents getters from subscribing to signals that become orphans (i.e., are never updated anymore) when navigation happens.
2. Clone the context value before converting it to a DeepSignal. This prevents the value from being permanently modified, causing modifications to persist in the cached page and thus making these modifications apparent when the cached page is revisited.

This part needs to be examined and refactored in detail, but for now, it is enough with these workarounds, so the development is unblocked.

cc: @luisherranz

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
