### PR TITLE
Fix activity panel showing incorrect currency

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/index.js
@@ -19,7 +19,7 @@ import { getNewPath } from '@woocommerce/navigation';
 import { getAdminLink } from '@woocommerce/settings';
 import { ORDERS_STORE_NAME, ITEMS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { CurrencyContext } from '@woocommerce/currency';
+import { CurrencyContext, CurrencyFactory } from '@woocommerce/currency';
 
 /**
  * Internal dependencies
@@ -259,7 +259,11 @@ function OrdersPanel( { unreadOrdersCount, orderStatuses } ) {
 		}
 
 		// If the order currency is different from the store currency, we show the currency code and amount in the order currency.
-		return `${ decodeEntities( symbol ) }${ total }`;
+		return CurrencyFactory( {
+			...storeCurrency,
+			symbol: decodeEntities( symbol ),
+			code: orderCurrencyCode,
+		} ).formatAmount( total );
 	};
 
 	const {

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/index.js
@@ -4,6 +4,7 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useMemo, useContext } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 import PropTypes from 'prop-types';
 import interpolateComponents from '@automattic/interpolate-components';
 import {
@@ -28,7 +29,6 @@ import {
 	ActivityCardPlaceholder,
 } from '~/activity-panel/activity-card';
 import { getAdminSetting } from '~/utils/admin-settings';
-import { getCountryCode } from '~/dashboard/utils';
 import './style.scss';
 
 function recordOrderEvent( eventName ) {
@@ -240,23 +240,26 @@ function OrdersPanel( { unreadOrdersCount, orderStatuses } ) {
 
 	const currencyContext = useContext( CurrencyContext );
 
-	const getFormattedOrderTotal = ( total, countryState ) => {
-		if ( ! countryState ) {
+	const storeCurrency = currencyContext.getCurrencyConfig();
+	const { currencySymbols = {} } = getAdminSetting( 'onboarding', {} );
+	const getFormattedOrderTotal = ( total, orderCurrencyCode ) => {
+		if ( ! orderCurrencyCode ) {
 			return null;
 		}
 
-		const country = getCountryCode( countryState );
-		const { currencySymbols = {}, localeInfo = {} } = getAdminSetting(
-			'onboarding',
-			{}
-		);
-		const currency = currencyContext.getDataForCountry(
-			country,
-			localeInfo,
-			currencySymbols
-		);
-		currencyContext.setCurrency( currency );
-		return currencyContext.formatAmount( total );
+		// If the order currency is the same as the store currency, we show the formatted amount.
+		if ( storeCurrency && storeCurrency.code === orderCurrencyCode ) {
+			return currencyContext.formatAmount( total );
+		}
+		const symbol = currencySymbols[ orderCurrencyCode ];
+
+		if ( ! symbol ) {
+			// This should never happen, but if it does, we'll just show the currency code.
+			return `${ orderCurrencyCode }${ total }`;
+		}
+
+		// If the order currency is different from the store currency, we show the currency code and amount in the order currency.
+		return `${ decodeEntities( symbol ) }${ total }`;
 	};
 
 	const {

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
@@ -108,7 +108,7 @@ describe( 'OrdersPanel', () => {
 		const { getByText } = render(
 			<OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } />
 		);
-		expect( getByText( '€123' ) ).toBeInTheDocument();
+		expect( getByText( '€123.00' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should show order total correctly with a currency not in currencySymbols', () => {

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
@@ -22,6 +22,21 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
+jest.mock( '~/utils/admin-settings', () => ( {
+	...jest.requireActual( '~/utils/admin-settings' ),
+	getAdminSetting: jest.fn().mockReturnValue( {
+		currencySymbols: {
+			EUR: '&euro;',
+			USD: '&#36;',
+		},
+	} ),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	getAdminLink: jest.fn().mockReturnValue( '' ),
+} ) );
+
 describe( 'OrdersPanel', () => {
 	it( 'should render an empty order card', () => {
 		useSelect.mockReturnValue( {
@@ -34,6 +49,7 @@ describe( 'OrdersPanel', () => {
 			screen.queryByText( 'You’ve fulfilled all your orders' )
 		).toBeInTheDocument();
 	} );
+
 	it( 'should record activity_panel_orders_orders_begin_fulfillment Tracks event when order is clicked', () => {
 		useSelect.mockReturnValue( {
 			orders: [
@@ -54,5 +70,64 @@ describe( 'OrdersPanel', () => {
 			'activity_panel_orders_orders_begin_fulfillment',
 			{}
 		);
+	} );
+
+	it( 'should format order total correctly with the same currency as store currency', () => {
+		useSelect.mockReturnValue( {
+			orders: [
+				{
+					total: 123,
+					id: 1,
+					number: 1,
+					currency: 'USD',
+				},
+			],
+			isError: false,
+			isRequesting: false,
+		} );
+		const { getByText } = render(
+			<OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } />
+		);
+		expect( getByText( '$123.00' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show order total correctly with a different currency from store currency', () => {
+		useSelect.mockReturnValue( {
+			orders: [
+				{
+					total: 123,
+					id: 1,
+					number: 1,
+					currency: 'EUR',
+				},
+			],
+			isError: false,
+			isRequesting: false,
+		} );
+
+		const { getByText } = render(
+			<OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } />
+		);
+		expect( getByText( '€123' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show order total correctly with a currency not in currencySymbols', () => {
+		useSelect.mockReturnValue( {
+			orders: [
+				{
+					total: 123,
+					id: 1,
+					number: 1,
+					currency: 'BTC',
+				},
+			],
+			isError: false,
+			isRequesting: false,
+		} );
+
+		const { getByText } = render(
+			<OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } />
+		);
+		expect( getByText( 'BTC123' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce/changelog/43733-fix-activity-panel-currency
+++ b/plugins/woocommerce/changelog/43733-fix-activity-panel-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix activity panel showing incorrect currency


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41840.

> Currently, the activity panel always shows the dollar currency ($) regardless of the order currency. it is just a formatting issue as the amounts are correct.

This PR fixes the `getFormattedOrderTotal` logic and adds unit tests for it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Install `wc-smooth-generator` plugin
3. Skip core profiler
4. Go to WooCommerce > Settings 
5. Change store currency to `EUR`
6. Run `wp wc generate orders 3 --status=processing`
7. Go to WooCommerce > Home
8. Hide the setup onboarding task list
9. Observe that the activity panel is shown
10. Click on "Orders" tab of the activity panel
11. Confirm it shows the correct currency (`€`)
12. Go to WooCommerce > Settings 
13. Change store currency to any other currency such as `New Taiwan dollar (NT$)`
14. Run `wp wc generate orders 3 --status=processing`
15. Go to WooCommerce > Home
16. Click on "Orders" tab of the activity panel
17. Observing that old orders still display the total price in `€`, but the new order price is displayed in the new currency.

![Screenshot 2024-01-17 at 17 55 20](https://github.com/woocommerce/woocommerce/assets/4344253/1e6a15d7-ba07-4a0e-b0d2-5e4a4d23eff8)



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix activity panel showing incorrect currency

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
