### PR TITLE
Do not access change_feature_enable() statically. Closes #43175.

### DIFF
--- a/plugins/woocommerce/changelog/43428-fix-43175-fatal-error-features-controller
+++ b/plugins/woocommerce/changelog/43428-fix-43175-fatal-error-features-controller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error. Do not access change_feature_enable() statically.

--- a/plugins/woocommerce/src/Internal/Admin/Marketplace.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketplace.php
@@ -20,7 +20,9 @@ class Marketplace {
 	 */
 	final public function init() {
 		if ( false === FeaturesUtil::feature_is_enabled( 'marketplace' ) ) {
-			FeaturesController::change_feature_enable( 'marketplace', true );
+			/** Feature controller instance @var FeaturesController $feature_controller */
+			$feature_controller = wc_get_container()->get( FeaturesController::class );
+			$feature_controller->change_feature_enable( 'marketplace', true );
 		}
 
 		add_action( 'admin_menu', array( $this, 'register_pages' ), 70 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Do not access change_feature_enable() statically.

Closes https://github.com/woocommerce/woocommerce/issues/43175.

Duplicate of @helgatheviking's https://github.com/woocommerce/woocommerce/pull/43176, which is having problems with  the automated builds.

When the "Marketplace" feature is disabled in `WooCommerce > Settings > Advanced > Features` (see screenshot) before you update WooCommerce, you will get a fatal error when you update.

```
Fatal error: Non-static method Automattic\WooCommerce\Internal\Features\FeaturesController::change_feature_enable() cannot be called statically in /app/wp-content/plugins/woocommerce/src/Internal/Admin/Marketplace.php:23
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Have an earlier version of WooCommerce, like 8.4.0, checked out in your local environment.
2. Disable the Marketplace feature flag. (This corresponds to the option `woocommerce_feature_marketplace_enabled` being set to `no` in the database.)
3. Check out this branch. You should be able to access WooCommerce now without the fatal error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix fatal error. Do not access change_feature_enable() statically.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

#### Screenshots

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/48df444b-8219-4d5c-b11b-e1afd4604e0f">

