### PR TITLE
Add support for specifying filters when searching orders.

### DIFF
--- a/plugins/woocommerce/changelog/fix-41454
+++ b/plugins/woocommerce/changelog/fix-41454
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow merchants to select products/customers/all when searching a string in orders.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2938,6 +2938,11 @@ ul.wc_coupon_list_block {
 		display: none;
 	}
 
+	select.search-filter {
+		margin-right: 4px;
+		margin-bottom: 3px;
+	}
+
 	.tablenav {
 		.select2-selection--single {
 			height: 32px;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -372,7 +372,7 @@ class ListTable extends WP_List_Table {
 			'type'     => $this->order_type,
 		);
 
-		foreach ( array( 'status', 's', 'm', '_customer_user' ) as $query_var ) {
+		foreach ( array( 'status', 's', 'm', '_customer_user', 'search_filter' ) as $query_var ) {
 			$this->request[ $query_var ] = sanitize_text_field( wp_unslash( $_REQUEST[ $query_var ] ?? '' ) );
 		}
 
@@ -533,8 +533,10 @@ class ListTable extends WP_List_Table {
 			$this->has_filter            = true;
 		}
 
-		$filter = trim( sanitize_text_field( $this->request['filter'] ) );
-
+		$filter = trim( sanitize_text_field( $this->request['search_filter'] ) );
+		if( ! empty( $filter ) ) {
+			$this->order_query_args['search_filter'] = $filter;
+		}
 	}
 
 	/**
@@ -1588,9 +1590,9 @@ class ListTable extends WP_List_Table {
 			'all'       => __( 'All', 'woocommerce' ),
 		);
 ?>
-		<select name="filter" id="order-search-filter">
+		<select name="search_filter" id="order-search-filter">
 			<?php foreach ( $options as $value => $label ) { ?>
-				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, isset( $_REQUEST['filter'] ) ? $_REQUEST['filter'] : 'customers' ); ?>><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, isset( $_REQUEST['search_filter'] ) ? $_REQUEST['search_filter'] : 'customers' ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php }
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -532,6 +532,9 @@ class ListTable extends WP_List_Table {
 			$this->order_query_args['s'] = $search_term;
 			$this->has_filter            = true;
 		}
+
+		$filter = trim( sanitize_text_field( $this->request['filter'] ) );
+
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -372,7 +372,7 @@ class ListTable extends WP_List_Table {
 			'type'     => $this->order_type,
 		);
 
-		foreach ( array( 'status', 's', 'm', '_customer_user', 'search_filter' ) as $query_var ) {
+		foreach ( array( 'status', 's', 'm', '_customer_user', 'search-filter' ) as $query_var ) {
 			$this->request[ $query_var ] = sanitize_text_field( wp_unslash( $_REQUEST[ $query_var ] ?? '' ) );
 		}
 
@@ -533,7 +533,7 @@ class ListTable extends WP_List_Table {
 			$this->has_filter            = true;
 		}
 
-		$filter = trim( sanitize_text_field( $this->request['search_filter'] ) );
+		$filter = trim( sanitize_text_field( $this->request['search-filter'] ) );
 		if( ! empty( $filter ) ) {
 			$this->order_query_args['search_filter'] = $filter;
 		}
@@ -1590,9 +1590,9 @@ class ListTable extends WP_List_Table {
 			'all'       => __( 'All', 'woocommerce' ),
 		);
 ?>
-		<select name="search_filter" id="order-search-filter">
+		<select name="search-filter" id="order-search-filter">
 			<?php foreach ( $options as $value => $label ) { ?>
-				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, isset( $_REQUEST['search_filter'] ) ? $_REQUEST['search_filter'] : 'customers' ); ?>><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $_REQUEST['search-filter'] ?? 'all' ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php }
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1537,4 +1537,57 @@ class ListTable extends WP_List_Table {
 		return $html;
 	}
 
+	/**
+	 * Renders the search box with various options to limit order search results.
+	 * @param string $text The search button text.
+	 * @param string $input_id The search input ID.
+	 *
+	 * @return void
+	 */
+	public function search_box( $text, $input_id ) {
+		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) {
+			return;
+		}
+
+		$input_id = $input_id . '-search-input';
+
+		if ( ! empty( $_REQUEST['orderby'] ) ) {
+			echo '<input type="hidden" name="orderby" value="' . esc_attr( $_REQUEST['orderby'] ) . '" />';
+		}
+		if ( ! empty( $_REQUEST['order'] ) ) {
+			echo '<input type="hidden" name="order" value="' . esc_attr( $_REQUEST['order'] ) . '" />';
+		}
+		if ( ! empty( $_REQUEST['post_mime_type'] ) ) {
+			echo '<input type="hidden" name="post_mime_type" value="' . esc_attr( $_REQUEST['post_mime_type'] ) . '" />';
+		}
+		if ( ! empty( $_REQUEST['detached'] ) ) {
+			echo '<input type="hidden" name="detached" value="' . esc_attr( $_REQUEST['detached'] ) . '" />';
+		}
+		?>
+		<p class="search-box">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo $text; ?>:</label>
+			<input type="search" id="<?php echo esc_attr( $input_id ); ?>" name="s" value="<?php _admin_search_query(); ?>" />
+			<?php $this->search_filter(); ?>
+			<?php submit_button( $text, '', '', false, array( 'id' => 'search-submit' ) ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Renders the search filter dropdown.
+	 *
+	 * @return void
+	 */
+	private function search_filter() {
+		$options = array(
+			'customers' => __( 'Customers', 'woocommerce' ),
+			'products'  => __( 'Products', 'woocommerce' ),
+			'all'       => __( 'All', 'woocommerce' ),
+		);
+?>
+		<select name="filter" id="order-search-filter">
+			<?php foreach ( $options as $value => $label ) { ?>
+				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, isset( $_REQUEST['filter'] ) ? $_REQUEST['filter'] : 'customers' ); ?>><?php echo esc_html( $label ); ?></option>
+			<?php }
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -534,7 +534,7 @@ class ListTable extends WP_List_Table {
 		}
 
 		$filter = trim( sanitize_text_field( $this->request['search-filter'] ) );
-		if( ! empty( $filter ) ) {
+		if ( ! empty( $filter ) ) {
 			$this->order_query_args['search_filter'] = $filter;
 		}
 	}
@@ -728,7 +728,7 @@ class ListTable extends WP_List_Table {
 		global $wpdb;
 
 		$orders_table = esc_sql( OrdersTableDataStore::get_orders_table_name() );
-		$utc_offset = wc_timezone_offset();
+		$utc_offset   = wc_timezone_offset();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$order_dates = $wpdb->get_results(
@@ -1352,7 +1352,7 @@ class ListTable extends WP_List_Table {
 	 * @return int Number of orders that were trashed.
 	 */
 	private function do_delete( array $ids, bool $force_delete = false ): int {
-		$changed      = 0;
+		$changed = 0;
 
 		foreach ( $ids as $id ) {
 			$order = wc_get_order( $id );
@@ -1544,6 +1544,7 @@ class ListTable extends WP_List_Table {
 
 	/**
 	 * Renders the search box with various options to limit order search results.
+	 *
 	 * @param string $text The search button text.
 	 * @param string $input_id The search input ID.
 	 *
@@ -1557,20 +1558,14 @@ class ListTable extends WP_List_Table {
 		$input_id = $input_id . '-search-input';
 
 		if ( ! empty( $_REQUEST['orderby'] ) ) {
-			echo '<input type="hidden" name="orderby" value="' . esc_attr( $_REQUEST['orderby'] ) . '" />';
+			echo '<input type="hidden" name="orderby" value="' . esc_attr( sanitize_text_field( wp_unslash( $_REQUEST['orderby'] ) ) ) . '" />';
 		}
 		if ( ! empty( $_REQUEST['order'] ) ) {
-			echo '<input type="hidden" name="order" value="' . esc_attr( $_REQUEST['order'] ) . '" />';
-		}
-		if ( ! empty( $_REQUEST['post_mime_type'] ) ) {
-			echo '<input type="hidden" name="post_mime_type" value="' . esc_attr( $_REQUEST['post_mime_type'] ) . '" />';
-		}
-		if ( ! empty( $_REQUEST['detached'] ) ) {
-			echo '<input type="hidden" name="detached" value="' . esc_attr( $_REQUEST['detached'] ) . '" />';
+			echo '<input type="hidden" name="order" value="' . esc_attr( sanitize_text_field( wp_unslash( $_REQUEST['order'] ) ) ) . '" />';
 		}
 		?>
 		<p class="search-box">
-			<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo $text; ?>:</label>
+			<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $text ); ?>:</label>
 			<input type="search" id="<?php echo esc_attr( $input_id ); ?>" name="s" value="<?php _admin_search_query(); ?>" />
 			<?php $this->search_filter(); ?>
 			<?php submit_button( $text, '', '', false, array( 'id' => 'search-submit' ) ); ?>
@@ -1589,10 +1584,11 @@ class ListTable extends WP_List_Table {
 			'products'  => __( 'Products', 'woocommerce' ),
 			'all'       => __( 'All', 'woocommerce' ),
 		);
-?>
+		?>
 		<select name="search-filter" id="order-search-filter">
 			<?php foreach ( $options as $value => $label ) { ?>
-				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $_REQUEST['search-filter'] ?? 'all' ); ?>><?php echo esc_html( $label ); ?></option>
-			<?php }
+				<option value="<?php echo esc_attr( wp_unslash( sanitize_text_field( $value ) ) ); ?>" <?php selected( $value, sanitize_text_field( wp_unslash( $_REQUEST['search-filter'] ?? 'all' ) ) ); ?>><?php echo esc_html( $label ); ?></option>
+				<?php
+			}
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -101,7 +101,7 @@ class OrdersTableSearchQuery {
 
 	/**
 	 * Generate JOIN clause for a given search filter.
-	 * Right now we only have the products filter that actually does a JOIN, but in the future we may add more -- for example, custom order fields, payment tokens and so on. This function makes it easier to add more filters in the future.
+	 * Right now we only have the products filter that actually does a JOIN, but in the future we may add more -- for example, custom order fields, payment tokens, and so on. This function makes it easier to add more filters in the future.
 	 *
 	 * If a search filter needs a JOIN, it will also need a WHERE clause.
 	 *
@@ -147,7 +147,7 @@ class OrdersTableSearchQuery {
 	}
 
 	/**
-	 * Generates WHERE clause for a given search filter. Right now we only have the products and customers filters that actually use WHERE, but the in future we may add more -- for example, order custom fields, payment tokens etc. This function makes it easier to add more filters in the future.
+	 * Generates WHERE clause for a given search filter. Right now we only have the products and customers filters that actually use WHERE, but in the future we may add more -- for example, custom order fields, payment tokens and so on. This function makes it easier to add more filters in the future.
 	 *
 	 * @param string $search_filter Name of the search filter.
 	 *

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -100,10 +100,10 @@ class OrdersTableSearchQuery {
 	}
 
 	/**
-	 * Generate JOIN clause for different search filter.
-	 * Right now we only have the products filter that actually does any join, but in future we may add more, for example, in order search, or payment tokens etc. This function is to make it easier to add more filters in the future.
+	 * Generate JOIN clause for a given search filter.
+	 * Right now we only have the products filter that actually does a JOIN, but in the future we may add more -- for example, custom order fields, payment tokens and so on. This function makes it easier to add more filters in the future.
 	 *
-	 * If a search filter needs a join, it will also need a where clause.
+	 * If a search filter needs a JOIN, it will also need a WHERE clause.
 	 *
 	 * @param string $search_filter Name of the search filter.
 	 *
@@ -141,13 +141,13 @@ class OrdersTableSearchQuery {
 			$where[] = $this->generate_where_for_search_filter( $search_filter );
 		}
 
-		$where = implode( ' OR ', $where );
+		$where_statement = implode( ' OR ', $where );
 
-		return " ( $where ) ";
+		return " ( $where_statement ) ";
 	}
 
 	/**
-	 * Generates where clause for different search filter. Right now we only have the products and customers filter that actually use any `where`, but in future we may add more, for example, in order search, or payment tokens etc. This function is to make it easier to add more filters in the future.
+	 * Generates WHERE clause for a given search filter. Right now we only have the products and customers filters that actually use WHERE, but the in future we may add more -- for example, order custom fields, payment tokens etc. This function makes it easier to add more filters in the future.
 	 *
 	 * @param string $search_filter Name of the search filter.
 	 *

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -29,7 +29,7 @@ class OrdersTableSearchQuery {
 	 *
 	 * @var string
 	 */
-	private $search_filter;
+	private $search_filters;
 
 	/**
 	 * Creates the JOIN and WHERE clauses needed to execute a search of orders.
@@ -41,22 +41,24 @@ class OrdersTableSearchQuery {
 	public function __construct( OrdersTableQuery $query ) {
 		$this->query       = $query;
 		$this->search_term = urldecode( $query->get( 's' ) );
-		$this->search_filter = urldecode( $query->get( 'search_filter' ) );
-
-		$this->sanitize_search_filter();
+		$this->search_filters = $this->sanitize_search_filters( urldecode( $query->get( 'search_filter' ) ) );
 	}
 
 	/**
 	 * Sanitize search filter param.
+	 *
+	 * @return array Array of search filters.
 	 */
-	public function sanitize_search_filter() {
+	private function sanitize_search_filters( $search_filter ) : array {
 		$available_filters = array(
-			'customers',
+			'customers', // customers also searches in meta.
 			'products',
-			'all'
 		);
-		if ( ! in_array( $this->search_filter, $available_filters ) ) {
-			$this->search_filter = 'all';
+
+		if ( 'all' === $search_filter || '' === $search_filter ) {
+			return $available_filters;
+		} else {
+			return array_intersect( $available_filters, array( $search_filter ) );
 		}
 	}
 
@@ -86,16 +88,34 @@ class OrdersTableSearchQuery {
 	 * @return string
 	 */
 	private function generate_join(): string {
-		if( 'products' !== $this->search_filter && 'all' !== $this->search_filter ) {
-			return '';
+		$join = array();
+
+		foreach ( $this->search_filters as $search_filter ) {
+			$join[] = $this->generate_join_for_search_filter( $search_filter );
 		}
 
-		$orders_table = $this->query->get_table_name( 'orders' );
-		$items_table  = $this->query->get_table_name( 'items' );
+		return implode( ' ', $join );
+	}
 
-		return "
-			LEFT JOIN $items_table AS search_query_items ON search_query_items.order_id = $orders_table.id
-		";
+	/**
+	 * Generate JOIN clause for different search filter.
+	 * Right now we only have the products filter that actually does any join, but in future we may add more, for example, in order search, or payment tokens etc. This function is to make it easier to add more filters in the future.
+	 *
+	 * If a search filter needs a join, it will also need a where clause.
+	 *
+	 * @param string $search_filter Name of the search filter.
+	 *
+	 * @return string JOIN clause.
+	 */
+	private function generate_join_for_search_filter( $search_filter ) : string {
+		if ( 'products' === $search_filter ) {
+			$orders_table = $this->query->get_table_name( 'orders' );
+			$items_table  = $this->query->get_table_name( 'items' );
+			return "
+				LEFT JOIN $items_table AS search_query_items ON search_query_items.order_id = $orders_table.id
+			";
+		}
+		return '';
 	}
 
 	/**
@@ -106,28 +126,49 @@ class OrdersTableSearchQuery {
 	 * @return string
 	 */
 	private function generate_where(): string {
-		global $wpdb;
-		$where             = '';
+		$where             = array();
 		$possible_order_id = (string) absint( $this->search_term );
 		$order_table       = $this->query->get_table_name( 'orders' );
 
+
 		// Support the passing of an order ID as the search term.
 		if ( (string) $this->query->get( 's' ) === $possible_order_id ) {
-			$where = "`$order_table`.id = $possible_order_id OR ";
+			$where[] = "`$order_table`.id = $possible_order_id";
 		}
 
-		$meta_sub_query = $this->generate_where_for_meta_table();
+		foreach ( $this->search_filters as $search_filter ) {
+			$where[] = $this->generate_where_for_search_filter( $search_filter );
+		}
 
-		if( $this->search_filter === 'products' || $this->search_filter === 'all' ) {
-			$where .= $wpdb->prepare(
-				'search_query_items.order_item_name LIKE %s OR',
+		$where = implode( ' OR ', $where );
+
+		return " ( $where ) ";
+	}
+
+	/**
+	 * Generates where clause for different search filter. Right now we only have the products and customers filter that actually use any `where`, but in future we may add more, for example, in order search, or payment tokens etc. This function is to make it easier to add more filters in the future.
+	 *
+	 * @param string $search_filter Name of the search filter.
+	 *
+	 * @return string WHERE clause.
+	 */
+	private function generate_where_for_search_filter( string $search_filter ) : string {
+		global $wpdb;
+
+		$order_table = $this->query->get_table_name( 'orders' );
+
+		if( 'products' === $search_filter ) {
+			return $wpdb->prepare(
+				'search_query_items.order_item_name LIKE %s',
 				'%' . $wpdb->esc_like( $this->search_term ) . '%'
 			);
 		}
 
-		$where .= "`$order_table`.id IN ( $meta_sub_query ) ";
-
-		return " ( $where ) ";
+		if( 'customers' === $search_filter ) {
+			$meta_sub_query = $this->generate_where_for_meta_table();
+			return "`$order_table`.id IN ( $meta_sub_query ) ";
+		}
+		return '';
 	}
 
 	/**
@@ -169,14 +210,10 @@ GROUP BY search_query_meta.order_id
 	 * @return string
 	 */
 	private function get_meta_fields_to_be_searched(): string {
-		$meta_fields_to_search = array();
-
-		if( $this->search_filter === 'customers' || $this->search_filter === 'all' ) {
-			$meta_fields_to_search = array(
-				'_billing_address_index',
-				'_shipping_address_index',
-			);
-		}
+		$meta_fields_to_search = array(
+			'_billing_address_index',
+			'_shipping_address_index',
+		);
 
 		/**
 		 * Controls the order meta keys to be included in search queries.

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -108,7 +108,7 @@ class WC_Unit_Tests_Bootstrap {
 				$helpers_directory = $tests_directory . '/php/helpers';
 
 				// Support loading top-level classes from the `php/helpers` directory.
-				if ( ! strpos( $class, '\\' ) !== false ) {
+				if (  false === strpos( $class, '\\' ) ) {
 					$helper_path = realpath( "$helpers_directory/$class.php" );
 
 					if ( dirname( $helper_path ) === $helpers_directory && file_exists( $helper_path ) ) {

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -108,7 +108,7 @@ class WC_Unit_Tests_Bootstrap {
 				$helpers_directory = $tests_directory . '/php/helpers';
 
 				// Support loading top-level classes from the `php/helpers` directory.
-				if (  false === strpos( $class, '\\' ) ) {
+				if ( false === strpos( $class, '\\' ) ) {
 					$helper_path = realpath( "$helpers_directory/$class.php" );
 
 					if ( dirname( $helper_path ) === $helpers_directory && file_exists( $helper_path ) ) {

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -108,7 +108,7 @@ class WC_Unit_Tests_Bootstrap {
 				$helpers_directory = $tests_directory . '/php/helpers';
 
 				// Support loading top-level classes from the `php/helpers` directory.
-				if ( ! str_contains( $class, '\\' ) ) {
+				if ( ! strpos( $class, '\\' ) !== false ) {
 					$helper_path = realpath( "$helpers_directory/$class.php" );
 
 					if ( dirname( $helper_path ) === $helpers_directory && file_exists( $helper_path ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -455,7 +455,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$customer_order = new \WC_Order();
 		$customer_order->set_billing_first_name( 'Customer name' );
 		$customer_order->set_billing_email( 'customer@woo.test' );
-		$customer_order->set_status('completed' );
+		$customer_order->set_status( 'completed' );
 		$customer_order->save();
 
 		$test_product = WC_Helper_Product::create_simple_product( true, array( 'name' => 'Product name' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -447,7 +447,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Setup some dummy orders, to help testing the search filter.
+	 * Set up some dummy orders, to help test the search filter.
 	 *
 	 * @return array Order IDs
 	 */
@@ -469,7 +469,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox The 'search_filter' argument works with 'customer' param is passed.
+	 * @testDox The 'search_filter' argument works with a 'customer' param is passed in.
 	 */
 	public function test_query_s_filters_customers() {
 		$orders = $this->setup_dummy_orders_for_search_filter();
@@ -491,7 +491,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox The 'search_filter' argument works with 'product' param is passed.
+	 * @testDox The 'search_filter' argument works with a 'product' param is passed in.
 	 */
 	public function test_query_s_filters_products() {
 		$orders = $this->setup_dummy_orders_for_search_filter();
@@ -513,7 +513,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox The 'search_filter' argument works with 'all' param is passed.
+	 * @testDox The 'search_filter' argument works with an 'all' param is passed in.
 	 */
 	public function test_query_s_filters_all() {
 		$orders = $this->setup_dummy_orders_for_search_filter();

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -469,7 +469,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox The 'search_filter' argument works with a 'customer' param is passed in.
+	 * @testDox The 'search_filter' argument works with a 'customer' param passed in.
 	 */
 	public function test_query_s_filters_customers() {
 		$orders = $this->setup_dummy_orders_for_search_filter();
@@ -491,7 +491,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox The 'search_filter' argument works with a 'product' param is passed in.
+	 * @testDox The 'search_filter' argument works with a 'product' param passed in.
 	 */
 	public function test_query_s_filters_products() {
 		$orders = $this->setup_dummy_orders_for_search_filter();
@@ -513,7 +513,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox The 'search_filter' argument works with an 'all' param is passed in.
+	 * @testDox The 'search_filter' argument works with an 'all' param passed in.
 	 */
 	public function test_query_s_filters_all() {
 		$orders = $this->setup_dummy_orders_for_search_filter();

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -446,4 +446,95 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $query->orders );
 	}
 
+	/**
+	 * Setup some dummy orders, to help testing the search filter.
+	 *
+	 * @return array Order IDs
+	 */
+	private function setup_dummy_orders_for_search_filter() {
+		$customer_order = new \WC_Order();
+		$customer_order->set_billing_first_name( 'Customer name' );
+		$customer_order->set_billing_email( 'customer@woo.test' );
+		$customer_order->set_status('completed' );
+		$customer_order->save();
+
+		$test_product = WC_Helper_Product::create_simple_product( true, array( 'name' => 'Product name' ) );
+		$test_product->save();
+		$product_order = new WC_Order();
+		$product_order->add_product( $test_product );
+		$product_order->set_status( 'completed' );
+		$product_order->save();
+
+		return array( $customer_order->get_id(), $product_order->get_id() );
+	}
+
+	/**
+	 * @testDox The 'search_filter' argument works with 'customer' param is passed.
+	 */
+	public function test_query_s_filters_customers() {
+		$orders = $this->setup_dummy_orders_for_search_filter();
+
+		$query_args = array(
+			's'      => '',
+			'return' => 'ids',
+		);
+
+		$query_args['search_filter'] = 'customers';
+
+		$query_args['s'] = 'Customer';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $orders[0] ), $query->orders );
+
+		$query_args['s'] = 'Product';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertCount( 0, $query->orders );
+	}
+
+	/**
+	 * @testDox The 'search_filter' argument works with 'product' param is passed.
+	 */
+	public function test_query_s_filters_products() {
+		$orders = $this->setup_dummy_orders_for_search_filter();
+
+		$query_args = array(
+			's'      => '',
+			'return' => 'ids',
+		);
+
+		$query_args['search_filter'] = 'products';
+
+		$query_args['s'] = 'Product';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $orders[1] ), $query->orders );
+
+		$query_args['s'] = 'Customer';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertCount( 0, $query->orders );
+	}
+
+	/**
+	 * @testDox The 'search_filter' argument works with 'all' param is passed.
+	 */
+	public function test_query_s_filters_all() {
+		$orders = $this->setup_dummy_orders_for_search_filter();
+
+		$query_args = array(
+			's'      => '',
+			'return' => 'ids',
+		);
+
+		$query_args['search_filter'] = 'all';
+
+		$query_args['s'] = 'Product';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $orders[1] ), $query->orders );
+
+		$query_args['s'] = 'Customer';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $orders[0] ), $query->orders );
+
+		$query_args['s'] = 'name';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( $orders, $query->orders );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request: 

This PR adds a select box to the left of the search button to the admin HPOS screen. This allows merchants to select whether they want to search in products or in customer data for the term that they are searching. The primary reason here is performance, in testing on a store with 2.5 million orders, it would take around 1.3s ~ 1.5s to search in the product, about 2.38 ~ 3s to search in customers, but about 5 ~ 6s to search in both.

This PR enables merchants to decide where they want to search, and that way they can enjoy about 2x faster searching when they want to search for products or customers.

Additionally, this also refactors the OrderTableSearchQuery class to support more filters down the line.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially addresses #41454

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On shop with HPOS authoritative, create a product called "Product Common".
2. Create an order with this product. Make sure that you do not use the term "Customer" in any of the customer field (name, address, etc). 
3. Create another order **without** this product. Make sure that you do not use the term "Product" in any of the fields. In the customer name, add "Customer Common".
4. Go admin view at `/wp-admin/admin.php?page=wc-orders` and see the search form in top right corner:
<img width="1519" alt="Screenshot 2024-01-09 at 2 39 54 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/dc7337ee-010f-421a-941b-2d230b907665">
5. Search for term  "Product" while having "Customers" selected in the dropdown. No orders should show up.

6. Search for term "Customer" while having "Customers" selected in the dropdown. Order created in step 3 should show up.
7. Search for term "Common" while having "Customers" selected in the dropdown. Order created in step 3 should show up, but order created in step 2 will not.
8. Similarly, repeat the same for terms "Product", "Customer" and "Common" with "Product" selected in dropdown. No orders will show for term "Customer", whereas, order created in step 2 should show up for term "Product" and "Common".
9. Repeat the same for terms "Product", "Customer" and "Common" with "All" selected in dropdown. The behavior here should be exactly the same as the trunk, i.e. order in step 2 will show up for Product, order in step 3 will show for Customer, and both the orders will show up for "Common".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement

#### Message <!-- Add a changelog message here -->

 Allow selecting search criteria - Products/Customers/All when searching orders.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
