### PR TITLE
Use GMT date when fetching cancellation orders.

### DIFF
--- a/plugins/woocommerce/changelog/fix-43593
+++ b/plugins/woocommerce/changelog/fix-43593
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use GMT date when fetching orders to auto-cancel.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -987,10 +987,24 @@ WHERE
 	/**
 	 * Get unpaid orders last updated before the specified date.
 	 *
-	 * @param  int $date Timestamp.
-	 * @return array
+	 * @param  int $date This timestamp is expected in the timezone in WordPress settings legacy reason, even though it's not a good practice.
+	 *
+	 * @return array Array of order IDs.
 	 */
 	public function get_unpaid_orders( $date ) {
+		$timezone_offset = wc_timezone_offset();
+		$gmt_timestamp   = $date - $timezone_offset;
+		return $this->get_unpaid_orders_gmt( absint( $gmt_timestamp ) );
+	}
+
+	/**
+	 * Get unpaid orders last updated before the specified GMT date.
+	 *
+	 * @param int $gmt_timestamp GMT timestamp.
+	 *
+	 * @return array Array of order IDs.
+	 */
+	public function get_unpaid_orders_gmt( $gmt_timestamp ) {
 		global $wpdb;
 
 		$orders_table    = self::get_orders_table_name();
@@ -1004,7 +1018,7 @@ WHERE
 				AND {$orders_table}.status = %s
 				AND {$orders_table}.date_updated_gmt < %s",
 				'wc-pending',
-				gmdate( 'Y-m-d H:i:s', absint( $date ) )
+				gmdate( 'Y-m-d H:i:s', absint( $gmt_timestamp ) )
 			)
 		);
 		// phpcs:enable

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -987,7 +987,7 @@ WHERE
 	/**
 	 * Get unpaid orders last updated before the specified date.
 	 *
-	 * @param  int $date This timestamp is expected in the timezone in WordPress settings legacy reason, even though it's not a good practice.
+	 * @param  int $date This timestamp is expected in the timezone in WordPress settings for legacy reason, even though it's not a good practice.
 	 *
 	 * @return array Array of order IDs.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1207,7 +1207,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 */
 	public function test_get_unpaid_orders(): void {
 		// phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- Intentional usage since timezone is changed for this file.
-		$now = current_time( 'timestamp' );
+		$now = current_time( 'timestamp', 1 );
 
 		// Create a few orders.
 		$orders_by_status = array(
@@ -1236,8 +1236,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEqualsCanonicalizing( $unpaid_ids, $this->sut->get_unpaid_orders( $now ) );
 		$this->assertEqualsCanonicalizing( $unpaid_ids, $this->sut->get_unpaid_orders( $now - HOUR_IN_SECONDS ) );
 
-		// No unpaid orders from before yesterday.
-		$this->assertCount( 0, $this->sut->get_unpaid_orders( $now - WEEK_IN_SECONDS ) );
+		$this->assertCount( 0, $this->sut->get_unpaid_orders( $now - DAY_IN_SECONDS ) );
 
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1207,7 +1207,8 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 */
 	public function test_get_unpaid_orders(): void {
 		// phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- Intentional usage since timezone is changed for this file.
-		$now_gmt = current_time( 'timestamp', 1 );
+		$now_gmt = time();
+		// phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- Testing a legacy code that does expect the offset timestamp.
 		$now_ist = current_time( 'timestamp', 0 ); // IST (Indian standard time) is 5.5 hours ahead of GMT and is set as timezone for this class.
 
 		// Create a few orders.
@@ -3028,7 +3029,6 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->set_date_created( '2023-09-01T00:30:00' ); // This would be 2023-08-31T18:00:00 UTC given the current timezone.
 		$this->sut->create( $order );
 
-
 		$query = new OrdersTableQuery( array( 'date_created_gmt' => '2023-09-01' ) );
 		$this->assertEquals( 0, count( $query->orders ) ); // Should not return anything as the order was created on 2023-08-31 UTC.
 
@@ -3058,9 +3058,12 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->toggle_cot_authoritative( true );
 		$this->enable_cot_sync();
 
-		add_action( 'woocommerce_delete_shop_order_transients', function ( $order_id ) {
-			wc_get_order( $order_id );
-		} );
+		add_action(
+			'woocommerce_delete_shop_order_transients',
+			function ( $order_id ) {
+				wc_get_order( $order_id );
+			}
+		);
 		$order = OrderHelper::create_order();
 
 		$this->assertEquals( 1, $order->get_customer_id() );
@@ -3087,7 +3090,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 
 		$order = OrderHelper::create_order();
 
-		// set the cache
+		// set the cache.
 		wc_get_order( $order->get_id() );
 
 		$order->add_meta_data( 'test_key', 'test_value' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In `get_unpaid_orders` the passed `$date` parameter is a timezone-based timestamp, but we used it as a UTC-based timestamp. This caused issues as the function will return unpaid orders not yet eligible for cancellation and would cancel it, in timezones that are ahead of UTC (countries towards the east of the GMT line). 

This is fixed by converting the timestamp to UTC before comparing it with the order-modified timestamps.

Closes #43593 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set HPOS to authoritative, set the hold stock setting to 60 min in WooCommerce > Settings > Products > Inventory
2. Set the WordPress site time zone to any timezone greater than +1 UTC, such as IST (which is +5:30)
3. Check out an order with any product via checkout flow.
4. Open the new order in wc-admin, and set the order status to pending payment.
5. Using the CLI, manually run the cron job for cancelling unpaid order like so: `wp eval "wc_cancel_unpaid_orders();"`
6. Refresh the order admin page for the new order. Check that it's not cancelled.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
