### PR TITLE
Properly Configured Wireit Production Builds

### DIFF
--- a/packages/js/admin-layout/changelog/43716-fix-production-builds
+++ b/packages/js/admin-layout/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/admin-layout/package.json
+++ b/packages/js/admin-layout/package.json
@@ -95,6 +95,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"

--- a/packages/js/ai/changelog/43716-fix-production-builds
+++ b/packages/js/ai/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/ai/package.json
+++ b/packages/js/ai/package.json
@@ -125,6 +125,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"

--- a/packages/js/block-templates/changelog/43716-fix-production-builds
+++ b/packages/js/block-templates/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -121,6 +121,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"

--- a/packages/js/components/changelog/43716-fix-production-builds
+++ b/packages/js/components/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -206,6 +206,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"babel.config.js",

--- a/packages/js/customer-effort-score/changelog/43716-fix-production-builds
+++ b/packages/js/customer-effort-score/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -130,6 +130,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"

--- a/packages/js/experimental/changelog/43716-fix-production-builds
+++ b/packages/js/experimental/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -140,6 +140,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"

--- a/packages/js/onboarding/changelog/43716-fix-production-builds
+++ b/packages/js/onboarding/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -126,6 +126,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"

--- a/packages/js/product-editor/changelog/43716-fix-production-builds
+++ b/packages/js/product-editor/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -180,6 +180,12 @@
 		"build:project:bundle": {
 			"command": "webpack",
 			"clean": "if-file-deleted",
+			"env": {
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				}
+			},
 			"files": [
 				"webpack.config.js",
 				"src/**/*.scss"

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -264,8 +264,14 @@
 			"command": "webpack",
 			"clean": "if-file-deleted",
 			"env": {
-				"NODE_ENV": "production",
-				"WC_ADMIN_PHASE": "core"
+				"NODE_ENV": {
+					"external": true,
+					"default": "production"
+				},
+				"WC_ADMIN_PHASE": {
+					"external": true,
+					"default": "core"
+				}
 			},
 			"files": [
 				"webpack.config.js",

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -383,10 +383,12 @@
 			"clean": "if-file-deleted",
 			"env": {
 				"NODE_ENV": {
-					"external": true
+					"external": true,
+					"default": "production"
 				},
 				"BABEL_ENV": {
-					"external": true
+					"external": true,
+					"default": "default"
 				},
 				"WOOCOMMERCE_BLOCKS_PHASE": {
 					"external": true

--- a/plugins/woocommerce/changelog/43716-fix-production-builds
+++ b/plugins/woocommerce/changelog/43716-fix-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected build configuration for packages that weren't outputting minified code.


### PR DESCRIPTION
After updating to `0.14.3` it became possible to set default values for external environment vars. We should be setting all defaults to "production" in order to
make sure the builds are minimal in size.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

At the time that I added `wireit` it was only possible to set an environment variable to _either_ "external" (set by an outside script) or to a specific value limited to the execution of that script. Now that we've updated to `0.14.3` it is now possible to do both. This pull request updates the configuration of all Webpack builds so that they're correctly using it as well as setting the default to "production" appropriately.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Passing CI will be ran in production mode for all affected packages.
2. Check the output of different builds and verify that they look as expected to.
3. Make sure that things like code navigation still work fine with the now-production builds.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Corrected build configuration for packages that weren't outputting minified code.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
