### PR TITLE
Product Editor: Load layout templates from the REST API

### DIFF
--- a/packages/js/product-editor/changelog/update-use-use-layout-template
+++ b/packages/js/product-editor/changelog/update-use-use-layout-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Load layout templates via the REST API.

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -35,7 +35,10 @@ import {
 	WPError,
 	getProductErrorMessage,
 } from '../../../utils/get-product-error-message';
-import { ProductEditorBlockEditProps, ProductTemplate } from '../../../types';
+import type {
+	ProductEditorBlockEditProps,
+	ProductTemplate,
+} from '../../../types';
 import { ProductDetailsSectionDescriptionBlockAttributes } from './types';
 
 export function ProductDetailsSectionDescriptionBlockEdit( {

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -29,14 +29,13 @@ import { useEntityId } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { ProductEditorSettings } from '../../../components';
-import { ProductTemplate } from '../../../components/editor';
 import { BlockFill } from '../../../components/block-slot-fill';
 import { useValidations } from '../../../contexts/validation-context';
 import {
 	WPError,
 	getProductErrorMessage,
 } from '../../../utils/get-product-error-message';
-import { ProductEditorBlockEditProps } from '../../../types';
+import { ProductEditorBlockEditProps, ProductTemplate } from '../../../types';
 import { ProductDetailsSectionDescriptionBlockAttributes } from './types';
 
 export function ProductDetailsSectionDescriptionBlockEdit( {

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -38,6 +38,7 @@ import {
  */
 import useProductEntityProp from '../../hooks/use-product-entity-prop';
 import { useConfirmUnsavedProductChanges } from '../../hooks/use-confirm-unsaved-product-changes';
+import { useProductTemplate } from '../../hooks/use-product-template';
 import { PostTypeContext } from '../../contexts/post-type-context';
 import { store as productEditorUiStore } from '../../store/product-editor-ui';
 import { ModalEditor } from '../modal-editor';
@@ -107,6 +108,11 @@ export function BlockEditor( {
 		{ postType }
 	);
 
+	const { productTemplate } = useProductTemplate(
+		productTemplateId,
+		productType
+	);
+
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		postType,
@@ -116,21 +122,6 @@ export function BlockEditor( {
 	const { updateEditorSettings } = useDispatch( 'core/editor' );
 
 	useLayoutEffect( () => {
-		const productTemplates = settings?.productTemplates ?? [];
-		const productTemplate = productTemplates.find( ( template ) => {
-			if ( productTemplateId === template.id ) {
-				return true;
-			}
-
-			if ( ! productType ) {
-				return false;
-			}
-
-			// Fallback to the product type if the product does not have any product
-			// template associated to itself.
-			return template.productData.type === productType;
-		} );
-
 		const layoutTemplates = settings?.layoutTemplates ?? [];
 
 		let layoutTemplateId = productTemplate?.layoutTemplateId;
@@ -159,7 +150,7 @@ export function BlockEditor( {
 			...settings,
 			productTemplate,
 		} as Partial< ProductEditorSettings > );
-	}, [ settings, postType, productTemplateId, productType ] );
+	}, [ settings, postType, productTemplate, productType ] );
 
 	// Check if the Modal editor is open from the store.
 	const isModalEditorOpen = useSelect( ( select ) => {

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -59,7 +59,8 @@ function getLayoutTemplateId(
 		return 'product-variation';
 	}
 
-	return undefined;
+	// Fallback to simple product if no layout template is set.
+	return 'simple-product';
 }
 export function BlockEditor( {
 	context,

--- a/packages/js/product-editor/src/components/editor/types.ts
+++ b/packages/js/product-editor/src/components/editor/types.ts
@@ -8,22 +8,17 @@ import {
 } from '@wordpress/block-editor';
 import { Template } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import { ProductTemplate } from '../../types';
+
 export type LayoutTemplate = {
 	id: string;
 	title: string;
 	description: string;
 	area: string;
 	blockTemplates: Template[];
-};
-
-export type ProductTemplate = {
-	id: string;
-	title: string;
-	description: string | null;
-	icon: string | null;
-	order: number;
-	layoutTemplateId: string;
-	productData: Partial< Product >;
 };
 
 export type ProductEditorSettings = Partial<

--- a/packages/js/product-editor/src/components/editor/types.ts
+++ b/packages/js/product-editor/src/components/editor/types.ts
@@ -24,7 +24,6 @@ export type LayoutTemplate = {
 export type ProductEditorSettings = Partial<
 	EditorSettings & EditorBlockListSettings
 > & {
-	layoutTemplates: LayoutTemplate[];
 	productTemplates: ProductTemplate[];
 	productTemplate?: ProductTemplate;
 };

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useCurrencyInputProps as __experimentalUseCurrencyInputProps } from './
 export { useVariationSwitcher as __experimentalUseVariationSwitcher } from './use-variation-switcher';
 export { default as __experimentalUseProductEntityProp } from './use-product-entity-prop';
 export { default as __experimentalUseProductMetadata } from './use-product-metadata';
+export { useProductTemplate as __experimentalUseProductTemplate } from './use-product-template';

--- a/packages/js/product-editor/src/hooks/use-product-template/index.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/index.ts
@@ -1,0 +1,1 @@
+export * from './use-product-template';

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -48,6 +48,17 @@ describe( 'useProductTemplate', () => {
 						type: 'simple',
 					},
 				},
+				{
+					id: 'standard-product-template',
+					title: 'Standard Product Template',
+					description: 'Standard Product Template description',
+					icon: 'icon',
+					layoutTemplateId: 'layout-template-4',
+					order: 4,
+					productData: {
+						type: 'simple',
+					},
+				},
 			],
 		};
 	} );
@@ -83,9 +94,19 @@ describe( 'useProductTemplate', () => {
 
 	it( 'should return undefined if no matching product template by id or type', () => {
 		const { result } = renderHook( () =>
-			useProductTemplate( 'invalid-template-id', 'variable' )
+			useProductTemplate( 'invalid-template-id', 'external' )
 		);
 
 		expect( result.current.productTemplate ).toBeUndefined();
+	} );
+
+	it( 'should use the standard product template if the product type is variable', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( 'template-1', 'variable' )
+		);
+
+		expect( result.current.productTemplate?.id ).toEqual(
+			'standard-product-template'
+		);
 	} );
 } );

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useProductTemplate } from '../use-product-template';
+
+const originalProductBlockEditorSettings =
+	globalThis.window.productBlockEditorSettings;
+
+describe( 'useProductTemplate', () => {
+	beforeEach( () => {
+		globalThis.window.productBlockEditorSettings = {
+			productTemplates: [
+				{
+					id: 'template-1',
+					title: 'Template 1',
+					description: 'Template 1 description',
+					icon: 'icon',
+					order: 1,
+					layoutTemplateId: 'layout-template-1',
+					productData: {
+						type: 'simple',
+					},
+				},
+				{
+					id: 'template-2',
+					title: 'Template 2',
+					description: 'Template 2 description',
+					icon: 'icon',
+					layoutTemplateId: 'layout-template-2',
+					order: 2,
+					productData: {
+						type: 'grouped',
+					},
+				},
+				{
+					id: 'template-3',
+					title: 'Template 3',
+					description: 'Template 3 description',
+					icon: 'icon',
+					layoutTemplateId: 'layout-template-3',
+					order: 3,
+					productData: {
+						type: 'simple',
+					},
+				},
+			],
+		};
+	} );
+
+	afterEach( () => {
+		globalThis.window.productBlockEditorSettings =
+			originalProductBlockEditorSettings;
+	} );
+
+	it( 'should return the product template if it exists', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( 'template-3', 'simple' )
+		);
+
+		expect( result.current.productTemplate?.id ).toEqual( 'template-3' );
+	} );
+
+	it( 'should return the first product template with a matching type in the productData if no matching product template by id', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( 'invalid-template-id', 'grouped' )
+		);
+
+		expect( result.current.productTemplate?.id ).toEqual( 'template-2' );
+	} );
+
+	it( 'should return the first product template with a matching type in the productData if no product template id is set', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( undefined, 'grouped' )
+		);
+
+		expect( result.current.productTemplate?.id ).toEqual( 'template-2' );
+	} );
+
+	it( 'should return undefined if no matching product template by id or type', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( 'invalid-template-id', 'variable' )
+		);
+
+		expect( result.current.productTemplate ).toBeUndefined();
+	} );
+} );

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -109,4 +109,12 @@ describe( 'useProductTemplate', () => {
 			'standard-product-template'
 		);
 	} );
+
+	it( 'should use the product type to match if the product template id matches a template with a different product type', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( 'template-2', 'simple' )
+		);
+
+		expect( result.current.productTemplate?.id ).toEqual( 'template-1' );
+	} );
 } );

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -21,7 +21,7 @@ export const useProductTemplate = (
 	productType: ProductType | undefined
 ) => {
 	const productTemplates =
-		window.productBlockEditorSettings.productTemplates ?? [];
+		window.productBlockEditorSettings?.productTemplates ?? [];
 	const productTemplate = productTemplates.find( ( template ) => {
 		if ( productTemplateId === template.id ) {
 			return true;

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -22,23 +22,22 @@ export const useProductTemplate = (
 ) => {
 	const productTemplates =
 		window.productBlockEditorSettings?.productTemplates ?? [];
-	const productTemplate = productTemplates.find( ( template ) => {
-		if ( productTemplateId === template.id ) {
-			return true;
-		}
 
-		if ( ! productType ) {
-			return false;
-		}
+	let matchingProductTemplate = productTemplates.find(
+		( productTemplate ) => productTemplateId === productTemplate.id
+	);
 
-		// Fallback to the product type if the product does not have any product
-		// template associated to itself.
-		return template.productData.type === productType;
-	} );
+	if ( ! matchingProductTemplate ) {
+		// Fallback to the first template with the same product type.
+		matchingProductTemplate = productTemplates.find(
+			( productTemplate ) =>
+				productTemplate.productData.type === productType
+		);
+	}
 
 	// When we switch to getting the product template from the API,
 	// this will be needed.
 	const isResolving = false;
 
-	return { productTemplate, isResolving };
+	return { productTemplate: matchingProductTemplate, isResolving };
 };

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -28,15 +28,20 @@ export const useProductTemplate = (
 			? 'standard-product-template'
 			: productTemplateId;
 
+	const productTypeToFind =
+		productType === 'variable' ? 'simple' : productType;
+
 	let matchingProductTemplate = productTemplates.find(
-		( productTemplate ) => productTemplateIdToFind === productTemplate.id
+		( productTemplate ) =>
+			productTemplate.id === productTemplateIdToFind &&
+			productTemplate.productData.type === productTypeToFind
 	);
 
 	if ( ! matchingProductTemplate ) {
 		// Fallback to the first template with the same product type.
 		matchingProductTemplate = productTemplates.find(
 			( productTemplate ) =>
-				productTemplate.productData.type === productType
+				productTemplate.productData.type === productTypeToFind
 		);
 	}
 

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -23,8 +23,13 @@ export const useProductTemplate = (
 	const productTemplates =
 		window.productBlockEditorSettings?.productTemplates ?? [];
 
+	const productTemplateIdToFind =
+		productType === 'variable'
+			? 'standard-product-template'
+			: productTemplateId;
+
 	let matchingProductTemplate = productTemplates.find(
-		( productTemplate ) => productTemplateId === productTemplate.id
+		( productTemplate ) => productTemplateIdToFind === productTemplate.id
 	);
 
 	if ( ! matchingProductTemplate ) {

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { ProductType } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { ProductTemplate } from '../../types';
+
+declare global {
+	interface Window {
+		productBlockEditorSettings: {
+			productTemplates: ProductTemplate[];
+		};
+	}
+}
+
+export const useProductTemplate = (
+	productTemplateId: string | undefined,
+	productType: ProductType | undefined
+) => {
+	const productTemplates =
+		window.productBlockEditorSettings.productTemplates ?? [];
+	const productTemplate = productTemplates.find( ( template ) => {
+		if ( productTemplateId === template.id ) {
+			return true;
+		}
+
+		if ( ! productType ) {
+			return false;
+		}
+
+		// Fallback to the product type if the product does not have any product
+		// template associated to itself.
+		return template.productData.type === productType;
+	} );
+
+	// When we switch to getting the product template from the API,
+	// this will be needed.
+	const isResolving = false;
+
+	return { productTemplate, isResolving };
+};

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -2,6 +2,17 @@
  * External dependencies
  */
 import { BlockAttributes, BlockEditProps } from '@wordpress/blocks';
+import { Product } from '@woocommerce/data';
+
+export type ProductTemplate = {
+	id: string;
+	title: string;
+	description: string | null;
+	icon: string | null;
+	order: number;
+	layoutTemplateId: string;
+	productData: Partial< Product >;
+};
 
 export interface ProductEditorContext {
 	postId: number;

--- a/plugins/woocommerce/changelog/update-use-use-layout-template
+++ b/plugins/woocommerce/changelog/update-use-use-layout-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove putting template layouts on the productBlockEditorSettings JS global.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -224,18 +224,6 @@ class Init {
 	 * Get the product editor settings.
 	 */
 	private function get_product_editor_settings() {
-		$layout_template_registry = wc_get_container()->get( LayoutTemplateRegistry::class );
-		$layout_template_logger   = BlockTemplateLogger::get_instance();
-
-		$editor_settings = array();
-
-		foreach ( $layout_template_registry->instantiate_layout_templates() as $layout_template ) {
-			$editor_settings['layoutTemplates'][] = $layout_template->to_json();
-
-			$layout_template_logger->log_template_events_to_file( $layout_template->get_id() );
-			$editor_settings['layoutTemplateEvents'][] = $layout_template_logger->get_formatted_template_events( $layout_template->get_id() );
-		}
-
 		$editor_settings['productTemplates'] = array_map(
 			function ( $product_template ) {
 				return $product_template->to_json();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR uses `useLayoutTemplate` to load the layout templates from the REST API.

A followup PR will deprecate/remove obsolete code on the backend, related to `BlockTemplateRegistry`, which has been superseded by `LayoutTemplateRegistry`.

Part of #40620

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Automated tests

1. Run the unit tests for `useProductTemplate` hook and verify they pass.

```
pnpm --filter=@woocommerce/product-editor test:js
```

#### Manual tests

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. In the **Network** tab of the browser dev tools, verify that a single request to `/wp-json/wc/v3/layout-templates/simple-product` was made (you can filter by `layout-templates`)
3. Enter a product name and then add some variations in the **Variations** tab
4. Click **Edit** on a variation.
5. In the **Network** tab of the browser dev tools, verify that a single request to `/wp-json/wc/v3/layout-templates/product-variation` was made
6. Verify the variation template looks correct in the product editor (no visual changes/regressions)
7. Go back to the **Main Product**
8.  In the **Network** tab of the browser dev tools, verify that another request to `/wp-json/wc/v3/layout-templates/simple-product` was made (since the page completely refreshes, this is not cached)
9. Verify when you Change product type that is works as expected (no visual changes/regressions) (note: all of our product templates currently use the same `simple-product` layout template, except for a variation, which uses `product-variation`)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
