### PR TITLE
[E2E Tests] Product Gallery > Thumbnails block: Refactor code to remove unnecessary wait for timeout

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
@@ -65,10 +65,6 @@ test.describe( `${ blockData.name }`, () => {
 
 		await expect( thumbnailsBlock ).toBeVisible();
 
-		// We should refactor this.
-		// eslint-disable-next-line playwright/no-wait-for-timeout
-		await page.waitForTimeout( 500 );
-
 		// Test the default (left) position of thumbnails by cross-checking:
 		// - The Gallery block has the classes "is-layout-flex" and "is-nowrap".
 		// - The Thumbnails block has a lower index than the Large Image block.

--- a/plugins/woocommerce/changelog/test-42060-refactor-product-gallery-thumbnails-e2e-test
+++ b/plugins/woocommerce/changelog/test-42060-refactor-product-gallery-thumbnails-e2e-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Refactor E2E test for the Product Gallery Thumbnails block to remove unnecessary waitForTimeout statement
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42060  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure Playwright tests pass, and they include tests from `tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Refactor E2E tests to remove unecessary waitForTimeout statement
</details>
