### PR TITLE
Logging: QoL improvements to the single file view

### DIFF
--- a/plugins/woocommerce/changelog/update-log-file-view-tweaks
+++ b/plugins/woocommerce/changelog/update-log-file-view-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Allow a log file line that has been highlighted to be un-highlighted

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1391,7 +1391,6 @@ table.wc_status_table--tools {
 	.line {
 		display: block;
 		width: 100%;
-		scroll-margin-top: 6em;
 		position: relative;
 
 		&:before {
@@ -1407,6 +1406,7 @@ table.wc_status_table--tools {
 		&:target {
 			box-shadow: 0 0.16em 0.16em -0.16em #c3c4c7, 0 -0.16em 0.16em -0.16em #c3c4c7;
 			z-index: 1;
+			scroll-margin-top: 50vh;
 
 			.line-content {
 				background: #fff8c5;
@@ -4370,7 +4370,7 @@ table.wc_shipping {
 	.wc-backbone-modal-back-inactive {
 		display: none;
 	}
-	
+
 	#btn-next.is-busy {
 		background-image: linear-gradient(-45deg, #fafafa 33%, #e0e0e0 33%, #e0e0e0 70%, #fafafa 70%);
 		animation-duration: 2.5s;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -294,6 +294,17 @@ class PageController {
 				?>
 			<?php endwhile; ?>
 		</section>
+		<script>
+			// Clear the line number hash and highlight with a click.
+			document.documentElement.addEventListener( 'click', ( event ) => {
+				if ( window.location.hash && ! event.target.classList.contains( 'line-anchor' ) ) {
+					let scrollPos = document.documentElement.scrollTop;
+					window.location.hash = '';
+					document.documentElement.scrollTop = scrollPos;
+					history.replaceState( null, '', window.location.pathname + window.location.search );
+				}
+			} );
+		</script>
 		<?php
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This makes two simple changes to the single log file view, both related to the GitHub-like feature of highlighting and linking to a particular line in the file:

* When selecting a line to highlight, or linking to a particular line from elsewhere, position that line in the middle of the viewport so you can see the context of other lines on either side of it.
* While a line is highlighted, clear that highlight, and remove the associated hash from the URL, by clicking anywhere else in the viewport.

### How to test the changes in this Pull Request:

1. After checking out this branch, update the stylesheet by running `pnpm --filter=@woocommerce/plugin-woocommerce build`.
1. Ensure that log storage is set to use the file system. If #42979 hasn't been merged yet, you can do this by setting a constant in your wp-config.php file: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`
2. To ensure that you have some lengthy log files available, install [this file](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966/6a6e6c131b0d89d3f5558493f5e1ceab274a2e5a) as an mu-plugin in your test site.
3. Go to WooCommerce > Status > Tools and find the Debug Log Generator tool. Click the Generate button 3 or 4 times to generate a good number of log entries.
4. Now go to WooCommerce > Status > Logs. Click on the log file with the greatest file size to view it.
5. Scroll down through the file contents a ways, and click on one of the line numbers. The line should vertically center in the viewport, and be highlighted in yellow. In the URL, a hash should be added that contains the line number.
6. Now click somewhere else on the page. The highlight should disappear, and the hash should be removed from the URL. The page should _not_ change its scroll position, though.
7. Now return to the log file list table view. Search for something that will turn up some results using the "Search within files" input. On the results screen, click the link on one of the results to view it in context of its containing file. This should take you back to the single file view, with the relevant file line highlighted and vertically centered in the viewport (assuming there are enough lines in the file to do that).
