### PR TITLE
Improve the validation process when changing the product type

### DIFF
--- a/plugins/woocommerce/changelog/add-43280
+++ b/plugins/woocommerce/changelog/add-43280
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Remove the required validation constraint from the LINK TO THE EXTERNAL PRODUCT field

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -354,7 +354,6 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 							'value'   => 'url',
 							'message' => __( 'Link to the external product is an invalid URL.', 'woocommerce' ),
 						),
-						'required'    => __( 'Link to the external product is required.', 'woocommerce' ),
 					),
 				)
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43280

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products` -> `Add new` from the left side menu.
4. Under the `General` tab a description `This is a standard product. Change product type` should be shown below the `Basic details` section.
5. When clicking the `Change product type` a dropdown menu should be shown listing all the available product types. 
<img width="686" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c112df55-7b60-4883-bcfb-731505c16714">

6. From the list the `Standard product` should be highlighted in blue.
7. When selecting the `Affiliate product` from the list and error should be shown highlighting the `NAME` field in red.
8. Fill the `NAME` field and then select the `Affiliate product` from the list again.
9. The change should be applied successfully. (The product now should be of type `external`)
10. Clicking the `Standard product` again should be done without showing any error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
