### PR TITLE
[Experimental][Refactor] Reduce complexity of custom field registration function

### DIFF
--- a/plugins/woocommerce/changelog/43663-update-reduce-custom-field-registration
+++ b/plugins/woocommerce/changelog/43663-update-reduce-custom-field-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Skipping changelog as this is behind a feature flag and will not be available.
+

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -316,16 +316,15 @@ class CheckoutFields {
 		);
 
 		$field_data['attributes'] = $this->register_field_attributes( $id, $options['attributes'] ?? [] );
-		/**
-		 * Handle Checkbox fields.
-		 */
+
 		if ( 'checkbox' === $type ) {
-			// Checkbox fields are always optional. Log a warning if it's set explicitly as true.
-			$field_data['required'] = false;
-			if ( isset( $options['required'] ) && true === $options['required'] ) {
-				$message = sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id );
-				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			$result = $this->process_checkbox_field( $options, $field_data );
+
+			// $result will be false if an error that will prevent the field being registered is encountered.
+			if ( false === $result ) {
+				return;
 			}
+			$field_data = $result;
 		}
 
 		if ( 'select' === $type ) {
@@ -396,6 +395,28 @@ class CheckoutFields {
 		}
 
 		$field_data['options'] = $cleaned_options;
+		return $field_data;
+	}
+
+	/**
+	 * Processes the options for a checkbox field and returns the new field_options array.
+	 *
+	 * @param array $options     The options supplied during field registration.
+	 * @param array $field_data  The field data array to be updated.
+	 *
+	 * @return array|false The updated $field_data array or false if an error was encountered.
+	 */
+	private function process_checkbox_field( $options, $field_data ) {
+		$id = $options['id'];
+
+		// Checkbox fields are always optional. Log a warning if it's set explicitly as true.
+		$field_data['required'] = false;
+
+		if ( isset( $options['required'] ) && true === $options['required'] ) {
+			$message = sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+		}
+
 		return $field_data;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Create new functions to handle processing custom field registration.
The reason for this change is the existing `register_checkout_field` was getting rather long. Splitting it down into smaller functions makes more sense and each part is easier to reason with.

Specifically what was added is:

- `validate_options`
- `process_checkbox_field`
- `process_select_field`

`validate_options` handles checking the "base" options supplied during field registration to catch any errors, such as missing ID, unsupported type.

The `process_{type}_field` functions process settings specific to that field type. While the checkbox check is only a few lines long it made sense to move it to its own function so as to establish a pattern for future supported field types.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

<details>
<summary>Example snippet</summary>

```php
add_action(
	'woocommerce_blocks_loaded',
	function() {

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-on-porch',
				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
				'location' => 'address',
				'type'     => 'checkbox',
			),
		);

		woocommerce_blocks_register_checkout_field(
			array(
				'id'            => 'namespace/gov-id',
				'label'         => 'Government ID',
				'optionalLabel' => 'Government ID (optional)',
				'location'      => 'additional',
				'required'      => true,
				'attributes'    => array(
					'autocomplete'     => 'government-id',
					'aria-describedby' => 'some-element',
					'aria-label'       => 'custom label',
					'pattern'          => '[a-z0-9]{5}',
					'title'            => 'Title of textbox',
					'data-custom'      => 'custom data',
				),
			),
		);

		add_filter('woocommerce_blocks_validate_additional_field_namespace/gov-id', function ( \WP_Error $error, $value, $schema, $key ) {
			if ('12345' !== $value) {
				$error->add( 'invalid_gov_id', 'Sorry but only people with government ID: 12345 can order.' );
			}
			return $error;
		}, 10, 4);

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'namespace/type-of-contact',
				'label'    => 'Type of contact',
				'location' => 'contact',
				'type'     => 'select',
				'options'  => array(
					array(
						'label' => 'Company',
						'value' => 'company',
					),
					array(
						'label' => 'Individual',
						'value' => 'individual',
					),
				),
				'attributes' => array(
					'aria-label' => 'my fancy label',
					'data-custom' => 'custom data',
				),
			)
		);

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'namespace/marketing-opt-in',
				'label'    => 'Do you want to subscribe to our newsletter?',
				'location' => 'contact',
				'type'     => 'checkbox',
			)
		);
	}
);
```

</details>

1. Add the snippet above to your site. It registers three fields, they are all valid.
2. Load the checkout block and check they render as expected.
3. Place the order and verify the info comes through on the order confirmation/emails. (After https://github.com/woocommerce/woocommerce/pull/43449 is merged)
4. Edit the `'plugin-namespace/leave-on-porch' and add `'required' => true` to the options.
5. Reload the checkout page ensure you see a warning, but check the field is still registered.
6. Change the `type` to `foo`. Load the checkout page and ensure the field is not registered. Ensure a warning is shown.
7. Reset `type` to `checkbox`.
8. Set the `location` to `foo`. Load the checkout page and ensure the field is not registered. Ensure a warning is shown.
9. Remove the `id`. Load the checkout page and ensure the field is not registered. Ensure a warning is shown.
10. Reset the `id`.
11. Update `'namespace/type-of-contact'`. Duplicate one of the options.
12. Load the checkout page and ensure the field is registered without duplicate options. Ensure a warning is shown.
13. Change `options` to a non-array type.  Load the checkout page and ensure the field is not registered. Ensure a warning is shown.
14. Change the `options` to an empty array.  Load the checkout page and ensure the field is not registered. Ensure a warning is shown.
15. Remove `label`.  Load the checkout page and ensure the field is not registered. Ensure a warning is shown. Replace `label`.
16. Change the id so that it no longer has a namespace, e.g. it will become `'id' => 'namespace-type-of-contact'`.  Load the checkout page and ensure the field is not registered. Ensure a warning is shown. Reset the `id`.
17. Duplicate one of the field registrations. Ensure that a warning is shown but only one field is registered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Skipping changelog as this is behind a feature flag and will not be available.
</details>
