### PR TITLE
Product Gallery: Use @container rule to adjust overlay link count font size

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -413,7 +413,7 @@ $admin-bar-mobile-height: 46px;
 		top: 0;
 		width: 100%;
 		height: 100%;
-		line-height: 1.5em;
+		line-height: 1.5;
 
 		.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
 			font-size: 1.2rem;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -437,17 +437,29 @@ $admin-bar-mobile-height: 46px;
 			.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
 				font-size: 1rem;
 			}
+
+			.wc-block-product-gallery-thumbnails__thumbnail__view-all {
+				font-size: 0.6rem;
+			}
 		}
 
 		@container (width > 70px) {
 			.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
 				font-size: 1.2rem;
 			}
+
+			.wc-block-product-gallery-thumbnails__thumbnail__view-all {
+				font-size: 0.8rem;
+			}
 		}
 
 		@container (width > 100px) {
 			.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
 				font-size: 1.4rem;
+			}
+
+			.wc-block-product-gallery-thumbnails__thumbnail__view-all {
+				font-size: 1rem;
 			}
 		}
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -402,6 +402,7 @@ $admin-bar-mobile-height: 46px;
 	}
 
 	.wc-block-product-gallery-thumbnails__thumbnail__overlay {
+		container-type: inline-size;
 		cursor: pointer;
 		display: flex;
 		flex-direction: column;
@@ -412,8 +413,10 @@ $admin-bar-mobile-height: 46px;
 		top: 0;
 		width: 100%;
 		height: 100%;
+		line-height: 1.5em;
 
 		.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
+			font-size: 1.2rem;
 			font-weight: 700;
 		}
 
@@ -426,28 +429,25 @@ $admin-bar-mobile-height: 46px;
 			color: #fff;
 		}
 
-		@mixin thumbnail-overlay-text-font-size($remaining-count-size, $view-all-size, $view-all-display: block) {
-			.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
-				font-size: $remaining-count-size;
+		@container (width < 70px) {
+			.wc-block-product-gallery-thumbnails__thumbnail__view-all {
+				display: none;
 			}
 
-			.wc-block-product-gallery-thumbnails__thumbnail__view-all {
-				font-size: $view-all-size;
-				display: $view-all-display;
+			.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
+				font-size: 1rem;
 			}
 		}
 
-		@include thumbnail-overlay-text-font-size(clamp(1rem, 1.5vw, 2rem), clamp(0.75rem, 0.5vw, 2rem));
+		@container (width > 70px) {
+			.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
+				font-size: 1.2rem;
+			}
+		}
 
-		@for $i from 3 through 8 {
-			#{$gallery}[data-thumbnails-number-of-thumbnails='#{$i}'] & {
-				@if $i == 3 {
-					@include thumbnail-overlay-text-font-size(clamp(1rem, 1.5vw, 2rem), clamp(0.75rem, 0.5vw, 2rem));
-				} @else if $i == 4 or $i == 5 {
-					@include thumbnail-overlay-text-font-size(clamp(1rem, 1.25vw, 2rem), clamp(0.75rem, 0.25vw, 2rem));
-				} @else { // For 6, 7, and 8
-					@include thumbnail-overlay-text-font-size(clamp(1rem, 1.25vw, 2rem), null, none);
-				}
+		@container (width > 100px) {
+			.wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count {
+				font-size: 1.4rem;
 			}
 		}
 	}

--- a/plugins/woocommerce-blocks/changelog/43294-product-gallery-overlay-link-font-size
+++ b/plugins/woocommerce-blocks/changelog/43294-product-gallery-overlay-link-font-size
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Use @container rule to adjust overlay link count font size.

--- a/plugins/woocommerce/changelog/43294-product-gallery-overlay-link-font-size
+++ b/plugins/woocommerce/changelog/43294-product-gallery-overlay-link-font-size
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Use @container rule to adjust overlay link count font size.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes some adjustments to the overlay link count text font size. Previously it didn't scale well in that it sometimes displays the font size too big for the container and sometimes too small depending on the thumbnail sizes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Appearance > Editor > Templates > Single Product
2. Clear customizations (click on convert from classic block if necessary).
3. Add the Product Gallery block.
4. Test various "Number of thumbnails" settings 3 through 8.
5. Go to the frontend with a product that has 8+ gallery images and make sure the overlay link count text font size is displayed nicely. ( not too small or large regardless of thumbnail size ).
6. Try testing with the product gallery in full width mode.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
