### PR TITLE
Fix CYS updateStorePatters to use the new images endpoint structure

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -248,7 +248,20 @@ export const updateStorePatterns = async (
 			},
 		} );
 
+		const { is_ai_generated } = await apiFetch< {
+			is_ai_generated: boolean;
+		} >( {
+			path: '/wc/private/ai/store-info',
+			method: 'GET',
+		} );
+
 		if ( ! images.images.length ) {
+			if ( is_ai_generated ) {
+				throw new Error(
+					'AI content not generated: images not available'
+				);
+			}
+
 			await resetPatternsAndProducts()();
 			return;
 		}

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -238,7 +238,7 @@ export const updateStorePatterns = async (
 
 		const { images } = await apiFetch< {
 			ai_content_generated: boolean;
-			images: Array< unknown >;
+			images: { images: Array< unknown >; search_term: string };
 		} >( {
 			path: '/wc/private/ai/images',
 			method: 'POST',
@@ -248,7 +248,7 @@ export const updateStorePatterns = async (
 			},
 		} );
 
-		if ( ! images.length ) {
+		if ( ! images.images.length ) {
 			await resetPatternsAndProducts()();
 			return;
 		}

--- a/plugins/woocommerce/changelog/43285-fix-cys-images-endpoint-bug
+++ b/plugins/woocommerce/changelog/43285-fix-cys-images-endpoint-bug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Use the new AI images endpoint response structure.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
@@ -102,7 +102,10 @@ class Images extends AbstractRoute {
 		$images = ( new Pexels() )->get_images( $ai_connection, $token, $business_description );
 
 		if ( is_wp_error( $images ) ) {
-			$images = [];
+			$images = array(
+				'images'      => array(),
+				'search_term' => '',
+			);
 		}
 
 		return rest_ensure_response(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the `updateStorePatters` function to use the new `/wc/private/ai/images` endpoint response format.
After the changes made here https://github.com/woocommerce/woocommerce/pull/42800/files#diff-96ca6f0343fd0afa90d5c3c29bf472c77c45920d3e8f6aa5d64a71d049d25198R96-R99 it returns an array with `images` and `search_term` (whereas before it returned just the `images`).

It also makes the flow fail when the store was previously AI-generated and the images endpoint fails.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
**Initial Setup**
1. Create a new WooCommerce installation with this version.
2. Ensure Jetpack is installed and your site is connected with JP.
3. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
4. Ensure the Woo AI plugin is installed and activated (available on this monorepo).
5. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

**Testing steps**
_Pre-requisite_: make sure you click on `Resets Customize Your Store changes` in `/wp-admin/tools.php?page=woocommerce-admin-test-helper` if you have already tried the CYS flow before in your store.

1. Modify the `request` function on the `plugins/woocommerce/src/Blocks/Images/Pexels.php` class to return an error (to simulate an error from the Pexels API):
```
private function request( string $search_term, int $per_page = 100 ) {
                return new \WP_Error( 'pexels_api_error', __( 'Request to the Pexels API failed.', 'woocommerce' ), $error_msg );
```
2. Head over to WooCommerce -> Home and click on "Start Customizing".
3. Click the Design with AI button.
4. Fill out a business description and proceed.
5. Make sure the store is generated and the patterns and products have the default content.
6. Remove the line of code added in step 1.
7. Repeat the process and make sure this time the result is AI-generated.
8. Add the line of code again and make sure you get an error (because the `images` endpoint fails and the store is already AI-generated).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Use the new AI images endpoint response structure.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
