### PR TITLE
Remove old noticed on classic checkout when applying coupon code

### DIFF
--- a/plugins/woocommerce/changelog/43244-fix-43161-remove-previous-notices
+++ b/plugins/woocommerce/changelog/43244-fix-43161-remove-previous-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove old noticed on classic checkout when applying coupon code

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -572,7 +572,7 @@ jQuery( function( $ ) {
 			return false;
 		},
 		submit_error: function( error_message ) {
-			$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message' ).remove();
+			$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message, .is-error, .is-success' ).remove();
 			wc_checkout_form.$checkout_form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + error_message + '</div>' ); // eslint-disable-line max-len
 			wc_checkout_form.$checkout_form.removeClass( 'processing' ).unblock();
 			wc_checkout_form.$checkout_form.find( '.input-text, select, input:checkbox' ).trigger( 'validate' ).trigger( 'blur' );

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -407,7 +407,7 @@ jQuery( function( $ ) {
 						var $form = $( 'form.checkout' );
 
 						// Remove notices from all sources
-						$( '.woocommerce-error, .woocommerce-message' ).remove();
+						$( '.woocommerce-error, .woocommerce-message, .is-error, .is-success' ).remove();
 
 						// Add new errors returned by this event
 						if ( data.messages ) {
@@ -626,7 +626,7 @@ jQuery( function( $ ) {
 				url:		wc_checkout_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'apply_coupon' ),
 				data:		data,
 				success:	function( code ) {
-					$( '.woocommerce-error, .woocommerce-message' ).remove();
+					$( '.woocommerce-error, .woocommerce-message, .is-error, .is-success' ).remove();
 					$form.removeClass( 'processing' ).unblock();
 
 					if ( code ) {
@@ -666,7 +666,7 @@ jQuery( function( $ ) {
 				url:     wc_checkout_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'remove_coupon' ),
 				data:    data,
 				success: function( code ) {
-					$( '.woocommerce-error, .woocommerce-message' ).remove();
+					$( '.woocommerce-error, .woocommerce-message, .is-error, .is-success' ).remove();
 					container.removeClass( 'processing' ).unblock();
 
 					if ( code ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43161.

Ensure that old notices are removed when applying coupon codes in the shortcode-based checkout.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a coupon code.
2. Create a test page and add the following checkout shortcode to it:
```
[woocommerce_checkout]
```
3. Go to the frontend and add a product to the cart.
4. Go to the test page with the checkout shortcode.
5. Apply the coupon code multiple times.
6. Verify that, apart from the `Have a coupon?` notice, only one notice appears for the applied coupon code.
7. Apply an invalid coupon code.
8. Verify that, apart from the `Have a coupon?` notice, only one notice appears for the invalid coupon code.
9. Remove the applied coupon code.
10. Verify that, apart from the `Have a coupon?` notice, only one notice appears for the removed coupon code. 

## Apply valid coupon code

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1070" alt="Screenshot 2024-01-03 at 17 34 05" src="https://github.com/woocommerce/woocommerce/assets/3323310/ae13f14d-c884-497c-8375-a8de14742031">
</td>
<td valign="top">After:
<br><br>
<img width="1040" alt="Screenshot 2024-01-03 at 17 22 57" src="https://github.com/woocommerce/woocommerce/assets/3323310/d2e3b1fe-c0f0-48ac-b090-abc4fb06161d">
</td>
</tr>
</table>

## Apply invalid coupon code

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1077" alt="Screenshot 2024-01-03 at 17 35 54" src="https://github.com/woocommerce/woocommerce/assets/3323310/a3616c49-4d33-4255-86de-10ab64c6927f">
</td>
<td valign="top">After:
<br><br>
<img width="1062" alt="Screenshot 2024-01-03 at 17 23 28" src="https://github.com/woocommerce/woocommerce/assets/3323310/b9153783-e82d-4913-be8b-27e211d6ea0f">
</td>
</tr>
</table>

## Remove coupon code

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1081" alt="Screenshot 2024-01-03 at 17 36 21" src="https://github.com/woocommerce/woocommerce/assets/3323310/d0b862d7-0030-447a-b575-f94c63003ee1">
</td>
<td valign="top">After:
<br><br>
<img width="1073" alt="Screenshot 2024-01-03 at 17 23 50" src="https://github.com/woocommerce/woocommerce/assets/3323310/11c38728-0c6a-4daf-9e51-39bf929168c0">
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove old noticed on classic checkout when applying coupon code

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
