### PR TITLE
Switch request method of reset install endpoint to POST

### DIFF
--- a/plugins/woocommerce/changelog/43150-update-switch-reset-install-to-post
+++ b/plugins/woocommerce/changelog/43150-update-switch-reset-install-to-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improve availability of rest installation endpoint by changing the request method.

--- a/plugins/woocommerce/changelog/43150-update-switch-reset-install-to-post
+++ b/plugins/woocommerce/changelog/43150-update-switch-reset-install-to-post
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Improve availability of rest installation endpoint by changing the request method.
+Improve availability of the reset installation process endpoint by changing request method.

--- a/plugins/woocommerce/changelog/43150-update-switch-reset-install-to-post
+++ b/plugins/woocommerce/changelog/43150-update-switch-reset-install-to-post
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Improve availability of the reset installation process endpoint by changing request method.
+Improve availability of rest installation endpoint by changing the request method.

--- a/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/abstract-wc-rest-wccom-site-controller.php
+++ b/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/abstract-wc-rest-wccom-site-controller.php
@@ -25,7 +25,7 @@ abstract class WC_REST_WCCOM_Site_Controller extends WC_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wccom-site/v2';
+	protected $namespace = 'wccom-site/v3';
 
 	/**
 	 * Check whether user has permission to access controller's endpoints.

--- a/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -57,8 +57,15 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_WCCOM_Site_Control
 						),
 					),
 				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/reset',
+			array(
 				array(
-					'methods'             => WP_REST_Server::DELETABLE,
+					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'reset_install' ),
 					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Some hosts do not support DELETE request method and return an error on request to reset installation endpoint (`DELETE /wp-json/wccom-site/v2/installer`). This PR switches the method to POST and path to `/wp-json/wccom-site/v3/installer/reset`.  The namespace of the wccom-site API has been changed to v3.


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

## Preconditions
- Connect the store to your account on WooCommerce.com from **WP admin -> WooCommerce -> Extensions -> My subscriptions. Ensure you perform the connection from behalf of admin user of the store.
- Comment out [lines 102-110](https://github.com/woocommerce/woocommerce/blob/2800be9b7bae98b3d43247948671e63a96edb234/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php#L102-L110) and [114-122](https://github.com/woocommerce/woocommerce/blob/2800be9b7bae98b3d43247948671e63a96edb234/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php#L114-L122) in file `/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php` to bypass validation of authentication credentials and allow testing API endpoints through Curl.


## Confirm the endpoint is available under the new method and path
1. Send an installation request to v3 endpoint  (ensure to replace string `<SITE_DOMAIN>` with your site domain):
```bash
curl --request POST \
  --url 'https://wp.test:4443/wp-json/wccom-site/v3/installer/reset?token=XXX&signature=YYY' \
  --header 'Content-Type: application/json' \
  --data '{
	"product-id": 123,
	"idempotency-key": "ABC"
}'

```
2. Confirm you receive a non-404 response, which proves the endpoint is available. E.g.:
```json
{
	"success": false,
	"error_code": "no_initiated_installation_found",
	"error_message": "No initiated installation for the product found",
	"state": null
}
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Improve availability of rest installation endpoint by changing the request method.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
