### PR TITLE
Product template association

### DIFF
--- a/packages/js/product-editor/changelog/add-41586-product-template-association
+++ b/packages/js/product-editor/changelog/add-41586-product-template-association
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Load/save the product template from/to the product meta data

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -117,12 +117,19 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 
 				await validate( productTemplate.productData );
 
-				await editEntityRecord(
-					'postType',
-					'product',
-					productId,
-					productTemplate.productData
-				);
+				const productMetaData =
+					productTemplate.productData.meta_data ?? [];
+
+				await editEntityRecord( 'postType', 'product', productId, {
+					...productTemplate.productData,
+					meta_data: [
+						...productMetaData,
+						{
+							key: '_product_template_id',
+							value: productTemplate.id,
+						},
+					],
+				} );
 
 				await saveEditedEntityRecord< Product >(
 					'postType',

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
 import { PluginArea } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
+import { Product } from '@woocommerce/data';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
@@ -32,7 +33,6 @@ import {
 	useEntityBlockEditor,
 	useEntityProp,
 } from '@wordpress/core-data';
-import { Product } from '@woocommerce/data';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41586

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products` -> `Add new` from the left side menu.
3. Set the `Name` of the product.
4. Under the `General` tab a description `This is a standard product. Change product type` should be shown below the `Basic details` section.
5. When clicking the `Change product type` a dropdown menu should be shown listing all the available product types. 
<img width="686" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c112df55-7b60-4883-bcfb-731505c16714">

6. From the list, when selecting a different type the product changes must be saved and the editor layout should change according to the selected type.
7. The selected product template id should be sent and stored as part of the product meta data. 
<img width="857" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/f996811a-60ca-474b-a90a-6e7b005f5905">

8. Editing the product should load the stored product template id as part of the meta data. 
<img width="862" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/66cc31ee-2386-409b-ad54-6eef6ebb26aa">

9. Note that filling all the required fields is mandatory before changing the product type.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
