### PR TITLE
Fix incorrect layout of Product Collection placeholder on Firefox

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/editor.scss
@@ -40,6 +40,7 @@ $max-button-width: calc((100% - #{ $total-gap-width }) / #{ $max-columns });
 		grid-gap: $gap-small;
 		margin: $gap-large auto;
 		max-width: 1000px;
+		width: 100%;
 	}
 
 	.wc-blocks-product-collection__collection-button {

--- a/plugins/woocommerce/changelog/fix-product-collection-layout-firefox
+++ b/plugins/woocommerce/changelog/fix-product-collection-layout-firefox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect layout of Product Collection placeholder in Firefox browser


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There's new flow of adding Product Collection with the placeholder in which you can choose Collection. It displays incorrectly in the Firefox browser.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. In Firefox:
1. Add new post
2. Add Product Collection block
3. Make sure the layout is correct (check the screenshot below). Narrow down the browser width and make sure block is responsive (the number of columns decreases).
4. Repeat in Product Catalog template

**Do the same in Chrome and Safari browsers.**

Before | After
-- | --
![image](https://github.com/woocommerce/woocommerce/assets/20098064/d8fe7cde-b547-4bbd-8294-a52e167aab5f) | <img width="1205" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/7b37c43d-423b-4123-aa13-168c1d902078">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
