### PR TITLE
Set WOOCOMMERCE_BLOCKS_PHASE to experimental when generating PR live branch

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -36,6 +36,8 @@ jobs:
               id: prepare
               env:
                   CURRENT_VERSION: ${{ steps.version.outputs.version }}
+                  # Build with experimental blocks.
+                  WOOCOMMERCE_BLOCKS_PHASE: 3
               run: |
 
                   # Current version must compare greather than any previously used current version for this PR.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I missed in a previous PR that I was only setting `WOOCOMMERCE_BLOCKS_PHASE` to experimental for the action that built live branches on trunk.

There is also a question here of if the live branch on trunk should have the flag set. For now I think it's fine, after all this branch still essentially just for testing. But if someone has an issue with trunk live branch having experimental features in future it would be simple to revisit. TLDR; the risk is low. 
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Using the TM script create a JN live branch from this PR
2. See that experimental blocks are available for use on that live branch.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Set blocks to experimental when building live branches for PRs.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
