### PR TITLE
Fix async version bump bug

### DIFF
--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -129,7 +129,7 @@ export const versionBumpCommand = new Command( 'version-bump' )
 			Logger.notice(
 				`Bumping versions in ${ owner }/${ name } on ${ workingBranch } branch`
 			);
-			bumpFiles( tmpRepoPath, version );
+			await bumpFiles( tmpRepoPath, version );
 
 			if ( dryRun ) {
 				const diff = await git.diffSummary();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds an await to the version bump function call, so that we wait for it to complete before creating the commit.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout `trunk`.
2. Edit `tools/monorepo-utils/src/code-freeze/commands/version-bump/bump.ts` to add the following, on the line after `await updatePluginFile...` to simulate the bump taking a longer amount of time: `await ( ms => new Promise( ( resolve ) => setTimeout( resolve, ms ) ) )( 2500 );`
3. Build the monorepo tooling: `pnpm --filter=./tools/monorepo-utils build`
4. Create a fork of this repo if you do not have one already. In your fork, create a new branch (`release/9.9.9`) based off of trunk.
5. Run `GITHUB_TOKEN=... pnpm utils code-freeze version-bump -o jonathansadowski -b release/9.9.9 9.9.9`. Add your own `GITHUB_TOKEN`, and replace `jonathansadowski` with the owner of your fork.
6. A PR should be created demonstrating the bug (only one file is updated). Close that PR without merging and delete the branch.
7. Checkout this branch. Your changes from step 2 should be retained after checking out this branch, but if not, reapply them.
8. Build the monorepo tooling: `pnpm --filter=./tools/monorepo-utils build`
9. Repeat step 5. Verify the PR updates all 5 files, and not just the first (`composer.json`, `package.json`, `readme.txt`, `class-woocommerce.php`, and `woocommerce.php`)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
