### PR TITLE
[Experimental] Use CheckboxList component in interactivity attribute filter

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/style.scss
@@ -1,7 +1,3 @@
-//  Import styles we need to render the checkbox list and checkbox control.
-@import "../../../../../../packages/components/checkbox-list/style";
-@import "../../../../../../packages/components/checkbox-control/style";
-
 .wp-block-woocommerce-collection-attribute-filter {
 	.style-dropdown {
 		position: relative;

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/style.scss
@@ -77,8 +77,7 @@
 		}
 	}
 
-	.wc-blocks-components-form-token-field-wrapper
-		.components-form-token-field__input-container {
+	.wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
 		@include reset-color();
 		@include reset-typography();
 		border: 0;
@@ -119,8 +118,7 @@
 	}
 }
 
-.wc-blocks-components-form-token-field-wrapper:not(.single-selection)
-	.components-form-token-field__input-container {
+.wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
 	padding: $gap-smallest 30px $gap-smallest $gap-smaller;
 
 	.components-form-token-field__token-text {
@@ -128,8 +126,7 @@
 		border: 1px solid;
 		border-right: 0;
 		border-radius: 25px 0 0 25px;
-		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest)
-			em($gap-small);
+		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest) em($gap-small);
 		line-height: 22px;
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/inner-blocks/stock-filter/style.scss
@@ -1,10 +1,5 @@
 @import "../../../shared/styles/style";
 
-//  Import styles we need to render the checkbox list and checkbox control.
-@import "../../../../../../packages/components/checkbox-list/style";
-@import "../../../../../../packages/components/checkbox-control/style";
-
-
 .wp-block-woocommerce-stock-filter {
 	h1,
 	h2,
@@ -82,7 +77,8 @@
 		}
 	}
 
-	.wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
+	.wc-blocks-components-form-token-field-wrapper
+		.components-form-token-field__input-container {
 		@include reset-color();
 		@include reset-typography();
 		border: 0;
@@ -123,15 +119,17 @@
 	}
 }
 
-.wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
-	padding: $gap-smallest 30px $gap-smallest  $gap-smaller;
+.wc-blocks-components-form-token-field-wrapper:not(.single-selection)
+	.components-form-token-field__input-container {
+	padding: $gap-smallest 30px $gap-smallest $gap-smaller;
 
 	.components-form-token-field__token-text {
 		background-color: $white;
 		border: 1px solid;
 		border-right: 0;
 		border-radius: 25px 0 0 25px;
-		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest) em($gap-small);
+		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest)
+			em($gap-small);
 		line-height: 22px;
 	}
 

--- a/plugins/woocommerce/changelog/43217-dev-use-checkbox-list-attribute-filter
+++ b/plugins/woocommerce/changelog/43217-dev-use-checkbox-list-attribute-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+[Experimental] Use CheckboxList component in interactivity attribute filter

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
@@ -2,7 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\InteractivityComponents\Dropdown;
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Blocks\InteractivityComponents\CheckboxList;
 
 /**
  * CollectionAttributeFilter class.
@@ -179,7 +179,7 @@ final class CollectionAttributeFilter extends AbstractBlock {
 			$attribute_terms
 		);
 
-		$filter_content = 'dropdown' === $attributes['displayStyle'] ? $this->render_attribute_dropdown( $attribute_options, $attributes ) : $this->render_attribute_list( $attribute_options, $attributes );
+		$filter_content = 'dropdown' === $attributes['displayStyle'] ? $this->render_attribute_dropdown( $attribute_options, $attributes ) : $this->render_attribute_checkbox_list( $attribute_options, $attributes );
 
 		$context = array(
 			'attributeSlug' => str_replace( 'pa_', '', $product_attribute->slug ),
@@ -237,69 +237,34 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	}
 
 	/**
-	 * Render the list.
+	 * Render the attribute filter checkbox list.
 	 *
-	 * @param array $options    Data to render the list.
-	 * @param bool  $attributes Block attributes.
+	 * @param mixed $options Attribute filter options to render in the checkbox list.
+	 * @param mixed $show_counts Whether to show counts for each option.
+	 * @return string
 	 */
-	private function render_attribute_list( $options, $attributes ) {
+	private function render_attribute_checkbox_list( $options, $show_counts ) {
 		if ( empty( $options ) ) {
 			return '';
 		}
 
-		$output = '<ul class="wc-block-checkbox-list wc-block-components-checkbox-list wc-block-stock-filter-list">';
-		foreach ( $options as $option ) {
-			$output .= $this->render_list_item_template( $option, $attributes['showCounts'] );
-		}
-		$output .= '</ul>';
-		return $output;
-	}
+		$list_options = array_map(
+			function( $option ) use ( $show_counts ) {
+				return array(
+					'id'      => $option['slug'] . '-' . $option['term_id'],
+					'checked' => $option['selected'],
+					'label'   => $show_counts ? sprintf( '%1$s (%2$d)', $option['name'], $option['count'] ) : $option['name'],
+					'value'   => $option['slug'],
+				);
+			},
+			$options
+		);
 
-	/**
-	 * Render the list item.
-	 *
-	 * @param array $option      Data to render the list item.
-	 * @param bool  $show_counts Whether to display the count.
-	 */
-	private function render_list_item_template( $option, $show_counts ) {
-		$count_html = $show_counts ?
-			sprintf(
-				'<span class="wc-filter-element-label-list-count">
-				<span aria-hidden="true">%1$s</span>
-				<span class="screen-reader-text">%2$s</span>
-				</span>',
-				$option['count'],
-				// translators: %d is the number of products.
-				sprintf( _n( '%d product', '%d products', $option['count'], 'woocommerce' ), $option['count'] )
-			) :
-			'';
-
-		$template = '<li>
-			<div class="wc-block-components-checkbox wc-block-checkbox-list__checkbox">
-				<label for="%1$s">
-					<input
-						id="%1$s"
-						class="wc-block-components-checkbox__input"
-						type="checkbox"
-						aria-invalid="false"
-						data-wc-on--change="actions.updateProducts"
-						data-wc-context=\'{ "attributeTermSlug": "%5$s" }\'
-						value="%5$s"
-						%4$s
-					/>
-					<svg class="wc-block-components-checkbox__mark" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 20"><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"></path></svg>
-					<span class="wc-block-components-checkbox__label">%2$s %3$s</span>
-				</label>
-			</div>
-		</li>';
-
-		return sprintf(
-			$template,
-			esc_attr( $option['slug'] ) . '-' . $option['term_id'],
-			esc_html( $option['name'] ),
-			$count_html,
-			checked( $option['selected'], true, false ),
-			esc_attr( $option['slug'] )
+		return CheckboxList::render(
+			array(
+				'items'     => $list_options,
+				'on_change' => 'woocommerce/collection-attribute-filter::actions.updateProducts',
+			)
 		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionAttributeFilter.php
@@ -179,7 +179,9 @@ final class CollectionAttributeFilter extends AbstractBlock {
 			$attribute_terms
 		);
 
-		$filter_content = 'dropdown' === $attributes['displayStyle'] ? $this->render_attribute_dropdown( $attribute_options, $attributes ) : $this->render_attribute_checkbox_list( $attribute_options, $attributes );
+		$filter_content = 'dropdown' === $attributes['displayStyle'] ?
+			$this->render_attribute_dropdown( $attribute_options, $attributes ) :
+			$this->render_attribute_checkbox_list( $attribute_options, $attributes );
 
 		$context = array(
 			'attributeSlug' => str_replace( 'pa_', '', $product_attribute->slug ),
@@ -240,13 +242,15 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	 * Render the attribute filter checkbox list.
 	 *
 	 * @param mixed $options Attribute filter options to render in the checkbox list.
-	 * @param mixed $show_counts Whether to show counts for each option.
+	 * @param mixed $attributes Block attributes.
 	 * @return string
 	 */
-	private function render_attribute_checkbox_list( $options, $show_counts ) {
+	private function render_attribute_checkbox_list( $options, $attributes ) {
 		if ( empty( $options ) ) {
 			return '';
 		}
+
+		$show_counts = $attributes['showCounts'] ?? false;
 
 		$list_options = array_map(
 			function( $option ) use ( $show_counts ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionRatingFilter.php
@@ -3,7 +3,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\InteractivityComponents\CheckboxList;
 use Automattic\WooCommerce\Blocks\InteractivityComponents\Dropdown;
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
  * Collection Rating Filter Block


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To solve https://github.com/woocommerce/woocommerce/issues/43171 the simplest thing was to do the work we needed to do anyway: move CollectionAttributeFilter to use the reusable CheckboxList component.

Closes #43171

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Add attribute filter to page or template
2. Test it as normal in checkbox mode, ensuring that selecting options still filters down the products as before

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[Experimental] Use CheckboxList component in interactivity attribute filter

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
