### PR TITLE
Settings: Make minor corrections to the HTML markup of settings fields

### DIFF
--- a/plugins/woocommerce/changelog/remix-41077-settings-html-fixes
+++ b/plugins/woocommerce/changelog/remix-41077-settings-html-fixes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make minor corrections to the HTML markup of settings fields

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -253,6 +253,11 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					$value['value'] = self::get_option( $value['id'], $value['default'] );
 				}
 
+				$row_class_attribute = '';
+				if ( $value['row_class'] ) {
+					$row_class_attribute = " class=\"{$value['row_class']}\"";
+				}
+
 				// Custom attribute handling.
 				$custom_attributes = array();
 
@@ -287,7 +292,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						break;
 
 					case 'info':
-						?><tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						?><tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc"/><td style="<?php echo esc_attr( $value['css'] ); ?>">
 						<?php
 						echo wp_kses_post( wpautop( wptexturize( $value['text'] ) ) );
@@ -320,7 +325,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					case 'tel':
 						$option_value = $value['value'];
 
-						?><tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						?><tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -345,7 +350,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -373,7 +378,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -399,7 +404,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -442,7 +447,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$show_desc_at_end = $value['desc_at_end'] ?? false;
 
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -509,13 +514,18 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							$visibility_class[] = $value['row_class'];
 						}
 
+						$container_class_attribute = '';
+						if ( count( $visibility_class ) > 0 ) {
+							$container_class_attribute = ' class="' . implode( ' ', $visibility_class ) . '"';
+						}
+
 						$must_disable = $value['disabled'] ?? false;
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
 							$has_tooltip             = isset( $value['tooltip'] ) && '' !== $value['tooltip'];
 							$tooltip_container_class = $has_tooltip ? 'with-tooltip' : '';
 							?>
-								<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
+								<tr<?php echo esc_html( $container_class_attribute ); ?>>
 									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
 									<td class="forminp forminp-checkbox <?php echo esc_html( $tooltip_container_class ); ?>">
 										<?php if ( $has_tooltip ) : ?>
@@ -525,7 +535,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							<?php
 						} else {
 							?>
-								<fieldset class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
+								<fieldset<?php echo esc_html( $container_class_attribute ); ?>>
 							<?php
 						}
 
@@ -580,7 +590,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 							<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html . $disabled_message; // WPCS: XSS ok. ?></label>
 						</th>
@@ -614,7 +624,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						?>
-						<tr valign="top" class="single_select_page"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr class="single_select_page <?php echo esc_attr( $value['row_class'] );?>">
 							<th scope="row" class="titledesc">
 								<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -639,7 +649,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							);
 						}
 						?>
-						<tr valign="top" class="single_select_page"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr class="single_select_page <?php echo esc_attr( $value['row_class'] );?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></label>
 							</th>
@@ -679,7 +689,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							$state   = '*';
 						}
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -703,7 +713,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 						asort( $countries );
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -732,7 +742,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						);
 						$option_value = wc_parse_relative_date_option( $value['value'] );
 						?>
-						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -326,7 +326,8 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					case 'tel':
 						$option_value = $value['value'];
 
-						?><tr<?php echo esc_html( $row_class_attribute ); ?>>
+						?>
+						<tr<?php echo esc_html( $row_class_attribute ); ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -625,7 +626,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						?>
-						<tr class="single_select_page <?php echo esc_attr( $value['row_class'] );?>">
+						<tr class="single_select_page <?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -650,7 +651,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							);
 						}
 						?>
-						<tr class="single_select_page <?php echo esc_attr( $value['row_class'] );?>">
+						<tr class="single_select_page <?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></label>
 							</th>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -293,7 +293,8 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 					case 'info':
 						?><tr<?php echo esc_html( $row_class_attribute ); ?>>
-							<th scope="row" class="titledesc"/><td style="<?php echo esc_attr( $value['css'] ); ?>">
+							<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
+							<td style="<?php echo esc_attr( $value['css'] ); ?>">
 						<?php
 						echo wp_kses_post( wpautop( wptexturize( $value['text'] ) ) );
 						echo '</td></tr>';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a remix of #41077, which languished for too long, had merge conflicts, and needed a changelog. I have added @sagehenstudio as a co-author. **Please make sure the co-author tag is retained when squash-merging this!**

This makes some small adjustments to the HTML markup of settings controls to ensure valid markup:

* Removes the deprecated `valign` attribute from table row elements
* Removes the errant `"` from the end of some table row elements
* Centralizes the logic for determining if a table row element should have a class attribute

I also added one small enhancement to the `info` setting type, to allow it to use a `title` property, like every other setting type.

### How to test the changes in this Pull Request:

1. With this branch checked out, go through the tabs at WooCommerce > Settings and make sure all of the settings UI looks normal, and nothing looks broken.
2. To test the title attribute on the info setting, you can add this code snippet:
    ```php
	add_filter(
		'woocommerce_general_settings',
		function( $settings ) {
			$test_settings = array(
				array(
					'title' => __( 'Test settings', 'woocommerce' ),
					'type'  => 'title',
					'desc'  => __( 'This is for testing a PR.', 'woocommerce' ),
					'id'    => 'test_1',
				),
				array(
					'id' => 'test_setting_1',
					'title' => 'Info setting',
					'text' => 'Here is some info! Very important info.',
					'type' => 'info',
				),
				array(
					'type' => 'sectionend',
					'id'   => 'test_1',
				),
			);
	
			return array_merge( $test_settings, $settings );
		}
	);
    ```
    With this snippet added, go to the General tab of WC Settings. You should see a "Test settings" section at the top. The "Info setting" title should look just like the other setting titles on the page, and the info content should be indented the same amount as other setting inputs.