### PR TITLE
[Experimental] Handle adding attributes during fields registration

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -113,6 +113,20 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 				if ( field.hidden ) {
 					return null;
 				}
+
+				const fieldProps = {
+					id: `${ id }-${ field.key }`,
+					errorId: `${ addressType }_${ field.key }`,
+					label: field.required ? field.label : field.optionalLabel,
+					// These may come from core locale settings or the attributes option on custom fields.
+					autoCapitalize: field.autocapitalize,
+					autoComplete: field.autocomplete,
+					errorMessage: field.errorMessage,
+					required: field.required,
+					className: `wc-block-components-address-form__${ field.key }`,
+					...field.attributes,
+				};
+
 				if ( field.type === 'checkbox' ) {
 					return (
 						<CheckboxControl
@@ -126,20 +140,10 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 									[ field.key ]: checked,
 								} );
 							} }
+							{ ...fieldProps }
 						/>
 					);
 				}
-				const fieldProps = {
-					id: `${ id }-${ field.key }`,
-					errorId: `${ addressType }_${ field.key }`,
-					label: field.required ? field.label : field.optionalLabel,
-					autoCapitalize: field.autocapitalize,
-					autoComplete: field.autocomplete,
-					errorMessage: field.errorMessage,
-					required: field.required,
-					className: `wc-block-components-address-form__${ field.key }`,
-					...field.attributes,
-				};
 
 				if (
 					field.key === 'country' &&

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -138,6 +138,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 					errorMessage: field.errorMessage,
 					required: field.required,
 					className: `wc-block-components-address-form__${ field.key }`,
+					...field.attributes,
 				};
 
 				if (

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -16,7 +16,6 @@ type CustomFieldAttributes = Pick<
 	| 'disabled'
 	| 'readOnly'
 	| 'pattern'
-	| 'placeholder'
 	| 'title'
 	| 'autoCapitalize'
 	| 'autoComplete'

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { ComboboxControlOption } from '@woocommerce/base-components/combobox';
+import type { AllHTMLAttributes, AriaAttributes } from 'react';
 
 /**
  * Internal dependencies
@@ -9,12 +10,18 @@ import { ComboboxControlOption } from '@woocommerce/base-components/combobox';
 import { getSetting } from './utils';
 
 // A list of attributes that can be added to a custom field when registering it.
-type CustomFieldAttributes =
+type CustomFieldAttributes = Pick<
+	AllHTMLAttributes< HTMLInputElement >,
 	| 'maxLength'
 	| 'disabled'
 	| 'readOnly'
 	| 'pattern'
-	| 'placeholder';
+	| 'placeholder'
+	| 'title'
+	| 'autoCapitalize'
+	| 'autoComplete'
+> &
+	AriaAttributes;
 
 export interface FormField {
 	// The label for the field.
@@ -35,8 +42,8 @@ export interface FormField {
 	type?: string;
 	// The options if this is a select field
 	options?: ComboboxControlOption[];
-	// Additional attributes added when registering a field
-	attributes?: Record< CustomFieldAttributes, string >;
+	// Additional attributes added when registering a field. String in key is required for data attributes.
+	attributes?: Record< keyof CustomFieldAttributes, string >;
 }
 
 export interface LocaleSpecificFormField extends Partial< FormField > {

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -13,7 +13,6 @@ import { getSetting } from './utils';
 type CustomFieldAttributes = Pick<
 	AllHTMLAttributes< HTMLInputElement >,
 	| 'maxLength'
-	| 'disabled'
 	| 'readOnly'
 	| 'pattern'
 	| 'title'

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -8,6 +8,14 @@ import { ComboboxControlOption } from '@woocommerce/base-components/combobox';
  */
 import { getSetting } from './utils';
 
+// A list of attributes that can be added to a custom field when registering it.
+type CustomFieldAttributes =
+	| 'maxLength'
+	| 'disabled'
+	| 'readOnly'
+	| 'pattern'
+	| 'placeholder';
+
 export interface FormField {
 	// The label for the field.
 	label: string;
@@ -27,6 +35,8 @@ export interface FormField {
 	type?: string;
 	// The options if this is a select field
 	options?: ComboboxControlOption[];
+	// Additional attributes added when registering a field
+	attributes?: Record< CustomFieldAttributes, string >;
 }
 
 export interface LocaleSpecificFormField extends Partial< FormField > {

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -17,7 +17,7 @@ export type CheckboxControlProps = {
 	children?: React.ReactChildren;
 	hasError?: boolean;
 	checked?: boolean;
-	disabled?: boolean | 'true' | 'false';
+	disabled?: string | boolean | undefined;
 };
 
 /**
@@ -33,11 +33,9 @@ export const CheckboxControl = ( {
 	checked = false,
 	disabled = false,
 	...rest
-}: CheckboxControlProps & Record< string, string > ): JSX.Element => {
+}: CheckboxControlProps & Record< string, unknown > ): JSX.Element => {
 	const instanceId = useInstanceId( CheckboxControl );
 	const checkboxId = id || `checkbox-control-${ instanceId }`;
-
-	const isDisabled = disabled === true || disabled === 'true';
 
 	return (
 		<div
@@ -57,7 +55,7 @@ export const CheckboxControl = ( {
 					onChange={ ( event ) => onChange( event.target.checked ) }
 					aria-invalid={ hasError === true }
 					checked={ checked }
-					disabled={ isDisabled }
+					disabled={ !! disabled }
 					{ ...rest }
 				/>
 				<svg

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -17,7 +17,7 @@ export type CheckboxControlProps = {
 	children?: React.ReactChildren;
 	hasError?: boolean;
 	checked?: boolean;
-	disabled?: boolean;
+	disabled?: boolean | 'true' | 'false';
 };
 
 /**
@@ -33,9 +33,11 @@ export const CheckboxControl = ( {
 	checked = false,
 	disabled = false,
 	...rest
-}: CheckboxControlProps ): JSX.Element => {
+}: CheckboxControlProps & Record< string, string > ): JSX.Element => {
 	const instanceId = useInstanceId( CheckboxControl );
 	const checkboxId = id || `checkbox-control-${ instanceId }`;
+
+	const isDisabled = disabled === true || disabled === 'true';
 
 	return (
 		<div
@@ -55,7 +57,7 @@ export const CheckboxControl = ( {
 					onChange={ ( event ) => onChange( event.target.checked ) }
 					aria-invalid={ hasError === true }
 					checked={ checked }
-					disabled={ disabled }
+					disabled={ isDisabled }
 					{ ...rest }
 				/>
 				<svg

--- a/plugins/woocommerce-blocks/packages/components/text-input/text-input.tsx
+++ b/plugins/woocommerce-blocks/packages/components/text-input/text-input.tsx
@@ -62,7 +62,7 @@ const TextInput = forwardRef< HTMLInputElement, TextInputProps >(
 					'wc-block-components-text-input',
 					className,
 					{
-						'is-active': isActive || value,
+						'is-active': isActive || value || rest.placeholder,
 					}
 				) }
 			>

--- a/plugins/woocommerce-blocks/packages/components/text-input/text-input.tsx
+++ b/plugins/woocommerce-blocks/packages/components/text-input/text-input.tsx
@@ -62,7 +62,7 @@ const TextInput = forwardRef< HTMLInputElement, TextInputProps >(
 					'wc-block-components-text-input',
 					className,
 					{
-						'is-active': isActive || value || rest.placeholder,
+						'is-active': isActive || value,
 					}
 				) }
 			>

--- a/plugins/woocommerce/changelog/43379-add-custom-fields-attributes
+++ b/plugins/woocommerce/changelog/43379-add-custom-fields-attributes
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: add
+Comment: Allow adding attributes when registering custom checkout fields in the Checkout block.
 
-Allow adding attributes when registering custom checkout fields in the Checkout block.

--- a/plugins/woocommerce/changelog/43379-add-custom-fields-attributes
+++ b/plugins/woocommerce/changelog/43379-add-custom-fields-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow adding attributes when registering custom checkout fields in the Checkout block.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -333,7 +333,6 @@ class CheckoutFields {
 
 			// These are formatted in camelCase because React components expect them that way.
 			$allowed_attributes = array(
-				'placeholder',
 				'maxLength',
 				'disabled',
 				'readOnly',

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -343,7 +343,7 @@ class CheckoutFields {
 			$valid_attributes = array_filter(
 				$options['attributes'],
 				function( $_, $key ) use ( $allowed_attributes ) {
-					return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0;
+					return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0 || strpos( $key, 'data-' ) === 0;
 				},
 				ARRAY_FILTER_USE_BOTH
 			);

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -338,6 +338,9 @@ class CheckoutFields {
 				'disabled',
 				'readOnly',
 				'pattern',
+				'autocomplete',
+				'autocapitalize',
+				'title',
 			);
 
 			$valid_attributes = array_filter(

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -304,70 +304,18 @@ class CheckoutFields {
 		}
 
 		$field_data = array(
-			'label'          => $options['label'],
-			'hidden'         => false,
-			'type'           => $type,
-			'optionalLabel'  => empty( $options['optionalLabel'] ) ? sprintf(
+			'label'         => $options['label'],
+			'hidden'        => false,
+			'type'          => $type,
+			'optionalLabel' => empty( $options['optionalLabel'] ) ? sprintf(
 			/* translators: %s Field label. */
 				__( '%s (optional)', 'woocommerce' ),
 				$options['label']
 			) : $options['optionalLabel'],
-			'required'       => empty( $options['required'] ) ? false : $options['required'],
-			'autocomplete'   => empty( $options['autocomplete'] ) ? '' : $options['autocomplete'],
-			'autocapitalize' => empty( $options['autocapitalize'] ) ? '' : $options['autocapitalize'],
+			'required'      => empty( $options['required'] ) ? false : $options['required'],
 		);
 
-		// We check if attributes are valid. This is done to prevent too much nesting and also to allow field registration
-		// even if the attributes property is invalid. We can just skip it and register the field without attributes.
-		$has_attributes = false;
-		if ( ! empty( $options['attributes'] ) ) {
-
-			if ( ! is_array( $options['attributes'] ) || 0 === count( $options['attributes'] ) ) {
-				$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
-				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
-			}
-			$has_attributes = true;
-		}
-
-		if ( $has_attributes ) {
-
-			// These are formatted in camelCase because React components expect them that way.
-			$allowed_attributes = array(
-				'maxLength',
-				'disabled',
-				'readOnly',
-				'pattern',
-				'autocomplete',
-				'autocapitalize',
-				'title',
-			);
-
-			$valid_attributes = array_filter(
-				$options['attributes'],
-				function( $_, $key ) use ( $allowed_attributes ) {
-					return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0 || strpos( $key, 'data-' ) === 0;
-				},
-				ARRAY_FILTER_USE_BOTH
-			);
-
-			// Any invalid attributes should show a doing_it_wrong warning. It shouldn't stop field registration, though.
-			if ( count( $options['attributes'] ) !== count( $valid_attributes ) ) {
-				$invalid_attributes = array_diff_key( $options['attributes'], $valid_attributes );
-				$message            = sprintf( 'Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode( ', ', $invalid_attributes ) );
-				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
-			}
-
-			// Escape attributes to remove any malicious code.
-			$cleaned_attributes = array_map(
-				function( $value ) {
-					return esc_attr( $value );
-				},
-				$valid_attributes
-			);
-
-			$field_data['attributes'] = $cleaned_attributes;
-		}
-
+		$field_data['attributes'] = $this->register_field_attributes( $id, $options['attributes'] ?? [] );
 		/**
 		 * Handle Checkbox fields.
 		 */
@@ -432,6 +380,66 @@ class CheckoutFields {
 		$this->additional_fields[ $id ] = $field_data;
 
 		$this->fields_locations[ $location ][] = $id;
+	}
+
+	/**
+	 * Processes the attributes supplied during field registration.
+	 *
+	 * @param array $id         The field ID.
+	 * @param array $attributes The attributes supplied during field registration.
+	 *
+	 * @return array The processed attributes.
+	 */
+	private function register_field_attributes( $id, $attributes ) {
+
+		// We check if attributes are valid. This is done to prevent too much nesting and also to allow field registration
+		// even if the attributes property is invalid. We can just skip it and register the field without attributes.
+		$has_attributes = false;
+
+		if ( empty( $attributes ) ) {
+			return [];
+		}
+
+		if ( ! is_array( $attributes ) || 0 === count( $attributes ) ) {
+			$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			return [];
+		}
+
+
+		// These are formatted in camelCase because React components expect them that way.
+		$allowed_attributes = array(
+			'maxLength',
+			'disabled',
+			'readOnly',
+			'pattern',
+			'autocomplete',
+			'autocapitalize',
+			'title',
+		);
+
+		$valid_attributes = array_filter(
+			$attributes,
+			function( $_, $key ) use ( $allowed_attributes ) {
+				return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0 || strpos( $key, 'data-' ) === 0;
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+
+		// Any invalid attributes should show a doing_it_wrong warning. It shouldn't stop field registration, though.
+		if ( count( $attributes ) !== count( $valid_attributes ) ) {
+			$invalid_attributes = array_keys( array_diff_key( $attributes, $valid_attributes ) );
+			$message            = sprintf( 'Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode( ', ', $invalid_attributes ) );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+		}
+
+		// Escape attributes to remove any malicious code and return them.
+		return array_map(
+			function( $value ) {
+				return esc_attr( $value );
+			},
+			$valid_attributes
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -410,7 +410,6 @@ class CheckoutFields {
 		// These are formatted in camelCase because React components expect them that way.
 		$allowed_attributes = array(
 			'maxLength',
-			'disabled',
 			'readOnly',
 			'pattern',
 			'autocomplete',

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -343,7 +343,7 @@ class CheckoutFields {
 			$valid_attributes = array_filter(
 				$options['attributes'],
 				function( $_, $key ) use ( $allowed_attributes ) {
-					return in_array( $key, $allowed_attributes, true );
+					return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0;
 				},
 				ARRAY_FILTER_USE_BOTH
 			);

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -406,7 +406,6 @@ class CheckoutFields {
 			return [];
 		}
 
-
 		// These are formatted in camelCase because React components expect them that way.
 		$allowed_attributes = array(
 			'maxLength',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR adds support for attributes when registering custom fields.

The list of supported attributes is:
- `maxLength`
- `placeholder`
- `pattern`
- `disabled`
- `readOnly`
- `title`
- `aria-`
- `data-`

Currently we do _not_ support custom attributes on `select` fields (see pdFofs-1Ge-p2) 

It also includes some TypeScript modifications to support this new key on checkout fields.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42137 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet to your site:
```php
add_action(
	'woocommerce_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id'            => 'namespace/gov-id',
				'label'         => 'Government ID',
				'optionalLabel' => 'Government ID (optional)',
				'location'      => 'additional',
				'required'      => true,
				'type'          => 'text',
				'attributes'    => array(
					'autocomplete'     => 'government-id',
					'aria-describedby' => 'some-element',
					'aria-label'       => 'custom label',
					'title'            => 'Title of textbox',
					'data-custom'      => 'custom data',
				),
			),
		);
	}
);
```

2. Visit the Checkout block and ensure the Government ID field is showing a placeholder and it is not overlapping with the label.
3. Enter a value into the Government ID field that does not conform to the pattern (e.g. 12345) tab out of the field and ensure an error is shown.
4. Correct the value to one that does conform to the pattern (e.g. ABCDE) and ensure the warning is removed.
5. Try to enter more than 5 characters. It should not let you.
6. In the snippet, remove the `pattern` property. Reload and repeat step 3. Ensure the error does not show.
7. Add `'disabled' => true` to the `attributes` array in the snippet.
8. View the Checkout block and ensure the field is disabled and that you cannot interact with it.
10. [Dev only instruction] Inspect the element, ensure it has the correct `aria-describedby`, `data-custom` , and `aria-label` attributes.
11. Remove the `attributes` array completely. Reload the page and ensure no errors or warnings are shown.

#### Error handling

1. Log in as admin.
2. Add an invalid attribute to the array `'foo' => 'bar'` and reload the page. Expect to see a `doing_it_wrong` warning. The field should still register, but the invalid attribute should not be there.
3. In the snippet, change `attributes` to a string rather than an array.
4. View the Checkout block and expect to see a `doing_it_wrong` warning. The field should still register though.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Allow adding attributes when registering custom checkout fields in the Checkout block.
</details>