### PR TITLE
Fix product prices not being updated on scheduled sale automatically.

### DIFF
--- a/plugins/woocommerce/changelog/fix-41569
+++ b/plugins/woocommerce/changelog/fix-41569
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product prices not being updated on scheduled automatically.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -648,7 +648,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			}
 
 			$product_price_props = array( 'date_on_sale_from', 'date_on_sale_to', 'regular_price', 'sale_price', 'product_type' );
-			if ( count( array_intersect( $product_price_props, $this->updated_props ) ) > 0 || array_key_exists( 'price', $product->get_changes() ) ) {
+			if ( count( array_intersect( $product_price_props, $this->updated_props ) ) > 0 ) {
 				if ( $product->is_on_sale( 'edit' ) ) {
 					update_post_meta( $product->get_id(), '_price', $product->get_sale_price( 'edit' ) );
 					$product->set_price( $product->get_sale_price( 'edit' ) );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -647,7 +647,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				}
 			}
 
-			if ( in_array( 'date_on_sale_from', $this->updated_props, true ) || in_array( 'date_on_sale_to', $this->updated_props, true ) || in_array( 'regular_price', $this->updated_props, true ) || in_array( 'sale_price', $this->updated_props, true ) || in_array( 'product_type', $this->updated_props, true ) ) {
+			$product_price_props = array( 'date_on_sale_from', 'date_on_sale_to', 'regular_price', 'sale_price', 'product_type' );
+			if ( count( array_intersect( $product_price_props, $this->updated_props ) ) > 0 || array_key_exists( 'price', $product->get_changes() ) ) {
 				if ( $product->is_on_sale( 'edit' ) ) {
 					update_post_meta( $product->get_id(), '_price', $product->get_sale_price( 'edit' ) );
 					$product->set_price( $product->get_sale_price( 'edit' ) );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -647,6 +647,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				}
 			}
 
+			/**
+			 * It's tempting to add a check for `_price` in the updated props, so that when `wc_scheduled_sales` is called, we don't have to rely on `date_on_sale_from` being present in the list of updated props.
+			 *
+			 * However, it has a side effect of overriding the `_price` meta value with the `_sale_price` meta value when product is in sale, or with `_regular_price` meta value when product is not in sale. This is not desirable, because `_price` can also be set as a temporary active price for a product, and we don't want to override it.
+			 *
+			 * If we want to preserve previous sales schedules, a better way would be to store them in dedicated meta keys as logs.
+			 */
 			$product_price_props = array( 'date_on_sale_from', 'date_on_sale_to', 'regular_price', 'sale_price', 'product_type' );
 			if ( count( array_intersect( $product_price_props, $this->updated_props ) ) > 0 ) {
 				if ( $product->is_on_sale( 'edit' ) ) {

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -449,6 +449,7 @@ function wc_scheduled_sales() {
 
 				if ( $sale_price ) {
 					$product->set_price( $sale_price );
+					$product->set_date_on_sale_from( '' );
 				} else {
 					$product->set_date_on_sale_to( '' );
 					$product->set_date_on_sale_from( '' );

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -2,6 +2,7 @@
 
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
  * Tests relating to the WC_Abstract_Product class.
  */
@@ -113,8 +114,8 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_addition_of_invalid_product_downloads_by_shop_manager() {
 		wp_set_current_user( $this->shop_manager_user );
-		$downloads        = $this->product->get_downloads();
-		$downloads[]      = array(
+		$downloads   = $this->product->get_downloads();
+		$downloads[] = array(
 			'id'   => '',
 			'file' => 'https://also.not.yet.added/file.pdf',
 			'name' => 'Another file',
@@ -187,8 +188,8 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_on_sale_scheduled() {
 		$product = WC_Helper_Product::create_simple_product( true, array( 'sale_price' => 5 ) );
-		$product->set_date_on_sale_from( date('Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
-		$product->set_date_on_sale_to( date('Y-m-d H:i:s',time() + DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ) );
 		$product->save();
 
 		$this->assertTrue( $product->is_on_sale() );
@@ -200,8 +201,8 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_on_sale_past_schedule() {
 		$product = WC_Helper_Product::create_simple_product( true, array( 'sale_price' => 5 ) );
-		$product->set_date_on_sale_from( date('Y-m-d H:i:s', time() - DAY_IN_SECONDS * 2 ) );
-		$product->set_date_on_sale_to( date('Y-m-d H:i:s',time() - DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS * 2 ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
 		$product->save();
 
 		$this->assertFalse( $product->is_on_sale() );
@@ -213,8 +214,8 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_on_sale_future_schedule() {
 		$product = WC_Helper_Product::create_simple_product( true, array( 'sale_price' => 5 ) );
-		$product->set_date_on_sale_from( date('Y-m-d H:i:s', time() + DAY_IN_SECONDS ) );
-		$product->set_date_on_sale_to( date('Y-m-d H:i:s',time() + DAY_IN_SECONDS * 2 ) );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS * 2 ) );
 		$product->save();
 
 		$this->assertFalse( $product->is_on_sale() );

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -163,4 +163,61 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 			'If a shop manager attempts to change an existing downloadable file to a valid path (that is covered by an approved directory rule) that is okay.'
 		);
 	}
+
+	/**
+	 * @testDox By default, product is not on sale.
+	 */
+	public function test_on_sale() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->assertFalse( $product->is_on_sale() );
+		$this->assertEquals( $product->get_regular_price(), $product->get_price() );
+	}
+
+	/**
+	 * @testDox Product is on sale when sale price is set and less than regular price, even without a sale schedule.
+	 */
+	public function test_on_sale_sale_price_is_set() {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'sale_price' => 5 ) );
+		$this->assertTrue( $product->is_on_sale() );
+		$this->assertEquals( 5, $product->get_price() );
+	}
+
+	/**
+	 * @testDox Product is on sale when schedule is set and current date is within schedule.
+	 */
+	public function test_on_sale_scheduled() {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'sale_price' => 5 ) );
+		$product->set_date_on_sale_from( date('Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( date('Y-m-d H:i:s',time() + DAY_IN_SECONDS ) );
+		$product->save();
+
+		$this->assertTrue( $product->is_on_sale() );
+		$this->assertEquals( 5, $product->get_price() );
+	}
+
+	/**
+	 * @testDox Product is not on sale when past schedule is set.
+	 */
+	public function test_on_sale_past_schedule() {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'sale_price' => 5 ) );
+		$product->set_date_on_sale_from( date('Y-m-d H:i:s', time() - DAY_IN_SECONDS * 2 ) );
+		$product->set_date_on_sale_to( date('Y-m-d H:i:s',time() - DAY_IN_SECONDS ) );
+		$product->save();
+
+		$this->assertFalse( $product->is_on_sale() );
+		$this->assertEquals( $product->get_regular_price(), $product->get_price() );
+	}
+
+	/**
+	 * @testDox Product is not on sale when future schedule is set.
+	 */
+	public function test_on_sale_future_schedule() {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'sale_price' => 5 ) );
+		$product->set_date_on_sale_from( date('Y-m-d H:i:s', time() + DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( date('Y-m-d H:i:s',time() + DAY_IN_SECONDS * 2 ) );
+		$product->save();
+
+		$this->assertFalse( $product->is_on_sale() );
+		$this->assertEquals( $product->get_regular_price(), $product->get_price() );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -199,9 +199,9 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox Price is changed when scheduled date for product is passed.
+	 * @testDox Sales price is applied when scheduled sale starts.
 	 */
-	public function test_wc_scheduled_sales() {
+	public function test_wc_scheduled_sales_sale_start() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_price( 100 );
 		$product->set_regular_price( 100);
@@ -217,5 +217,26 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		wc_scheduled_sales();
 
 		$this->assertEquals( 50, wc_get_product( $product->get_id() )->get_price() );
+	}
+
+	/**
+	 * @testDox Sales price is removed when scheduled sale ends.
+	 */
+	public function test_wc_scheduled_sales_sale_end() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 100 );
+		$product->set_regular_price( 100);
+		$product->set_sale_price( 50 );
+		$product->set_date_on_sale_to(  date('Y-m-d H:i:s', time() + 10 )  );
+		$product->save();
+
+		// Bypass product after save hook to prevent price change on save.
+		update_post_meta( $product->get_id(), '_sale_price_dates_to', time() - 5 );
+
+		$this->assertEquals( 50, wc_get_product( $product->get_id() )->get_price() );
+
+		wc_scheduled_sales();
+
+		$this->assertEquals( 100, wc_get_product( $product->get_id() )->get_price() );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -8,6 +8,7 @@
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
  * Class WC_Stock_Functions_Tests.
  */
@@ -204,9 +205,9 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	public function test_wc_scheduled_sales_sale_start() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_price( 100 );
-		$product->set_regular_price( 100);
+		$product->set_regular_price( 100 );
 		$product->set_sale_price( 50 );
-		$product->set_date_on_sale_from(  date('Y-m-d H:i:s', time() + 10 )  );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() + 10 ) );
 		$product->save();
 
 		// Bypass product after save hook to prevent price change on save.
@@ -225,9 +226,9 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	public function test_wc_scheduled_sales_sale_end() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_price( 100 );
-		$product->set_regular_price( 100);
+		$product->set_regular_price( 100 );
 		$product->set_sale_price( 50 );
-		$product->set_date_on_sale_to(  date('Y-m-d H:i:s', time() + 10 )  );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() + 10 ) );
 		$product->save();
 
 		// Bypass product after save hook to prevent price change on save.

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -197,4 +197,25 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 			update_option( 'woocommerce_calc_taxes', 'no' );
 		}
 	}
+
+	/**
+	 * @testDox Price is changed when scheduled date for product is passed.
+	 */
+	public function test_wc_scheduled_sales() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 100 );
+		$product->set_regular_price( 100);
+		$product->set_sale_price( 50 );
+		$product->set_date_on_sale_from(  date('Y-m-d H:i:s', time() + 10 )  );
+		$product->save();
+
+		// Bypass product after save hook to prevent price change on save.
+		update_post_meta( $product->get_id(), '_sale_price_dates_from', time() - 5 );
+
+		$this->assertEquals( 100, wc_get_product( $product->get_id() )->get_price() );
+
+		wc_scheduled_sales();
+
+		$this->assertEquals( 50, wc_get_product( $product->get_id() )->get_price() );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR essentially reverts #39948, and there closes #41569, but reopens #34696.

In 39948, we stopped clearing the sales start date, when a sale is supposed to be started. However, this had an unintended consequence, in that we used the clearing of the sales start date prop as a trigger to update the product price to the sale price. So this broke the product sale price updation flow when a product sale is scheduled sometime in the future.

I tried using the price change as a trigger, instead of clearing the scheduled date param, but that means we will over write the product price, either with the sale price or with the regular price whenever the price is changed. This can also have unintended consequences, especially if someone is using the `_price` prop as a temporary active product price, which will then become a no-op unless a regular price is also changed.

Ultimately, I am opting to revert the PR, and perhaps we can use custom product meta to store sales schedules which can target 34696 instead of this fix.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new product, set the regular price to 100, sale price to 50. Set the sale schedule to start few days in future. Note the product ID of this product. 
2. Go to the product listing page, and verify that the listed product price is 100 (and not 50).
3. Via WP CLI (`wp shell`), update the product schedule sales start date to sometime in the past and run the sale cron, like so:
```php
// XXX should be replaced the by product ID from step 1
$p = wc_get_product( XXX ); 

// Update the sale start date to sometime in past directly
update_post_meta( $p->get_id(), '_sale_price_dates_from', time() - 1000 );

// Call the sale schedule cron job manually.
wc_scheduled_sales();
```
5. Refresh the product list page again, you should now see sale prices for the product.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
