### PR TITLE
Product Gallery: Add additional closing of the pop-up

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -53,7 +53,16 @@ const productGallery = {
 		},
 	},
 	actions: {
-		closeDialog: () => {
+		closeDialog: ( event: MouseEvent ) => {
+			// Prevent closing the dialog when clicking on the image.
+			if (
+				( event.target as HTMLElement ).classList.contains(
+					'wc-block-woocommerce-product-gallery-large-image__image'
+				)
+			) {
+				return;
+			}
+
 			const context = getContext();
 			closeDialog( context );
 		},

--- a/plugins/woocommerce-blocks/changelog/add-43000-product-gallery-popup-image-wrapper-click-closing
+++ b/plugins/woocommerce-blocks/changelog/add-43000-product-gallery-popup-image-wrapper-click-closing
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Add closing of the pop-up when clicking outside of the pop-up image.

--- a/plugins/woocommerce/changelog/add-43000-product-gallery-popup-image-wrapper-click-closing
+++ b/plugins/woocommerce/changelog/add-43000-product-gallery-popup-image-wrapper-click-closing
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Add closing of the pop-up when clicking outside of the pop-up image.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -78,7 +78,7 @@ class ProductGallery extends AbstractBlock {
 		$gallery_dialog = strtr(
 			'
 		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess">
-			<dialog data-wc-bind--open="context.isDialogOpen">
+			<dialog data-wc-bind--open="context.isDialogOpen" data-wc-on--click="actions.closeDialog">
 			<div class="wc-block-product-gallery-dialog__header">
 			<div class="wc-block-product-galler-dialog__header-right">
 				<button class="wc-block-product-gallery-dialog__close" data-wc-on--click="actions.closeDialog">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the functionality of pop-up closing when clicking outside of the pop-up image (in addition to the existing 'x' icon closing method).

Closes #43000.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Appearance > Editor > Templates > Single Product (clear customizations)
2. Click on the editor and you should see "Transform into blocks" action button.
3. Add the Product Gallery block.
4. Make sure you have the `Full-screen when clicked` setting enabled.
5. Open a product with multiple images added to the product gallery.
6. Ensure you can open the Product Gallery pop-up correctly.
7. Ensure the closing of the pop-up works correctly:
	- You can close the pop-up using the 'X' icon.
	- You can close the pop-up by clicking outside of the pop-up image.
	- The pop-up doesn't close when you click on the image or the next/previous buttons.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
