### PR TITLE
[Product Block Editor]: render empty state for the Cross-sells section

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-render-empty-state-for-cross-section
+++ b/packages/js/product-editor/changelog/update-product-editor-render-empty-state-for-cross-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: render empty state for the Cross-sells section

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -35,3 +35,4 @@ export { init as initTaxonomy } from './generic/taxonomy';
 export { init as initText } from './generic/text';
 export { init as initNumber } from './generic/number';
 export { init as initUpsells } from './product-fields/upsells';
+export { init as initCrossSells } from './product-fields/cross-sells';

--- a/packages/js/product-editor/src/blocks/product-fields/cross-sells/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/cross-sells/block.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-cross-sells",
+	"title": "Product Cross-sells",
+	"category": "woocommerce",
+	"description": "Linked product - Cross-sells setion",
+	"keywords": [ "products", "linked" ],
+	"textdomain": "default",
+	"attributes": {
+		"__contentEditable": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": true
+	}
+}

--- a/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { AdviceCard } from '../../../components/advice-card';
+import type { CrossSellsBlockEditComponent } from './types';
+import { CashRegister } from '../../../images/cash-register';
+
+export function CrossSellsBlockEdit( {
+	attributes,
+}: CrossSellsBlockEditComponent ) {
+	const blockProps = useWooBlockProps( attributes );
+
+	const isEmpty = true; // @todo: implement.
+
+	if ( isEmpty ) {
+		return (
+			<div { ...blockProps }>
+				<AdviceCard
+					tip={ __(
+						'Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.',
+						'woocommerce'
+					) }
+					image={ <CashRegister /> }
+					isDismissible={ true }
+				/>
+			</div>
+		);
+	}
+
+	return <div { ...blockProps } />;
+}

--- a/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
@@ -17,6 +17,8 @@ export function CrossSellsBlockEdit( {
 }: CrossSellsBlockEditComponent ) {
 	const blockProps = useWooBlockProps( attributes );
 
+	console.log( { CrossSellsBlockEdit } );
+
 	const isEmpty = true; // @todo: implement.
 
 	if ( isEmpty ) {

--- a/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/cross-sells/edit.tsx
@@ -17,8 +17,6 @@ export function CrossSellsBlockEdit( {
 }: CrossSellsBlockEditComponent ) {
 	const blockProps = useWooBlockProps( attributes );
 
-	console.log( { CrossSellsBlockEdit } );
-
 	const isEmpty = true; // @todo: implement.
 
 	if ( isEmpty ) {

--- a/packages/js/product-editor/src/blocks/product-fields/cross-sells/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/cross-sells/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { CrossSellsBlockEdit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
+
+const { name, ...metadata } = blockConfiguration;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: CrossSellsBlockEdit,
+};
+
+export const init = () =>
+	registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );

--- a/packages/js/product-editor/src/blocks/product-fields/cross-sells/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/cross-sells/types.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import {
+	// @ts-expect-error no exported member.
+	ComponentType,
+} from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import type {
+	ProductEditorBlockAttributes,
+	ProductEditorBlockEditProps,
+} from '../../../types';
+
+export type CrossSellsBlockEditProps =
+	ProductEditorBlockEditProps< ProductEditorBlockAttributes >;
+
+export type CrossSellsBlockEditComponent =
+	ComponentType< CrossSellsBlockEditProps >;

--- a/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/upsells/edit.tsx
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { AdviceCard } from '../../../components/advice-card';
-import { ShoppingBags } from '../../../images/shopping-bugs';
+import { ShoppingBags } from '../../../images/shopping-bags';
 import type { UpsellsBlockEditComponent } from './types';
 
 export function UpsellsBlockEdit( { attributes }: UpsellsBlockEditComponent ) {

--- a/plugins/woocommerce/changelog/update-product-editor-render-empty-state-for-cross-section
+++ b/plugins/woocommerce/changelog/update-product-editor-render-empty-state-for-cross-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: render empty state for the Cross-sells section

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -1141,7 +1141,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			)
 		);
 
-		$linked_products_group->add_section(
+		$linked_product_cross_sells_section = $linked_products_group->add_section(
 			array(
 				'id'             => 'product-linked-cross-sells-section',
 				'order'          => 20,
@@ -1158,6 +1158,17 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					array(
 						'expression' => 'editedProduct.type === "external" || editedProduct.type === "grouped"',
 					),
+				),
+			)
+		);
+
+		$linked_product_cross_sells_section->add_block(
+			array(
+				'id'         => 'product-linked-cross-sells',
+				'blockName'  => 'woocommerce/product-cross-sells',
+				'order'      => 10,
+				'attributes' => array(
+					'property' => 'upsell_ids',
 				),
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR added the Advice card to the Cross-sells section of the Linked product tab.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce/issues/42915
Depends on https://github.com/woocommerce/woocommerce/pull/43127
Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Product Editor app
2. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

3. Edit/create a product by using the new Product Editor app
4. Click on the `Linked products` section (tab)
5. Confirm you see the empty state in the Cross-sell section: it's an advice card with an image and tip text:

<img width="1002" alt="Screenshot 2023-12-27 at 19 55 25" src="https://github.com/woocommerce/woocommerce/assets/77539/0ce730ae-0444-42c2-a8c0-908bdd67f1c7">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
