### PR TITLE
Implement useLayoutTemplate hook

### DIFF
--- a/packages/js/block-templates/README.md
+++ b/packages/js/block-templates/README.md
@@ -17,11 +17,11 @@ import metadata from './block.json';
 import { Edit } from './edit';
 
 registerWooBlockType( {
-  name: metadata.name,
-  metadata: metadata,
-  settings: {
-    edit: Edit,
-  }
+	name: metadata.name,
+	metadata: metadata,
+	settings: {
+		edit: Edit,
+	},
 } );
 ```
 
@@ -32,6 +32,43 @@ registerWooBlockType( {
 #### Returns
 
 - `WPBlockType | undefined`: The block type if it was registered successfully, otherwise `undefined`.
+
+### useLayoutTemplate
+
+This hook is used to retrieve a layout template from the server.
+
+#### Usage
+
+```js
+import { useLayoutTemplate } from '@woocommerce/block-templates';
+
+export function Example() {
+	const { layoutTemplate, isResolving } =
+		useLayoutTemplate( 'my-layout-template' );
+
+	return (
+		<div>
+			{ isResolving && <p>Loading layout template...</p> }
+			{ layoutTemplate && (
+				<p>{ JSON.stringify( layoutTemplate, null, 4 ) }</p>
+			) }
+			{ ! layoutTemplate && ! isResolving && (
+				<p>'Layout template does not exist!'</p>
+			) }
+		</div>
+	);
+}
+```
+
+#### Parameters
+
+- _layoutTemplateId_ `string`: The id of the layout template to retrieve.
+
+#### Returns
+
+- `Object`
+    - _layoutTemplate_ `Object | undefined`: The layout template if it was found, otherwise `null`.
+    - _isResolving_ `boolean`: Whether or not the layout template is resolving.
 
 ### useWooBlockProps
 
@@ -45,25 +82,18 @@ If you define a ref for the element, it is important to pass the ref to this hoo
 import { useWooBlockProps } from '@woocommerce/block-templates';
 
 export function Edit( { attributes } ) {
-  const { blockProps } = useWooBlockProps( 
-    attributes,
-    {
-      className: 'my-block',
-    }
-  );
+	const { blockProps } = useWooBlockProps( attributes, {
+		className: 'my-block',
+	} );
 
-  return (
-    <div { ...blockProps }>
-      Block content
-    </div>
-  );
+	return <div { ...blockProps }>Block content</div>;
 }
 ```
 
 #### Parameters
 
-- _attributes_: `Object`: Block attributes.
-- _props_: `Object`: Optional. Props to pass to the element.
+- _attributes_ `Object`: Block attributes.
+- _props_ `Object`: Optional. Props to pass to the element.
 
 #### Returns
 

--- a/packages/js/block-templates/changelog/add-use-layout-template
+++ b/packages/js/block-templates/changelog/add-use-layout-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added useLayoutTemplate React hook, to load layout templates via the REST API

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/block-editor": "^9.8.0",
 		"@wordpress/blocks": "^12.24.0",
 		"@wordpress/data": "wp-6.0",
+		"@wordpress/core-data": "wp-6.0",
 		"@wordpress/element": "wp-6.0"
 	},
 	"devDependencies": {

--- a/packages/js/block-templates/src/hooks/use-layout-template/index.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/index.ts
@@ -1,2 +1,1 @@
 export * from './use-layout-template';
-export * from './use-woo-block-props';

--- a/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
@@ -39,9 +39,14 @@ export const useLayoutTemplate = ( layoutTemplateId: string | undefined ) => {
 	const { record: layoutTemplate, isResolving } = useEntityRecord(
 		'root',
 		'wcLayoutTemplate',
-		layoutTemplateId,
+		// Because of the regression mentioned below, REST API requests will still be triggered
+		// even when the query is disabled. This means that if we pass `undefined`/`null` as the ID,
+		// the query will be triggered with no ID, which will return all layout templates.
+		// To prevent this, we pass `__invalid-template-id` as the ID when there is no layout template ID.
+		// A request will still be triggered, but it will return no results.
+		layoutTemplateId || '__invalid-template-id',
 		// Only perform the query if we have a layout template ID; otherwise, just return null.
-		// Note: Until we are using Gutenberg 17.2, the REST API will still be triggered even
+		// Note: Until we are using Gutenberg 17.2, the REST API requests will still be triggered even
 		// when the query is disabled due to a regression. See:
 		// https://github.com/WordPress/gutenberg/pull/56108
 		{ enabled: !! layoutTemplateId }

--- a/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
@@ -46,9 +46,9 @@ export const useLayoutTemplate = ( layoutTemplateId: string | undefined ) => {
 		// A request will still be triggered, but it will return no results.
 		layoutTemplateId || '__invalid-template-id',
 		// Only perform the query if we have a layout template ID; otherwise, just return null.
-		// Note: Until we are using Gutenberg 17.2, the REST API requests will still be triggered even
-		// when the query is disabled due to a regression. See:
-		// https://github.com/WordPress/gutenberg/pull/56108
+		// Note: Until we are using @woocommerce/core-data 6.24.0 (Gutenberg 17.2),
+		// the REST API requests will still be triggered even when the query is disabled due to a regression.
+		// See: https://github.com/WordPress/gutenberg/pull/56108
 		{ enabled: !! layoutTemplateId }
 	);
 

--- a/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
@@ -39,7 +39,12 @@ export const useLayoutTemplate = ( layoutTemplateId: string | undefined ) => {
 	const { record: layoutTemplate, isResolving } = useEntityRecord(
 		'root',
 		'wcLayoutTemplate',
-		layoutTemplateId
+		layoutTemplateId,
+		// Only perform the query if we have a layout template ID; otherwise, just return null.
+		// Note: Until we are using Gutenberg 17.2, the REST API will still be triggered even
+		// when the query is disabled due to a regression. See:
+		// https://github.com/WordPress/gutenberg/pull/56108
+		{ enabled: !! layoutTemplateId }
 	);
 
 	return { layoutTemplate, isResolving };

--- a/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
@@ -15,7 +15,7 @@ import { useEntityRecord } from '@wordpress/core-data';
 // eslint-disable-next-line @woocommerce/dependency-group
 import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
 
-export const useLayoutTemplate = ( layoutTemplateId: string ) => {
+export const useLayoutTemplate = ( layoutTemplateId: string | undefined ) => {
 	const layoutTemplateEntity = useSelect( ( select: typeof WPSelect ) => {
 		const { getEntity } = select( 'core' );
 		return getEntity( 'root', 'wcLayoutTemplate' );

--- a/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
@@ -17,8 +17,8 @@ import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
 
 export const useLayoutTemplate = ( layoutTemplateId: string | undefined ) => {
 	const layoutTemplateEntity = useSelect( ( select: typeof WPSelect ) => {
-		const { getEntity } = select( 'core' );
-		return getEntity( 'root', 'wcLayoutTemplate' );
+		const { getEntityConfig } = select( 'core' );
+		return getEntityConfig( 'root', 'wcLayoutTemplate' );
 	} );
 
 	const { addEntities } = useDispatch( 'core' );

--- a/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet, natively (not until 7.0.0).
+// Including `@types/wordpress__data` as a devDependency causes build issues,
+// so just going type-free for now.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityRecord } from '@wordpress/core-data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet, natively (not until 7.0.0).
+// Including `@types/wordpress__data` as a devDependency causes build issues,
+// so just going type-free for now.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
+
+export const useLayoutTemplate = ( layoutTemplateId: string ) => {
+	const layoutTemplateEntity = useSelect( ( select: typeof WPSelect ) => {
+		const { getEntity } = select( 'core' );
+		return getEntity( 'root', 'wcLayoutTemplate' );
+	} );
+
+	const { addEntities } = useDispatch( 'core' );
+
+	useEffect( () => {
+		if ( ! layoutTemplateEntity ) {
+			addEntities( [
+				{
+					kind: 'root',
+					name: 'wcLayoutTemplate',
+					baseURL: '/wc/v3/layout-templates',
+					label: 'Layout Templates',
+				},
+			] );
+		}
+	}, [ addEntities, layoutTemplateEntity ] );
+
+	const { record: layoutTemplate, isResolving } = useEntityRecord(
+		'root',
+		'wcLayoutTemplate',
+		layoutTemplateId
+	);
+
+	return { layoutTemplate, isResolving };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,9 @@ importers:
       '@wordpress/blocks':
         specifier: ^12.24.0
         version: 12.24.0(react@17.0.2)
+      '@wordpress/core-data':
+        specifier: wp-6.0
+        version: 4.4.5(react@17.0.2)
       '@wordpress/data':
         specifier: wp-6.0
         version: 6.6.1(react@17.0.2)
@@ -8539,7 +8542,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-create-class-features-plugin': 7.23.6(@babel/core@7.12.9)
+      '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.5):
@@ -8549,7 +8552,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-create-class-features-plugin': 7.23.6(@babel/core@7.23.5)
+      '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.23.5)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.6):
@@ -22570,7 +22573,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.6
       '@wordpress/compose': 4.2.0(react@17.0.2)
-      '@wordpress/deprecated': 3.41.0
+      '@wordpress/deprecated': 3.6.1
       '@wordpress/element': 3.2.0
       '@wordpress/is-shallow-equal': 4.24.0
       '@wordpress/priority-queue': 2.47.0
@@ -52985,7 +52988,7 @@ packages:
       webpack: '>=5.32.0'
     dependencies:
       ansis: 1.5.6
-      webpack: 5.89.0(webpack-cli@3.3.12)
+      webpack: 5.89.0(webpack-cli@5.1.4)
 
   /webpack-rtl-plugin@2.0.0:
     resolution: {integrity: sha512-lROgFkiPjapg9tcZ8FiLWeP5pJoG00018aEjLTxSrVldPD1ON+LPlhKPHjb7eE8Bc0+KL23pxcAjWDGOv9+UAw==}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the `useLayoutTemplate` React hook, which can be used to load a layout template.

A follow up PR will modify the new product editor to use this hook to load the layout templates.

Part of #40620

#### Why no unit tests?

My plan was to write a few unit tests that verified the following:

- the first time a layout template with a given id was requested, a request to the REST API would be made (mocked, of course)
- the second time a layout template with a given id was requested, no request to the REST API would be made

So, I started with a simple test just to get things going:

```ts
/**
 * External dependencies
 */
import { renderHook } from '@testing-library/react-hooks';

/**
 * Internal dependencies
 */
import { useLayoutTemplate } from '../use-layout-template';

describe( 'useLayoutTemplate', () => {
	it( 'should return the layout template and isResolving', () => {
		const { result } = renderHook( () =>
			useLayoutTemplate( 'layout-template-id' )
		);

		expect( result.current ).toEqual( {
			layoutTemplate: undefined,
			isResolving: true,
		} );
	} );
} );

```

Unfortunately, due to circular dependency issues in `@wordpress/data` (I believe, based on some searching), I got the following error when running `pnpm --filter=@woocommerce/block-templates test:js` with this test file:

```
 FAIL  src/hooks/use-layout-template/test/use-layout-template.test.ts
  useLayoutTemplate
    ✕ should return the layout template and isResolving (39 ms)

  ● useLayoutTemplate › should return the layout template and isResolving

    TypeError: (0 , core_data_1.useEntityRecord) is not a function

      37 |      }, [ addEntities, layoutTemplateEntity ] );
      38 |
    > 39 |      const { record: layoutTemplate, isResolving } = useEntityRecord(
         |                                                                     ^
      40 |              'root',
      41 |              'wcLayoutTemplate',
      42 |              layoutTemplateId

      at useLayoutTemplate (src/hooks/use-layout-template/use-layout-template.ts:39:65)
      at src/hooks/use-layout-template/test/use-layout-template.test.ts:14:21
```

I couldn't find a way to get this to work. I don't want to mock all of `@wordpress/data` and `@wordpress/core-data`, because I ultimately don't want to test that `useLayoutTemplate` calls any functions in those packages... that is an implementation detail. I only want to verify that the REST API ends up getting called.

Given this, I opted to forgo unit tests for this simple hook. 😞

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**), and the following manual test helper in an mu-plugin:

PHP file:
```php
<?php

function example_enqueue_footer_script() {
	wp_enqueue_script(
		'use-layout-template-footer',
		plugin_dir_url( __FILE__ ) . 'use-layout-template-footer.js',
		[],
		filemtime( dirname( __FILE__ ) . '/use-layout-template-footer.js' ),
		true,
	);
}

add_action( 'admin_enqueue_scripts', 'example_enqueue_footer_script' );
```

JS file:
```js
wp.plugins.registerPlugin( 'use-layout-template-footer', {
    scope: 'woocommerce-product-block-editor',
    render: function() {
        const layoutTemplateIdInputRef = wp.element.useRef( null );

        const [ layoutTemplateId, setLayoutTemplateId ] = wp.element.useState( null );

        const { layoutTemplate, isResolving } = wc.blockTemplates.useLayoutTemplate( layoutTemplateId );

        const layoutTemplateAsString = isResolving
            ? 'Loading layout template...'
            : layoutTemplate
                ? JSON.stringify( layoutTemplate, null, 4 )
                : 'Layout template does not exist';

        return wp.element.createElement(
            wp.element.Fragment,
            {},
            wp.element.createElement(
                wc.adminLayout.WooFooterItem,
                {
                    order: 1000,
                },
                wp.element.createElement(
                    'div',
                    {
                        style: {
                            display: 'flex',
                            flexDirection: 'column',
                            maxHeight: '500px',
                            padding: '32px',
                            backgroundColor: 'black',
                            color: 'white',
                        }
                    },
                    wp.element.createElement(
                        'div',
                        {},
                        wp.element.createElement(
                            'label',
                            {},
                            'Layout template:',
                            wp.element.createElement(
                                'input',
                                {
                                    ref: layoutTemplateIdInputRef,
                                    type: 'text',
                                },
                                null,
                            ),
                        ),
                        wp.element.createElement(
                            'button',
                            {
                                onClick: () => {
                                    setLayoutTemplateId( layoutTemplateIdInputRef.current.value );
                                },
                            },
                            'Load',
                        ),
                    ),
                    wp.element.createElement(
                        'div',
                        {
                            style: {
                                flex: '1',
                                overflow: 'auto',
                                whiteSpace: 'pre',
                                fontFamily: 'monospace',
                            }
                        },
                        layoutTemplateAsString,
                    ),
                )
            ),
        );
    }
} );
```

1. Go to **Products** > **Add New**
2. You should see the manual test helper in the footer...

<img width="1255" alt="Screenshot 2024-01-06 at 08 16 27" src="https://github.com/woocommerce/woocommerce/assets/2098816/ad10ce6c-604e-4c0b-ba1c-1b030d4023fb">

3. Enter a layout template id that exists, such as `simple-product` and click **Load**
4. Verify a network request to the `/wc/v3/layout-templates/` endpoint was made
5. Verify that the layout template is shown...

<img width="1255" alt="Screenshot 2024-01-06 at 08 21 55" src="https://github.com/woocommerce/woocommerce/assets/2098816/8af08dac-35a2-4f6e-a7f1-d9345ba0b48d">

6. Enter a layout template id that does not exist, such as `invalid-layout-template` and click **Load**
7. Verify a network request to the `/wc/v3/layout-templates/` endpoint was made
8. Verify that no layout template is shown
9. Enter the same layout template id used in step (3) (`simple-product`) and lick **Load**
10. Verify no network request to the `/wc/v3/layout-templates/` endpoint was made
11. Verify that the layout template is shown

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
