### PR TITLE
Fix Mini-Cart price disappearing on hover

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/component-frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/component-frontend.tsx
@@ -49,7 +49,7 @@ const renderMiniCartFrontend = () => {
 				style: el.dataset.style ? JSON.parse( el.dataset.style ) : {},
 				miniCartIcon: el.dataset.miniCartIcon,
 				addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
-				hasHiddenPrice: el.dataset.hasHiddenPrice,
+				hasHiddenPrice: el.dataset.hasHiddenPrice !== 'false',
 				priceColor: el.dataset.priceColor
 					? JSON.parse( el.dataset.priceColor )
 					: {},

--- a/plugins/woocommerce/changelog/43550-fix-mini-cart-disappearing-price
+++ b/plugins/woocommerce/changelog/43550-fix-mini-cart-disappearing-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Mini-Cart total price disappearing when hovering or focusing the Mini-Cart button


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The React-side of the Mini-Cart block wasn't reading properly the `Display total price` attribute, so even when the attribute was set to true, the price was not displayed. For shoppers, that was only visible when hover or focusing the button or interacting with the Cart in any other way.

Kudos to @nielslange for finding this issue.

### How to test the changes in this Pull Request:

1. In a page, add the Mini-Cart block and set the `Display total price` attribute to true.
2. Visit the page in the frontend.
3. Hover the Mini-Cart block.
4. Verify the price doesn't disappear.

Before:

[Enregistrament de pantalla del 2024-01-12 11-14-31.webm](https://github.com/woocommerce/woocommerce/assets/3616980/2bce8fad-589a-47ed-b204-598f370a5761)

After:

[Enregistrament de pantalla del 2024-01-12 11-13-46.webm](https://github.com/woocommerce/woocommerce/assets/3616980/43bda25c-18eb-4cb5-a04e-0c2f3e59a679)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix Mini-Cart total price disappearing when hovering or focusing the Mini-Cart button

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
