### PR TITLE
[Experimental] Add custom validation hooks for additional checkout fields

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -109,6 +109,21 @@ const getErrorContextFromParam = ( param: string ): string | undefined => {
 };
 
 /**
+ * Gets appropriate error context from additional field location.
+ */
+const getErrorContextFromAdditionalFieldLocation = (
+	location: string
+): string | undefined => {
+	switch ( location ) {
+		case 'contact':
+			return noticeContexts.CONTACT_INFORMATION;
+
+		default:
+			return undefined;
+	}
+};
+
+/**
  * Processes the response for an invalid param error, with response code rest_invalid_param.
  */
 const processInvalidParamResponse = (

--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -42,7 +42,12 @@ export const getErrorDetails = (
 			acc,
 			[
 				param,
-				{ code, message, additional_errors: additionalErrors = [] },
+				{
+					code,
+					message,
+					additional_errors: additionalErrors = [],
+					data,
+				},
 			]
 		) => {
 			return [
@@ -52,6 +57,7 @@ export const getErrorDetails = (
 					id: `${ param }_${ code }`,
 					code,
 					message: decodeEntities( message ),
+					data,
 				},
 				...( Array.isArray( additionalErrors )
 					? additionalErrors.flatMap( ( additionalError ) => {

--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -70,7 +70,7 @@ export const getErrorDetails = (
 							) {
 								return [];
 							}
-							return [
+							const errorObject = [
 								{
 									param,
 									id: `${ param }_${ additionalError.code }`,
@@ -80,6 +80,13 @@ export const getErrorDetails = (
 									),
 								},
 							];
+							if ( typeof additionalError.data !== 'undefined' ) {
+								return [
+									...errorObject,
+									...getErrorDetails( additionalError ),
+								];
+							}
+							return errorObject;
 					  } )
 					: [] ),
 			];

--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -15,6 +15,7 @@ type ApiParamError = {
 	id: string;
 	code: string;
 	message: string;
+	data?: ApiErrorResponseData;
 };
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -117,7 +117,8 @@ const getErrorContextFromAdditionalFieldLocation = (
 	switch ( location ) {
 		case 'contact':
 			return noticeContexts.CONTACT_INFORMATION;
-
+		case 'additional':
+			return noticeContexts.ADDITIONAL_INFORMATION;
 		default:
 			return undefined;
 	}

--- a/plugins/woocommerce/changelog/43435-add-custom-fields-validation
+++ b/plugins/woocommerce/changelog/43435-add-custom-fields-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Skipping this changelog because this work is behind a feature flag and will not be available.
+

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -474,6 +474,40 @@ class CheckoutFields {
 	}
 
 	/**
+	 * Validate an additional field against any custom validation rules. The result should be a WP_Error or true.
+	 *
+	 * @param true|\WP_Error $result       The current result of validating the field against the schema (before any custom validation has been applied).
+	 * @param string         $key          The key of the field.
+	 * @param mixed          $field_value  The value of the field.
+	 * @param array          $field_schema The schema of the field.
+	 *
+	 * @since 8.6.0
+	 */
+	public function validate_field( $result, $key, $field_value, $field_schema ) {
+
+		/**
+		 * Filter the result of validating an additional field.
+		 *
+		 * @param true|\WP_Error $result       The current result of validating the field.
+		 * @param mixed          $field_value  The value of the field.
+		 * @param array          $field_schema The schema of the field.
+		 * @param string         $key          The key of the field.
+		 *
+		 * @since 8.6.0
+		 */
+		$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $result, $field_value, $field_schema, $key );
+
+		if ( is_wp_error( $filtered_result ) || true === $filtered_result ) {
+			return $filtered_result;
+		}
+
+		// Show a warning and return the original result from schema validation if the filter returns something unexpected.
+		_doing_it_wrong( 'woocommerce_blocks_validate_additional_field_' . $key, 'The filter should return a WP_Error or true.', '8.6.0' );
+		return $result;
+
+	}
+
+	/**
 	 * Update the default locale with additional fields without country limitations.
 	 *
 	 * @param array $locale The locale to update.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -500,10 +500,7 @@ class CheckoutFields {
 			return $filtered_result;
 		}
 
-		// Show a warning and return the original result from schema validation if the filter returns something unexpected.
-		_doing_it_wrong( esc_html( 'woocommerce_blocks_validate_additional_field_' . $key ), 'The filter should return a WP_Error.', '8.6.0' );
-		return new \WP_Error();
-
+		return new \WP_Error( 'invalid_additional_field_validation_result', 'Invalid result for woocommerce_blocks_validate_additional_field_' . esc_html( $key ) . '. The filter should return a WP_Error.' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -476,34 +476,33 @@ class CheckoutFields {
 	/**
 	 * Validate an additional field against any custom validation rules. The result should be a WP_Error or true.
 	 *
-	 * @param true|\WP_Error $result       The current result of validating the field against the schema (before any custom validation has been applied).
-	 * @param string         $key          The key of the field.
-	 * @param mixed          $field_value  The value of the field.
-	 * @param array          $field_schema The schema of the field.
+	 * @param string $key          The key of the field.
+	 * @param mixed  $field_value  The value of the field.
+	 * @param array  $field_schema The schema of the field.
 	 *
 	 * @since 8.6.0
 	 */
-	public function validate_field( $result, $key, $field_value, $field_schema ) {
+	public function validate_field( $key, $field_value, $field_schema ) {
 
 		/**
 		 * Filter the result of validating an additional field.
 		 *
-		 * @param true|\WP_Error $result       The current result of validating the field.
-		 * @param mixed          $field_value  The value of the field.
-		 * @param array          $field_schema The schema of the field.
-		 * @param string         $key          The key of the field.
+		 * @param \WP_Error $error        A WP_Error that extensions may add errors to.
+		 * @param mixed     $field_value  The value of the field.
+		 * @param array     $field_schema The schema of the field.
+		 * @param string    $key          The key of the field.
 		 *
 		 * @since 8.6.0
 		 */
-		$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $result, $field_value, $field_schema, $key );
+		$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, new \WP_Error(), $field_value, $field_schema, $key );
 
-		if ( is_wp_error( $filtered_result ) || true === $filtered_result ) {
+		if ( is_wp_error( $filtered_result ) ) {
 			return $filtered_result;
 		}
 
 		// Show a warning and return the original result from schema validation if the filter returns something unexpected.
-		_doing_it_wrong( 'woocommerce_blocks_validate_additional_field_' . $key, 'The filter should return a WP_Error or true.', '8.6.0' );
-		return $result;
+		_doing_it_wrong( esc_html( 'woocommerce_blocks_validate_additional_field_' . $key ), 'The filter should return a WP_Error.', '8.6.0' );
+		return new \WP_Error();
 
 	}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -484,6 +484,7 @@ class CheckoutFields {
 	 */
 	public function validate_field( $key, $field_value, $field_schema ) {
 
+		$error = new \WP_Error();
 		try {
 			/**
 			 * Filter the result of validating an additional field.
@@ -495,7 +496,20 @@ class CheckoutFields {
 			 *
 			 * @since 8.6.0
 			 */
-			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, new \WP_Error(), $field_value, $field_schema, $key );
+			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $error, $field_value, $field_schema, $key );
+
+			if ( $error !== $filtered_result ) {
+
+				// Different WP_Error was returned. This would remove errors from other filters. Skip filtering and allow the order to place without validating this field.
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				trigger_error(
+					sprintf(
+						'The filter %s encountered an error. One of the filters returned a new WP_Error. Filters should use the same WP_Error passed to the filter and use the WP_Error->add function to add errors.						The field will not have any custom validation applied to it.',
+						'woocommerce_blocks_validate_additional_field_' . esc_html( $key ),
+					),
+					E_USER_WARNING
+				);
+			}
 		} catch ( \Exception $e ) {
 
 			// One of the filters errored so skip them and validate the field. This allows the checkout process to continue.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -510,7 +510,7 @@ class CheckoutFields {
 					E_USER_WARNING
 				);
 			}
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 
 			// One of the filters errored so skip them and validate the field. This allows the checkout process to continue.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -459,6 +459,21 @@ class CheckoutFields {
 	}
 
 	/**
+	 * Gets the location of a field.
+	 *
+	 * @param string $field_key The key of the field to get the location for.
+	 * @return string The location of the field.
+	 */
+	public function get_field_location( $field_key ) {
+		foreach ( $this->fields_locations as $location => $fields ) {
+			if ( in_array( $field_key, $fields, true ) ) {
+				return $location;
+			}
+		}
+		return '';
+	}
+
+	/**
 	 * Update the default locale with additional fields without country limitations.
 	 *
 	 * @param array $locale The locale to update.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -500,7 +500,16 @@ class CheckoutFields {
 			return $filtered_result;
 		}
 
-		return new \WP_Error( 'invalid_additional_field_validation_result', 'Invalid result for woocommerce_blocks_validate_additional_field_' . esc_html( $key ) . '. The filter should return a WP_Error.' );
+		// If the filters didn't return a valid value, ignore them and return an empty WP_Error. This allows the order to complete.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		trigger_error(
+			sprintf(
+				'The filter %s did not return a valid value. The field will not have any custom validation applied to it.',
+				'woocommerce_blocks_validate_additional_field_' . esc_html( $key )
+			),
+			E_USER_WARNING
+		);
+		return new \WP_Error();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -215,8 +215,9 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			$result = rest_validate_value_from_schema( $address[ $key ], $properties[ $key ], $key );
 
 			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
-			if ( in_array( $key, $additional_keys, true ) ) {
-				$result = $this->additional_fields_controller->validate_field( $result, $key, $address[ $key ], $properties[ $key ] );
+			// Skip additional validation if the schema validation failed.
+			if ( true === $result && in_array( $key, $additional_keys, true ) ) {
+				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $properties[ $key ] );
 			}
 
 			if ( is_wp_error( $result ) ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -220,7 +220,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $properties[ $key ] );
 			}
 
-			if ( is_wp_error( $result ) ) {
+			if ( is_wp_error( $result ) && $result->has_errors() ) {
 				$errors->add( $result->get_error_code(), $result->get_error_message() );
 			}
 		}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -193,6 +193,9 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			);
 		}
 
+		// Get additional field keys here as we need to know if they are present in the address for validation.
+		$additional_keys = array_keys( $this->get_additional_address_fields_schema() );
+
 		foreach ( array_keys( $address ) as $key ) {
 
 			// Skip email here it will be validated in BillingAddressSchema.
@@ -210,6 +213,12 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			}
 
 			$result = rest_validate_value_from_schema( $address[ $key ], $properties[ $key ], $key );
+
+			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
+			if ( in_array( $key, $additional_keys, true ) ) {
+				$result = $this->additional_fields_controller->validate_field( $result, $key, $address[ $key ], $properties[ $key ] );
+			}
+
 			if ( is_wp_error( $result ) ) {
 				$errors->add( $result->get_error_code(), $result->get_error_message() );
 			}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -369,38 +369,19 @@ class CheckoutSchema extends AbstractSchema {
 
 			$field_value = isset( $fields[ $key ] ) ? $fields[ $key ] : null;
 
+			// Run schema validation first then custom validation after.
 			$result = rest_validate_value_from_schema( $field_value, $properties[ $key ], $key );
+			$result = $this->additional_fields_controller->validate_field( $result, $key, $field_value, $properties[ $key ] );
 
-			/**
-			 * Filter the result of validating an additional field.
-			 *
-			 * @param true|\WP_Error $result       The current result of validating the field.
-			 * @param mixed          $field_value  The value of the field.
-			 * @param array          $field_schema The schema for the field.
-			 * @param string         $key          The key of the field.
-			 *
-			 * @since 8.6.0
-			 */
-			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $result, $field_value, $properties[ $key ], $key );
-
-			// If filtered result is not true and not WP_Error then show a warning and continue as normal.
-			if ( true !== $filtered_result && ! is_wp_error( $filtered_result ) ) {
-				_doing_it_wrong( esc_html( 'woocommerce_blocks_validate_additional_field_' . $key ), 'The filter must return either true or a WP_Error object.', '8.6.0' );
-			}
-
-			if ( is_wp_error( $filtered_result ) ) {
+			if ( is_wp_error( $result ) ) {
 				$location = $this->additional_fields_controller->get_field_location( $key );
-				$filtered_result->add_data(
+				$result->add_data(
 					[
 						'key'      => $key,
 						'location' => $location,
 					]
 				);
-			}
 
-			$result = $filtered_result;
-
-			if ( is_wp_error( $result ) ) {
 				$errors->add( $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
 			}
 		}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -369,11 +369,13 @@ class CheckoutSchema extends AbstractSchema {
 
 			$field_value = isset( $fields[ $key ] ) ? $fields[ $key ] : null;
 
-			// Run schema validation first then custom validation after.
 			$result = rest_validate_value_from_schema( $field_value, $properties[ $key ], $key );
-			$result = $this->additional_fields_controller->validate_field( $result, $key, $field_value, $properties[ $key ] );
 
-			if ( is_wp_error( $result ) ) {
+			// Only allow custom validation on fields that pass the schema validation.
+			if ( true === $result ) {
+				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $properties[ $key ] );
+			}
+
 				$location = $this->additional_fields_controller->get_field_location( $key );
 				$result->add_data(
 					[

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -379,7 +379,13 @@ class CheckoutSchema extends AbstractSchema {
 			if ( is_wp_error( $result ) && $result->has_errors() ) {
 				$location = $this->additional_fields_controller->get_field_location( $key );
 				foreach ( $result->get_error_codes() as $code ) {
-					$result->add_data( [ 'location' => $location, 'key' => $key ] , $code );
+					$result->add_data(
+						[
+							'location' => $location,
+							'key'      => $key,
+						],
+						$code
+					);
 				}
 				$errors->merge_from( $result );
 			}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -376,15 +376,12 @@ class CheckoutSchema extends AbstractSchema {
 				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $properties[ $key ] );
 			}
 
+			if ( is_wp_error( $result ) && $result->has_errors() ) {
 				$location = $this->additional_fields_controller->get_field_location( $key );
-				$result->add_data(
-					[
-						'key'      => $key,
-						'location' => $location,
-					]
-				);
-
-				$errors->add( $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+				foreach ( $result->get_error_codes() as $code ) {
+					$result->add_data( [ 'location' => $location, 'key' => $key ] , $code );
+				}
+				$errors->merge_from( $result );
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a new hook: `woocommerce_blocks_validate_additional_field_%s` which allows custom validation rules to run against an additional field.
This hook is called by the `CheckoutFields->validate_field` function, which in turn is called by the `CheckoutSchema` and `AbstractAddressSchema`.

Closes #42136

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Prerequisite, add the following snippet to your site:

```php
add_action(
	'woocommerce_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id' => 'namespace/gov-id',
				'label' => 'Government ID',
				'optionalLabel' => 'Government ID (optional)',
				'location' => 'address',
				'required' => true,
			),
		);

	add_filter('woocommerce_blocks_validate_additional_field_namespace/gov-id', function ( $error, $value, $schema, $key ) {
				if ( '12345' !== $value ) {
					$error->add( 'invalid_gov_id', 'Sorry but only people with government ID: 12345 can order.' );
				}
				return $error;
			}, 10, 4);
	}
);

```

1. Add the snippet to your site.
2. Add an item to your cart.
3. Load the Checkout block and ensure you see the Government ID field rendered inside the Shipping and Billing address sections.
4. Keep the `Use same address for billing` box _checked_.
5. Fill the checkout form and enter `54321` into the Government ID field.
6. Submit the form and ensure the checkout is unsuccessful. Ensure you see an error notice in the address section for Government ID.
7. Uncheck the `Use same address for billing` box and ensure the error is present in both shipping _and_ billing sections.
8. Change the value of the Government ID field in the _shipping_ address to `12345`.
9. Try to check out again and ensure the error is gone from shipping, but remains in billing.
10. Change the value of the Government ID field in the billing address to `12345`.
11. Try to check out and ensure it's successful.
12. In the snippet, update the `location` value to `contact`.
13. Add an item to your cart and reload the checkout block. The Government ID field will now render in the contact details section.
14. Repeat the test with a value of `54321` ensuring the error appears in the contact section.
15. Change it to `12345` and ensure checkout is successful.
16. In the snippet, update the `location` value to `additional`.
17. Add an item to your cart and reload the checkout block. The Government ID field will now render in the additional information section.
18. Repeat the test with a value of `54321` ensuring the error appears in the additional information section.
19. Change it to `12345` and ensure checkout is successful.

#### Multiple validation callbacks

1. In the snippet, add another custom validation hook, like this:

```php
add_filter('woocommerce_blocks_validate_additional_field_namespace/gov-id', function ( $error, $value, $schema, $key ) {
	if ('54321' !== $value) {
		$error->add( 'invalid_gov_id_2', 'Sorry but only people with government ID: 54321 can order.' );
	}
	return $error;
}, 10, 4);
```

2. Re-run the test, but this time set the value to `02468`
3. Ensure you see _two_ errors in the correct section.
4. Move the field to `contact` and repeat, ensuring the errors appear in the correct place.
5. Enter `54321` as the value and ensure only one error shows.

#### Incorrect filter return values

1. Enable debug logging on your site (so that errors/warnings are printed to `debug.log` or some other way of tracking warnings.
2. Change the `woocommerce_blocks_validate_additional_field_namespace/gov-id` filter so it returns a string: `'test'`
3. Try to check out and ensure it works.
4. Check the debug log and ensure a warning is shown about the filter returning an incorrect value.
5. Change the `woocommerce_blocks_validate_additional_field_namespace/gov-id` filter so it throws an exception.
6. Try to check out and ensure it works.
7. Check the debug log and ensure a warning is shown about the filter erroring, it should show the exception message.
8. Change the `woocommerce_blocks_validate_additional_field_namespace/gov-id` filter so it returns a `new WP_Error()`.
9. Try to check out and ensure it works.
10. Check the debug log and ensure a warning is shown about the filter erroring, it should show a warning about returning a different WP_Error.

#### Store API

<details>
<summary>Example payload - Expand to see</summary>

```json
{
  "shipping_address": {
    "first_name": "John",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test Road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": "",
		"namespace/gov-id": "12345"
	},
  "billing_address": {
    "first_name": "Jon",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": "",
    "email": "john@testmail.com",
    "namespace/gov-id": "54321",
    "phone": ""
  },
  "customer_note": "",
  "create_account": false,
  "payment_method": "bacs",
  "payment_data": [
    {
      "key": "wc-bacs-new-payment-method",
      "value": false
    }
  ]
}
```

</details>

1. Reset the snippet back to the original at the start of these instructions.
10. Add an item to your cart using store API.
11. Try to check out using the example payload.
12. Expect a 401 response with an error about Government ID, it should match the error in the snippet.
13. Repeat the test with an invalid value in the shipping address
14. Change the `namespace/gov-id` value in the both addresses to `12345` and try to check out, it should work.
15. In the original snippet, change the `location` field to `contact` or `additional`.
16. In the example payload, remove `namespace/gov-id` from both addresses and add a new section at the top level: `additional_fields`

<details>
<summary>Example payload with `additional_fields`</summary>

```json
{
  "shipping_address": {
    "first_name": "John",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test Road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": ""
	},
  "billing_address": {
    "first_name": "Jon",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": "",
    "email": "test@mail.com",
    "phone": ""
  },
	"additional_fields": {
		"namespace/gov-id": "54321"
	},
  "customer_note": "",
  "create_account": false,
  "payment_method": "bacs",
  "payment_data": [
    {
      "key": "wc-bacs-new-payment-method",
      "value": false
    }
  ]
}
```

17. Add an item to your cart using Store API and try to check out with the example payload.
18. Ensure you get a 401 response and see the error for `namespace/gov-id` in the body. 
19. Ensure the response contains a `data` key which describes the location. It will be either `additional` or `contact` depending what you picked on step 7.

</details>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Skipping this changelog because this work is behind a feature flag and will not be available.
</details>
