### PR TITLE
Product Gallery Pager: Improve accessibility

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -51,6 +51,9 @@ const productGallery = {
 		get pagerDotFillOpacity(): number {
 			return state.isSelected ? 1 : 0.2;
 		},
+		get pagerButtonPressed(): boolean {
+			return state.isSelected ? true : false;
+		},
 	},
 	actions: {
 		closeDialog: () => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -308,6 +308,13 @@ $admin-bar-mobile-height: 46px;
 	margin-top: 0;
 	margin-bottom: 0;
 	padding: 0;
+
+	button {
+		border: none;
+		background: none;
+		padding: 0;
+		cursor: pointer;
+	}
 }
 
 .wc-block-product-gallery-pager__pager-item {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -312,6 +312,9 @@ $admin-bar-mobile-height: 46px;
 	button {
 		border: none;
 		background: none;
+		color: inherit;
+		font-size: inherit;
+		font-weight: inherit;
 		padding: 0;
 		cursor: pointer;
 	}

--- a/plugins/woocommerce-blocks/changelog/fix-43306-product-gallery-pager-accessibility
+++ b/plugins/woocommerce-blocks/changelog/fix-43306-product-gallery-pager-accessibility
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Improve the accessibility of the Product Gallery Pager.

--- a/plugins/woocommerce/changelog/fix-43306-product-gallery-pager-accessibility
+++ b/plugins/woocommerce/changelog/fix-43306-product-gallery-pager-accessibility
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: Improve the accessibility of the Product Gallery Pager.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryPager.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryPager.php
@@ -115,11 +115,13 @@ class ProductGalleryPager extends AbstractBlock {
 
 			$is_first_pager_item = 0 === $key;
 			$pager_item          = sprintf(
-				'<li class="wc-block-product-gallery-pager__pager-item %2$s">%1$s</li>',
+				'<li class="wc-block-product-gallery-pager__pager-item %2$s"><button aria-pressed="%3$s" data-wc-bind--aria-pressed="state.pagerButtonPressed">%1$s</button></li>',
 				'dots' === $pager_display_mode ? $this->get_dot_icon( $is_first_pager_item ) : $key + 1,
-				$is_first_pager_item ? 'wc-block-product-gallery-pager__pager-item--is-active' : ''
+				$is_first_pager_item ? 'wc-block-product-gallery-pager__pager-item--is-active' : '',
+				$is_first_pager_item ? 'true' : 'false'
 			);
-			$p                   = new \WP_HTML_Tag_Processor( $pager_item );
+
+			$p = new \WP_HTML_Tag_Processor( $pager_item );
 
 			if ( $p->next_tag() ) {
 				$p->set_attribute(
@@ -158,7 +160,7 @@ class ProductGalleryPager extends AbstractBlock {
 		$initial_opacity = $is_active ? '1' : '0.2';
 		return sprintf(
 			'<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<circle cx="6" cy="6" r="6" fill="black" fill-opacity="%1$s" data-wc-bind--fill-opacity="state.pagerDotFillOpacity"  />
+				<circle cx="6" cy="6" r="6" fill="black" fill-opacity="%1$s" data-wc-bind--fill-opacity="state.pagerDotFillOpacity" />
 			</svg>',
 			$initial_opacity
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves accessibility by adding a `button` wrapper to the pager elements and adds the `aria-pressed` attribute.

Closes #43306.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Appearance > Editor > Templates > Single Product (clear customizations)
2. Click on the editor and you should see "Transform into blocks" action button.
3. Add the Product Gallery block.
4. Open a Product that has multiple images in its gallery.
5. Ensure the Pager buttons are styled correctly for both variants (dots and numbers).
6. Ensure you can tab through the buttons (using keyboard only).
7. Check if the `aria-pressed` attribute gets added correctly to the buttons (test using a browser inspector).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
