### PR TITLE
Use different delays for initial click and hold when incrementing number on NumberControl

### DIFF
--- a/packages/js/product-editor/changelog/update-number-control-increment
+++ b/packages/js/product-editor/changelog/update-number-control-increment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use different delays for initial click and hold when incrementing number on NumberControl

--- a/packages/js/product-editor/src/components/number-control/number-control.tsx
+++ b/packages/js/product-editor/src/components/number-control/number-control.tsx
@@ -40,6 +40,10 @@ export type NumberProps = {
 	step?: number;
 };
 
+const MEDIUM_DELAY = 500;
+
+const SHORT_DELAY = 100;
+
 export const NumberControl: React.FC< NumberProps > = ( {
 	value,
 	onChange,
@@ -76,12 +80,18 @@ export const NumberControl: React.FC< NumberProps > = ( {
 
 	const timeoutRef = useRef< number | null >( null );
 
+	const isInitialClick = useRef< boolean >( false );
+
 	const incrementValue = () =>
 		onChange( String( parseFloat( value || '0' ) + increment ) );
 
 	useEffect( () => {
 		if ( increment !== 0 ) {
-			timeoutRef.current = setTimeout( incrementValue, 100 );
+			timeoutRef.current = setTimeout(
+				incrementValue,
+				isInitialClick.current ? MEDIUM_DELAY : SHORT_DELAY
+			);
+			isInitialClick.current = false;
 		} else if ( timeoutRef.current ) {
 			clearTimeout( timeoutRef.current );
 		}
@@ -91,6 +101,8 @@ export const NumberControl: React.FC< NumberProps > = ( {
 			}
 		};
 	}, [ increment, value ] );
+
+	const resetIncrement = () => setIncrement( 0 );
 
 	return (
 		<BaseControl
@@ -130,8 +142,10 @@ export const NumberControl: React.FC< NumberProps > = ( {
 											)
 										);
 										setIncrement( step );
+										isInitialClick.current = true;
 									} }
-									onMouseUp={ () => setIncrement( 0 ) }
+									onMouseLeave={ resetIncrement }
+									onMouseUp={ resetIncrement }
 									onBlur={ unfocusIfOutside }
 									isSmall
 									aria-hidden="true"
@@ -153,8 +167,10 @@ export const NumberControl: React.FC< NumberProps > = ( {
 											)
 										);
 										setIncrement( -step );
+										isInitialClick.current = true;
 									} }
-									onMouseUp={ () => setIncrement( 0 ) }
+									onMouseLeave={ resetIncrement }
+									onMouseUp={ resetIncrement }
 									isSmall
 									aria-hidden="true"
 									aria-label={ __(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds different delays for initial click and hold when incrementing number on NumberControl, to prevent a "double" increment from occurring when the user just wants to increment once.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following as a mu-plugin:
```php
<?php

function YOUR_PREFIX_add_block( $product_name_block ) {
  $parent = $product_name_block->get_parent();

  $parent->add_block(
    array(
      'id' => 'test_id3',
      'blockName' => 'woocommerce/product-number-field',
      'attributes' => array(
        'label' => __( 'Field', 'woocommerce' ),
        'property' => 'meta_data.test3',
        'step' => 2,
        )
    )
  );
}

add_action( 'woocommerce_block_template_area_product-form_after_add_block_product-name', 'YOUR_PREFIX_add_block' );
```
2. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
3. Go to Products > Add
4. Check the newly added field on the Basic details section
5. Check the "up" and "down" buttons and click them.
6. Hold the click for a while. Notice that the second increment takes longer to occur, and then it occurs faster.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
