### PR TITLE
Fix for product meta lookup table incorrectly marking a product as onsale Closes #43008

### DIFF
--- a/plugins/woocommerce/changelog/43011-patch-1
+++ b/plugins/woocommerce/changelog/43011-patch-1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Use regular_price to determine if product is not sale and don't rely only on price for product_meta_lookup
+Use regular_price to determine if product is not sale and don't rely only on price for product_meta_lookup.

--- a/plugins/woocommerce/changelog/43011-patch-1
+++ b/plugins/woocommerce/changelog/43011-patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use regular_price to determine if product is not sale and don't rely only on price for product_meta_lookup

--- a/plugins/woocommerce/changelog/43011-patch-1
+++ b/plugins/woocommerce/changelog/43011-patch-1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Use regular_price to determine if product is not sale and don't rely only on price for product_meta_lookup.
+Use regular_price to determine if product is not sale and don't rely only on price for product_meta_lookup

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1562,11 +1562,13 @@ function wc_update_product_lookup_tables_column( $column ) {
 						{$wpdb->wc_product_meta_lookup} lookup_table
 						LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
 						LEFT JOIN {$wpdb->postmeta} meta2 ON lookup_table.product_id = meta2.post_id AND meta2.meta_key = '_sale_price'
+	  					LEFT JOIN {$wpdb->postmeta} meta3 ON lookup_table.product_id = meta3.post_id AND meta3.meta_key = '_regular_price'
 					SET
 						lookup_table.`{$column}` = IF (
 							CAST( meta1.meta_value AS DECIMAL ) >= 0
 							AND CAST( meta2.meta_value AS CHAR ) != ''
 							AND CAST( meta1.meta_value AS DECIMAL( 10, %d ) ) = CAST( meta2.meta_value AS DECIMAL( 10, %d ) )
+							AND CAST( meta3.meta_value AS DECIMAL( 10, %d ) ) > CAST( meta2.meta_value AS DECIMAL( 10, %d ) )
 						, 1, 0 )
 					",
 					$decimals,

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1572,6 +1572,8 @@ function wc_update_product_lookup_tables_column( $column ) {
 						, 1, 0 )
 					",
 					$decimals,
+					$decimals,
+					$decimals,
 					$decimals
 				)
 			);


### PR DESCRIPTION
Determine if a product is on sale based on regular price, which is how its done in the WC_Product class https://github.com/woocommerce/woocommerce/blob/7122669d448acb90d0f8a7177b76baaccec2e76b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php#L1634

Currently `$product->is_on_sale() == false` when `_regular_price` and `_sale_price` are the same, but the product lookup table ignores the `_regular_price` and only checks that `_price` and `_sale_price` are the same.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/43008 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a simple test product in WC > Products. Make sure it's not "on sale" and take note of its ID.
1. Force an update of the meta lookup table by running `wp eval "wc_update_product_lookup_tables_column( 'onsale' );"`.
1. Confirm the product is not on sale in the lookup table:
   ```
   > wp db query "SELECT onsale FROM $(wp db prefix)wc_product_meta_lookup WHERE product_id = <product_id>;"
   +--------+
   | onsale |
   +--------+
   |      0 |
   +--------+
   ```
1. Now go back and edit the product and set a sale price.
1. Confirm that the product appears on sale in the lookup table:
   ```
   > wp db query "SELECT onsale FROM $(wp db prefix)wc_product_meta_lookup WHERE product_id = <product_id>;"
   +--------+
   | onsale |
   +--------+
   |      1 |
   +--------+
   ```
1. To simulate the product having `regular_price`, `sale_price` and `price` all set to the same value run the following command:
   ```shell
   wp post meta update <product_id> _sale_price `wp post meta get <product_id> _regular_price`
   wp post meta update <product_id> _price `wp post meta get <product_id> _regular_price`
   ```
   Not that this is only to expedite testing, but this is in fact possible via the admin UI if one disables frontend validation (for example, by disabling JS).
4. Force (again) an update of the meta lookup table by running `wp eval "wc_update_product_lookup_tables_column( 'onsale' );"`.
5. Confirm that the product is not marked as being on sale in the lookup tables:
   ```
   > wp db query "SELECT onsale FROM $(wp db prefix)wc_product_meta_lookup WHERE product_id = <product_id>;"
   +--------+
   | onsale |
   +--------+
   |      0 |
   +--------+
   ```

<!--
Original instructions:
Create a few products, set some on sale and set some with sale price the same as regular price

```sql
SELECT
    IF (
        CAST(meta1.meta_value AS DECIMAL) >= 0
        AND CAST(meta2.meta_value AS CHAR) != ''
        AND CAST(meta1.meta_value AS DECIMAL(10, 2)) = CAST(meta2.meta_value AS DECIMAL(10, 2))
        AND CAST(meta3.meta_value AS DECIMAL(10, 2)) > CAST(meta2.meta_value AS DECIMAL(10, 2))
    , 1, 0) AS new_on_sale,
    lookup_table.product_id,
    lookup_table.onsale,
    meta1.meta_value as _meta_price,
    meta2.meta_value as _meta_sale_price,
    meta3.meta_value as _meta_regular_price
FROM
    wp_wc_product_meta_lookup lookup_table
    LEFT JOIN wp_postmeta meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
    LEFT JOIN wp_postmeta meta2 ON lookup_table.product_id = meta2.post_id AND meta2.meta_key = '_sale_price'
    LEFT JOIN wp_postmeta meta3 ON lookup_table.product_id = meta3.post_id AND meta3.meta_key = '_regular_price'
```

you would see new_on_sale has the correct value and onsale has the value woocommerce set-->
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Use regular_price to determine if product is not sale and don't rely only on price for product_meta_lookup
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
