### PR TITLE
Apply Rector suggestions for PHP 8.1

### DIFF
--- a/plugins/woocommerce/changelog/as-diff-D128575
+++ b/plugins/woocommerce/changelog/as-diff-D128575
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Apply Rector suggestions for PHP 8.1

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -365,7 +365,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$import = self::import_sample_products_from_csv( $template_path );
 
-		if ( is_wp_error( $import ) || 0 === count( $import['imported'] ) ) {
+		if ( is_wp_error( $import ) || ! is_array( $import['imported'] ) || 0 === count( $import['imported'] ) ) {
 			return new \WP_Error(
 				'woocommerce_rest_product_creation_error',
 				/* translators: %s is template name */

--- a/plugins/woocommerce/src/Admin/API/Plugins.php
+++ b/plugins/woocommerce/src/Admin/API/Plugins.php
@@ -548,7 +548,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		if ( ! class_exists( '\WooCommerce\Square\Handlers\Connection' ) ) {
 			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to Square.', 'woocommerce' ), 500 );
 		}
-
+		$has_cbd_industry = false;
 		if ( 'US' === WC()->countries->get_base_country() ) {
 			$profile = get_option( OnboardingProfile::DATA_OPTION, array() );
 			if ( ! empty( $profile['industry'] ) ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/DataStore.php
@@ -162,7 +162,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Returns an array of ids of included categories, based on query arguments from the user.
 	 *
 	 * @param array $query_args Parameters supplied by the user.
-	 * @return string
+	 * @return array
 	 */
 	protected function get_included_categories_array( $query_args ) {
 		if ( isset( $query_args['category_includes'] ) && is_array( $query_args['category_includes'] ) && count( $query_args['category_includes'] ) > 0 ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Segmenter.php
@@ -258,6 +258,7 @@ class Segmenter extends ReportsSegmenter {
 			return array();
 		}
 
+		$segments = null;
 		$product_segmenting_table = $wpdb->prefix . 'wc_order_product_lookup';
 		$unique_orders_table      = '';
 		$segmenting_where         = '';
@@ -279,7 +280,7 @@ class Segmenter extends ReportsSegmenter {
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
-			if ( ! isset( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
+			if ( ! isset( $this->query_args['product_includes'] ) || ! is_array( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
 				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce' ) );
 			}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Segmenter.php
@@ -258,7 +258,7 @@ class Segmenter extends ReportsSegmenter {
 			return array();
 		}
 
-		$segments = null;
+		$segments                 = null;
 		$product_segmenting_table = $wpdb->prefix . 'wc_order_product_lookup';
 		$unique_orders_table      = '';
 		$segmenting_where         = '';

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Segmenter.php
@@ -374,7 +374,7 @@ class Segmenter extends ReportsSegmenter {
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
-			if ( ! isset( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
+			if ( ! isset( $this->query_args['product_includes'] ) || ! is_array( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
 				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce' ) );
 			}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Segmenter.php
@@ -165,7 +165,7 @@ class Segmenter extends ReportsSegmenter {
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
-			if ( ! isset( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
+			if ( ! isset( $this->query_args['product_includes'] ) || ! is_array( count( $this->query_args['product_includes'] ) ) || count( $this->query_args['product_includes'] ) !== 1 ) {
 				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce' ) );
 			}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Segmenter.php
@@ -368,6 +368,7 @@ class Segmenter {
 
 			if (
 				isset( $this->query_args['product_includes'] ) &&
+				is_array( $this->query_args['product_includes'] ) &&
 				count( $this->query_args['product_includes'] ) === 1
 			) {
 				$args['parent'] = $this->query_args['product_includes'][0];

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -175,7 +175,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$this->add_sql_query_params( $query_args );
 			$params = $this->get_limit_params( $query_args );
 
-			if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
+			if ( isset( $query_args['taxes'] ) && is_array( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
 				$total_results = count( $query_args['taxes'] );
 				$total_pages   = (int) ceil( $total_results / $params['per_page'] );
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
@@ -77,6 +77,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$order_tax_lookup_table = self::get_db_table_name();
 
 		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
+			$query_args['taxes'] = (array) $query_args['taxes'];
 			$tax_id_placeholders = implode( ',', array_fill( 0, count( $query_args['taxes'] ), '%d' ) );
 			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
 			$taxes_where_clause .= $wpdb->prepare( " AND {$order_tax_lookup_table}.tax_rate_id IN ({$tax_id_placeholders})", $query_args['taxes'] );
@@ -115,6 +116,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			FROM {$wpdb->prefix}woocommerce_tax_rates
 		";
 		if ( ! empty( $args['include'] ) ) {
+			$args['include'] = (array) $args['include'];
 			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
 			$tax_placeholders = implode( ',', array_fill( 0, count( $args['include'] ), '%d' ) );
 			$query           .= $wpdb->prepare( " WHERE tax_rate_id IN ({$tax_placeholders})", $args['include'] );

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -586,6 +586,7 @@ class TimeInterval {
 		}
 
 		if (
+			! is_array( $value ) ||
 			2 !== count( $value ) ||
 			! is_numeric( $value[0] ) ||
 			! is_numeric( $value[1] )
@@ -618,6 +619,7 @@ class TimeInterval {
 		}
 
 		if (
+			! is_array( $value ) ||
 			2 !== count( $value ) ||
 			! rest_parse_date( $value[0] ) ||
 			! rest_parse_date( $value[1] )

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Segmenter.php
@@ -140,7 +140,7 @@ class Segmenter extends ReportsSegmenter {
 	 * @param array  $query_params SQL query parameter array.
 	 * @param string $table_name Name of main SQL table for the data store (used as basis for JOINS).
 	 *
-	 * @return array
+	 * @return array|null
 	 * @throws \Automattic\WooCommerce\Admin\API\Reports\ParameterException In case of segmenting by variations, when no parent product is specified.
 	 */
 	protected function get_segments( $type, $query_params, $table_name ) {
@@ -148,7 +148,7 @@ class Segmenter extends ReportsSegmenter {
 		if ( ! isset( $this->query_args['segmentby'] ) || '' === $this->query_args['segmentby'] ) {
 			return array();
 		}
-
+		$segments = null;
 		$product_segmenting_table = $wpdb->prefix . 'wc_order_product_lookup';
 		$unique_orders_table      = 'uniq_orders';
 		$segmenting_where         = '';

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Segmenter.php
@@ -148,7 +148,7 @@ class Segmenter extends ReportsSegmenter {
 		if ( ! isset( $this->query_args['segmentby'] ) || '' === $this->query_args['segmentby'] ) {
 			return array();
 		}
-		$segments = null;
+		$segments                 = null;
 		$product_segmenting_table = $wpdb->prefix . 'wc_order_product_lookup';
 		$unique_orders_table      = 'uniq_orders';
 		$segmenting_where         = '';

--- a/plugins/woocommerce/src/Admin/API/Themes.php
+++ b/plugins/woocommerce/src/Admin/API/Themes.php
@@ -192,7 +192,7 @@ class Themes extends \WC_REST_Data_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
+		$params = [ 'context' => $this->get_context_param( array( 'default' => 'view' ) ) ];
 		$params['pluginzip'] = array(
 			'description'       => __( 'A zip file of the theme to be uploaded.', 'woocommerce' ),
 			'type'              => 'file',

--- a/plugins/woocommerce/src/Admin/API/Themes.php
+++ b/plugins/woocommerce/src/Admin/API/Themes.php
@@ -192,7 +192,7 @@ class Themes extends \WC_REST_Data_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = [ 'context' => $this->get_context_param( array( 'default' => 'view' ) ) ];
+		$params              = array( 'context' => $this->get_context_param( array( 'default' => 'view' ) ) );
 		$params['pluginzip'] = array(
 			'description'       => __( 'A zip file of the theme to be uploaded.', 'woocommerce' ),
 			'type'              => 'file',

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -167,6 +167,7 @@ class PageController {
 			return apply_filters( 'woocommerce_navigation_get_breadcrumbs', array( '' ), $current_page );
 		}
 
+		$current_page['title'] = (array) $current_page['title'];
 		if ( 1 === count( $current_page['title'] ) ) {
 			$breadcrumbs = $current_page['title'];
 		} else {

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PluginsActivatedRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PluginsActivatedRuleProcessor.php
@@ -41,7 +41,7 @@ class PluginsActivatedRuleProcessor implements RuleProcessorInterface {
 	 * @return bool Whether the rule passes or not.
 	 */
 	public function process( $rule, $stored_state ) {
-		if ( 0 === count( $rule->plugins ) ) {
+		if ( ! is_countable( $rule->plugins ) || 0 === count( $rule->plugins ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -113,7 +113,7 @@ class RemoteInboxNotificationsEngine extends RemoteSpecsEngine {
 	public static function run() {
 		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
 
-		if ( $specs === false || ! is_countable( $specs ) || count( $specs ) === 0 ) {
+		if ( false === $specs || ! is_countable( $specs ) || count( $specs ) === 0 ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -113,7 +113,7 @@ class RemoteInboxNotificationsEngine extends RemoteSpecsEngine {
 	public static function run() {
 		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
 
-		if ( $specs === false || count( $specs ) === 0 ) {
+		if ( $specs === false || ! is_countable( $specs ) || count( $specs ) === 0 ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -25,7 +25,7 @@ class SpecRunner {
 
 		// Create or update the note.
 		$existing_note_ids = $data_store->get_notes_with_name( $spec->slug );
-		if ( count( $existing_note_ids ) === 0 ) {
+		if ( ! is_countable( $existing_note_ids ) || count( $existing_note_ids ) === 0 ) {
 			$note = new Note();
 			$note->set_status( Note::E_WC_ADMIN_NOTE_PENDING );
 		} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Subset of WPCOM changes for PHP 8.1 compatibility based on the D128575-code diff.

Ref: p7H4VZ-4x1-p2

<!-- Begin testing instructions -->
### How to test the changes in this Pull Request:

The changes on this PR are based on changes currently made in WPCOM, As there are no logic changes, only compatibility with PHP 8.1, it was deemed unnecessary to include testing instructions. To put it simply, the current tests should be able to complete without any problems, and that should be sufficient.

In any case, I wanted to provide some basic testing steps in case we want to test some file changes:

- `plugins/woocommerce/src/Admin/API/OnboardingTasks.php`
    - Go to `wp-admin/admin.php?page=wc-admin&task=products`
    - Click Grouped product.
    - You should be able to see guided tour.
- `plugins/woocommerce/src/Admin/API/Plugins.php`
    - No need to test this one. It just initialized a variable with a default value.
    - Also, I haven’t found a way to test this one. Seems related to Square.
- `plugins/woocommerce/src/Admin/API/Reports/Categories/DataStore.php`
    - This one doesn't need testing. The return type just got updated in the docblock. There's no code change.
- `plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Segmenter.php`
    - Didn’t find a way to test this but testing Coupon stats should be enough.
    - Go to Analytics > Coupons. Charts should be visible.
- `plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Segmenter.php`
    - Didn’t find a way to test this but testing Orders stats should be enough.
    - Go to Analytics > Orders. Charts should be visible.
- `plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Segmenter.php`
    - Didn’t find a way to test this but testing Products stats should be enough.
    - Go to Analytics > Products. Charts should be visible.
- `plugins/woocommerce/src/Admin/API/Reports/Segmenter.php`
    - Didn’t find a way to test this but checking any Analytics page should be enough. the code doesn’t do anything harmful. just adds a type check before `count`
- `plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php`
`plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php`
    - Create a couple tax rates, apply a different country code for each one.
    - Create two orders one for each tax rate.
    - Go to Analytics > Taxes. It should show orders correctly.
- `plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php`
    - Didn’t find a way to test this. Code only adds a type check. In any case [unit tests](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php#L979) should cover it. 
- `plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Segmenter.php`
    - Doesn't need testing. The return type just got updated in the docblock and just initializes a variable with a default value.
- `plugins/woocommerce/src/Admin/API/Themes.php`
    - No need to test this one as it just fixes how the variable is initialized.
    - In any case visiting any WooCommerce page should confirm it works since the code is run on every page to register the `wc-admin/themes`  REST route.
- `plugins/woocommerce/src/Admin/PageController.php`
    - Visit any WooCommerce page. The page title should be correct.
- `plugins/woocommerce/src/Admin/RemoteInboxNotifications/PluginsActivatedRuleProcessor.php`
    - No need to test this as it only added a type check before `count`
- `plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php`
    - No need to test this as it only added a type check before `count`
- `plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php`
    - No need to test this as it only added a type check before `count`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>