### PR TITLE
Fix error when adding to cart from the Product Collection block if Google Analytics plugin is enabled (II)

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -7,7 +7,6 @@ import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { Cart } from '@woocommerce/type-defs/cart';
 import { createRoot } from '@wordpress/element';
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
-import { doAction } from '@wordpress/hooks';
 
 interface Context {
 	isLoading: boolean;
@@ -136,7 +135,6 @@ const { state } = store< Store >( 'woocommerce/product-button', {
 		*addToCart() {
 			const context = getContext();
 			const { productId, quantityToAdd } = context;
-			const product = getProductById( state.cart, productId );
 
 			context.isLoading = true;
 
@@ -144,15 +142,6 @@ const { state } = store< Store >( 'woocommerce/product-button', {
 				yield dispatch( storeKey ).addItemToCart(
 					productId,
 					quantityToAdd
-				);
-
-				// Adding a manual trigger of the event for backward compatibility
-				// and symmetry ("remove" event is triggered properly from Cart and Mini Cart).
-				// The events will be revisited and unified in scope of:
-				// https://github.com/woocommerce/woocommerce/pull/42946
-				yield doAction(
-					`experimental__woocommerce_blocks-cart-add-item`,
-					product
 				);
 
 				// After the cart is updated, sync the temporary number of items again.

--- a/plugins/woocommerce/changelog/43177-fix-add-to-cart-google-analytics-error-ii
+++ b/plugins/woocommerce/changelog/43177-fix-add-to-cart-google-analytics-error-ii
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Product Button: remove the `experimental__woocommerce_blocks-cart-add-item` event to avoid conflicts with extensions.
+


### PR DESCRIPTION
This reverts commit 4fec136da1e08b3fbbbf0e9d01cf7fab71be5c46.

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/42946 introduced the `experimental__woocommerce_blocks-cart-add-item` event to the Add to Cart button of the Products and Product Collection blocks. However, it was causing issues with other extensions.

In https://github.com/woocommerce/woocommerce/pull/43172 I tried an alternative solution, but that was giving problems if the product added to the cart was not already in the cart.

Based on that, we decided to revert #42946 for now and work on an alternative solution in the future.

### How to test the changes in this Pull Request:

1. Install the [WooCommerce Google Analytics Integration](https://wordpress.org/plugins/woocommerce-google-analytics-integration/) plugin.
2. Enable it and go to its settings `/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics`.
3. In _Google Analytics Tracking ID_, set a fake code (ie: `GT-12345`).
4. Now create a post or page and add the _Products (Beta)_ and _Product Collection_ blocks.
5. Save and go to the frontend.
6. Add a product to your cart using _Products (Beta)_ and _Product Collection_ blocks.
7. Try adding to cart products which are already in the cart and products which are not yet in the cart.
8. **Expected:** In all cases the product should be added to the cart successfully and there should be no errors (check also the browser console <kbd>F12</kbd> > Console to verify there are no errors there either.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Product Button: remove the `experimental__woocommerce_blocks-cart-add-item` event to avoid conflicts with extensions.

</details>
