### PR TITLE
[Product Block Editor]: render empty state for the Upsells section

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-render-empty-state-for-upsells-section
+++ b/packages/js/product-editor/changelog/update-product-editor-render-empty-state-for-upsells-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: add Upsell advice

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -34,3 +34,4 @@ export { init as initNoticeHasVariations } from './product-fields/notice-has-var
 export { init as initTaxonomy } from './generic/taxonomy';
 export { init as initText } from './generic/text';
 export { init as initNumber } from './generic/number';
+export { init as initUpsells } from './product-fields/upsells';

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/block.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-upsells",
+	"title": "Product Upsells",
+	"category": "woocommerce",
+	"description": "Show a list of products that are related or can be used as an upsell to the current product.",
+	"keywords": [ "products", "linked" ],
+	"textdomain": "default",
+	"attributes": {
+		"__contentEditable": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": true
+	}
+}

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+
+/**
+ * Internal dependencies
+ */
+import type { UpsellsBlockEditComponent } from './types';
+
+export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
+	const blockProps = useWooBlockProps( attributes );
+
+	return <div { ...blockProps }></div>;
+}

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -15,16 +15,22 @@ import type { UpsellsBlockEditComponent } from './types';
 export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
 	const blockProps = useWooBlockProps( attributes );
 
-	return (
-		<div { ...blockProps }>
-			<AdviceCard
-				tip={ __(
-					'Tip: Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.',
-					'woocommerce'
-				) }
-				image={ <ShoppingBags /> }
-				isDismissible={ true }
-			/>
-		</div>
-	);
+	const isEmpty = true; // @todo: implement.
+
+	if ( isEmpty ) {
+		return (
+			<div { ...blockProps }>
+				<AdviceCard
+					tip={ __(
+						'Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.',
+						'woocommerce'
+					) }
+					image={ <ShoppingBags /> }
+					isDismissible={ true }
+				/>
+			</div>
+		);
+	}
+
+	return <div { ...blockProps } />;
 }

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -3,14 +3,28 @@
  */
 import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { AdviceCard } from '../../../components/advice-card';
+import { ShoppingBags } from '../../../images/shopping-bugs';
 import type { UpsellsBlockEditComponent } from './types';
 
 export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
 	const blockProps = useWooBlockProps( attributes );
 
-	return <div { ...blockProps }></div>;
+	return (
+		<div { ...blockProps }>
+			<AdviceCard
+				tip={ __(
+					'Tip: Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.',
+					'woocommerce'
+				) }
+				image={ <ShoppingBags /> }
+				isDismissible={ true }
+			/>
+		</div>
+	);
 }

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { UpsellsBlockEdit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
+
+const { name, ...metadata } = blockConfiguration;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: UpsellsBlockEdit,
+};
+
+export const init = () =>
+	registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/types.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import {
+	// @ts-expect-error no exported member.
+	ComponentType,
+} from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import {
+	ProductEditorBlockAttributes,
+	ProductEditorBlockEditProps,
+} from '../../../types';
+
+export type UpsellsBlockEditProps =
+	ProductEditorBlockEditProps< ProductEditorBlockAttributes >;
+
+export type UpsellsBlockEditComponent = ComponentType< UpsellsBlockEditProps >;

--- a/plugins/woocommerce/changelog/update-product-editor-render-empty-state-for-upsells-section
+++ b/plugins/woocommerce/changelog/update-product-editor-render-empty-state-for-upsells-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: add Upsell advice

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -1119,7 +1119,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			return;
 		}
 
-		$linked_products_group->add_section(
+		$linked_product_upsells_section = $linked_products_group->add_section(
 			array(
 				'id'         => 'product-linked-upsells-section',
 				'order'      => 10,
@@ -1131,6 +1131,17 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'<br /><a href="https://woo.com/document/related-products-up-sells-and-cross-sells/" target="_blank" rel="noreferrer">',
 						'</a>'
 					),
+				),
+			)
+		);
+
+		$linked_product_upsells_section->add_block(
+			array(
+				'id'         => 'product-linked-upsells',
+				'blockName'  => 'woocommerce/product-upsells',
+				'order'      => 10,
+				'attributes' => array(
+					'property' => 'upsell_ids',
 				),
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR renders the empty state for the Upsells section of the Linked Product tab. For this, it introduces the `woocommerce/product-upsells` block.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

~Depends on https://github.com/woocommerce/woocommerce/pull/43082, https://github.com/woocommerce/woocommerce/pull/43115~

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Product Editor app
2. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

3. Edit/create a product by using the new Product Editor app
4. Click on the `Linked products` section (tab)
5. Confirm you see the empty state in the Upsells section: it's an advice card with an image and tip text:

<img width="911" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/495aacc6-4028-41de-bd3b-8facc481523b">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
