### PR TITLE
Remove usage of PHP 8+ function from bootstrapper

### DIFF
--- a/plugins/woocommerce/changelog/update-legacy-test-bootstrap
+++ b/plugins/woocommerce/changelog/update-legacy-test-bootstrap
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This fixes an edge case when trying to run the php unit test suite in certain environments
+
+

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -108,7 +108,7 @@ class WC_Unit_Tests_Bootstrap {
 				$helpers_directory = $tests_directory . '/php/helpers';
 
 				// Support loading top-level classes from the `php/helpers` directory.
-				if ( ! str_contains( $class, '\\' ) ) {
+				if ( false === strpos( $class, '\\' ) ) {
 					$helper_path = realpath( "$helpers_directory/$class.php" );
 
 					if ( dirname( $helper_path ) === $helpers_directory && file_exists( $helper_path ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WordPress Core comes with a polyfill for the `str_contains` function, but the polyfill doesn't seem to be loading in time when running the test suite via wp-env with PHP 7.4. This simply replaces `str_contains` with a different function that achieves that same purpose and is compatible with PHP 7.4.

### How to test the changes in this Pull Request:

1. Make sure you don't have any customizations in a `.wp-env.override.json` file that would change the PHP version running in the container to something higher than 7.4.
1. From the `plugins/woocommerce` directory, set up the wp-env container: `pnpm env:dev`
2. On the `trunk` branch, run `pnpm run test:php:env`. It will try to set up and run the phpunit test suite, but it should get halted with an error, "Call to undefined function str_contains()"
3. Check out this branch and re-run the tests. This time the test suite should begin running successfully. (You don't need to wait for the whole thing to finish!)
