### PR TITLE
Remove Variable product template from the product template list

### DIFF
--- a/packages/js/product-editor/changelog/add-43225
+++ b/packages/js/product-editor/changelog/add-43225
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Always fallback to the standard product template in case the given product type is variable

--- a/plugins/woocommerce/changelog/add-43225
+++ b/plugins/woocommerce/changelog/add-43225
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Remove Variable product from the product template list

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -282,19 +282,6 @@ class Init {
 				),
 			)
 		);
-		$templates[] = new ProductTemplate(
-			array(
-				'id'                 => 'variable-product-template',
-				'title'              => __( 'Variable product', 'woocommerce' ),
-				'description'        => __( 'A product with variations like color or size.', 'woocommerce' ),
-				'order'              => 40,
-				'icon'               => null,
-				'layout_template_id' => 'simple-product',
-				'product_data'       => array(
-					'type' => 'variable',
-				),
-			)
-		);
 
 		return $templates;
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -72,9 +72,12 @@ class RedirectionController {
 			}
 
 			$product_data = $product_template->get_product_data();
-			$product_type = $product_data['type'];
+			$product_data_type = $product_data['type'];
+			// Treat a variable product as a simple product since there is not a product template
+			// for variable products.
+			$product_type = $product->get_type() === 'variable' ? 'simple' : $product->get_type();
 
-			if ( isset( $product_type ) && $product_type !== $product->get_type() ) {
+			if ( isset( $product_data_type ) && $product_data_type !== $product_type ) {
 				continue;
 			}
 
@@ -82,7 +85,7 @@ class RedirectionController {
 				return true;
 			}
 
-			if ( isset( $product_type ) ) {
+			if ( isset( $product_data_type ) ) {
 				if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
 					return true;
 				}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -71,7 +71,7 @@ class RedirectionController {
 				continue;
 			}
 
-			$product_data = $product_template->get_product_data();
+			$product_data      = $product_template->get_product_data();
 			$product_data_type = $product_data['type'];
 			// Treat a variable product as a simple product since there is not a product template
 			// for variable products.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43225

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products` -> `Add new` from the left side menu.
3. Set the `Name` of the product.
4. Under the `General` tab a description `This is a standard product. Change product type` should be shown below the `Basic details` section.
5. When clicking the `Change product type` a dropdown menu should be shown listing all the available product types except the `variable` one. 
<img width="754" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/e09a1357-5564-4a15-a4ff-347da4427582">

6. If the created product is of `variable` type, then the `Standard product` should be highlighted by default.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
