### PR TITLE
Add Filter Hook in OrdersScheduler.php for Customizing WooCommerce Analytics Data

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -81,6 +81,21 @@ class OrdersScheduler extends ImportScheduler {
 			$items = self::get_items_from_posts_table( $limit, $page, $days, $skip_existing );
 		}
 
+		/**
+		 * Filters the object of orders count and array of ids for orders analytics stats.
+		 *
+		 * Returns an object of count and ids of order for order analytics stats.
+		 *
+		 * If any modification is needed for orders analytics data, this hook can be used.
+		 *
+		 * @since 8.8.3
+		 *
+		 * @param object   $items         Total count of order ids and array of those ids.
+		 * @param int      $limit         Number of records to retrieve.
+		 * @param int      $page          Page number.
+		 * @param int|bool $days          Number of days prior to current date to limit search results.
+		 * @param bool     $skip_existing Skip already imported orders.
+		 */
 		return apply_filters(
             'woocommerce_analytics_orders_schedule_items',
             $items,

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -71,13 +71,24 @@ class OrdersScheduler extends ImportScheduler {
 	 * @param int      $page  Page number.
 	 * @param int|bool $days Number of days prior to current date to limit search results.
 	 * @param bool     $skip_existing Skip already imported orders.
+	 *
+	 * @return object Total counts.
 	 */
 	public static function get_items( $limit = 10, $page = 1, $days = false, $skip_existing = false ) {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			return self::get_items_from_orders_table( $limit, $page, $days, $skip_existing );
+			$items = self::get_items_from_orders_table( $limit, $page, $days, $skip_existing );
 		} else {
-			return self::get_items_from_posts_table( $limit, $page, $days, $skip_existing );
+			$items = self::get_items_from_posts_table( $limit, $page, $days, $skip_existing );
 		}
+
+		return apply_filters(
+            'woocommerce_analytics_orders_schedule_items',
+            $items,
+            $limit,
+            $page,
+            $days,
+            $skip_existing
+        );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Closes #43505

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a test plugin at `wp-content/plugins/test/test.php`
2. Cpoy and paste the code into test.php
```php
<?php
/**
 * Plugin Name: Test code
 * Description: Can be used to test https://github.com/woocommerce/woocommerce/pull/43515. Remove after it is tested.
 * WC tested up to: 8.8.2
 */

add_filter(
    'woocommerce_analytics_orders_schedule_items', function ( $items ) {
        $ids = $items->ids;

        foreach ( $ids as $key => $id ) {
            // Here you can check and exclude or filter out any order by checking any condition.
            unset( $ids[ $key ] );
        }

        $items->ids   = $ids;
        $items->total = count( $ids );

        return $items;
	}
);
```
4. Make sure woocommerce is active
5. Go to woocommerce analytics order menu
![image](https://github.com/woocommerce/woocommerce/assets/32583103/58aa6357-e016-4f08-b143-c5668445771f)
6. get the data saved.
7. Go to `Analytics -> Setting` and delete all the analytics and remove analytics cache
8. Re-generate the analytics data.
9. You will find the orders data are skipped in analytics.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
