### PR TITLE
CYS - Core: implement 'noAI' flowType

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -50,6 +50,7 @@ import { CustomizeStoreContext } from './';
 import { recordEvent } from '@woocommerce/tracks';
 import { AiOfflineModal } from '~/customize-store/assembler-hub/onboarding-tour/ai-offline-modal';
 import { useQuery } from '@woocommerce/navigation';
+import { FlowType } from '../types';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
@@ -62,7 +63,7 @@ export const Layout = () => {
 		CustomizeStoreContext
 	);
 
-	const aiOnline = context.aiOnline;
+	const aiOnline = context.flowType === FlowType.AIOnline;
 	const { customizing } = useQuery();
 
 	const [ showAiOfflineModal, setShowAiOfflineModal ] = useState(
@@ -130,7 +131,7 @@ export const Layout = () => {
 						hasCompleteSurvey={
 							!! context?.transitionalScreen?.hasCompleteSurvey
 						}
-						aiOnline={ !! context?.aiOnline }
+						aiOnline={ context?.flowType === FlowType.AIOnline }
 					/>
 				</EntityProvider>
 			</EntityProvider>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -17,6 +17,7 @@ import { VariationContainer } from '../variation-container';
 import { FontPairingVariationPreview } from './preview';
 import { Look } from '~/customize-store/design-with-ai/types';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
+import { FlowType } from '~/customize-store/types';
 
 export const FontPairing = () => {
 	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
@@ -33,7 +34,7 @@ export const FontPairing = () => {
 	} );
 
 	const { context } = useContext( CustomizeStoreContext );
-	const aiOnline = context.aiOnline;
+	const aiOnline = context.flowType === FlowType.AIOnline;
 
 	const fontPairings = useMemo(
 		() =>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-color-palette.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-color-palette.tsx
@@ -20,6 +20,7 @@ import { CustomizeStoreContext } from '../';
 import { SidebarNavigationScreen } from './sidebar-navigation-screen';
 import { ADMIN_URL } from '~/utils/admin-settings';
 import { ColorPalette, ColorPanel } from './global-styles';
+import { FlowType } from '~/customize-store/types';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
@@ -56,18 +57,19 @@ const SidebarNavigationScreenColorPaletteContent = () => {
 
 export const SidebarNavigationScreenColorPalette = () => {
 	const {
-		context: { aiOnline },
+		context: { flowType },
 	} = useContext( CustomizeStoreContext );
 
-	const description = aiOnline
-		? __(
-				'Based on the info you shared, our AI tool recommends using this color palette. Want to change it? You can select or add new colors below, or update them later in <EditorLink>Editor</EditorLink> | <StyleLink>Styles</StyleLink>.',
-				'woocommerce'
-		  )
-		: __(
-				'Choose the color palette that best suits your brand. Want to change it? Create your custom color palette below, or update it later in <EditorLink>Editor</EditorLink> | <StyleLink>Styles</StyleLink>.',
-				'woocommerce'
-		  );
+	const description =
+		flowType === FlowType.AIOnline
+			? __(
+					'Based on the info you shared, our AI tool recommends using this color palette. Want to change it? You can select or add new colors below, or update them later in <EditorLink>Editor</EditorLink> | <StyleLink>Styles</StyleLink>.',
+					'woocommerce'
+			  )
+			: __(
+					'Choose the color palette that best suits your brand. Want to change it? Create your custom color palette below, or update it later in <EditorLink>Editor</EditorLink> | <StyleLink>Styles</StyleLink>.',
+					'woocommerce'
+			  );
 
 	return (
 		<SidebarNavigationScreen

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
@@ -15,10 +15,11 @@ import { SidebarNavigationScreen } from './sidebar-navigation-screen';
 import { ADMIN_URL } from '~/utils/admin-settings';
 import { FontPairing } from './global-styles';
 import { CustomizeStoreContext } from '..';
+import { FlowType } from '~/customize-store/types';
 
 export const SidebarNavigationScreenTypography = () => {
 	const { context } = useContext( CustomizeStoreContext );
-	const aiOnline = context.aiOnline;
+	const aiOnline = context.flowType === FlowType.AIOnline;
 
 	const label = aiOnline
 		? __(

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/index.tsx
@@ -10,6 +10,7 @@ import { AnyInterpreter, Sender } from 'xstate';
  */
 import {
 	CustomizeStoreComponent,
+	FlowType,
 	customizeStoreStateMachineContext,
 } from '../types';
 import { designWithAiStateMachineDefinition } from './state-machine';
@@ -44,7 +45,7 @@ export const DesignWithAiController = ( {
 } ) => {
 	// Assign aiOnline value from the parent context if it exists. Otherwise, ai is online by default.
 	designWithAiStateMachineDefinition.context.aiOnline =
-		parentContext?.aiOnline ?? true;
+		parentContext?.flowType === FlowType.AIOnline;
 	const [ state, send, service ] = useMachine(
 		designWithAiStateMachineDefinition,
 		{

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -4,7 +4,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * External dependencies
  */
-import { EventObject, Sender, createMachine } from 'xstate';
+import { Sender, createMachine } from 'xstate';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useMachine, useSelector } from '@xstate/react';
 import {

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -4,7 +4,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * External dependencies
  */
-import { Sender, createMachine } from 'xstate';
+import { EventObject, Sender, createMachine } from 'xstate';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useMachine, useSelector } from '@xstate/react';
 import {
@@ -39,11 +39,13 @@ import {
 	CustomizeStoreComponentMeta,
 	CustomizeStoreComponent,
 	customizeStoreStateMachineContext,
+	FlowType,
 } from './types';
 import { ThemeCard } from './intro/types';
 import './style.scss';
 import { navigateOrParent, attachParentListeners } from './utils';
 import useBodyClass from './hooks/use-body-class';
+import { isWooExpress } from '~/utils/is-woo-express';
 
 export type customizeStoreStateMachineEvents =
 	| introEvents
@@ -160,7 +162,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 		transitionalScreen: {
 			hasCompleteSurvey: false,
 		},
-		aiOnline: true,
+		flowType: FlowType.noAI,
 	} as customizeStoreStateMachineContext,
 	invoke: {
 		src: 'browserPopstateHandler',
@@ -212,8 +214,25 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 		},
 		intro: {
 			id: 'intro',
-			initial: 'preIntro',
+			initial: 'flowType',
 			states: {
+				flowType: {
+					on: {
+						// Always is not available in the current version of XState.
+						// eslint-disable-next-line xstate/prefer-always
+						'': [
+							{
+								target: 'intro',
+								cond: 'isNotWooExpress',
+								actions: 'assignNoAI',
+							},
+							{
+								target: 'preIntro',
+								cond: 'isWooExpress',
+							},
+						],
+					},
+				},
 				preIntro: {
 					type: 'parallel',
 					states: {
@@ -435,11 +454,13 @@ export const CustomizeStoreController = ( {
 					);
 				},
 				isAiOnline: ( _ctx ) => {
-					return _ctx.aiOnline;
+					return _ctx.flowType === FlowType.AIOnline;
 				},
 				isAiOffline: ( _ctx ) => {
-					return ! _ctx.aiOnline;
+					return _ctx.flowType === FlowType.AIOffline;
 				},
+				isWooExpress: () => isWooExpress(),
+				isNotWooExpress: () => ! isWooExpress(),
 			},
 		} );
 	}, [ actionOverrides, servicesOverrides ] );

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -11,6 +11,7 @@ import { customizeStoreStateMachineEvents } from '..';
 import {
 	aiStatusResponse,
 	customizeStoreStateMachineContext,
+	FlowType,
 	RecommendThemesAPIResponse,
 } from '../types';
 import { events } from './';
@@ -109,7 +110,7 @@ export const assignAiStatus = assign<
 	customizeStoreStateMachineContext,
 	customizeStoreStateMachineEvents // this is actually the wrong type for the event but I still don't know how to type this properly
 >( {
-	aiOnline: ( _context, _event ) => {
+	flowType: ( _context, _event ) => {
 		const indicator = ( _event as DoneInvokeEvent< aiStatusResponse > ).data
 			.status.indicator;
 		const status = indicator !== 'critical' && indicator !== 'major';
@@ -120,7 +121,7 @@ export const assignAiStatus = assign<
 			online: status ? 'yes' : 'no',
 		} );
 
-		return status;
+		return status ? FlowType.AIOnline : FlowType.AIOffline;
 	},
 } );
 
@@ -128,13 +129,20 @@ export const assignAiOffline = assign<
 	customizeStoreStateMachineContext,
 	customizeStoreStateMachineEvents // this is actually the wrong type for the event but I still don't know how to type this properly
 >( {
-	aiOnline: () => {
+	flowType: () => {
 		// @ts-expect-error temp workaround;
 		window.cys_aiOnline = false;
 		recordEvent( 'customize_your_store_ai_status', {
 			online: 'no',
 		} );
 
-		return false;
+		return FlowType.AIOffline;
 	},
+} );
+
+export const assignNoAI = assign<
+	customizeStoreStateMachineContext,
+	customizeStoreStateMachineEvents // this is actually the wrong type for the event but I still don't know how to type this properly
+>( {
+	flowType: FlowType.noAI,
 } );

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -13,7 +13,7 @@ import {
 /**
  * Internal dependencies
  */
-import { CustomizeStoreComponent } from '../types';
+import { CustomizeStoreComponent, FlowType } from '../types';
 import { SiteHub } from '../assembler-hub/site-hub';
 import { ThemeCard } from './theme-card';
 import {
@@ -30,6 +30,7 @@ import {
 	DefaultBanner,
 	ExistingAiThemeBanner,
 	ExistingThemeBanner,
+	CoreBanner,
 } from './intro-banners';
 
 export type events =
@@ -51,6 +52,7 @@ const BANNER_COMPONENTS = {
 	'jetpack-offline': JetpackOfflineBanner,
 	'existing-ai-theme': ExistingAiThemeBanner,
 	'existing-theme': ExistingThemeBanner,
+	[ FlowType.noAI ]: CoreBanner,
 	default: DefaultBanner,
 };
 
@@ -82,8 +84,10 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 
 	let modalStatus: ModalStatus = 'no-modal';
 	let bannerStatus: BannerStatus = 'default';
-
 	switch ( true ) {
+		case context.flowType === FlowType.noAI:
+			bannerStatus = FlowType.noAI;
+			break;
 		case isNetworkOffline:
 			bannerStatus = 'network-offline';
 			break;

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -203,6 +203,20 @@ export const ThemeHasModsBanner = ( {
 	);
 };
 
+export const CoreBanner = () => {
+	return (
+		<BaseIntroBanner
+			bannerTitle={ __( 'Design your own', 'woocommerce' ) }
+			bannerText={ __(
+				'Quickly create a beautiful store using our built-in store designer. Choose your layout, select a style, and much more.',
+				'woocommerce'
+			) }
+			bannerClass="core-banner"
+			bannerButtonOnClick={ () => {} }
+		/>
+	);
+};
+
 export const ExistingAiThemeBanner = ( {
 	setOpenDesignChangeWarningModal,
 }: {

--- a/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
@@ -11,6 +11,7 @@ import { AnyInterpreter } from 'xstate';
  */
 import { Intro } from '../';
 import { useNetworkStatus } from '~/utils/react-hooks/use-network-status';
+import { FlowType } from '~/customize-store/types';
 
 jest.mock( '../../assembler-hub/site-hub', () => ( {
 	SiteHub: jest.fn( () => null ),
@@ -44,7 +45,7 @@ describe( 'Intro Banners', () => {
 					transitionalScreen: {
 						hasCompleteSurvey: false,
 					},
-					aiOnline: true,
+					flowType: FlowType.AIOnline,
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -82,7 +83,7 @@ describe( 'Intro Banners', () => {
 					transitionalScreen: {
 						hasCompleteSurvey: false,
 					},
-					aiOnline: true,
+					flowType: FlowType.AIOnline,
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -126,7 +127,7 @@ describe( 'Intro Banners', () => {
 					transitionalScreen: {
 						hasCompleteSurvey: false,
 					},
-					aiOnline: true,
+					flowType: FlowType.AIOnline,
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }

--- a/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-modal.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-modal.test.tsx
@@ -9,6 +9,7 @@ import { AnyInterpreter } from 'xstate';
  * Internal dependencies
  */
 import { Intro } from '../';
+import { FlowType } from '~/customize-store/types';
 
 jest.mock( '../../assembler-hub/site-hub', () => ( {
 	SiteHub: jest.fn( () => null ),
@@ -42,7 +43,7 @@ describe( 'Intro Modals', () => {
 					transitionalScreen: {
 						hasCompleteSurvey: false,
 					},
-					aiOnline: true,
+					flowType: FlowType.AIOnline,
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -97,7 +98,7 @@ describe( 'Intro Modals', () => {
 					transitionalScreen: {
 						hasCompleteSurvey: false,
 					},
-					aiOnline: true,
+					flowType: FlowType.AIOnline,
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -150,7 +151,7 @@ describe( 'Intro Modals', () => {
 					transitionalScreen: {
 						hasCompleteSurvey: false,
 					},
-					aiOnline: true,
+					flowType: FlowType.AIOnline,
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }

--- a/plugins/woocommerce-admin/client/customize-store/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/types.ts
@@ -35,6 +35,15 @@ export type aiStatusResponse = {
 	};
 };
 
+export enum FlowType {
+	// Flow when the AI is online.
+	AIOnline = 'AIOnline',
+	// Flow when the AI is offline because the AI endpoints are down.
+	AIOffline = 'AIOffline',
+	// Flow when the AI isn't available in the site. E.g. the site is not on a paid plan.
+	noAI = 'noAI',
+}
+
 export type customizeStoreStateMachineContext = {
 	themeConfiguration: Record< string, unknown >; // placeholder for theme configuration until we know what it looks like
 	intro: {
@@ -48,5 +57,5 @@ export type customizeStoreStateMachineContext = {
 	transitionalScreen: {
 		hasCompleteSurvey: boolean;
 	};
-	aiOnline: boolean;
+	flowType: FlowType;
 };

--- a/plugins/woocommerce-admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/index.tsx
@@ -19,7 +19,6 @@ import FrequentlyAskedQuestionsSimple from './faq-simple';
 
 declare global {
 	interface Window {
-		wcCalypsoBridge: unknown;
 		location: Location;
 		wcSettings: {
 			admin: {

--- a/plugins/woocommerce-admin/client/utils/is-woo-express.ts
+++ b/plugins/woocommerce-admin/client/utils/is-woo-express.ts
@@ -1,0 +1,10 @@
+declare global {
+	interface Window {
+		wcCalypsoBridge?: {
+			isWooExpress: boolean;
+		};
+	}
+}
+
+export const isWooExpress = (): boolean =>
+	window.wcCalypsoBridge !== undefined && window.wcCalypsoBridge.isWooExpress;

--- a/plugins/woocommerce/changelog/43368-42901-cys-offline-flow-core-ensure-that-jetpack-plugin-isnt-a-required-dependency
+++ b/plugins/woocommerce/changelog/43368-42901-cys-offline-flow-core-ensure-that-jetpack-plugin-isnt-a-required-dependency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+CYS: Implement `noAI` flow.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces a refactor about using the boolean about the AI status. With the implementation of the assembler in Core, we have three statuses:

- `AIOnline` when the AI is online.
- `AIOffline` when the AI is offline because the AI endpoints are down
- `NoAI ' when the AI isn't available on the site. E.g. the site is not on a paid plan. (happy to change name if you have a better suggestion).

Also, it introduces a new state called `flowType` that, based on some condition, checks if the flow is NoAI.


Part of #42901 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Local Installation

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Head over to WooCommerce -> Home and click on "Start Customizing".
5. Ensure that the layout looks like this image:

![image](https://github.com/woocommerce/woocommerce/assets/4463174/8a6cf1be-6bc4-4f04-aebd-183db7c84744)



### JN Installation


1. Create a new WooCommerce installation with this version.
2. Ensure Jetpack is installed and your site is connected with JP.
3. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
4. Ensure the Woo AI plugin is installed and activated (available on this monorepo).
5. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
6. Head over to WooCommerce -> Home and click on "Start Customizing".
7. Ensure that all the flow works correctly.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: Implement `noAI` flow.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
