### PR TITLE
[CYS - Core] Update the homepage with default patterns when the assembler is loaded

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -243,11 +243,13 @@ export const Layout = () => {
 						</div>
 						{ ! isEditorLoading &&
 							shouldTourBeShown &&
-							! showAiOfflineModal && (
+							( FlowType.AIOnline === context.flowType ||
+								FlowType.noAI === context.flowType ) && (
 								<OnboardingTour
 									skipTour={ skipTour }
 									takeTour={ takeTour }
 									onClose={ onClose }
+									flowType={ context.flowType }
 									{ ...onboardingTourProps }
 								/>
 							) }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
@@ -10,6 +10,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 export * from './use-onboarding-tour';
+import { FlowType } from '~/customize-store/types';
 
 type OnboardingTourProps = {
 	onClose: () => void;
@@ -17,17 +18,52 @@ type OnboardingTourProps = {
 	takeTour: () => void;
 	showWelcomeTour: boolean;
 	setIsResizeHandleVisible: ( isVisible: boolean ) => void;
+	flowType: FlowType.AIOnline | FlowType.noAI;
+};
+
+const getLabels = ( flowType: FlowType.AIOnline | FlowType.noAI ) => {
+	switch ( flowType ) {
+		case FlowType.AIOnline:
+			return {
+				heading: __(
+					'Welcome to your AI-generated store!',
+					'woocommerce'
+				),
+				descriptions: {
+					desktop: __(
+						'This is where you can start customizing the look and feel of your store, including adding your logo, and changing colors and layouts. Take a quick tour to discover what’s possible.',
+						'woocommerce'
+					),
+				},
+			};
+		case FlowType.noAI:
+			return {
+				heading: __(
+					"Discover what's possible with the store designer",
+					'woocommerce'
+				),
+				descriptions: {
+					desktop: __(
+						"Start designing your store, including adding your logo, changing color schemes, and choosing layouts. Take a quick tour to discover what's possible.",
+						'woocommerce'
+					),
+				},
+			};
+	}
 };
 
 export const OnboardingTour = ( {
 	onClose,
 	skipTour,
 	takeTour,
+	flowType,
 	showWelcomeTour,
 	setIsResizeHandleVisible,
 }: OnboardingTourProps ) => {
 	const [ placement, setPlacement ] =
 		useState< TourKitTypes.WooConfig[ 'placement' ] >( 'left' );
+
+	const { heading, descriptions } = getLabels( flowType );
 
 	if ( showWelcomeTour ) {
 		return (
@@ -71,16 +107,8 @@ export const OnboardingTour = ( {
 								primaryButton: {
 									text: __( 'Take a tour', 'woocommerce' ),
 								},
-								descriptions: {
-									desktop: __(
-										"This is where you can start customizing the look and feel of your store, including adding your logo, and changing colors and layouts. Take a quick tour to discover what's possible.",
-										'woocommerce'
-									),
-								},
-								heading: __(
-									'Welcome to your AI-generated store!',
-									'woocommerce'
-								),
+								descriptions,
+								heading,
 								skipButton: {
 									isVisible: true,
 								},

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/test/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/test/index.tsx
@@ -9,6 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { OnboardingTour } from '../index';
+import { FlowType } from '~/customize-store/types';
 
 jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
 jest.mock( '../../', () => ( {
@@ -26,6 +27,7 @@ describe( 'OnboardingTour', () => {
 		takeTour: jest.Mock;
 		setShowWelcomeTour: jest.Mock;
 		showWelcomeTour: boolean;
+		flowType: FlowType.AIOnline | FlowType.noAI;
 		setIsResizeHandleVisible: ( isVisible: boolean ) => void;
 	};
 
@@ -37,14 +39,25 @@ describe( 'OnboardingTour', () => {
 			setShowWelcomeTour: jest.fn(),
 			showWelcomeTour: true,
 			setIsResizeHandleVisible: jest.fn(),
+			flowType: FlowType.AIOnline,
 		};
 	} );
 
-	it( 'should render welcome tour', () => {
+	it( 'should render welcome tour mentioning the AI when the flowType is AIOnline', () => {
 		render( <OnboardingTour { ...props } /> );
 
 		expect(
 			screen.getByText( /Welcome to your AI-generated store!/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render welcome tour not mentioning the AI when the flowType is AIOnline', () => {
+		render( <OnboardingTour { ...props } flowType={ FlowType.noAI } /> );
+
+		expect(
+			screen.getByText(
+				/Discover what's possible with the store designer/i
+			)
 		).toBeInTheDocument();
 	} );
 

--- a/plugins/woocommerce-admin/client/customize-store/data/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/data/actions.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @woocommerce/dependency-group */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * External dependencies
+ */
+import { resolveSelect, dispatch } from '@wordpress/data';
+// @ts-ignore No types for this exist yet.
+import { store as coreStore } from '@wordpress/core-data';
+// @ts-ignore No types for this exist yet.
+
+/**
+ * Internal dependencies
+ */
+import {
+	patternsToNameMap,
+	getTemplatePatterns,
+} from '../assembler-hub/hooks/use-home-templates';
+import { setLogoWidth } from '../utils';
+import { HOMEPAGE_TEMPLATES } from './homepageTemplates';
+
+// Update the current theme template
+export const updateTemplate = async ( {
+	homepageTemplateId,
+}: {
+	homepageTemplateId: keyof typeof HOMEPAGE_TEMPLATES;
+} ) => {
+	// @ts-ignore No types for this exist yet.
+	const { invalidateResolutionForStoreSelector } = dispatch( coreStore );
+
+	// Ensure that the patterns are up to date because we populate images and content in previous step.
+	invalidateResolutionForStoreSelector( 'getBlockPatterns' );
+	invalidateResolutionForStoreSelector( '__experimentalGetTemplateForLink' );
+
+	const patterns = ( await resolveSelect(
+		coreStore
+		// @ts-ignore No types for this exist yet.
+	).getBlockPatterns() ) as Pattern[];
+	const patternsByName = patternsToNameMap( patterns );
+	const homepageTemplate = getTemplatePatterns(
+		HOMEPAGE_TEMPLATES[ homepageTemplateId ].blocks,
+		patternsByName
+	);
+
+	let content = [ ...homepageTemplate ]
+		.filter( Boolean )
+		.map( ( pattern ) => pattern.content )
+		.join( '\n\n' );
+
+	// Replace the logo width with the default width.
+	content = setLogoWidth( content );
+
+	const currentTemplate = await resolveSelect(
+		coreStore
+		// @ts-ignore No types for this exist yet.
+	).__experimentalGetTemplateForLink( '/' );
+
+	// @ts-ignore No types for this exist yet.
+	const { saveEntityRecord } = dispatch( coreStore );
+
+	await saveEntityRecord(
+		'postType',
+		currentTemplate.type,
+		{
+			id: currentTemplate.id,
+			content,
+		},
+		{
+			throwOnError: true,
+		}
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -19,12 +19,8 @@ import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/compo
 import { designWithAiStateMachineContext } from './types';
 import { FONT_PAIRINGS } from '../assembler-hub/sidebar/global-styles/font-pairing-variations/constants';
 import { COLOR_PALETTES } from '../assembler-hub/sidebar/global-styles/color-palette-variations/constants';
-import {
-	patternsToNameMap,
-	getTemplatePatterns,
-} from '../assembler-hub/hooks/use-home-templates';
 import { HOMEPAGE_TEMPLATES } from '../data/homepageTemplates';
-import { setLogoWidth } from '../utils';
+import { updateTemplate } from '../data/actions';
 
 const { escalate } = actions;
 
@@ -389,58 +385,6 @@ const updateGlobalStyles = async ( {
 				colorPalette?.settings || {},
 				fontPairing?.settings || {}
 			),
-		},
-		{
-			throwOnError: true,
-		}
-	);
-};
-
-// Update the current theme template
-const updateTemplate = async ( {
-	homepageTemplateId,
-}: {
-	homepageTemplateId: keyof typeof HOMEPAGE_TEMPLATES;
-} ) => {
-	// @ts-ignore No types for this exist yet.
-	const { invalidateResolutionForStoreSelector } = dispatch( coreStore );
-
-	// Ensure that the patterns are up to date because we populate images and content in previous step.
-	invalidateResolutionForStoreSelector( 'getBlockPatterns' );
-	invalidateResolutionForStoreSelector( '__experimentalGetTemplateForLink' );
-
-	const patterns = ( await resolveSelect(
-		coreStore
-		// @ts-ignore No types for this exist yet.
-	).getBlockPatterns() ) as Pattern[];
-	const patternsByName = patternsToNameMap( patterns );
-	const homepageTemplate = getTemplatePatterns(
-		HOMEPAGE_TEMPLATES[ homepageTemplateId ].blocks,
-		patternsByName
-	);
-
-	let content = [ ...homepageTemplate ]
-		.filter( Boolean )
-		.map( ( pattern ) => pattern.content )
-		.join( '\n\n' );
-
-	// Replace the logo width with the default width.
-	content = setLogoWidth( content );
-
-	const currentTemplate = await resolveSelect(
-		coreStore
-		// @ts-ignore No types for this exist yet.
-	).__experimentalGetTemplateForLink( '/' );
-
-	// @ts-ignore No types for this exist yet.
-	const { saveEntityRecord } = dispatch( coreStore );
-
-	await saveEntityRecord(
-		'postType',
-		currentTemplate.type,
-		{
-			id: currentTemplate.id,
-			content,
 		},
 		{
 			throwOnError: true,

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/actions.ts
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { getNewPath } from '@woocommerce/navigation';
+/**
+ * Internal dependencies
+ */
+import { attachIframeListeners, onIframeLoad } from '../utils';
+
+const redirectToAssemblerHub = async () => {
+	const assemblerUrl = getNewPath( {}, '/customize-store/assembler-hub', {} );
+	const iframe = document.createElement( 'iframe' );
+	iframe.classList.add( 'cys-fullscreen-iframe' );
+	iframe.src = assemblerUrl;
+
+	const showIframe = () => {
+		if ( iframe.style.opacity === '1' ) {
+			// iframe is already visible
+			return;
+		}
+
+		const loader = document.getElementsByClassName(
+			'woocommerce-onboarding-loader'
+		);
+		if ( loader[ 0 ] ) {
+			( loader[ 0 ] as HTMLElement ).style.display = 'none';
+		}
+
+		iframe.style.opacity = '1';
+	};
+
+	iframe.onload = () => {
+		// Hide loading UI
+		attachIframeListeners( iframe );
+		onIframeLoad( showIframe );
+
+		// Ceiling wait time set to 60 seconds
+		setTimeout( showIframe, 60 * 1000 );
+		window.history?.pushState( {}, '', assemblerUrl );
+	};
+
+	document.body.appendChild( iframe );
+};
+
+export const actions = {
+	redirectToAssemblerHub,
+};

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/index.tsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { useMachine, useSelector } from '@xstate/react';
+import { AnyInterpreter, Sender } from 'xstate';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { customizeStoreStateMachineEvents } from '..';
+import {
+	CustomizeStoreComponent,
+	customizeStoreStateMachineContext,
+} from '../types';
+import { designWithNoAiStateMachineDefinition } from './state-machine';
+import { findComponentMeta } from '~/utils/xstate/find-component';
+import { AssembleHubLoader } from '../design-with-ai/pages';
+
+export type DesignWithoutAiComponent = typeof AssembleHubLoader;
+export type DesignWithoutAiComponentMeta = {
+	component: DesignWithoutAiComponent;
+};
+
+export const DesignWithNoAiController = ( {
+	parentMachine,
+}: {
+	parentMachine?: AnyInterpreter;
+	sendEventToParent?: Sender< customizeStoreStateMachineEvents >;
+	parentContext?: customizeStoreStateMachineContext;
+} ) => {
+	const [ , , service ] = useMachine( designWithNoAiStateMachineDefinition, {
+		devTools: process.env.NODE_ENV === 'development',
+		parent: parentMachine,
+	} );
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps -- false positive due to function name match, this isn't from react std lib
+	const currentNodeMeta = useSelector( service, ( currentState ) =>
+		findComponentMeta< DesignWithoutAiComponentMeta >(
+			currentState?.meta ?? undefined
+		)
+	);
+
+	const [ CurrentComponent, setCurrentComponent ] =
+		useState< DesignWithoutAiComponent | null >( null );
+	useEffect( () => {
+		if ( currentNodeMeta?.component ) {
+			setCurrentComponent( () => currentNodeMeta?.component );
+		}
+	}, [ CurrentComponent, currentNodeMeta?.component ] );
+
+	return (
+		<>
+			<div className={ `woocommerce-design-without-ai__container` }>
+				{ CurrentComponent ? <CurrentComponent /> : <div /> }
+			</div>
+		</>
+	);
+};
+
+//loader should send event 'THEME_SUGGESTED' when it's done
+export const DesignWithoutAi: CustomizeStoreComponent = ( {
+	parentMachine,
+	context,
+} ) => {
+	return (
+		<>
+			<DesignWithNoAiController
+				parentMachine={ parentMachine }
+				parentContext={ context }
+			/>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { Sender } from 'xstate';
+/**
+ * Internal dependencies
+ */
+import { updateTemplate } from '../data/actions';
+import { HOMEPAGE_TEMPLATES } from '../data/homepageTemplates';
+
+const assembleSite = async () => {
+	await updateTemplate( {
+		homepageTemplateId: 'template1' as keyof typeof HOMEPAGE_TEMPLATES,
+	} );
+};
+
+const browserPopstateHandler =
+	() => ( sendBack: Sender< { type: 'EXTERNAL_URL_UPDATE' } > ) => {
+		const popstateHandler = () => {
+			sendBack( { type: 'EXTERNAL_URL_UPDATE' } );
+		};
+		window.addEventListener( 'popstate', popstateHandler );
+		return () => {
+			window.removeEventListener( 'popstate', popstateHandler );
+		};
+	};
+
+export const services = {
+	assembleSite,
+	browserPopstateHandler,
+};

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { EventObject, createMachine } from 'xstate';
+import { getQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+
+import { AssembleHubLoader } from '../design-with-ai/pages';
+
+import { FlowType } from '../types';
+import { DesignWithoutAIStateMachineContext } from './types';
+import { services } from './services';
+import { actions } from './actions';
+
+export const hasStepInUrl = (
+	_ctx: unknown,
+	_evt: unknown,
+	{ cond }: { cond: unknown }
+) => {
+	const { path = '' } = getQuery() as { path: string };
+	const pathFragments = path.split( '/' );
+	return (
+		pathFragments[ 2 ] === // [0] '', [1] 'customize-store', [2] design step slug
+		( cond as { step: string | undefined } ).step
+	);
+};
+
+export const designWithNoAiStateMachineDefinition = createMachine(
+	{
+		id: 'designWithoutAI',
+		predictableActionArguments: true,
+		preserveActionOrder: true,
+		schema: {
+			context: {} as DesignWithoutAIStateMachineContext,
+			events: {} as EventObject,
+		},
+		invoke: {
+			src: 'browserPopstateHandler',
+		},
+		on: {
+			EXTERNAL_URL_UPDATE: {
+				target: 'navigate',
+			},
+		},
+		context: {
+			startLoadingTime: null,
+			flowType: FlowType.noAI,
+			apiCallLoader: {
+				hasErrors: false,
+			},
+		},
+		initial: 'navigate',
+		states: {
+			navigate: {
+				always: [
+					{
+						cond: {
+							type: 'hasStepInUrl',
+							step: 'design',
+						},
+						target: 'preAssembleSite',
+					},
+				],
+			},
+			preAssembleSite: {
+				type: 'parallel',
+				states: {
+					assembleSite: {
+						initial: 'pending',
+						states: {
+							pending: {
+								invoke: {
+									src: 'assembleSite',
+									onDone: {
+										target: 'done',
+									},
+									onError: {
+										actions: [ 'assignAPICallLoaderError' ],
+									},
+								},
+							},
+							done: {
+								type: 'final',
+							},
+						},
+						onDone: {
+							target: '#designWithoutAI.showAssembleHub',
+						},
+					},
+				},
+			},
+			showAssembleHub: {
+				meta: {
+					component: AssembleHubLoader,
+				},
+				entry: [ 'redirectToAssemblerHub' ],
+				type: 'final',
+			},
+		},
+	},
+	{
+		actions,
+		services,
+		guards: {
+			hasStepInUrl,
+		},
+	}
+);

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { FlowType } from '../types';
+
+export type DesignWithoutAIStateMachineContext = {
+	startLoadingTime: number | null;
+	apiCallLoader: {
+		hasErrors: boolean;
+	};
+	flowType: FlowType.noAI;
+};

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -30,7 +30,7 @@ import {
 	DefaultBanner,
 	ExistingAiThemeBanner,
 	ExistingThemeBanner,
-	CoreBanner,
+	NoAIBanner,
 } from './intro-banners';
 
 export type events =
@@ -39,7 +39,8 @@ export type events =
 	| { type: 'CLICKED_ON_BREADCRUMB' }
 	| { type: 'SELECTED_BROWSE_ALL_THEMES' }
 	| { type: 'SELECTED_ACTIVE_THEME'; payload: { theme: string } }
-	| { type: 'SELECTED_NEW_THEME'; payload: { theme: string } };
+	| { type: 'SELECTED_NEW_THEME'; payload: { theme: string } }
+	| { type: 'DESIGN_WITHOUT_AI' };
 
 export * as actions from './actions';
 export * as services from './services';
@@ -52,7 +53,7 @@ const BANNER_COMPONENTS = {
 	'jetpack-offline': JetpackOfflineBanner,
 	'existing-ai-theme': ExistingAiThemeBanner,
 	'existing-theme': ExistingThemeBanner,
-	[ FlowType.noAI ]: CoreBanner,
+	[ FlowType.noAI ]: NoAIBanner,
 	default: DefaultBanner,
 };
 

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -21,6 +21,7 @@ export const BaseIntroBanner = ( {
 	bannerTitle,
 	bannerText,
 	bannerClass,
+	showAIDisclaimer,
 	buttonIsLink,
 	bannerButtonOnClick,
 	bannerButtonText,
@@ -30,6 +31,7 @@ export const BaseIntroBanner = ( {
 	bannerTitle: string;
 	bannerText: string;
 	bannerClass: string;
+	showAIDisclaimer: boolean;
 	buttonIsLink?: boolean;
 	bannerButtonOnClick?: () => void;
 	bannerButtonText?: string;
@@ -58,23 +60,25 @@ export const BaseIntroBanner = ( {
 						</Button>
 					) }
 					{ secondaryButton }
-					<p className="ai-disclaimer">
-						{ interpolateComponents( {
-							mixedString: __(
-								'Powered by experimental AI. {{link}}Learn more{{/link}}',
-								'woocommerce'
-							),
-							components: {
-								link: (
-									<Link
-										href="https://automattic.com/ai-guidelines"
-										target="_blank"
-										type="external"
-									/>
+					{ showAIDisclaimer && (
+						<p className="ai-disclaimer">
+							{ interpolateComponents( {
+								mixedString: __(
+									'Powered by experimental AI. {{link}}Learn more{{/link}}',
+									'woocommerce'
 								),
-							},
-						} ) }
-					</p>
+								components: {
+									link: (
+										<Link
+											href="https://automattic.com/ai-guidelines"
+											target="_blank"
+											type="external"
+										/>
+									),
+								},
+							} ) }
+						</p>
+					) }
 				</div>
 				{ children }
 			</div>
@@ -95,6 +99,7 @@ export const NetworkOfflineBanner = () => {
 			) }
 			bannerClass="offline-banner"
 			bannerButtonOnClick={ () => {} }
+			showAIDisclaimer={ true }
 		/>
 	);
 };
@@ -122,6 +127,7 @@ export const JetpackOfflineBanner = ( {
 				} );
 			} }
 			bannerButtonText={ __( 'Find out how', 'woocommerce' ) }
+			showAIDisclaimer={ true }
 		/>
 	);
 };
@@ -147,6 +153,7 @@ export const ExistingThemeBanner = ( {
 				setOpenDesignChangeWarningModal( true );
 			} }
 			bannerButtonText={ __( 'Design with AI', 'woocommerce' ) }
+			showAIDisclaimer={ true }
 		/>
 	);
 };
@@ -174,6 +181,7 @@ export const DefaultBanner = ( {
 				} );
 			} }
 			bannerButtonText={ __( 'Design with AI', 'woocommerce' ) }
+			showAIDisclaimer={ true }
 		/>
 	);
 };
@@ -199,11 +207,16 @@ export const ThemeHasModsBanner = ( {
 				setOpenDesignChangeWarningModal( true );
 			} }
 			bannerButtonText={ __( 'Design with AI', 'woocommerce' ) }
+			showAIDisclaimer={ true }
 		/>
 	);
 };
 
-export const CoreBanner = () => {
+export const NoAIBanner = ( {
+	sendEvent,
+}: {
+	sendEvent: React.ComponentProps< typeof Intro >[ 'sendEvent' ];
+} ) => {
 	return (
 		<BaseIntroBanner
 			bannerTitle={ __( 'Design your own', 'woocommerce' ) }
@@ -211,8 +224,14 @@ export const CoreBanner = () => {
 				'Quickly create a beautiful store using our built-in store designer. Choose your layout, select a style, and much more.',
 				'woocommerce'
 			) }
-			bannerClass="core-banner"
-			bannerButtonOnClick={ () => {} }
+			bannerClass="no-ai-banner"
+			bannerButtonText={ __( 'Start designing', 'woocommerce' ) }
+			bannerButtonOnClick={ () => {
+				sendEvent( {
+					type: 'DESIGN_WITHOUT_AI',
+				} );
+			} }
+			showAIDisclaimer={ false }
 		/>
 	);
 };
@@ -260,6 +279,7 @@ export const ExistingAiThemeBanner = ( {
 			} }
 			bannerButtonText={ __( 'Customize', 'woocommerce' ) }
 			secondaryButton={ secondaryButton }
+			showAIDisclaimer={ true }
 		>
 			<div className={ 'woocommerce-block-preview-container' }>
 				<div className="iframe-container">

--- a/plugins/woocommerce/changelog/43457-43420-cys-core-update-homepage-with-default-patterns-when-the-assembler-is-loaded
+++ b/plugins/woocommerce/changelog/43457-43420-cys-core-update-homepage-with-default-patterns-when-the-assembler-is-loaded
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+[CYS - Core] Update the homepage with default patterns when the assembler is loaded.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces two new folders in the project:
- `design-without-ai` that contains all the logic (including the state machine) for the `NoAI` flow.
- `data` that contains all the common logic for both flows.

Also, this PR sets a default homepage when the merchant lands on the assembler. 

Please keep in mind that the current flow is still WIP and contains multiple bugs.

Closes #43420.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Local Installation

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Active TT4 theme.
5. Head over to WooCommerce -> Home and click on "Start Customizing".
6. Ensure that the layout looks like this image:

![image](https://github.com/woocommerce/woocommerce/assets/4463174/5df3f6ab-e041-42a4-9075-b5c48bc21a0d)



### JN Installation


1. Create a new WooCommerce installation with this version.
2. Ensure Jetpack is installed and your site is connected with JP.
3. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
4. Ensure the Woo AI plugin is installed and activated (available on this monorepo).
5. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
7. Head over to WooCommerce -> Home and click on "Start Customizing".
8. Ensure that all the flow works correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

[CYS - Core] Update the homepage with default patterns when the assembler is loaded.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
