### PR TITLE
Fix occurrences where Installer_Error exception is returned instead of being thrown

### DIFF
--- a/plugins/woocommerce/changelog/43108-fix-installer-error-exception
+++ b/plugins/woocommerce/changelog/43108-fix-installer-error-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an error in plugin auto-installer triggered in certain installation failure scenarios.

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
@@ -74,13 +74,13 @@ class WC_WCCOM_Site_Installation_Step_Activate_Product implements WC_WCCOM_Site_
 		}
 
 		if ( empty( $filename ) ) {
-			return new Installer_Error( Installer_Error_Codes::UNKNOWN_FILENAME );
+			throw new Installer_Error( Installer_Error_Codes::UNKNOWN_FILENAME );
 		}
 
 		$result = activate_plugin( $filename );
 
 		if ( is_wp_error( $result ) ) {
-			return new Installer_Error( Installer_Error_Codes::PLUGIN_ACTIVATION_ERROR, $result->get_error_message() );
+			throw new Installer_Error( Installer_Error_Codes::PLUGIN_ACTIVATION_ERROR, $result->get_error_message() );
 		}
 	}
 
@@ -112,7 +112,7 @@ class WC_WCCOM_Site_Installation_Step_Activate_Product implements WC_WCCOM_Site_
 		}
 
 		if ( empty( $theme_slug ) ) {
-			return new Installer_Error( Installer_Error_Codes::UNKNOWN_FILENAME );
+			throw new Installer_Error( Installer_Error_Codes::UNKNOWN_FILENAME );
 		}
 
 		switch_theme( $theme_slug );

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
@@ -50,6 +50,8 @@ class WC_WCCOM_Site_Installation_Step_Activate_Product implements WC_WCCOM_Site_
 	 * Activate plugin.
 	 *
 	 * @param int $product_id Product ID.
+	 * @return void
+	 * @throws WC_REST_WCCOM_Site_Installer_Error If plugin activation failed.
 	 */
 	private function activate_plugin( $product_id ) {
 		// Clear plugins cache used in `WC_Helper::get_local_woo_plugins`.
@@ -88,6 +90,8 @@ class WC_WCCOM_Site_Installation_Step_Activate_Product implements WC_WCCOM_Site_
 	 * Activate theme.
 	 *
 	 * @param int $product_id Product ID.
+	 * @return void
+	 * @throws WC_REST_WCCOM_Site_Installer_Error If theme activation failed.
 	 */
 	private function activate_theme( $product_id ) {
 		// Clear plugins cache used in `WC_Helper::get_local_woo_themes`.

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-get-product-info.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-get-product-info.php
@@ -114,7 +114,7 @@ class WC_WCCOM_Site_Installation_Step_Get_Product_Info implements WC_WCCOM_Site_
 		$updates = WC_Helper_Updater::get_update_data();
 
 		if ( empty( $updates[ $product_id ]['package'] ) ) {
-			return new Installer_Error( Installer_Error_Codes::WCCOM_PRODUCT_MISSING_PACKAGE );
+			throw new Installer_Error( Installer_Error_Codes::WCCOM_PRODUCT_MISSING_PACKAGE );
 		}
 
 		return $updates[ $product_id ]['package'];

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-unpack-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-unpack-product.php
@@ -33,6 +33,9 @@ class WC_WCCOM_Site_Installation_Step_Unpack_Product implements WC_WCCOM_Site_In
 
 	/**
 	 * Run the step installation process.
+	 *
+	 * @return WC_WCCOM_Site_Installation_State
+	 * @throws WC_REST_WCCOM_Site_Installer_Error If the package unpacked path is not returned.
 	 */
 	public function run() {
 		$upgrader      = WC_WCCOM_Site_Installer::get_wp_upgrader();

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-unpack-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-unpack-product.php
@@ -39,7 +39,7 @@ class WC_WCCOM_Site_Installation_Step_Unpack_Product implements WC_WCCOM_Site_In
 		$unpacked_path = $upgrader->unpack_package( $this->state->get_download_path(), true );
 
 		if ( empty( $unpacked_path ) ) {
-			return new Installer_Error( Installer_Error_Codes::MISSING_UNPACKED_PATH );
+			throw new Installer_Error( Installer_Error_Codes::MISSING_UNPACKED_PATH );
 		}
 
 		$this->state->set_unpacked_path( $unpacked_path );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR fixes an error that can occur when functions return `Installer_Error` exception instead of throwing it. The resulting error looks like this:

```
[25-Dec-2023 17:57:15 UTC] PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed in /var/www/html/wp-includes/functions.php:625
Stack trace:
#0 /var/www/html/wp-includes/functions.php(625): serialize(Array)
#1 /var/www/html/wp-includes/option.php(795): maybe_serialize(Array)
#2 /var/www/html/wp-content/plugins/woocommerce/includes/wccom-site/installation/class-wc-wccom-site-installation-state-storage.php(73): update_option('wccom-product-i...', Array)
#3 /var/www/html/wp-content/plugins/woocommerce/includes/wccom-site/installation/class-wc-wccom-site-installation-manager.php(206): WC_WCCOM_Site_Installation_State_Storage::save_state(Object(WC_WCCOM_Site_Installation_State))
#4 /var/www/html/wp-content/plugins/woocommerce/includes/wccom-site/installation/class-wc-wccom-site-installation-manager.php(77): WC_WCCOM_Site_Installation_Manager->run_step('get_product_inf...', Object(WC_WCCOM_Site_Installation_State))
#5 [internal function]: WC_WCCOM_Site_Installation_Manager->{closure}('get_product_inf...', 0)
#6 /var/www/html/wp-content/plugins/woocommerce/includes/wccom-site/installation/class-wc-wccom-site-installation-manager.php(78): array_walk(Array, Object(Closure))
#7 /var/www/html/wp-content/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller-v2.php(140): WC_WCCOM_Site_Installation_Manager->run_installation('activate_produc...')
#8 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1193): WC_REST_WCCOM_Site_Installer_Controller_V2->install(Object(WP_REST_Request))
#9 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1041): WP_REST_Server->respond_to_request(Object(WP_REST_Request), '/wccom-site/v2/...', Array, NULL)
#10 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(431): WP_REST_Server->dispatch(Object(WP_REST_Request))
#11 /var/www/html/wp-includes/rest-api.php(424): WP_REST_Server->serve_request('/wccom-site/v2/...')
#12 /var/www/html/wp-includes/class-wp-hook.php(324): rest_api_loaded(Object(WP))
#13 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#14 /var/www/html/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#15 /var/www/html/wp-includes/class-wp.php(418): do_action_ref_array('parse_request', Array)
#16 /var/www/html/wp-includes/class-wp.php(813): WP->parse_request('')
#17 /var/www/html/wp-includes/functions.php(1336): WP->main('')
#18 /var/www/html/wp-blog-header.php(16): wp()
#19 /var/www/html/index.php(17): require('/var/www/html/w...')
#20 {main}
  thrown in /var/www/html/wp-includes/functions.php on line 625
```

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

## Preconditions
- Ensure you have an active subscription to a product on WooCommerce.com. Jot down the product ID.
- Connect the store to your account on WooCommerce.com from **WP admin -> WooCommerce -> Extensions -> My subscriptions.**. Ensure you perform the connection from behalf of admin user of the store.
- Comment out [lines 102-110](https://github.com/woocommerce/woocommerce/blob/2800be9b7bae98b3d43247948671e63a96edb234/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php#L102-L110) and [114-122](https://github.com/woocommerce/woocommerce/blob/2800be9b7bae98b3d43247948671e63a96edb234/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php#L114-L122) in file `/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php` to bypass validation of authentication credentials and allow testing API endpoints through Curl.
- Simulate an installer error when package information is not present by adding `$updates[ $product_id ]['package'] = null;` on [line 115](https://github.com/woocommerce/woocommerce/blob/3735306efd2212de72db3dda5b749074942e0ef3/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-get-product-info.php#L115) in file `/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-get-product-info.php`.

## Reproduce the bug on trunk branch
1. Send an installation request (ensure to replace strings `<SITE_DOMAIN>` and `<PRODUCT_ID>` with your site domain and product ID you got previously):
```bash
curl --request POST \
  --url 'https://<SITE_DOMAIN>/wp-json/wccom-site/v2/installer?token=XXX&signature=YYY' \
  --header 'Content-Type: application/json' \
  --data '{
	"product-id": <PRODUCT_ID>,
	"run-until-step": "activate_product",
	"idempotency-key": "ABC"
}'
```
2. Confirm you get a 500 response with `internal_server_error`.
3. Confirm there is an error log `PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed` in your debug logs file.

## Confirm the bugfix
1. Send a request to reset the installation state (ensure to replace strings <SITE_DOMAIN> and <PRODUCT_ID> with your site domain and product ID you got previously):
```bash
curl --request DELETE \
  --url 'https://<SITE_DOMAIN>/wp-json/wccom-site/v2/installer?token=XXX&signature=YYY' \
  --header 'Content-Type: application/json' \
  --data '{
	"product-id": <PRODUCT_ID>,
	"idempotency-key": "ABC"
}'
```
3. Switch to this PR's branch and retry the request from the previous section.
4. Confirm you received an error response, with 400 code and response body explaining that the installation failed due to error `wccom_product_missing_package`:

```json
{
	"success": false,
	"error_code": "installation_failed",
	"error_message": "The installation of the plugin failed",
	"state": {
		"product_id": 3574467,
		"idempotency_key": "U69RPmLbuBHe",
		"last_step_name": "get_product_info",
		"last_step_status": "failed",
		"last_step_error": "wccom_product_missing_package",
		"product_type": null,
		"product_name": null,
		"already_installed_plugin_info": null,
		"started_seconds_ago": 13
	}
}
```




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix an error in plugin auto-installer triggered in certain installation failure scenarios.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
