### PR TITLE
Fix Consent API integration with OSA (trunk-based)

### DIFF
--- a/plugins/woocommerce/changelog/fix-osa-consent-revoke
+++ b/plugins/woocommerce/changelog/fix-osa-consent-revoke
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes handling for cookie consent for order attribution.

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution-blocks.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution-blocks.js
@@ -1,5 +1,5 @@
 // Extend checkout block's request data with order attribution data.
 window.wp.data.dispatch( window.wc.wcBlocksData.CHECKOUT_STORE_KEY ).__internalSetExtensionData(
 	'woocommerce/order-attribution',
-	window.wc_order_attribution.sbjsDataToSchema( window.sbjs.get )
+	window.wc_order_attribution.getData()
 );

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution-blocks.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution-blocks.js
@@ -1,5 +1,0 @@
-// Extend checkout block's request data with order attribution data.
-window.wp.data.dispatch( window.wc.wcBlocksData.CHECKOUT_STORE_KEY ).__internalSetExtensionData(
-	'woocommerce/order-attribution',
-	window.wc_order_attribution.getData()
-);

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -50,7 +50,7 @@
 		// Update inputs if any exist.
 		if( $( `input[name^="${params.prefix}"]` ) ) {
 			for( const key of Object.keys( wc_order_attribution.fields ) ) {
-				$( `input[name="${params.prefix}${key}"]` ).value = values? values[ key ] : values;
+				$( `input[name="${params.prefix}${key}"]` ).value = values && values[ key ] || '';
 			}
 		}
 	};

--- a/plugins/woocommerce/client/legacy/js/frontend/wp-consent-api-integration.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/wp-consent-api-integration.js
@@ -1,20 +1,19 @@
 ( function () {
 	'use strict';
 
-	// Check init order attribution on consent change.
-	const CONSENT_CATEGORY_MARKING = 'marketing';
+	// Set order attribution on consent change.
 	document.addEventListener( 'wp_listen_for_consent_change', ( e ) => {
 		const changedConsentCategory = e.detail;
 		for ( const key in changedConsentCategory ) {
-			if ( changedConsentCategory.hasOwnProperty( key ) && key === CONSENT_CATEGORY_MARKING ) {
+			if ( changedConsentCategory.hasOwnProperty( key ) && key === window.wc_order_attribution.params.consentCategory ) {
 				window.wc_order_attribution.setOrderTracking( changedConsentCategory[ key ] === 'allow' );
 		}
 		}
 	} );
 
-	// Init order attribution as soon as consent type is defined.
+	// Set order attribution as soon as consent type is defined.
 	document.addEventListener( 'wp_consent_type_defined', () => {
-		window.wc_order_attribution.setOrderTracking( wp_has_consent( CONSENT_CATEGORY_MARKING ) );
+		window.wc_order_attribution.setOrderTracking( wp_has_consent( window.wc_order_attribution.params.consentCategory ) );
 	} );
 }() );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/wp-consent-api-integration.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/wp-consent-api-integration.js
@@ -1,4 +1,4 @@
-( function ( $ ) {
+( function () {
 	'use strict';
 
 	// Check init order attribution on consent change.
@@ -6,19 +6,15 @@
 	document.addEventListener( 'wp_listen_for_consent_change', ( e ) => {
 		const changedConsentCategory = e.detail;
 		for ( const key in changedConsentCategory ) {
-			if ( changedConsentCategory.hasOwnProperty( key ) ) {
-				if ( key === CONSENT_CATEGORY_MARKING && changedConsentCategory[ key ] === 'allow' ) {
-					window.wc_order_attribution.setAllowTrackingConsent( true );
-				}
-			}
+			if ( changedConsentCategory.hasOwnProperty( key ) && key === CONSENT_CATEGORY_MARKING ) {
+				window.wc_order_attribution.setOrderTracking( changedConsentCategory[ key ] === 'allow' );
+		}
 		}
 	} );
 
 	// Init order attribution as soon as consent type is defined.
-	$( document ).on( 'wp_consent_type_defined', () => {
-		if ( wp_has_consent( CONSENT_CATEGORY_MARKING ) ) {
-			window.wc_order_attribution.setAllowTrackingConsent( true );
-		}
+	document.addEventListener( 'wp_consent_type_defined', () => {
+		window.wc_order_attribution.setOrderTracking( wp_has_consent( CONSENT_CATEGORY_MARKING ) );
 	} );
-}( jQuery ) );
+}() );
 

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAttributionServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAttributionServiceProvider.php
@@ -33,11 +33,13 @@ class OrderAttributionServiceProvider extends AbstractInterfaceServiceProvider {
 	 * Register the classes.
 	 */
 	public function register() {
+		$this->share_with_implements_tags( WPConsentAPI::class );
 		$this->share_with_implements_tags( OrderAttributionController::class )
 			->addArguments(
 				array(
 					LegacyProxy::class,
 					FeaturesController::class,
+					WPConsentAPI::class,
 				)
 			);
 		$this->share_with_implements_tags( OrderAttributionBlocksController::class )
@@ -48,6 +50,5 @@ class OrderAttributionServiceProvider extends AbstractInterfaceServiceProvider {
 					OrderAttributionController::class,
 				)
 			);
-		$this->share_with_implements_tags( WPConsentAPI::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
+++ b/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
@@ -18,11 +18,11 @@ class WPConsentAPI {
 
 
 	/**
-     * Identifier of the consent category used for order attribution.
+	 * Identifier of the consent category used for order attribution.
 	 *
 	 * @var string
 	 */
-	public static $CONSENT_CATEGORY = 'marketing';
+	public static $consent_category = 'marketing';
 
 	/**
 	 * Register the consent API.
@@ -67,7 +67,7 @@ class WPConsentAPI {
 		add_filter(
 			'wc_order_attribution_allow_tracking',
 			function() {
-				return function_exists( 'wp_has_consent' ) && wp_has_consent( self::$CONSENT_CATEGORY );
+				return function_exists( 'wp_has_consent' ) && wp_has_consent( self::$consent_category );
 			}
 		);
 	}
@@ -104,7 +104,7 @@ class WPConsentAPI {
 			'wp-consent-api-integration',
 			sprintf(
 				'window.wc_order_attribution.params.consentCategory = %s;',
-				wp_json_encode( self::$CONSENT_CATEGORY )
+				wp_json_encode( self::$consent_category )
 			),
 			'before'
 		);

--- a/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
+++ b/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
@@ -16,6 +16,14 @@ class WPConsentAPI {
 
 	use ScriptDebug;
 
+
+	/**
+     * Identifier of the consent category used for order attribution.
+	 *
+	 * @var string
+	 */
+	public static $CONSENT_CATEGORY = 'marketing';
+
 	/**
 	 * Register the consent API.
 	 *
@@ -59,7 +67,7 @@ class WPConsentAPI {
 		add_filter(
 			'wc_order_attribution_allow_tracking',
 			function() {
-				return function_exists( 'wp_has_consent' ) && wp_has_consent( 'marketing' );
+				return function_exists( 'wp_has_consent' ) && wp_has_consent( self::$CONSENT_CATEGORY );
 			}
 		);
 	}
@@ -88,6 +96,17 @@ class WPConsentAPI {
 			array( 'wp-consent-api', 'wc-order-attribution' ),
 			Constants::get_constant( 'WC_VERSION' ),
 			true
+		);
+
+		// Add data for the script above. `wp_enqueue_script` API does not allow data attributes,
+		// so we need a separate script tag and pollute the global scope.
+		wp_add_inline_script(
+			'wp-consent-api-integration',
+			sprintf(
+				'window.wc_order_attribution.params.consentCategory = %s;',
+				wp_json_encode( self::$CONSENT_CATEGORY )
+			),
+			'before'
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
+++ b/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
@@ -80,12 +80,12 @@ class WPConsentAPI {
 	 */
 	private function enqueue_consent_api_scripts() {
 		wp_enqueue_script(
-			'wp-consent-api-integration-js',
+			'wp-consent-api-integration',
 			plugins_url(
 				"assets/js/frontend/wp-consent-api-integration{$this->get_script_suffix()}.js",
 				WC_PLUGIN_FILE
 			),
-			array( 'wp-consent-api' ),
+			array( 'wp-consent-api', 'wc-order-attribution' ),
 			Constants::get_constant( 'WC_VERSION' ),
 			true
 		);

--- a/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
+++ b/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
@@ -85,7 +85,7 @@ class WPConsentAPI {
 				"assets/js/frontend/wp-consent-api-integration{$this->get_script_suffix()}.js",
 				WC_PLUGIN_FILE
 			),
-			array( 'jquery', 'wp-consent-api' ),
+			array( 'wp-consent-api' ),
 			Constants::get_constant( 'WC_VERSION' ),
 			true
 		);

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionBlocksController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionBlocksController.php
@@ -72,50 +72,6 @@ class OrderAttributionBlocksController implements RegisterHooksInterface {
 		}
 
 		$this->extend_api();
-
-		// Bail early on admin requests to avoid asset registration.
-		if ( is_admin() ) {
-			return;
-		}
-
-		add_action(
-			'init',
-			function() {
-				$this->register_assets();
-			}
-		);
-
-		add_action(
-			'wp_enqueue_scripts',
-			function() {
-				$this->enqueue_scripts();
-			}
-		);
-	}
-
-	/**
-	 * Register scripts.
-	 */
-	private function register_assets() {
-		wp_register_script(
-			'wc-order-attribution-blocks',
-			plugins_url(
-				"assets/js/frontend/order-attribution-blocks{$this->get_script_suffix()}.js",
-				WC_PLUGIN_FILE
-			),
-			array( 'wc-order-attribution', 'wp-data', 'wc-blocks-checkout' ),
-			Constants::get_constant( 'WC_VERSION' ),
-			true
-		);
-	}
-
-	/**
-	 * Enqueue the Order Attribution script.
-	 *
-	 * @return void
-	 */
-	private function enqueue_scripts() {
-		wp_enqueue_script( 'wc-order-attribution-blocks' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -425,7 +425,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'type'                 => $source_data['type'] ?? '',
 			'medium'               => $source_data['utm_medium'] ?? '',
 			'source'               => $source_data['utm_source'] ?? '',
-			'device_type'          => strtolower( $source_data['device_type'] ?? '(unknown)' ),
+			'device_type'          => strtolower( $source_data['device_type'] ?? 'unknown' ),
 			'origin_label'         => strtolower( $origin_label ),
 			'session_pages'        => $source_data['session_pages'] ?? 0,
 			'session_count'        => $source_data['session_count'] ?? 0,

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -67,13 +67,13 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 *
 	 * @param LegacyProxy         $proxy      The legacy proxy.
 	 * @param FeaturesController  $controller The feature controller.
-	 * @param WPConsentAPI		  $consent    The WPConsentAPI integration.
+	 * @param WPConsentAPI        $consent    The WPConsentAPI integration.
 	 * @param WC_Logger_Interface $logger     The logger object. If not provided, it will be obtained from the proxy.
 	 */
 	final public function init( LegacyProxy $proxy, FeaturesController $controller, WPConsentAPI $consent, ?WC_Logger_Interface $logger = null ) {
 		$this->proxy              = $proxy;
 		$this->feature_controller = $controller;
-		$this->consent			  = $consent;
+		$this->consent            = $consent;
 		$this->logger             = $logger ?? $proxy->call_function( 'wc_get_logger' );
 		$this->set_fields_and_prefix();
 	}
@@ -93,7 +93,6 @@ class OrderAttributionController implements RegisterHooksInterface {
 		if ( ! $this->feature_controller->feature_is_enabled( 'order_attribution' ) ) {
 			return;
 		}
-
 
 		// Register WPConsentAPI integration.
 		$this->consent->register();
@@ -270,7 +269,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 				'session'       => $session_length,
 				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
 				'prefix'        => $this->field_prefix,
-				'allowTracking' => $allow_tracking === 'yes' ? true : false,
+				'allowTracking' => 'yes' === $allow_tracking ? true : false,
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -254,7 +254,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 				'session'       => $session_length,
 				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
 				'prefix'        => $this->field_prefix,
-				'allowTracking' => $allow_tracking,
+				'allowTracking' => $allow_tracking === 'yes' ? true : false,
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -188,7 +188,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 */
 	private function maybe_set_admin_source( WC_Order $order ) {
 		if ( function_exists( 'is_admin' ) && is_admin() ) {
-			$order->add_meta_data( $this->get_meta_prefixed_field( 'source_type' ), 'admin' );
+			$order->add_meta_data( $this->get_meta_prefixed_field( 'type' ), 'admin' );
 			$order->save();
 		}
 	}
@@ -410,7 +410,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 */
 	private function send_order_tracks( array $source_data, WC_Order $order ) {
 		$origin_label        = $this->get_origin_label(
-			$source_data['source_type'] ?? '',
+			$source_data['type'] ?? '',
 			$source_data['utm_source'] ?? '',
 			false
 		);

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Internal\Orders;
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\Integrations\WPConsentAPI;
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 use Automattic\WooCommerce\Internal\Traits\ScriptDebug;
 use Automattic\WooCommerce\Internal\Traits\OrderAttributionMeta;
@@ -28,6 +29,13 @@ class OrderAttributionController implements RegisterHooksInterface {
 	use OrderAttributionMeta {
 		get_prefixed_field as public;
 	}
+
+	/**
+	 * The WPConsentAPI integration instance.
+	 *
+	 * @var WPConsentAPI
+	 */
+	private $consent;
 
 	/**
 	 * The FeatureController instance.
@@ -59,11 +67,13 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 *
 	 * @param LegacyProxy         $proxy      The legacy proxy.
 	 * @param FeaturesController  $controller The feature controller.
+	 * @param WPConsentAPI		  $consent    The WPConsentAPI integration.
 	 * @param WC_Logger_Interface $logger     The logger object. If not provided, it will be obtained from the proxy.
 	 */
-	final public function init( LegacyProxy $proxy, FeaturesController $controller, ?WC_Logger_Interface $logger = null ) {
+	final public function init( LegacyProxy $proxy, FeaturesController $controller, WPConsentAPI $consent, ?WC_Logger_Interface $logger = null ) {
 		$this->proxy              = $proxy;
 		$this->feature_controller = $controller;
+		$this->consent			  = $consent;
 		$this->logger             = $logger ?? $proxy->call_function( 'wc_get_logger' );
 		$this->set_fields_and_prefix();
 	}
@@ -83,6 +93,10 @@ class OrderAttributionController implements RegisterHooksInterface {
 		if ( ! $this->feature_controller->feature_is_enabled( 'order_attribution' ) ) {
 			return;
 		}
+
+
+		// Register WPConsentAPI integration.
+		$this->consent->register();
 
 		add_action(
 			'wp_enqueue_scripts',

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -269,7 +269,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 				'session'       => $session_length,
 				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
 				'prefix'        => $this->field_prefix,
-				'allowTracking' => 'yes' === $allow_tracking ? true : false,
+				'allowTracking' => 'yes' === $allow_tracking,
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -227,7 +227,9 @@ class OrderAttributionController implements RegisterHooksInterface {
 		wp_enqueue_script(
 			'wc-order-attribution',
 			plugins_url( "assets/js/frontend/order-attribution{$this->get_script_suffix()}.js", WC_PLUGIN_FILE ),
-			array( 'sourcebuster-js' ),
+			// Technically, we do not need 'wp-data', 'wc-blocks-checkout' for classic checkout,
+			// but we do not seem to distingush and load blocks scripts there anyway.
+			array( 'sourcebuster-js', 'wp-data', 'wc-blocks-checkout' ),
 			Constants::get_constant( 'WC_VERSION' ),
 			true
 		);

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -367,6 +367,10 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 * @return void
 	 */
 	private function set_order_source_data( array $source_data, WC_Order $order ) {
+		// If all the values are empty, bail.
+		if ( empty( array_filter( $source_data ) ) ) {
+			return;
+		}
 		foreach ( $source_data as $key => $value ) {
 			$order->add_meta_data( $this->get_meta_prefixed_field( $key ), $value );
 		}

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -188,7 +188,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 */
 	private function maybe_set_admin_source( WC_Order $order ) {
 		if ( function_exists( 'is_admin' ) && is_admin() ) {
-			$order->add_meta_data( $this->get_meta_prefixed_field( 'type' ), 'admin' );
+			$order->add_meta_data( $this->get_meta_prefixed_field( 'source_type' ), 'admin' );
 			$order->save();
 		}
 	}
@@ -410,7 +410,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 */
 	private function send_order_tracks( array $source_data, WC_Order $order ) {
 		$origin_label        = $this->get_origin_label(
-			$source_data['type'] ?? '',
+			$source_data['source_type'] ?? '',
 			$source_data['utm_source'] ?? '',
 			false
 		);

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -309,7 +309,9 @@ trait OrderAttributionMeta {
 
 			default:
 				$label  = '';
-				$source = __( 'Unknown', 'woocommerce' );
+				$source = $translated ?
+					__( 'Unknown', 'woocommerce' )
+					: 'Unknown';
 				break;
 		}
 

--- a/plugins/woocommerce/templates/order/attribution-data-fields.php
+++ b/plugins/woocommerce/templates/order/attribution-data-fields.php
@@ -6,7 +6,7 @@
  *
  * @see     Automattic\WooCommerce\Internal\Orders\OrderAttributionController
  * @package WooCommerce\Templates
- * @version 8.4.0
+ * @version 8.4.1
  */
 
 declare( strict_types=1 );

--- a/plugins/woocommerce/templates/order/attribution-data-fields.php
+++ b/plugins/woocommerce/templates/order/attribution-data-fields.php
@@ -6,7 +6,7 @@
  *
  * @see     Automattic\WooCommerce\Internal\Orders\OrderAttributionController
  * @package WooCommerce\Templates
- * @version 8.4.1
+ * @version 8.4.0
  */
 
 declare( strict_types=1 );

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderAttributionControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderAttributionControllerTest.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Tests\Internal\Orders;
 
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\Integrations\WPConsentAPI;
 use Automattic\WooCommerce\Internal\Orders\OrderAttributionController;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Testing\Tools\DependencyManagement\MockableLegacyProxy;
@@ -46,11 +47,15 @@ class OrderAttributionControllerTest extends WP_UnitTestCase {
 			->with( 'order_attribution' )
 			->willReturn( true );
 
+		$wp_consent_mock = $this->getMockBuilder( WPConsentAPI::class )
+			->onlyMethods( array( 'register' ) )
+			->getMock();
+
 		$logger_mock = $this->getMockBuilder( WC_Logger::class )
 			->onlyMethods( array( 'log' ) )
 			->getMock();
 
-		$this->attribution_fields_class->init( $legacy_proxy, $feature_mock, $logger_mock );
+		$this->attribution_fields_class->init( $legacy_proxy, $feature_mock, $wp_consent_mock, $logger_mock );
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-up from https://github.com/woocommerce/woocommerce/pull/39701
and alternative version of https://github.com/woocommerce/woocommerce/pull/41856
that is based on `trunk` and **does not** require https://github.com/woocommerce/woocommerce/pull/41690 .

It still uses a hardcoded fields list, disregarding `wc_order_attribution_tracking_fields` hook.
If this branch gets merged #41690 will need to be updated.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- [Stop tracking order attribution when the consent is revoked on the same page.](https://github.com/woocommerce/woocommerce/commit/60d16fe9f6a83836830c83c19352144ae147b8a4) 
    Switch `wp_consent_type_defined` to VanillaJS event, as this is what the latest Complianz dispatches.
    Remove jQuery dependency.
- [Update checkout block data when consent is given/revoked on the same page](https://github.com/woocommerce/woocommerce/pull/41856/commits/c2deff5176d9d44671ea4a09301f9ea116a33aac) 
c2deff5


Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Install WP Consent API plugin
1. Setup another plugin that uses WP Consent API, like Complianz

##### Denied by default
When you install Compilanz, the marketing data collection should be disabled by default, so even if you do not click anything in the cookie banner, `wc_order_attribution.params.allowTracking` should be set to `false` and no order attribution data should be collected. 

:lady_beetle: This integration was broken as the `WPConsentAPI` register was not called, and `-blocs` integration disregarded `wc_order_attribution.params.allowTracking` setting.

0. Make sure Complianz is set up in `opt-in` mode, for example by picking GDPR(EU) at `/wp-admin/admin.php?page=cmplz-wizard&step=1&section=1`
1. Open shop page in incognito mode. Do not click anything in the cookie banner
2. Add something to the cart and proceed to the block/classic checkout
3. Open dev tools
   - For classic checkout: Check that all `document.querySelectorAll('input[name^=wc_order_attribution_]');` inputs have empty values
   - For block checkout, monitor network tab and `/checkout` XHR
   - `wc_order_attribution.params.allowTracking` should be set to `false` 
4. "Place order"
	- For classic checkout, confirm that submitted POST **does not** contain `wc_order_attribution_*`  values
	- For block checkout, the `woocommerce/order-attribution` extension payload contains all `null`s 
6. Check that the placed order has no order attribution data in the `/wp-admin/admin.php?page=wc-orders&action=edit&id=`


##### Consent granted on the checkout page
:bug: This behavior was covered by JS code for classic checkout, so only registering `WPConsentAPI` would be all we need. But the behavior was broken for blocks

1. Start a new incognito session. Do not click anything in the cookie banner
2. Add something to the cart and proceed to the block/classic checkout
3. Open dev tools
   - For classic checkout: Check that all `document.querySelectorAll('input[name^=wc_order_attribution_]');` inputs have empty values
   - For block checkout, monitor network tab and `/checkout` XHR
   - `wc_order_attribution.params.allowTracking` should be set to `false` 
4. Grant "marketing" consent without reloading the page
   - For classic checkout: Check that all `document.querySelectorAll('input[name^=wc_order_attribution_]');` inputs have set values
   - `wc_order_attribution.params.allowTracking` should be set to `true` 
4. "Place order"
	- For classic checkout, confirm that submitted POST **does** contain `wc_order_attribution_*`  values
	- For block checkout, the `woocommerce/order-attribution` extension payload contains OSA data
6. Check that the placed order has order attribution data in the `/wp-admin/admin.php?page=wc-orders&action=edit&id=`

##### Consent granted before
1. Start a new incognito session. Do grant marketing consent in the cookie banner, reload the page
2. Add something to the cart and proceed to the block/classic checkout
3. Open dev tools
   - For classic checkout: Check that all `document.querySelectorAll('input[name^=wc_order_attribution_]');` inputs have set  values
   - For block checkout, monitor the network tab and `/checkout` XHRvalues
   - `wc_order_attribution.params.allowTracking` should be set to `true` 
4. "Place order"
	- For classic checkout, confirm that submitted POST **does** contain `wc_order_attribution_*`  values
	- For block checkout, the `woocommerce/order-attribution` extension payload contains OSA data
6. Check that the placed order has order attribution data in the `/wp-admin/admin.php?page=wc-orders&action=edit&id=`


##### Consent revoked on the checkout page
I didn't manage to simulate this behavior with the Compilanz UI, but theoretically, API supports this, so I believe we should be prepared for such behavior from another plugin.

To support this behavior, we need the majority of JS changes from this PR.

1. Start a new incognito session. Do grant marketing consent in the cookie banner, reload the page, or play with granting it at any later step before revoking it.
2. Add something to the cart and proceed to the block/classic checkout
3. Open dev tools
   - For classic checkout: Check that all `document.querySelectorAll('input[name^=wc_order_attribution_]');` inputs have set values
   - For block checkout, monitor the network tab and `/checkout` XHRvalues
   - `wc_order_attribution.params.allowTracking` should be set to `true` 
4. :yellow_circle: Simulate revoking the consent 
   ```js
   document.body.dispatchEvent(new CustomEvent('wp_listen_for_consent_change',{detail: {marketing: 'no'}}));
   ```

   - For classic checkout: Check that all `document.querySelectorAll('input[name^=wc_order_attribution_]');` inputs have empty values
   - `wc_order_attribution.params.allowTracking` should be set to `false` 
4. "Place order"
	- For classic checkout, confirm that submitted POST **does not** contain `wc_order_attribution_*`  values
	- For block checkout, the `woocommerce/order-attribution` extension payload contains all `null`s
6. Check that the placed order has no order attribution data in the `/wp-admin/admin.php?page=wc-orders&action=edit&id=`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
