### PR TITLE
Prevent Command Palette scripts to enqueue unnecessary scripts in the editor

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
+import { useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -34,21 +35,24 @@ const registerWooCommerceAnalyticsCommand = ( { label, path, origin } ) => {
 const WooCommerceAnalyticsCommands = () => {
 	const { editedPostType } = useEditedPostType();
 	const origin = editedPostType ? editedPostType + '-editor' : null;
-	if (
-		window.hasOwnProperty( 'wcCommandPaletteAnalytics' ) &&
-		window.wcCommandPaletteAnalytics.hasOwnProperty( 'reports' ) &&
-		Array.isArray( window.wcCommandPaletteAnalytics.reports )
-	) {
-		const analyticsReports = window.wcCommandPaletteAnalytics.reports;
 
-		analyticsReports.forEach( ( analyticsReport ) => {
-			registerWooCommerceAnalyticsCommand( {
-				label: analyticsReport.title,
-				path: analyticsReport.path,
-				origin,
+	useEffect( () => {
+		if (
+			window.hasOwnProperty( 'wcCommandPaletteAnalytics' ) &&
+			window.wcCommandPaletteAnalytics.hasOwnProperty( 'reports' ) &&
+			Array.isArray( window.wcCommandPaletteAnalytics.reports )
+		) {
+			const analyticsReports = window.wcCommandPaletteAnalytics.reports;
+
+			analyticsReports.forEach( ( analyticsReport ) => {
+				registerWooCommerceAnalyticsCommand( {
+					label: analyticsReport.title,
+					path: analyticsReport.path,
+					origin,
+				} );
 			} );
-		} );
-	}
+		}
+	}, [ origin ] );
 
 	return null;
 };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -136,71 +136,74 @@ const WooCommerceCommands = () => {
 		wasCommandPaletteOpen.current = isCommandPaletteOpen;
 	}, [ isCommandPaletteOpen, origin ] );
 
-	registerCommandWithTracking( {
-		name: 'woocommerce/add-new-product',
-		label: __( 'Add new product', 'woocommerce' ),
-		icon: plus,
-		callback: () => {
-			document.location = addQueryArgs( 'post-new.php', {
-				post_type: 'product',
-			} );
-		},
-		origin,
-	} );
-	registerCommandWithTracking( {
-		name: 'woocommerce/add-new-order',
-		label: __( 'Add new order', 'woocommerce' ),
-		icon: plus,
-		callback: () => {
-			document.location = addQueryArgs( 'admin.php', {
-				page: 'wc-orders',
-				action: 'new',
-			} );
-		},
-		origin,
-	} );
-	registerCommandWithTracking( {
-		name: 'woocommerce/view-products',
-		label: __( 'Products', 'woocommerce' ),
-		icon: box,
-		callback: () => {
-			document.location = addQueryArgs( 'edit.php', {
-				post_type: 'product',
-			} );
-		},
-		origin,
-	} );
-	registerCommandWithTracking( {
-		name: 'woocommerce/view-orders',
-		label: __( 'Orders', 'woocommerce' ),
-		icon: box,
-		callback: () => {
-			document.location = addQueryArgs( 'admin.php', {
-				page: 'wc-orders',
-			} );
-		},
-		origin,
-	} );
-	dispatch( commandsStore ).registerCommandLoader( {
-		name: 'woocommerce/product',
-		hook: useProductCommandLoader,
-	} );
-
-	if (
-		window.hasOwnProperty( 'wcCommandPaletteSettings' ) &&
-		window.wcCommandPaletteSettings.hasOwnProperty( 'settingsTabs' ) &&
-		Array.isArray( window.wcCommandPaletteSettings.settingsTabs )
-	) {
-		const settingsCommands = window.wcCommandPaletteSettings.settingsTabs;
-
-		settingsCommands.forEach( ( settingsCommand ) => {
-			registerWooCommerceSettingsCommand( {
-				label: settingsCommand.label,
-				tab: settingsCommand.key,
-				origin,
-			} );
+	useEffect( () => {
+		registerCommandWithTracking( {
+			name: 'woocommerce/add-new-product',
+			label: __( 'Add new product', 'woocommerce' ),
+			icon: plus,
+			callback: () => {
+				document.location = addQueryArgs( 'post-new.php', {
+					post_type: 'product',
+				} );
+			},
+			origin,
 		} );
-	}
+		registerCommandWithTracking( {
+			name: 'woocommerce/add-new-order',
+			label: __( 'Add new order', 'woocommerce' ),
+			icon: plus,
+			callback: () => {
+				document.location = addQueryArgs( 'admin.php', {
+					page: 'wc-orders',
+					action: 'new',
+				} );
+			},
+			origin,
+		} );
+		registerCommandWithTracking( {
+			name: 'woocommerce/view-products',
+			label: __( 'Products', 'woocommerce' ),
+			icon: box,
+			callback: () => {
+				document.location = addQueryArgs( 'edit.php', {
+					post_type: 'product',
+				} );
+			},
+			origin,
+		} );
+		registerCommandWithTracking( {
+			name: 'woocommerce/view-orders',
+			label: __( 'Orders', 'woocommerce' ),
+			icon: box,
+			callback: () => {
+				document.location = addQueryArgs( 'admin.php', {
+					page: 'wc-orders',
+				} );
+			},
+			origin,
+		} );
+		dispatch( commandsStore ).registerCommandLoader( {
+			name: 'woocommerce/product',
+			hook: useProductCommandLoader,
+		} );
+
+		if (
+			window.hasOwnProperty( 'wcCommandPaletteSettings' ) &&
+			window.wcCommandPaletteSettings.hasOwnProperty( 'settingsTabs' ) &&
+			Array.isArray( window.wcCommandPaletteSettings.settingsTabs )
+		) {
+			const settingsCommands =
+				window.wcCommandPaletteSettings.settingsTabs;
+
+			settingsCommands.forEach( ( settingsCommand ) => {
+				registerWooCommerceSettingsCommand( {
+					label: settingsCommand.label,
+					tab: settingsCommand.key,
+					origin,
+				} );
+			} );
+		}
+	}, [ origin ] );
 
 	return null;
 };

--- a/plugins/woocommerce/changelog/43221-fix-command-palette-unnecessary-scripts
+++ b/plugins/woocommerce/changelog/43221-fix-command-palette-unnecessary-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `Store "core/interface" is already registered.` error in the block editor.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -578,10 +578,13 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					}
 				}
 
+
+				$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'command-palette' );
+				$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER .  'wp-admin-scripts/' . $script_assets_filename;
 				wp_enqueue_script(
 					'wc-admin-command-palette',
 					WCAdminAssets::get_url( 'wp-admin-scripts/command-palette', 'js' ),
-					array(),
+					$script_assets['dependencies'],
 					WCAdminAssets::get_file_version( 'js' ),
 					true
 				);
@@ -617,10 +620,12 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					}, $analytics_reports );
 					$formatted_analytics_reports = array_filter( $formatted_analytics_reports, 'is_array' );
 
+					$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'command-palette-analytics' );
+					$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER .  'wp-admin-scripts/' . $script_assets_filename;
 					wp_enqueue_script(
 						'wc-admin-command-palette-analytics',
 						WCAdminAssets::get_url( 'wp-admin-scripts/command-palette-analytics', 'js' ),
-						array(),
+						$script_assets['dependencies'],
 						WCAdminAssets::get_file_version( 'js' ),
 						true
 					);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -578,7 +578,13 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					}
 				}
 
-				WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette' );
+				wp_enqueue_script(
+					'wc-admin-command-palette',
+					WCAdminAssets::get_url( 'wp-admin-scripts/command-palette', 'js' ),
+					array(),
+					WCAdminAssets::get_file_version( 'js' ),
+					true
+				);
 				wp_localize_script(
 					'wc-admin-command-palette',
 					'wcCommandPaletteSettings',
@@ -611,7 +617,13 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					}, $analytics_reports );
 					$formatted_analytics_reports = array_filter( $formatted_analytics_reports, 'is_array' );
 
-					WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette-analytics' );
+					wp_enqueue_script(
+						'wc-admin-command-palette-analytics',
+						WCAdminAssets::get_url( 'wp-admin-scripts/command-palette-analytics', 'js' ),
+						array(),
+						WCAdminAssets::get_file_version( 'js' ),
+						true
+					);
 					wp_localize_script(
 						'wc-admin-command-palette-analytics',
 						'wcCommandPaletteAnalytics',

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -557,6 +557,25 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		}
 
 		/**
+		 * Enqueue a script in the block editor.
+		 * Similar to `WCAdminAssets::register_script()` but without enqueuing unnecessary dependencies.
+		 *
+		 * @return void
+		 */
+		private function enqueue_block_editor_script( $script_path_name, $script_name ) {
+			$script_assets_filename = WCAdminAssets::get_script_asset_filename( $script_path_name, $script_name );
+			$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER .  $script_path_name . '/' . $script_assets_filename;
+
+			wp_enqueue_script(
+				'wc-admin-' . $script_name,
+				WCAdminAssets::get_url( $script_path_name . '/' . $script_name, 'js' ),
+				$script_assets['dependencies'],
+				WCAdminAssets::get_file_version( 'js' ),
+				true
+			);
+		}
+
+		/**
 		 * Enqueue block editor assets.
 		 *
 		 * @return void
@@ -578,16 +597,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					}
 				}
 
-
-				$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'command-palette' );
-				$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER .  'wp-admin-scripts/' . $script_assets_filename;
-				wp_enqueue_script(
-					'wc-admin-command-palette',
-					WCAdminAssets::get_url( 'wp-admin-scripts/command-palette', 'js' ),
-					$script_assets['dependencies'],
-					WCAdminAssets::get_file_version( 'js' ),
-					true
-				);
+				self::enqueue_block_editor_script( 'wp-admin-scripts', 'command-palette' );
 				wp_localize_script(
 					'wc-admin-command-palette',
 					'wcCommandPaletteSettings',
@@ -620,15 +630,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					}, $analytics_reports );
 					$formatted_analytics_reports = array_filter( $formatted_analytics_reports, 'is_array' );
 
-					$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'command-palette-analytics' );
-					$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER .  'wp-admin-scripts/' . $script_assets_filename;
-					wp_enqueue_script(
-						'wc-admin-command-palette-analytics',
-						WCAdminAssets::get_url( 'wp-admin-scripts/command-palette-analytics', 'js' ),
-						$script_assets['dependencies'],
-						WCAdminAssets::get_file_version( 'js' ),
-						true
-					);
+					self::enqueue_block_editor_script( 'wp-admin-scripts', 'command-palette-analytics' );
 					wp_localize_script(
 						'wc-admin-command-palette-analytics',
 						'wcCommandPaletteAnalytics',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes how we enqueue the command palette scripts. Instead of using `WCAdminAssets::register_script()`, now we call `wp_enqueue_script()` directly.

`WCAdminAssets::register_script()` had some drawbacks:

* It was enqueuing some extra dependencies which we don't really need.
* Those dependencies were causing a `Store "core/interface" is already registered.` JS error.

### How to test the changes in this Pull Request:

1. Open your browser console (<kbd>F12</kbd> > _Console_).
2. Create a new post.
3. Verify there is no JS error like `Store "core/interface" is already registered.` in the console.
4. Smoke test the command palette. You can open it with <kbd>Control</kbd>+<kbd>K</kbd> (<kbd>Cmd</kbd>+<kbd>K</kbd> on Mac) and search for _Products_, when clicking on it, verify you are redirected to the Products page.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix `Store "core/interface" is already registered.` error in the block editor.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
