### PR TITLE
Track core profiler individual plugin installation success/failure

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -154,11 +154,20 @@ const recordFailedPluginInstallations = (
 	_context: unknown,
 	_event: PluginsInstallationCompletedWithErrorsEvent
 ) => {
+	const failedExtensions = _event.payload.errors.map(
+		( error: PluginInstallError ) => getPluginTrackKey( error.plugin )
+	);
+
 	recordEvent( 'coreprofiler_store_extensions_installed_and_activated', {
 		success: false,
-		failed_extensions: _event.payload.errors.map(
-			( error: PluginInstallError ) => getPluginTrackKey( error.plugin )
-		),
+		failed_extensions: failedExtensions,
+	} );
+
+	failedExtensions.forEach( ( extension ) => {
+		recordEvent( 'coreprofiler_store_extension_installed_and_activated', {
+			success: false,
+			installed_extension: extension,
+		} );
 	} );
 };
 

--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -163,10 +163,11 @@ const recordFailedPluginInstallations = (
 		failed_extensions: failedExtensions,
 	} );
 
-	failedExtensions.forEach( ( extension ) => {
+	_event.payload.errors.forEach( ( error: PluginInstallError ) => {
 		recordEvent( 'coreprofiler_store_extension_installed_and_activated', {
 			success: false,
-			extension,
+			extension: getPluginTrackKey( error.plugin ),
+			error_message: error.error,
 		} );
 	} );
 };

--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -166,7 +166,7 @@ const recordFailedPluginInstallations = (
 	failedExtensions.forEach( ( extension ) => {
 		recordEvent( 'coreprofiler_store_extension_installed_and_activated', {
 			success: false,
-			installed_extension: extension,
+			extension,
 		} );
 	} );
 };
@@ -199,7 +199,7 @@ const recordSuccessfulPluginInstallation = (
 
 		recordEvent( 'coreprofiler_store_extension_installed_and_activated', {
 			success: true,
-			installed_extension: pluginKey,
+			extension: pluginKey,
 			install_time: installTime,
 		} );
 	}

--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -193,9 +193,15 @@ const recordSuccessfulPluginInstallation = (
 	};
 
 	for ( const installedPlugin of installationCompletedResult.installedPlugins ) {
-		trackData[
-			'install_time_' + getPluginTrackKey( installedPlugin.plugin )
-		] = getTimeFrame( installedPlugin.installTime );
+		const pluginKey = getPluginTrackKey( installedPlugin.plugin );
+		const installTime = getTimeFrame( installedPlugin.installTime );
+		trackData[ 'install_time_' + pluginKey ] = installTime;
+
+		recordEvent( 'coreprofiler_store_extension_installed_and_activated', {
+			success: true,
+			installed_extension: pluginKey,
+			install_time: installTime,
+		} );
 	}
 
 	recordEvent(

--- a/plugins/woocommerce/changelog/43309-add-track-individual-plugin-installation
+++ b/plugins/woocommerce/changelog/43309-add-track-individual-plugin-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Track core profiler individual plugin installation success/failure

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
@@ -129,6 +129,15 @@ class AsyncPluginsInstallLogger implements PluginsInstallLogger {
 		$option['plugins'][ $plugin_name ]['status']   = 'failed';
 		$option['status']                              = 'failed';
 
+		wc_admin_record_tracks_event(
+			'coreprofiler_store_extension_installed_and_activated',
+			array(
+				'success'             => false,
+				'installed_extension' => $plugin_name,
+				'error_message'       => $error_message,
+			)
+		);
+
 		$this->update( $option );
 	}
 

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
@@ -20,7 +20,7 @@ class AsyncPluginsInstallLogger implements PluginsInstallLogger {
 	 * @param string $option_name option name.
 	 */
 	public function __construct( string $option_name ) {
-		$this->option_name  = $option_name;
+		$this->option_name = $option_name;
 		add_option(
 			$this->option_name,
 			array(
@@ -223,7 +223,18 @@ class AsyncPluginsInstallLogger implements PluginsInstallLogger {
 				continue;
 			}
 
-			$track_data[ 'install_time_' . $this->get_plugin_track_key( $plugin ) ] = $this->get_timeframe( $data['time'][ $plugin ] );
+			$plugin_track_key                                  = $this->get_plugin_track_key( $plugin );
+			$install_time                                      = $this->get_timeframe( $data['time'][ $plugin ] );
+			$track_data[ 'install_time_' . $plugin_track_key ] = $install_time;
+
+			wc_admin_record_tracks_event(
+				'coreprofiler_store_extension_installed_and_activated',
+				array(
+					'success'             => true,
+					'installed_extension' => $plugin_track_key,
+					'install_time'        => $install_time,
+				)
+			);
 		}
 
 		wc_admin_record_tracks_event( 'coreprofiler_store_extensions_installed_and_activated', $track_data );

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
@@ -132,9 +132,9 @@ class AsyncPluginsInstallLogger implements PluginsInstallLogger {
 		wc_admin_record_tracks_event(
 			'coreprofiler_store_extension_installed_and_activated',
 			array(
-				'success'             => false,
-				'installed_extension' => $plugin_name,
-				'error_message'       => $error_message,
+				'success'       => false,
+				'extension'     => $plugin_name,
+				'error_message' => $error_message,
 			)
 		);
 
@@ -239,9 +239,9 @@ class AsyncPluginsInstallLogger implements PluginsInstallLogger {
 			wc_admin_record_tracks_event(
 				'coreprofiler_store_extension_installed_and_activated',
 				array(
-					'success'             => true,
-					'installed_extension' => $plugin_track_key,
-					'install_time'        => $install_time,
+					'success'      => true,
+					'extension'    => $plugin_track_key,
+					'install_time' => $install_time,
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/39919


- Add `coreprofiler_store_extension_installed_and_activated` track to track  individual plugin installation 

Props:

```
{
    success: boolean,
    extension: string;
    install_time?: string;
   error_message?: string
}
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### async - installation

1. Create a new JN site -- use `Want more options?` and select `Include WooCommerce Beta Tester`
2. Go to your WP plugins directory and make `mailpoet` directory. 
3. Create an empty `test.txt` file in the `mailpoet` directory. This will make the installation fail. 
4. Start the new core profiler. 
5. Open a new tab and navigate to `Tools -> Plugin File Editor`
6. Choose `WooCommerce` from the dropdown and click the select button.
7. Navigate to `src/Admin/PluginsHelper.php` file
8. Add `sleep(31);` at the line 196 
9. Click on `Update file` button
10. Switch back to the core profiler tab.
11. Proceed to the plugins step.
12. Click on `Continue` button on the plugins step.
13. Within 30 seconds, switch back to the plugin file editor and remove `sleep(31)` and click on `Update file` button again.
![Screen Shot 2023-09-14 at 3 45 42 PM](https://github.com/woocommerce/woocommerce/assets/4723145/41ad5557-f22f-452b-9369-01a9d51f2200)

14. Wait for the core profiler to complete and go to  `WooCommerce -> Status -> Scheduled Actions` and make sure `woocommerce_plugins_install_and_activate_async_callback` hook exists. 
15. Wait for `woocommerce_plugins_install_and_activate_async_callback` to complete.
16. Go to `WooCommerce -> Status -> Logs` and click `tracks-2023-MM-DD` log (choose the latest) and click `View`
17. Search for `wcadmin_coreprofiler_store_extension_installed_and_activated` and make sure it exists. 


mailpoet - success = 0
![Screenshot 2024-01-08 at 17 13 18](https://github.com/woocommerce/woocommerce/assets/4344253/ded651db-e7cc-46af-bad4-f4a7df464cb2)

other plugins such as jetpack - success = 0
<img width="912" alt="Screenshot 2024-01-05 at 15 54 11" src="https://github.com/woocommerce/woocommerce/assets/4344253/35a695d0-339d-448a-84e8-eda1e8bd81b8">



### sync - installation 

1. Create a new JN site -- use `Want more options?` and select `Include WooCommerce Beta Tester`
2. Start the new core profiler. 
3. Open your browser developer console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to set debug for tracks.
4. Go to your WP plugins directory and make `mailpoet` directory. 
5. Create an empty `test.txt` file in the `mailpoet` directory. This will make the installation fail. 
6. Go to the plugins page and click `Continue`
7. You should see the plugins page with an error.
8. Observe that `wcadmin_coreprofiler_store_extension_installed_and_activated` events are recorded with success prop is false for mailpoet plugin and true for other plugins.

<img width="629" alt="Screenshot 2024-01-05 at 16 00 12" src="https://github.com/woocommerce/woocommerce/assets/4344253/348aad29-4164-425b-b053-3d931f276a10">

![Screenshot 2024-01-08 at 17 20 09](https://github.com/woocommerce/woocommerce/assets/4344253/ca909b4e-41b6-41b4-a650-ce3f2ae5e0a2)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Track core profiler individual plugin installation success/failure

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
