### PR TITLE
[Experimental] Add: notice informing users about the usage of filter blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/warning.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/components/warning.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings';
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const Warning = () => {
+	const isWidgetEditor = getSetting< boolean >( 'isWidgetEditor' );
+	if ( isWidgetEditor ) {
+		return (
+			<Notice status="info" isDismissible={ false }>
+				{ __(
+					'The widget area containing Collection Filters block needs to be placed on a product archive page for filters to function properly.',
+					'woocommerce'
+				) }
+			</Notice>
+		);
+	}
+
+	const isSiteEditor = getSetting< boolean >( 'isSiteEditor' );
+	if ( ! isSiteEditor ) {
+		return (
+			<Notice status="warning" isDismissible={ false }>
+				{ __(
+					'When added to a post or page, Collection Filters block needs to be nested inside a Product Collection block to function properly.',
+					'woocommerce'
+				) }
+			</Notice>
+		);
+	}
+
+	return null;
+};
+
+export default Warning;

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/edit.tsx
@@ -1,16 +1,19 @@
 /**
  * External dependencies
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { Template } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 import { getSetting } from '@woocommerce/settings';
 import type { AttributeSetting } from '@woocommerce/types';
-import { Template } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { EditProps, FilterType } from './types';
 import { getAllowedBlocks } from './utils';
+import Warning from './components/warning';
+import './editor.scss';
 
 const DISALLOWED_BLOCKS = [
 	'woocommerce/filter-wrapper',
@@ -51,8 +54,17 @@ const Edit = ( props: EditProps ) => {
 
 	const blockProps = useBlockProps();
 
+	const isNested = useSelect( ( select ) => {
+		const { getBlockParentsByBlockName } = select( 'core/block-editor' );
+		return !! getBlockParentsByBlockName(
+			props.clientId,
+			'woocommerce/product-collection'
+		).length;
+	} );
+
 	return (
 		<nav { ...blockProps }>
+			{ ! isNested && <Warning /> }
 			<InnerBlocks
 				template={ template }
 				allowedBlocks={ allowedBlocks }

--- a/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/collection-filters/editor.scss
@@ -1,0 +1,5 @@
+.wp-block-woocommerce-collection-filters {
+	.components-notice {
+		margin: 0;
+	}
+}

--- a/plugins/woocommerce/changelog/fix-43210-collection-filters-in-post-editor
+++ b/plugins/woocommerce/changelog/fix-43210-collection-filters-in-post-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add a notice to inform merchants about the usage of filter blocks.
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CollectionFilters.php
@@ -61,10 +61,13 @@ final class CollectionFilters extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
+		global $pagenow;
 		parent::enqueue_data( $attributes );
 
 		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme(), true );
 		$this->asset_data_registry->add( 'isProductArchive', is_shop() || is_product_taxonomy(), true );
+		$this->asset_data_registry->add( 'isSiteEditor', 'site-editor.php' === $pagenow, true );
+		$this->asset_data_registry->add( 'isWidgetEditor', 'widgets.php' === $pagenow || 'customize.php' === $pagenow, true );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds some notices to the `Collection Filters` block in these cases:
- A `warning` when merchants add the `Collection Filters` block to a post or page without nested in the `Product Collection` block.
- A `info` notice when new filter blocks are used as widgets in classic themes.

I thought about using dynamic parent/ancestor property to limit the discovery of new filter blocks in post/page editor but I think a notice is better because unable to find filter blocks on the post/page editor can make merchants confused. Having them available widely but with guidance for unexpected usecases is better IMO.

![image](https://github.com/woocommerce/woocommerce/assets/5423135/9cdbf665-353e-4a48-be55-ac5b2841bc61)
![image](https://github.com/woocommerce/woocommerce/assets/5423135/dd304c06-6449-4d9c-98dd-00ac6c0e1f2a)


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43210  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate a block theme.
2. Add a new page.
3. Add `Collection Filters` block to the page.
4. See warning.
5. Add `Product Collection` block to the page.
6. Move the `Collection Filters` block into the `Product Collection`.
7. See the warning disappear.'
8. Edit the `Product Catalog` template.
9. Add the `Collection Filters` block to the template.
10. See no warning.

For Classic themes:

1. Active the Storefront theme.
2. Go to Appearance > Widgets.
3. Add `Collection Filters` block to the sidebar.
4. See the notice.
5. Save changes.
6. Go to Appearance > Customize > Widgets > Sidebar.
7. See the same notice there.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
