### PR TITLE
Add e2e tests for user customization of block templates

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/README.md
+++ b/plugins/woocommerce-blocks/tests/e2e/README.md
@@ -26,12 +26,20 @@ End-to-end tests are powered by Playwright. The test site is spun up using `wp-e
 
 ### Running tests for the first time
 
+In the root directory, run:
+
 ```sh
 nvm use
 ```
 
 ```sh
-npm install
+pnpm install
+```
+
+Now change directory to `plugins/woocommerce-blocks/`:
+
+```sh
+cd plugins/woocommerce-blocks/
 ```
 
 ```sh

--- a/plugins/woocommerce-blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/scripts/products.sh
@@ -21,7 +21,21 @@ image2=$(wp post list --post_type=attachment --field=ID --name="hoodie-green-1.j
 image3=$(wp post list --post_type=attachment --field=ID --name="hoodie-2.jpg" --format=ids)
 wp post meta update $post_id _product_image_gallery "$image1,$image2,$image3"
 
+# Create a tag, so we can add tests for tag-related blocks and templates.
+tag_id=$(wp wc product_tag create --name="Recommended" --slug="recommended" --description="Curated products selected by our experts" --porcelain --user=1)
+wp wc product update $post_id --tags="[ { \"id\": $tag_id } ]" --user=1
+
 # This is a non-hacky work around to set up the cross sells product.
 product_id=$(wp post list --post_type=product --field=ID --name="Cap" --format=ids)
 crossell_id=$(wp post list --post_type=product --field=ID --name="Beanie" --format=ids)
 wp post meta update $crossell_id _crosssell_ids "$product_id"
+
+# Enable attribute archives.
+attribute_ids=$(wp wc product_attribute list --fields=id --format=ids --user=1)
+if [ -n "$attribute_ids" ]; then
+  for id in $attribute_ids; do
+    wp wc product_attribute update "$id" --has_archives=true --user=1
+  done
+else
+  echo "No attribute IDs found."
+fi

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/mini-cart-template-part.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/mini-cart-template-part.block_theme.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const permalink = '/shop';
+const templateName = 'Mini-Cart';
+const templatePath = 'woocommerce/woocommerce//mini-cart';
+const templateType = 'wp_template_part';
+const miniCartBlockName = 'woocommerce/mini-cart';
+
+test.describe( 'Mini-Cart template part', async () => {
+	test( 'can be modified and reverted', async ( {
+		admin,
+		frontendUtils,
+		editorUtils,
+		page,
+	} ) => {
+		// Verify the template can be edited.
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.getByLabel( 'Mini-Cart Items' )
+			.getByLabel( 'Add block' )
+			.click();
+		await page.getByRole( 'option', { name: 'Paragraph' } ).click();
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.getByLabel( 'Empty block' )
+			.fill( 'Hello World in the template' );
+
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await page.getByLabel( 'Add to cart' ).first().click();
+		let block = await frontendUtils.getBlockByName( miniCartBlockName );
+		await block.click();
+		await expect( page.getByRole( 'dialog' ) ).toContainText(
+			'Hello World in the template'
+		);
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			'path=/wp_template_part/all'
+		);
+		const templatePartRow = page.getByRole( 'row', {
+			name: templateName,
+		} );
+		await expect( templatePartRow ).toBeVisible();
+		await expect( templatePartRow ).toContainText( 'Customized' );
+		templatePartRow.getByRole( 'button', { name: 'Actions' } ).click();
+
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await expect( templatePartRow ).not.toContainText( 'Customized' );
+		await page.goto( permalink );
+		await page.getByLabel( 'Add to cart' ).first().click();
+		block = await frontendUtils.getBlockByName( miniCartBlockName );
+		await block.click();
+		await expect( page.getByRole( 'dialog' ) ).not.toContainText(
+			'Hello World in the template'
+		);
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/mini-cart-template-part.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/mini-cart-template-part.block_theme.spec.ts
@@ -47,20 +47,9 @@ test.describe( 'Mini-Cart template part', async () => {
 		// Verify the edition can be reverted.
 		await admin.visitAdminPage(
 			'site-editor.php',
-			'path=/wp_template_part/all'
+			`path=/${ templateType }/all`
 		);
-		const templatePartRow = page.getByRole( 'row', {
-			name: templateName,
-		} );
-		await expect( templatePartRow ).toContainText( 'Customized' );
-		templatePartRow.getByRole( 'button', { name: 'Actions' } ).click();
-
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Clear customizations',
-			} )
-			.click();
-		await expect( templatePartRow ).not.toContainText( 'Customized' );
+		await editorUtils.revertTemplateCustomizations( templateName );
 		await page.goto( permalink );
 		await page.getByLabel( 'Add to cart' ).first().click();
 		block = await frontendUtils.getBlockByName( miniCartBlockName );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/mini-cart-template-part.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/mini-cart-template-part.block_theme.spec.ts
@@ -52,7 +52,6 @@ test.describe( 'Mini-Cart template part', async () => {
 		const templatePartRow = page.getByRole( 'row', {
 			name: templateName,
 		} );
-		await expect( templatePartRow ).toBeVisible();
 		await expect( templatePartRow ).toContainText( 'Customized' );
 		templatePartRow.getByRole( 'button', { name: 'Actions' } ).click();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-catalog-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-catalog-template.block_theme.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const permalink = '/shop';
+const templateName = 'Product catalog';
+const templatePath = 'woocommerce/woocommerce//archive-product';
+const templateType = 'wp_template';
+
+test.describe( 'Product catalog template', async () => {
+	test( 'can be modified and reverted', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Verify the template can be edited.
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello World in the template' },
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' ).first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			'path=/wp_template/all'
+		);
+		const templateRow = page.getByRole( 'row', {
+			name: templateName,
+		} );
+		await expect( templateRow ).toBeVisible();
+		await expect( templateRow ).toContainText( 'Customized' );
+		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
+
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await expect( templateRow ).not.toContainText( 'Customized' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-catalog-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-catalog-template.block_theme.spec.ts
@@ -39,15 +39,14 @@ test.describe( 'Product catalog template', async () => {
 		const templateRow = page.getByRole( 'row', {
 			name: templateName,
 		} );
-		await expect( templateRow ).toBeVisible();
 		await expect( templateRow ).toContainText( 'Customized' );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-
 		await page
 			.getByRole( 'menuitem', {
 				name: 'Clear customizations',
 			} )
 			.click();
+
 		await expect( templateRow ).not.toContainText( 'Customized' );
 		await page.goto( permalink );
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-catalog-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-catalog-template.block_theme.spec.ts
@@ -34,21 +34,11 @@ test.describe( 'Product catalog template', async () => {
 		// Verify the edition can be reverted.
 		await admin.visitAdminPage(
 			'site-editor.php',
-			'path=/wp_template/all'
+			`path=/${ templateType }/all`
 		);
-		const templateRow = page.getByRole( 'row', {
-			name: templateName,
-		} );
-		await expect( templateRow ).toContainText( 'Customized' );
-		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Clear customizations',
-			} )
-			.click();
-
-		await expect( templateRow ).not.toContainText( 'Customized' );
+		await editorUtils.revertTemplateCustomizations( templateName );
 		await page.goto( permalink );
+
 		await expect(
 			page.getByText( 'Hello World in the template' )
 		).toHaveCount( 0 );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results-template.block_theme.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const permalink = '/?s=shirt&post_type=product';
+const templateName = 'Product Search Results';
+const templatePath = 'woocommerce/woocommerce//product-search-results';
+const templateType = 'wp_template';
+
+test.describe( 'Product Search Results template', async () => {
+	test( 'can be modified and reverted', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Verify the template can be edited.
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello World in the template' },
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' ).first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			'path=/wp_template/all'
+		);
+		const templateRow = page.getByRole( 'row', {
+			name: templateName,
+		} );
+		await expect( templateRow ).toBeVisible();
+		await expect( templateRow ).toContainText( 'Customized' );
+		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
+
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await expect( templateRow ).not.toContainText( 'Customized' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results-template.block_theme.spec.ts
@@ -34,20 +34,9 @@ test.describe( 'Product Search Results template', async () => {
 		// Verify the edition can be reverted.
 		await admin.visitAdminPage(
 			'site-editor.php',
-			'path=/wp_template/all'
+			`path=/${ templateType }/all`
 		);
-		const templateRow = page.getByRole( 'row', {
-			name: templateName,
-		} );
-		await expect( templateRow ).toContainText( 'Customized' );
-		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Clear customizations',
-			} )
-			.click();
-
-		await expect( templateRow ).not.toContainText( 'Customized' );
+		await editorUtils.revertTemplateCustomizations( templateName );
 		await page.goto( permalink );
 		await expect(
 			page.getByText( 'Hello World in the template' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results-template.block_theme.spec.ts
@@ -39,15 +39,14 @@ test.describe( 'Product Search Results template', async () => {
 		const templateRow = page.getByRole( 'row', {
 			name: templateName,
 		} );
-		await expect( templateRow ).toBeVisible();
 		await expect( templateRow ).toContainText( 'Customized' );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-
 		await page
 			.getByRole( 'menuitem', {
 				name: 'Clear customizations',
 			} )
 			.click();
+
 		await expect( templateRow ).not.toContainText( 'Customized' );
 		await page.goto( permalink );
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
@@ -34,20 +34,9 @@ test.describe( 'Products by Attribute template', async () => {
 		// Verify the edition can be reverted.
 		await admin.visitAdminPage(
 			'site-editor.php',
-			'path=/wp_template/all'
+			`path=/${ templateType }/all`
 		);
-		const templateRow = page.getByRole( 'row', {
-			name: templateName,
-		} );
-		await expect( templateRow ).toContainText( 'Customized' );
-		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Clear customizations',
-			} )
-			.click();
-
-		await expect( templateRow ).not.toContainText( 'Customized' );
+		await editorUtils.revertTemplateCustomizations( templateName );
 		await page.goto( permalink );
 		await expect(
 			page.getByText( 'Hello World in the template' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const permalink = '/color/blue';
+const templateName = 'Products by Attribute';
+const templatePath = 'woocommerce/woocommerce//taxonomy-product_attribute';
+const templateType = 'wp_template';
+
+test.describe( 'Products by Attribute template', async () => {
+	test( 'can be modified and reverted', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Verify the template can be edited.
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello World in the template' },
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' ).first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			'path=/wp_template/all'
+		);
+		const templateRow = page.getByRole( 'row', {
+			name: templateName,
+		} );
+		await expect( templateRow ).toBeVisible();
+		await expect( templateRow ).toContainText( 'Customized' );
+		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
+
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await expect( templateRow ).not.toContainText( 'Customized' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
@@ -39,15 +39,14 @@ test.describe( 'Products by Attribute template', async () => {
 		const templateRow = page.getByRole( 'row', {
 			name: templateName,
 		} );
-		await expect( templateRow ).toBeVisible();
 		await expect( templateRow ).toContainText( 'Customized' );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-
 		await page
 			.getByRole( 'menuitem', {
 				name: 'Clear customizations',
 			} )
 			.click();
+
 		await expect( templateRow ).not.toContainText( 'Customized' );
 		await page.goto( permalink );
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
@@ -34,20 +34,9 @@ test.describe( 'Products by Category template', async () => {
 		// Verify the edition can be reverted.
 		await admin.visitAdminPage(
 			'site-editor.php',
-			'path=/wp_template/all'
+			`path=/${ templateType }/all`
 		);
-		const templateRow = page.getByRole( 'row', {
-			name: templateName,
-		} );
-		await expect( templateRow ).toContainText( 'Customized' );
-		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Clear customizations',
-			} )
-			.click();
-
-		await expect( templateRow ).not.toContainText( 'Customized' );
+		await editorUtils.revertTemplateCustomizations( templateName );
 		await page.goto( permalink );
 		await expect(
 			page.getByText( 'Hello World in the template' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const permalink = '/product-category/clothing';
+const templateName = 'Products by Category';
+const templatePath = 'woocommerce/woocommerce//taxonomy-product_cat';
+const templateType = 'wp_template';
+
+test.describe( 'Products by Category template', async () => {
+	test( 'can be modified and reverted', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Verify the template can be edited.
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello World in the template' },
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' ).first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			'path=/wp_template/all'
+		);
+		const templateRow = page.getByRole( 'row', {
+			name: templateName,
+		} );
+		await expect( templateRow ).toBeVisible();
+		await expect( templateRow ).toContainText( 'Customized' );
+		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
+
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await expect( templateRow ).not.toContainText( 'Customized' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
@@ -39,15 +39,14 @@ test.describe( 'Products by Category template', async () => {
 		const templateRow = page.getByRole( 'row', {
 			name: templateName,
 		} );
-		await expect( templateRow ).toBeVisible();
 		await expect( templateRow ).toContainText( 'Customized' );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-
 		await page
 			.getByRole( 'menuitem', {
 				name: 'Clear customizations',
 			} )
 			.click();
+
 		await expect( templateRow ).not.toContainText( 'Customized' );
 		await page.goto( permalink );
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const permalink = '/product-tag/recommended/';
+const templateName = 'Products by Tag';
+const templatePath = 'woocommerce/woocommerce//taxonomy-product_tag';
+const templateType = 'wp_template';
+
+test.describe( 'Products by Tag template', async () => {
+	test( 'can be modified and reverted', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Verify the template can be edited.
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello World in the template' },
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' ).first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			'path=/wp_template/all'
+		);
+		const templateRow = page.getByRole( 'row', {
+			name: templateName,
+		} );
+		await expect( templateRow ).toBeVisible();
+		await expect( templateRow ).toContainText( 'Customized' );
+		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
+
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await expect( templateRow ).not.toContainText( 'Customized' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
@@ -39,15 +39,14 @@ test.describe( 'Products by Tag template', async () => {
 		const templateRow = page.getByRole( 'row', {
 			name: templateName,
 		} );
-		await expect( templateRow ).toBeVisible();
 		await expect( templateRow ).toContainText( 'Customized' );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-
 		await page
 			.getByRole( 'menuitem', {
 				name: 'Clear customizations',
 			} )
 			.click();
+
 		await expect( templateRow ).not.toContainText( 'Customized' );
 		await page.goto( permalink );
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
@@ -34,20 +34,9 @@ test.describe( 'Products by Tag template', async () => {
 		// Verify the edition can be reverted.
 		await admin.visitAdminPage(
 			'site-editor.php',
-			'path=/wp_template/all'
+			`path=/${ templateType }/all`
 		);
-		const templateRow = page.getByRole( 'row', {
-			name: templateName,
-		} );
-		await expect( templateRow ).toContainText( 'Customized' );
-		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Clear customizations',
-			} )
-			.click();
-
-		await expect( templateRow ).not.toContainText( 'Customized' );
+		await editorUtils.revertTemplateCustomizations( templateName );
 		await page.goto( permalink );
 		await expect(
 			page.getByText( 'Hello World in the template' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -39,15 +39,14 @@ test.describe( 'Single Product template', async () => {
 		const templateRow = page.getByRole( 'row', {
 			name: templateName,
 		} );
-		await expect( templateRow ).toBeVisible();
 		await expect( templateRow ).toContainText( 'Customized' );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-
 		await page
 			.getByRole( 'menuitem', {
 				name: 'Clear customizations',
 			} )
 			.click();
+
 		await expect( templateRow ).not.toContainText( 'Customized' );
 		await page.goto( permalink );
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -34,20 +34,9 @@ test.describe( 'Single Product template', async () => {
 		// Verify the edition can be reverted.
 		await admin.visitAdminPage(
 			'site-editor.php',
-			'path=/wp_template/all'
+			`path=/${ templateType }/all`
 		);
-		const templateRow = page.getByRole( 'row', {
-			name: templateName,
-		} );
-		await expect( templateRow ).toContainText( 'Customized' );
-		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Clear customizations',
-			} )
-			.click();
-
-		await expect( templateRow ).not.toContainText( 'Customized' );
+		await editorUtils.revertTemplateCustomizations( templateName );
 		await page.goto( permalink );
 		await expect(
 			page.getByText( 'Hello World in the template' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const permalink = '/product/hoodie';
+const templateName = 'Single Product';
+const templatePath = 'woocommerce/woocommerce//single-product';
+const templateType = 'wp_template';
+
+test.describe( 'Single Product template', async () => {
+	test( 'can be modified and reverted', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Verify the template can be edited.
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello World in the template' },
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' ).first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			'path=/wp_template/all'
+		);
+		const templateRow = page.getByRole( 'row', {
+			name: templateName,
+		} );
+		await expect( templateRow ).toBeVisible();
+		await expect( templateRow ).toContainText( 'Customized' );
+		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
+
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await expect( templateRow ).not.toContainText( 'Customized' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the template' )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -351,6 +351,22 @@ export class EditorUtils {
 			.waitFor();
 	}
 
+	async revertTemplateCustomizations( templateName: string ) {
+		const templateRow = this.page.getByRole( 'row', {
+			name: templateName,
+		} );
+		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
+		await this.page
+			.getByRole( 'menuitem', {
+				name: 'Clear customizations',
+			} )
+			.click();
+		await this.page
+			.getByRole( 'button', { name: 'Dismiss this notice' } )
+			.getByText( `"${ templateName }" reverted.` )
+			.waitFor();
+	}
+
 	async publishAndVisitPost() {
 		await this.editor.publishPost();
 		const url = new URL( this.page.url() );

--- a/plugins/woocommerce/changelog/43426-add-block-templates-e2e-tests
+++ b/plugins/woocommerce/changelog/43426-add-block-templates-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Add e2e tests for user customization of block templates
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a test to all templates to verify that it can be edited and reverted.

I also took the chance to update the docs on running WC Blocks e2e tests, as they were outdated since the monorepo merge.

> [!TIP]
> Tip for the reviewer: all templates have the same test, the only thing that changes accross files is the `permalink`, `templateName` and `templatePath` constants on top of the file. So you only need to review one of the templates test files.
> 
> The test for the Mini-Cart template part is slightly different, so its worth reviewing it separately.

Part of https://github.com/woocommerce/woocommerce/issues/43412.

### How to test the changes in this Pull Request:

Note: no need to test when testing the release.

1. Verify Playwright e2e tests pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Add e2e tests for user customization of block templates

</details>
