### PR TITLE
Fix variations initial load

### DIFF
--- a/packages/js/product-editor/changelog/fix-variations_initial_load
+++ b/packages/js/product-editor/changelog/fix-variations_initial_load
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue when generating variations for the first time in the new editor.

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -21,7 +21,6 @@ import { ProductEditorBlockEditProps } from '../../../types';
 
 export function SectionBlockEdit( {
 	attributes,
-	clientId,
 }: ProductEditorBlockEditProps< SectionBlockAttributes > ) {
 	const { description, title, blockGap } = attributes;
 

--- a/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
@@ -70,10 +70,6 @@ export function useVariations( { productId }: UseVariationsProps ) {
 		}
 	}
 
-	useEffect( () => {
-		getCurrentVariationsPage( { product_id: productId } );
-	}, [ productId ] );
-
 	function onPageChange( page: number ) {
 		getCurrentVariationsPage( {
 			product_id: productId,
@@ -457,6 +453,12 @@ export function useVariations( { productId }: UseVariationsProps ) {
 	} = useProductVariationsHelper();
 
 	const wasGenerating = useRef( false );
+
+	useEffect( () => {
+		if ( ! isGenerating ) {
+			getCurrentVariationsPage( { product_id: productId } );
+		}
+	}, [ productId, isGenerating ] );
 
 	useEffect( () => {
 		if ( isGenerating ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This addresses an issue where we were retrieving variations while they were still being generated, causing only a couple variations to show and sometimes none.

Prior:
https://github.com/woocommerce/woocommerce/assets/2240960/9c0842b7-69f5-46e3-94f9-cd0743733450

Now:
https://github.com/woocommerce/woocommerce/assets/2240960/dbb248dc-06a0-43ae-9cfb-93e0e9ea16f9

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor under the **Advanced > Features** setting
2. Click **Products > Add new**
3. Add a name and save as draft
4. Go to the **Variations** tab
5. Click **Add variation options** and add one attribute with several terms
6. Once added the variations should be generated and shown in the table correctly below.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
