### PR TITLE
Fix commands with tags breaking the command palette

### DIFF
--- a/plugins/woocommerce/changelog/43269-fix-command-palette-commands-with-tags
+++ b/plugins/woocommerce/changelog/43269-fix-command-palette-commands-with-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix WooCommerce Settings and Analytics commands with tags breaking the command palette
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -592,7 +592,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					) {
 						$formatted_settings_tabs[] = array(
 							'key'   => $key,
-							'label' => $label,
+							'label' => wp_strip_all_tags( $label ),
 						);
 					}
 				}
@@ -622,7 +622,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 							is_string( $path ) && $path !== ""
 						) {
 							return array(
-								'title' => $title,
+								'title' => wp_strip_all_tags( $title ),
 								'path' => $path,
 							);
 						}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<img src="https://github.com/woocommerce/woocommerce/assets/3616980/42da8d43-ec6d-4c6f-8a89-fba7789fbbec" width="344" alt="" />

Some plugins, like AutomateWoo, add an Analytics or Settings screen with an HTML or React tag in the title (see screenshot above). WooCommerce would automatically create a command for them, but when hovering or focusing that command, the editor would crash with an error similar to `DOMException: Document.querySelector: '[cmdk-item=""][data-value="woocommerce analytics: <automatewoo-icon aria-label="automatewoo"></automatewoo-icon>workflows"]' is not a valid selector`.

[Enregistrament de pantalla del 2024-01-10 15-17-51.webm](https://github.com/woocommerce/woocommerce/assets/3616980/f072a535-a0cc-4095-a322-a3b0190b7b62)

The issue is only reproducible when hovering or focusing a command which contains an HTML/React tag in the name.

The issue causes the entire editor to crash.

This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Install AutomateWoo.
2. Create a post and press <kbd>Ctrl</kbd>+<kbd>K</kbd> (<kbd>Cmd</kbd>+<kbd>K</kbd> on Mac) to open the Command Palette.
3. Search for `WooCommerce Analytics: Workflows`.
![](https://github.com/woocommerce/woocommerce/assets/3616980/e4c8f708-bb39-4608-a35d-ed226077c8c2)
4. Click on it and verify you are redirected to the `Analytics > [AW] Workflows` page (the URL will look like `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fautomatewoo-runs-by-date`) and there is no JS error.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Fix WooCommerce Settings and Analytics commands with tags breaking the command palette

</details>
