### PR TITLE
[Experimental] Add additional information block for custom checkout fields

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/context/event-emit/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/event-emit/utils.ts
@@ -35,6 +35,7 @@ export enum noticeContexts {
 	BILLING_ADDRESS = 'wc/checkout/billing-address',
 	SHIPPING_METHODS = 'wc/checkout/shipping-methods',
 	CHECKOUT_ACTIONS = 'wc/checkout/checkout-actions',
+	ADDITIONAL_INFORMATION = 'wc/checkout/additional-information',
 }
 
 export interface ResponseType extends Record< string, unknown > {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/index.tsx
@@ -159,7 +159,7 @@ const settings = {
 				);
 			},
 		},
-		// Adds the additional information block
+		// Adds the additional information block.
 		{
 			save( { attributes }: { attributes: { className: string } } ) {
 				return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/index.tsx
@@ -116,6 +116,11 @@ const settings = {
 									{},
 									[]
 								),
+								createBlock(
+									'woocommerce/checkout-additional-information-block',
+									{},
+									[]
+								),
 								showOrderNotes
 									? createBlock(
 											'woocommerce/checkout-order-note-block',
@@ -152,6 +157,84 @@ const settings = {
 					( block: { name: string } ) =>
 						block.name === 'woocommerce/checkout-fields-block'
 				);
+			},
+		},
+		// Adds the additional information block
+		{
+			save( { attributes }: { attributes: { className: string } } ) {
+				return (
+					<div
+						className={ classnames(
+							'is-loading',
+							attributes.className
+						) }
+					/>
+				);
+			},
+			isEligible: (
+				_attributes: Record< string, unknown >,
+				innerBlocks: BlockInstance[]
+			) => {
+				const checkoutFieldsBlock = innerBlocks.find(
+					( block: { name: string } ) =>
+						block.name === 'woocommerce/checkout-fields-block'
+				);
+
+				if ( ! checkoutFieldsBlock ) {
+					return false;
+				}
+
+				// Top level block is the fields block, we then need to search within that for the additional information block.
+				return ! checkoutFieldsBlock.innerBlocks.some(
+					( block: { name: string } ) =>
+						block.name ===
+						'woocommerce/checkout-additional-information-block'
+				);
+			},
+			migrate: (
+				attributes: Record< string, unknown >,
+				innerBlocks: BlockInstance[]
+			) => {
+				const checkoutFieldsBlockIndex = innerBlocks.findIndex(
+					( block: { name: string } ) =>
+						block.name === 'woocommerce/checkout-fields-block'
+				);
+
+				if ( checkoutFieldsBlockIndex === -1 ) {
+					return false;
+				}
+
+				const checkoutFieldsBlock =
+					innerBlocks[ checkoutFieldsBlockIndex ];
+
+				const insertIndex = checkoutFieldsBlock.innerBlocks.findIndex(
+					( block: { name: string } ) =>
+						block.name ===
+						'wp-block-woocommerce-checkout-payment-block'
+				);
+
+				if ( insertIndex === -1 ) {
+					return false;
+				}
+
+				innerBlocks[ checkoutFieldsBlockIndex ] =
+					checkoutFieldsBlock.innerBlocks
+						.slice( 0, insertIndex )
+						.concat(
+							createBlock(
+								'woocommerce/checkout-additional-information-block',
+								{},
+								[]
+							)
+						)
+						.concat(
+							innerBlocks.slice(
+								insertIndex + 1,
+								innerBlocks.length
+							)
+						);
+
+				return [ attributes, innerBlocks ];
 			},
 		},
 	],

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/attributes.tsx
@@ -11,10 +11,7 @@ import formStepAttributes from '../../form-step/attributes';
 export default {
 	...formStepAttributes( {
 		defaultTitle: __( 'Additional order information', 'woocommerce' ),
-		defaultDescription: __(
-			'Enter any additional information about your order.',
-			'woocommerce'
-		),
+		defaultDescription: '',
 	} ),
 	className: {
 		type: 'string',

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/attributes.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import formStepAttributes from '../../form-step/attributes';
+
+export default {
+	...formStepAttributes( {
+		defaultTitle: __( 'Additional order information', 'woocommerce' ),
+		defaultDescription: __(
+			'Enter any additional information about your order.',
+			'woocommerce'
+		),
+	} ),
+	className: {
+		type: 'string',
+		default: '',
+	},
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
+};

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.json
@@ -19,7 +19,7 @@
 			"type": "object",
 			"default": {
 				"remove": true,
-				"move": true
+				"move": false
 			}
 		}
 	},

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.json
@@ -1,0 +1,30 @@
+{
+	"name": "woocommerce/checkout-additional-information-block",
+	"version": "1.0.0",
+	"title": "Additional information",
+	"description": "Render additional fields in the 'Additional information' location.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false
+	},
+	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": true,
+				"move": true
+			}
+		}
+	},
+	"parent": [ "woocommerce/checkout-fields-block" ],
+	"textdomain": "woocommerce",
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
@@ -2,22 +2,18 @@
  * External dependencies
  */
 import { noticeContexts } from '@woocommerce/base-context';
-import { __ } from '@wordpress/i18n';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import type { FunctionComponent } from 'react';
-import NoticeBanner from '@woocommerce/base-components/notice-banner';
 
 const Block: FunctionComponent = () => {
-	const { additionalFields, isEditor } = useSelect( ( select ) => {
+	const { additionalFields } = useSelect( ( select ) => {
 		const store = select( CHECKOUT_STORE_KEY );
-		const editorStore = select( 'core/editor' );
 		return {
 			additionalFields: store.getAdditionalFields(),
-			isEditor: !! editorStore,
 		};
 	} );
 
@@ -31,19 +27,8 @@ const Block: FunctionComponent = () => {
 		...additionalFields,
 	};
 
-	if ( ADDITIONAL_FORM_KEYS.length === 0 && ! isEditor ) {
+	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
 		return null;
-	}
-
-	if ( ADDITIONAL_FORM_KEYS.length === 0 && isEditor ) {
-		return (
-			<NoticeBanner status="warning" isDismissible={ false }>
-				{ __(
-					'There are no custom fields registered. This block will not be visible on the front-end.',
-					'woocommerce'
-				) }
-			</NoticeBanner>
-		);
 	}
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
@@ -2,18 +2,22 @@
  * External dependencies
  */
 import { noticeContexts } from '@woocommerce/base-context';
+import { __ } from '@wordpress/i18n';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import type { FunctionComponent } from 'react';
+import NoticeBanner from '@woocommerce/base-components/notice-banner';
 
 const Block: FunctionComponent = () => {
-	const { additionalFields } = useSelect( ( select ) => {
+	const { additionalFields, isEditor } = useSelect( ( select ) => {
 		const store = select( CHECKOUT_STORE_KEY );
+		const editorStore = select( 'core/editor' );
 		return {
 			additionalFields: store.getAdditionalFields(),
+			isEditor: !! editorStore,
 		};
 	} );
 
@@ -27,8 +31,19 @@ const Block: FunctionComponent = () => {
 		...additionalFields,
 	};
 
-	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
+	if ( ADDITIONAL_FORM_KEYS.length === 0 && ! isEditor ) {
 		return null;
+	}
+
+	if ( ADDITIONAL_FORM_KEYS.length === 0 && isEditor ) {
+		return (
+			<NoticeBanner status="warning" isDismissible={ false }>
+				{ __(
+					'There are no custom fields registered. This block will not be visible on the front-end.',
+					'woocommerce'
+				) }
+			</NoticeBanner>
+		);
 	}
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
@@ -1,5 +1,50 @@
-const Block = ( { className }: { className?: string } ): React.ReactElement => {
-	return <div className={ className }>Additional information block!</div>;
+/**
+ * External dependencies
+ */
+import { noticeContexts } from '@woocommerce/base-context';
+import { StoreNoticesContainer } from '@woocommerce/blocks-components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
+import { Form } from '@woocommerce/base-components/cart-checkout';
+import type { FunctionComponent } from 'react';
+
+const Block: FunctionComponent = () => {
+	const { additionalFields } = useSelect( ( select ) => {
+		const store = select( CHECKOUT_STORE_KEY );
+		return {
+			additionalFields: store.getAdditionalFields(),
+		};
+	} );
+
+	const { setAdditionalFields } = useDispatch( CHECKOUT_STORE_KEY );
+
+	const onChangeForm = ( additionalValues ) => {
+		setAdditionalFields( additionalValues );
+	};
+
+	const additionalFieldValues = {
+		...additionalFields,
+	};
+
+	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			<StoreNoticesContainer
+				context={ noticeContexts.ADDITIONAL_INFORMATION }
+			/>
+			<Form
+				id="additional-information"
+				addressType="additional-information"
+				onChange={ onChangeForm }
+				values={ additionalFieldValues }
+				fields={ ADDITIONAL_FORM_KEYS }
+			/>
+		</>
+	);
 };
 
 export default Block;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
@@ -1,0 +1,5 @@
+const Block = ( { className }: { className?: string } ): React.ReactElement => {
+	return <div className={ className }>Additional information block!</div>;
+};
+
+export default Block;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import Noninteractive from '@woocommerce/base-components/noninteractive';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import './editor.scss';
+
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<Noninteractive>
+				<Block />
+			</Noninteractive>
+		</div>
+	);
+};
+
+export const Save = (): JSX.Element => {
+	return <div { ...useBlockProps.save() } />;
+};

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
@@ -4,6 +4,7 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { FormStepBlock } from '@woocommerce/blocks/checkout/form-step';
 import classnames from 'classnames';
+import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -22,7 +23,11 @@ export const Edit = ( {
 		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
-} ): JSX.Element => {
+} ) => {
+	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<FormStepBlock
 			setAttributes={ setAttributes }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import Noninteractive from '@woocommerce/base-components/noninteractive';
+import { FormStepBlock } from '@woocommerce/blocks/checkout/form-step';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -10,14 +11,29 @@ import Noninteractive from '@woocommerce/base-components/noninteractive';
 import Block from './block';
 import './editor.scss';
 
-export const Edit = (): JSX.Element => {
-	const blockProps = useBlockProps();
+export const Edit = ( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: {
+		title: string;
+		description: string;
+		showStepNumber: boolean;
+		className: string;
+	};
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+} ): JSX.Element => {
 	return (
-		<div { ...blockProps }>
-			<Noninteractive>
-				<Block />
-			</Noninteractive>
-		</div>
+		<FormStepBlock
+			setAttributes={ setAttributes }
+			attributes={ attributes }
+			className={ classnames(
+				'wc-block-checkout__additional-information-fields',
+				attributes?.className
+			) }
+		>
+			<Block />
+		</FormStepBlock>
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/editor.scss
@@ -1,0 +1,12 @@
+// Adjust padding and margins in the editor to improve selected block outlines.
+.wp-block-woocommerce-checkout-order-note-block {
+	margin-top: 20px;
+	margin-bottom: 20px;
+	padding-top: 4px;
+	padding-bottom: 4px;
+
+	.wc-block-checkout__add-note {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
@@ -27,7 +27,6 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ) => {
-	console.log( { title, description, showStepNumber, children, className } );
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { FormStep } from '@woocommerce/blocks-components';
+import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
+import { useSelect } from '@wordpress/data';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+
+const FrontendBlock = ( {
+	title,
+	description,
+	showStepNumber,
+	children,
+	className,
+}: {
+	title: string;
+	description: string;
+	showStepNumber: boolean;
+	children: JSX.Element;
+	className?: string;
+} ) => {
+	const checkoutIsProcessing = useSelect( ( select ) =>
+		select( CHECKOUT_STORE_KEY ).isProcessing()
+	);
+
+	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<FormStep
+			id="additional-information-fields"
+			disabled={ checkoutIsProcessing }
+			className={ classnames(
+				'wc-block-checkout__additional-information-fields',
+				className
+			) }
+			title={ title }
+			description={ description }
+			showStepNumber={ showStepNumber }
+		>
+			<Block />
+			{ children }
+		</FormStep>
+	);
+};
+
+export default FrontendBlock;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
@@ -6,10 +6,13 @@ import { FormStep } from '@woocommerce/blocks-components';
 import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
+
 /**
  * Internal dependencies
  */
 import Block from './block';
+import attributes from './attributes';
 
 const FrontendBlock = ( {
 	title,
@@ -24,6 +27,7 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ) => {
+	console.log( { title, description, showStepNumber, children, className } );
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
@@ -50,4 +54,4 @@ const FrontendBlock = ( {
 	);
 };
 
-export default FrontendBlock;
+export default withFilteredAttributes( attributes )( FrontendBlock );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/index.tsx
@@ -9,8 +9,10 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import { Edit, Save } from './edit';
 import './style.scss';
+import attributes from './attributes';
 
 registerBlockType( 'woocommerce/checkout-additional-information-block', {
+	attributes,
 	icon: {
 		src: (
 			<Icon

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { Icon, customPostType } from '@wordpress/icons';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { Edit, Save } from './edit';
+import './style.scss';
+
+registerBlockType( 'woocommerce/checkout-additional-information-block', {
+	icon: {
+		src: (
+			<Icon
+				icon={ customPostType }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/style.scss
@@ -1,0 +1,29 @@
+.wc-block-checkout__add-note {
+	margin: em($gap-large) 0;
+}
+
+.is-mobile,
+.is-small,
+.is-medium {
+	.wc-block-checkout__add-note {
+		border-bottom: 1px solid $universal-border-light;
+		margin-bottom: em($gap);
+		margin-top: em($gap);
+		padding: em($gap) 0;
+	}
+}
+
+.wc-block-checkout__add-note .wc-block-components-textarea {
+	margin-top: $gap;
+
+	&:focus {
+		background-color: #fff;
+		color: $input-text-active;
+		outline: 0;
+		box-shadow: 0 0 0 1px $input-border-gray;
+	}
+}
+
+.wc-block-components-form .wc-block-checkout__order-notes.wc-block-components-checkout-step {
+	padding-left: 0;
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -47,6 +47,7 @@ export const Edit = ( {
 		[ 'woocommerce/checkout-billing-address-block', {}, [] ],
 		[ 'woocommerce/checkout-shipping-methods-block', {}, [] ],
 		[ 'woocommerce/checkout-payment-block', {}, [] ],
+		[ 'woocommerce/checkout-additional-information-block', {}, [] ],
 		[ 'woocommerce/checkout-order-note-block', {}, [] ],
 		[ 'woocommerce/checkout-terms-block', {}, [] ],
 		[ 'woocommerce/checkout-actions-block', {}, [] ],

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/component-metadata.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/component-metadata.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import CHECKOUT_ACTIONS from './checkout-actions-block/block.json';
+import CHECKOUT_ADDITIONAL_INFORMATION from './checkout-additional-information-block/block.json';
 import CHECKOUT_BILLING_ADDRESS from './checkout-billing-address-block/block.json';
 import CHECKOUT_CONTACT_INFORMATION from './checkout-contact-information-block/block.json';
 import CHECKOUT_EXPRESS_PAYMENT from './checkout-express-payment-block/block.json';
@@ -25,6 +26,7 @@ import CHECKOUT_ORDER_SUMMARY_CART_ITEMS from './checkout-order-summary-cart-ite
 
 export default {
 	CHECKOUT_ACTIONS,
+	CHECKOUT_ADDITIONAL_INFORMATION,
 	CHECKOUT_BILLING_ADDRESS,
 	CHECKOUT_CONTACT_INFORMATION,
 	CHECKOUT_EXPRESS_PAYMENT,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/index.tsx
@@ -8,6 +8,7 @@ import './checkout-terms-block';
 import './checkout-contact-information-block';
 import './checkout-billing-address-block';
 import './checkout-actions-block';
+import './checkout-additional-information-block';
 import './checkout-order-note-block';
 import './checkout-order-summary-block';
 import './checkout-payment-block';

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
@@ -110,6 +110,16 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
+	metadata: metadata.CHECKOUT_ADDITIONAL_INFORMATION,
+	component: lazy(
+		() =>
+			import(
+				/* webpackChunkName: "checkout-blocks/additional-information" */ './checkout-additional-information-block/block'
+			)
+	),
+} );
+
+registerCheckoutBlock( {
 	metadata: metadata.CHECKOUT_ORDER_NOTE,
 	component: lazy(
 		() =>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
@@ -114,7 +114,7 @@ registerCheckoutBlock( {
 	component: lazy(
 		() =>
 			import(
-				/* webpackChunkName: "checkout-blocks/additional-information" */ './checkout-additional-information-block/block'
+				/* webpackChunkName: "checkout-blocks/additional-information" */ './checkout-additional-information-block/frontend'
 			)
 	),
 } );

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -55,6 +55,7 @@ export type ContactForm = CoreContactForm & Record< string, FormField >;
 export type FormFields = AddressForm & ContactForm;
 export type AddressFormValues = Omit< ShippingAddress, 'email' >;
 export type ContactFormValues = { email: string };
+export type AdditionalInformationFormValues = Record< string, string >;
 export type FormType =
 	| 'billing'
 	| 'shipping'

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -55,7 +55,11 @@ export type ContactForm = CoreContactForm & Record< string, FormField >;
 export type FormFields = AddressForm & ContactForm;
 export type AddressFormValues = Omit< ShippingAddress, 'email' >;
 export type ContactFormValues = { email: string };
-export type FormType = 'billing' | 'shipping' | 'contact';
+export type FormType =
+	| 'billing'
+	| 'shipping'
+	| 'contact'
+	| 'additional-information';
 
 export interface CoreAddress {
 	first_name: string;

--- a/plugins/woocommerce-blocks/tests/e2e/bin/pages/checkout.html
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/pages/checkout.html
@@ -32,6 +32,10 @@
 <div class="wp-block-woocommerce-checkout-payment-block"></div>
 <!-- /wp:woocommerce/checkout-payment-block -->
 
+<!-- wp:woocommerce/checkout-additional-information-block -->
+<div class="wp-block-woocommerce-checkout-additional-information-block"></div>
+<!-- /wp:woocommerce/checkout-additional-information-block -->
+
 <!-- wp:woocommerce/checkout-order-note-block -->
 <div class="wp-block-woocommerce-checkout-order-note-block"></div>
 <!-- /wp:woocommerce/checkout-order-note-block -->

--- a/plugins/woocommerce/changelog/43274-add-rebase-42081-additional-fields
+++ b/plugins/woocommerce/changelog/43274-add-rebase-42081-additional-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow additional fields to be rendered at the end of the Checkout block.

--- a/plugins/woocommerce/changelog/43274-add-rebase-42081-additional-fields
+++ b/plugins/woocommerce/changelog/43274-add-rebase-42081-additional-fields
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Allow additional fields to be rendered at the end of the Checkout block.

--- a/plugins/woocommerce/changelog/43274-add-rebase-42081-additional-fields
+++ b/plugins/woocommerce/changelog/43274-add-rebase-42081-additional-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Allow additional fields to be rendered at the end of the Checkout block.  This is locked behind a feature flag, the fields won't show up until we remove the feature gate.
+

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2586,6 +2586,10 @@ EOT;
 <div class="wp-block-woocommerce-checkout-payment-block"></div>
 <!-- /wp:woocommerce/checkout-payment-block -->
 
+<!-- wp:woocommerce/checkout-additional-information-block -->
+<div class="wp-block-woocommerce-checkout-additional-information-block"></div>
+<!-- /wp:woocommerce/checkout-additional-information-block -->
+
 <!-- wp:woocommerce/checkout-order-note-block -->
 <div class="wp-block-woocommerce-checkout-order-note-block"></div>
 <!-- /wp:woocommerce/checkout-order-note-block -->

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -169,7 +169,8 @@ class Checkout extends AbstractBlock {
 					<div data-block-name="woocommerce/checkout-shipping-address-block" class="wp-block-woocommerce-checkout-shipping-address-block"></div>
 					<div data-block-name="woocommerce/checkout-billing-address-block" class="wp-block-woocommerce-checkout-billing-address-block"></div>
 					<div data-block-name="woocommerce/checkout-shipping-methods-block" class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
-					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>' .
+					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>
+					<div data-block-name="woocommerce/checkout-additional-information-block" class="wp-block-woocommerce-checkout-additional-information-block"></div>' .
 					( isset( $attributes['showOrderNotes'] ) && false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
 					( isset( $attributes['showPolicyLinks'] ) && false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
 					'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -218,6 +218,22 @@ class Checkout extends AbstractBlock {
 			$content                      = preg_replace( $shipping_address_block_regex, $local_pickup_inner_blocks, $content );
 		}
 
+		/**
+		 * Add the Additional Information block to checkouts missing it.
+		 */
+		$additional_information_inner_blocks = '$0' . PHP_EOL . PHP_EOL . '<div data-block-name="woocommerce/checkout-additional-information-block" class="wp-block-woocommerce-checkout-additional-information-block"></div>' . PHP_EOL . PHP_EOL;
+		$has_additional_information_regex    = '/<div[^<]*?data-block-name="woocommerce\/checkout-additional-information-block"[^>]*?>/mi';
+		$has_additional_information_block          = preg_match( $has_additional_information_regex, $content );
+
+		if ( ! $has_additional_information_block ) {
+			$payment_block_regex = '/<div[^<]*?data-block-name="woocommerce\/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"[^>]*?><\/div>/mi';
+			//$old = $content;
+			//echo htmlentities( json_encode( $content ) );
+			$content                      = preg_replace( $payment_block_regex, $additional_information_inner_blocks, $content );
+			//echo htmlentities( json_encode( $content ) );
+			//die();
+		}
+
 		return $content;
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -223,15 +223,11 @@ class Checkout extends AbstractBlock {
 		 */
 		$additional_information_inner_blocks = '$0' . PHP_EOL . PHP_EOL . '<div data-block-name="woocommerce/checkout-additional-information-block" class="wp-block-woocommerce-checkout-additional-information-block"></div>' . PHP_EOL . PHP_EOL;
 		$has_additional_information_regex    = '/<div[^<]*?data-block-name="woocommerce\/checkout-additional-information-block"[^>]*?>/mi';
-		$has_additional_information_block          = preg_match( $has_additional_information_regex, $content );
+		$has_additional_information_block    = preg_match( $has_additional_information_regex, $content );
 
 		if ( ! $has_additional_information_block ) {
 			$payment_block_regex = '/<div[^<]*?data-block-name="woocommerce\/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"[^>]*?><\/div>/mi';
-			//$old = $content;
-			//echo htmlentities( json_encode( $content ) );
-			$content                      = preg_replace( $payment_block_regex, $additional_information_inner_blocks, $content );
-			//echo htmlentities( json_encode( $content ) );
-			//die();
+			$content             = preg_replace( $payment_block_regex, $additional_information_inner_blocks, $content );
 		}
 
 		return $content;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -480,6 +480,7 @@ class Checkout extends AbstractBlock {
 		return [
 			'Checkout',
 			'CheckoutActionsBlock',
+			'CheckoutAdditionalInformationBlock',
 			'CheckoutBillingAddressBlock',
 			'CheckoutContactInformationBlock',
 			'CheckoutExpressPaymentBlock',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutAdditionalInformationBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CheckoutAdditionalInformationBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * CheckoutAdditionalInformationBlock class.
+ */
+class CheckoutAdditionalInformationBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'checkout-additional-information-block';
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is based on https://github.com/woocommerce/woocommerce/pull/43088 

It introduces the "Additional Information Block" which is used in the Checkout Block to render custom fields added by the merchant/developers with the `additional` location.

The PR includes changes to migrating from v1 checkout (before inner blocks) in case any stores are suddenly updating since we made those changes

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42081

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


#### Prerequisites to testing

1. Ensure you run `composer install` before testing as this PR introduces new classes.
2. Add the following snippet to your site.
```php
add_action(
	'woocommerce_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-on-porch',
				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'checkbox',
			),
		);

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/location-on-porch',
				'label'    => __( 'Describe where we should hide the parcel', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'text',
			)
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-with-neighbor',
				'label'    => __( 'Which neighbor should we leave it with if unable to hide?', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'select',
				'options'  => [
					[
						'label' => 'Neighbor to the left',
						'value' => 'left'
					],
					[
						'label' => 'Neighbor to the right',
						'value' => 'right'
					],
					[
						'label' => 'Neighbor across the road',
						'value' => 'across'
					],
					[
						'label' => 'Do not leave with a neighbor',
						'value' => 'none'
					],
				]
			)
		);
	}
);
```
3. Install and activate https://wordpress.org/plugins/jsm-show-post-meta/ 

#### In the Checkout Block

1. Go to the Checkout block and scroll down to just before the place order button, you should see the additional fields there.
<img width="719" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/19db310d-c473-4ce0-bd4f-19ddc41f689e">

2. Try to submit the form without filling any fields. The "Which neighbor should we leave it with if unable to hide?" should show an error.
3. Fill in the fields and ensure they work correctly, you can add/remove data from them and check/uncheck the box/select different options.
4. Submit the order and ensure it is successful.
5. Log in as admin and view the order you just placed. Scroll down to the metadata fields added by the `JSM Show Post Metadata` plugin.
6. You should see an entry called `_additional_fields` ensure the values match what you entered.

#### Store API

<details>
<summary>Example API request - expand to see</summary>

```json
{
  "shipping_address": {
    "first_name": "John",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test Road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": ""
	},
  "billing_address": {
    "first_name": "Jon",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": "",
    "email": "test@mail.com",
    "phone": ""
  },
	"additional_fields": {
		"plugin-namespace/leave-on-porch": "yes",
		"plugin-namespace/location-on-porch": "Behind the plant pot",
		"plugin-namespace/leave-with-neighbor": "across"
	},
  "customer_note": "",
  "create_account": false,
  "payment_method": "bacs",
  "payment_data": [
    {
      "key": "wc-bacs-new-payment-method",
      "value": false
    }
  ]
}
```

</details>

1. Add an item to your cart using Store API.
2. Use the example payload to submit the order.
3. Repeat, but this time remove the `"plugin-namespace/leave-with-neighbor": "across"` value, you should get an error.
4. Replace it, and remove the other two values (`"plugin-namespace/leave-on-porch"` and `"plugin-namespace/location-on-porch"`)
5. Ensure the order is placed successfully.

#### In the editor

1. Open the Checkout block in your editor.
2. Scroll down, you should see your custom fields in the "Additional information" section
3. Ensure you can edit the title and description.
4. Change them, save the page.
5. View the page on the front-end and ensure the changes are visible.
6. Remove the snippet and ensure the block is not visible in the editor.

#### Migrating from v1 checkout

1. Create a new page in the page editor, change to code view.
2. Enter the following content and save the page:
```html
<!-- wp:woocommerce/checkout -->
<div class="wp-block-woocommerce-checkout is-loading"></div>
<!-- /wp:woocommerce/checkout -->
``` 
3. Reload the page then switch back to the blocks view. Expect to see the additional fields block with your custom fields in.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Allow additional fields to be rendered at the end of the Checkout block.

This is locked behind a feature flag, the fields won't show up until we remove the feature gate.
</details>
