### PR TITLE
Add tracking to non-WooCommerce commands

### DIFF
--- a/plugins/woocommerce/changelog/43265-update-command-palette-external-commands-tracking
+++ b/plugins/woocommerce/changelog/43265-update-command-palette-external-commands-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add tracking to non-WooCommerce commands in the Command Palette.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a follow-up of https://github.com/woocommerce/woocommerce/pull/41605 and https://github.com/woocommerce/woocommerce/pull/41838, with the goal to add tracking when the user triggers a non-WooCommerce Command.

[Tracking added to non-WooCommerce commands](https://github.com/woocommerce/woocommerce/assets/3616980/2a957dac-89f5-4539-ba60-548a36426049)

> [!CAUTION]
> The current implementation has some technical flaws I want to highlight:
> 
> * It relies on specific DOM selectors like `.commands-command-menu__container [role="option"]`. We can't assume they won't change in future versions of Gutenberg, so that would be introducing a possible breakage point in the future.
> * It adds `keydown` and `click` listeners to the document, which is not optimal.
> 
> That is because I didn't find a way to "hook" into commands created by Gutenberg or other third parties. So I needed to keep track of the selected option and listen to click and <kbd>Enter</kbd> presses to know when an option was triggered. > As mentioned, this is far from optimal and likely to break in future versions of Gutenberg, but it's the only solution I could find for now.
> 
> Based on all of that, I think we need to make the decision on whether the mentioned trade-offs are worth having this tracking or not. cc @sunyatasattva @pmcpinto 
> 
> Note: We could alternatively open an issue in Gutenberg suggesting to add a way to hook into Gutenberg commands. This would simplify our solution.

### How to test the changes in this Pull Request:

0. To test tracking, open the browser console (<kbd>F12</kbd>) and run `localStorage.setItem( 'debug', 'wc-admin:*' );`.
1. Go to the post editor (Posts > Add New).
2. Press <kbd>Ctrl</kbd>+<kbd>K</kbd> to open the Command Palette.
3. Type `breadcrumbs` as the search term in the Command Palette.
4. Click on the first command that appears.
5. Verify an event has been triggered  (in the browser console you will see something like `wc-admin:tracks recordevent wcadmin_woocommerce_command_palette_submit 
{ name: "hide block breadcrumbs", origin: "post-editor" }`).
6. Now repeat steps 2-5, but instead of clicking on the option, press <kbd>Enter</kbd>.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add tracking to non-WooCommerce commands in the Command Palette.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
