### PR TITLE
Revert "Show feedback bar only once (#41787)"

### DIFF
--- a/packages/js/product-editor/changelog/fix-revert_showing_feedback_bar_once
+++ b/packages/js/product-editor/changelog/fix-revert_showing_feedback_bar_once
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Revert "Show feedback bar only once (#41787)" #43178

--- a/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
+++ b/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
@@ -12,7 +12,6 @@ import {
 	createElement,
 	createInterpolateElement,
 	Fragment,
-	useState,
 } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { Pill } from '@woocommerce/components';
@@ -31,10 +30,9 @@ export type FeedbackBarProps = {
 };
 
 export function FeedbackBar( { productType }: FeedbackBarProps ) {
-	const { shouldShowFeedbackBar } = useFeedbackBar();
+	const { hideFeedbackBar, shouldShowFeedbackBar } = useFeedbackBar();
 	const { showCesModal, showProductMVPFeedbackModal } =
 		useCustomerEffortScoreModal();
-	const [ isFeedbackBarHidden, setIsFeedbackBarHidden ] = useState( false );
 
 	const getProductTracksProps = () => {
 		const tracksProps = {
@@ -177,7 +175,6 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 				type: 'snackbar',
 			}
 		);
-		setIsFeedbackBarHidden( true );
 	};
 
 	const onTurnOffEditorClick = () => {
@@ -185,7 +182,7 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 			...getProductTracksProps(),
 		} );
 
-		setIsFeedbackBarHidden( true );
+		hideFeedbackBar();
 
 		showProductMVPFeedbackModal();
 	};
@@ -195,12 +192,12 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 			...getProductTracksProps(),
 		} );
 
-		setIsFeedbackBarHidden( true );
+		hideFeedbackBar();
 	};
 
 	return (
 		<>
-			{ shouldShowFeedbackBar && ! isFeedbackBarHidden && (
+			{ shouldShowFeedbackBar && (
 				<div className="woocommerce-product-mvp-ces-footer">
 					<Pill>Beta</Pill>
 					<div className="woocommerce-product-mvp-ces-footer__message">

--- a/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
+++ b/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { resolveSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useState, useCallback } from '@wordpress/element';
+import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
@@ -12,8 +11,26 @@ import { PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME } from '../../constants';
 
 export const useFeedbackBar = () => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
-	const [ shouldShowFeedbackBar, setShouldShowFeedbackBar ] =
-		useState( false );
+
+	const { shouldShowFeedbackBar } = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
+
+		const showFeedbackBarOption = getOption(
+			PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME
+		) as string;
+
+		const resolving = ! hasFinishedResolution( 'getOption', [
+			PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME,
+		] );
+
+		return {
+			shouldShowFeedbackBar:
+				! resolving &&
+				window.wcTracks?.isEnabled &&
+				showFeedbackBarOption === 'yes',
+		};
+	}, [] );
 
 	const showFeedbackBar = () => {
 		updateOptions( {
@@ -41,32 +58,15 @@ export const useFeedbackBar = () => {
 		}
 	};
 
-	const showFeedbackBarOnce = () => {
+	const hideFeedbackBar = () => {
 		updateOptions( {
 			[ PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME ]: 'no',
 		} );
-		setShouldShowFeedbackBar( true );
 	};
-
-	const fetchShowFeedbackBarOption = useCallback( () => {
-		return resolveSelect( OPTIONS_STORE_NAME )
-			.getOption< string >( PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME )
-			.then( ( showFeedbackBarOption ) => {
-				if (
-					window.wcTracks?.isEnabled &&
-					showFeedbackBarOption === 'yes'
-				) {
-					showFeedbackBarOnce();
-				}
-			} );
-	}, [] );
-
-	useEffect( () => {
-		fetchShowFeedbackBarOption();
-	}, [] );
 
 	return {
 		shouldShowFeedbackBar,
 		maybeShowFeedbackBar,
+		hideFeedbackBar,
 	};
 };


### PR DESCRIPTION
This reverts commit defa590f3225bc2f88c134da8058e21ca182ff7a.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR reverts the changes added in PR #41787. The feedback bar should always be visible after the user creates or updates a product with the new experience, as it's an easy way to allow them to share feedback or switch to the classic experience quickly.

![Screenshot 2023-12-29 at 14 15 26](https://github.com/woocommerce/woocommerce/assets/1314156/aadb3ebf-7537-4318-aed4-f3e4def5db5e)

More context here: p1703661230362809-slack-C01CMSA1VHS 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**.
2. Under **WooCommerce > Settings > Advanced > Woo.com** verify that the `Enable tracking` option is `enabled`.  
3. Go to **Products > Add New**.
4. Add a product name and press `Save draft`.
5. Verify that the feedback bar is visible (it could take a couple of seconds to appear).
6. Refresh the page and verify that the feedback bar is still visible.

![Screen Capture on 2023-11-29 at 15-43-16](https://github.com/woocommerce/woocommerce/assets/1314156/4939a3af-fcea-4f42-a738-f0fdf0811423)

8. Go to **Tools > WCA Test Helper** and modify the option `woocommerce_product_editor_show_feedback_bar` as `yes`.
9. Now go to **Products > Add New**, the feedback bar should be visible again.
10. Verify that the buttons `turn it off` and the `x` hide the feedback bar.
11. We won't hide the feedback bar after sharing feedback in case the user wants to share more feedback later. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>