### PR TITLE
CYS: fix PHP warnings and pattern button

### DIFF
--- a/plugins/woocommerce/changelog/43354-fix-cys-php-warnings-and-pattern
+++ b/plugins/woocommerce/changelog/43354-fix-cys-php-warnings-and-pattern
@@ -1,0 +1,5 @@
+Significance: minor
+Type: fix
+
+Fix PHP warnings and remove opinionated styles from the `Banner` button.
+

--- a/plugins/woocommerce/changelog/43354-fix-cys-php-warnings-and-pattern
+++ b/plugins/woocommerce/changelog/43354-fix-cys-php-warnings-and-pattern
@@ -2,4 +2,3 @@ Significance: minor
 Type: fix
 
 Fix PHP warnings and remove opinionated styles from the `Banner` button.
-

--- a/plugins/woocommerce/patterns/banner.php
+++ b/plugins/woocommerce/patterns/banner.php
@@ -31,9 +31,9 @@ $second_description = $content['descriptions'][1]['default'] ?? '';
 
 		<!-- wp:buttons {"style":{"spacing":{"blockGap":"0","margin":{"top":"20px","bottom":"0"}}}} -->
 		<div class="wp-block-buttons" style="margin-top:20px;margin-bottom:0">
-			<!-- wp:button {"style":{"typography":{"fontSize":"16px"},"color":{"text":"#000000","background":"#ffffff"},"border":{"width":"0px","style":"none"}},"className":"is-style-fill"} -->
+			<!-- wp:button {"style":{"typography":{"fontSize":"16px"},"border":{"width":"0px","style":"none"}},"className":"is-style-fill"} -->
 			<div class="wp-block-button has-custom-font-size is-style-fill" style="font-size:16px">
-				<a class="wp-block-button__link has-text-color has-background wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="border-style:none;border-width:0px;color:#000000;background-color:#ffffff">
+				<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="border-style:none;border-width:0px;">
 					<?php echo esc_html( $banner_button ); ?>
 				</a>
 			</div>

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -243,6 +243,9 @@ class BlockPatterns {
 				for each page load. This way we only do it once on registration.
 				For more context: https://github.com/woocommerce/woocommerce-blocks/pull/11733
 			*/
+
+			$content = array();
+			$images = array();
 			if ( ! is_null( $pattern_data_from_dictionary ) ) {
 				$content = $pattern_data_from_dictionary['content'];
 				$images  = $pattern_data_from_dictionary['images'] ?? array();
@@ -391,7 +394,7 @@ class BlockPatterns {
 	 */
 	private function get_pattern_from_dictionary( $dictionary, $slug ) {
 		foreach ( $dictionary as $pattern_dictionary ) {
-			if ( $pattern_dictionary['slug'] === $slug ) {
+			if ( isset($pattern_dictionary['slug']) && $pattern_dictionary['slug'] === $slug ) {
 				return $pattern_dictionary;
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -245,7 +245,7 @@ class BlockPatterns {
 			*/
 
 			$content = array();
-			$images = array();
+			$images  = array();
 			if ( ! is_null( $pattern_data_from_dictionary ) ) {
 				$content = $pattern_data_from_dictionary['content'];
 				$images  = $pattern_data_from_dictionary['images'] ?? array();
@@ -394,7 +394,7 @@ class BlockPatterns {
 	 */
 	private function get_pattern_from_dictionary( $dictionary, $slug ) {
 		foreach ( $dictionary as $pattern_dictionary ) {
-			if ( isset($pattern_dictionary['slug']) && $pattern_dictionary['slug'] === $slug ) {
+			if ( isset( $pattern_dictionary['slug'] ) && $pattern_dictionary['slug'] === $slug ) {
 				return $pattern_dictionary;
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1. Fix PHP warnings about `slug` key not present and `$images` variable not being defined.
2. Remove styling from the `Banner` pattern button.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a new store, which hasn't gone through the `Customize your store` flow, create a new page or post.
2. Insert the `Banner` pattern, save, and make sure the button does not have custom styles (see screenshots below).
3. Check the `debug.log` and make sure there are no PHP warnings related to `slug` key not being present and `$images` not being defined.

| Before | After |
|--------|--------|
| <img width="1302" alt="Screenshot 2024-01-08 at 11 51 30" src="https://github.com/woocommerce/woocommerce/assets/186112/24af3ed2-f73d-41a9-8b5d-801821d2efa2">|  <img width="1303" alt="Screenshot 2024-01-08 at 11 26 23" src="https://github.com/woocommerce/woocommerce/assets/186112/75f44d40-132b-4d7f-bd35-6e652a493c5c">|

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix PHP warnings and remove opinionated styles from the `Banner` button.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
