### PR TITLE
Fix product task redirect to support grouped and external products

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -24,32 +24,19 @@ export const useCreateProductByType = () => {
 	const isNewExperienceEnabled =
 		window.wcAdminFeatures[ 'new-product-management-experience' ];
 
-	const createProductByType = async ( type: ProductTypeKey ) => {
-		setIsRequesting( true );
-
+	const getProductEditPageLink = async (
+		type: ProductTypeKey,
+		classicEditor: boolean
+	) => {
 		if (
 			type === 'physical' ||
 			type === 'variable' ||
-			type === 'digital' ||
-			type === 'grouped' ||
-			type === 'external'
+			type === 'digital'
 		) {
-			if ( isNewExperienceEnabled ) {
-				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
-				return;
-			}
-			const assignment = await loadExperimentAssignment(
-				EXPERIMENT_NAME
-			);
-			if ( assignment.variationName === 'treatment' ) {
-				const _feature_nonce = getAdminSetting( '_feature_nonce' );
-				window.location.href = getAdminLink(
-					`post-new.php?post_type=product&product_block_editor=1&_feature_nonce=${ _feature_nonce }`
-				);
-				return;
-			}
+			return classicEditor
+				? getAdminLink( 'post-new.php?post_type=product' )
+				: getNewPath( {}, '/add-product', {} );
 		}
-
 		try {
 			const data: {
 				id?: number;
@@ -61,15 +48,51 @@ export const useCreateProductByType = () => {
 				{ _fields: [ 'id' ] }
 			);
 			if ( data && data.id ) {
-				const link = getAdminLink(
-					`post.php?post=${ data.id }&action=edit&wc_onboarding_active_task=products&tutorial=true`
-				);
-				window.location.href = link;
-				return;
+				return classicEditor
+					? getAdminLink(
+							`post.php?post=${ data.id }&action=edit&wc_onboarding_active_task=products&tutorial=true`
+					  )
+					: getNewPath( {}, '/product/' + data.id, {} );
 			}
 			throw new Error( 'Unexpected empty data response from server' );
 		} catch ( error ) {
 			createNoticesFromResponse( error );
+		}
+	};
+
+	const createProductByType = async ( type: ProductTypeKey ) => {
+		setIsRequesting( true );
+
+		if (
+			type === 'physical' ||
+			type === 'variable' ||
+			type === 'digital' ||
+			type === 'grouped' ||
+			type === 'external'
+		) {
+			if ( isNewExperienceEnabled ) {
+				const url = await getProductEditPageLink( type, false );
+				if ( url ) {
+					navigateTo( { url } );
+				}
+				return;
+			}
+			const assignment = await loadExperimentAssignment(
+				EXPERIMENT_NAME
+			);
+			if ( assignment.variationName === 'treatment' ) {
+				const url = await getProductEditPageLink( type, true );
+				const _feature_nonce = getAdminSetting( '_feature_nonce' );
+				window.location.href =
+					url +
+					`&product_block_editor=1&_feature_nonce=${ _feature_nonce }`;
+				return;
+			}
+		}
+
+		const url = await getProductEditPageLink( type, true );
+		if ( url ) {
+			navigateTo( { url } );
 		}
 		setIsRequesting( false );
 	};

--- a/plugins/woocommerce/changelog/fix-product-task-redirect
+++ b/plugins/woocommerce/changelog/fix-product-task-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product task redirection to allow use for external and grouped products with the new product editor.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43050 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the new product editor is **disabled**
2. Go to **WooCommerce > Home** and with the task list displayed click the `Add products` task 
3. Go through the all of the product types ( physical, grouped, external, in particular ) this should all redirect to the classic editor and have the correct product type selected.
4. Go to the abacus experiments and look for: `woocommerce_product_creation_experience_add_external_and_grouped_202401_v1`
5. Scroll down to `Audience` and add the `treatment` bookmarklet to your browser toolbar.
6. Go back to `Add products` task and click the bookmarklet ( it should show a successful popup )
7. Click `Grouped` product, it should redirect to the new editor with the grouped product template ( it should have also enabled the new product editor feature flag ) ( grouped product doesn't show the `Shipping` & `Variations` tab for example and hides most of the fields aside from the `SKU` in the inventory tab )
8. Now disable the product editor feature flag again in **WooCommerce > Settings > Advanced > Features**
9. Follow step 7 & 8 again for the physical product, variable product, and external product.
10. Now keep the product editor feature flag enabled.
11. Go to the task list and click each product type ( physical, grouped, external, in particular )
12. It should redirect to the new editor and show the correct template ( grouped product doesn't show the `Shipping` & `Variations` tab for example and hides most of the fields aside from the `SKU` in the inventory tab ).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
