### PR TITLE
Show default patterns and products if the images request fails

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -248,13 +248,6 @@ export const updateStorePatterns = async (
 			},
 		} );
 
-		const { is_ai_generated } = await apiFetch< {
-			is_ai_generated: boolean;
-		} >( {
-			path: '/wc/private/ai/store-info',
-			method: 'GET',
-		} );
-
 		if ( ! images.length ) {
 			await resetPatternsAndProducts()();
 			return;

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -255,7 +255,7 @@ export const updateStorePatterns = async (
 			method: 'GET',
 		} );
 
-		if ( ! images.length && ! is_ai_generated ) {
+		if ( ! images.length ) {
 			await resetPatternsAndProducts()();
 			return;
 		}

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -199,6 +199,34 @@ export const queryAiEndpoint = createMachine(
 	}
 );
 
+const resetPatternsAndProducts = () => async () => {
+	await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+		woocommerce_blocks_allow_ai_connection: 'yes',
+	} );
+
+	const response = await apiFetch< {
+		is_ai_generated: boolean;
+	} >( {
+		path: '/wc/private/ai/store-info',
+		method: 'GET',
+	} );
+
+	if ( response.is_ai_generated ) {
+		return;
+	}
+
+	return Promise.all( [
+		apiFetch( {
+			path: '/wc/private/ai/patterns',
+			method: 'DELETE',
+		} ),
+		apiFetch( {
+			path: '/wc/private/ai/products',
+			method: 'DELETE',
+		} ),
+	] );
+};
+
 export const updateStorePatterns = async (
 	context: designWithAiStateMachineContext
 ) => {
@@ -219,6 +247,18 @@ export const updateStorePatterns = async (
 					context.businessInfoDescription.descriptionText,
 			},
 		} );
+
+		const { is_ai_generated } = await apiFetch< {
+			is_ai_generated: boolean;
+		} >( {
+			path: '/wc/private/ai/store-info',
+			method: 'GET',
+		} );
+
+		if ( ! images.length && ! is_ai_generated ) {
+			await resetPatternsAndProducts()();
+			return;
+		}
 
 		const [ response ] = await Promise.all< {
 			ai_content_generated: boolean;
@@ -474,33 +514,6 @@ const saveAiResponseToOption = ( context: designWithAiStateMachineContext ) => {
 	} );
 };
 
-const resetPatternsAndProducts = () => async () => {
-	await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
-		woocommerce_blocks_allow_ai_connection: 'yes',
-	} );
-
-	const response = await apiFetch< {
-		is_ai_generated: boolean;
-	} >( {
-		path: '/wc/private/ai/store-info',
-		method: 'GET',
-	} );
-
-	if ( response.is_ai_generated ) {
-		return;
-	}
-
-	return Promise.all( [
-		apiFetch( {
-			path: '/wc/private/ai/patterns',
-			method: 'DELETE',
-		} ),
-		apiFetch( {
-			path: '/wc/private/ai/products',
-			method: 'DELETE',
-		} ),
-	] );
-};
 
 export const services = {
 	browserPopstateHandler,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -514,7 +514,6 @@ const saveAiResponseToOption = ( context: designWithAiStateMachineContext ) => {
 	} );
 };
 
-
 export const services = {
 	browserPopstateHandler,
 	queryAiEndpoint,

--- a/plugins/woocommerce/changelog/43157-default-content-on-images-failure
+++ b/plugins/woocommerce/changelog/43157-default-content-on-images-failure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Ensure the user is led to the Assembler with the default content whenever the Pexels API is down on the initial store setup.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
@@ -102,7 +102,7 @@ class Images extends AbstractRoute {
 		$images = ( new Pexels() )->get_images( $ai_connection, $token, $business_description );
 
 		if ( is_wp_error( $images ) ) {
-			return $this->error_to_response( $images );
+			$images = [];
 		}
 
 		return rest_ensure_response(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR resets patterns and products to default when the request to the images endpoint (Pexels API) fails, only the first time (when the `is_ai_generated` is false).

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/42994

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
**Initial Setup**
1. Create a new WooCommerce installation with this version.
2. Ensure Jetpack is installed and your site is connected with JP.
3. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
4. Ensure the Woo AI plugin is installed and activated (available on this monorepo).
5. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

**Testing steps**
1. Modify the `request` function on the `plugins/woocommerce/src/Blocks/Images/Pexels.php` class to return an error (to simulate an error from the Pexels API):
```
private function request( string $search_term, int $per_page = 100 ) {
                return new \WP_Error( 'pexels_api_error', __( 'Request to the Pexels API failed.', 'woocommerce' ), $error_msg );
```
2. Head over to WooCommerce -> Home and click on "Start Customizing".
3. Click the Design with AI button.
4. Fill out a business description and proceed.
5. Make sure the store is generated and the patterns and products have the default content.
6. Remove the line of code added in step 1.
7. Repeat the process and make sure this time the result is AI-generated.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure the user is led to the Assembler with the default content whenever the Pexels API is down on the initial store setup.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
