### PR TITLE
Layout templates REST API

### DIFF
--- a/plugins/woocommerce/changelog/add-layout-templates-rest-api
+++ b/plugins/woocommerce/changelog/add-layout-templates-rest-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Template layout REST API endpoints.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -39,7 +39,13 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'                => array(),
+				'args'                => array(
+					'area' => array(
+						'description' => __( 'Area to get templates for.', 'woocommerce' ),
+						'type'        => 'string',
+						'default'     => '',
+					),
+				),
 			)
 		);
 
@@ -78,6 +84,10 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 		$registered_layout_templates = $template_registry->get_all_registered();
 
 		foreach ( $registered_layout_templates as $layout_template ) {
+			if ( ! empty( $request['area'] ) && $layout_template->get_area() !== $request['area'] ) {
+				continue;
+			}
+
 			$layout_templates[] = $layout_template->get_formatted_template();
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -88,7 +88,7 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 				continue;
 			}
 
-			$layout_templates[] = $layout_template->get_formatted_template();
+			$layout_templates[] = $layout_template->to_json();
 		}
 
 		$response = rest_ensure_response( $layout_templates );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -123,7 +123,7 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 			return new WP_Error( 'woocommerce_rest_layout_template_invalid_id', __( 'Invalid layout template ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		$response = rest_ensure_response( $layout_templates[0] );
+		$response = rest_ensure_response( current( $layout_templates ) );
 
 		return $response;
 	}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -42,17 +42,39 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 				'args'                => array(),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>\w[\w\s\-]*)',
+			array(
+				'args' => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(),
+				),
+			)
+		);
 	}
 
 	public function get_items_permissions_check( $request ) {
 		return true;
 	}
 
+	public function get_item_permissions_check( $request ) {
+		return true;
+	}
+
 	public function get_items( $request ) {
 		$layout_templates = array();
 
-		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
-
+		$template_registry           = wc_get_container()->get( BlockTemplateRegistry::class );
 		$registered_layout_templates = $template_registry->get_all_registered();
 
 		foreach ( $registered_layout_templates as $layout_template ) {
@@ -60,6 +82,21 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 		}
 
 		$response = rest_ensure_response( $layout_templates );
+
+		return $response;
+	}
+
+	public function get_item( $request ) {
+		$id = $request['id'];
+
+		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
+		$layout_template   = $template_registry->get_registered( $id );
+
+		if ( ! $layout_template ) {
+			return new WP_Error( 'woocommerce_rest_layout_template_invalid_id', __( 'Invalid layout template ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$response = rest_ensure_response( $layout_template->get_formatted_template() );
 
 		return $response;
 	}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -5,13 +5,16 @@
  * Handles requests to /layout-templates.
  *
  * @package WooCommerce\RestApi
- * @since 8.5.0
+ * @since 8.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
 
+/**
+ * REST API Layout Templates controller class.
+ */
 class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 
 	/**
@@ -29,7 +32,7 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 	protected $rest_base = 'layout-templates';
 
 	/**
-	 * Register the routes for layouts.
+	 * Register the routes for template layouts.
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -69,14 +72,29 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 		);
 	}
 
-	public function get_items_permissions_check( $request ) {
+	/**
+	 * Check if a given request has access to read template layouts.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 */
+	public function get_items_permissions_check( $request ): bool {
 		return true;
 	}
 
-	public function get_item_permissions_check( $request ) {
+	/**
+	 * Check if a given request has access to read a template layout.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 */
+	public function get_item_permissions_check( $request ): bool {
 		return true;
 	}
 
+	/**
+	 * Handle request for template layouts.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 */
 	public function get_items( $request ) {
 		$layout_templates = $this->get_layout_templates(
 			array(
@@ -89,6 +107,11 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 		return $response;
 	}
 
+	/**
+	 * Handle request for a single template layout.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 */
 	public function get_item( $request ) {
 		$layout_templates = $this->get_layout_templates(
 			array(
@@ -105,6 +128,11 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 		return $response;
 	}
 
+	/**
+	 * Get layout templates.
+	 *
+	 * @param array $query_params Query params.
+	 */
 	private function get_layout_templates( array $query_params ): array {
 		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -107,15 +107,6 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 
 	private function get_layout_templates( array $query_params ): array {
 		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
-		$class_names              = $layout_template_registry->get_class_names( $query_params );
-
-		$layout_templates = array();
-
-		foreach ( $class_names as $class_name ) {
-			$layout_template    = new $class_name();
-			$layout_templates[] = $layout_template->to_json();
-		}
-
-		return $layout_templates;
+		return $layout_template_registry->instantiate_layout_templates( $query_params );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -106,7 +106,7 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 			return new WP_Error( 'woocommerce_rest_layout_template_invalid_id', __( 'Invalid layout template ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		$response = rest_ensure_response( $layout_template->get_formatted_template() );
+		$response = rest_ensure_response( $layout_template->to_json() );
 
 		return $response;
 	}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -10,7 +10,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplateRegistry;
+use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
 
 class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 
@@ -106,23 +106,13 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 	}
 
 	private function get_layout_templates( array $query_params ): array {
-		$area_to_match = isset( $query_params['area'] ) ? $query_params['area'] : null;
-		$id_to_match   = isset( $query_params['id'] ) ? $query_params['id'] : null;
-
-		$template_registry           = wc_get_container()->get( BlockTemplateRegistry::class );
-		$registered_layout_templates = $template_registry->get_all_registered();
+		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
+		$class_names              = $layout_template_registry->get_class_names( $query_params );
 
 		$layout_templates = array();
 
-		foreach ( $registered_layout_templates as $layout_template ) {
-			if ( ! empty( $area_to_match ) && $layout_template->get_area() !== $area_to_match ) {
-				continue;
-			}
-
-			if ( ! empty( $id_to_match ) && $layout_template->get_id() !== $id_to_match ) {
-				continue;
-			}
-
+		foreach ( $class_names as $class_name ) {
+			$layout_template    = new $class_name();
 			$layout_templates[] = $layout_template->to_json();
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -107,6 +107,12 @@ class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
 
 	private function get_layout_templates( array $query_params ): array {
 		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
-		return $layout_template_registry->instantiate_layout_templates( $query_params );
+
+		return array_map(
+			function( $layout_template ) {
+				return $layout_template->to_json();
+			},
+			$layout_template_registry->instantiate_layout_templates( $query_params )
+		);
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * REST API Layout Templates controller
+ *
+ * Handles requests to /layout-templates.
+ *
+ * @package WooCommerce\RestApi
+ * @since 8.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplateRegistry;
+
+class WC_REST_Layout_Templates_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'layout-templates';
+
+	/**
+	 * Register the routes for layouts.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => array(),
+			)
+		);
+	}
+
+	public function get_items_permissions_check( $request ) {
+		return true;
+	}
+
+	public function get_items( $request ) {
+		$layout_templates = array();
+
+		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
+
+		$registered_layout_templates = $template_registry->get_all_registered();
+
+		foreach ( $registered_layout_templates as $layout_template ) {
+			$layout_templates[] = $layout_template->get_formatted_template();
+		}
+
+		$response = rest_ensure_response( $layout_templates );
+
+		return $response;
+	}
+}

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -143,6 +143,7 @@ class Server {
 			'coupons'                  => 'WC_REST_Coupons_Controller',
 			'customer-downloads'       => 'WC_REST_Customer_Downloads_Controller',
 			'customers'                => 'WC_REST_Customers_Controller',
+			'layout-templates'         => 'WC_REST_Layout_Templates_Controller',
 			'network-orders'           => 'WC_REST_Network_Orders_Controller',
 			'order-notes'              => 'WC_REST_Order_Notes_Controller',
 			'order-refunds'            => 'WC_REST_Order_Refunds_Controller',

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -6,12 +6,14 @@
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\SimpleProductTemplate;
-use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\ProductVariationTemplate;
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplate;
 use Automattic\WooCommerce\Admin\PageController;
-use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplateRegistry;
+use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
+
 use Automattic\WooCommerce\Internal\Admin\BlockTemplates\BlockTemplateLogger;
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\SimpleProductTemplate;
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\ProductVariationTemplate;
+
 use WP_Block_Editor_Context;
 
 /**
@@ -212,12 +214,12 @@ class Init {
 	 * Get the product editor settings.
 	 */
 	private function get_product_editor_settings() {
-		$layout_template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
+		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
 		$layout_template_logger   = BlockTemplateLogger::get_instance();
 
 		$editor_settings = array();
 
-		foreach ( $layout_template_registry->get_all_registered() as $layout_template ) {
+		foreach ( $layout_template_registry->instantiate_layout_templates() as $layout_template ) {
 			$editor_settings['layoutTemplates'][] = $layout_template->to_json();
 
 			$layout_template_logger->log_template_events_to_file( $layout_template->get_id() );
@@ -372,14 +374,22 @@ class Init {
 	 * Register product editor templates.
 	 */
 	public function register_product_editor_templates() {
-		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
+		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
 
-		if ( ! $template_registry->get_registered( 'simple-product' ) ) {
-			$template_registry->register( new SimpleProductTemplate() );
+		if ( ! $layout_template_registry->is_registered( 'simple-product' ) ) {
+			$layout_template_registry->register(
+				'simple-product',
+				'product-form',
+				SimpleProductTemplate::class
+			);
 		}
 
-		if ( ! $template_registry->get_registered( 'product-variation' ) ) {
-			$template_registry->register( new ProductVariationTemplate() );
+		if ( ! $layout_template_registry->is_registered( 'product-variation' ) ) {
+			$layout_template_registry->register(
+				'product-variation',
+				'product-form',
+				ProductVariationTemplate::class
+			);
 		}
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTem
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplate;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplateRegistry;
-use Automattic\WooCommerce\Internal\Admin\BlockTemplates\Block;
 use Automattic\WooCommerce\Internal\Admin\BlockTemplates\BlockTemplateLogger;
 use WP_Block_Editor_Context;
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -374,7 +374,13 @@ class Init {
 	 */
 	public function register_product_editor_templates() {
 		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
-		$template_registry->register( new SimpleProductTemplate() );
-		$template_registry->register( new ProductVariationTemplate() );
+
+		if ( ! $template_registry->get_registered( 'simple-product' ) ) {
+			$template_registry->register( new SimpleProductTemplate() );
+		}
+
+		if ( ! $template_registry->get_registered( 'product-variation' ) ) {
+			$template_registry->register( new ProductVariationTemplate() );
+		}
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -68,6 +68,8 @@ class Init {
 
 			add_action( 'current_screen', array( $this, 'set_current_screen_to_block_editor_if_wc_admin' ) );
 
+			add_action( 'rest_api_init', array( $this, 'register_product_editor_templates' ) );
+
 			// Make sure the block registry is initialized so that core blocks are registered.
 			BlockRegistry::get_instance();
 
@@ -370,7 +372,7 @@ class Init {
 	/**
 	 * Register product editor templates.
 	 */
-	private function register_product_editor_templates() {
+	public function register_product_editor_templates() {
 		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
 		$template_registry->register( new SimpleProductTemplate() );
 		$template_registry->register( new ProductVariationTemplate() );

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -29,6 +29,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\Restoc
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\UtilsClassesServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\BatchProcessingServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\BlockTemplatesServiceProvider;
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\LayoutTemplatesServiceProvider;
 
 /**
  * PSR11 compliant dependency injection container for WooCommerce.
@@ -76,6 +77,7 @@ final class Container {
 		MarketingServiceProvider::class,
 		MarketplaceServiceProvider::class,
 		BlockTemplatesServiceProvider::class,
+		LayoutTemplatesServiceProvider::class,
 		LoggingServiceProvider::class,
 	);
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
@@ -71,6 +71,8 @@ final class BlockTemplateRegistry {
 	 * Get a single registered template.
 	 *
 	 * @param string $id ID of the template.
+	 *
+	 * @return BlockTemplateInterface|null
 	 */
 	public function get_registered( $id ): ?BlockTemplateInterface {
 		return isset( $this->templates[ $id ] ) ? $this->templates[ $id ] : null;

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
@@ -71,8 +71,6 @@ final class BlockTemplateRegistry {
 	 * Get a single registered template.
 	 *
 	 * @param string $id ID of the template.
-	 *
-	 * @return BlockTemplateInterface|null
 	 */
 	public function get_registered( $id ): ?BlockTemplateInterface {
 		return isset( $this->templates[ $id ] ) ? $this->templates[ $id ] : null;

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LayoutTemplatesServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LayoutTemplatesServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
+
+use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
+use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
+
+class LayoutTemplatesServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * The classes/interfaces that are serviced by this service provider.
+	 *
+	 * @var array
+	 */
+	protected $provides = array(
+		LayoutTemplateRegistry::class,
+	);
+
+	/**
+	 * Register the classes.
+	 */
+	public function register() {
+		$this->share( LayoutTemplateRegistry::class );
+	}
+}

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LayoutTemplatesServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LayoutTemplatesServiceProvider.php
@@ -5,6 +5,9 @@ namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
 
+/**
+ * Service provider for layout templates.
+ */
 class LayoutTemplatesServiceProvider extends AbstractServiceProvider {
 
 	/**

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -96,8 +96,9 @@ final class LayoutTemplateRegistry {
 
 		$layout_templates_info = $this->get_matching_layout_templates_info( $query_params );
 		foreach ( $layout_templates_info as $layout_template_info ) {
-			$layout_template    = $this->get_layout_template_instance( $layout_template_info );
-			$layout_templates[] = $layout_template;
+			$layout_template = $this->get_layout_template_instance( $layout_template_info );
+
+			$layout_templates[ $layout_template->get_id() ] = $layout_template;
 		}
 
 		return $layout_templates;
@@ -108,7 +109,7 @@ final class LayoutTemplateRegistry {
 	 *
 	 * @param array $layout_template_info Layout template info.
 	 */
-	private function get_layout_template_instance( $layout_template_info ) {
+	private function get_layout_template_instance( $layout_template_info ): BlockTemplateInterface {
 		$class_name = $layout_template_info['class_name'];
 
 		// Return the instance if it already exists.

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -160,6 +160,17 @@ final class LayoutTemplateRegistry {
 		 */
 		do_action( 'woocommerce_layout_template_after_instantiation', $layout_template_info['id'], $layout_template_info['area'], $layout_template_instance );
 
+		// Call the old, soon-to-be-deprecated, register hook.
+
+		/**
+		 * Fires when a template is registered.
+		 *
+		 * @param BlockTemplateInterface $template Template that was registered.
+		 *
+		 * @since 8.2.0
+		 */
+		do_action( 'woocommerce_block_template_register', $layout_template_instance );
+
 		return $layout_template_instance;
 	}
 

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Automattic\WooCommerce\LayoutTemplates;
+
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
+
+final class LayoutTemplateRegistry {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var LayoutTemplateRegistry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Layout templates info.
+	 *
+	 * @var array
+	 */
+	protected $layout_templates_info = array();
+
+	/**
+	 * Get the instance of the class.
+	 */
+	public static function get_instance(): LayoutTemplateRegistry {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register a single layout template.
+	 *
+	 * @param string                  $layout_template_id    Layout template ID.
+	 * @param string                  $layout_template_area  Layout template area.
+	 * @param LayoutTemplateInterface $template Layout template to register.
+	 *
+	 * @throws \ValueError If a layout template with the same ID already exists.
+	 */
+	public function register( $layout_template_id, $layout_template_area, $layout_template_class_name ) {
+		if ( isset( $this->layout_templates_info[ $layout_template_id ] ) ) {
+			throw new \ValueError( 'A layout template with the specified ID already exists in the registry.' );
+		}
+
+		if ( empty( $layout_template_area ) ) {
+			throw new \ValueError( 'The specified layout template area is empty.' );
+		}
+
+		if ( ! class_exists( $layout_template_class_name ) ) {
+			throw new \ValueError( 'The specified layout template class does not exist.' );
+		}
+
+		if ( ! is_subclass_of( $layout_template_class_name, BlockTemplateInterface::class ) ) {
+			throw new \ValueError( 'The specified layout template class does not implement the BlockTemplateInterface.' );
+		}
+
+		$this->layout_templates_info[ $layout_template_id ] = array(
+			'area'       => $layout_template_area,
+			'class_name' => $layout_template_class_name,
+		);
+	}
+
+	/**
+	 * Get a single layout template class name by ID.
+	 *
+	 * @param string $id Layout template ID.
+	 *
+	 * @return string|null
+	 */
+	public function get_class_name( string $id ): ?string {
+		$layout_template_info = isset( $this->layout_templates_info[ $id ] ) ? $this->layout_templates_info[ $id ] : null;
+
+		return ! empty( $template_template_info ) && isset( $layout_template_info['class_name'] )
+			? $layout_template_info['class_name']
+			: null;
+	}
+
+	/**
+	 * Get marching layout template class names.
+	 *
+	 * @return string[]
+	 */
+	public function get_class_names( array $query_params ): array {
+		$area_to_match = isset( $query_params['area'] ) ? $query_params['area'] : null;
+		$id_to_match   = isset( $query_params['id'] ) ? $query_params['id'] : null;
+
+		$class_names = array();
+
+		foreach ( $this->layout_templates_info as $layout_template_info ) {
+			if ( ! empty( $area_to_match ) && isset( $layout_template_info['area'] ) && $layout_template_info['area'] !== $area_to_match ) {
+				continue;
+			}
+
+			if ( ! empty( $id_to_match ) && isset( $layout_template_info['id'] ) && $layout_template_info['id'] !== $id_to_match ) {
+				continue;
+			}
+
+			$class_names[] = $layout_template_info['class_name'];
+		}
+
+		return $class_names;
+	}
+}

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -80,6 +80,7 @@ final class LayoutTemplateRegistry {
 		}
 
 		$this->layout_templates_info[ $layout_template_id ] = array(
+			'id'         => $layout_template_id,
 			'area'       => $layout_template_area,
 			'class_name' => $layout_template_class_name,
 		);
@@ -110,6 +111,8 @@ final class LayoutTemplateRegistry {
 	private function get_layout_template_instance( $layout_template_info ) {
 		$class_name = $layout_template_info['class_name'];
 
+		// Return the instance if it already exists.
+
 		$layout_template_instance = isset( $this->layout_template_instances[ $class_name ] )
 			? $this->layout_template_instances[ $class_name ]
 			: null;
@@ -118,8 +121,35 @@ final class LayoutTemplateRegistry {
 			return $layout_template_instance;
 		}
 
+		// Call the before instantiation hooks.
+
+		/**
+		 * Fires before a layout template is instantiated.
+		 *
+		 * @param string $layout_template_id Layout template ID.
+		 * @param string $layout_template_area Layout template area.
+		 *
+		 * @since 8.6.0
+		 */
+		do_action( 'woocommerce_layout_template_before_instantiation', $layout_template_info['id'], $layout_template_info['area'] );
+
+		// Instantiate the layout template.
+
 		$layout_template_instance                       = new $class_name();
 		$this->layout_template_instances[ $class_name ] = $layout_template_instance;
+
+		// Call the after instantiation hooks.
+
+		/**
+		 * Fires after a layout template is instantiated.
+		 *
+		 * @param string $layout_template_id Layout template ID.
+		 * @param string $layout_template_area Layout template area.
+		 * @param BlockTemplateInterface $layout_template Layout template instance.
+		 *
+		 * @since 8.6.0
+		 */
+		do_action( 'woocommerce_layout_template_after_instantiation', $layout_template_info['id'], $layout_template_info['area'], $layout_template_instance );
 
 		return $layout_template_instance;
 	}
@@ -135,12 +165,12 @@ final class LayoutTemplateRegistry {
 
 		$matching_layout_templates_info = array();
 
-		foreach ( $this->layout_templates_info as $id => $layout_template_info ) {
+		foreach ( $this->layout_templates_info as $layout_template_info ) {
 			if ( ! empty( $area_to_match ) && $layout_template_info['area'] !== $area_to_match ) {
 				continue;
 			}
 
-			if ( ! empty( $id_to_match ) && $id !== $id_to_match ) {
+			if ( ! empty( $id_to_match ) && $layout_template_info['id'] !== $id_to_match ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -93,9 +93,9 @@ final class LayoutTemplateRegistry {
 	public function instantiate_layout_templates( array $query_params = array() ): array {
 		$layout_templates = array();
 
-		$class_names = $this->get_class_names( $query_params );
-		foreach ( $class_names as $class_name ) {
-			$layout_template    = $this->get_layout_template_instance( $class_name );
+		$layout_templates_info = $this->get_matching_layout_templates_info( $query_params );
+		foreach ( $layout_templates_info as $layout_template_info ) {
+			$layout_template    = $this->get_layout_template_instance( $layout_template_info );
 			$layout_templates[] = $layout_template;
 		}
 
@@ -105,9 +105,11 @@ final class LayoutTemplateRegistry {
 	/**
 	 * Instantiate a single layout template and return it.
 	 *
-	 * @param string $class_name Class name of the layout template.
+	 * @param array $layout_template_info Layout template info.
 	 */
-	private function get_layout_template_instance( $class_name ) {
+	private function get_layout_template_instance( $layout_template_info ) {
+		$class_name = $layout_template_info['class_name'];
+
 		$layout_template_instance = isset( $this->layout_template_instances[ $class_name ] )
 			? $this->layout_template_instances[ $class_name ]
 			: null;
@@ -123,15 +125,15 @@ final class LayoutTemplateRegistry {
 	}
 
 	/**
-	 * Get matching layout template class names.
+	 * Get matching layout templates info.
 	 *
 	 * @param array $query_params Query params.
 	 */
-	private function get_class_names( array $query_params = array() ): array {
+	private function get_matching_layout_templates_info( array $query_params = array() ): array {
 		$area_to_match = isset( $query_params['area'] ) ? $query_params['area'] : null;
 		$id_to_match   = isset( $query_params['id'] ) ? $query_params['id'] : null;
 
-		$class_names = array();
+		$matching_layout_templates_info = array();
 
 		foreach ( $this->layout_templates_info as $id => $layout_template_info ) {
 			if ( ! empty( $area_to_match ) && $layout_template_info['area'] !== $area_to_match ) {
@@ -142,9 +144,9 @@ final class LayoutTemplateRegistry {
 				continue;
 			}
 
-			$class_names[] = $layout_template_info['class_name'];
+			$matching_layout_templates_info[] = $layout_template_info;
 		}
 
-		return $class_names;
+		return $matching_layout_templates_info;
 	}
 }

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -63,12 +63,24 @@ final class LayoutTemplateRegistry {
 		);
 	}
 
+	public function instantiate_layout_templates( array $query_params ): array {
+		$layout_templates = array();
+
+		$class_names = $this->get_class_names( $query_params );
+		foreach ( $class_names as $class_name ) {
+			$layout_template    = new $class_name();
+			$layout_templates[] = $layout_template->to_json();
+		}
+
+		return $layout_templates;
+	}
+
 	/**
 	 * Get matching layout template class names.
 	 *
 	 * @return string[]
 	 */
-	public function get_class_names( array $query_params ): array {
+	private function get_class_names( array $query_params ): array {
 		$area_to_match = isset( $query_params['area'] ) ? $query_params['area'] : null;
 		$id_to_match   = isset( $query_params['id'] ) ? $query_params['id'] : null;
 

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -88,11 +88,20 @@ final class LayoutTemplateRegistry {
 
 		$class_names = $this->get_class_names( $query_params );
 		foreach ( $class_names as $class_name ) {
-			$layout_template    = new $class_name();
+			$layout_template    = $this->get_layout_template_instance( $class_name );
 			$layout_templates[] = $layout_template;
 		}
 
 		return $layout_templates;
+	}
+
+	/**
+	 * Instantiate a single layout template and return it.
+	 *
+	 * @param string $class_name Class name of the layout template.
+	 */
+	private function get_layout_template_instance( $class_name ) {
+		return new $class_name();
 	}
 
 	/**

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -31,6 +31,10 @@ final class LayoutTemplateRegistry {
 		return self::$instance;
 	}
 
+	public function is_registered( $layout_template_id ): bool {
+		return isset( $this->layout_templates_info[ $layout_template_id ] );
+	}
+
 	/**
 	 * Register a single layout template.
 	 *
@@ -41,7 +45,7 @@ final class LayoutTemplateRegistry {
 	 * @throws \ValueError If a layout template with the same ID already exists.
 	 */
 	public function register( $layout_template_id, $layout_template_area, $layout_template_class_name ) {
-		if ( isset( $this->layout_templates_info[ $layout_template_id ] ) ) {
+		if ( $this->is_registered( $layout_template_id ) ) {
 			throw new \ValueError( 'A layout template with the specified ID already exists in the registry.' );
 		}
 
@@ -63,13 +67,13 @@ final class LayoutTemplateRegistry {
 		);
 	}
 
-	public function instantiate_layout_templates( array $query_params ): array {
+	public function instantiate_layout_templates( array $query_params = array() ): array {
 		$layout_templates = array();
 
 		$class_names = $this->get_class_names( $query_params );
 		foreach ( $class_names as $class_name ) {
 			$layout_template    = new $class_name();
-			$layout_templates[] = $layout_template->to_json();
+			$layout_templates[] = $layout_template;
 		}
 
 		return $layout_templates;
@@ -80,7 +84,7 @@ final class LayoutTemplateRegistry {
 	 *
 	 * @return string[]
 	 */
-	private function get_class_names( array $query_params ): array {
+	private function get_class_names( array $query_params = array() ): array {
 		$area_to_match = isset( $query_params['area'] ) ? $query_params['area'] : null;
 		$id_to_match   = isset( $query_params['id'] ) ? $query_params['id'] : null;
 

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -64,21 +64,6 @@ final class LayoutTemplateRegistry {
 	}
 
 	/**
-	 * Get a single layout template class name by ID.
-	 *
-	 * @param string $id Layout template ID.
-	 *
-	 * @return string|null
-	 */
-	public function get_class_name( string $id ): ?string {
-		$layout_template_info = isset( $this->layout_templates_info[ $id ] ) ? $this->layout_templates_info[ $id ] : null;
-
-		return ! empty( $template_template_info ) && isset( $layout_template_info['class_name'] )
-			? $layout_template_info['class_name']
-			: null;
-	}
-
-	/**
 	 * Get marching layout template class names.
 	 *
 	 * @return string[]

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -130,18 +130,6 @@ final class LayoutTemplateRegistry {
 			return $layout_template_instance;
 		}
 
-		// Call the before instantiation hooks.
-
-		/**
-		 * Fires before a layout template is instantiated.
-		 *
-		 * @param string $layout_template_id Layout template ID.
-		 * @param string $layout_template_area Layout template area.
-		 *
-		 * @since 8.6.0
-		 */
-		do_action( 'woocommerce_layout_template_before_instantiation', $layout_template_info['id'], $layout_template_info['area'] );
-
 		// Instantiate the layout template.
 
 		$layout_template_instance                       = new $class_name();

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -24,6 +24,13 @@ final class LayoutTemplateRegistry {
 	protected $layout_templates_info = array();
 
 	/**
+	 * Layout template instances.
+	 *
+	 * @var array
+	 */
+	protected $layout_template_instances = array();
+
+	/**
 	 * Get the instance of the class.
 	 */
 	public static function get_instance(): LayoutTemplateRegistry {
@@ -101,7 +108,18 @@ final class LayoutTemplateRegistry {
 	 * @param string $class_name Class name of the layout template.
 	 */
 	private function get_layout_template_instance( $class_name ) {
-		return new $class_name();
+		$layout_template_instance = isset( $this->layout_template_instances[ $class_name ] )
+			? $this->layout_template_instances[ $class_name ]
+			: null;
+
+		if ( ! empty( $layout_template_instance ) ) {
+			return $layout_template_instance;
+		}
+
+		$layout_template_instance                       = new $class_name();
+		$this->layout_template_instances[ $class_name ] = $layout_template_instance;
+
+		return $layout_template_instance;
 	}
 
 	/**

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -42,6 +42,14 @@ final class LayoutTemplateRegistry {
 	}
 
 	/**
+	 * Unregister all layout templates.
+	 */
+	public function unregister_all() {
+		$this->layout_templates_info     = array();
+		$this->layout_template_instances = array();
+	}
+
+	/**
 	 * Check if a layout template is registered.
 	 *
 	 * @param string $layout_template_id Layout template ID.

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -4,6 +4,9 @@ namespace Automattic\WooCommerce\LayoutTemplates;
 
 use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
 
+/**
+ * Layout template registry.
+ */
 final class LayoutTemplateRegistry {
 
 	/**
@@ -31,6 +34,11 @@ final class LayoutTemplateRegistry {
 		return self::$instance;
 	}
 
+	/**
+	 * Check if a layout template is registered.
+	 *
+	 * @param string $layout_template_id Layout template ID.
+	 */
 	public function is_registered( $layout_template_id ): bool {
 		return isset( $this->layout_templates_info[ $layout_template_id ] );
 	}
@@ -38,11 +46,14 @@ final class LayoutTemplateRegistry {
 	/**
 	 * Register a single layout template.
 	 *
-	 * @param string                  $layout_template_id    Layout template ID.
-	 * @param string                  $layout_template_area  Layout template area.
-	 * @param LayoutTemplateInterface $template Layout template to register.
+	 * @param string $layout_template_id         Layout template ID.
+	 * @param string $layout_template_area       Layout template area.
+	 * @param string $layout_template_class_name Layout template class to register.
 	 *
 	 * @throws \ValueError If a layout template with the same ID already exists.
+	 * @throws \ValueError If the specified layout template area is empty.
+	 * @throws \ValueError If the specified layout template class does not exist.
+	 * @throws \ValueError If the specified layout template class does not implement the BlockTemplateInterface.
 	 */
 	public function register( $layout_template_id, $layout_template_area, $layout_template_class_name ) {
 		if ( $this->is_registered( $layout_template_id ) ) {
@@ -67,6 +78,11 @@ final class LayoutTemplateRegistry {
 		);
 	}
 
+	/**
+	 * Instantiate the matching layout templates and return them.
+	 *
+	 * @param array $query_params Query params.
+	 */
 	public function instantiate_layout_templates( array $query_params = array() ): array {
 		$layout_templates = array();
 
@@ -82,7 +98,7 @@ final class LayoutTemplateRegistry {
 	/**
 	 * Get matching layout template class names.
 	 *
-	 * @return string[]
+	 * @param array $query_params Query params.
 	 */
 	private function get_class_names( array $query_params = array() ): array {
 		$area_to_match = isset( $query_params['area'] ) ? $query_params['area'] : null;

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -64,7 +64,7 @@ final class LayoutTemplateRegistry {
 	}
 
 	/**
-	 * Get marching layout template class names.
+	 * Get matching layout template class names.
 	 *
 	 * @return string[]
 	 */

--- a/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
+++ b/plugins/woocommerce/src/LayoutTemplates/LayoutTemplateRegistry.php
@@ -89,12 +89,12 @@ final class LayoutTemplateRegistry {
 
 		$class_names = array();
 
-		foreach ( $this->layout_templates_info as $layout_template_info ) {
-			if ( ! empty( $area_to_match ) && isset( $layout_template_info['area'] ) && $layout_template_info['area'] !== $area_to_match ) {
+		foreach ( $this->layout_templates_info as $id => $layout_template_info ) {
+			if ( ! empty( $area_to_match ) && $layout_template_info['area'] !== $area_to_match ) {
 				continue;
 			}
 
-			if ( ! empty( $id_to_match ) && isset( $layout_template_info['id'] ) && $layout_template_info['id'] !== $id_to_match ) {
+			if ( ! empty( $id_to_match ) && $id !== $id_to_match ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
@@ -83,4 +83,13 @@ class WC_REST_Layout_Templates_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'description', $data );
 		$this->assertArrayHasKey( 'blockTemplates', $data );
 	}
+
+	/**
+	 * Test getting a single layout template with invalid id.
+	 */
+	public function test_get_single_item_with_invalid_id() {
+		$response = $this->do_rest_get_request( 'layout-templates/invalid-layout-template' );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
@@ -20,6 +20,8 @@ class WC_REST_Layout_Templates_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
 
+		$layout_template_registry->unregister_all();
+
 		$layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
 		$layout_template_registry->register( 'simple-product', 'product-form', SimpleProductTemplate::class );
 		$layout_template_registry->register( 'product-variation', 'product-form', ProductVariationTemplate::class );
@@ -40,6 +42,24 @@ class WC_REST_Layout_Templates_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertCount( 3, $data );
 
 		$this->assertArrayHasKey( 'test-layout-template', $data );
+		$this->assertArrayHasKey( 'simple-product', $data );
+		$this->assertArrayHasKey( 'product-variation', $data );
+	}
+
+	/**
+	 * Test getting all layout templates for a specific area.
+	 */
+	public function test_get_all_items_for_area() {
+		$response = $this->do_rest_get_request( 'layout-templates', array( 'area' => 'product-form' ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertNotEmpty( $data );
+
+		$this->assertCount( 2, $data );
+
 		$this->assertArrayHasKey( 'simple-product', $data );
 		$this->assertArrayHasKey( 'product-variation', $data );
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
@@ -63,4 +63,24 @@ class WC_REST_Layout_Templates_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'simple-product', $data );
 		$this->assertArrayHasKey( 'product-variation', $data );
 	}
+
+	/**
+	 * Test getting a single layout template.
+	 */
+	public function test_get_single_item() {
+		$response = $this->do_rest_get_request( 'layout-templates/test-layout-template' );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertNotEmpty( $data );
+
+		$this->assertEquals( 'test-layout-template', $data['id'] );
+		$this->assertEquals( 'test', $data['area'] );
+
+		$this->assertArrayHasKey( 'title', $data );
+		$this->assertArrayHasKey( 'description', $data );
+		$this->assertArrayHasKey( 'blockTemplates', $data );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
@@ -1,0 +1,46 @@
+<?php
+
+use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
+
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\SimpleProductTemplate;
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\ProductVariationTemplate;
+
+use Automattic\WooCommerce\Tests\LayoutTemplates\TestLayoutTemplate;
+
+/**
+ * class WC_REST_Layout_Templates_Controller_Tests.
+ * Layout Templates Controller tests for V3 REST API.
+ */
+class WC_REST_Layout_Templates_Controller_Tests extends WC_REST_Unit_Test_Case {
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
+
+		$layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
+		$layout_template_registry->register( 'simple-product', 'product-form', SimpleProductTemplate::class );
+		$layout_template_registry->register( 'product-variation', 'product-form', ProductVariationTemplate::class );
+	}
+
+	/**
+	 * Test getting all layout templates.
+	 */
+	public function test_get_all_items() {
+		$response = $this->do_rest_get_request( 'layout-templates' );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertNotEmpty( $data );
+
+		$this->assertCount( 3, $data );
+
+		$this->assertArrayHasKey( 'test-layout-template', $data );
+		$this->assertArrayHasKey( 'simple-product', $data );
+		$this->assertArrayHasKey( 'product-variation', $data );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller-tests.php
@@ -65,6 +65,19 @@ class WC_REST_Layout_Templates_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting all layout templates for an invalid area.
+	 */
+	public function test_get_all_items_for_invalid_area() {
+		$response = $this->do_rest_get_request( 'layout-templates', array( 'area' => 'invalid-area' ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEmpty( $data );
+	}
+
+	/**
 	 * Test getting a single layout template.
 	 */
 	public function test_get_single_item() {

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -208,9 +208,23 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 			$this->assertInstanceOf( TestLayoutTemplate::class, $layout_template );
 		};
 
+		$deprecated_register_hook_called = false;
+
+		$deprecated_register_hook = function( $layout_template ) use ( &$deprecated_register_hook_called ) {
+			$deprecated_register_hook_called = true;
+
+			$this->assertInstanceOf( TestLayoutTemplate::class, $layout_template );
+
+			$this->assertEquals( 'test-layout-template', $layout_template->get_id() );
+			$this->assertEquals( 'test', $layout_template->get_area() );
+
+		};
+
 		try {
 			add_action( 'woocommerce_layout_template_before_instantiation', $before_instantiation_hook, 10, 2 );
 			add_action( 'woocommerce_layout_template_after_instantiation', $after_instantiation_hook, 10, 3 );
+
+			add_action( 'woocommerce_block_template_register', $deprecated_register_hook );
 
 			$this->layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
 
@@ -227,9 +241,16 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 				$after_instantiation_hook_called,
 				'woocommerce_layout_template_after_instantiation hook was not called.'
 			);
+
+			$this->assertTrue(
+				$deprecated_register_hook_called,
+				'woocommerce_block_template_register hook was not called.'
+			);
 		} finally {
 			remove_action( 'woocommerce_layout_template_before_instantiation', $before_instantiation_hook );
 			remove_action( 'woocommerce_layout_template_after_instantiation', $after_instantiation_hook );
+
+			remove_action( 'woocommerce_block_template_register', $deprecated_register_hook );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -188,15 +188,6 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 	 * Test layout template instantiation actions are fired.
 	 */
 	public function test_instantiation_actions() {
-		$before_instantiation_hook_called = false;
-
-		$before_instantiation_hook = function( string $layout_template_id, string $area ) use ( &$before_instantiation_hook_called ) {
-			$before_instantiation_hook_called = true;
-
-			$this->assertEquals( 'test-layout-template', $layout_template_id );
-			$this->assertEquals( 'test', $area );
-		};
-
 		$after_instantiation_hook_called = false;
 
 		$after_instantiation_hook = function( string $layout_template_id, string $area, $layout_template ) use ( &$after_instantiation_hook_called ) {
@@ -221,7 +212,6 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 		};
 
 		try {
-			add_action( 'woocommerce_layout_template_before_instantiation', $before_instantiation_hook, 10, 2 );
 			add_action( 'woocommerce_layout_template_after_instantiation', $after_instantiation_hook, 10, 3 );
 
 			add_action( 'woocommerce_block_template_register', $deprecated_register_hook );
@@ -230,11 +220,6 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 
 			$this->layout_template_registry->instantiate_layout_templates(
 				array( 'id' => 'test-layout-template' )
-			);
-
-			$this->assertTrue(
-				$before_instantiation_hook_called,
-				'woocommerce_layout_template_before_instantiation hook was not called.'
 			);
 
 			$this->assertTrue(
@@ -247,7 +232,6 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 				'woocommerce_block_template_register hook was not called.'
 			);
 		} finally {
-			remove_action( 'woocommerce_layout_template_before_instantiation', $before_instantiation_hook );
 			remove_action( 'woocommerce_layout_template_after_instantiation', $after_instantiation_hook );
 
 			remove_action( 'woocommerce_block_template_register', $deprecated_register_hook );

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -110,4 +110,44 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 			$this->assertInstanceOf( $template_info['class_name'], $layout_template );
 		}
 	}
+
+	/**
+	 * Test instantiating layout templates with area query param.
+	 */
+	public function test_instantiate_with_area_query_param() {
+		foreach ( $this->layout_templates_to_register as $template_id => $template_info ) {
+			$this->layout_template_registry->register( $template_id, $template_info['area'], $template_info['class_name'] );
+		}
+
+		$layout_templates = $this->layout_template_registry->instantiate_layout_templates(
+			array( 'area' => 'product-form' )
+		);
+
+		$this->assertCount( 2, $layout_templates );
+
+		foreach ( $layout_templates as $layout_template ) {
+			$template_info = $this->layout_templates_to_register[ $layout_template->get_id() ];
+			$this->assertInstanceOf( $template_info['class_name'], $layout_template );
+		}
+	}
+
+	/**
+	 * Test instantiating layout templates with id query param.
+	 */
+	public function test_instantiate_with_id_query_param() {
+		foreach ( $this->layout_templates_to_register as $template_id => $template_info ) {
+			$this->layout_template_registry->register( $template_id, $template_info['area'], $template_info['class_name'] );
+		}
+
+		$layout_templates = $this->layout_template_registry->instantiate_layout_templates(
+			array( 'id' => 'simple-product' )
+		);
+
+		$this->assertCount( 1, $layout_templates );
+
+		foreach ( $layout_templates as $layout_template ) {
+			$template_info = $this->layout_templates_to_register[ $layout_template->get_id() ];
+			$this->assertInstanceOf( $template_info['class_name'], $layout_template );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -167,4 +167,53 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( $layout_templates_again[0], $layout_templates[0] );
 	}
+
+	/**
+	 * Test layout template instantiation actions are fired.
+	 */
+	public function test_instantiation_actions() {
+		$before_instantiation_hook_called = false;
+
+		$before_instantiation_hook = function( string $layout_template_id, string $area ) use ( &$before_instantiation_hook_called ) {
+			$before_instantiation_hook_called = true;
+
+			$this->assertEquals( 'test-layout-template', $layout_template_id );
+			$this->assertEquals( 'test', $area );
+		};
+
+		$after_instantiation_hook_called = false;
+
+		$after_instantiation_hook = function( string $layout_template_id, string $area, $layout_template ) use ( &$after_instantiation_hook_called ) {
+			$after_instantiation_hook_called = true;
+
+			$this->assertEquals( 'test-layout-template', $layout_template_id );
+			$this->assertEquals( 'test', $area );
+
+			$this->assertInstanceOf( TestLayoutTemplate::class, $layout_template );
+		};
+
+		try {
+			add_action( 'woocommerce_layout_template_before_instantiation', $before_instantiation_hook, 10, 2 );
+			add_action( 'woocommerce_layout_template_after_instantiation', $after_instantiation_hook, 10, 3 );
+
+			$this->layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
+
+			$this->layout_template_registry->instantiate_layout_templates(
+				array( 'id' => 'test-layout-template' )
+			);
+
+			$this->assertTrue(
+				$before_instantiation_hook_called,
+				'woocommerce_layout_template_before_instantiation hook was not called.'
+			);
+
+			$this->assertTrue(
+				$after_instantiation_hook_called,
+				'woocommerce_layout_template_after_instantiation hook was not called.'
+			);
+		} finally {
+			remove_action( 'woocommerce_layout_template_before_instantiation', $before_instantiation_hook );
+			remove_action( 'woocommerce_layout_template_after_instantiation', $after_instantiation_hook );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -150,4 +150,21 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 			$this->assertInstanceOf( $template_info['class_name'], $layout_template );
 		}
 	}
+
+	/**
+	 * Test layout templates are only instantiated once.
+	 */
+	public function test_cached_instances() {
+		$this->layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
+
+		$layout_templates = $this->layout_template_registry->instantiate_layout_templates(
+			array( 'id' => 'test-layout-template' )
+		);
+
+		$layout_templates_again = $this->layout_template_registry->instantiate_layout_templates(
+			array( 'id' => 'test-layout-template' )
+		);
+
+		$this->assertSame( $layout_templates_again[0], $layout_templates[0] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -178,7 +178,10 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 			array( 'id' => 'test-layout-template' )
 		);
 
-		$this->assertSame( $layout_templates_again[0], $layout_templates[0] );
+		$this->assertCount( 1, $layout_templates );
+		$this->assertCount( 1, $layout_templates_again );
+
+		$this->assertSame( current( $layout_templates_again ), current( $layout_templates ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -34,4 +34,37 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $this->layout_template_registry->is_registered( 'test-layout-template' ) );
 	}
+
+	/**
+	 * Test registering a layout template with an existing ID.
+	 */
+	public function test_register_duplicate_id() {
+		$this->expectException( \ValueError::class );
+		$this->layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
+		$this->layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
+	}
+
+	/**
+	 * Test registering a layout template with an empty area.
+	 */
+	public function test_register_empty_area() {
+		$this->expectException( \ValueError::class );
+		$this->layout_template_registry->register( 'test-layout-template', '', TestLayoutTemplate::class );
+	}
+
+	/**
+	 * Test registering a layout template with a non-existing class.
+	 */
+	public function test_register_non_existing_class() {
+		$this->expectException( \ValueError::class );
+		$this->layout_template_registry->register( 'test-layout-template', 'test', 'NonExistingClass' );
+	}
+
+	/**
+	 * Test registering a layout template with a class that does not implement the BlockTemplateInterface.
+	 */
+	public function test_register_non_block_template_class() {
+		$this->expectException( \ValueError::class );
+		$this->layout_template_registry->register( 'test-layout-template', 'test', \stdClass::class );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -4,6 +4,9 @@ namespace Automattic\WooCommerce\Tests\LayoutTemplates;
 
 use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
 
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\SimpleProductTemplate;
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\ProductVariationTemplate;
+
 use WC_Unit_Test_Case;
 
 /**
@@ -18,10 +21,32 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 	protected $layout_template_registry;
 
 	/**
+	 * Layout templates to register.
+	 *
+	 * @var array
+	 */
+	protected $layout_templates_to_register;
+
+	/**
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
 		$this->layout_template_registry = new LayoutTemplateRegistry();
+
+		$this->layout_templates_to_register = array(
+			'test-layout-template' => array(
+				'area'       => 'test',
+				'class_name' => TestLayoutTemplate::class,
+			),
+			'simple-product'       => array(
+				'area'       => 'product-form',
+				'class_name' => SimpleProductTemplate::class,
+			),
+			'product-variation'    => array(
+				'area'       => 'product-form',
+				'class_name' => ProductVariationTemplate::class,
+			),
+		);
 	}
 
 	/**
@@ -66,5 +91,23 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 	public function test_register_non_block_template_class() {
 		$this->expectException( \ValueError::class );
 		$this->layout_template_registry->register( 'test-layout-template', 'test', \stdClass::class );
+	}
+
+	/**
+	 * Test instantiating layout templates.
+	 */
+	public function test_instantiate() {
+		foreach ( $this->layout_templates_to_register as $template_id => $template_info ) {
+			$this->layout_template_registry->register( $template_id, $template_info['area'], $template_info['class_name'] );
+		}
+
+		$layout_templates = $this->layout_template_registry->instantiate_layout_templates();
+
+		$this->assertCount( 3, $layout_templates );
+
+		foreach ( $layout_templates as $layout_template ) {
+			$template_info = $this->layout_templates_to_register[ $layout_template->get_id() ];
+			$this->assertInstanceOf( $template_info['class_name'], $layout_template );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\LayoutTemplates;
+
+use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the LayoutTemplateRegistry class.
+ */
+class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
+	/**
+	 * Layout template registry.
+	 *
+	 * @var LayoutTemplateRegistry
+	 */
+	protected $layout_template_registry;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		$this->layout_template_registry = new LayoutTemplateRegistry();
+	}
+
+	/**
+	 * Test registering a layout template.
+	 */
+	public function test_register() {
+		$this->assertFalse( $this->layout_template_registry->is_registered( 'test-layout-template' ) );
+
+		$this->layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
+
+		$this->assertTrue( $this->layout_template_registry->is_registered( 'test-layout-template' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/LayoutTemplateRegistryTest.php
@@ -94,6 +94,19 @@ class LayoutTemplateRegistryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test unregistering a layout template.
+	 */
+	public function test_unregister() {
+		$this->layout_template_registry->register( 'test-layout-template', 'test', TestLayoutTemplate::class );
+
+		$this->assertTrue( $this->layout_template_registry->is_registered( 'test-layout-template' ) );
+
+		$this->layout_template_registry->unregister_all( 'test-layout-template' );
+
+		$this->assertFalse( $this->layout_template_registry->is_registered( 'test-layout-template' ) );
+	}
+
+	/**
 	 * Test instantiating layout templates.
 	 */
 	public function test_instantiate() {

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/TestLayoutTemplate.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/TestLayoutTemplate.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\LayoutTemplates;
+
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
+
+/**
+ * Test layout template.
+ */
+class TestLayoutTemplate implements BlockTemplateInterface {
+	/**
+	 * Get the layout template ID.
+	 */
+	public function get_id(): string {
+		return 'test-layout-template';
+	}
+
+	/**
+	 * Get the layout template title.
+	 */
+	public function get_title(): string {
+		return 'Test layout template';
+	}
+
+	/**
+	 * Get the layout template description.
+	 */
+	public function get_description(): string {
+		return 'A test layout template';
+	}
+
+	/**
+	 * Get the layout template area.
+	 */
+	public function get_area(): string {
+		return 'test';
+	}
+
+	/**
+	 * Get the layout template blocks.
+	 *
+	 * @param string $id_base Block ID base.
+	 */
+	public function generate_block_id( string $id_base ): string {
+		return $id_base . '-test';
+	}
+
+	/**
+	 * Get the layout template blocks.
+	 */
+	public function &get_root_template(): BlockTemplateInterface {
+		return $this;
+	}
+
+	/**
+	 * Get the layout template blocks.
+	 *
+	 * @param string $block_id Block ID.
+	 */
+	public function get_block( string $block_id ): ?BlockInterface {
+		return null;
+	}
+
+	/**
+	 * Get the layout template blocks.
+	 *
+	 * @param string $block_id Block ID.
+	 */
+	public function remove_block( string $block_id ) {
+	}
+
+	/**
+	 * Get the layout template blocks.
+	 */
+	public function remove_blocks() {
+	}
+
+	/**
+	 * Get the layout template blocks.
+	 */
+	public function get_formatted_template(): array {
+		return array();
+	}
+
+	/**
+	 * Get the layout template blocks.
+	 */
+	public function to_json(): array {
+		return array();
+	}
+}

--- a/plugins/woocommerce/tests/php/src/LayoutTemplates/TestLayoutTemplate.php
+++ b/plugins/woocommerce/tests/php/src/LayoutTemplates/TestLayoutTemplate.php
@@ -87,6 +87,12 @@ class TestLayoutTemplate implements BlockTemplateInterface {
 	 * Get the layout template blocks.
 	 */
 	public function to_json(): array {
-		return array();
+		return array(
+			'id'             => $this->get_id(),
+			'title'          => $this->get_title(),
+			'description'    => $this->get_description(),
+			'area'           => $this->get_area(),
+			'blockTemplates' => array(),
+		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the following:

- `LayoutTemplateRegistry`: A replacement for `BlockTemplateRegistry` that registers layout template class names instead of layout template instances, allowing layout templates to be instantiated only when they are requested.
- Lifecycle actions that can be used to execute code before layout templates are instantiated and after they are instantiated. This provides extensions with efficient ways to hook up their template modification actions before a template is instantiated, so that the modifications are made and to do things after a template is instantiated (such as make further modifications, if their code structure/preference necessitates that approach).
    - `woocommerce_layout_template_before_instantiation`
    - `woocommerce_layout_template_after_instantiation`
- REST API endpoints for `/wc/v3/layout-templates`

The REST API endpoints are not yet used by the new product editor. This will be done in a followup PR (see issue #40620)

Closes #40618.

### Still to do in this PR:

- [x] ~~Remove `BlockTemplateRegistry` and any related code that uses it (this is no longer used as of this PR)~~ -- will do as part of a follow up PR
- [x] Unit tests for `LayoutTemplateRegistry`
- [x] REST API endpoint tests

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Automated tests:

1. Verify registry unit tests pass:

```bash
cd plugins/woocommerce
pnpm env:test
pnpm test:unit:env --filter 'Automattic\\WooCommerce\\Tests\\LayoutTemplates'
```

2. Verify REST API tests pass:

```bash
cd plugins/woocommerce
pnpm env:test
pnpm test:unit:env --filter 'WC_REST_Layout_Templates_Controller_Tests'
```

Manual tests:

_Note: Use Postman or another tool to access REST API endpoints. Instructions assume your site is at `http://localhost:8888`. Adjust accordingly._

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Verify that `http://localhost:8888/wp-json/wc/v3/layout-templates/simple-product` returns a single layout template, and that it is the correct layout template
4. Verify that `http://localhost:8888/wp-json/wc/v3/layout-templates/invalid` returns a 404 error, as no layout template with that id exists
5. Verify that `http://localhost:8888/wp-json/wc/v3/layout-templates` returns all layout templates in the system. On a setup with no additional layout templates added by extensions, that should be the `simple-product` and `product-variation` layout templates
6. Verify that `http://localhost:8888/wp-json/wc/v3/layout-templates?area=product-form` returns all `product-form` area layout templates, which in a default setup, is the same as the previous step.
7. Verify that `http://localhost:8888/wp-json/wc/v3/layout-templates?area=invalid` returns no layout templates.
8. Add the following code to a plugin or mu-plugin, which registers two new templates:
    - `CustomProductFormTemplate` (id: `custom-product-form-template`, area: `product-form`)
    - `ExampleTemplate` (id: `example-template`, area: `example`)

The constructors for these two layout templates log a message to `debug.log`, which you can use to verify that they are only instantiated when they are requested.

```php
<?php

use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\ProductFormTemplateInterface;
use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;

use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\AbstractProductFormTemplate;

add_action(
	'rest_api_init',
	function () {
		class CustomProductFormTemplate extends AbstractProductFormTemplate implements ProductFormTemplateInterface {
			public function __construct() {
				error_log( 'CustomProductFormTemplate instantiated' );

				$this->add_group( // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.ThisFoundOutsideClass
					[
						'id'         => 'general',
						'order'      => 10,
						'attributes' => [
							'title' => 'General',
						],
					]
				);
			}

			public function get_id(): string {
				return 'custom-product-form-template';
			}

			public function get_title(): string {
				return 'Custom product layout template';
			}

			public function get_description(): string {
				return 'A custom product layout template';
			}
		}

		class ExampleTemplate implements BlockTemplateInterface {
			public function __construct() {
				error_log( 'ExampleTemplate instantiated' );
			}

			public function get_id(): string {
				return 'example-template';
			}

			public function get_title(): string {
				return 'Example template';
			}

			public function get_description(): string {
				return 'An example template';
			}

			public function get_area(): string {
				return 'example';
			}

			public function generate_block_id( string $id_base ): string {
				return $id_base . '-example';
			}

			public function &get_root_template(): BlockTemplateInterface {
				return $this; // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.ThisFoundOutsideClass
			}

			public function get_block( string $block_id ): ?BlockInterface {
				return null;
			}

			public function remove_block( string $block_id ) {
			}

			public function remove_blocks() {
			}

			public function get_formatted_template(): array {
				return [];
			}

			public function to_json(): array {
				return [
					'id'             => $this->get_id(), // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.ThisFoundOutsideClass
					'title'          => $this->get_title(), // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.ThisFoundOutsideClass
					'description'    => $this->get_description(), // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.ThisFoundOutsideClass
					'area'           => $this->get_area(), // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.ThisFoundOutsideClass
					'blockTemplates' => [],
				];
			}
		}

		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );

		$layout_template_registry->register(
			'custom-product-form-template',
			'product-form',
			CustomProductFormTemplate::class
		);

		$layout_template_registry->register(
			'example-template',
			'example',
			ExampleTemplate::class
		);
	}
);
```

9. Verify that `http://localhost:8888/wp-json/wc/v3/layout-templates` returns all layout templates in the system. It should be the `simple-product`, `product-variation`, `custom-product-form-template`, and `example-template` layout templates.
10. Verify that `http://localhost:8888/wp-json/wc/v3/layout-templates?area=product-form` returns all `product-form` area layout templates, which should be the `simple-product`, `product-variation`, and `custom-product-form-template` layout templates.
11. Go to **Products** > **Add New**
12. Verify fields display as expected (no regression)
13. Try different types of products, including variable products and individual variations. Verify fields display as expected (no regression)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
