### PR TITLE
Fix error when adding to cart from the Product Collection block if Google Analytics plugin was enabled

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -152,7 +152,7 @@ const { state } = store< Store >( 'woocommerce/product-button', {
 				// https://github.com/woocommerce/woocommerce/pull/42946
 				yield doAction(
 					`experimental__woocommerce_blocks-cart-add-item`,
-					product
+					{ product }
 				);
 
 				// After the cart is updated, sync the temporary number of items again.

--- a/plugins/woocommerce/changelog/43172-fix-add-to-cart-google-analytics-error
+++ b/plugins/woocommerce/changelog/43172-fix-add-to-cart-google-analytics-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Product Button: update the signature of the `experimental__woocommerce_blocks-cart-add-item` event so it doesn't cause issue with existing extensions.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This modifies how the `experimental__woocommerce_blocks-cart-add-item` event is fired in the Product Collection and Products block is triggered, as it was causing an issue with Google Analytics Integration.

That event was introduced in https://github.com/woocommerce/woocommerce/pull/42946.

Note: I'm making the changelog entry a _Comment_ instead of a _Message_, as #42946 already mentions the changes that affect users.

### How to test the changes in this Pull Request:

1. Create a post or page.
2. Add the _Products (Beta)_ and _Product Collection_ blocks.
3. Save and go to the frontend.
4. Open console in your browser (<kbd>F12</kbd> → _Console_).
5. In the console add:

```
wp.hooks.addAction(
  'experimental__woocommerce_blocks-cart-add-item',
  'my-namespace',
  ( { product } ) => { console.log( 'Item added to cart: ' + product.name ); }
)
```

6. Add a product to your cart using _Products (Beta)_ and _Product Collection_ blocks.
7. **Expected:** In both cases you should get `Item added to cart: <<PRODUCT NAME>>` in the console.
8. Now, install the [WooCommerce Google Analytics Integration](https://wordpress.org/plugins/woocommerce-google-analytics-integration/) plugin.
9. Enable it and go to its settings `/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics`.
10. In _Google Analytics Tracking ID_, set a fake code (ie: `GT-12345`).
11. Install Google Analytics Debugger ([Chrome](https://chromewebstore.google.com/detail/jnkmfdileelhofjcijamephohjechhna), [Firefox](https://addons.mozilla.org/ca/firefox/addon/ga-debugger/)) to your browser.
12. Go back to the frontend and add a product to your cart using both blocks.
13. **Expected:** Verify in the browser console you see the add to cart event being fired. It looks like this:

```
Processing GTAG command: ["event", "add_to_cart", {event_category: "ecommerce", event_label: "Add to Cart", items: [{id: "woo-belt", name: "Belt", quantity: 1, category: "", price: "55"}]}]
```

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Product Button: update the signature of the `experimental__woocommerce_blocks-cart-add-item` event so it doesn't cause issue with existing extensions.

</details>
