### PR TITLE
Add tooltip attribute to Pricing field

### DIFF
--- a/packages/js/product-editor/changelog/add-42825_tooltip_attribute_to_pricing_field
+++ b/packages/js/product-editor/changelog/add-42825_tooltip_attribute_to_pricing_field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tooltip attribute to Pricing field #43144

--- a/packages/js/product-editor/src/blocks/generic/pricing/README.md
+++ b/packages/js/product-editor/src/blocks/generic/pricing/README.md
@@ -27,6 +27,13 @@ Label that appears on top of the price field.
 
 Help text that appears below the price field.
 
+### tooltip
+
+-   **Type:** `String`
+-   **Required:** `No`
+
+Tooltip text that is shown when hovering the icon at the side of the label.
+
 ## Usage
 
 Here's the code that adds the field from the screenshot after the Summary field:
@@ -45,6 +52,7 @@ if ( ! function_exists( 'add_pricing_field' ) ) {
           'label'    => __( 'Example price field', 'woocommerce'),
           'property' => 'custom_price',
           'help'     => 'This is a help text',
+          'tooltip'  => 'This is a tooltip',
         ],
       ]
     );

--- a/packages/js/product-editor/src/blocks/generic/pricing/block.json
+++ b/packages/js/product-editor/src/blocks/generic/pricing/block.json
@@ -17,6 +17,9 @@
 		},
 		"help": {
 			"type": "string"
+		},
+		"tooltip": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/pricing/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/pricing/edit.tsx
@@ -6,11 +6,7 @@ import { Link } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useInstanceId } from '@wordpress/compose';
-import {
-	createElement,
-	createInterpolateElement,
-	Fragment,
-} from '@wordpress/element';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,

--- a/packages/js/product-editor/src/blocks/generic/pricing/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/pricing/edit.tsx
@@ -6,7 +6,11 @@ import { Link } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useInstanceId } from '@wordpress/compose';
-import { createElement, createInterpolateElement } from '@wordpress/element';
+import {
+	createElement,
+	createInterpolateElement,
+	Fragment,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
@@ -21,13 +25,14 @@ import { useCurrencyInputProps } from '../../../hooks/use-currency-input-props';
 import { PricingBlockAttributes } from './types';
 import { ProductEditorBlockEditProps } from '../../../types';
 import useProductEntityProp from '../../../hooks/use-product-entity-prop';
+import { Label } from '../../../components/label/label';
 
 export function Edit( {
 	attributes,
 	context: { postType },
 }: ProductEditorBlockEditProps< PricingBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { property, label, help, disabled } = attributes;
+	const { property, label, help, disabled, tooltip } = attributes;
 	const [ price, setPrice ] = useProductEntityProp< string >( property, {
 		postType,
 		fallbackValue: '',
@@ -54,6 +59,7 @@ export function Edit( {
 		BaseControl,
 		'wp-block-woocommerce-product-pricing-field'
 	) as string;
+	const labelToShow = label || __( 'Price', 'woocommerce' );
 
 	return (
 		<div { ...blockProps }>
@@ -63,7 +69,13 @@ export function Edit( {
 					disabled={ disabled }
 					id={ priceId }
 					name={ property }
-					label={ label || __( 'Price', 'woocommerce' ) }
+					label={
+						tooltip ? (
+							<Label label={ labelToShow } tooltip={ tooltip } />
+						) : (
+							labelToShow
+						)
+					}
 				/>
 			</BaseControl>
 		</div>

--- a/packages/js/product-editor/src/blocks/generic/pricing/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/pricing/edit.tsx
@@ -28,7 +28,13 @@ export function Edit( {
 	context: { postType },
 }: ProductEditorBlockEditProps< PricingBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { property, label, help, disabled, tooltip } = attributes;
+	const {
+		property,
+		label = __( 'Price', 'woocommerce' ),
+		help,
+		disabled,
+		tooltip,
+	} = attributes;
 	const [ price, setPrice ] = useProductEntityProp< string >( property, {
 		postType,
 		fallbackValue: '',
@@ -55,7 +61,6 @@ export function Edit( {
 		BaseControl,
 		'wp-block-woocommerce-product-pricing-field'
 	) as string;
-	const labelToShow = label || __( 'Price', 'woocommerce' );
 
 	return (
 		<div { ...blockProps }>
@@ -67,9 +72,9 @@ export function Edit( {
 					name={ property }
 					label={
 						tooltip ? (
-							<Label label={ labelToShow } tooltip={ tooltip } />
+							<Label label={ label } tooltip={ tooltip } />
 						) : (
-							labelToShow
+							label
 						)
 					}
 				/>

--- a/packages/js/product-editor/src/blocks/generic/pricing/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/pricing/types.ts
@@ -7,4 +7,5 @@ export interface PricingBlockAttributes extends BlockAttributes {
 	property: string;
 	label: string;
 	help?: string;
+	tooltip?: string;
 }

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
@@ -18,6 +18,9 @@
 		"isRequired": {
 			"type": "boolean",
 			"default": false
+		},
+		"tooltip": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
@@ -28,6 +28,7 @@ import { useValidation } from '../../../contexts/validation-context';
 import { useCurrencyInputProps } from '../../../hooks/use-currency-input-props';
 import { SalePriceBlockAttributes } from './types';
 import { ProductEditorBlockEditProps } from '../../../types';
+import { Label } from '../../../components/label/label';
 
 export function Edit( {
 	attributes,
@@ -35,7 +36,7 @@ export function Edit( {
 	context,
 }: ProductEditorBlockEditProps< SalePriceBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { label, help, isRequired } = attributes;
+	const { label, help, isRequired, tooltip } = attributes;
 	const [ regularPrice, setRegularPrice ] = useEntityProp< string >(
 		'postType',
 		context.postType || 'product',
@@ -125,7 +126,13 @@ export function Edit( {
 					id={ regularPriceId }
 					name={ 'regular_price' }
 					ref={ regularPriceRef }
-					label={ label }
+					label={
+						tooltip ? (
+							<Label label={ label } tooltip={ tooltip } />
+						) : (
+							label
+						)
+					}
 					onBlur={ validateRegularPrice }
 				/>
 			</BaseControl>

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
@@ -14,6 +14,9 @@
 		},
 		"help": {
 			"type": "string"
+		},
+		"tooltip": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
@@ -21,6 +21,7 @@ import { useValidation } from '../../../contexts/validation-context';
 import { useCurrencyInputProps } from '../../../hooks/use-currency-input-props';
 import { SalePriceBlockAttributes } from './types';
 import { ProductEditorBlockEditProps } from '../../../types';
+import { Label } from '../../../components/label/label';
 
 export function Edit( {
 	attributes,
@@ -28,7 +29,7 @@ export function Edit( {
 	context,
 }: ProductEditorBlockEditProps< SalePriceBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { label, help } = attributes;
+	const { label, help, tooltip } = attributes;
 	const [ regularPrice ] = useEntityProp< string >(
 		'postType',
 		context.postType || 'product',
@@ -94,7 +95,13 @@ export function Edit( {
 					id={ salePriceId }
 					name={ 'sale_price' }
 					ref={ salePriceRef }
-					label={ label }
+					label={
+						tooltip ? (
+							<Label label={ label } tooltip={ tooltip } />
+						) : (
+							label
+						)
+					}
 					onBlur={ validateSalePrice }
 				/>
 			</BaseControl>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a tooltip attribute to the generic `Pricing` field, the `Regular price`, and the `Sale price`. The original issue only referred to the generic `Pricing` field, but I think adding the tooltip to the specific `Product editor` prices would be good as well.

Closes #42825.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following plugin:
```
<?php
/*
 * Plugin Name:       My Plugin
*/

function YOUR_PREFIX_add_block( $product_name_block ) {
  $parent = $product_name_block->get_parent();

  $parent->add_block(
    [
      'id'         => 'example-pricing-field',
      'blockName'  => 'woocommerce/product-pricing-field',
      'order'      => 10,
      'attributes' => [
        'label'    => __( 'Example price field', 'woocommerce'),
        'property' => 'custom_price',
        'help'     => 'This is a help text',
        'tooltip'  => __( 'My tooltip' ),
      ],
    ]
  );
}

add_action( 'woocommerce_block_template_area_product-form_after_add_block_product-name', 'YOUR_PREFIX_add_block' );
```
2. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
3. Go to Products > Add
4. Check the newly added field on the `Basic details` section
5. Verify the tooltip with the text `My tooltip` is visible
6. Now checkout the branch `add/42825_tooltip_attribute_to_pricing_field_test`
7. Verify the List prices and Sale prices are correct under `General` and `Pricing` tabs

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
