### PR TITLE
41827-improve-coupon-usage-by-user-query-performance

### DIFF
--- a/plugins/woocommerce/changelog/pr-43731
+++ b/plugins/woocommerce/changelog/pr-43731
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Fix wpdb- argument type for coupons query

--- a/plugins/woocommerce/changelog/pr-43731
+++ b/plugins/woocommerce/changelog/pr-43731
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Fix wpdb- argument type for coupons query
+Fix wpdb->prepare argument type for coupons query

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -441,7 +441,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		global $wpdb;
 		$usage_count = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value = %d;",
+				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value = %s;",
 				$coupon->get_id(),
 				$user_id
 			)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The sql query can be slow on big data sets, because the post meta value is type of string, and we are quering with a number.

Closes #41827.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Via **WooCommerce ▸ Marketing ▸ Coupons**, create a new coupon.
2. As in the following screenshot, you should set a usage limit per user (here, I am setting the limit to `2`):

<img width="1275" alt="'Usage limit per user' setting in the coupon editor" src="https://github.com/woocommerce/woocommerce/assets/3594411/5dcaf157-9a28-4c43-b85b-6f5eb7da68ee">

3. Head over to the storefront, add items to the cart and apply the coupon. This should work as expected. Go ahead and checkout *(coupon has now been used once by this user).*
4. Repeat! *(Coupon has now been used twice by this user.)*
5. Repeat! This time, assuming the usage limit per user was set to two, the limit has been reached. You should see an error message as follows:

<img width="999" alt="'Coupon usage limit reached' warning/error in the cart" src="https://github.com/woocommerce/woocommerce/assets/3594411/368c9e88-13d7-4592-83a0-bbd5151231d2">

The above steps should give us confidence that nothing functional has broken (because the cart/checkout flow will trigger execution of the modified code, so long as the coupon has a user usage limit). 

The following are the original testing instructions (useful for developer-based testing and to see the actual change in performance characteristics):

1. Run the default query, without the data type change on a big data set.
7. Run the query with the updated data type change on the same data set.
8. Observe the better performance.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
