### PR TITLE
[Product Block Editor]: fix feature flag to hide the Linked products

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-fix-proper-flag-for-linked-product
+++ b/plugins/woocommerce/changelog/update-product-editor-fix-proper-flag-for-linked-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+[Product Block Editor]" use proper flag to handle the Linked Product feature visibility

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -1110,7 +1110,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 	 * Adds the linked products group blocks to the template.
 	 */
 	private function add_linked_products_group_blocks() {
-		if ( ! Features::is_enabled( 'product-virtual-downloadable' ) ) {
+		if ( ! Features::is_enabled( 'product-linked' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue that hides/shows the Linked product tab in the Product editor


Closes issue reported here https://github.com/woocommerce/woocommerce/pull/43013#discussion_r1436474746

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use the WCA plugin to set the feature flags
2. Ensure the flag associated with the Linked product is disabled
  - Enable the WCA plugin
  - Click on Tools -> WCA Test Helper
  - Click on Features tab
  - Toggle `off` the product-linked feature
3. Go to Product editor
4. Confirm the Linked product tab is not visible 
<img width="913" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/d8176729-49f8-403a-b0a9-578fe6e7ce11">
5. Enable Linked Product flag
6. Confirm the Linked Product tab is visible
 
<img width="912" alt="Screenshot 2023-12-26 at 12 09 56" src="https://github.com/woocommerce/woocommerce/assets/77539/ac691fbb-011c-4faf-80bd-41e6d5141f03">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
