### PR TITLE
[Enhancement] Add a featured product button

### DIFF
--- a/packages/js/product-editor/changelog/add-39679
+++ b/packages/js/product-editor/changelog/add-39679
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a featured product button

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -1,18 +1,18 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { useInstanceId } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	createElement,
 	Fragment,
 	useEffect,
 	useState,
 } from '@wordpress/element';
-
-import { useInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { starEmpty } from '@wordpress/icons';
 import { cleanForSlug } from '@wordpress/url';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	PRODUCTS_STORE_NAME,
 	WCDataSelector,
@@ -33,13 +33,13 @@ import { useEntityProp, useEntityId } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { AUTO_DRAFT_NAME } from '../../../utils';
 import { EditProductLinkModal } from '../../../components/edit-product-link-modal';
+import { Label } from '../../../components/label/label';
 import { useValidation } from '../../../contexts/validation-context';
-import { NameBlockAttributes } from './types';
 import { useProductEdits } from '../../../hooks/use-product-edits';
 import { ProductEditorBlockEditProps } from '../../../types';
-import { Label } from '../../../components/label/label';
+import { AUTO_DRAFT_NAME } from '../../../utils';
+import { NameBlockAttributes } from './types';
 
 export function Edit( {
 	attributes,
@@ -156,6 +156,10 @@ export function Edit( {
 		}
 	}, [] );
 
+	function renderFeaturedSuffix() {
+		return <Button icon={ starEmpty } />;
+	}
+
 	return (
 		<>
 			<div { ...blockProps }>
@@ -189,6 +193,7 @@ export function Edit( {
 								validateName();
 							}
 						} }
+						suffix={ renderFeaturedSuffix() }
 					/>
 				</BaseControl>
 

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -166,21 +166,22 @@ export function Edit( {
 	}
 
 	function renderFeaturedSuffix() {
+		const markedText = __( 'Mark as featured', 'woocommerce' );
+		const unmarkedText = __( 'Unmark as featured', 'woocommerce' );
+		const tooltipText = featured ? unmarkedText : markedText;
+
 		return (
-			<Tooltip
-				text={ __( 'Mark as featured', 'woocommerce' ) }
-				position="top center"
-			>
+			<Tooltip text={ tooltipText } position="top center">
 				{ featured ? (
 					<Button
 						icon={ starFilled }
-						aria-label={ __( 'Unmark as featured', 'woocommerce' ) }
+						aria-label={ unmarkedText }
 						onClick={ handleSuffixClick }
 					/>
 				) : (
 					<Button
 						icon={ starEmpty }
-						aria-label={ __( 'Mark as featured', 'woocommerce' ) }
+						aria-label={ markedText }
 						onClick={ handleSuffixClick }
 					/>
 				) }

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
@@ -18,10 +17,12 @@ import {
 	WCDataSelector,
 	Product,
 } from '@woocommerce/data';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import classNames from 'classnames';
 import {
 	Button,
 	BaseControl,
+	Tooltip,
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
@@ -164,7 +165,14 @@ export function Edit( {
 	}
 
 	function renderFeaturedSuffix() {
-		return <Button icon={ starEmpty } onClick={ handleSuffixClick } />;
+		return (
+			<Tooltip
+				text={ __( 'Mark as featured', 'woocommerce' ) }
+				position="top center"
+			>
+				<Button icon={ starEmpty } onClick={ handleSuffixClick } />
+			</Tooltip>
+		);
 	}
 
 	return (

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -10,7 +10,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { starEmpty } from '@wordpress/icons';
+import { starEmpty, starFilled } from '@wordpress/icons';
 import { cleanForSlug } from '@wordpress/url';
 import {
 	PRODUCTS_STORE_NAME,
@@ -158,10 +158,11 @@ export function Edit( {
 		}
 	}, [] );
 
-	const [ _, setFeatured ] = useProductEntityProp< boolean >( 'featured' );
+	const [ featured, setFeatured ] =
+		useProductEntityProp< boolean >( 'featured' );
 
 	function handleSuffixClick() {
-		setFeatured( true );
+		setFeatured( ! featured );
 	}
 
 	function renderFeaturedSuffix() {
@@ -170,7 +171,19 @@ export function Edit( {
 				text={ __( 'Mark as featured', 'woocommerce' ) }
 				position="top center"
 			>
-				<Button icon={ starEmpty } onClick={ handleSuffixClick } />
+				{ featured ? (
+					<Button
+						icon={ starFilled }
+						aria-label={ __( 'Unmark as featured', 'woocommerce' ) }
+						onClick={ handleSuffixClick }
+					/>
+				) : (
+					<Button
+						icon={ starEmpty }
+						aria-label={ __( 'Mark as featured', 'woocommerce' ) }
+						onClick={ handleSuffixClick }
+					/>
+				) }
 			</Tooltip>
 		);
 	}

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -37,6 +37,7 @@ import { EditProductLinkModal } from '../../../components/edit-product-link-moda
 import { Label } from '../../../components/label/label';
 import { useValidation } from '../../../contexts/validation-context';
 import { useProductEdits } from '../../../hooks/use-product-edits';
+import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { AUTO_DRAFT_NAME } from '../../../utils';
 import { NameBlockAttributes } from './types';
@@ -156,8 +157,14 @@ export function Edit( {
 		}
 	}, [] );
 
+	const [ _, setFeatured ] = useProductEntityProp< boolean >( 'featured' );
+
+	function handleSuffixClick() {
+		setFeatured( true );
+	}
+
 	function renderFeaturedSuffix() {
-		return <Button icon={ starEmpty } />;
+		return <Button icon={ starEmpty } onClick={ handleSuffixClick } />;
 	}
 
 	return (

--- a/packages/js/product-editor/src/blocks/product-fields/name/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/name/editor.scss
@@ -1,5 +1,4 @@
 .product-details-section {
-
 	&__product-link {
 		color: #757575;
 		font-size: 12px;
@@ -29,5 +28,9 @@
 		.components-base-control__help {
 			color: $studio-red-50;
 		}
+	}
+
+	.components-input-control__suffix {
+		margin-right: 0;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39679

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products` -> `Add new` from the left side menu.
3. As part of the `Name` field a new star icon button should be shown on the right side.
4. Clicking it marks the product as featured.
5. When hovered, we show a tooltip that reads: `Mark as featured` 
<img width="725" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/e0563989-ebce-41a5-8c3e-fa6658dbae3f">

6. When clicked, the icon changes from an outlined star to a filled star. Clicking it again reverts to the original icon.
7. Saving the product should persist it as `featured` product if the star icon is filled.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
