### PR TITLE
[Product Block Editor]: Add `Linked product` tab

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-add-product-linked-tab
+++ b/plugins/woocommerce/changelog/update-product-editor-add-product-linked-tab
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-add `product-linked` feature flag
+[Product Block Editor]: add `Linked products` tab

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -151,7 +151,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			);
 		}
 
-		// Linked Products tabgit.
+		// Linked Products tab.
 		if ( Features::is_enabled( 'product-linked' ) ) {
 			$this->add_group(
 				array(

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -151,7 +151,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			);
 		}
 
-		// Linked Products tab.
+		// Linked Products tabgit.
 		if ( Features::is_enabled( 'product-linked' ) ) {
 			$this->add_group(
 				array(
@@ -160,11 +160,11 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'attributes'     => array(
 						'title' => __( 'Linked products', 'woocommerce' ),
 					),
-					'hideConditions' => array(
+					'hideConditions' => Features::is_enabled( 'product-linked' ) ? array(
 						array(
 							'expression' => 'editedProduct.type === "grouped"',
 						),
-					),
+					) : null,
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -150,6 +150,24 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				)
 			);
 		}
+
+		// Linked Products tab.
+		if ( Features::is_enabled( 'product-linked' ) ) {
+			$this->add_group(
+				array(
+					'id'             => $this::GROUP_IDS['LINKED_PRODUCTS'],
+					'order'          => 60,
+					'attributes'     => array(
+						'title' => __( 'Linked products', 'woocommerce' ),
+					),
+					'hideConditions' => array(
+						array(
+							'expression' => 'editedProduct.type === "grouped"',
+						),
+					),
+				)
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -16,12 +16,13 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 	 * The context name used to identify the editor.
 	 */
 	const GROUP_IDS = array(
-		'GENERAL'      => 'general',
-		'ORGANIZATION' => 'organization',
-		'PRICING'      => 'pricing',
-		'INVENTORY'    => 'inventory',
-		'SHIPPING'     => 'shipping',
-		'VARIATIONS'   => 'variations',
+		'GENERAL'         => 'general',
+		'ORGANIZATION'    => 'organization',
+		'PRICING'         => 'pricing',
+		'INVENTORY'       => 'inventory',
+		'SHIPPING'        => 'shipping',
+		'VARIATIONS'      => 'variations',
+		'LINKED_PRODUCTS' => 'linked-products',
 	);
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR registers the new `Linked Product` only when the `linked-product` flag is enabled.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Depends on https://github.com/woocommerce/woocommerce/pull/43006
Part of https://github.com/woocommerce/woocommerce/issues/42915
Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Tools > WCA Test Helper
2. Go to the Features tab
3. Enable the `product-linked` flag
<img width="463" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/b5b0408f-e499-435e-8089-2caa0df7cb34">

5. Go to the block editor
6. Confirm that you see the new `Linked Product` tab

<img width="900" alt="Screenshot 2023-12-20 at 16 17 21" src="https://github.com/woocommerce/woocommerce/assets/77539/3be1720d-eab2-4444-90cd-2e01fdecb108">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
