### PR TITLE
Fix bug when searching orders with a term starting with d, s, or f

### DIFF
--- a/plugins/woocommerce/changelog/43085-fix-43084-search-query-prepare
+++ b/plugins/woocommerce/changelog/43085-fix-43084-search-query-prepare
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug when searching orders with a term starting with d, s, or f.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -93,10 +93,9 @@ class OrdersTableSearchQuery {
 		$where .= $wpdb->prepare(
 			"
 			search_query_items.order_item_name LIKE %s
-			OR `$order_table`.id IN ( $meta_sub_query )
 			",
 			'%' . $wpdb->esc_like( $this->search_term ) . '%'
-		);
+		) . " OR `$order_table`.id IN ( $meta_sub_query ) ";
 
 		return " ( $where ) ";
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -91,9 +91,7 @@ class OrdersTableSearchQuery {
 		$meta_sub_query = $this->generate_where_for_meta_table();
 
 		$where .= $wpdb->prepare(
-			"
-			search_query_items.order_item_name LIKE %s
-			",
+			'search_query_items.order_item_name LIKE %s',
 			'%' . $wpdb->esc_like( $this->search_term ) . '%'
 		) . " OR `$order_table`.id IN ( $meta_sub_query ) ";
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This moves the `$meta_sub_query` used in `OrdersTableSearchQuery::prepare()` out of the call to `$wpdb->prepare()`.  Since the `$meta_sub_query` is already prepared and contains a like clause in it starting with `%`, any search terms starting with prepare identifiers would cause the prepare to fail due to the incorrect number of parameters.

Closes #43084 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a site with HPOS enabled, go to the admin -> Orders
2. Enter a search query starting with d, s, or f.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Fix bug when searching orders with a term starting with d, s, or f.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
