### PR TITLE
Fix is_read value in Admin notes

### DIFF
--- a/plugins/woocommerce/changelog/43096-fix-16504-vendor-notes-deletion
+++ b/plugins/woocommerce/changelog/43096-fix-16504-vendor-notes-deletion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix `is_read` value in Admin notes.

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -111,8 +111,8 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$note->set_date_created( $note_row->date_created );
 			$note->set_date_reminder( $note_row->date_reminder );
 			$note->set_is_snoozable( $note_row->is_snoozable );
-			$note->set_is_deleted( (int) $note_row->is_deleted );
-			isset( $note_row->is_read ) && $note->set_is_read( (int) $note_row->is_read );
+			$note->set_is_deleted( $note_row->is_deleted );
+			isset( $note_row->is_read ) && $note->set_is_read( $note_row->is_read );
 			$note->set_layout( $note_row->layout );
 			$note->set_image( $note_row->image );
 			$this->read_actions( $note );

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -110,9 +110,9 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$note->set_source( $note_row->source );
 			$note->set_date_created( $note_row->date_created );
 			$note->set_date_reminder( $note_row->date_reminder );
-			$note->set_is_snoozable( $note_row->is_snoozable );
-			$note->set_is_deleted( $note_row->is_deleted );
-			isset( $note_row->is_read ) && $note->set_is_read( $note_row->is_read );
+			$note->set_is_snoozable( (bool) $note_row->is_snoozable );
+			$note->set_is_deleted( (bool) $note_row->is_deleted );
+			$note->set_is_read( (bool) $note_row->is_read );
 			$note->set_layout( $note_row->layout );
 			$note->set_image( $note_row->image );
 			$this->read_actions( $note );
@@ -163,11 +163,11 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 					'source'        => $note->get_source(),
 					'date_created'  => $date_created_to_db,
 					'date_reminder' => $date_reminder_to_db,
-					'is_snoozable'  => $note->get_is_snoozable(),
+					'is_snoozable'  => (int) $note->get_is_snoozable(),
 					'layout'        => $note->get_layout(),
 					'image'         => $note->get_image(),
-					'is_deleted'    => $note->get_is_deleted(),
-					'is_read'       => $note->get_is_read(),
+					'is_deleted'    => (int) $note->get_is_deleted(),
+					'is_read'       => (int) $note->get_is_read(),
 				),
 				array( 'note_id' => $note->get_id() )
 			);

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -112,7 +112,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$note->set_date_reminder( $note_row->date_reminder );
 			$note->set_is_snoozable( (bool) $note_row->is_snoozable );
 			$note->set_is_deleted( (bool) $note_row->is_deleted );
-			$note->set_is_read( (bool) $note_row->is_read );
+			isset( $note_row->is_read ) && $note->set_is_read( (bool) $note_row->is_read );
 			$note->set_layout( $note_row->layout );
 			$note->set_image( $note_row->image );
 			$this->read_actions( $note );

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -37,6 +37,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			'layout'       => $note->get_layout(),
 			'image'        => $note->get_image(),
 			'is_deleted'   => (int) $note->get_is_deleted(),
+			'is_read'      => (int) $note->get_is_read(),
 		);
 
 		$note_to_be_inserted['content_data']  = wp_json_encode( $note->get_content_data() );
@@ -110,8 +111,8 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$note->set_date_created( $note_row->date_created );
 			$note->set_date_reminder( $note_row->date_reminder );
 			$note->set_is_snoozable( $note_row->is_snoozable );
-			$note->set_is_deleted( (bool) $note_row->is_deleted );
-			isset( $note_row->is_read ) && $note->set_is_read( (bool) $note_row->is_read );
+			$note->set_is_deleted( (int) $note_row->is_deleted );
+			isset( $note_row->is_read ) && $note->set_is_read( (int) $note_row->is_read );
 			$note->set_layout( $note_row->layout );
 			$note->set_image( $note_row->image );
 			$this->read_actions( $note );

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -339,7 +339,7 @@ class Note extends \WC_Data {
 	 * Get deleted status.
 	 *
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
-	 * @return array
+	 * @return bool
 	 */
 	public function get_is_deleted( $context = 'view' ) {
 		return $this->get_prop( 'is_deleted', $context );
@@ -349,7 +349,7 @@ class Note extends \WC_Data {
 	 * Get is_read status.
 	 *
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
-	 * @return array
+	 * @return bool
 	 */
 	public function get_is_read( $context = 'view' ) {
 		return $this->get_prop( 'is_read', $context );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-data-store.php
@@ -45,7 +45,7 @@ class WC_Admin_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( $note->get_type(), $read_note->get_type() );
 		$this->assertEquals( $note->get_name(), $read_note->get_name() );
 		$this->assertEquals( $note->get_source(), $read_note->get_source() );
-		$this->assertEquals( $note->get_is_snoozable(), '0' !== $read_note->get_is_snoozable() );
+		$this->assertEquals( $note->get_is_snoozable(), false !== $read_note->get_is_snoozable() );
 		$this->assertEquals( $note->get_layout(), $read_note->get_layout() );
 		$this->assertEquals( $note->get_image(), $read_note->get_image() );
 		$this->assertEquals( $note->get_actions(), $read_note->get_actions() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 16504-gh-Automattic/woocommerce.com.

We were getting the below error in logs while deleting any vendor note:

```
WordPress database error Incorrect integer value: '' for column `wccom`.`wp_wc_admin_notes`.`is_read` at row 1 for query UPDATE `wp_wc_admin_notes` 
SET `name` = 'ww', `type` = 'info', `locale` = 'en_US', `title` = 'ww', `content` = 'ww', `content_data` = '{}', `status` = 'unactioned', `source` = 'wccom-vendor-notes', `date_created` = '2023-12-22 22:12:51', `date_reminder` = NULL, `is_snoozable` = '0', `layout` = 'plain', `image` = '', `is_deleted` = '1', `is_read` = '' 
WHERE `note_id` = '132' made by Automattic\WooCommerce\Admin\Notes\DataStore::update` 
```

This was happening because `is_read` value was not set with correct datatype in `create` and  `read` function in core: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Notes/DataStore.php#L66

The datatype for the is_read is tinyint(1). 

```sql
  `is_read` tinyint(1) NOT NULL DEFAULT 0,

```

- In this PR, we're adding is_read value to create and read functions  and removed unnecessary type casting.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Test for local Woo.com environments

**This test is intended for the Marketplace Engineering teams. If you're doing testing for the WooCommerce release, it's fine to disregard this section.**

We want to create a Vendor Note on our local WCCOM.

1. Create the zip file from this branch. First comment out or delete this line in `plugins/woocommerce/bin/build-zip.sh`. It is unnecessary for this test, and demands massive amounts of RAM which your local environment probably doesn't have.

```
pnpm --filter=@woocommerce/plugin-woocommerce makepot || exit "$?"
```
2. In your project, do `cd plugins/woocommerce` and `pnpm run build:zip`.
3. In the plugins admin of your local [WCCOM environment](https://woocommerce.test/wp-admin/plugins.php) upload the zip file the previous step created in the `plugins/woocommerce` folder of your WooCommerce project.
4. This should replace the existing version woocommerce version in your local WCCOM.  
5. If you get `Fatal error: Uncaught Exception: The authoritative table for orders storage can't be changed while there are orders out of sync` error after activating the plugin, run `wp wc cot sync` in CLI to sync your existing orders.  
6. Comment out this line of code: 19118-gh-Automattic/woocommerce.com/files#diff-cef8f1318e4c4bf8336fab0cef21d113214145b08456153b726ce2cb030ac533R80 if present. 
7. The following steps are done in the vendor notes admin in WCCOM. First create a vendor note at https://woocommerce.test/wp-admin/admin.php?page=wccom-vendor-notes-admin.
8. Confirm the vendor note is getting created. Does it appear in the `wp_wc_admin_notes` table of your WCCOM database? 
9. Delete the vendor note in the admin UI. Check the vendor note is getting deleted. Does the note record in the DB now have `1` for `is_deleted`?
10. Go to the "Deleted" list in the admin UI, and restore the vendor note. Does the note record in the DB now have `0` for `is_deleted`?

#### Test for WooCommerce: activity panel notes

This tests that we haven't broken [Activity Panel Notes](https://github.com/woocommerce/woocommerce/blob/1905534fb8bfd4b179ad2ab20e68d4d830ab5ea7/plugins/woocommerce-admin/docs/examples/activity-panel-inbox.md), which also use this class.

1. Create a PHP file in your `wp-content/plugins` folder and paste in this content. This is taken from the [example](https://github.com/woocommerce/woocommerce/blob/1905534fb8bfd4b179ad2ab20e68d4d830ab5ea7/plugins/woocommerce-admin/docs/examples/activity-panel-inbox.md) in the WooCommerce repo, with some added namespacing. (I've corrected the trunk version of the Markdown file in [this PR](https://github.com/woocommerce/woocommerce/pull/44504).)

```php
<?php
/**
 * Plugin Name: WooCommerce Activity Panel Inbox Example Plugin One
 * Plugin URI: https://woo.com/
 * Description: An example plugin.
 * Author: Automattic
 * Author URI: https://woo.com/
 * Text Domain: wapi-example-one
 * Version: 1.0.0
 */

use Automattic\WooCommerce\Admin\Notes\Note as Note;

class WooCommerce_Activity_Panel_Inbox_Example_Plugin_One {
	const NOTE_NAME = 'wapi-example-plugin-one';

	/**
	 * Adds a note to the merchant' inbox.
	 */
	public static function add_activity_panel_inbox_welcome_note() {
		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
			return;
		}

		if ( ! class_exists( 'WC_Data_Store' ) ) {
			return;
		}

		$data_store = WC_Data_Store::load( 'admin-note' );

		// First, see if we've already created this kind of note so we don't do it again.
		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
		foreach( (array) $note_ids as $note_id ) {
			$note         = Notes::get_note( $note_id );
			$content_data = $note->get_content_data();
 			if ( property_exists( $content_data, 'getting_started' ) ) {
				return;
			}
		}

		// Otherwise, add the note
		$activated_time = current_time( 'timestamp', 0 );
		$activated_time_formatted = date( 'F jS', $activated_time );
		$note = new Note();
		$note->set_title( __( 'Getting Started', 'wapi-example-plugin-one' ) );
		$note->set_content(
			sprintf(
				/* translators: a date, e.g. November 1st */
				__( 'Plugin activated on %s.', 'wapi-example-plugin-one' ),
				$activated_time_formatted
			)
		);
		$note->set_content_data( (object) array(
			'getting_started'     => true,
			'activated'           => $activated_time,
			'activated_formatted' => $activated_time_formatted,
		) );
		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
		$note->set_layout('plain');
		$note->set_image('');
		$note->set_name( self::NOTE_NAME );
		$note->set_source( 'wapi-example-plugin-one' );
		$note->set_layout('plain');
		$note->set_image('');
		// This example has two actions. A note can have 0 or 1 as well.
		$note->add_action(
			'settings',
			__( 'Open Settings', 'wapi-example-plugin-one' ),
			'?page=wc-settings&tab=general'
		);
		$note->add_action(
			'settings',
			__( 'Learn More', 'wapi-example-plugin-one' ),
			'https://github.com/woocommerce/woocommerce-admin/tree/main/docs'
		);
		$note->save();
	}

	/**
	 * Removes any notes this plugin created.
	 */
	public static function remove_activity_panel_inbox_notes() {
		if ( ! class_exists( 'Notes' ) ) {
			return;
		}

		Notes::delete_notes_with_name( self::NOTE_NAME );
	}
}

function wapi_example_one_activate() {
	WooCommerce_Activity_Panel_Inbox_Example_Plugin_One::add_activity_panel_inbox_welcome_note();
}
register_activation_hook( __FILE__, 'wapi_example_one_activate' );

function wapi_example_one_deactivate() {
	WooCommerce_Activity_Panel_Inbox_Example_Plugin_One::remove_activity_panel_inbox_notes();
}
register_deactivation_hook( __FILE__, 'wapi_example_one_deactivate' );
```

2. Go to `/wp-admin/plugins.php`. Activate the plugin "WooCommerce Activity Panel Inbox Example Plugin One".

<p>
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/73c11f48-359c-40b5-8130-3e888109f8ce">
</p>

3. View the `wp_wc_admin_notes` table in your local DB, and notice that the plugin has added a new record.

<p>
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/a06e99c7-f9ef-4e8a-8da5-35daf64f6ab0">
</p>

4. Go to a WooCommerce admin page like `wp-admin/admin.php?page=wc-settings&tab=general`. Click on the "Activity" button in the top right of your screen and notice this note that the plugin has created.

<p>
<img width="320" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/ef57130e-a58f-4690-ab51-da843fcfc24e">
</p>

5. Click on the "Open Settings" button in the note.
6. Refresh the DB record and note that the record is marked `is_read`.
7. View the Activity Inbox and see that the note no longer appears.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix `is_read` value in Admin notes. 

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>