### PR TITLE
[Woo beta tester]:  add User Preference panel

### DIFF
--- a/packages/js/data/changelog/update-woocommerce-beta-tester-add-user-preferences-tool
+++ b/packages/js/data/changelog/update-woocommerce-beta-tester-add-user-preferences-tool
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+[Data]: expose UserPreference TS prop

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -109,6 +109,7 @@ export {
 export { TaxClass } from './tax-classes/types';
 export { ProductTag, Query } from './product-tags/types';
 export { WCUser } from './user/types';
+export { UserPreferences } from './user/types';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-beta-tester/changelog/update-woocommerce-beta-tester-add-user-preferences-tool
+++ b/plugins/woocommerce-beta-tester/changelog/update-woocommerce-beta-tester-add-user-preferences-tool
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Woo Beta Tester]: add User Preference dev tool panel

--- a/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/index.scss
+++ b/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/index.scss
@@ -83,6 +83,7 @@
 	font-family: var(--woocommerce-product-editor-dev-tools-code-font-family);
 }
 
+.woocommerce-product-editor-dev-tools-user-preferences,
 .woocommerce-product-editor-dev-tools-product {
 	display: flex;
 	flex-direction: row;
@@ -90,6 +91,7 @@
 	height: 100%;
 }
 
+.woocommerce-product-editor-dev-tools-user-preferences-entity,
 .woocommerce-product-editor-dev-tools-product-entity {
 	flex: 1;
 

--- a/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/product-editor-dev-tools-bar.tsx
+++ b/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/product-editor-dev-tools-bar.tsx
@@ -24,6 +24,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { BlockInspectorTabPanel } from './block-inspector-tab-panel';
 import { HelpTabPanel } from './help-tab-panel';
 import { ProductTabPanel } from './product-tab-panel';
+import { UserPreferencesTabPanel } from './user-preferences-panel';
 
 function TabButton( {
 	name,
@@ -111,6 +112,15 @@ export function ProductEditorDevToolsBar( {
 							>
 								{ __( 'Product', 'woocommerce' ) }
 							</TabButton>
+
+							<TabButton
+								name="user-preferences"
+								selectedTab={ selectedTab }
+								onClick={ handleTabClick }
+							>
+								{ __( 'User Preferences', 'woocommerce' ) }
+							</TabButton>
+
 							<TabButton
 								name="help"
 								selectedTab={ selectedTab }
@@ -136,6 +146,9 @@ export function ProductEditorDevToolsBar( {
 					<ProductTabPanel
 						evaluationContext={ evaluationContext }
 						isSelected={ selectedTab === 'product' }
+					/>
+					<UserPreferencesTabPanel
+						isSelected={ selectedTab === 'user-preferences' }
 					/>
 					<HelpTabPanel isSelected={ selectedTab === 'help' } />
 				</div>

--- a/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/user-preferences-panel.tsx
+++ b/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/user-preferences-panel.tsx
@@ -25,22 +25,31 @@ export function UserPreferencesTabPanel( {
 	const { updateUserPreferences, ...userPreferences } = useUserPreferences();
 
 	const update = useCallback(
-		( preferences: UserPreferences | UserPreferenceProp, value? ) => {
+		(
+			preferences: UserPreferences | UserPreferenceProp,
+			value?,
+			force = false
+		) => {
 			const dataToUpdate =
 				typeof preferences === 'string'
 					? { [ preferences ]: value }
 					: preferences;
 
 			/*
-			 * Only update the preferences already defined.
+			 * When force is not True,
+			 * only update the preferences already defined
 			 * @todo: consider to implement straight in the data layer.
 			 */
-			Object.keys( dataToUpdate ).forEach( ( key: string ) => {
-				const userPreferenceKey = key as UserPreferenceProp;
-				if ( ! userPreferences.hasOwnProperty( userPreferenceKey ) ) {
-					delete dataToUpdate[ userPreferenceKey ];
-				}
-			} );
+			if ( ! force ) {
+				Object.keys( dataToUpdate ).forEach( ( key: string ) => {
+					const userPreferenceKey = key as UserPreferenceProp;
+					if (
+						! userPreferences.hasOwnProperty( userPreferenceKey )
+					) {
+						delete dataToUpdate[ userPreferenceKey ];
+					}
+				} );
+			}
 
 			updateUserPreferences( dataToUpdate );
 		},

--- a/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/user-preferences-panel.tsx
+++ b/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/user-preferences-panel.tsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { useUserPreferences, UserPreferences } from '@woocommerce/data';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { TabPanel } from './tab-panel';
+
+declare global {
+	interface Window {
+		__wca: object;
+	}
+}
+
+type UserPreferenceProp = keyof UserPreferences;
+
+export function UserPreferencesTabPanel( {
+	isSelected,
+}: {
+	isSelected: boolean;
+} ) {
+	const { updateUserPreferences, ...userPreferences } = useUserPreferences();
+
+	const update = useCallback(
+		( preferences: UserPreferences | UserPreferenceProp, value? ) => {
+			const dataToUpdate =
+				typeof preferences === 'string'
+					? { [ preferences ]: value }
+					: preferences;
+
+			/*
+			 * Only update the preferences already defined.
+			 * @todo: consider to implement straight in the data layer.
+			 */
+			Object.keys( dataToUpdate ).forEach( ( key: string ) => {
+				const userPreferenceKey = key as UserPreferenceProp;
+				if ( ! userPreferences.hasOwnProperty( userPreferenceKey ) ) {
+					delete dataToUpdate[ userPreferenceKey ];
+				}
+			} );
+
+			updateUserPreferences( dataToUpdate );
+		},
+		[ updateUserPreferences, userPreferences ]
+	);
+
+	// Expose updateUserPreferences globaly for debugging purposes.
+	window.__wca = {
+		...window.__wca,
+		updateUserPreferences: update,
+		userPreferences,
+	};
+
+	return (
+		<TabPanel isSelected={ isSelected }>
+			<div className="woocommerce-product-editor-dev-tools-user-preferences">
+				<div className="woocommerce-product-editor-dev-tools-user-preferences-entity">
+					{ JSON.stringify( userPreferences, null, 4 ) }
+				</div>
+			</div>
+		</TabPanel>
+	);
+}

--- a/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/user-preferences-panel.tsx
+++ b/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/user-preferences-panel.tsx
@@ -11,7 +11,7 @@ import { TabPanel } from './tab-panel';
 
 declare global {
 	interface Window {
-		__wca: object;
+		__wcbt: object;
 	}
 }
 
@@ -57,8 +57,8 @@ export function UserPreferencesTabPanel( {
 	);
 
 	// Expose updateUserPreferences globaly for debugging purposes.
-	window.__wca = {
-		...window.__wca,
+	window.__wcbt = {
+		...window.__wcbt,
 		updateUserPreferences: update,
 		userPreferences,
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the Developer tool's new `User Preferences` tab.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate the Woocommerce Beta Tester
2. Go to the Block editor 
3. Open the developer tool by clicking on three dots -> `Show developer tools`

<img width="356" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/bff2d3e3-04a4-478b-b5e1-8e98955e7c01">

4. Confirm you see the `User Preferences` tab
5. Click on it
6. Confirm you see the User Preferences there
<img width="818" alt="Screenshot 2023-12-26 at 15 49 10" src="https://github.com/woocommerce/woocommerce/assets/77539/440ea0d3-8a61-4c49-8294-5af2ff044926">
7. Open the client dev console
8. Confirm there is a global `__wcbt` constant defined only when the dev tool panel is opened
<img width="548" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/64841c77-5c3d-4432-ae49-1b648cff0b70">
9. Confirm you can edit the preference key by using the `updateUserPreferences` function:

https://github.com/woocommerce/woocommerce/assets/77539/2d31510e-fe70-4197-a589-51ec89a6522b

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
