### PR TITLE
Product Gallery block: Remove the experimental flag from the Product Gallery block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/index.ts
@@ -4,7 +4,6 @@
 import { gallery as icon } from '@wordpress/icons';
 import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
 import { createBlock } from '@wordpress/blocks';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -13,7 +12,7 @@ import edit from './edit';
 import metadata from './block.json';
 import './style.scss';
 
-const galleryBlock = isExperimentalBuild() ? 'woocommerce/product-gallery' : '';
+const galleryBlock = 'woocommerce/product-gallery';
 
 registerBlockSingleProductTemplate( {
 	blockName: metadata.name,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -14,7 +13,5 @@ import './inner-blocks/product-gallery-large-image-next-previous';
 import './inner-blocks/product-gallery-pager';
 import './inner-blocks/product-gallery-thumbnails';
 
-if ( isExperimentalBuild() ) {
-	// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core.
-	registerBlockType( metadata, ProductGalleryBlockSettings );
-}
+// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core.
+registerBlockType( metadata, ProductGalleryBlockSettings );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -12,11 +11,9 @@ import metadata from './block.json';
 import { Save } from './save';
 import { Icon } from './icons';
 
-if ( isExperimentalBuild() ) {
-	// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
-	registerBlockType( metadata, {
-		icon: Icon,
-		edit: Edit,
-		save: Save,
-	} );
-}
+// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
+registerBlockType( metadata, {
+	icon: Icon,
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -12,11 +11,9 @@ import { Edit } from './edit';
 import { Save } from './save';
 import metadata from './block.json';
 
-if ( isExperimentalBuild() ) {
-	// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
-	registerBlockType( metadata, {
-		icon,
-		edit: Edit,
-		save: Save,
-	} );
-}
+// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
+registerBlockType( metadata, {
+	icon,
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-pager/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-pager/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -12,13 +11,11 @@ import { Edit } from './edit';
 import metadata from './block.json';
 import './editor.scss';
 
-if ( isExperimentalBuild() ) {
-	// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
-	registerBlockType( metadata, {
-		icon: ProductGalleryPagerBlockIcon,
-		edit: Edit,
-		save() {
-			return null;
-		},
-	} );
-}
+// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
+registerBlockType( metadata, {
+	icon: ProductGalleryPagerBlockIcon,
+	edit: Edit,
+	save() {
+		return null;
+	},
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -11,13 +10,11 @@ import icon from './icon';
 import { Edit } from './edit';
 import metadata from './block.json';
 
-if ( isExperimentalBuild() ) {
-	// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
-	registerBlockType( metadata, {
-		icon,
-		edit: Edit,
-		save() {
-			return null;
-		},
-	} );
-}
+// @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
+registerBlockType( metadata, {
+	icon,
+	edit: Edit,
+	save() {
+		return null;
+	},
+} );

--- a/plugins/woocommerce-blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce-blocks/bin/webpack-entries.js
@@ -53,25 +53,19 @@ const blocks = {
 	'product-collection-no-results': {
 		customDir: 'product-collection/inner-blocks/no-results',
 	},
-	'product-gallery': {
-		isExperimental: true,
-	},
+	'product-gallery': {},
 	'product-gallery-large-image': {
 		customDir: 'product-gallery/inner-blocks/product-gallery-large-image',
-		isExperimental: true,
 	},
 	'product-gallery-large-image-next-previous': {
 		customDir:
 			'product-gallery/inner-blocks/product-gallery-large-image-next-previous',
-		isExperimental: true,
 	},
 	'product-gallery-pager': {
 		customDir: 'product-gallery/inner-blocks/product-gallery-pager',
-		isExperimental: true,
 	},
 	'product-gallery-thumbnails': {
 		customDir: 'product-gallery/inner-blocks/product-gallery-thumbnails',
-		isExperimental: true,
 	},
 	'product-new': {},
 	'product-on-sale': {},

--- a/plugins/woocommerce/changelog/43586-chore-42095-remove-experimental-flag-from-product-gallery-block
+++ b/plugins/woocommerce/changelog/43586-chore-42095-remove-experimental-flag-from-product-gallery-block
@@ -1,0 +1,4 @@
+Significance: major
+Type: add
+
+Add the Product Gallery block

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -240,6 +240,11 @@ final class BlockTypesController {
 			'ProductCategory',
 			'ProductCollection',
 			'ProductCollectionNoResults',
+			'ProductGallery',
+			'ProductGalleryLargeImage',
+			'ProductGalleryLargeImageNextPrevious',
+			'ProductGalleryPager',
+			'ProductGalleryThumbnails',
 			'ProductImage',
 			'ProductImageGallery',
 			'ProductNew',
@@ -291,11 +296,6 @@ final class BlockTypesController {
 		);
 
 		if ( Package::feature()->is_experimental_build() ) {
-			$block_types[] = 'ProductGallery';
-			$block_types[] = 'ProductGalleryLargeImage';
-			$block_types[] = 'ProductGalleryLargeImageNextPrevious';
-			$block_types[] = 'ProductGalleryPager';
-			$block_types[] = 'ProductGalleryThumbnails';
 			$block_types[] = 'ProductFilters';
 			$block_types[] = 'ProductFiltersStockStatus';
 			$block_types[] = 'ProductFiltersPrice';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
This PR removes the experimental flag from the Product Gallery block, making the block available in the production build.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42095 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Scenario 1: The block is available in the block inserter and can be added to the editor

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. Click on "Edit" to open the WordPress editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block." Click on it.
4. In the block inserter, search for "Product Gallery" or browse through the available blocks until you find it.
5. Click on the "Product Gallery" block to add it to your content.
6. Make sure the block is successfully added to the editor.

#### Scenario 2: Transform the Product Image Gallery into the Product Gallery block

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. On the top of the menu, click on Actions (three dots icon). Select "Clear customizations", if available.
3. Click on "Edit" to open the WordPress editor.
4. In the editor, select the Product Image Gallery block.
5. In the Block Toolbar, select the icon for the Product Image Gallery block. The "Transform to" menu will open. Select the Product Gallery (Beta) block.

![CleanShot 2024-01-16 at 16 22 17@2x](https://github.com/woocommerce/woocommerce/assets/20469356/06a2284d-8172-45a0-baf6-eeb10341f3f4)

6. Make sure the Product Image Gallery was successfully replaced by the Product Gallery (Beta) block.

#### Scenario 3: The block settings are available and configurable
1. After adding the Product Gallery (Beta) block to your editor, select the block by clicking on it.
2. In the right-hand sidebar or the block toolbar, you should see block-specific settings for the Product Gallery (Beta) block.
3. Verify that you can configure settings such as the display mode of the pager, display mode of the next/previous buttons, display mode and number of thumbnails.
4. Make changes to the settings and ensure that they are applied correctly to the block in the editor and on the frontend.

#### Scenario 4: Product Gallery Pop-Up

1. Add the WooCommerce Product Gallery (Beta) block to the editor and click on the Save button.
2. On the frontend, visit a variable product and click on the Large Image.
3. Make sure the Product Gallery Pop-Up opens and you can navigate through the images using the next/previous buttons.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add the Product Gallery block

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
