### PR TITLE
[Product Block Editor]: show three products by default in the Linked Products tab

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-default-products-number-in-linked-products-page
+++ b/packages/js/product-editor/changelog/update-product-editor-default-products-number-in-linked-products-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+[Product Block Editor]: show three products by default in the Linked Products tab

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -10,7 +10,7 @@ type getRelatedProductsOptions = {
 };
 
 const POSTS_NUMBER_TO_RANDOMIZE = 30;
-const POSTS_NUMBER_TO_PICK = 5;
+const POSTS_NUMBER_TO_PICK = 3;
 
 /**
  * Return related products for a given product ID.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #https://github.com/woocommerce/woocommerce/issues/43697

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Linked Product flag
  - Enable the WCA plugin
  - Click on `Tools` -> `WCA Test Helper`
  - Click on `Features` tab
  - Toggle on the `product-linked` feature 

<img width="456" alt="Screenshot 2023-12-26 at 11 36 05" src="https://github.com/woocommerce/woocommerce/assets/77539/a065ce77-fdbc-45bd-99dc-0c00e5cad328">

2. Enable the new Product Block editor
3. Ensure your site has products that have defined categories
4. Create a new Product
5. Go to the Linked Products tab
6. Ensure the product doesn't have defined related_ids:

```es6
wp.data.select( 'core' ).getEntityRecord( 'postType', 'product', [ <product-id> ] )?.related_ids
```

8. Click on the `Choose products for me` button of the Upsells or Cross-sells sections 
9. Confirm now it shows three random products

Before (trunk) | After (This branch)
------|------
<img width="670" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/210e5809-f261-4988-acb2-bb11c932684e"> | <img width="681" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/d0d38b24-1dcc-4bb6-a2af-6ff2a6a61206">


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
