### PR TITLE
[Product Block Editor]: implement `Choose products for me` button

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-add-choose-products-for-me-button
+++ b/packages/js/product-editor/changelog/update-product-editor-add-choose-products-for-me-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: implement `Choose products for me` button

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -106,18 +106,18 @@ export function LinkedProductListBlockEdit( {
 		filter();
 	}, [ filter ] );
 
-	function handleSelect( selectedProduct: Product ) {
+	function handleSelect( product: Product ) {
 		const newLinkedProductIds = selectSearchedProductDispatcher(
-			selectedProduct,
+			product,
 			state.linkedProducts
 		);
 
 		setLinkedProductIds( newLinkedProductIds );
 	}
 
-	function handleRemoveProductClick( removedProduct: Product ) {
+	function handleRemoveProductClick( product: Product ) {
 		const newLinkedProductIds = removeLinkedProductDispatcher(
-			removedProduct,
+			product,
 			state.linkedProducts
 		);
 

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -8,11 +8,10 @@ import {
 	useReducer,
 } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { PRODUCTS_STORE_NAME, Product } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { reusableBlock } from '@wordpress/icons';
-import { resolveSelect } from '@wordpress/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -39,6 +38,7 @@ import {
 	LinkedProductListBlockAttributes,
 	LinkedProductListBlockEmptyState,
 } from './types';
+import getRelatedProducts from '../../../utils/get-related-products';
 
 export function EmptyStateImage( {
 	image,
@@ -125,7 +125,6 @@ export function LinkedProductListBlockEdit( {
 	}
 
 	async function chooseProductsForMe() {
-		const { getRelatedProducts } = resolveSelect( PRODUCTS_STORE_NAME );
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',
 			payload: {
@@ -143,6 +142,10 @@ export function LinkedProductListBlockEdit( {
 				isLoading: false,
 			},
 		} );
+
+		if ( ! relatedProducts ) {
+			return;
+		}
 
 		const newLinkedProducts = selectSearchedProductDispatcher(
 			relatedProducts,

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -9,6 +9,14 @@ import {
 } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { reusableBlock } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityId } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -66,6 +74,19 @@ export function Edit( {
 		linkedProducts: [],
 		searchedProducts: [],
 	} );
+
+	const productId = useEntityId( 'postType', postType );
+	const product: Product = useSelect(
+		( select ) =>
+			// @ts-expect-error There are no types for this.
+			select( 'core' ).getEditedEntityRecord(
+				'postType',
+				'product',
+				productId
+			),
+		[ productId ]
+	);
+
 	const loadLinkedProductsDispatcher =
 		getLoadLinkedProductsDispatcher( dispatch );
 	const searchProductsDispatcher = getSearchProductsDispatcher( dispatch );
@@ -95,25 +116,44 @@ export function Edit( {
 		filter();
 	}, [ filter ] );
 
-	function handleSelect( product: Product ) {
+	function handleSelect( selectedProduct: Product ) {
 		const newLinkedProductIds = selectSearchedProductDispatcher(
-			product,
+			selectedProduct,
 			state.linkedProducts
 		);
+
 		setLinkedProductIds( newLinkedProductIds );
 	}
 
-	function handleRemoveProductClick( product: Product ) {
+	function handleRemoveProductClick( removedProduct: Product ) {
 		const newLinkedProductIds = removeLinkedProductDispatcher(
-			product,
+			removedProduct,
 			state.linkedProducts
 		);
 
 		setLinkedProductIds( newLinkedProductIds );
+	}
+
+	function choseProductsForMe() {
+		if ( ! product?.related_ids ) {
+			return;
+		}
+
+		setLinkedProductIds( product.related_ids );
 	}
 
 	return (
 		<div { ...blockProps }>
+			<div className="wp-block-woocommerce-product-linked-list-field__form-group-header">
+				<Button
+					variant="tertiary"
+					icon={ reusableBlock }
+					onClick={ choseProductsForMe }
+				>
+					{ __( 'Choose products for me', 'woocommerce' ) }
+				</Button>
+			</div>
+
 			<div className="wp-block-woocommerce-product-linked-list-field__form-group-content">
 				<ProductSelect
 					items={ state.searchedProducts }

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -124,7 +124,7 @@ export function LinkedProductListBlockEdit( {
 		setLinkedProductIds( newLinkedProductIds );
 	}
 
-	async function choseProductsForMe() {
+	async function chooseProductsForMe() {
 		const { getRelatedProducts } = resolveSelect( PRODUCTS_STORE_NAME );
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',
@@ -158,7 +158,7 @@ export function LinkedProductListBlockEdit( {
 				<Button
 					variant="tertiary"
 					icon={ reusableBlock }
-					onClick={ choseProductsForMe }
+					onClick={ chooseProductsForMe }
 				>
 					{ __( 'Choose products for me', 'woocommerce' ) }
 				</Button>

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/editor.scss
@@ -3,6 +3,12 @@
 	flex-direction: column;
 	gap: $grid-unit-30;
 
+	&__form-group-header {
+		display: flex;
+		flex-direction: row;
+		justify-content: right;
+	}
+
 	.woocommerce-advice-card {
 		min-height: 233px; // min height to cover the min rows rendered in the table on its back
 

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/index.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
-import { Edit } from './edit';
+import { LinkedProductListBlockEdit } from './edit';
 import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
@@ -11,7 +11,7 @@ export { metadata, name };
 
 export const settings = {
 	example: {},
-	edit: Edit,
+	edit: LinkedProductListBlockEdit,
 };
 
 export function init() {

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/reducer.ts
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/reducer.ts
@@ -8,7 +8,7 @@ export type State = {
 	linkedProducts: Product[];
 	searchedProducts: Product[];
 	isLoading?: boolean;
-	selectedProduct?: Product;
+	selectedProduct?: Product | Product[];
 };
 
 export type ActionType =
@@ -120,10 +120,14 @@ export function getSelectSearchedProductDispatcher(
 	dispatch: ( value: Action ) => void
 ) {
 	return function selectSearchedProductDispatcher(
-		selectedProduct: Product,
+		selectedProduct: Product | Product[],
 		linkedProducts: Product[]
 	) {
-		const newLinkedProducts = [ ...linkedProducts, selectedProduct ];
+		if ( ! Array.isArray( selectedProduct ) ) {
+			selectedProduct = [ selectedProduct ];
+		}
+
+		const newLinkedProducts = [ ...linkedProducts, ...selectedProduct ];
 
 		dispatch( {
 			type: 'SELECT_SEARCHED_PRODUCT',

--- a/packages/js/product-editor/src/index.ts
+++ b/packages/js/product-editor/src/index.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import registerProductEditorUiStore from './store/product-editor-ui';
-import registerProductEditorDataStore from './store/data';
 import registerProductEditorHooks from './wp-hooks';
 
 export * from './components';
@@ -38,6 +37,5 @@ export * from './contexts/validation-context/types';
 
 // Init the store
 registerProductEditorUiStore();
-registerProductEditorDataStore();
 
 registerProductEditorHooks();

--- a/packages/js/product-editor/src/index.ts
+++ b/packages/js/product-editor/src/index.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import registerProductEditorUiStore from './store/product-editor-ui';
+import registerProductEditorDataStore from './store/data';
 import registerProductEditorHooks from './wp-hooks';
 
 export * from './components';
@@ -37,5 +38,6 @@ export * from './contexts/validation-context/types';
 
 // Init the store
 registerProductEditorUiStore();
+registerProductEditorDataStore();
 
 registerProductEditorHooks();

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { select, resolveSelect } from '@wordpress/data';
-import { Product } from '@woocommerce/data';
+import type { Product } from '@woocommerce/data';
 
 export default async function getRelatedProducts( productId: number ) {
 	const { getEntityRecord } = select( 'core' );

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { select, resolveSelect } from '@wordpress/data';
+import { Product } from '@woocommerce/data';
+
+export default async function getRelatedProducts( productId: number ) {
+	const { getEntityRecord } = select( 'core' );
+	const product = getEntityRecord( 'postType', 'product', productId );
+	if ( ! product ) {
+		return;
+	}
+
+	const relatedProductIds = product?.related_ids;
+	if ( ! relatedProductIds ) {
+		return;
+	}
+
+	const { getEntityRecords } = resolveSelect( 'core' );
+	return ( await getEntityRecords( 'postType', 'product', {
+		include: relatedProductIds,
+	} ) ) as Product[];
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the `Choose products for me` button for the Upsells and Cross-sells sections of the Linked Product tab.

Part of https://github.com/woocommerce/woocommerce/issues/42922
Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure your testing site has a few products to test
2. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="300" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

3. Edit/create a product by using the new Product Editor app
4. Confirm you see the `Choose products for me` button in the Linked product sections

<img width="793" alt="Screenshot 2024-01-11 at 13 41 45" src="https://github.com/woocommerce/woocommerce/assets/77539/24fa7d2a-5943-4b10-ab30-127da0db72be">

5. Confirm _when the user clicks Choose products for me, we add five products_ 
6. Confimr _If a store has less than 5 other products that are publicly published and in-stock, then we choose the maximum number of products they have._
7. Confirm _If there are products already selected under Upsell / Cross-sell (regardless whether they are user-selected ones or auto-generated ones), they all get replaced with the new recommended suggestions._

https://github.com/woocommerce/woocommerce/assets/77539/82333bab-ae7b-498d-8c45-6a64c8c240fa

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
