### PR TITLE
[Product Block Editor]: introduce `<SectionActions />` component

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-add-section-actions-component
+++ b/packages/js/product-editor/changelog/update-product-editor-add-section-actions-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: introduce `<SectionActions />` slot

--- a/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
@@ -13,7 +13,6 @@ import { SectionDescriptionBlockAttributes } from './types';
 
 export function SectionDescriptionBlockEdit( {
 	attributes,
-	clientId,
 }: ProductEditorBlockEditProps< SectionDescriptionBlockAttributes > ) {
 	const { content } = attributes;
 	const blockProps = useWooBlockProps( attributes );
@@ -22,7 +21,6 @@ export function SectionDescriptionBlockEdit( {
 		<BlockFill
 			{ ...blockProps }
 			name="section-description"
-			clientId={ clientId }
 			slotContainerBlockName="woocommerce/product-section"
 		>
 			<div>{ content }</div>

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -66,16 +66,10 @@ export function SectionBlockEdit( {
 							) }
 						</h2>
 
-						<BlockSlot
-							name="section-actions"
-							clientId={ clientId }
-						/>
+						<BlockSlot name="section-actions" />
 					</div>
 
-					<BlockSlot
-						name="section-description"
-						clientId={ clientId }
-					/>
+					<BlockSlot name="section-description" />
 				</HeadingTagName>
 			) }
 

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -387,6 +387,6 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 					</Modal>
 				) }
 			</div>
-		</BlockFill>
+		</SectionActions>
 	);
 }

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -38,7 +38,6 @@ import {
 } from '../../../utils/get-product-error-message';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { ProductDetailsSectionDescriptionBlockAttributes } from './types';
-import SectionActions from '../../../components/block-slot-fill/section-actions';
 
 export function ProductDetailsSectionDescriptionBlockEdit( {
 	attributes,
@@ -254,7 +253,10 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 	}
 
 	return (
-		<SectionActions>
+		<BlockFill
+			name="section-description"
+			slotContainerBlockName="woocommerce/product-section"
+		>
 			<div { ...blockProps }>
 				<p>
 					{ createInterpolateElement(
@@ -387,6 +389,6 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 					</Modal>
 				) }
 			</div>
-		</SectionActions>
+		</BlockFill>
 	);
 }

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../utils/get-product-error-message';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { ProductDetailsSectionDescriptionBlockAttributes } from './types';
+import SectionActions from '../../../components/block-slot-fill/section-actions';
 
 export function ProductDetailsSectionDescriptionBlockEdit( {
 	attributes,
@@ -253,11 +254,7 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 	}
 
 	return (
-		<BlockFill
-			name="section-description"
-			clientId={ clientId }
-			slotContainerBlockName="woocommerce/product-section"
-		>
+		<SectionActions>
 			<div { ...blockProps }>
 				<p>
 					{ createInterpolateElement(

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
@@ -26,7 +26,6 @@ import {
 	getProductImageStyle,
 	ReorderProductsModal,
 } from '../../../components/add-products-modal';
-import { BlockFill } from '../../../components/block-slot-fill';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { UploadsBlockAttributes } from './types';
 import {
@@ -37,12 +36,11 @@ import { Shirt } from '../../../images/shirt';
 import { Pants } from '../../../images/pants';
 import { Glasses } from '../../../images/glasses';
 import { AdviceCard } from '../../../components/advice-card';
-import SectionActions from '../../../components/block-slot-fill/section-actions';
+import { SectionActions } from '../../../components/block-slot-fill';
 
 export function Edit( {
 	attributes,
 	context: { postType },
-	clientId,
 }: ProductEditorBlockEditProps< UploadsBlockAttributes > ) {
 	const { property } = attributes;
 	const blockProps = useWooBlockProps( attributes );

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
@@ -37,6 +37,7 @@ import { Shirt } from '../../../images/shirt';
 import { Pants } from '../../../images/pants';
 import { Glasses } from '../../../images/glasses';
 import { AdviceCard } from '../../../components/advice-card';
+import SectionActions from '../../../components/block-slot-fill/section-actions';
 
 export function Edit( {
 	attributes,
@@ -125,10 +126,7 @@ export function Edit( {
 
 	return (
 		<div { ...blockProps }>
-			<BlockFill
-				name="section-actions"
-				slotContainerBlockName="woocommerce/product-section"
-			>
+			<SectionActions>
 				<div className="wp-block-woocommerce-product-list-field__header">
 					{ ! isLoading && groupedProducts.length > 0 && (
 						<Button
@@ -145,7 +143,7 @@ export function Edit( {
 						{ __( 'Add products', 'woocommerce' ) }
 					</Button>
 				</div>
-			</BlockFill>
+			</>
 
 			<div className="wp-block-woocommerce-product-list-field__body">
 				{ ! isLoading && groupedProducts.length === 0 && (

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
@@ -38,7 +38,7 @@ import { Glasses } from '../../../images/glasses';
 import { AdviceCard } from '../../../components/advice-card';
 import { SectionActions } from '../../../components/block-slot-fill';
 
-export function Edit( {
+export function ProductListBlockEdit( {
 	attributes,
 	context: { postType },
 }: ProductEditorBlockEditProps< UploadsBlockAttributes > ) {

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
@@ -127,7 +127,6 @@ export function Edit( {
 		<div { ...blockProps }>
 			<BlockFill
 				name="section-actions"
-				clientId={ clientId }
 				slotContainerBlockName="woocommerce/product-section"
 			>
 				<div className="wp-block-woocommerce-product-list-field__header">

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/edit.tsx
@@ -143,7 +143,7 @@ export function Edit( {
 						{ __( 'Add products', 'woocommerce' ) }
 					</Button>
 				</div>
-			</>
+			</SectionActions>
 
 			<div className="wp-block-woocommerce-product-list-field__body">
 				{ ! isLoading && groupedProducts.length === 0 && (

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/index.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
-import { Edit } from './edit';
+import { ProductListBlockEdit } from './edit';
 import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
@@ -11,7 +11,7 @@ export { metadata, name };
 
 export const settings = {
 	example: {},
-	edit: Edit,
+	edit: ProductListBlockEdit,
 };
 
 export function init() {

--- a/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
@@ -39,7 +39,11 @@ export function BlockFill( {
 		[ clientId, slotContainerBlockName ]
 	);
 
-	if ( ! closestAncestorClientId ) return null;
+	if ( ! closestAncestorClientId ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'No closest ancestor client ID found for block fill.' );
+		return null;
+	}
 
 	return (
 		<Fill { ...props } name={ getName( name, closestAncestorClientId ) } />

--- a/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
@@ -4,7 +4,10 @@
 import { Fill } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
-import { useBlockEditContext } from '@wordpress/block-editor';
+import {
+	// @ts-expect-error no exported member.
+	useBlockEditContext,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-fill.tsx
@@ -4,6 +4,7 @@
 import { Fill } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
+import { useBlockEditContext } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -13,10 +14,11 @@ import { BlockFillProps } from './types';
 
 export function BlockFill( {
 	name,
-	clientId,
 	slotContainerBlockName,
 	...props
 }: BlockFillProps ) {
+	const { clientId } = useBlockEditContext();
+
 	const closestAncestorClientId = useSelect(
 		( select ) => {
 			// @ts-expect-error Outdated type definition.

--- a/packages/js/product-editor/src/components/block-slot-fill/block-slot.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-slot.tsx
@@ -3,7 +3,10 @@
  */
 import { Slot } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
-import { useBlockEditContext } from '@wordpress/block-editor';
+import {
+	// @ts-expect-error no exported member.
+	useBlockEditContext,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/block-slot-fill/block-slot.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/block-slot.tsx
@@ -3,6 +3,7 @@
  */
 import { Slot } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
+import { useBlockEditContext } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import { createElement } from '@wordpress/element';
 import { getName } from './utils/get-name';
 import { BlockSlotProps } from './types';
 
-export function BlockSlot( { name, clientId, ...props }: BlockSlotProps ) {
+export function BlockSlot( { name, ...props }: BlockSlotProps ) {
+	const { clientId } = useBlockEditContext();
 	return <Slot { ...props } name={ getName( name, clientId ) } />;
 }

--- a/packages/js/product-editor/src/components/block-slot-fill/index.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/index.ts
@@ -1,3 +1,4 @@
 export * from './block-fill';
 export * from './block-slot';
 export * from './types';
+export * from './section-actions';

--- a/packages/js/product-editor/src/components/block-slot-fill/index.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/index.ts
@@ -1,4 +1,4 @@
 export * from './block-fill';
 export * from './block-slot';
+export * from './section-actions/index';
 export * from './types';
-export * from './section-actions';

--- a/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
@@ -23,7 +23,7 @@ export default function SectionActions( {
 	return (
 		<BlockFill
 			{ ...restProps }
-			name="section-description"
+			name="section-actions"
 			slotContainerBlockName={ containerBlockName }
 		/>
 	);

--- a/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
@@ -16,7 +16,7 @@ export type SectionActionsProps = Omit<
 	containerBlockName?: string;
 };
 
-export default function SectionActions( {
+export function SectionActions( {
 	containerBlockName = 'woocommerce/product-section',
 	...restProps
 }: SectionActionsProps ) {

--- a/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { BlockFill } from '../block-fill';
+import { BlockFillProps } from '../types';
+
+export type SectionActionsProps = Omit<
+	BlockFillProps,
+	'name' | 'slotContainerBlockName'
+> & {
+	containerBlockName?: string;
+};
+
+export default function SectionActions( {
+	containerBlockName = 'woocommerce/product-section',
+	...restProps
+}: SectionActionsProps ) {
+	return (
+		<BlockFill
+			{ ...restProps }
+			name="section-description"
+			slotContainerBlockName={ containerBlockName }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/components/block-slot-fill/types.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/types.ts
@@ -4,7 +4,6 @@
 import { Fill, Slot } from '@wordpress/components';
 
 export type BlockSlotFillProps = {
-	clientId: string;
 	name: string;
 };
 

--- a/packages/js/product-editor/src/components/block-slot-fill/types.ts
+++ b/packages/js/product-editor/src/components/block-slot-fill/types.ts
@@ -4,7 +4,7 @@
 import { Fill, Slot } from '@wordpress/components';
 
 export type BlockSlotFillProps = {
-	name: string;
+	name: 'section-actions' | 'section-description';
 };
 
 export type BlockSlotProps = BlockSlotFillProps & Slot.Props;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces a new `<SectionActions />` slot component: an abstraction on top of the `<BlockFill />` component to simplify the API.

### Usage

In a block that is a child of a section block, you can populate the section actions:

```jsx

function CustomProductBlockEdit() {
  return (
    <>
      <SectionActions>
	<Button
		onClick={ handleProductAction }
		variant="secondary"
	>
		{ __( 'Product action!', 'woocommerce' ) }
	</Button>
      </SectionActions>

      // The rest of the block edit component
    </>
  );
}
```

### Relevant changes

* `clientId` prop was removed from BlockFill and BlockSlot components. It's picked by using the core hook
* Add the `<SectionActions>` slot component
* Update the product list block using the new slot to render the `Add products` button
* Janitorial, TS, tidy minor changes.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enble the new Product Editor
2. Create/edit a product setting Grouped product type
<img width="498" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/32436380-eec6-4423-a524-3c40e8aeb071">

3. Scroll down to see the `Products in this group` section
4. Confirm you see the `Add products` button
5. Confirm it works as expected
<img width="684" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/ce17b3d3-5fa0-4ac7-a36a-341d7e0cfa92">

Optionally
7. Install the React Developer Tools for your browser
8. Open the React Developer Tools tab
9. Filter the components by the `SectionActions` name

<img width="841" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/631b7dac-9f0d-4e1d-8320-60c75338ad30">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
