### PR TITLE
Redirect supported product types to the new experience based on the product template associated to it

### DIFF
--- a/packages/js/product-editor/changelog/add-43224
+++ b/packages/js/product-editor/changelog/add-43224
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Set the product template id also for unsupported product templates

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -203,7 +203,10 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 		try {
 			if ( isSaving ) return;
 
-			await validate( unsupportedProductTemplate?.productData );
+			const { id: productTemplateId, productData } =
+				unsupportedProductTemplate as ProductTemplate;
+
+			await validate( productData );
 
 			const product = ( await saveEditedEntityRecord< Product >(
 				'postType',
@@ -214,6 +217,8 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 				}
 			) ) ?? { id: productId };
 
+			const productMetaData = productData?.meta_data ?? [];
+
 			// Avoiding to save some changes that are not supported by the current product template.
 			// So in this case those changes are saved directly to the server.
 			await saveEntityRecord(
@@ -221,7 +226,14 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 				'product',
 				{
 					...product,
-					...unsupportedProductTemplate?.productData,
+					...productData,
+					meta_data: [
+						...productMetaData,
+						{
+							key: '_product_template_id',
+							value: productTemplateId,
+						},
+					],
 				},
 				// @ts-expect-error Expected 3 arguments, but got 4.
 				{

--- a/plugins/woocommerce/changelog/add-43224
+++ b/plugins/woocommerce/changelog/add-43224
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Redirect supported product types to the new experience based on the product template associated to it

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -62,7 +62,7 @@ class Init {
 			array_push( $this->supported_product_types, 'grouped' );
 		}
 
-		$this->redirection_controller = new RedirectionController( $this->supported_product_types );
+		$this->redirection_controller = new RedirectionController();
 
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			if ( ! Features::is_enabled( 'new-product-management-experience' ) ) {

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -33,6 +33,13 @@ class Init {
 	private $supported_product_types = array( 'simple' );
 
 	/**
+	 * Registered product templates.
+	 *
+	 * @var array
+	 */
+	private $product_templates = array();
+
+	/**
 	 * Redirection controller.
 	 *
 	 * @var RedirectionController
@@ -69,7 +76,7 @@ class Init {
 
 			add_action( 'current_screen', array( $this, 'set_current_screen_to_block_editor_if_wc_admin' ) );
 
-			add_action( 'rest_api_init', array( $this, 'register_product_editor_templates' ) );
+			add_action( 'rest_api_init', array( $this, 'register_layout_templates' ) );
 
 			// Make sure the block registry is initialized so that core blocks are registered.
 			BlockRegistry::get_instance();
@@ -79,6 +86,9 @@ class Init {
 
 			// Make sure the block template logger is initialized before any templates are created.
 			BlockTemplateLogger::get_instance();
+
+			$this->register_layout_templates();
+			$this->register_product_templates();
 		}
 	}
 
@@ -90,7 +100,6 @@ class Init {
 			return;
 		}
 
-		$this->register_product_editor_templates();
 		$editor_settings = $this->get_product_editor_settings();
 
 		$script_handle = 'wc-admin-edit-product';
@@ -227,26 +236,11 @@ class Init {
 			$editor_settings['layoutTemplateEvents'][] = $layout_template_logger->get_formatted_template_events( $layout_template->get_id() );
 		}
 
-		/**
-		 * Allows for new product template registration.
-		 *
-		 * @since 8.5.0
-		 */
-		$product_templates = apply_filters( 'woocommerce_product_editor_product_templates', $this->get_default_product_templates() );
-		$product_templates = $this->create_default_product_template_by_custom_product_type( $product_templates );
-
-		usort(
-			$product_templates,
-			function ( $a, $b ) {
-				return $a->get_order() - $b->get_order();
-			}
-		);
-
 		$editor_settings['productTemplates'] = array_map(
 			function ( $product_template ) {
 				return $product_template->to_json();
 			},
-			$product_templates
+			$this->product_templates
 		);
 
 		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => self::EDITOR_CONTEXT_NAME ) );
@@ -372,9 +366,9 @@ class Init {
 	}
 
 	/**
-	 * Register product editor templates.
+	 * Register layout templates.
 	 */
-	public function register_product_editor_templates() {
+	public function register_layout_templates() {
 		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
 
 		if ( ! $layout_template_registry->is_registered( 'simple-product' ) ) {
@@ -392,5 +386,27 @@ class Init {
 				ProductVariationTemplate::class
 			);
 		}
+	}
+
+	/**
+	 * Register product templates.
+	 */
+	public function register_product_templates() {
+		/**
+		 * Allows for new product template registration.
+		 *
+		 * @since 8.5.0
+		 */
+		$this->product_templates = apply_filters( 'woocommerce_product_editor_product_templates', $this->get_default_product_templates() );
+		$this->product_templates = $this->create_default_product_template_by_custom_product_type( $this->product_templates );
+
+		usort(
+			$this->product_templates,
+			function ( $a, $b ) {
+				return $a->get_order() - $b->get_order();
+			}
+		);
+
+		$this->redirection_controller->set_product_templates( $this->product_templates );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -94,7 +94,7 @@ class RedirectionController {
 	/**
 	 * Check if a product is supported by the new experience.
 	 *
-	 * @param array $product_tempaltes The registered product teamplates.
+	 * @param array $product_templates The registered product teamplates.
 	 */
 	public function set_product_templates( array $product_templates ): void {
 		$this->product_templates = $product_templates;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -21,6 +21,13 @@ class RedirectionController {
 	private $supported_product_types;
 
 	/**
+	 * Registered product templates.
+	 *
+	 * @var array
+	 */
+	private $product_templates = array();
+
+	/**
 	 * Set up the hooks used for redirection.
 	 *
 	 * @param array $supported_product_types Array of supported product types.
@@ -62,8 +69,17 @@ class RedirectionController {
 	 * @param integer $product_id Product ID.
 	 */
 	protected function is_product_supported( $product_id ): bool {
-		$product = $product_id ? wc_get_product( $product_id ) : null;
-		$digital_product = $product->is_downloadable() || $product->is_virtual();
+		$product             = $product_id ? wc_get_product( $product_id ) : null;
+		$digital_product     = $product->is_downloadable() || $product->is_virtual();
+		$product_template_id = $product->get_meta( '_product_template_id' );
+
+		if ( isset( $product_template_id ) ) {
+			foreach ( $this->product_templates as $product_template ) {
+				if ( $product_template_id === $product_template->get_id() && ! is_null( $product_template->get_layout_template_id() ) ) {
+					return true;
+				}
+			}
+		}
 
 		if ( $product && in_array( $product->get_type(), $this->supported_product_types, true ) ) {
 			if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
@@ -73,6 +89,15 @@ class RedirectionController {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if a product is supported by the new experience.
+	 *
+	 * @param array $product_tempaltes The registered product teamplates.
+	 */
+	public function set_product_templates( array $product_templates ): void {
+		$this->product_templates = $product_templates;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -72,7 +72,7 @@ class RedirectionController {
 			}
 
 			$product_data = $product_template->get_product_data();
-			$product_type = $product_data[ 'type' ];
+			$product_type = $product_data['type'];
 
 			if ( isset( $product_type ) && $product_type !== $product->get_type() ) {
 				continue;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -12,14 +12,6 @@ use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
  * Handle redirecting to the old or new editor based on features and support.
  */
 class RedirectionController {
-
-	/**
-	 * Supported product types.
-	 *
-	 * @var array
-	 */
-	private $supported_product_types;
-
 	/**
 	 * Registered product templates.
 	 *
@@ -29,12 +21,8 @@ class RedirectionController {
 
 	/**
 	 * Set up the hooks used for redirection.
-	 *
-	 * @param array $supported_product_types Array of supported product types.
 	 */
-	public function __construct( $supported_product_types ) {
-		$this->supported_product_types = $supported_product_types;
-
+	public function __construct() {
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			add_action( 'current_screen', array( $this, 'maybe_redirect_to_new_editor' ), 30, 0 );
 			add_action( 'current_screen', array( $this, 'redirect_non_supported_product_types' ), 30, 0 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43224

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products` -> `Add new` from the left side menu.
3. Set the `Name` of the product.
4. Under the `General` tab a description `This is a standard product. Change product type` should be shown below the `Basic details` section.
5. When clicking the `Change product type` a dropdown menu should be shown listing all the available product types. 
<img width="686" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c112df55-7b60-4883-bcfb-731505c16714">

9. Add some custom product types like follows. You can use a Code Snipped plugin or create a custom plugin as you want.
```php
add_action( 'init', 'register_demo_product_type', 0 );
function register_demo_product_type() {
	class WC_Product_Demo extends WC_Product {
		public function __construct( $product ) {
			parent::__construct( $product );
		}

		public function get_type() {
			return 'demo';
		}
	}
}

add_filter( 'product_type_selector', 'add_demo_product_type' );
function add_demo_product_type( $types ){
	$types[ 'demo' ] = __( 'Demo product', 'dm_product' );
	return $types; 
}

add_filter( 'woocommerce_product_editor_product_templates', 'register_product_template' );
function register_product_template( $templates ) {
	$templates[] = new Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplate(
		array(
			'id'                 => 'demo-product-template',
			'title'              => __( 'Product demo', 'woocommerce' ),
			'description'        => __( 'This is a demo product', 'woocommerce' ),
			'order'              => ( count( $templates ) + 1 ) * 10,
			'icon'               => 'bug',
			'layout_template_id' => 'simple-product',
			'product_data'       => array(
				'type' => 'demo',
			),
		)
	);
	
	return $templates;
}
```
17. With that you added support to the new product type created in point 9. And the menu now should looks like 
<img width="690" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/5f9b138a-a2a5-4631-baf1-cbac9f61a164">

19. Clicking the `Product demo` item should save the changes, apply the `simple-product` template to the editor and keep you in the same page without redirecting to the classic experience. 
20. Try to edit the same product from the product list. 
21. You should now be redirected to the new product edition experience and not to the classic.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
