### PR TITLE
Fix PHP warning related to logging severity threshold

### DIFF
--- a/plugins/woocommerce/changelog/43448-fix-logging-php-deprecated-warning
+++ b/plugins/woocommerce/changelog/43448-fix-logging-php-deprecated-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fixes a PHP deprecation warning introduced in PR-42979.
+

--- a/plugins/woocommerce/includes/class-wc-log-levels.php
+++ b/plugins/woocommerce/includes/class-wc-log-levels.php
@@ -78,7 +78,7 @@ abstract class WC_Log_Levels {
 	 * @return bool True if $level is a valid level.
 	 */
 	public static function is_valid_level( $level ) {
-		return array_key_exists( strtolower( $level ), self::$level_to_severity );
+		return is_string( $level ) && array_key_exists( strtolower( $level ), self::$level_to_severity );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR addresses the following PHP deprecation warning that was being triggered on any WP page after the merge of #42979:

> [10-Jan-2024 10:35:50 UTC] PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in [...]woocommerce/plugins/woocommerce/includes/class-wc-log-levels.php on line 81

The warning is triggered as part of `WC_Logger`'s initialization [here](https://github.com/woocommerce/woocommerce/blob/8fb3d394a52b450f7677329808e5a5608ff4bd35/plugins/woocommerce/includes/class-wc-logger.php#L74) as the [default threshold value](https://github.com/woocommerce/woocommerce/blob/8fb3d394a52b450f7677329808e5a5608ff4bd35/plugins/woocommerce/includes/class-wc-logger.php#L38) is actually `null`.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load any page on your site and make sure the warning doesn't appear.
2. Logging functionality (as described in #42979) shouldn't be affected. In particular, refer to step **Test the "Level threshold" setting** from that PR.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fixes a PHP deprecation warning introduced in PR-42979.

</details>
