### PR TITLE
Product Gallery block: Prevent page from scrolling when pop-up is open

### DIFF
--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -1,3 +1,7 @@
+body.modal-open {
+	overflow: hidden;
+}
+
 // These styles are for the server side rendered product grid blocks.
 .wc-block-grid__products .wc-block-grid__product-image {
 	text-decoration: none;

--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -1,4 +1,4 @@
-body.modal-open {
+body.wc-block-product-gallery-modal-open {
 	overflow: hidden;
 }
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -61,7 +61,9 @@ const productGallery = {
 		openDialog: () => {
 			const context = getContext();
 			context.isDialogOpen = true;
-			document.body.classList.add( 'modal-open' );
+			document.body.classList.add(
+				'wc-block-product-gallery-modal-open'
+			);
 		},
 		selectImage: () => {
 			const context = getContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -40,6 +40,7 @@ const closeDialog = ( context: ProductGalleryContext ) => {
 	context.isDialogOpen = false;
 	// Reset the main image.
 	context.selectedImage = context.firstMainImageId;
+	document.body.classList.remove( 'modal-open' );
 };
 
 const productGallery = {
@@ -60,6 +61,7 @@ const productGallery = {
 		openDialog: () => {
 			const context = getContext();
 			context.isDialogOpen = true;
+			document.body.classList.add( 'modal-open' );
 		},
 		selectImage: () => {
 			const context = getContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -40,7 +40,7 @@ const closeDialog = ( context: ProductGalleryContext ) => {
 	context.isDialogOpen = false;
 	// Reset the main image.
 	context.selectedImage = context.firstMainImageId;
-	document.body.classList.remove( 'modal-open' );
+	document.body.classList.remove( 'wc-block-product-gallery-modal-open' );
 };
 
 const productGallery = {

--- a/plugins/woocommerce/changelog/43378-fix-43343-prevent-page-scrolling-when-pop-up-is-open
+++ b/plugins/woocommerce/changelog/43378-fix-43343-prevent-page-scrolling-when-pop-up-is-open
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Prevent page scrolling when the Product Gallery Pop-Up is open.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Added a new class to the body element that is only applied when the pop-up is open.
- Remove the class from the body element when the pop-up is closed.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43343 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Three," "Twenty-twenty Four," etc.
2. On the left-hand side menu, click on Appearance > Editor > Templates
3. Find and select the 'Single Product' template from the list.
4. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
5. Inside the Page editor, click on the '+' button to add a new block.
6. In the block library that pops up, search for the 'Product Gallery' block. Click on it to add the block to the template.
7. Click on Save;
8. Visit a product page of a Variable Product;
9. Click on the Large Image;
10. When the pop-up appears scroll down the mouse and make sure you see the scroll bar does not appear to the right side.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Prevent page scrolling when the Product Gallery Pop-Up is open.

</details>
