### PR TITLE
Modify feedback modal actions

### DIFF
--- a/packages/js/customer-effort-score/changelog/dev-40086_adapt_feedback_modal_action_confirmation
+++ b/packages/js/customer-effort-score/changelog/dev-40086_adapt_feedback_modal_action_confirmation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add `onCancel` callback #43005

--- a/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
@@ -28,6 +28,7 @@ function FeedbackModal( {
 	title,
 	description,
 	onModalClose,
+	onCancel,
 	children,
 	isSubmitButtonDisabled,
 	submitButtonLabel,
@@ -38,6 +39,7 @@ function FeedbackModal( {
 	title: string;
 	description?: string;
 	onModalClose?: () => void;
+	onCancel?: () => void;
 	children?: JSX.Element;
 	isSubmitButtonDisabled?: boolean;
 	submitButtonLabel?: string;
@@ -78,7 +80,7 @@ function FeedbackModal( {
 			) }
 			{ children }
 			<div className="woocommerce-feedback-modal__buttons">
-				<Button isTertiary onClick={ closeModal } name="cancel">
+				<Button isTertiary onClick={ onCancel } name="cancel">
 					{ cancelButtonLabel }
 				</Button>
 				<Button

--- a/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
@@ -19,7 +19,8 @@ import classnames from 'classnames';
  * @param {string}   props.isSubmitButtonDisabled Boolean to enable/disable the send button.
  * @param {string}   props.submitButtonLabel      Label for the send button.
  * @param {string}   props.cancelButtonLabel      Label for the cancel button.
- * @param {Function} props.onModalClose           Callback for when user closes modal by clicking cancel.
+ * @param {Function} props.onModalClose           Function to call when user closes modal by clicking X.
+ * @param {Function} props.onCancel               Function to call when user presses cancel.
  * @param {Function} props.children               Children to be rendered.
  * @param {string}   props.className              Class name to addd to the modal.
  */

--- a/packages/js/customer-effort-score/src/components/feedback-modal/test/index.tsx
+++ b/packages/js/customer-effort-score/src/components/feedback-modal/test/index.tsx
@@ -33,7 +33,7 @@ describe( 'FeedbackModal', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should close modal when cancel button pressed', async () => {
+	it( 'should close modal when X button is pressed', async () => {
 		render(
 			<FeedbackModal
 				onSubmit={ mockRecordScoreCallback }
@@ -47,7 +47,7 @@ describe( 'FeedbackModal', () => {
 		await screen.findByRole( 'dialog' );
 
 		// Press cancel button.
-		fireEvent.click( screen.getByRole( 'button', { name: /Cancel/i } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: /Close/i } ) );
 
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );

--- a/packages/js/product-editor/changelog/dev-40086_adapt_feedback_modal_action_confirmation
+++ b/packages/js/product-editor/changelog/dev-40086_adapt_feedback_modal_action_confirmation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Modify feedback modal actions #43005

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
@@ -58,9 +58,18 @@ export const ProductMVPFeedbackModalContainer: React.FC< {
 
 	const onCloseModal = () => {
 		recordEvent( 'product_mvp_feedback', {
-			action: 'disable',
+			action: 'cancel',
 			checked: '',
 			comments: '',
+		} );
+		hideProductMVPFeedbackModal();
+	};
+
+	const onSkipFeedback = () => {
+		recordEvent( 'product_mvp_feedback', {
+			action: 'disable',
+			checked: '',
+			comments: 'Feedback skipped',
 		} );
 		hideProductMVPFeedbackModal();
 		window.location.href = classicEditorUrl;
@@ -74,6 +83,7 @@ export const ProductMVPFeedbackModalContainer: React.FC< {
 		<ProductMVPFeedbackModal
 			recordScoreCallback={ recordScore }
 			onCloseModal={ onCloseModal }
+			onSkipFeedback={ onSkipFeedback }
 		/>
 	);
 };

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -24,11 +24,13 @@ import { useDispatch } from '@wordpress/data';
  *
  * @param {Object}   props                     Component props.
  * @param {Function} props.recordScoreCallback Function to call when the results are sent.
- * @param {Function} props.onCloseModal        Callback for when user closes modal by clicking cancel.
+ * @param {Function} props.onCloseModal        Callback method called when user closes the modal by clicking the X.
+ * @param {Function} props.onSkipFeedback      Callback method called when user skips sending feedback.
  */
 function ProductMVPFeedbackModal( {
 	recordScoreCallback,
 	onCloseModal,
+	onSkipFeedback,
 }: {
 	recordScoreCallback: (
 		checked: string[],
@@ -36,6 +38,7 @@ function ProductMVPFeedbackModal( {
 		email: string
 	) => void;
 	onCloseModal?: () => void;
+	onSkipFeedback?: () => void;
 } ): JSX.Element | null {
 	const [ missingFeatures, setMissingFeatures ] = useState( false );
 	const [ missingPlugins, setMissingPlugins ] = useState( false );
@@ -105,6 +108,7 @@ function ProductMVPFeedbackModal( {
 				'woocommerce'
 			) }
 			onSubmit={ onSendFeedback }
+			onCancel={ onSkipFeedback }
 			onModalClose={ onCloseModal }
 			isSubmitButtonDisabled={ ! checked.length }
 			submitButtonLabel={ __( 'Send', 'woocommerce' ) }

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -24,8 +24,8 @@ import { useDispatch } from '@wordpress/data';
  *
  * @param {Object}   props                     Component props.
  * @param {Function} props.recordScoreCallback Function to call when the results are sent.
- * @param {Function} props.onCloseModal        Callback method called when user closes the modal by clicking the X.
- * @param {Function} props.onSkipFeedback      Callback method called when user skips sending feedback.
+ * @param {Function} props.onCloseModal        Function to call when user closes the modal by clicking the X.
+ * @param {Function} props.onSkipFeedback      Function to call when user skips sending feedback.
  */
 function ProductMVPFeedbackModal( {
 	recordScoreCallback,

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/test/index.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/test/index.tsx
@@ -28,7 +28,7 @@ describe( 'ProductMVPFeedbackModal', () => {
 		jest.resetAllMocks();
 	} );
 
-	it( 'should close the ProductMVPFeedback modal when skip button pressed', async () => {
+	it( 'should close the ProductMVPFeedback modal when X button pressed', async () => {
 		render(
 			<ProductMVPFeedbackModal
 				recordScoreCallback={ mockRecordScoreCallback }
@@ -37,7 +37,7 @@ describe( 'ProductMVPFeedbackModal', () => {
 		// Wait for the modal to render.
 		await screen.findByRole( 'dialog' );
 		// Press cancel button.
-		fireEvent.click( screen.getByRole( 'button', { name: /Skip/i } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: /Close/i } ) );
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 	it( 'should enable Send button when an option is checked', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to let users cancel the action when they press the `turn it off` button, in the feedback modal. Now the `X` behaves as a cancel button, just closing the modal without taking the users out of the new experience.

![Screenshot 2023-12-20 at 16 10 59](https://github.com/woocommerce/woocommerce/assets/1314156/89bce373-47dc-4be8-8b9a-21a7527e20b0)

Closes #40086.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**.
2. Under **WooCommerce > Settings > Advanced > Woo.com** verify that the `Enable tracking` option is `enabled`.  
3. Go to **Products > Add New**.
4. Add a product name and press `Save draft`.
5. Refresh the page.
6. Verify that the feedback bar is visible (it will appear after a few seconds).
7. Press the `turn it off` link.
8. The feedback modal will be visible.
9. Press the `X`.
10. Verify that the event `wcadmin_product_mvp_feedback` is being recorded with the props: action: "cancel".
11. The modal will be closed and the user will stay in the new experience.
12. Go to **Tools > WCA Test Helper > Options**
13. Search the option `woocommerce_product_editor_show_feedback_bar` and set it as `yes`.
14. Refresh the page and press `the turn it off` link.
15. Now press the `Skip` button.
16. Verify that the event `wcadmin_product_mvp_feedback` is being recorded with the props: action: "disable" and comments: "Feedback skipped".
17. The user should be redirected to the legacy experience.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
