### PR TITLE
Fix highlight tooltip deprecation notices

### DIFF
--- a/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
@@ -10,14 +10,8 @@ import {
 	CardHeader,
 	CardFooter,
 	Button,
-	IsolatedEventContainer,
 } from '@wordpress/components';
-import {
-	useState,
-	useEffect,
-	createPortal,
-	useLayoutEffect,
-} from '@wordpress/element';
+import { useState, useEffect, createPortal } from '@wordpress/element';
 import { close } from '@wordpress/icons';
 import { noop } from 'lodash';
 
@@ -42,12 +36,7 @@ function HighlightTooltip( {
 		delay > 0 ? null : show
 	);
 	const [ node, setNode ] = useState( null );
-	const [ anchorRect, setAnchorRect ] = useState( null );
 	const showTooltip = ( container ) => {
-		const element = document.getElementById( id );
-		if ( element && useAnchor ) {
-			setAnchorRect( element.getBoundingClientRect() );
-		}
 		if ( container ) {
 			container.classList.add( SHOW_CLASS );
 		}
@@ -116,18 +105,6 @@ function HighlightTooltip( {
 			}
 		}
 	}, [ show ] );
-
-	function updateSize() {
-		if ( useAnchor ) {
-			const element = document.getElementById( id );
-			setAnchorRect( element.getBoundingClientRect() );
-		}
-	}
-
-	useLayoutEffect( () => {
-		window.addEventListener( 'resize', updateSize );
-		return () => window.removeEventListener( 'resize', updateSize );
-	}, [] );
 
 	const triggerClose = () => {
 		setShowHighlight( false );

--- a/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
@@ -144,11 +144,18 @@ function HighlightTooltip( {
 		<div className="highlight-tooltip__portal">
 			{ showHighlight ? (
 				<>
-					<IsolatedEventContainer className="highlight-tooltip__overlay" />
+					{
+						/* eslint-disable jsx-a11y/no-static-element-interactions */
+						<div
+							className="highlight-tooltip__overlay"
+							onMouseDown={ () => setShowHighlight( false ) }
+						/>
+						/* eslint-enable jsx-a11y/no-static-element-interactions */
+					}
 					<Popover
 						className="highlight-tooltip__popover"
 						noArrow={ false }
-						anchorRect={ anchorRect }
+						anchor={ document.getElementById( id ) }
 						focusOnMount="container"
 					>
 						<Card size="medium">

--- a/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
@@ -31,6 +31,7 @@ function HighlightTooltip( {
 	delay,
 	onShow = noop,
 	useAnchor = false,
+	shouldCloseOnClickOutside = true,
 } ) {
 	const [ showHighlight, setShowHighlight ] = useState(
 		delay > 0 ? null : show
@@ -125,7 +126,11 @@ function HighlightTooltip( {
 						/* eslint-disable jsx-a11y/no-static-element-interactions */
 						<div
 							className="highlight-tooltip__overlay"
-							onMouseDown={ () => setShowHighlight( false ) }
+							onMouseDown={ ( event ) =>
+								shouldCloseOnClickOutside
+									? setShowHighlight( false )
+									: event.stopPropagation()
+							}
 						/>
 						/* eslint-enable jsx-a11y/no-static-element-interactions */
 					}

--- a/plugins/woocommerce/changelog/fix-43297_highlight_tooltip
+++ b/plugins/woocommerce/changelog/fix-43297_highlight_tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove deprecation notices of anchorRect and IsolatedEventContainer coming from HighlightTooltip component.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This issue fixes two deprecation notices caused by the highlight tooltip component
- `AnchorRect` usage for the popover replace by using `anchor` and passing in the element
- `IsolatedEventContainer` usage, replaced by a `div` as the event container did basically the same.

I did make one small tweak, if you click outside of the popup it will close automatically.

Closes #43297  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WordPress site
2. Finish the onboarding and go to **WooCommerce > Home**
3. Go to the **Add products** task but do nothing, instead hit the back button in the top left
4. Go back to the **Add products** task again
5. A `We're here for help` popup should appear.
6. Open your console and the ```deprecated.min.js?ver=73ad3591e7bc95f4777a:2 `anchorRect` prop in wp.components.Popover is deprecated since version 6.1. Please use `anchor` prop instead.``` warning and ```deprecated.min.js?ver=73ad3591e7bc95f4777a:2 wp.components.IsolatedEventContainer is deprecated since version 5.7.``` warning should **not** be present.
7. Resize the window, the popup should work correctly.
8. Click on the grey area, it should close the popup.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
