### PR TITLE
Apply Rector suggestions for PHP 8.1

### DIFF
--- a/plugins/woocommerce/changelog/as-diff-D129164
+++ b/plugins/woocommerce/changelog/as-diff-D129164
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Apply Rector suggestions for PHP 8.1

--- a/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -383,6 +383,7 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	public function get_extra_cost( $cost_string, $type, $package ) {
 		$cost         = $cost_string;
 		$cost_percent = false;
+		$cost_operator = '';
 		// @codingStandardsIgnoreStart
 		$pattern      =
 			'/' .           // Start regex.

--- a/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -383,7 +383,6 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	public function get_extra_cost( $cost_string, $type, $package ) {
 		$cost         = $cost_string;
 		$cost_percent = false;
-		$cost_operator = '';
 		// @codingStandardsIgnoreStart
 		$pattern      =
 			'/' .           // Start regex.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -107,6 +107,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 		$products = array_fill_keys( array_keys( $products ), 1 );
 	}
 
+	$product_id = null;
 	foreach ( $products as $product_id => $qty ) {
 		/* translators: %s: product name */
 		$titles[] = apply_filters( 'woocommerce_add_to_cart_qty_html', ( $qty > 1 ? absint( $qty ) . ' &times; ' : '' ), $product_id ) . apply_filters( 'woocommerce_add_to_cart_item_name_in_quotes', sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), strip_tags( get_the_title( $product_id ) ) ), $product_id );
@@ -419,6 +420,10 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 		$method_count = absint( $method_counts[ $key ] );
 	} else {
 		$method_count = 0;
+	}
+
+	if ( ! isset( $package['rates'] ) || ! is_array( $package['rates'] ) ) {
+		$package['rates'] = [];
 	}
 
 	// If not set, not available, or available methods have changed, set to the DEFAULT option.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -423,7 +423,7 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 	}
 
 	if ( ! isset( $package['rates'] ) || ! is_array( $package['rates'] ) ) {
-		$package['rates'] = [];
+		$package['rates'] = array();
 	}
 
 	// If not set, not available, or available methods have changed, set to the DEFAULT option.

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -29,14 +29,16 @@ function wc_notice_count( $notice_type = '' ) {
 	$notice_count = 0;
 	$all_notices  = WC()->session->get( 'wc_notices', array() );
 
-	if ( isset( $all_notices[ $notice_type ] ) ) {
+	if ( isset( $all_notices[ $notice_type ] ) && is_array( $all_notices[ $notice_type ] ) ) {
 
 		$notice_count = count( $all_notices[ $notice_type ] );
 
 	} elseif ( empty( $notice_type ) ) {
 
 		foreach ( $all_notices as $notices ) {
-			$notice_count += count( $notices );
+			if ( is_countable( $notices ) ) {
+				$notice_count += count( $notices );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -561,7 +561,7 @@ function wc_create_refund( $args = array() ) {
 		}
 
 		// Negative line items.
-		if ( count( $args['line_items'] ) > 0 ) {
+		if ( is_array( $args['line_items'] ) && count( $args['line_items'] ) > 0 ) {
 			$items = $order->get_items( array( 'line_item', 'fee', 'shipping' ) );
 
 			foreach ( $items as $item_id => $item ) {

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -991,9 +991,7 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 	$price = '' !== $args['price'] ? max( 0.0, (float) $args['price'] ) : (float) $product->get_price();
 	$qty   = '' !== $args['qty'] ? max( 0.0, (float) $args['qty'] ) : 1;
 
-	if ( '' === $price ) {
-		return '';
-	} elseif ( empty( $qty ) ) {
+	if ( empty( $qty ) ) {
 		return 0.0;
 	}
 
@@ -1080,9 +1078,7 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 	$price = '' !== $args['price'] ? max( 0.0, (float) $args['price'] ) : (float) $product->get_price();
 	$qty   = '' !== $args['qty'] ? max( 0.0, (float) $args['qty'] ) : 1;
 
-	if ( '' === $price ) {
-		return '';
-	} elseif ( empty( $qty ) ) {
+	if ( empty( $qty ) ) {
 		return 0.0;
 	}
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3487,7 +3487,7 @@ if ( ! function_exists( 'wc_display_item_downloads' ) ) {
 
 		$downloads = is_object( $item ) && $item->is_type( 'line_item' ) ? $item->get_item_downloads() : array();
 
-		if ( $downloads ) {
+		if ( ! empty( $downloads ) ) {
 			$i = 0;
 			foreach ( $downloads as $file ) {
 				$i ++;
@@ -3836,31 +3836,33 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
 	// Filter item data to allow 3rd parties to add more to the array.
 	$item_data = apply_filters( 'woocommerce_get_item_data', $item_data, $cart_item );
 
-	// Format item data ready to display.
-	foreach ( $item_data as $key => $data ) {
-		// Set hidden to true to not display meta on cart.
-		if ( ! empty( $data['hidden'] ) ) {
-			unset( $item_data[ $key ] );
-			continue;
-		}
-		$item_data[ $key ]['key']     = ! empty( $data['key'] ) ? $data['key'] : $data['name'];
-		$item_data[ $key ]['display'] = ! empty( $data['display'] ) ? $data['display'] : $data['value'];
-	}
+	if ( is_array( $item_data ) ) {
+	    // Format item data ready to display.
+	    foreach ( $item_data as $key => $data ) {
+		    // Set hidden to true to not display meta on cart.
+		    if ( ! empty( $data['hidden'] ) ) {
+			    unset( $item_data[ $key ] );
+			    continue;
+		    }
+		    $item_data[ $key ]['key']     = ! empty( $data['key'] ) ? $data['key'] : $data['name'];
+		    $item_data[ $key ]['display'] = ! empty( $data['display'] ) ? $data['display'] : $data['value'];
+	    }
 
-	// Output flat or in list format.
-	if ( count( $item_data ) > 0 ) {
-		ob_start();
+	    // Output flat or in list format.
+	    if ( count( $item_data ) > 0 ) {
+		    ob_start();
 
-		if ( $flat ) {
-			foreach ( $item_data as $data ) {
-				echo esc_html( $data['key'] ) . ': ' . wp_kses_post( $data['display'] ) . "\n";
-			}
-		} else {
-			wc_get_template( 'cart/cart-item-data.php', array( 'item_data' => $item_data ) );
-		}
+		    if ( $flat ) {
+			    foreach ( $item_data as $data ) {
+				    echo esc_html( $data['key'] ) . ': ' . wp_kses_post( $data['display'] ) . "\n";
+			    }
+		    } else {
+			    wc_get_template( 'cart/cart-item-data.php', array( 'item_data' => $item_data ) );
+		    }
 
-		return ob_get_clean();
-	}
+		    return ob_get_clean();
+	    }
+    }
 
 	return '';
 }

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1435,8 +1435,8 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 	 * Get the product thumbnail, or the placeholder if not set.
 	 *
 	 * @param string $size (default: 'woocommerce_thumbnail').
-	 * @param  array $attr Image attributes.
-	 * @param  bool  $placeholder True to return $placeholder if no image is found, or false to return an empty string.
+	 * @param  array  $attr Image attributes.
+	 * @param  bool   $placeholder True to return $placeholder if no image is found, or false to return an empty string.
 	 * @return string
 	 */
 	function woocommerce_get_product_thumbnail( $size = 'woocommerce_thumbnail', $attr = array(), $placeholder = true ) {
@@ -3837,32 +3837,32 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
 	$item_data = apply_filters( 'woocommerce_get_item_data', $item_data, $cart_item );
 
 	if ( is_array( $item_data ) ) {
-	    // Format item data ready to display.
-	    foreach ( $item_data as $key => $data ) {
-		    // Set hidden to true to not display meta on cart.
-		    if ( ! empty( $data['hidden'] ) ) {
-			    unset( $item_data[ $key ] );
-			    continue;
-		    }
-		    $item_data[ $key ]['key']     = ! empty( $data['key'] ) ? $data['key'] : $data['name'];
-		    $item_data[ $key ]['display'] = ! empty( $data['display'] ) ? $data['display'] : $data['value'];
-	    }
+		// Format item data ready to display.
+		foreach ( $item_data as $key => $data ) {
+			// Set hidden to true to not display meta on cart.
+			if ( ! empty( $data['hidden'] ) ) {
+				unset( $item_data[ $key ] );
+				continue;
+			}
+			$item_data[ $key ]['key']     = ! empty( $data['key'] ) ? $data['key'] : $data['name'];
+			$item_data[ $key ]['display'] = ! empty( $data['display'] ) ? $data['display'] : $data['value'];
+		}
 
-	    // Output flat or in list format.
-	    if ( count( $item_data ) > 0 ) {
-		    ob_start();
+		// Output flat or in list format.
+		if ( count( $item_data ) > 0 ) {
+			ob_start();
 
-		    if ( $flat ) {
-			    foreach ( $item_data as $data ) {
-				    echo esc_html( $data['key'] ) . ': ' . wp_kses_post( $data['display'] ) . "\n";
-			    }
-		    } else {
-			    wc_get_template( 'cart/cart-item-data.php', array( 'item_data' => $item_data ) );
-		    }
+			if ( $flat ) {
+				foreach ( $item_data as $data ) {
+					echo esc_html( $data['key'] ) . ': ' . wp_kses_post( $data['display'] ) . "\n";
+				}
+			} else {
+				wc_get_template( 'cart/cart-item-data.php', array( 'item_data' => $item_data ) );
+			}
 
-		    return ob_get_clean();
-	    }
-    }
+			return ob_get_clean();
+		}
+	}
 
 	return '';
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Subset of WPCOM changes for PHP 8.1 compatibility based on the D129164-code diff.

Ref: p7H4VZ-4x1-p2

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The changes on this PR are based on changes currently made in WPCOM, As there are no logic changes, only compatibility with PHP 8.1, it was deemed unnecessary to include testing instructions. To put it simply, the current tests should be able to complete without any problems, and that should be sufficient.

In any case, I'm including testing instructions for these changes.

**plugins/woocommerce/includes/wc-notice-functions.php**
**plugins/woocommerce/includes/wc-cart-functions.php**

- Verify notice is still shown after adding a product to the cart and the option “Redirect to the cart page after successful addition” is checked.

**plugins/woocommerce/includes/wc-cart-functions.php**

- Verify adding product to the cart while rates and shipping are enabled work as expected.

**plugins/woocommerce/includes/wc-order-functions.php**

- Verify refunds works as usual

**plugins/woocommerce/includes/wc-product-functions.php**

- Verify product prices are correct including tax
- Verify product prices are correct excluding tax

**plugins/woocommerce/includes/wc-template-functions.php**

- unfortunately we can't test this one as the `wc_display_item_downloads` isn’t used anywhere in WooCommerce.
- However, I made sure `wc_display_item_downloads` is working as expected by calling the method manually. It displays the download links as expected
  > <img width="267" alt="Screenshot 2024-01-24 at 17 04 53" src="https://github.com/woocommerce/woocommerce/assets/1025173/180520fd-78f0-4d10-b8f6-8d2414dd1b93">




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>