### PR TITLE
Add filter to block product grid add to cart button to allow extra HTML attributes

### DIFF
--- a/plugins/woocommerce/changelog/43699-add-filter-to-block-product-grid-add-to-cart
+++ b/plugins/woocommerce/changelog/43699-add-filter-to-block-product-grid-add-to-cart
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Added new woocommerce_blocks_product_grid_add_to_cart_attributes filter to block product grid to allow the add to cart buttons to have extra HTML attributes

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -666,6 +666,18 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			$attributes['class'] .= ' ajax_add_to_cart';
 		}
 
+		/**
+		 * Filter to add additional attributes to the HTML code of the generated add to cart button.
+		 * 
+		 * @since 8.6.0
+		 * 
+		 * @param array      $attributes An associative array containing default HTML attributes of the add to cart button.
+   		 * @param WC_Product $product    The WC_Product instance of the product that will be added to the cart once the button is pressed.
+		 *
+		 * @return array Returns an associative array derived from the default array passed as an argument and added the extra HTML attributes.
+		 */
+		$attributes = apply_filters( 'woocommerce_blocks_product_grid_add_to_cart_attributes', $attributes, $product );
+
 		return sprintf(
 			'<a href="%s" %s>%s</a>',
 			esc_url( $product->add_to_cart_url() ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -668,9 +668,9 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 
 		/**
 		 * Filter to add additional attributes to the HTML code of the generated add to cart button.
-		 * 
+		 *
 		 * @since 8.6.0
-		 * 
+		 *
 		 * @param array      $attributes An associative array containing default HTML attributes of the add to cart button.
    		 * @param WC_Product $product    The WC_Product instance of the product that will be added to the cart once the button is pressed.
 		 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -672,7 +672,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		 * @since 8.6.0
 		 *
 		 * @param array      $attributes An associative array containing default HTML attributes of the add to cart button.
-   		 * @param WC_Product $product    The WC_Product instance of the product that will be added to the cart once the button is pressed.
+		 * @param WC_Product $product    The WC_Product instance of the product that will be added to the cart once the button is pressed.
 		 *
 		 * @return array Returns an associative array derived from the default array passed as an argument and added the extra HTML attributes.
 		 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -667,7 +667,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		}
 
 		/**
-		 * Filter to add additional attributes to the HTML code of the generated add to cart button.
+		 * Filter to manipulate (add/modify/remove) attributes in the HTML code of the generated add to cart button.
 		 *
 		 * @since 8.6.0
 		 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/43699

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a test plugin  at `wp-content/plugins/test/test.php`
2. Include the following code:

```
<?php
/**
 * Plugin name: WooCommerce block product grid Add To Cart button extra HTML attribute test
 * Description: Used to test https://github.com/woocommerce/woocommerce/issues/43699
 * WC Tested up to: 8.6.0
*/

function test_blocks_product_grid_add_to_cart_attributes( $cart_button_attributes, $product ) {
  $cart_button_attributes['data-testdata'] = 'test_success';
  return $cart_button_attributes;
}
add_filter( 'woocommerce_blocks_product_grid_add_to_cart_attributes', 'test_blocks_product_grid_add_to_cart_attributes', 10, 2 );

```
4. Make sure only the test plugin above and WooCommerce are active
5. Make sure there are products in the inventory
6. Create a page using Gutenberg editor and add a product grid block (like Newest Products for example)
7. Publish and visit this page
8. In the source code, the add to cart buttons HTML code should also include a new HTML attribute with the name `data-testdata` and the value `test_success`.

<!-- End testing instructions -->

### Changelog entry

-   [X] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [X] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Added new woocommerce_blocks_product_grid_add_to_cart_attributes filter to block product grid to allow the add to cart buttons to have extra HTML attributes

</details>
