### PR TITLE
Product Gallery: Fix Large Image snapping position on window resize

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -155,15 +155,16 @@ $admin-bar-mobile-height: 46px;
 		width: 100%;
 		display: flex;
 		align-items: center;
+		scroll-snap-align: none center;
 	}
 
 	.wc-block-product-gallery-large-image__container {
 		display: flex;
 		overflow-x: hidden;
 		scroll-snap-type: x mandatory;
+		scroll-behavior: auto;
 		width: fit-content;
 		height: fit-content;
-		scroll-behavior: auto;
 		align-items: center;
 	}
 

--- a/plugins/woocommerce-blocks/changelog/fix-42852-product-gallery-block-snapping-position-on-resize
+++ b/plugins/woocommerce-blocks/changelog/fix-42852-product-gallery-block-snapping-position-on-resize
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Fix Large Image snapping position on window resize.

--- a/plugins/woocommerce/changelog/fix-42852-product-gallery-block-snapping-position-on-resize
+++ b/plugins/woocommerce/changelog/fix-42852-product-gallery-block-snapping-position-on-resize
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Fix Large Image snapping position on window resize.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR fixes the issue with the Product Gallery Large Image losing focus of the current ("focused") image on browser window resize.

Closes #42852 .

| Before | After |
| ------ | ----- |
|![fl61KTGOaI](https://github.com/woocommerce/woocommerce/assets/905781/bb8c88d4-78a2-4343-bca8-c1494a2c2304)|![oOofzECJFs](https://github.com/woocommerce/woocommerce/assets/905781/34c02956-c9aa-420f-bea8-53ad0fa8aaeb)|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Appearance > Editor > Templates > Single Product (clear customizations)
2. Click on the editor and you should see "Transform into blocks" action button.
3. Add the Product Gallery block (it's best if it's set to full-width layout).
4. Open a Product that has multiple images in its gallery.
5. Scroll to an image (make sure you are not testing on the default, first image).
6. Ensure the image stays correctly in focus when resizing the browser window. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
