### PR TITLE
Fix Subscriptions autorenewals column for WooPayments pre-install promo in Settings > Payments

### DIFF
--- a/plugins/woocommerce-admin/changelog/fix-41476-payment-settings-woopayments-promo-subscriptions
+++ b/plugins/woocommerce-admin/changelog/fix-41476-payment-settings-woopayments-promo-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not sanitize HTML for WooCommerce Subscriptions column in Settings > Payments > Payment Methods table.

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -194,7 +194,8 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 						className={ column.className }
 						width={ column.width }
 						dangerouslySetInnerHTML={
-							( column.className.includes( 'sort' ) || column.className.includes( 'renewals' ) )
+							column.className.includes( 'sort' ) ||
+							column.className.includes( 'renewals' )
 								? {
 										__html: column.html,
 								  }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -194,7 +194,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 						className={ column.className }
 						width={ column.width }
 						dangerouslySetInnerHTML={
-							column.className.includes( 'sort' )
+							( column.className.includes( 'sort' ) || column.className.includes( 'renewals' ) )
 								? {
 										__html: column.html,
 								  }

--- a/plugins/woocommerce/changelog/fix-41476-payment-settings-woopayments-promo-subscriptions
+++ b/plugins/woocommerce/changelog/fix-41476-payment-settings-woopayments-promo-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add supports entry to pseudo-gateway for WooPayments pre-install promotion.

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
@@ -36,6 +36,34 @@ class WCPaymentGatewayPreInstallWCPayPromotion extends \WC_Payment_Gateway {
 		$this->method_description = $wc_pay_spec->content;
 		$this->has_fields         = false;
 
+		// Set the promotion pseudo-gateway support features.
+		// If the promotion spec provides the supports property, use it.
+		if ( property_exists( $wc_pay_spec, 'supports' ) ) {
+			$this->supports = $wc_pay_spec->supports;
+		} else {
+			// Otherwise, use the default supported features in line with WooPayments ones.
+			// We include all features here, even if some of them are behind settings, since this is for info only.
+			$this->supports = array(
+				// Regular features.
+				'products',
+				'refunds',
+				// Subscriptions features.
+				'subscriptions',
+				'multiple_subscriptions',
+				'subscription_cancellation',
+				'subscription_reactivation',
+				'subscription_suspension',
+				'subscription_amount_changes',
+				'subscription_date_changes',
+				'subscription_payment_method_change_admin',
+				'subscription_payment_method_change_customer',
+				'subscription_payment_method_change',
+				// Saved cards features.
+				'tokenization',
+				'add_payment_method',
+			);
+		}
+
 		// Get setting values.
 		$this->enabled = false;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Provide `supports` entry for the WooPayments pre-install promo pseudo-gateway, especially the WooCommerce Subscriptions related ones. This way, the WooPayments line in `Settings > Payments > Payment Methods` will have the `Automatic Recurring Payments` column with the right markup, indicating that WooPayments fully supports WooCommerce Subscriptions.

Closes #41476 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a new site with WC from this PR branch.
2. Skip the profiler and pick a WooPayments-supported country (e.g., the US).
3. Do not install WooPayments.
4. Install and activate the WooCommerce Subscriptions extension.
5. Make sure marketplace suggestions are allowed.
6. In the site's WP admin, go to `WooCommerce > Settings > Payments` and in the `Payment Methods` table, for WooCommerce Payments, in the `Automatic Recurring Payments` column you should have both a checkmark and a question mark with tooltips on hover.

<!-- End testing instructions -->

### Screenshots

| Before | After |
|--------|--------|
|<img width="1052" alt="283179749-6a73ca7e-2c09-48db-9962-75e1617cce2b" src="https://github.com/woocommerce/woocommerce/assets/8830539/fbfbe595-27f4-48f5-add2-04cc89e0ed53">|<img width="1528" alt="Screenshot 2024-01-09 at 22 21 55" src="https://github.com/woocommerce/woocommerce/assets/8830539/728ebd95-a2db-4970-bf83-41106cea0963">|

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
