### PR TITLE
[Experimental] Add: Filter blocks migration

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/downgrade.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/downgrade.tsx
@@ -7,7 +7,7 @@ import { PanelBody, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock, BlockInstance } from '@wordpress/blocks';
 
-const Inspector = ( { clientId }: { clientId: string } ) => {
+const Downgrade = ( { clientId }: { clientId: string } ) => {
 	const { replaceBlock } = useDispatch( 'core/block-editor' );
 	const block = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getBlock( clientId );
@@ -69,4 +69,4 @@ const Inspector = ( { clientId }: { clientId: string } ) => {
 	);
 };
 
-export default Inspector;
+export default Downgrade;

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/inspector.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { PanelBody, Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock, BlockInstance } from '@wordpress/blocks';
+
+const Inspector = ( { clientId }: { clientId: string } ) => {
+	const { replaceBlock } = useDispatch( 'core/block-editor' );
+	const block = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getBlock( clientId );
+	} );
+
+	const downgradeBlock = () => {
+		if ( ! block ) return;
+		const filterBlock = block.innerBlocks[ 0 ];
+		const filterType = filterBlock.name.replace(
+			'woocommerce/collection-',
+			''
+		);
+		const innerBlocks: BlockInstance[] = [
+			createBlock( `woocommerce/${ filterType }`, {
+				...filterBlock.attributes,
+				heading: '',
+			} ),
+		];
+		const headingBlock = filterBlock.innerBlocks.find(
+			( item ) => item.name === 'core/heading'
+		);
+
+		if ( headingBlock ) {
+			innerBlocks.unshift(
+				createBlock( 'core/heading', headingBlock.attributes )
+			);
+		}
+
+		replaceBlock(
+			clientId,
+			createBlock(
+				`woocommerce/filter-wrapper`,
+				{ filterType },
+				innerBlocks
+			)
+		);
+	};
+
+	if ( block?.innerBlocks.length !== 1 ) return null;
+
+	return (
+		<InspectorControls key="inspector">
+			<PanelBody title={ __( 'Legacy Block', 'woocommerce' ) }>
+				<p>
+					{ __(
+						'You can restore to legacy filter blocks incase something went wrong.',
+						'woocommerce'
+					) }
+				</p>
+				<Button
+					variant="secondary"
+					size="small"
+					onClick={ downgradeBlock }
+				>
+					{ __( 'Restore', 'woocommerce' ) }
+				</Button>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Inspector;

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/upgrade.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/upgrade.tsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { replace } from '@wordpress/icons';
+import {
+	PanelBody,
+	Button,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
+
+const Upgrade = ( { clientId }: { clientId: string } ) => {
+	const block = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getBlock( clientId );
+	} );
+	const { replaceBlock } = useDispatch( 'core/block-editor' );
+
+	const upgradeBlock = useCallback( () => {
+		if ( ! block || ! block.innerBlocks ) return;
+		const filterType = block.attributes.filterType;
+		const filterBlock = block.innerBlocks.find(
+			( item ) => item.name === `woocommerce/${ filterType }`
+		);
+		if ( ! filterBlock ) return;
+
+		const { lock, ...filterBlockAttributes } = filterBlock.attributes;
+		const headingBlock = block.innerBlocks.find(
+			( item ) => item.name === 'core/heading'
+		);
+
+		replaceBlock(
+			clientId,
+			createBlock( `woocommerce/collection-filters`, {}, [
+				createBlock(
+					`woocommerce/collection-${ filterType }`,
+					filterBlockAttributes,
+					headingBlock
+						? [
+								createBlock(
+									'core/heading',
+									headingBlock.attributes
+								),
+						  ]
+						: []
+				),
+			] )
+		);
+	}, [ block, clientId, replaceBlock ] );
+
+	return (
+		<>
+			<InspectorControls key="inspector">
+				<PanelBody title={ __( 'Block Upgrade', 'woocommerce' ) }>
+					<p>
+						{ __(
+							'We have created new filter blocks with better performance and flexibility.',
+							'woocommerce'
+						) }
+					</p>
+					<Button
+						variant="primary"
+						size="small"
+						onClick={ upgradeBlock }
+					>
+						{ __( 'Upgrade', 'woocommerce' ) }
+					</Button>
+				</PanelBody>
+			</InspectorControls>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						onClick={ upgradeBlock }
+						icon={ replace }
+						label={ __(
+							'Upgrade to new filter block',
+							'woocommerce'
+						) }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+		</>
+	);
+};
+
+export default Upgrade;

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
@@ -12,7 +12,7 @@ import type { AttributeSetting } from '@woocommerce/types';
  */
 import { EditProps, FilterType } from './types';
 import { getAllowedBlocks } from './utils';
-import Inspector from './components/inspector';
+import Downgrade from './components/downgrade';
 import Warning from './components/warning';
 import './editor.scss';
 
@@ -66,7 +66,7 @@ const Edit = ( props: EditProps ) => {
 	return (
 		<nav { ...blockProps }>
 			{ ! isNested && <Warning /> }
-			<Inspector clientId={ props.clientId } />
+			<Downgrade clientId={ props.clientId } />
 			<InnerBlocks
 				template={ template }
 				allowedBlocks={ allowedBlocks }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
@@ -12,6 +12,7 @@ import type { AttributeSetting } from '@woocommerce/types';
  */
 import { EditProps, FilterType } from './types';
 import { getAllowedBlocks } from './utils';
+import Inspector from './components/inspector';
 import Warning from './components/warning';
 import './editor.scss';
 
@@ -65,6 +66,7 @@ const Edit = ( props: EditProps ) => {
 	return (
 		<nav { ...blockProps }>
 			{ ! isNested && <Warning /> }
+			<Inspector clientId={ props.clientId } />
 			<InnerBlocks
 				template={ template }
 				allowedBlocks={ allowedBlocks }

--- a/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/edit.tsx
@@ -1,19 +1,81 @@
 /**
  * External dependencies
  */
-import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import type { BlockEditProps } from '@wordpress/blocks';
+import {
+	useBlockProps,
+	InnerBlocks,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { createBlock, type BlockEditProps } from '@wordpress/blocks';
+import { PanelBody, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { Attributes } from './types';
 
-const Edit = ( { attributes }: BlockEditProps< Attributes > ) => {
+const Edit = ( { attributes, clientId }: BlockEditProps< Attributes > ) => {
+	const block = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getBlock( clientId );
+	} );
+	const { replaceBlock } = useDispatch( 'core/block-editor' );
+
+	const upgradeBlock = useCallback( () => {
+		if ( ! block || ! block.innerBlocks ) return;
+		const filterType = block.attributes.filterType;
+		const filterBlock = block.innerBlocks.find(
+			( item ) => item.name === `woocommerce/${ filterType }`
+		);
+		if ( ! filterBlock ) return;
+
+		const { lock, ...filterBlockAttributes } = filterBlock.attributes;
+		const headingBlock = block.innerBlocks.find(
+			( item ) => item.name === 'core/heading'
+		);
+
+		replaceBlock(
+			clientId,
+			createBlock( `woocommerce/collection-filters`, {}, [
+				createBlock(
+					`woocommerce/collection-${ filterType }`,
+					filterBlockAttributes,
+					headingBlock
+						? [
+								createBlock(
+									'core/heading',
+									headingBlock.attributes
+								),
+						  ]
+						: []
+				),
+			] )
+		);
+	}, [ block, clientId, replaceBlock ] );
+
 	const blockProps = useBlockProps();
 
 	return (
 		<div { ...blockProps }>
+			<InspectorControls key="inspector">
+				<PanelBody title={ __( 'Block Upgrade', 'woocommerce' ) }>
+					<p>
+						{ __(
+							'We have created new filter blocks with better performance and flexibility.',
+							'woocommerce'
+						) }
+					</p>
+					<Button
+						variant="primary"
+						size="small"
+						onClick={ upgradeBlock }
+					>
+						{ __( 'Upgrade', 'woocommerce' ) }
+					</Button>
+				</PanelBody>
+			</InspectorControls>
 			<InnerBlocks
 				allowedBlocks={ [ 'core/heading' ] }
 				template={ [

--- a/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/edit.tsx
@@ -1,100 +1,21 @@
 /**
  * External dependencies
  */
-import {
-	useBlockProps,
-	InnerBlocks,
-	InspectorControls,
-	BlockControls,
-} from '@wordpress/block-editor';
-import { createBlock, type BlockEditProps } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
-import { replace } from '@wordpress/icons';
-import {
-	PanelBody,
-	Button,
-	ToolbarButton,
-	ToolbarGroup,
-} from '@wordpress/components';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
  */
-import { Attributes } from './types';
+import { EditProps } from './types';
+import Upgrade from '../collection-filters/components/upgrade';
 
-const Edit = ( { attributes, clientId }: BlockEditProps< Attributes > ) => {
-	const block = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getBlock( clientId );
-	} );
-	const { replaceBlock } = useDispatch( 'core/block-editor' );
-
-	const upgradeBlock = useCallback( () => {
-		if ( ! block || ! block.innerBlocks ) return;
-		const filterType = block.attributes.filterType;
-		const filterBlock = block.innerBlocks.find(
-			( item ) => item.name === `woocommerce/${ filterType }`
-		);
-		if ( ! filterBlock ) return;
-
-		const { lock, ...filterBlockAttributes } = filterBlock.attributes;
-		const headingBlock = block.innerBlocks.find(
-			( item ) => item.name === 'core/heading'
-		);
-
-		replaceBlock(
-			clientId,
-			createBlock( `woocommerce/collection-filters`, {}, [
-				createBlock(
-					`woocommerce/collection-${ filterType }`,
-					filterBlockAttributes,
-					headingBlock
-						? [
-								createBlock(
-									'core/heading',
-									headingBlock.attributes
-								),
-						  ]
-						: []
-				),
-			] )
-		);
-	}, [ block, clientId, replaceBlock ] );
-
+const Edit = ( { attributes, clientId }: EditProps ) => {
 	const blockProps = useBlockProps();
 
 	return (
 		<div { ...blockProps }>
-			<InspectorControls key="inspector">
-				<PanelBody title={ __( 'Block Upgrade', 'woocommerce' ) }>
-					<p>
-						{ __(
-							'We have created new filter blocks with better performance and flexibility.',
-							'woocommerce'
-						) }
-					</p>
-					<Button
-						variant="primary"
-						size="small"
-						onClick={ upgradeBlock }
-					>
-						{ __( 'Upgrade', 'woocommerce' ) }
-					</Button>
-				</PanelBody>
-			</InspectorControls>
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						onClick={ upgradeBlock }
-						icon={ replace }
-						label={ __(
-							'Upgrade to new filter block',
-							'woocommerce'
-						) }
-					/>
-				</ToolbarGroup>
-			</BlockControls>
+			{ isExperimentalBuild() && <Upgrade clientId={ clientId } /> }
 			<InnerBlocks
 				allowedBlocks={ [ 'core/heading' ] }
 				template={ [

--- a/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/edit.tsx
@@ -5,12 +5,19 @@ import {
 	useBlockProps,
 	InnerBlocks,
 	InspectorControls,
+	BlockControls,
 } from '@wordpress/block-editor';
 import { createBlock, type BlockEditProps } from '@wordpress/blocks';
-import { PanelBody, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
+import { replace } from '@wordpress/icons';
+import {
+	PanelBody,
+	Button,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -76,6 +83,18 @@ const Edit = ( { attributes, clientId }: BlockEditProps< Attributes > ) => {
 					</Button>
 				</PanelBody>
 			</InspectorControls>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						onClick={ upgradeBlock }
+						icon={ replace }
+						label={ __(
+							'Upgrade to new filter block',
+							'woocommerce'
+						) }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 			<InnerBlocks
 				allowedBlocks={ [ 'core/heading' ] }
 				template={ [

--- a/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/filter-wrapper/types.ts
@@ -1,4 +1,11 @@
-export interface Attributes {
+/**
+ * External dependencies
+ */
+import { type BlockEditProps } from '@wordpress/blocks';
+
+export type Attributes = {
 	heading: string;
 	filterType: string;
-}
+};
+
+export type EditProps = BlockEditProps< Attributes >;

--- a/plugins/woocommerce/changelog/fix-42168-filter-blocks-migration
+++ b/plugins/woocommerce/changelog/fix-42168-filter-blocks-migration
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Filter blocks: Migration handler
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds manual migration logic that enables merchants to:
- Upgrade current filter block to the new ones without losing any setting/content.
- Revert/restore the converted one back to current filter blocks.

Auto migration is ready by running `upgradeBlock()` inside `useEffect`, but we only do the manual part for now. Once the filter block is out of the beta phase, we will add the auto migration script.

Closes #42168 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the Product Catalog template. Add `Product Filters` pattern to the template that contains all current filter blocks.
2. Edit each filter block, try change the heading content/style and filter block settings, style.
3. Select the filter wrapper block:
  - See the Upgrade button in the toolbar.
  - See the Upgrade panel in the sidebar.
4. Click on either toolbar/sidebar upgrade button, see the block is migrade to its new corresponding filter block.
5. See the style and setting are preserved.
6. See the Restore button on sidebar.
7. Click on the restore button, see the block is restored to use current filter block, without any settings/content lost.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
