### PR TITLE
Remove `UTM` from Order Attribution metabox labels 

### DIFF
--- a/plugins/woocommerce/changelog/tweak-order-attribution-metabox-labels
+++ b/plugins/woocommerce/changelog/tweak-order-attribution-metabox-labels
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Clarify order attribution campaign, medium and source labels.
+Simplify order attribution metabox labels for campaign, medium and source.

--- a/plugins/woocommerce/changelog/tweak-order-attribution-metabox-labels
+++ b/plugins/woocommerce/changelog/tweak-order-attribution-metabox-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Clarify order attribution campaign, medium and source labels.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -79,6 +79,6 @@ class OrderAttribution {
 			// Only show more details toggle if there is more than just the origin.
 			'has_more_details' => array( 'origin' ) !== array_keys( $meta ),
 		);
-		wc_get_template( 'order/attribution-data-fields.php', $template_data );
+		wc_get_template( 'order/attribution-details.php', $template_data );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -74,8 +74,10 @@ class OrderAttribution {
 
 		$this->format_meta_data( $meta );
 
-		$template_data = array(
+		$use_utm_labels = isset( $meta['type'] ) && 'utm' === $meta['type'];
+		$template_data  = array(
 			'meta'             => $meta,
+			'use_utm_labels'   => $use_utm_labels,
 			// Only show more details toggle if there is more than just the origin.
 			'has_more_details' => array( 'origin' ) !== array_keys( $meta ),
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -74,10 +74,8 @@ class OrderAttribution {
 
 		$this->format_meta_data( $meta );
 
-		$use_utm_labels = isset( $meta['source_type'] ) && 'utm' === $meta['source_type'];
-		$template_data  = array(
+		$template_data = array(
 			'meta'             => $meta,
-			'use_utm_labels'   => $use_utm_labels,
 			// Only show more details toggle if there is more than just the origin.
 			'has_more_details' => array( 'origin' ) !== array_keys( $meta ),
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -74,7 +74,7 @@ class OrderAttribution {
 
 		$this->format_meta_data( $meta );
 
-		$use_utm_labels = isset( $meta['type'] ) && 'utm' === $meta['type'];
+		$use_utm_labels = isset( $meta['source_type'] ) && 'utm' === $meta['source_type'];
 		$template_data  = array(
 			'meta'             => $meta,
 			'use_utm_labels'   => $use_utm_labels,

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Display the Order Attribution Data metabox.
+ * Display the Order Attribution details metabox.
  *
- * This template is used to display the order source data metabox on the edit order screen.
+ * This template is used to display the order attribution data metabox on the edit order screen.
  *
  * @see     Automattic\WooCommerce\Internal\Orders\OrderAttributionController
  * @package WooCommerce\Templates

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -56,11 +56,7 @@ defined( 'ABSPATH' ) || exit;
 
 		<?php if ( array_key_exists( 'utm_campaign', $meta ) ) : ?>
 			<h4>
-				<?php if ( $use_utm_labels ) : ?>
-					<?php esc_html_e( 'UTM campaign', 'woocommerce' ); ?>
-				<?php else : ?>
-					<?php esc_html_e( 'Campaign', 'woocommerce' ); ?>
-				<?php endif; ?>
+				<?php esc_html_e( 'Campaign', 'woocommerce' ); ?>
 			</h4>
 			<span class="order-attribution-utm-campaign">
 				<?php echo esc_html( $meta['utm_campaign'] ); ?>
@@ -69,11 +65,7 @@ defined( 'ABSPATH' ) || exit;
 
 		<?php if ( array_key_exists( 'utm_source', $meta ) ) : ?>
 			<h4>
-				<?php if ( $use_utm_labels ) : ?>
-					<?php esc_html_e( 'UTM source', 'woocommerce' ); ?>
-				<?php else : ?>
-					<?php esc_html_e( 'Source', 'woocommerce' ); ?>
-				<?php endif; ?>
+				<?php esc_html_e( 'Source', 'woocommerce' ); ?>
 
 			</h4>
 			<span class="order-attribution-utm-source">
@@ -83,11 +75,7 @@ defined( 'ABSPATH' ) || exit;
 
 		<?php if ( array_key_exists( 'utm_medium', $meta ) ) : ?>
 			<h4>
-				<?php if ( $use_utm_labels ) : ?>
-					<?php esc_html_e( 'UTM medium', 'woocommerce' ); ?>
-				<?php else : ?>
-					<?php esc_html_e( 'Medium', 'woocommerce' ); ?>
-				<?php endif; ?>
+				<?php esc_html_e( 'Medium', 'woocommerce' ); ?>
 			</h4>
 			<span class="order-attribution-utm-medium">
 				<?php echo esc_html( $meta['utm_medium'] ); ?>

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -55,21 +55,40 @@ defined( 'ABSPATH' ) || exit;
 		<?php endif; ?>
 
 		<?php if ( array_key_exists( 'utm_campaign', $meta ) ) : ?>
-			<h4><?php esc_html_e( 'UTM campaign', 'woocommerce' ); ?></h4>
+			<h4>
+				<?php if ( $use_utm_labels ) : ?>
+					<?php esc_html_e( 'UTM campaign', 'woocommerce' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'Campaign', 'woocommerce' ); ?>
+				<?php endif; ?>
+			</h4>
 			<span class="order-attribution-utm-campaign">
 				<?php echo esc_html( $meta['utm_campaign'] ); ?>
 			</span>
 		<?php endif; ?>
 
 		<?php if ( array_key_exists( 'utm_source', $meta ) ) : ?>
-			<h4><?php esc_html_e( 'UTM source', 'woocommerce' ); ?></h4>
+			<h4>
+				<?php if ( $use_utm_labels ) : ?>
+					<?php esc_html_e( 'UTM source', 'woocommerce' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'Source', 'woocommerce' ); ?>
+				<?php endif; ?>
+
+			</h4>
 			<span class="order-attribution-utm-source">
 				<?php echo esc_html( $meta['utm_source'] ); ?>
 			</span>
 		<?php endif; ?>
 
 		<?php if ( array_key_exists( 'utm_medium', $meta ) ) : ?>
-			<h4><?php esc_html_e( 'UTM medium', 'woocommerce' ); ?></h4>
+			<h4>
+				<?php if ( $use_utm_labels ) : ?>
+					<?php esc_html_e( 'UTM medium', 'woocommerce' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'Medium', 'woocommerce' ); ?>
+				<?php endif; ?>
+			</h4>
 			<span class="order-attribution-utm-medium">
 				<?php echo esc_html( $meta['utm_medium'] ); ?>
 			</span>

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -6,7 +6,7 @@
  *
  * @see     Automattic\WooCommerce\Internal\Orders\OrderAttributionController
  * @package WooCommerce\Templates
- * @version 8.6.0
+ * @version 8.6.0-dev
  */
 
 declare( strict_types=1 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR changes the behavior of the Order attribution metabox on the Order Edit page to no longer prefix the labels with `UTM `. Ff the attribution type is `utm`, then it should be understood that `Campaign`, `Source`, and `Medium` values are derived from the corresponding UTM parameters. It also renames the template to make it a bit more consistent with other templates.

Here come the screenshots:
- Bad: Without these changes, the labels always have `UTM `, even if it's a referral, for example:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/212c0f8c-fb4d-4e50-bea4-3b3f2fed6651)
    This is inaccurate and could potentially be confusing for merchants.
- Bad: UTM attribution labels have the redundant `UTM `, too:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/a7728b7d-f441-40e0-9abb-f2987252a632)
- Good: Referral attribution (labels don't have `UTM`):
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/196be705-80b4-44a2-95ed-cdfcebbbea37)
- Good: Orders with a UTM source type also no longer have `UTM` in the label:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/25cb0349-4ad3-49b1-9066-5a024d127a39)



#### 📝 Note
We should probably also tag removing `utm_` from these meta keys as technical debt since they aren't always UTM (for a referral attribution, for example).

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up WooCommerce and create all the orders using incognito:
    - Via referral. Go to any website (<woo.com>, for example) and edit a link `href` in developer tools to point to the store. Add items to the cart and complete the checkout.
    - Organic. Same as above, but use <google.com>.
    - Using UTM parameters. Open the store with a URL like `https://woocommerce.store/shop/?utm_source=newsletter&utm_medium=email&utm_campaign=sale&utm_content=utmcontent&utm_term=utm_term`. Add items to the cart and complete the checkout.
    - Typein. Like above, but without any parameters.
    - Web admin. Create from the Add Order page.
    - Unknown. Create another from the Add Order page, but then erase the associated metadata from the db:
     ```
    DELETE FROM `wp_wc_orders_meta` WHERE `order_id` = 414 AND `meta_key` LIKE '_wc_order_attribution%';
    DELETE FROM `wp_postmeta` WHERE `post_id` = 414 AND `meta_key` LIKE '_wc_order_attribution%';
    ```
3. Confirm all items appear correctly labeled in the Orders Table `wp-admin/admin.php?page=wc-orders`:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/7dae5c85-233c-4060-b1ee-120bdc7d79e8)

4. Confirm that the labels in the **Order attribution** metabox  **are never prefixed with `UTM`**:
![image](https://github.com/woocommerce/woocommerce/assets/228780/25cb0349-4ad3-49b1-9066-5a024d127a39) ![image](https://github.com/woocommerce/woocommerce/assets/228780/8df05d42-5c1f-4c32-9eda-cb8cfe58c15e) ![image](https://github.com/woocommerce/woocommerce/assets/228780/62894bb2-4df3-4e50-9b46-f7e2bd36244f) ![image](https://github.com/woocommerce/woocommerce/assets/228780/6955bb46-c914-41f1-af27-30382e5d69a1) ![image](https://github.com/woocommerce/woocommerce/assets/228780/ea9595be-6ca3-4249-b89a-cff975ffee16) ![image](https://github.com/woocommerce/woocommerce/assets/228780/1effd4d6-4be9-4150-b8ae-a749d8ebd2db)




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Clarify order attribution campaign, medium and source labels.


</details>
