### PR TITLE
[Product Block Editor]: update the conditions to hide the Cross-sells section

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-handle-upsells-and-cross-sections-visibility
+++ b/plugins/woocommerce/changelog/update-product-editor-handle-upsells-and-cross-sections-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+[Product Block Editor]: update the conditions to hide the Cross-sells section

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -161,11 +161,6 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'attributes'     => array(
 						'title' => __( 'Linked products', 'woocommerce' ),
 					),
-					'hideConditions' => Features::is_enabled( 'product-linked' ) ? array(
-						array(
-							'expression' => 'editedProduct.type === "grouped"',
-						),
-					) : null,
 				)
 			);
 		}
@@ -1146,6 +1141,11 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						__( 'By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. %1$sLearn more about linked products.%2$s', 'woocommerce' ),
 						'<br /><a href="https://woo.com/document/related-products-up-sells-and-cross-sells/" target="_blank" rel="noreferrer">',
 						'</a>'
+					),
+				),
+				'hideConditions' => array(
+					array(
+						'expression' => 'editedProduct.type === "external" || editedProduct.type === "grouped"',
 					),
 				),
 			)

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -156,9 +156,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		if ( Features::is_enabled( 'product-linked' ) ) {
 			$this->add_group(
 				array(
-					'id'             => $this::GROUP_IDS['LINKED_PRODUCTS'],
-					'order'          => 60,
-					'attributes'     => array(
+					'id'         => $this::GROUP_IDS['LINKED_PRODUCTS'],
+					'order'      => 60,
+					'attributes' => array(
 						'title' => __( 'Linked products', 'woocommerce' ),
 					),
 				)
@@ -1132,9 +1132,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 
 		$linked_products_group->add_section(
 			array(
-				'id'         => 'product-linked-cross-sells-section',
-				'order'      => 20,
-				'attributes' => array(
+				'id'             => 'product-linked-cross-sells-section',
+				'order'          => 20,
+				'attributes'     => array(
 					'title'       => __( 'Cross-sells', 'woocommerce' ),
 					'description' => sprintf(
 						/* translators: %1$s: Learn more about linked products. %2$s: Learn more about linked products.*/


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Addressing the requirement defined in https://github.com/woocommerce/woocommerce/issues/42915:

> When the product is a Grouped Product or an External/Affiliate Product, the Cross-sell section should be hidden. Only the Upsell section should appear.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce/issues/42915

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new Product Editor
2. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

3. Go to the Create Product assistant page: `http://<host>/wp-admin/admin.php?page=wc-admin&task=products`
4. Create a `Physical product`, `Grouped product` and `External product` products.

<img width="681" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/cd7e7313-7fcc-460a-8ce5-0084fa2f2a04">

5. Go to the Product Editor page
6. Click on the `Linked products` section (tab)
7. Confirm that the `Grouped product` and `External product` product pages don't show the `Cross-sells` section:

<img width="885" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/791cdd84-f683-4799-b983-b9204f86bc74">

8. Confirm the `Physical product` product shows both sections:

<img width="954" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/f171bad5-de27-4b66-ac6a-6ab2b7df467e">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
