### PR TITLE
Add hook to exclude certain properties from HPOS sync/verification

### DIFF
--- a/plugins/woocommerce/changelog/fix-41907
+++ b/plugins/woocommerce/changelog/fix-41907
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add hook 'woocommerce_hpos_sync_ignored_order_props' to allow keys to be ignored during HPOS sync/verification.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -583,11 +583,7 @@ class CLIRunner {
 	 * @return array Failed IDs with meta details.
 	 */
 	private function verify_meta_data( array $order_ids, array $failed_ids ) : array {
-		$meta_keys_to_ignore = array(
-			'_paid_date', // This has been deprecated and replaced by '_date_paid' in the CPT datastore.
-			'_completed_date', // This has been deprecated and replaced by '_date_completed' in the CPT datastore.
-			'_edit_lock',
-		);
+		$meta_keys_to_ignore = $this->synchronizer->get_ignored_order_props();
 
 		global $wpdb;
 		if ( ! count( $order_ids ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -5,7 +5,6 @@
 
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
-use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Caches\OrderCacheController;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\BatchProcessing\{ BatchProcessingController, BatchProcessorInterface };
@@ -333,6 +332,24 @@ class DataSynchronizer implements BatchProcessorInterface {
 		);
 
 		return $interval;
+	}
+
+	/**
+	 * Keys that can be ignored during synchronization or verification.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @return string[]
+	 */
+	public function get_ignored_order_props() {
+		return apply_filters(
+			'woocommerce_hpos_sync_ignored_order_props',
+			array(
+				'_paid_date', // This has been deprecated and replaced by '_date_paid' in the CPT datastore.
+				'_completed_date', // This has been deprecated and replaced by '_date_completed' in the CPT datastore.
+				'_edit_lock',
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
 use Automattic\WooCommerce\Caches\OrderCacheController;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
+use Automattic\WooCommerce\Internal\Admin\Orders\EditLock;
 use Automattic\WooCommerce\Internal\BatchProcessing\{ BatchProcessingController, BatchProcessorInterface };
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
@@ -348,12 +349,15 @@ class DataSynchronizer implements BatchProcessorInterface {
 		 * @param string[] List of order properties or meta keys.
 		 * @since 8.6.0
 		 */
-		return apply_filters(
-			'woocommerce_hpos_sync_ignored_order_props',
+		$ignored_props = apply_filters( 'woocommerce_hpos_sync_ignored_order_props', array() );
+		$ignored_props = array_filter( array_map( 'trim', array_filter( $ignored_props, 'is_string' ) ) );
+
+		return array_merge(
+			$ignored_props,
 			array(
 				'_paid_date', // This has been deprecated and replaced by '_date_paid' in the CPT datastore.
 				'_completed_date', // This has been deprecated and replaced by '_date_completed' in the CPT datastore.
-				'_edit_lock',
+				EditLock::META_KEY_NAME,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -337,11 +337,17 @@ class DataSynchronizer implements BatchProcessorInterface {
 	/**
 	 * Keys that can be ignored during synchronization or verification.
 	 *
-	 * @since 7.8.0
+	 * @since 8.6.0
 	 *
 	 * @return string[]
 	 */
 	public function get_ignored_order_props() {
+		/**
+		 * Allows modifying the list of order properties that are ignored during HPOS synchronization or verification.
+		 *
+		 * @param string[] List of order properties or meta keys.
+		 * @since 8.6.0
+		 */
 		return apply_filters(
 			'woocommerce_hpos_sync_ignored_order_props',
 			array(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -98,6 +98,15 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	);
 
 	/**
+	 * Meta keys that are considered ephemereal and do not trigger a full save (updating modified date) when changed.
+	 *
+	 * @var string[]
+	 */
+	protected $ephemeral_meta_keys = array(
+		EditLock::META_KEY_NAME,
+	);
+
+	/**
 	 * Handles custom metadata in the wc_orders_meta table.
 	 *
 	 * @var OrdersTableDataStoreMeta
@@ -2964,9 +2973,7 @@ CREATE TABLE $meta_table (
 	private function should_save_after_meta_change( $order, $meta = null ) {
 		$current_time      = $this->legacy_proxy->call_function( 'current_time', 'mysql', 1 );
 		$current_date_time = new \WC_DateTime( $current_time, new \DateTimeZone( 'GMT' ) );
-		$skip_for          = array(
-			EditLock::META_KEY_NAME,
-		);
-		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) && ( ! is_object( $meta ) || ! in_array( $meta->key, $skip_for, true ) );
+
+		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) && ( ! is_object( $meta ) || ! in_array( $meta->key, $this->ephemeral_meta_keys, true ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3239,4 +3239,25 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertContains( 'user@woo.test', $coupon->get_used_by( 'edit' ) );
 	}
 
+	/**
+	 * Tests that changes to certain keys don't trigger full order updates.
+	 */
+	public function test_ephemeral_meta_updates() {
+		$this->toggle_cot_authoritative( true );
+
+		// Set order in the past so that we can accurately compare dates.
+		$order = WC_Helper_Order::create_order();
+		$order->set_date_modified( time() - DAY_IN_SECONDS );
+		$order->save();
+
+		$date_modified = $order->get_date_modified();
+		$order->update_meta_data( '_edit_lock', 'whatever' );
+		$order->save_meta_data();
+		$this->assertEquals( $date_modified, $order->get_date_modified() );
+
+		$order->update_meta_data( 'other_meta', 'whatever' );
+		$order->save_meta_data();
+		$this->assertNotEquals( $date_modified, $order->get_date_modified() );
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Certain order properties (or metadata) are not relevant for HPOS verification. For example, `_edit_lock` which is an ephemeral key. So far we've been hardcoding these keys in various places. This PR aims to tidy things a bit by providing a new API to access these keys.

It also introduces hook `woocommerce_hpos_sync_ignored_order_props` which would allow 3rd party code to add new keys to be ignored by sync/verification code.

I used this opportunity to fix fix a similar situation in the HPOS datastore, where we were hardcoding `_edit_lock` as one of the bits of metadata that shouldn't trigger a full order save (thus changing the order modified date), and moved it to an array inside the class instead.

Closes #41907.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Given this is mostly a small refactor, I believe making sure that tests are passing is enough.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
