### PR TITLE
[Product Block Editor]: add loading for the `Choose products for me` button

### DIFF
--- a/packages/js/product-editor/changelog/update-roduct-editor-add-choose-buttton-loading-state
+++ b/packages/js/product-editor/changelog/update-roduct-editor-add-choose-buttton-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: add loading for the `Choose products for me` button

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -6,6 +6,7 @@ import {
 	useCallback,
 	useEffect,
 	useReducer,
+	useState,
 } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
@@ -125,6 +126,8 @@ export function LinkedProductListBlockEdit( {
 		setLinkedProductIds( newLinkedProductIds );
 	}
 
+	const [ isChoosingProducts, setIsChoosingProducts ] = useState( false );
+
 	async function chooseProductsForMe() {
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',
@@ -133,9 +136,11 @@ export function LinkedProductListBlockEdit( {
 			},
 		} );
 
-		const relatedProducts = ( await getRelatedProducts( productId, {
-			fallbackToRandomProducts: true,
-		} ) ) as Product[];
+		const relatedProducts = ( await getRelatedProducts(
+			productId
+		) ) as Product[];
+
+		setIsChoosingProducts( true );
 
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',
@@ -143,6 +148,8 @@ export function LinkedProductListBlockEdit( {
 				isLoading: false,
 			},
 		} );
+
+		setIsChoosingProducts( false );
 
 		if ( ! relatedProducts ) {
 			return;
@@ -163,6 +170,7 @@ export function LinkedProductListBlockEdit( {
 					variant="tertiary"
 					icon={ reusableBlock }
 					onClick={ chooseProductsForMe }
+					isBusy={ isChoosingProducts }
 				>
 					{ __( 'Choose products for me', 'woocommerce' ) }
 				</Button>

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -136,11 +136,11 @@ export function LinkedProductListBlockEdit( {
 			},
 		} );
 
+		setIsChoosingProducts( true );
+
 		const relatedProducts = ( await getRelatedProducts( productId, {
 			fallbackToRandomProducts: true,
 		} ) ) as Product[];
-
-		setIsChoosingProducts( true );
 
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -171,6 +171,7 @@ export function LinkedProductListBlockEdit( {
 					icon={ reusableBlock }
 					onClick={ chooseProductsForMe }
 					isBusy={ isChoosingProducts }
+					disabled={ isChoosingProducts }
 				>
 					{ __( 'Choose products for me', 'woocommerce' ) }
 				</Button>

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -127,7 +127,6 @@ export function LinkedProductListBlockEdit( {
 	}
 
 	const [ isChoosingProducts, setIsChoosingProducts ] = useState( false );
-
 	async function chooseProductsForMe() {
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',
@@ -171,6 +170,7 @@ export function LinkedProductListBlockEdit( {
 					icon={ reusableBlock }
 					onClick={ chooseProductsForMe }
 					isBusy={ isChoosingProducts }
+					disabled={ isChoosingProducts }
 				>
 					{ __( 'Choose products for me', 'woocommerce' ) }
 				</Button>

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -127,6 +127,7 @@ export function LinkedProductListBlockEdit( {
 	}
 
 	const [ isChoosingProducts, setIsChoosingProducts ] = useState( false );
+
 	async function chooseProductsForMe() {
 		dispatch( {
 			type: 'LOADING_LINKED_PRODUCTS',
@@ -135,9 +136,9 @@ export function LinkedProductListBlockEdit( {
 			},
 		} );
 
-		const relatedProducts = ( await getRelatedProducts(
-			productId
-		) ) as Product[];
+		const relatedProducts = ( await getRelatedProducts( productId, {
+			fallbackToRandomProducts: true,
+		} ) ) as Product[];
 
 		setIsChoosingProducts( true );
 
@@ -170,7 +171,6 @@ export function LinkedProductListBlockEdit( {
 					icon={ reusableBlock }
 					onClick={ chooseProductsForMe }
 					isBusy={ isChoosingProducts }
-					disabled={ isChoosingProducts }
 				>
 					{ __( 'Choose products for me', 'woocommerce' ) }
 				</Button>

--- a/packages/js/product-editor/src/blocks/generic/section/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/section/editor.scss
@@ -64,10 +64,22 @@
 		max-width: 300px;
 	}
 
+	// <ActionSections /> slot.
 	&__actions {
 		display: flex;
 		justify-content: flex-end;
 		gap: $grid-unit;
+
+		/*
+		 * Core removes the "loading" animation styles
+		 * from the button when it's disabled, so we
+		 * let's add them back.
+		 */ 
+		.components-button.is-tertiary.is-busy:disabled {
+			background-image: linear-gradient( -45deg, #fafafa 33%, #e0e0e0 0, #e0e0e0 70%, #fafafa 0 );
+			background-size: 100px 100%;
+			opacity: 1;
+		}
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR sets a `loading` state to the `Choose products for me` button.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

2. Enable the new Product Block editor
3. Create/edit a new Product
4. Go to the Linked Products section
5. Click on the `Choose products for me` button
6. Confirm you see the loading state
7. Confirm the button is disabled

You'd like to throttle the request using the network tab.

The video below shows the whole testing workflow:

https://github.com/woocommerce/woocommerce/assets/77539/5eb6d501-3ff5-494a-a14c-d5a2b593e960


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
