### PR TITLE
HPOS: Remove buggy check in the data cleanup tool.

### DIFF
--- a/plugins/woocommerce/changelog/fix-42848
+++ b/plugins/woocommerce/changelog/fix-42848
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+HPOS: Remove buggy check in the data cleanup tool.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -173,13 +173,11 @@ class LegacyDataHandler {
 	/**
 	 * Checks whether an HPOS-backed order is newer than the corresponding post.
 	 *
-	 * @param int|\WC_Order $order An HPOS order.
+	 * @param \WC_Abstract_Order $order An HPOS order.
 	 * @return bool TRUE if the order is up to date with the corresponding post.
 	 * @throws \Exception When the order is not an HPOS order.
 	 */
-	private function is_order_newer_than_post( $order ): bool {
-		$order = is_a( $order, 'WC_Order' ) ? $order : wc_get_order( absint( $order ) );
-
+	private function is_order_newer_than_post( \WC_Abstract_Order $order ): bool {
 		if ( ! is_a( $order->get_data_store()->get_current_class_name(), OrdersTableDataStore::class, true ) ) {
 			throw new \Exception( __( 'Order is not an HPOS order.', 'woocommerce' ) );
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
@@ -81,6 +81,8 @@ class LegacyDataHandlerTests extends WC_Unit_Test_Case {
 
 		// Cleanup the refund order.
 		$this->sut->cleanup_post_data( $refund_order->get_id() );
+		$this->assertEquals( 1, $this->sut->count_orders_for_cleanup() );
+		$this->assertEquals( 2, wc_get_container()->get( DataSynchronizer::class )->get_current_orders_pending_sync_count() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
@@ -42,7 +42,7 @@ class LegacyDataHandlerTests extends WC_Unit_Test_Case {
 	 */
 	public function test_post_data_cleanup() {
 		$this->enable_cot_sync();
-		$orders = array(
+		$orders       = array(
 			OrderHelper::create_order(),
 			OrderHelper::create_order(),
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the `is_order_newer_than_post` method in `LegacyDataHandler` class, we were verifying the order type against the WC_Order object. This is buggy because orders can also be of types Refund, Subscriptions, etc. This PR relaxes this check to WC_Abstract_Order to allow order subtypes.

Follow up from #42848 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With HPOS authoritative and sync enabled, create an order, and add a refund to that order.
2. Disable the order sync.
3. Run the cleanup command: `wp wc hpos cleanup all`. Check that there should not be any errors.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
