### PR TITLE
[Experimental] Render headings as inner blocks of collection filters

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
@@ -2,82 +2,24 @@
  * External dependencies
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { sprintf, __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import type { AttributeSetting } from '@woocommerce/types';
 
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
-const template = [
-	[
-		'woocommerce/collection-active-filters',
-		{},
-		[
-			[
-				'core/heading',
-				{ content: __( 'Active Filters', 'woocommerce' ), level: 3 },
-			],
-		],
-	],
-	[
-		'woocommerce/collection-price-filter',
-		{},
-		[
-			[
-				'core/heading',
-				{ content: __( 'Filter by Price', 'woocommerce' ), level: 3 },
-			],
-		],
-	],
-	[
-		'woocommerce/collection-stock-filter',
-		{},
-		[
-			[
-				'core/heading',
-				{
-					content: __( 'Filter by Stock Status', 'woocommerce' ),
-					level: 3,
-				},
-			],
-		],
-	],
-	[
-		'woocommerce/collection-rating-filter',
-		{},
-		[
-			[
-				'core/heading',
-				{
-					content: __( 'Filter by Rating', 'woocommerce' ),
-					level: 3,
-				},
-			],
-		],
-	],
-];
-
 const firstAttribute = ATTRIBUTES.find( Boolean );
+
+const template = [
+	[ 'woocommerce/collection-active-filters', {} ],
+	[ 'woocommerce/collection-price-filter', {} ],
+	[ 'woocommerce/collection-stock-filter', {} ],
+	[ 'woocommerce/collection-rating-filter', {} ],
+];
 
 if ( firstAttribute ) {
 	template.push( [
 		'woocommerce/collection-attribute-filter',
-		{
-			attributeId: parseInt( firstAttribute?.attribute_id, 10 ),
-		},
-		[
-			[
-				'core/heading',
-				{
-					content: sprintf(
-						// translators: %s is the attribute label.
-						__( 'Filter by %s', 'woocommerce' ),
-						firstAttribute.attribute_label
-					),
-					level: 3,
-				},
-			],
-		],
+		{ attributeId: parseInt( firstAttribute?.attribute_id, 10 ) },
 	] );
 }
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
@@ -9,55 +9,76 @@ import type { AttributeSetting } from '@woocommerce/types';
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
 const template = [
-	[ 'woocommerce/collection-active-filters', {} ],
 	[
-		'core/heading',
-		{
-			content: __( 'Filter by Price', 'woocommerce' ),
-			level: 3,
-		},
+		'woocommerce/collection-active-filters',
+		{},
+		[
+			[
+				'core/heading',
+				{ content: __( 'Active Filters', 'woocommerce' ), level: 3 },
+			],
+		],
 	],
-	[ 'woocommerce/collection-price-filter', {} ],
 	[
-		'core/heading',
-		{
-			content: __( 'Filter by Stock status', 'woocommerce' ),
-			level: 3,
-		},
+		'woocommerce/collection-price-filter',
+		{},
+		[
+			[
+				'core/heading',
+				{ content: __( 'Filter by Price', 'woocommerce' ), level: 3 },
+			],
+		],
 	],
-	[ 'woocommerce/collection-stock-filter', {} ],
 	[
-		'core/heading',
-		{
-			content: __( 'Filter by Rating', 'woocommerce' ),
-			level: 3,
-		},
+		'woocommerce/collection-stock-filter',
+		{},
+		[
+			[
+				'core/heading',
+				{
+					content: __( 'Filter by Stock Status', 'woocommerce' ),
+					level: 3,
+				},
+			],
+		],
 	],
-	[ 'woocommerce/collection-rating-filter', {} ],
+	[
+		'woocommerce/collection-rating-filter',
+		{},
+		[
+			[
+				'core/heading',
+				{
+					content: __( 'Filter by Rating', 'woocommerce' ),
+					level: 3,
+				},
+			],
+		],
+	],
 ];
 
 const firstAttribute = ATTRIBUTES.find( Boolean );
 
 if ( firstAttribute ) {
-	template.push(
+	template.push( [
+		'woocommerce/collection-attribute-filter',
+		{
+			attributeId: parseInt( firstAttribute?.attribute_id, 10 ),
+		},
 		[
-			'core/heading',
-			{
-				content: sprintf(
-					// translators: %s is the attribute label.
-					__( 'Filter by %s', 'woocommerce' ),
-					firstAttribute.attribute_label
-				),
-				level: 3,
-			},
+			[
+				'core/heading',
+				{
+					content: sprintf(
+						// translators: %s is the attribute label.
+						__( 'Filter by %s', 'woocommerce' ),
+						firstAttribute.attribute_label
+					),
+					level: 3,
+				},
+			],
 		],
-		[
-			'woocommerce/collection-attribute-filter',
-			{
-				attributeId: parseInt( firstAttribute?.attribute_id, 10 ),
-			},
-		]
-	);
+	] );
 }
 
 const Edit = () => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { Disabled } from '@wordpress/components';
@@ -23,6 +23,7 @@ const Edit = ( props: EditProps ) => {
 	return (
 		<div { ...blockProps }>
 			<Inspector { ...props } />
+			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 			<Disabled>
 				<ul
 					className={ classNames( 'wc-block-active-filters__list', {

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
@@ -1,14 +1,11 @@
 /**
  * External dependencies
  */
-import {
-	useBlockProps,
-	InnerBlocks,
-	useInnerBlocksProps,
-} from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { Disabled } from '@wordpress/components';
+import { Template } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -24,19 +21,20 @@ const Edit = ( props: EditProps ) => {
 		className: 'wc-block-active-filters',
 	} );
 
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: [
-			[
-				'core/heading',
-				{ content: __( 'Active Filters', 'woocommerce' ), level: 3 },
-			],
+	const template: Template[] = [
+		[
+			'core/heading',
+			{ content: __( 'Active Filters', 'woocommerce' ), level: 3 },
 		],
-	} );
+	];
 
 	return (
-		<div { ...innerBlocksProps }>
+		<div { ...blockProps }>
 			<Inspector { ...props } />
-			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
+			<InnerBlocks
+				template={ template }
+				allowedBlocks={ [ 'core/heading' ] }
+			/>
 			<Disabled>
 				<ul
 					className={ classNames( 'wc-block-active-filters__list', {

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	InnerBlocks,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { Disabled } from '@wordpress/components';
@@ -20,8 +24,17 @@ const Edit = ( props: EditProps ) => {
 		className: 'wc-block-active-filters',
 	} );
 
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: [
+			[
+				'core/heading',
+				{ content: __( 'Active Filters', 'woocommerce' ), level: 3 },
+			],
+		],
+	} );
+
 	return (
-		<div { ...blockProps }>
+		<div { ...innerBlocksProps }>
 			<Inspector { ...props } />
 			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 			<Disabled>

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
@@ -25,8 +25,6 @@ if ( isExperimentalBuild() ) {
 			),
 		},
 		edit: Edit,
-		save() {
-			return <InnerBlocks.Content />;
-		},
+		save: InnerBlocks.Content,
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
@@ -5,6 +5,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { Icon } from '@wordpress/icons';
 import { toggle } from '@woocommerce/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -24,5 +25,8 @@ if ( isExperimentalBuild() ) {
 			),
 		},
 		edit: Edit,
+		save() {
+			return <InnerBlocks.Content />;
+		},
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
@@ -3,7 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InnerBlocks,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { getSetting } from '@woocommerce/settings';
 import {
 	useCollection,
@@ -21,6 +25,7 @@ import {
 	withSpokenMessages,
 	Notice,
 } from '@wordpress/components';
+import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
@@ -38,7 +43,6 @@ import { AttributeDropdown } from './components/attribute-dropdown';
 import './style.scss';
 import { extractBuiltInColor } from '../../utils';
 import { useStyleProps } from '../../../../base/hooks';
-import styled from '@emotion/styled';
 
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
@@ -186,6 +190,7 @@ const Edit = ( props: EditProps ) => {
 	const Wrapper = ( { children }: { children: ReactNode } ) => (
 		<div { ...blockProps }>
 			<Toolbar />
+			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 			{ children }
 		</div>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import {
 	BlockControls,
 	InnerBlocks,
 	useBlockProps,
+	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { getSetting } from '@woocommerce/settings';
 import {
@@ -25,7 +26,6 @@ import {
 	withSpokenMessages,
 	Notice,
 } from '@wordpress/components';
-import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
@@ -96,6 +96,27 @@ const Edit = ( props: EditProps ) => {
 	} );
 
 	const blockProps = useBlockProps();
+
+	const template = [
+		[
+			'core/heading',
+			{
+				content: attributeObject
+					? sprintf(
+							// translators: %s is the attribute label.
+							__( 'Filter by %s', 'woocommerce' ),
+							attributeObject.label
+					  )
+					: __( 'Filter Products by Attribute', 'woocommerce' ),
+				level: 3,
+			},
+		],
+	];
+
+	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/heading' ],
+		template,
+	} );
 
 	useEffect( () => {
 		if ( ! attributeObject?.taxonomy ) {
@@ -188,9 +209,8 @@ const Edit = ( props: EditProps ) => {
 	);
 
 	const Wrapper = ( { children }: { children: ReactNode } ) => (
-		<div { ...blockProps }>
+		<div { ...innerBlockProps }>
 			<Toolbar />
-			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 			{ children }
 		</div>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/edit.tsx
@@ -7,7 +7,6 @@ import {
 	BlockControls,
 	InnerBlocks,
 	useBlockProps,
-	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { getSetting } from '@woocommerce/settings';
 import {
@@ -26,6 +25,7 @@ import {
 	withSpokenMessages,
 	Notice,
 } from '@wordpress/components';
+import { Template } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -97,7 +97,7 @@ const Edit = ( props: EditProps ) => {
 
 	const blockProps = useBlockProps();
 
-	const template = [
+	const template: Template[] = [
 		[
 			'core/heading',
 			{
@@ -112,11 +112,6 @@ const Edit = ( props: EditProps ) => {
 			},
 		],
 	];
-
-	const innerBlockProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: [ 'core/heading' ],
-		template,
-	} );
 
 	useEffect( () => {
 		if ( ! attributeObject?.taxonomy ) {
@@ -209,7 +204,7 @@ const Edit = ( props: EditProps ) => {
 	);
 
 	const Wrapper = ( { children }: { children: ReactNode } ) => (
-		<div { ...innerBlockProps }>
+		<div { ...blockProps }>
 			<Toolbar />
 			{ children }
 		</div>
@@ -261,6 +256,10 @@ const Edit = ( props: EditProps ) => {
 	return (
 		<Wrapper>
 			<Inspector { ...props } />
+			<InnerBlocks
+				template={ template }
+				allowedBlocks={ [ 'core/heading' ] }
+			/>
 			<Disabled>
 				{ displayStyle === 'dropdown' ? (
 					<AttributeDropdown

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/index.tsx
@@ -15,8 +15,6 @@ import Edit from './edit';
 if ( isExperimentalBuild() ) {
 	registerBlockType( metadata, {
 		edit: Edit,
-		save() {
-			return <InnerBlocks.Content />;
-		},
+		save: InnerBlocks.Content,
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/index.tsx
@@ -3,6 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -14,5 +15,8 @@ import Edit from './edit';
 if ( isExperimentalBuild() ) {
 	registerBlockType( metadata, {
 		edit: Edit,
+		save() {
+			return <InnerBlocks.Content />;
+		},
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/edit.tsx
@@ -1,13 +1,10 @@
 /**
  * External dependencies
  */
-import {
-	InnerBlocks,
-	useBlockProps,
-	useInnerBlocksProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import { Template } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -25,19 +22,20 @@ const Edit = ( props: EditProps ) => {
 		} ),
 	} );
 
-	const innerBlockProps = useInnerBlocksProps( blockProps, {
-		template: [
-			[
-				'core/heading',
-				{ content: __( 'Filter by Price', 'woocommerce' ), level: 3 },
-			],
+	const template: Template[] = [
+		[
+			'core/heading',
+			{ content: __( 'Filter by Price', 'woocommerce' ), level: 3 },
 		],
-	} );
+	];
 
 	return (
-		<div { ...innerBlockProps }>
+		<div { ...blockProps }>
 			<Inspector { ...props } />
-			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
+			<InnerBlocks
+				template={ template }
+				allowedBlocks={ [ 'core/heading' ] }
+			/>
 			<PriceSlider { ...props } />
 		</div>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import classNames from 'classnames';
 
 /**
@@ -23,6 +23,7 @@ const Edit = ( props: EditProps ) => {
 	return (
 		<div { ...blockProps }>
 			<Inspector { ...props } />
+			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 			<PriceSlider { ...props } />
 		</div>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/edit.tsx
@@ -1,8 +1,13 @@
 /**
  * External dependencies
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import classNames from 'classnames';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,8 +25,17 @@ const Edit = ( props: EditProps ) => {
 		} ),
 	} );
 
+	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		template: [
+			[
+				'core/heading',
+				{ content: __( 'Filter by Price', 'woocommerce' ), level: 3 },
+			],
+		],
+	} );
+
 	return (
-		<div { ...blockProps }>
+		<div { ...innerBlockProps }>
 			<Inspector { ...props } />
 			<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 			<PriceSlider { ...props } />

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/index.tsx
@@ -24,8 +24,6 @@ if ( isExperimentalBuild() ) {
 			),
 		},
 		edit: Edit,
-		save() {
-			return <InnerBlocks.Content />;
-		},
+		save: InnerBlocks.Content,
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/price-filter/index.tsx
@@ -4,6 +4,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, currencyDollar } from '@wordpress/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -23,5 +24,8 @@ if ( isExperimentalBuild() ) {
 			),
 		},
 		edit: Edit,
+		save() {
+			return <InnerBlocks.Content />;
+		},
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/edit.tsx
@@ -4,12 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
-import {
-	InnerBlocks,
-	useBlockProps,
-	useInnerBlocksProps,
-} from '@wordpress/block-editor';
-import type { BlockEditProps } from '@wordpress/blocks';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import type { BlockEditProps, Template } from '@wordpress/blocks';
 import Rating, {
 	RatingValues,
 } from '@woocommerce/base-components/product-rating';
@@ -73,15 +69,12 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 		className: classnames( 'wc-block-rating-filter', className ),
 	} );
 
-	const innerBlockProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: [ 'core/heading' ],
-		template: [
-			[
-				'core/heading',
-				{ content: __( 'Filter by Rating', 'woocommerce' ), level: 3 },
-			],
+	const template: Template[] = [
+		[
+			'core/heading',
+			{ content: __( 'Filter by Rating', 'woocommerce' ), level: 3 },
 		],
-	} );
+	];
 
 	const isEditor = true;
 
@@ -210,8 +203,11 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 	return (
 		<>
 			<Inspector { ...props } />
-			<div { ...innerBlockProps }>
-				<InnerBlocks { ...innerBlockProps } />
+			<div { ...blockProps }>
+				<InnerBlocks
+					template={ template }
+					allowedBlocks={ [ 'core/heading' ] }
+				/>
 				<Disabled>
 					{ displayNoProductRatingsNotice && <NoRatings /> }
 					<div

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/edit.tsx
@@ -4,7 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import type { BlockEditProps } from '@wordpress/blocks';
 import Rating, {
 	RatingValues,
@@ -67,6 +71,16 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 
 	const blockProps = useBlockProps( {
 		className: classnames( 'wc-block-rating-filter', className ),
+	} );
+
+	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/heading' ],
+		template: [
+			[
+				'core/heading',
+				{ content: __( 'Filter by Rating', 'woocommerce' ), level: 3 },
+			],
+		],
 	} );
 
 	const isEditor = true;
@@ -196,8 +210,8 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 	return (
 		<>
 			<Inspector { ...props } />
-			<div { ...blockProps }>
-				<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
+			<div { ...innerBlockProps }>
+				<InnerBlocks { ...innerBlockProps } />
 				<Disabled>
 					{ displayNoProductRatingsNotice && <NoRatings /> }
 					<div

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/edit.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
-import { useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import type { BlockEditProps } from '@wordpress/blocks';
 import Rating, {
 	RatingValues,
@@ -21,6 +21,7 @@ import { CheckboxList } from '@woocommerce/blocks-components';
 import FormTokenField from '@woocommerce/base-components/form-token-field';
 import { Disabled, Notice, withSpokenMessages } from '@wordpress/components';
 import { useStyleProps } from '@woocommerce/base-hooks';
+import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
@@ -33,7 +34,6 @@ import { useSetWraperVisibility } from '../../../filter-wrapper/context';
 import './editor.scss';
 import { Inspector } from '../attribute-filter/components/inspector-controls';
 import { extractBuiltInColor } from '../../utils';
-import styled from '@emotion/styled';
 
 const NoRatings = () => (
 	<Notice status="warning" isDismissible={ false }>
@@ -197,6 +197,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 		<>
 			<Inspector { ...props } />
 			<div { ...blockProps }>
+				<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 				<Disabled>
 					{ displayNoProductRatingsNotice && <NoRatings /> }
 					<div

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/index.tsx
@@ -26,18 +26,6 @@ registerBlockType( metadata, {
 		...metadata.attributes,
 	},
 	edit,
-	// Save the props to post content.
-	save( { attributes }: { attributes: Attributes } ) {
-		const { className } = attributes;
-
-		return (
-			<div
-				{ ...useBlockProps.save( {
-					className: classNames( 'is-loading', className ),
-				} ) }
-			>
-				<InnerBlocks.Content />
-			</div>
-		);
+	save: InnerBlocks.Content,
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/index.tsx
@@ -4,7 +4,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -35,7 +35,9 @@ registerBlockType( metadata, {
 				{ ...useBlockProps.save( {
 					className: classNames( 'is-loading', className ),
 				} ) }
-			/>
+			>
+				<InnerBlocks.Content />
+			</div>
 		);
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/rating-filter/index.tsx
@@ -11,7 +11,6 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
  */
 import edit from './edit';
 import metadata from './block.json';
-import type { Attributes } from './types';
 
 registerBlockType( metadata, {
 	icon: {
@@ -27,5 +26,4 @@ registerBlockType( metadata, {
 	},
 	edit,
 	save: InnerBlocks.Content,
-	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
@@ -3,18 +3,14 @@
  */
 import { useMemo } from '@wordpress/element';
 import classnames from 'classnames';
-import {
-	InnerBlocks,
-	useBlockProps,
-	useInnerBlocksProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
 import { CheckboxList } from '@woocommerce/blocks-components';
 import Label from '@woocommerce/base-components/filter-element-label';
 import FormTokenField from '@woocommerce/base-components/form-token-field';
-import type { BlockEditProps } from '@wordpress/blocks';
+import type { BlockEditProps, Template } from '@wordpress/blocks';
 import { getSetting } from '@woocommerce/settings';
 import { useCollectionData } from '@woocommerce/base-context/hooks';
 import { useStyleProps } from '@woocommerce/base-hooks';
@@ -47,14 +43,12 @@ const Edit = ( props: BlockEditProps< BlockProps > ) => {
 		),
 	} );
 
-	const innerBlockProps = useInnerBlocksProps( blockProps, {
-		template: [
-			[
-				'core/heading',
-				{ content: __( 'Filter by Stock Status', 'woocommerce' ) },
-			],
+	const template: Template[] = [
+		[
+			'core/heading',
+			{ content: __( 'Filter by Stock Status', 'woocommerce' ) },
 		],
-	} );
+	];
 
 	const { className, style } = useStyleProps( props.attributes );
 	const builtInColor = extractBuiltInColor( className );
@@ -106,9 +100,12 @@ const Edit = ( props: BlockEditProps< BlockProps > ) => {
 	return (
 		<>
 			{
-				<div { ...innerBlockProps }>
+				<div { ...blockProps }>
 					<Inspector { ...props } />
-					<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
+					<InnerBlocks
+						template={ template }
+						allowedBlocks={ [ 'core/heading' ] }
+					/>
 					<Disabled>
 						<div
 							className={ classnames(

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
@@ -3,7 +3,11 @@
  */
 import { useMemo } from '@wordpress/element';
 import classnames from 'classnames';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
@@ -41,6 +45,15 @@ const Edit = ( props: BlockEditProps< BlockProps > ) => {
 			'wc-block-stock-filter',
 			props.attributes.className
 		),
+	} );
+
+	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		template: [
+			[
+				'core/heading',
+				{ content: __( 'Filter by Stock Status', 'woocommerce' ) },
+			],
+		],
 	} );
 
 	const { className, style } = useStyleProps( props.attributes );
@@ -93,7 +106,7 @@ const Edit = ( props: BlockEditProps< BlockProps > ) => {
 	return (
 		<>
 			{
-				<div { ...blockProps }>
+				<div { ...innerBlockProps }>
 					<Inspector { ...props } />
 					<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 					<Disabled>

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { useMemo } from '@wordpress/element';
 import classnames from 'classnames';
-import { useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
@@ -95,6 +95,7 @@ const Edit = ( props: BlockEditProps< BlockProps > ) => {
 			{
 				<div { ...blockProps }>
 					<Inspector { ...props } />
+					<InnerBlocks allowedBlocks={ [ 'core/heading' ] } />
 					<Disabled>
 						<div
 							className={ classnames(

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/edit.tsx
@@ -46,7 +46,10 @@ const Edit = ( props: BlockEditProps< BlockProps > ) => {
 	const template: Template[] = [
 		[
 			'core/heading',
-			{ content: __( 'Filter by Stock Status', 'woocommerce' ) },
+			{
+				content: __( 'Filter by Stock Status', 'woocommerce' ),
+				level: 3,
+			},
 		],
 	];
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/index.tsx
@@ -24,8 +24,6 @@ if ( isExperimentalBuild() ) {
 			),
 		},
 		edit,
-		save() {
-			return <InnerBlocks.Content />;
-		},
+		save: InnerBlocks.Content,
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/index.tsx
@@ -4,6 +4,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, box } from '@wordpress/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -23,5 +24,8 @@ if ( isExperimentalBuild() ) {
 			),
 		},
 		edit,
+		save() {
+			return <InnerBlocks.Content />;
+		},
 	} );
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionActiveFilters.php
@@ -49,7 +49,7 @@ final class CollectionActiveFilters extends AbstractBlock {
 		$active_filters = apply_filters( 'collection_active_filters_data', array(), $this->get_filter_query_params( $query_id ) );
 
 		if ( empty( $active_filters ) ) {
-			return $content;
+			return '';
 		}
 
 		$context = array(
@@ -68,8 +68,8 @@ final class CollectionActiveFilters extends AbstractBlock {
 		ob_start();
 		?>
 
-		<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		<div <?php echo $wrapper_attributes; ?>>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+			<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<ul class="wc-block-active-filters__list %3$s">
 				<?php foreach ( $active_filters as $filter ) : ?>
 				<li>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
@@ -133,7 +133,7 @@ final class CollectionAttributeFilter extends AbstractBlock {
 			empty( $block->context['collectionData']['attribute_counts'] ) ||
 			empty( $attributes['attributeId'] )
 		) {
-			return $content;
+			return '';
 		}
 
 		$product_attribute = wc_get_attribute( $attributes['attributeId'] );
@@ -180,13 +180,14 @@ final class CollectionAttributeFilter extends AbstractBlock {
 		);
 
 		return sprintf(
-			'<div %1$s>%2$s</div>',
+			'<div %1$s>%2$s%3$s</div>',
 			get_block_wrapper_attributes(
 				array(
 					'data-wc-context'     => wp_json_encode( $context ),
 					'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-attribute-filter' ) ),
 				)
 			),
+			$content,
 			$filter_content
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionPriceFilter.php
@@ -116,7 +116,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 			empty( $block->context['collectionData'] ) ||
 			empty( $block->context['collectionData']['price_range'] )
 		) {
-			return $content;
+			return '';
 		}
 
 		$price_range = $block->context['collectionData']['price_range'];
@@ -147,7 +147,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 
 		// Max range shouldn't be 0.
 		if ( ! $max_range ) {
-			return $content;
+			return '';
 		}
 
 		// CSS variables for the range bar style.
@@ -197,6 +197,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 		ob_start();
 		?>
 			<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+				<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<div data-wc-context="<?php echo esc_attr( wp_json_encode( $data ) ); ?>" >
 					<div
 						class="range"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
@@ -118,6 +118,10 @@ final class CollectionRatingFilter extends AbstractBlock {
 		$display_style = $attributes['displayStyle'] ?? 'list';
 		$show_counts   = $attributes['showCounts'] ?? false;
 
+		if ( empty( $rating_counts ) ) {
+			return '';
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verification is not required here.
 		$selected_ratings_query_param = isset( $_GET[ self::RATING_FILTER_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::RATING_FILTER_QUERY_VAR ] ) ) : '';
 
@@ -215,6 +219,7 @@ final class CollectionRatingFilter extends AbstractBlock {
 	 * @param mixed  $selected_ratings_query The url query param for selected ratings.
 	 * @param bool   $show_counts Whether to show the counts.
 	 * @param string $select_type The select type. (single|multiple).
+	 * @param string $text_color The text color.
 	 * @return array<array-key, array>
 	 */
 	private function get_dropdown_props( $rating_counts, $selected_ratings_query, $show_counts, $select_type, $text_color ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
@@ -139,10 +139,12 @@ final class CollectionRatingFilter extends AbstractBlock {
 
 		return sprintf(
 			'<div %1$s>
-				<div class="wc-block-rating-filter__controls">%2$s</div>
+				%2$s
+				<div class="wc-block-rating-filter__controls">%3$s</div>
 				<div class="wc-block-rating-filter__actions"></div>
 			</div>',
 			$wrapper_attributes,
+			$content,
 			$input
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionStockFilter.php
@@ -128,10 +128,12 @@ final class CollectionStockFilter extends AbstractBlock {
 
 		return sprintf(
 			'<div %1$s>
-				<div class="wc-block-stock-filter__controls">%2$s</div>
+				%2$s
+				<div class="wc-block-stock-filter__controls">%3$s</div>
 				<div class="wc-block-stock-filter__actions"></div>
 			</div>',
 			$wrapper_attributes,
+			$content,
 			$this->get_stock_filter_html( $stock_status_counts, $attributes ),
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We needed to achieve not displaying filter headings when there is nothing to filter. For example when there are no product ratings it makes no sense to render the "Filter by rating" header on its own since nothing can be filtered.

To do this, this PR adjusts all the new experimental filter blocks to accept only core/heading as an inner block. With this change we can render the inner blocks on PHP side, but if we don't have any data (e.g. no product ratings) we can simply not render the whole block including inner blocks.

This also adjusts the collection filters template that auto inserts all the filter blocks. It now inserts the headings as child blocks.

Closes #42055 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. You can firstly insert the new collection filters block in the editor. You should see that inner heading blocks are inserted. You can test that it saves by updating / saving and then reload the page to ensure the inner heading blocks are retained.

2. Each block has different conditions in which it will not render. Rating can be tested for example, by ensuring you have no product reviews. (In my test site I just manually delete them all). Once this is done, view the frontend page corresponding to your collection filters and see that nothing is rendered for the rating filter.

3. for Price Filter it should pretty much always render unless something has gone wrong. (I might not have considered edge cases here, please enlighten me if I have missed some).

4. for Stock Status filter TBD

5. for active filters, nothing should render unless at least one filter is active on the page. e.g. with no query params on the page the heading should not render. If you choose a single filter like price range, the heading should render along with the active filter.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Hide block headings when there are no filter options for experimental collection filter blocks.

</details>
