### PR TITLE
Fix: Collection data being leaked between Collection Filters blocks

### DIFF
--- a/plugins/woocommerce/changelog/43044-fix-42975-collection-data-leak
+++ b/plugins/woocommerce/changelog/43044-fix-42975-collection-data-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix the collection data cache being leak between `Collection Filters` blocks.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
@@ -54,25 +54,6 @@ final class CollectionFilters extends AbstractBlock {
 	}
 
 	/**
-	 * Extra data passed through from server to client for block.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 *                           Note, this will be empty in the editor context when the block is
-	 *                           not in the post content on editor load.
-	 */
-	protected function enqueue_data( array $attributes = [] ) {
-		parent::enqueue_data( $attributes );
-
-		if ( ! is_admin() ) {
-			/**
-			 * At this point, WP starts rendering the Collection Filters block,
-			 * we can safely unset the current response.
-			 */
-			$this->current_response = null;
-		}
-	}
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -81,6 +62,16 @@ final class CollectionFilters extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		if ( is_admin() ) {
+			return $content;
+		}
+
+		/**
+		 * At this point, WP starts rendering the Collection Filters block,
+		 * we can safely unset the current response.
+		 */
+		$this->current_response = null;
+
 		$attributes_data = array(
 			'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-filters' ) ),
 			'class'               => 'wc-block-collection-filters',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR update the `CollectionFilters` class to unset the cached collection data response right before rendering start, so the cache is ready to process next `Collection Filters` blocks if exist.

This implementation has a limitation in theory: the cached response is still leaked to `Collection Filters` blocks that are added as inner block of a `Collection Filters` block. I accept that limitation because:
-  Gutenberg [hasn't provided](https://github.com/WordPress/gutenberg/issues/22592) any method to exclude a block from being added to other block.
- We can limit it be using `subscribe` but I don't think it worth the effort and the potential performance issue.
- `Collection Filters` when is added inside another `Collection Filters` block won't work properly even the data leak issue is fixed completely.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42975.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a page containing `Product Collection` block and multiple `Collection Filters` blocks, each contain a single (new) filter block. You can also use the test page content for your convinent.
2. On the frontend, see all filter blocks rendered correctly.

<details>
<summary>Test page content</summary>

```
<!-- wp:woocommerce/collection-filters -->
<!-- wp:woocommerce/collection-active-filters /-->

<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Filter by Price</h3>
<!-- /wp:heading -->

<!-- wp:woocommerce/collection-price-filter /-->
<!-- /wp:woocommerce/collection-filters -->

<!-- wp:woocommerce/collection-filters -->
<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Filter by Rating</h3>
<!-- /wp:heading -->

<!-- wp:woocommerce/collection-rating-filter {"selectType":"single"} -->
<div class="wp-block-woocommerce-collection-rating-filter is-loading"></div>
<!-- /wp:woocommerce/collection-rating-filter -->
<!-- /wp:woocommerce/collection-filters -->

<!-- wp:woocommerce/collection-filters -->
<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Filter by Stock status</h3>
<!-- /wp:heading -->

<!-- wp:woocommerce/collection-stock-filter {"selectType":"single"} /-->
<!-- /wp:woocommerce/collection-filters -->

<!-- wp:woocommerce/collection-filters -->
<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Filter by Color</h3>
<!-- /wp:heading -->

<!-- wp:woocommerce/collection-attribute-filter {"queryParam":{"calculate_attribute_counts":{"taxonomy":"pa_color","queryType":"or"}},"attributeId":1} /-->
<!-- /wp:woocommerce/collection-filters -->

<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"priceRange":{"min":20}},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true}} -->
<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->

<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->

<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->

<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
<!-- /wp:woocommerce/product-template -->

<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:woocommerce/product-collection-no-results -->
<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"medium"} -->
<p class="has-medium-font-size"><strong>No results found</strong></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>You can try <a href="#" class="wc-link-clear-any-filters">clearing any filters</a> or head to our <a href="#" class="wc-link-stores-home">store's home</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
<!-- /wp:woocommerce/product-collection-no-results --></div>
<!-- /wp:woocommerce/product-collection -->
```

</details>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fix the collection data cache being leak between `Collection Filters` blocks.
</details>
