### PR TITLE
[Product Block Editor]: fallback with random products when no related products

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-choose-random-products
+++ b/packages/js/product-editor/changelog/update-product-editor-choose-random-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: fallback with random products when there isn't related products in the Linked Products tab

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -132,9 +132,9 @@ export function LinkedProductListBlockEdit( {
 			},
 		} );
 
-		const relatedProducts = ( await getRelatedProducts(
-			productId
-		) ) as Product[];
+		const relatedProducts = ( await getRelatedProducts( productId, {
+			fallbackToRandomProducts: true,
+		} ) ) as Product[];
 
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',

--- a/packages/js/product-editor/src/utils/get-related-products/Readme.md
+++ b/packages/js/product-editor/src/utils/get-related-products/Readme.md
@@ -1,0 +1,38 @@
+# Get Related Products
+
+Helper function to retrieve related products for a given product.
+
+## Usage
+
+`getRelatedProducts` is an asynchronous function that returns related products for a specified product ID.
+If no related products are found, and the `fallbackToRandomProducts` flag is set to `true`, it returns a random set of products.
+
+### Syntax
+
+```es6
+getRelatedProducts( productId, options )
+```
+
+#### Parameters
+
+- `productId` (number): The ID of the product for which related products are to be fetched.
+- `options` (Object): An object containing the following property:
+  - `fallbackToRandomProducts` (boolean): Optional. If set to `true`, the function will return random products if no related products are found. Default is `false`.
+
+#### Return
+
+- Promise<Product[] | undefined>: A promise that resolves to an array of related products or `undefined` if none are found and `fallbackToRandomProducts` is `false`.
+
+### Example
+
+```javascript
+import getRelatedProducts from './path-to-getRelatedProducts';
+
+getRelatedProducts( 123, { fallbackToRandomProducts: true } )
+  .then( relatedProducts => {
+    console.log( relatedProducts );
+  } )
+  .catch( error => {
+    console.error( 'Error fetching related products:', error );
+  } );
+```

--- a/packages/js/product-editor/src/utils/get-related-products/Readme.md
+++ b/packages/js/product-editor/src/utils/get-related-products/Readme.md
@@ -17,7 +17,7 @@ getRelatedProducts( productId, options )
 
 - `productId` (number): The ID of the product for which related products are to be fetched.
 - `options` (Object): An object containing the following property:
-  - `fallbackToRandomProducts` (boolean): Optional. If set to `true`, the function will return random products if no related products are found. Default is `false`.
++ `fallbackToRandomProducts` (boolean): Optional. If set to `true`, the function will return random products if no related products are found. Default is `false`.
 
 #### Return
 

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -4,20 +4,65 @@
 import { select, resolveSelect } from '@wordpress/data';
 import type { Product } from '@woocommerce/data';
 
-export default async function getRelatedProducts( productId: number ) {
+type getRelatedProductsOptions = {
+	// If true, return random products if no related products are found.
+	fallbackToRandomProducts?: boolean;
+};
+
+const POSTS_NUMBER_TO_RANDOMIZE = 30;
+
+/**
+ * Return related products for a given product ID.
+ * If fallbackToRandomProducts is true,
+ * return random products if no related products are found.
+ *
+ * @param {number}  productId - Product ID.
+ * @param {boolean} options   - Options.
+ * @return {Promise<Product[] | undefined>} Related products.
+ */
+export default async function getRelatedProducts(
+	productId: number,
+	options: getRelatedProductsOptions = {}
+): Promise< Product[] | undefined > {
 	const { getEntityRecord } = select( 'core' );
 	const product = getEntityRecord( 'postType', 'product', productId );
 	if ( ! product ) {
 		return;
 	}
 
-	const relatedProductIds = product?.related_ids;
-	if ( ! relatedProductIds ) {
-		return;
+	let relatedProductIds = product?.related_ids;
+	if ( ! relatedProductIds?.length ) {
+		if ( ! options?.fallbackToRandomProducts ) {
+			return;
+		}
+
+		// Pick the last `POSTS_NUMBER_TO_RANDOMIZE` posts
+		const lastPost = ( await resolveSelect( 'core' ).getEntityRecords(
+			'postType',
+			'product',
+			{
+				_fields: [ 'id' ],
+				per_page: POSTS_NUMBER_TO_RANDOMIZE,
+			}
+		) ) as Product[];
+
+		if ( ! lastPost?.length ) {
+			return;
+		}
+
+		const lastPostIds = lastPost.map( ( post ) => post.id );
+
+		// Pick five random post IDs
+		relatedProductIds = lastPostIds
+			?.sort( () => Math.random() - 0.5 )
+			.slice( 0, 5 );
 	}
 
-	const { getEntityRecords } = resolveSelect( 'core' );
-	return ( await getEntityRecords( 'postType', 'product', {
-		include: relatedProductIds,
-	} ) ) as Product[];
+	return ( await resolveSelect( 'core' ).getEntityRecords(
+		'postType',
+		'product',
+		{
+			include: relatedProductIds,
+		}
+	) ) as Product[];
 }

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -10,6 +10,7 @@ type getRelatedProductsOptions = {
 };
 
 const POSTS_NUMBER_TO_RANDOMIZE = 30;
+const POSTS_NUMBER_TO_PICK = 5;
 
 /**
  * Return related products for a given product ID.
@@ -52,10 +53,10 @@ export default async function getRelatedProducts(
 
 		const lastPostIds = lastPost.map( ( post ) => post.id );
 
-		// Pick five random post IDs
+		// Pick POSTS_NUMBER_TO_PICK random post IDs
 		relatedProductIds = lastPostIds
-			?.sort( () => Math.random() - 0.5 )
-			.slice( 0, 5 );
+			.sort( () => Math.random() - 0.5 )
+			.slice( 0, POSTS_NUMBER_TO_PICK );
 	}
 
 	return ( await resolveSelect( 'core' ).getEntityRecords(

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -16,8 +16,8 @@ const POSTS_NUMBER_TO_RANDOMIZE = 30;
  * If fallbackToRandomProducts is true,
  * return random products if no related products are found.
  *
- * @param {number}  productId - Product ID.
- * @param {boolean} options   - Options.
+ * @param {number}                    productId - Product ID.
+ * @param {getRelatedProductsOptions} options   - Options.
  * @return {Promise<Product[] | undefined>} Related products.
  */
 export default async function getRelatedProducts(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This allows to suggest random products in the Linked Products tab when the current product doesn't have related ones, as requested in the issue:

> If the user don’t have tags / attributes etc added yet, then we choose 5 randomly selected products that are publicly published and in-stock.

Also, it documents the getRelatedProducts() helper [function](https://github.com/woocommerce/woocommerce/blob/ea58165654d9a322f321654d9721c8846d361212/packages/js/product-editor/src/utils/get-related-products/Readme.md). 

Closes https://github.com/woocommerce/woocommerce/issues/42922

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure your site has products that have defined categories
2. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

3. Enable the new Product Block editor
4. Create a new Product
5. Go to the Linked Products tab
6. Ensure the product doesn't have defined related_ids:

```es6
wp.data.select( 'core' ).getEntityRecord( 'postType', 'product', [ <product-id> ] )?.related_ids
```

8. Click on the `Choose products for me` button of the Upsells or Cross-sells sections 
9. **Before (trunk)** Confirm the app doesn't provide any linked products 
10. **After (this PR)** Confirm the suggests five random products

https://github.com/woocommerce/woocommerce/assets/77539/42defd5a-ffc2-4b62-b30a-d05f59c7163c

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
