### PR TITLE
[Product Block Editor]: Be able to dismiss AdviceCard instances

### DIFF
--- a/packages/js/data/changelog/update-product-editor-dismiss-linked-product-empty-advices
+++ b/packages/js/data/changelog/update-product-editor-dismiss-linked-product-empty-advices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: dismiss AdviceCard by clicking close button

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -30,7 +30,9 @@ export type UserPreferences = {
 	variations_report_columns?: string;
 	local_attributes_notice_dismissed_ids?: number[];
 	variable_items_without_price_notice_dismissed?: Record< number, string >;
-	product_upsells_advice_dismissed?: 'yes' | 'no';
+	product_advice_card_dismissed?: {
+		[ key: string ]: number;
+	};
 };
 
 export type WoocommerceMeta = UserPreferences & {

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -30,6 +30,7 @@ export type UserPreferences = {
 	variations_report_columns?: string;
 	local_attributes_notice_dismissed_ids?: number[];
 	variable_items_without_price_notice_dismissed?: Record< number, string >;
+	product_upsells_advice_dismissed?: 'yes' | 'no';
 };
 
 export type WoocommerceMeta = UserPreferences & {

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -39,6 +39,7 @@ export type WoocommerceMeta = UserPreferences & {
 	task_list_tracked_started_tasks?: string;
 	variable_items_without_price_notice_dismissed?: string;
 	local_attributes_notice_dismissed_ids?: string;
+	product_advice_card_dismissed?: string;
 };
 
 export type WCUser<

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -31,7 +31,7 @@ export type UserPreferences = {
 	local_attributes_notice_dismissed_ids?: number[];
 	variable_items_without_price_notice_dismissed?: Record< number, string >;
 	product_advice_card_dismissed?: {
-		[ key: string ]: number;
+		[ key: string ]: 'yes' | 'no';
 	};
 };
 

--- a/packages/js/product-editor/changelog/update-product-editor-dismiss-linked-product-empty-advices
+++ b/packages/js/product-editor/changelog/update-product-editor-dismiss-linked-product-empty-advices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: dismiss AdviceCard by clicking close button

--- a/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
@@ -28,7 +28,6 @@ export function CrossSellsBlockEdit( {
 						'woocommerce'
 					) }
 					image={ <CashRegister /> }
-					isDismissible={ true }
 				/>
 			</div>
 		);

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -1,11 +1,6 @@
 /**
  * External dependencies
  */
-import { useUserPreferences } from '@woocommerce/data';
-
-/**
- * External dependencies
- */
 import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { __ } from '@wordpress/i18n';
@@ -19,15 +14,11 @@ import type { UpsellsBlockEditComponent } from './types';
 
 export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
 	const blockProps = useWooBlockProps( attributes );
+	console.log( '(001) blockProps: ', blockProps );
 
 	const isEmpty = true; // @todo: implement.
 
-	const {
-		updateUserPreferences,
-		product_upsells_advice_dismissed: upsellsAdviceDismissed,
-	} = useUserPreferences();
-
-	if ( isEmpty && upsellsAdviceDismissed !== 'yes' ) {
+	if ( isEmpty ) {
 		return (
 			<div { ...blockProps }>
 				<AdviceCard
@@ -36,12 +27,6 @@ export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
 						'woocommerce'
 					) }
 					image={ <ShoppingBags /> }
-					isDismissible={ true }
-					onDismiss={ () => {
-						updateUserPreferences( {
-							product_upsells_advice_dismissed: 'yes',
-						} );
-					} }
 				/>
 			</div>
 		);

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -1,6 +1,11 @@
 /**
  * External dependencies
  */
+import { useUserPreferences } from '@woocommerce/data';
+
+/**
+ * External dependencies
+ */
 import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { __ } from '@wordpress/i18n';
@@ -17,7 +22,12 @@ export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
 
 	const isEmpty = true; // @todo: implement.
 
-	if ( isEmpty ) {
+	const {
+		updateUserPreferences,
+		product_upsells_advice_dismissed: upsellsAdviceDismissed,
+	} = useUserPreferences();
+
+	if ( isEmpty && upsellsAdviceDismissed !== 'yes' ) {
 		return (
 			<div { ...blockProps }>
 				<AdviceCard
@@ -27,6 +37,11 @@ export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
 					) }
 					image={ <ShoppingBags /> }
 					isDismissible={ true }
+					onDismiss={ () => {
+						updateUserPreferences( {
+							product_upsells_advice_dismissed: 'yes',
+						} );
+					} }
 				/>
 			</div>
 		);

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -14,7 +14,6 @@ import type { UpsellsBlockEditComponent } from './types';
 
 export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {
 	const blockProps = useWooBlockProps( attributes );
-	console.log( '(001) blockProps: ', blockProps );
 
 	const isEmpty = true; // @todo: implement.
 

--- a/packages/js/product-editor/src/components/advice-card/index.tsx
+++ b/packages/js/product-editor/src/components/advice-card/index.tsx
@@ -11,6 +11,8 @@ import {
 	CardHeader,
 } from '@wordpress/components';
 import { close } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
+import { useUserPreferences } from '@woocommerce/data';
 
 export interface AdviceCardProps {
 	tip?: string;
@@ -22,9 +24,37 @@ export interface AdviceCardProps {
 export const AdviceCard: React.FC< AdviceCardProps > = ( {
 	tip,
 	image = null,
-	isDismissible = false,
-	onDismiss = () => {},
+	isDismissible = true,
+	onDismiss,
 } ) => {
+	// Generate a unique ID for the advice card.
+	const adviceCardId = useInstanceId(
+		AdviceCard,
+		'advice-card-instance'
+	) as string;
+
+	const { updateUserPreferences, product_advice_card_dismissed } =
+		useUserPreferences();
+
+	if ( ! onDismiss ) {
+		onDismiss = () => {
+			updateUserPreferences( {
+				product_advice_card_dismissed: {
+					...product_advice_card_dismissed,
+					[ adviceCardId ]: 'yes',
+				},
+			} );
+		};
+	}
+
+	// Check if the advice card has been dismissed.
+	if (
+		product_advice_card_dismissed &&
+		product_advice_card_dismissed?.[ adviceCardId ] === 'yes'
+	) {
+		return null;
+	}
+
 	return (
 		<Card className="woocommerce-advice-card">
 			{ isDismissible && (

--- a/plugins/woocommerce/changelog/update-product-editor-dismiss-linked-product-empty-advices
+++ b/plugins/woocommerce/changelog/update-product-editor-dismiss-linked-product-empty-advices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: dismiss AdviceCard by clicking close button

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -185,6 +185,7 @@ class Init {
 				'variable_product_block_tour_shown',
 				'local_attributes_notice_dismissed_ids',
 				'variable_items_without_price_notice_dismissed',
+				'product_upsells_advice_dismissed',
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -185,7 +185,7 @@ class Init {
 				'variable_product_block_tour_shown',
 				'local_attributes_notice_dismissed_ids',
 				'variable_items_without_price_notice_dismissed',
-				'product_upsells_advice_dismissed',
+				'product_advice_card_dismissed',
 			)
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request lets users dismiss the AdviceCard intances by clicking the close button.
The state keeps persistent since it's stored in the user preferences.

~Depends on https://github.com/woocommerce/woocommerce/pull/43116~
Closes https://github.com/woocommerce/woocommerce/issues/42915

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Product Editor app
2. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

3. Edit/create a product by using the new Product Editor app
4. Go to the Linked Product tab
5. Confirm you see the Advice in the Upsells and Cross-sells sections
6. Confirm you can close it by clicking on the close button

<img width="720" alt="Screenshot 2024-01-03 at 18 09 00" src="https://github.com/woocommerce/woocommerce/assets/77539/26474712-3a1c-430d-9081-80c46b4555aa">

7.  Confirm the AdviceCard instances keep closing after a hard-refresh

Additionally...

8. Activate the Beta Tester plugin
9. Show the developer tools

<img width="448" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/1bc756ac-bccd-4feb-8bb2-9e5c1781da46">

10. Click on the `User Preferences` tab
11. Confirm you see the `product_advice_card_dismissed` prop
12. Open the dev console
13. Clean the `product_advice_card_dismissed` by running the following code:

```js
__wcbt.updateUserPreferences( 'product_advice_card_dismissed', {} );
```

14. Confirm you see the advice cards again

<img width="1727" alt="Screenshot 2024-01-03 at 18 24 07" src="https://github.com/woocommerce/woocommerce/assets/77539/6161b192-8cf9-4203-9b2d-7f34631321de">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>