### PR TITLE
[Product Block Editor]: exclude the current product from the suggested ones to use in the Linked Product tab

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-remove-current-from-products-list
+++ b/packages/js/product-editor/changelog/update-product-editor-remove-current-from-products-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: exclude the current product from the suggested ones to use in the Linked Product tab

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -98,7 +98,12 @@ export function LinkedProductListBlockEdit( {
 
 	const filter = useCallback(
 		( search = '' ) => {
-			return searchProductsDispatcher( linkedProductIds ?? [], search );
+			// Exclude the current product and any already linked products.
+			const exclude = [ productId ];
+			if ( linkedProductIds ) {
+				exclude.push( ...linkedProductIds );
+			}
+			return searchProductsDispatcher( exclude, search );
 		},
 		[ linkedProductIds ]
 	);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


This PR removes the current product from the suggested list when setting linked products.

Closes https://github.com/woocommerce/woocommerce/issues/43536

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

2. Enable the new Product Block editor
3. Ensure you have a few products with a categoria/tag (`music`)
4. Create/edit a new Product (`bass`)
5. Set the same category/tag that the other products (`music`)
6. Add/save the product (*)
7. Go to the linked products tab
8. Filter the products by the product name `bass`


Before | After
-------|-----
<img width="687" alt="Screenshot 2024-01-15 at 14 47 34" src="https://github.com/woocommerce/woocommerce/assets/77539/936593a0-0188-4ffc-812f-d1f3e4e0f6a0"> | <img width="703" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/614e38b0-6840-4b81-8a85-82aaf81897a5">

The video below shows the desired behavior:

https://github.com/woocommerce/woocommerce/assets/77539/7dddb2f9-442c-4b18-94b8-5531ea170c7b

_**(*)** Disclaimer: Add/save the post shouldn't;te be needed. We're going to tackle this issue in a follow up._

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
