### PR TITLE
[Product Editor] Fix blank editor when clicking Add New while already in editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-blank-form-on-add-new
+++ b/packages/js/product-editor/changelog/fix-product-editor-blank-form-on-add-new
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: No changelog because this fixes a regression that was introduced in the same release.
+
+

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -158,7 +158,16 @@ export function BlockEditor( {
 			...settings,
 			productTemplate,
 		} as Partial< ProductEditorSettings > );
-	}, [ settings, postType, productTemplate, productType, layoutTemplate ] );
+
+		// We don't need to include onChange or updateEditorSettings in the dependencies,
+		// since we get new instances of them on every render, which would cause an infinite loop.
+		//
+		// We include productId in the dependencies to make sure that the effect is run when the
+		// product is changed, since we need to synchronize the blocks with the template and update
+		// the blocks by calling onChange.
+		//
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ layoutTemplate, settings, productTemplate, productId ] );
 
 	// Check if the Modal editor is open from the store.
 	const isModalEditorOpen = useSelect( ( select ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the scenario where clicking on the **Products** > **Add New** item in the admin sidebar, when in the new product editor viewing a saved product, would result in a blank editor.

https://github.com/woocommerce/woocommerce/assets/2098816/50d70901-0a0d-468b-8da1-1044e8e5ca7a

To reproduce:

1. Create/edit a product
2. Save
3. Click on the Add New item of the Products menu
4. Confirm the app doesn’t load the template
5. Confirm the app does load the template after a hard-refresh

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Save draft
3. Click on **Products** > **Add New**
4. Verify the form loads and is not blank

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
