### PR TITLE
Show rating stars for the cross-sells products

### DIFF
--- a/packages/js/product-editor/changelog/43148-fix-typo-in-43116-that-breaks-ci-and-builds
+++ b/packages/js/product-editor/changelog/43148-fix-typo-in-43116-that-breaks-ci-and-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix typo that broke the CI pipeline and the build process.

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { AdviceCard } from '../../../components/advice-card';
-import { ShoppingBags } from '../../../images/shopping-bugs';
+import { ShoppingBags } from '../../../images/shopping-bags';
 import type { UpsellsBlockEditComponent } from './types';
 
 export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/cart-cross-sells-product-list/cart-cross-sells-product.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/cart-cross-sells-product-list/cart-cross-sells-product.tsx
@@ -12,7 +12,7 @@ import { ProductResponseItem } from '@woocommerce/types';
  */
 import { Block as ProductImage } from '../../../atomic/blocks/product-elements/image/block';
 import { Block as ProductName } from '../../../atomic/blocks/product-elements/title/block';
-import { Block as ProductRating } from '../../../atomic/blocks/product-elements/rating/block';
+import { Block as ProductRating } from '../../../atomic/blocks/product-elements/rating-stars/block';
 import { Block as ProductPrice } from '../../../atomic/blocks/product-elements/price/block';
 import { Block as ProductButton } from '../../../atomic/blocks/product-elements/button/block';
 import { ImageSizing } from '../../../atomic/blocks/product-elements/image/types';
@@ -32,7 +32,6 @@ const CartCrossSellsProduct = ( {
 				parentClassName={ 'wp-block-cart-cross-sells-product' }
 			>
 				<ProductDataContextProvider
-					// Setting isLoading to false, given this parameter is required.
 					isLoading={ false }
 					product={ product }
 				>
@@ -45,13 +44,23 @@ const CartCrossSellsProduct = ( {
 							saleBadgeAlign={ 'left' }
 							imageSizing={ ImageSizing.SINGLE }
 							isDescendentOfQueryLoop={ false }
+							scale={ 'cover' }
+							aspectRatio={ '1:1' }
 						/>
 						<ProductName
 							align={ '' }
 							headingLevel={ 3 }
 							showProductLink={ true }
 						/>
-						<ProductRating />
+						<ProductRating
+							isDescendentOfQueryLoop={ false }
+							isDescendentOfSingleProductBlock={ false }
+							productId={ product.id }
+							postId={ 0 }
+							shouldDisplayMockedReviewsWhenProductHasNoReviews={
+								false
+							}
+						/>
 						<ProductPrice />
 					</div>
 					<ProductButton />

--- a/plugins/woocommerce/changelog/fix-42033-show-cross-sells-products-rating-stars
+++ b/plugins/woocommerce/changelog/fix-42033-show-cross-sells-products-rating-stars
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Display rating stars instead of plain text for Cross-Sells products on the Cart block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42033.

Recently, I noticed that the rating stars for the cross-sells products on the _Cart block_ were no longer visible. Instead, the rating text, e.g. _"Rated 2.5 out of 5 based on 2 customer ratings"_, was visible. This issue is caused because some required CSS definitions do not get loaded. 

In https://github.com/woocommerce/woocommerce-blocks/pull/10005, @albarin introduced the _Product Rating Stars block_. In this PR, I'm switching from the _Product Ratings block_ to the _Product Rating Stars block_, as that block loads the required CSS correctly and therefore the rating stars become visible again.

I also added missing props to the `<ProductImage>` and `<ProductRating>` components to address current TS errors. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a rating to a product. 
2. Define the rated product as a cross-sells product of another product.
3. Go to the frontend and add the second product to the cart.
4. Go to the Cart and verify that the rating stars are visible instead of the plain rating text.

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="818" alt="Screenshot 2023-12-22 at 13 10 44" src="https://github.com/woocommerce/woocommerce/assets/3323310/d71c578b-93c9-4310-a8be-1418e0ceee10">
</td>
<td valign="top">After:
<br><br>
<img width="810" alt="Screenshot 2023-12-22 at 13 07 50" src="https://github.com/woocommerce/woocommerce/assets/3323310/5ff0809b-fb13-4f0d-b159-af91b6ad6534">
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
