### PR TITLE
Hide sale badge if product image is disabled

### DIFF
--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -158,12 +158,6 @@
 	left: auto;
 }
 
-.wc-block-grid[data-content-visibility*='"image":false'] {
-	.wc-block-grid__product-onsale {
-		display: none;
-	}
-}
-
 // Element spacing.
 .wc-block-grid__product {
 	// Prevent link and image taking the full width unnecessarily, which might cause: https://github.com/woocommerce/woocommerce-blocks/issues/11438

--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -158,8 +158,7 @@
 	left: auto;
 }
 
-.wc-block-product-on-sale[data-content-visibility*='"image":false'] {
-	.wc-block-grid__product-onsale,
+.wc-block-grid[data-content-visibility*='"image":false'] {
 	.wc-block-grid__product-onsale {
 		display: none;
 	}

--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -158,6 +158,13 @@
 	left: auto;
 }
 
+.wc-block-product-on-sale[data-content-visibility*='"image":false'] {
+	.wc-block-grid__product-onsale,
+	.wc-block-grid__product-onsale {
+		display: none;
+	}
+}
+
 // Element spacing.
 .wc-block-grid__product {
 	// Prevent link and image taking the full width unnecessarily, which might cause: https://github.com/woocommerce/woocommerce-blocks/issues/11438

--- a/plugins/woocommerce/changelog/43334-fix-on-sale-badge-with-no-image
+++ b/plugins/woocommerce/changelog/43334-fix-on-sale-badge-with-no-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix on-sale badge covering product title when product image is disabled

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -614,6 +614,10 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			return '';
 		}
 
+		if ( empty( $this->attributes['contentVisibility']['image'] ) ) {
+			return '';
+		}
+
 		if ( ! $product->is_on_sale() ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue with the on-sale badge covering the product title when product image is disabled.

For reference the https://github.com/woocommerce/woocommerce-blocks/pull/10297 that introduced this issue.

| Before | After |
| ------ | ----- |
|![file.png](https://github.com/woocommerce/woocommerce/assets/2132595/2fe08cc6-02e6-48ca-884d-a41badd67ba9)|![file.png](https://github.com/woocommerce/woocommerce/assets/2132595/d7f7bb18-332c-4475-93a4-368a62a00864)|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following blocks to a post/page. `Hand-picked Products`,  `Best Selling Products`, `Products by Category`, `Newest Products`, `On Sale Products`, `Products by Attribute`, `Products by Tag`, `Top Rated Products`.
2. For each of these blocks, ensure the `Sale` badge is on the top right of the product image.
3. Now turn off Product Image in the inspector controls. Ensure the `Sale` badge is now hidden.
4. Save the post/page and ensure it shows the same in the frontend.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Fix on-sale badge covering product title when product image is disabled

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>