### PR TITLE
Fix possible duplication in certain HPOS related Tracks events

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracks-orders-search-duplication
+++ b/plugins/woocommerce/changelog/fix-tracks-orders-search-duplication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes possible duplication of certain Tracks events when HPOS is active.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -23,15 +23,15 @@ class WC_Orders_Tracking {
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_order_action' ), 51 );
 
 		add_action( 'load-edit.php', array( $this, 'track_orders_view' ), 10 );
-		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_orders_view' ), 10 ); // HPOS.
+		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_orders_view' ), 999 ); // HPOS.
 
 		add_action( 'load-post-new.php', array( $this, 'track_add_order_from_edit' ), 10 );
-		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_add_order_from_edit' ), 10 ); // HPOS.
+		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_add_order_from_edit' ), 999 ); // HPOS.
 
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_created_date_change' ), 10 );
 
 		add_action( 'load-edit.php', array( $this, 'track_search_in_orders_list' ) );
-		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_search_in_orders_list' ) ); // HPOS.
+		add_action( 'load-woocommerce_page_wc-orders', array( $this, 'track_search_in_orders_list' ), 999 ); // HPOS.
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_order_tracking_scripts' ) );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR makes sure we run the tracking-related code later than the handlers in core, so that if a redirect takes place, the event isn't tracked until you arrive to the correct page. This prevents a possible duplication of certain events, where the tracking code runs _before_ the redirect and then again after (in the new request).

Related to https://github.com/woocommerce/woocommerce/pull/42879.
Closes #43358.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Drop [this snippet](https://gist.githubusercontent.com/jorgeatorres/cd450223c16321b54ac752f0d6891dd7/raw/65671d942df949259dde3b0c6b14d8b58f001c26/capture-tracks.php) in `wp-content/mu-plugins`. It's designed to help us test that Tracks events are correctly being registered without actually contacting the Tracks endpoint. It'll dump any Tracks event to a `tracks-events` log file.
2. Go to WC > Settings > Advanced > Woo.com and make sure that "Allow usage of WooCommerce to be tracked" is checked.
3. Go to WC > Settings > Advanced > Features and make sure HPOS is chosen as datastore.
4. Make sure your site has a few orders (or create some if necessary).
5. Go to WC > Orders and perform a search.
6. Go to WC > Status > Logs, look for a file named `tracks-events-<date>-...` and make sure there's an entry for event `wcadmin_orders_view_search` with details about the recent search you made. There should only be such an entry per search⭑.
7. Don't forget to remove the mu-plugin and disable tracking in the settings if you had it disabled.

⭑ If desired, this can be contrasted with `trunk`, where the same search results in 2 events.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
