### PR TITLE
Fix notice template overwrites

### DIFF
--- a/plugins/woocommerce/changelog/43506-fix-43342-notice-template-overwrites
+++ b/plugins/woocommerce/changelog/43506-fix-43342-notice-template-overwrites
@@ -1,0 +1,4 @@
+Significance: major
+Type: fix
+
+Fixed a bug that prevented notice templates from being overwritten.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Notices.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Notices.php
@@ -42,7 +42,6 @@ class Notices {
 	 */
 	public function init() {
 		add_filter( 'woocommerce_kses_notice_allowed_tags', [ $this, 'add_kses_notice_allowed_tags' ] );
-		add_filter( 'wc_get_template', [ $this, 'get_notices_template' ], 10, 5 );
 		add_action( 'wp_head', [ $this, 'enqueue_notice_styles' ] );
 	}
 
@@ -67,28 +66,6 @@ class Notices {
 			),
 		);
 		return array_merge( $allowed_tags, $svg_args );
-	}
-
-	/**
-	 * Replaces core notice templates with those from blocks.
-	 *
-	 * The new notice templates match block components with matching icons and styling. The only difference is that core
-	 * only has notices for info, success, and error notices, whereas blocks has notices for info, success, error,
-	 * warning, and a default notice type.
-	 *
-	 * @param string $template Located template path.
-	 * @param string $template_name Template name.
-	 * @param array  $args Template arguments.
-	 * @param string $template_path Template path.
-	 * @param string $default_path Default path.
-	 * @return string
-	 */
-	public function get_notices_template( $template, $template_name, $args, $template_path, $default_path ) {
-		if ( in_array( $template_name, $this->notice_templates, true ) ) {
-			$template = $this->package->get_path( 'templates/' . $template_name );
-			wp_enqueue_style( 'wc-blocks-style' );
-		}
-		return $template;
 	}
 
 	/**

--- a/plugins/woocommerce/templates/notices/error.php
+++ b/plugins/woocommerce/templates/notices/error.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0-dev
+ * @version 8.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -32,7 +32,7 @@ $multiple = count( $notices ) > 1;
 	</svg>
 	<div class="wc-block-components-notice-banner__content">
 		<?php if ( $multiple ) { ?>
-			<p class="wc-block-components-notice-banner__summary"><?php esc_html_e( 'The following problems were found:', 'woo-gutenberg-products-block' ); ?></p>
+			<p class="wc-block-components-notice-banner__summary"><?php esc_html_e( 'The following problems were found:', 'woocommerce' ); ?></p>
 			<ul>
 			<?php foreach ( $notices as $notice ) : ?>
 				<li<?php echo wc_get_notice_data_attr( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>

--- a/plugins/woocommerce/templates/notices/error.php
+++ b/plugins/woocommerce/templates/notices/error.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0
+ * @version 8.5.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/notices/error.php
+++ b/plugins/woocommerce/templates/notices/error.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.1
+ * @version 8.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/notices/notice.php
+++ b/plugins/woocommerce/templates/notices/notice.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0-dev
+ * @version 8.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/notices/notice.php
+++ b/plugins/woocommerce/templates/notices/notice.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0
+ * @version 8.5.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/notices/notice.php
+++ b/plugins/woocommerce/templates/notices/notice.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.1
+ * @version 8.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/notices/success.php
+++ b/plugins/woocommerce/templates/notices/success.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0-dev
+ * @version 8.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/notices/success.php
+++ b/plugins/woocommerce/templates/notices/success.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0
+ * @version 8.5.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/notices/success.php
+++ b/plugins/woocommerce/templates/notices/success.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.1
+ * @version 8.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43342.

- Remove the filter for overwriting notice templates as the new notices are in core now.
- Remove the suffix `-dev` from the template version number.
- Replace the text domain `woo-gutenberg-products-block` with `woocommerce`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Place [this folder](https://github.com/woocommerce/woocommerce/files/13903543/woocommerce.zip) in the root folder of the activated theme.
2. Create a test page and add the following shortcode to it:
```
[woocommerce_cart]
```
3. Create a test page and add the following shortcode to it:
```
[woocommerce_checkout]
```
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced` and set the Cart page and the Checkout page to the ones created in steps 2. and 3.
5. Go to the frontend and add a product to the cart.
6. Go to the test page with the checkout shortcode.
7. Verify that the blue info notice shows the suffix ` → Overwritten notice.php template`.
8. Add an invalid coupon code.
9. Verify that the red error notice shows the suffix ` → Overwritten error.php template`. 
10. Go to the test page with the cart shortcode.
11. Delete the product from the cart.
12. Verify that the green success notice shows the suffix ` → Overwritten success.php template`.

### Overwritten notice.php template

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="754" alt="Screenshot 2024-01-11 at 20 08 59" src="https://github.com/woocommerce/woocommerce/assets/3323310/6f4ca394-0954-4e87-b1b8-07ab6bad7b0b">
</td>
<td valign="top">After:
<br><br>
<img width="757" alt="Screenshot 2024-01-11 at 20 05 49" src="https://github.com/woocommerce/woocommerce/assets/3323310/e79304df-9e15-4c2c-b7a9-4e3a0716698a">
</td>
</tr>
</table>

### Overwritten error.php template

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="746" alt="Screenshot 2024-01-11 at 20 09 20" src="https://github.com/woocommerce/woocommerce/assets/3323310/54215117-e0a9-4da5-86db-c0e25adee0b8">
</td>
<td valign="top">After:
<br><br>
<img width="750" alt="Screenshot 2024-01-11 at 20 06 07" src="https://github.com/woocommerce/woocommerce/assets/3323310/910886fa-6c39-44e2-9136-3c11250f4333">
</td>
</tr>
</table>

### Overwritten success.php template

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="749" alt="Screenshot 2024-01-11 at 20 09 37" src="https://github.com/woocommerce/woocommerce/assets/3323310/8b077e54-f17b-403c-84c0-3ae9003309bb">
</td>
<td valign="top">After:
<br><br>
<img width="749" alt="Screenshot 2024-01-11 at 20 06 24" src="https://github.com/woocommerce/woocommerce/assets/3323310/73f6c933-136e-49a0-a273-c54a9d267e19">
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixed a bug that prevented notice templates from being overwritten.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
