### PR TITLE
HPOS: fix handling order meta containing nonexistent class when sync is on

### DIFF
--- a/plugins/woocommerce/changelog/fix-unserialize-order-meta-with-nonexistent-class
+++ b/plugins/woocommerce/changelog/fix-unserialize-order-meta-with-nonexistent-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+HPOS: fix handling order meta containing nonexistent class when sync is on.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -737,7 +737,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					}
 				}
 			}
-			if ( 'object' === gettype( $meta->value ) && '__PHP_Incomplete_Class' === get_class( $meta->value ) ) {
+			if ( 'object' === gettype( $meta_data->value ) && '__PHP_Incomplete_Class' === get_class( $meta_data->value ) ) {
 				$meta_value = maybe_serialize( $meta_data->value );
 				$result     = $wpdb->insert(
 					_get_meta_table( 'post' ),

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -737,14 +737,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					}
 				}
 			}
-			try {
-				add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
-			} catch ( \Throwable $th ) {
-				$incomplete_object_message = 'The script tried to modify a property on an incomplete object';
-				if ( substr( $th->getMessage(), 0, strlen( $incomplete_object_message ) ) !== $incomplete_object_message ) {
-					throw $th;
-				}
-
+			if ( 'object' === gettype( $meta->value ) && '__PHP_Incomplete_Class' === get_class( $meta->value ) ) {
 				$meta_value = maybe_serialize( $meta_data->value );
 				$result     = $wpdb->insert(
 					_get_meta_table( 'post' ),
@@ -760,6 +753,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					throw $th;
 				}
 				wp_cache_delete( $order->get_id(), 'post_meta' );
+			} else {
+				add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
 			}
 		}
 

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -736,7 +736,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					}
 				}
 			}
-			if ( 'object' === gettype( $meta_data->value ) && '__PHP_Incomplete_Class' === get_class( $meta_data->value ) ) {
+			if ( is_object( $meta_data->value ) && '__PHP_Incomplete_Class' === get_class( $meta_data->value ) ) {
 				$meta_value = maybe_serialize( $meta_data->value );
 				$result     = $wpdb->insert(
 					_get_meta_table( 'post' ),

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -705,7 +705,6 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * Helper method to update order metadata from initialized order object.
 	 *
 	 * @param WC_Abstract_Order $order Order object.
-	 * @throws \Throwable If adding post meta fails with both `add_post_meta` and `$wpdb->insert`.
 	 */
 	protected function update_order_meta_from_object( $order ) {
 		global $wpdb;
@@ -748,10 +747,6 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					),
 					array( '%d', '%s', '%s' )
 				);
-
-				if ( ! $result ) {
-					throw $th;
-				}
 				wp_cache_delete( $order->get_id(), 'post_meta' );
 			} else {
 				add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -752,7 +752,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 						'post_id'    => $order->get_id(),
 						'meta_key'   => $meta_data->key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 						'meta_value' => $meta_value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-					)
+					),
+					array( '%d', '%s', '%s' )
 				);
 
 				if ( ! $result ) {

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -748,6 +749,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					array( '%d', '%s', '%s' )
 				);
 				wp_cache_delete( $order->get_id(), 'post_meta' );
+				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object`: "%s"', var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {
 				add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
 			}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -750,7 +750,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				);
 				wp_cache_delete( $order->get_id(), 'post_meta' );
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object`: "%s"', var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object` in order with ID %d: "%s"', $order->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {
 				add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2907,7 +2907,7 @@ CREATE TABLE $meta_table (
 					throw $th;
 				}
 
-				$meta_value = maybe_serialize( $meta_data->value );
+				$meta_value = maybe_serialize( $meta->value );
 				$wpdb->delete(
 					_get_meta_table( 'post' ),
 					array(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2909,6 +2909,7 @@ CREATE TABLE $meta_table (
 					),
 					array( '%d', '%s', '%s' )
 				);
+				wp_cache_delete( $object->get_id(), 'post_meta' );
 			} else {
 				delete_post_meta( $object->get_id(), $meta->key, $meta->value );
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2911,7 +2911,7 @@ CREATE TABLE $meta_table (
 				);
 				wp_cache_delete( $object->get_id(), 'post_meta' );
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta`: "%s"', var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta` in order with ID %d: "%s"', $object->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {
 				delete_post_meta( $object->get_id(), $meta->key, $meta->value );
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2880,7 +2880,6 @@ CREATE TABLE $meta_table (
 	 * @param \stdClass $meta (containing at least ->id).
 	 *
 	 * @return bool
-	 * @throws \Throwable If deleting post meta fails with both `delete_post_meta` and `$wpdb->delete`.
 	 */
 	public function delete_meta( &$object, $meta ) {
 		global $wpdb;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2898,7 +2898,7 @@ CREATE TABLE $meta_table (
 
 		if ( ! $changes_applied && $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() && isset( $meta->key ) ) {
 			self::$backfilling_order_ids[] = $object->get_id();
-			if ( 'object' === gettype( $meta->value ) && '__PHP_Incomplete_Class' === get_class( $meta->value ) ) {
+			if ( is_object( $meta->value ) && '__PHP_Incomplete_Class' === get_class( $meta->value ) ) {
 				$meta_value = maybe_serialize( $meta->value );
 				$wpdb->delete(
 					_get_meta_table( 'post' ),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2910,6 +2910,8 @@ CREATE TABLE $meta_table (
 					array( '%d', '%s', '%s' )
 				);
 				wp_cache_delete( $object->get_id(), 'post_meta' );
+				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta`: "%s"', var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {
 				delete_post_meta( $object->get_id(), $meta->key, $meta->value );
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3335,6 +3335,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->set_date_modified( time() + 1 );
 		$order->save();
 
+		// Test fetching an order with meta data containing an object of a non-existent class.
 		$fetched_order = wc_get_order( $order->get_id() );
 		$meta          = $fetched_order->get_meta( $meta_key );
 
@@ -3347,6 +3348,16 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 'Belgium', $meta_object_vars['country_name'] );
 		$this->assertEquals( 'Brussels', $meta_object_vars['city'] );
 		$this->assertEquals( 'Europe/Brussels', $meta_object_vars['timezone'] );
+	
+		// Test deleting meta data containing an object of a non-existent class.
+		$meta_data = $this->sut->read_meta( $order );
+		foreach ( $meta_data as $meta ) {
+			$this->sut->delete_meta( $order, (object) array( 'id' => $meta->meta_id ) );
+		}
+		$fetched_order = wc_get_order( $order->get_id() );
+
+		$this->assertEmpty( $fetched_order->get_meta_data() );
+		$this->assertEquals( '', get_post_meta( $order->get_id(), $meta_key, true ) );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3360,7 +3360,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 'object', gettype( $meta ) );
 		$this->assertEquals( '__PHP_Incomplete_Class', get_class( $meta ) );
 
-		$meta_object_vars = get_object_vars($meta);
+		$meta_object_vars = get_object_vars( $meta );
 		$this->assertEquals( 'geoiprecord', $meta_object_vars['__PHP_Incomplete_Class_Name'] );
 		$this->assertEquals( 'Belgium', $meta_object_vars['country_name'] );
 		$this->assertEquals( 'Brussels', $meta_object_vars['city'] );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3335,19 +3335,8 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->set_date_modified( time() + 1 );
 		$order->save();
 
-		$order_results = wc_get_orders(
-			array(
-				'limit'        => 300,
-				'offset'       => 0,
-				'order'        => 'DESC',
-				'order_by'     => 'ID',
-				'return'       => 'objects',
-				'meta_key'     => $meta_key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value'   => '', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-				'meta_compare' => '!=',
-			)
-		);
-		$meta          = $order_results[0]->get_meta( $meta_key );
+		$fetched_order = wc_get_order( $order->get_id() );
+		$meta          = $fetched_order->get_meta( $meta_key );
 
 		$this->assertNotEmpty( $meta );
 		$this->assertEquals( 'object', gettype( $meta ) );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3371,7 +3371,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 'Europe/Brussels', $meta_object_vars['timezone'] );
 
 		// Check that the log entry was created.
-		$this->assertEquals( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object`: "\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"', end( $fake_logger->warnings )['message'] );
+		$this->assertEquals( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object` in order with ID ' . $order->get_id() . ': "\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"', end( $fake_logger->warnings )['message'] );
 
 		// Test deleting meta data containing an object of a non-existent class.
 		$meta_data = $this->sut->read_meta( $order );
@@ -3384,7 +3384,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( '', get_post_meta( $order->get_id(), $meta_key, true ) );
 
 		// Check that the log entry was created.
-		$this->assertEquals( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta`: "\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"', end( $fake_logger->warnings )['message'] );
+		$this->assertEquals( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta` in order with ID ' . $order->get_id() . ': "\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"', end( $fake_logger->warnings )['message'] );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3315,4 +3315,22 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertNotEquals( $date_modified, $order->get_date_modified() );
 	}
 
+	/**
+	 * Tests that unserializing meta that contains a non-existent class doesn't cause a fatal error.
+	 */
+	public function test_unserialize_meta_with_nonexistent_class() {
+		// $this->toggle_cot_authoritative( true );
+
+		$order = WC_Helper_Order::create_order();
+		// $order->set_date_modified( time() - DAY_IN_SECONDS );
+		$order->save();
+
+		// $order->update_meta_data( 'test', new \WC_DateTime( 'now', new \DateTimeZone( 'UTC' ) ) );
+		$order->update_meta_data( 'test', 'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.833300000000001;s:9:"longitude";d:4.3333000000000004;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}}' );
+		$order->save_meta_data();
+
+		echo $order->get_meta( 'test' );
+		$this->assertNotFalse( $order->get_meta( 'test' ) );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3335,13 +3335,6 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->set_date_modified( time() );
 		$order->save();
 
-		// There is a suspicion that syncing with `__PHP_Incomplete_Class` objects in meta causes a fatal error, so let's sync the HPOS order to the CPT store.
-		$order->get_data_store()->backfill_post_record( $order );
-
-		// Another possible way to force sync.
-		$orders = array( $order_id => $order );
-		$this->sut->read_multiple( $orders );
-
 		$order_results = wc_get_orders(
 			array(
 				'limit'        => 300,

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3348,7 +3348,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 'Belgium', $meta_object_vars['country_name'] );
 		$this->assertEquals( 'Brussels', $meta_object_vars['city'] );
 		$this->assertEquals( 'Europe/Brussels', $meta_object_vars['timezone'] );
-	
+
 		// Test deleting meta data containing an object of a non-existent class.
 		$meta_data = $this->sut->read_meta( $order );
 		foreach ( $meta_data as $meta ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3332,7 +3332,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order_id = $order->get_id();
 
 		$wpdb->query( "INSERT INTO {$order_meta_table} (order_id, meta_key, meta_value) VALUES ({$order_id}, '{$meta_key}', '{$meta_value}')" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-		$order->set_date_modified( time() );
+		$order->set_date_modified( time() + 1 );
 		$order->save();
 
 		$order_results = wc_get_orders(

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3356,9 +3356,15 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		);
 		$meta          = $order_results[0]->get_meta( $meta_key );
 
-		// Unfortunately all the properties of `__PHP_Incomplete_Class` objects are private, so we can't test them directly.
 		$this->assertNotEmpty( $meta );
+		$this->assertEquals( 'object', gettype( $meta ) );
 		$this->assertEquals( '__PHP_Incomplete_Class', get_class( $meta ) );
+
+		$meta_object_vars = get_object_vars($meta);
+		$this->assertEquals( 'geoiprecord', $meta_object_vars['__PHP_Incomplete_Class_Name'] );
+		$this->assertEquals( 'Belgium', $meta_object_vars['country_name'] );
+		$this->assertEquals( 'Brussels', $meta_object_vars['city'] );
+		$this->assertEquals( 'Europe/Brussels', $meta_object_vars['timezone'] );
 	}
 
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Assume a plugin adds metadata to an order, and that metadata is a serialized object that uses a class that the plugin defines. Now assume the plugin is subsequently deactivated and the class definition necessary for deserializing the object in the order's metadata isn't available anymore. 

This is not an issue as long as the metadata isn't touched, but with HPOS *and* sync turned on, there are situations where the metadata is deserialized, changed (by WordPress Core’s `map_deep`), and the serialized again. Under PHP less than 8 this was not an issue, but under PHP 8 throws an error. 

There is [an open ticket](https://core.trac.wordpress.org/ticket/55257) in WordPress Core for this issue but it’s not clear when, how, and if the issue will be addressed. So to ship a fix for WooCommerce users experiencing this issue, this PR catches the error and tries to imitate the metadata actions using `$wpdb` directly. 

Detecting this specific error can, as far as I can tell, only be done by matching the kind of error message, which I find a bit sub-optimal. I'd love to hear ideas for alternative ways of detection. 

Closes #38304.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. ensure CI passes
2. check out the branch locally
3. run the new unit test under PHP 8.0 like so: `nvm use && wp-env stop && WP_ENV_PHP_VERSION=8.0 wp-env start && pnpm test:php:env --filter=test_unserialize_meta_with_nonexistent_class` -- the test should pass
4.  undo the actual fix by walking back a few commits like so: `git checkout 19b2ddf`
5. run the new unit test again: `pnpm test:php:env --filter=test_unserialize_meta_with_nonexistent_class` -- the test should now fail

#### Instructions for Manual Testing

1. Ensure to test this with WooCommerce running on *PHP 8.0 or later*. 
2. Under WooCommerce / Settings / Advanced / Features, ensure *both* HPOS is turned on *and* sync is also turned on. 
3. Install the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
4. Create an order. 
5. Find the order in wp-admin and note down it's ID. 
6. Add the following snippet, replacing `__ID__` with the ID of the order you just created. Make sure to select the "execute only once" option.

```php
$incomplete_meta_object_test = function() {
	$order = wc_get_order( __ID__ );
	global $wpdb;
	$order_id = $order->get_id();
	$meta_key = 'test_unserialize_meta_with_nonexistent_class';
	$meta_value = 'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.833300000000001;s:9:"longitude";d:4.3333000000000004;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}}';
	$order_meta_table = Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::get_meta_table_name();
	$wpdb->query( "INSERT INTO {$order_meta_table} (order_id, meta_key, meta_value) VALUES ({$order_id}, '{$meta_key}', '{$meta_value}')" );
	$order->set_date_modified( time() );
	$order->save();
	$order_results = wc_get_orders(array('limit' => 300,'offset' => 0,'order' => 'DESC','order_by' => 'ID','return' => 'objects','meta_key' => $meta_key,'meta_value' => '','meta_compare' => '!='));
	$meta = $order_results[0]->get_meta( $meta_key );
	$logger = wc_get_logger();
	$logger->error( 'results: ' . var_export( $meta, true ) );
};
add_action( 'woocommerce_after_register_post_type', $incomplete_meta_object_test );
```

7. Save the snippet, and click "Execute Once". 
8. Reload the page. You should not get an error. 
9. Possibly optional (?) -- to ensure the above instructions are correct, retry the same using the latest official WooCommerce. An error should be thrown in the last step after reloading: "Fatal error: Uncaught Error: The script tried to modify a property on an incomplete object. [...]" Another reload should make the error go away. When you look at the error logs (`http://localhost:8888/wp-admin/admin.php?page=wc-status&tab=logs`), the error should be in there as well. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
