### PR TITLE
Add e2e tests to verify Products by Category/Tag/Attribute templates default to Product Catalog template

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-attribute-template.block_theme.spec.ts
@@ -42,4 +42,42 @@ test.describe( 'Products by Attribute template', async () => {
 			page.getByText( 'Hello World in the template' )
 		).toHaveCount( 0 );
 	} );
+
+	test( 'defaults to the Product Catalog template', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Edit Product Catalog template and verify changes are visible.
+		await admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//archive-product',
+			postType: 'wp_template',
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Hello World in the Product Catalog template',
+			},
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page
+				.getByText( 'Hello World in the Product Catalog template' )
+				.first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`path=/wp_template/all`
+		);
+		await editorUtils.revertTemplateCustomizations( 'Product Catalog' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the Product Catalog template' )
+		).toHaveCount( 0 );
+	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-category-template.block_theme.spec.ts
@@ -42,4 +42,42 @@ test.describe( 'Products by Category template', async () => {
 			page.getByText( 'Hello World in the template' )
 		).toHaveCount( 0 );
 	} );
+
+	test( 'defaults to the Product Catalog template', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Edit Product Catalog template and verify changes are visible.
+		await admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//archive-product',
+			postType: 'wp_template',
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Hello World in the Product Catalog template',
+			},
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page
+				.getByText( 'Hello World in the Product Catalog template' )
+				.first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`path=/wp_template/all`
+		);
+		await editorUtils.revertTemplateCustomizations( 'Product Catalog' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the Product Catalog template' )
+		).toHaveCount( 0 );
+	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/products-by-tag-template.block_theme.spec.ts
@@ -42,4 +42,42 @@ test.describe( 'Products by Tag template', async () => {
 			page.getByText( 'Hello World in the template' )
 		).toHaveCount( 0 );
 	} );
+
+	test( 'defaults to the Product Catalog template', async ( {
+		admin,
+		editorUtils,
+		page,
+	} ) => {
+		// Edit Product Catalog template and verify changes are visible.
+		await admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//archive-product',
+			postType: 'wp_template',
+		} );
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Hello World in the Product Catalog template',
+			},
+		} );
+		await editorUtils.saveTemplate();
+		await page.goto( permalink );
+		await expect(
+			page
+				.getByText( 'Hello World in the Product Catalog template' )
+				.first()
+		).toBeVisible();
+
+		// Verify the edition can be reverted.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`path=/wp_template/all`
+		);
+		await editorUtils.revertTemplateCustomizations( 'Product Catalog' );
+		await page.goto( permalink );
+		await expect(
+			page.getByText( 'Hello World in the Product Catalog template' )
+		).toHaveCount( 0 );
+	} );
 } );

--- a/plugins/woocommerce/changelog/43471-add-block-templates-e2e-tests-default-product-catalog
+++ b/plugins/woocommerce/changelog/43471-add-block-templates-e2e-tests-default-product-catalog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Add e2e tests to verify Products by Category/Tag/Attribute templates default to Product Catalog template
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/43426.

Closes https://github.com/woocommerce/woocommerce/issues/43412.

This PR adds a test to Products by Category, Products by Tag and Products by Attribute templates to verify that they default to the Product Catalog template. That means that if they don't contain any edits but the Product Catalog template does, they will show the edits of the Product Catalog template.

> [!TIP]
> Tip for the reviewer: the test added to all three files is exactly the same. The only difference are some variables defined at the top of the file.

### How to test the changes in this Pull Request:

Note: no need to test when testing the release.

1. Verify Playwright e2e tests pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Add e2e tests to verify Products by Category/Tag/Attribute templates default to Product Catalog template

</details>
