### PR TITLE
Change marketplace install API request to POST instead of GET

### DIFF
--- a/plugins/woocommerce/changelog/43033-fix-install-url-signature-issue
+++ b/plugins/woocommerce/changelog/43033-fix-install-url-signature-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Changed an install-url request to POST instead of GET due to changes on Woo.com
+

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1193,7 +1193,7 @@ class WC_Helper {
 						'product_key' => $product_key,
 						'wc_version'  => WC()->version,
 					)
-				)
+				),
 			)
 		);
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1184,11 +1184,16 @@ class WC_Helper {
 	 * @return string
 	 */
 	public static function get_subscription_install_url( $product_key ) {
-		$install_url_response = WC_Helper_API::get(
+		$install_url_response = WC_Helper_API::post(
 			'install-url',
 			array(
 				'authenticated' => true,
-				'query_string'  => esc_url( '?product_key=' . $product_key . '&wc_version=' . WC()->version ),
+				'body'          => wp_json_encode(
+					array(
+						'product_key' => $product_key,
+						'wc_version'  => WC()->version,
+					)
+				)
 			)
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/42952 we introduced a method to retrieve the install url from a Woo.com API. This is failing and that API has now been switched to using `POST` instead of `GET`. This PR updates the request in WooCommerce to a `POST` request to support this change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Visit your [My Subscriptions](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions) page.
3. Ensure you're connected to Woo.com
4. Try to install an available subscription from here
5. Confirm you're able to install a free extension - this should happen on-site
6. Confirm you're able to install a paid extension - this should redirect you to the auto-installer on Woo.com to complete
7. Test around this issue.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Changed an install-url request to POST instead of GET due to changes on Woo.com

</details>
