### PR TITLE
Limit cookie dedupe logic to only WooCommerce Cart cookies

### DIFF
--- a/plugins/woocommerce/changelog/fix-only-dedub-cookies-with-same-path
+++ b/plugins/woocommerce/changelog/fix-only-dedub-cookies-with-same-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Limit cookie deduping to WooCommerce cookies only.

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -281,11 +281,16 @@ final class WC_Cart_Session {
 			}
 			list(, $cookie_value)             = explode( ':', $header, 2 );
 			list($cookie_name, $cookie_value) = explode( '=', trim( $cookie_value ), 2 );
-			if ( array_key_exists( $cookie_name, $final_cookies ) ) {
-				$update_cookies = true;
+
+			// Check if the cookie is one of the specified types.
+			if ( in_array( $cookie_name, array( 'woocommerce_items_in_cart', 'woocommerce_cart_hash' ), true ) ) {
+				if ( array_key_exists( $cookie_name, $final_cookies ) ) {
+					$update_cookies = true;
+				}
+				$final_cookies[ $cookie_name ] = $cookie_value;
 			}
-			$final_cookies[ $cookie_name ] = $cookie_value;
 		}
+
 		if ( $update_cookies ) {
 			header_remove( 'Set-Cookie' );
 			foreach ( $final_cookies as $cookie_name => $cookie_value ) {

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -299,7 +299,7 @@ final class WC_Cart_Session {
 			header_remove( 'Set-Cookie' );
 			foreach ( $final_cookies as $cookie ) {
 				// Using header here preserves previous cookie args.
-				header( "Set-Cookie: {$cookie}", false );
+				header( $cookie, false );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -272,32 +272,52 @@ final class WC_Cart_Session {
 	 * Remove duplicate cookies from the response.
 	 */
 	private function dedupe_cookies() {
+		$all_cookies    = array_filter(
+			headers_list(),
+			function( $header ) {
+				return stripos( $header, 'Set-Cookie:' ) !== false;
+			}
+		);
 		$final_cookies  = array();
 		$update_cookies = false;
+		foreach ( $all_cookies as $cookie ) {
 
-		foreach ( headers_list() as $header ) {
-			if ( stripos( $header, 'Set-Cookie:' ) === false ) {
-				continue;
-			}
-			list(, $cookie_value)             = explode( ':', $header, 2 );
+			list(, $cookie_value)             = explode( ':', $cookie, 2 );
 			list($cookie_name, $cookie_value) = explode( '=', trim( $cookie_value ), 2 );
 
-			// Check if the cookie is one of the specified types.
-			if ( in_array( $cookie_name, array( 'woocommerce_items_in_cart', 'woocommerce_cart_hash' ), true ) ) {
-				if ( array_key_exists( $cookie_name, $final_cookies ) ) {
+			if ( stripos( $cookie_name, 'woocommerce_' ) !== false ) {
+				$key = $this->find_cookie_by_name( $cookie_name, $final_cookies );
+				if ( false !== $key ) {
 					$update_cookies = true;
+					unset( $final_cookies[ $key ] );
 				}
-				$final_cookies[ $cookie_name ] = $cookie_value;
 			}
+			$final_cookies[] = $cookie;
 		}
 
 		if ( $update_cookies ) {
 			header_remove( 'Set-Cookie' );
-			foreach ( $final_cookies as $cookie_name => $cookie_value ) {
+			foreach ( $final_cookies as $cookie ) {
 				// Using header here preserves previous cookie args.
-				header( "Set-Cookie: {$cookie_name}={$cookie_value}", false );
+				header( "Set-Cookie: {$cookie}", false );
 			}
 		}
+	}
+
+	/**
+	 * Find a cookie by name in an array of cookies.
+	 *
+	 * @param  string $cookie_name Name of the cookie to find.
+	 * @param  array  $cookies     Array of cookies to search.
+	 * @return mixed               Key of the cookie if found, false if not.
+	 */
+	private function find_cookie_by_name( $cookie_name, $cookies ) {
+		foreach ( $cookies as $key => $cookie ) {
+			if ( strpos( $cookie, $cookie_name ) !== false ) {
+				return $key;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Builds from https://github.com/woocommerce/woocommerce/pull/42828 but only limit the logic to WooCommerce cookies.
<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/43463

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Like #42828 use this updated snippet

```php
add_action(
	'template_redirect',
	function() {
		if ( is_front_page() ) {
			return;
		}

		if ( is_page() ) {
			$products = wc_get_products(
				array(
					'posts_per_page' => 5,
					'status'         => 'publish',
					'type'           => 'simple',
				)
			);
			wc_empty_cart();
			foreach ( $products as $product ) {
				WC()->cart->add_to_cart( $product->get_id(), 1 );
			}
			header( 'Set-Cookie: my_cookie=value;path=/', false );
			header( 'Set-Cookie: my_cookie=value;path=/wp-admin', false );
			wp_redirect( get_site_url() );
			exit;
		}
	},
	20
);
```

1. Open the network tab in the browser inspector and make sure you're recording and that "Preserve log" is checked.
2. Visit any page that isn't the home page.
3. You will see 2 requests, open the 302 one.
4. See that Woo cookies aren't duplicated but other cookies are there fine.

<img width="1044" alt="image" src="https://github.com/woocommerce/woocommerce/assets/6165348/821c2b6f-d8c2-4dcb-8be2-8295431aa9c0">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
