### PR TITLE
More defensive coding when using `$product->get_attributes()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-43722
+++ b/plugins/woocommerce/changelog/fix-43722
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+More defensive coding when using `$product->get_attributes()`.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -8,6 +8,8 @@
  * @version  3.0.0
  */
 
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -295,6 +297,11 @@ class WC_Meta_Box_Product_Data {
 
 		if ( isset( $all_attributes ) && is_array( $all_attributes ) ) {
 			foreach ( $all_attributes as $attribute ) {
+				if ( ! is_a( $attribute, 'WC_Product_Attribute' ) ) {
+					$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+					$logger->warning( sprintf( 'found a product attribute that is not a `WC_Product_Attribute` in `prepare_set_attributes`: "%s", type %s', var_export( $attribute, true ), gettype( $attribute ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+					continue;
+				}
 				if ( $attribute->get_variation() ) {
 					$attribute_key = sanitize_title( $attribute->get_name() );
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -295,7 +295,7 @@ class WC_Meta_Box_Product_Data {
 	private static function prepare_set_attributes( $all_attributes, $key_prefix = 'attribute_', $index = null ) {
 		$attributes = array();
 
-		if ( isset( $all_attributes ) && is_array( $all_attributes ) ) {
+		if ( is_array( $all_attributes ) ) {
 			foreach ( $all_attributes as $attribute ) {
 				if ( ! is_a( $attribute, 'WC_Product_Attribute' ) ) {
 					$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -151,7 +151,7 @@ class WC_Meta_Box_Product_Data {
 	 * @return bool
 	 */
 	private static function filter_variation_attributes( $attribute ) {
-		return true === $attribute->get_variation();
+		return is_a( $attribute, 'WC_Product_Attribute' ) && true === $attribute->get_variation();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -293,7 +293,7 @@ class WC_Meta_Box_Product_Data {
 	private static function prepare_set_attributes( $all_attributes, $key_prefix = 'attribute_', $index = null ) {
 		$attributes = array();
 
-		if ( $all_attributes ) {
+		if ( isset( $all_attributes ) && is_array( $all_attributes ) ) {
 			foreach ( $all_attributes as $attribute ) {
 				if ( $attribute->get_variation() ) {
 					$attribute_key = sanitize_title( $attribute->get_name() );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -784,7 +784,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$attributes  = $product->get_attributes();
 			$meta_values = array();
 
-			if ( is_array( $attributes ) ) {
+			if ( isset( $attributes ) && is_array( $attributes ) ) {
 				foreach ( $attributes as $attribute_key => $attribute ) {
 					$value = '';
 
@@ -1109,7 +1109,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		// Get attributes to match in meta.
 		$product_attributes = $product->get_attributes();
-		if ( ! is_array( $product_attributes ) ) {
+		if ( ! issset( $product_attributes ) || ! is_array( $product_attributes ) ) {
 			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
 			$logger->warning( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`' );
 			return 0;

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -784,7 +784,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$attributes  = $product->get_attributes();
 			$meta_values = array();
 
-			if ( isset( $attributes ) && is_array( $attributes ) ) {
+			if ( is_array( $attributes ) ) {
 				foreach ( $attributes as $attribute_key => $attribute ) {
 					$value = '';
 
@@ -1109,7 +1109,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		// Get attributes to match in meta.
 		$product_attributes = $product->get_attributes();
-		if ( ! issset( $product_attributes ) || ! is_array( $product_attributes ) ) {
+		if ( ! is_array( $product_attributes ) ) {
 			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
 			$logger->warning( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`' );
 			return 0;

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\DownloadPermissionsAdjuster;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -1106,12 +1107,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// Get attributes to match in meta.
 		$product_attributes = $product->get_attributes();
 		if ( ! is_array( $product_attributes ) ) {
-			// TODO: log the problem
+			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+			$logger->warn( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`' );	
 			return 0;
 		}
 		foreach ( $product_attributes as $attribute ) {
 			if ( ! is_a( $attribute, 'WC_Product_Attribute' ) || ! $attribute->get_variation() ) {
-				// TODO: log the problem				
+				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+				$logger->warn( sprintf( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "%s", type %s', var_export( $attribute, true ), gettype( $attribute ) ) );
 				continue;
 			}
 			$meta_attribute_names[] = 'attribute_' . sanitize_title( $attribute->get_name() );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1104,8 +1104,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$meta_attribute_names = array();
 
 		// Get attributes to match in meta.
-		foreach ( $product->get_attributes() as $attribute ) {
-			if ( ! $attribute->get_variation() ) {
+		$product_attributes = $product->get_attributes();
+		if ( ! is_array( $product_attributes ) ) {
+			// TODO: log the problem
+			return 0;
+		}
+		foreach ( $product_attributes as $attribute ) {
+			if ( ! is_a( $attribute, 'WC_Product_Attribute' ) || ! $attribute->get_variation() ) {
+				// TODO: log the problem				
 				continue;
 			}
 			$meta_attribute_names[] = 'attribute_' . sanitize_title( $attribute->get_name() );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -784,7 +784,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$attributes  = $product->get_attributes();
 			$meta_values = array();
 
-			if ( $attributes ) {
+			if ( is_array( $attributes ) ) {
 				foreach ( $attributes as $attribute_key => $attribute ) {
 					$value = '';
 
@@ -797,7 +797,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 							wp_set_object_terms( $product->get_id(), array(), urldecode( $attribute_key ) );
 						}
 						continue;
-
+					} elseif ( ! is_a( $attribute, 'WC_Product_Attribute' ) ) {
+						$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+						$logger->warning( sprintf( 'found a product attribute that is not a `WC_Product_Attribute` in `update_attributes`: "%s", type %s', var_export( $attribute, true ), gettype( $attribute ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+						continue;
 					} elseif ( $attribute->is_taxonomy() ) {
 						wp_set_object_terms( $product->get_id(), wp_list_pluck( (array) $attribute->get_terms(), 'term_id' ), $attribute->get_name() );
 					} else {

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1108,13 +1108,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$product_attributes = $product->get_attributes();
 		if ( ! is_array( $product_attributes ) ) {
 			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-			$logger->warn( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`' );
+			$logger->warning( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`' );
 			return 0;
 		}
 		foreach ( $product_attributes as $attribute ) {
 			if ( ! is_a( $attribute, 'WC_Product_Attribute' ) || ! $attribute->get_variation() ) {
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-				$logger->warn( sprintf( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "%s", type %s', var_export( $attribute, true ), gettype( $attribute ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+				$logger->warning( sprintf( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "%s", type %s', var_export( $attribute, true ), gettype( $attribute ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 				continue;
 			}
 			$meta_attribute_names[] = 'attribute_' . sanitize_title( $attribute->get_name() );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1108,13 +1108,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$product_attributes = $product->get_attributes();
 		if ( ! is_array( $product_attributes ) ) {
 			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-			$logger->warn( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`' );	
+			$logger->warn( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`' );
 			return 0;
 		}
 		foreach ( $product_attributes as $attribute ) {
 			if ( ! is_a( $attribute, 'WC_Product_Attribute' ) || ! $attribute->get_variation() ) {
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-				$logger->warn( sprintf( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "%s", type %s', var_export( $attribute, true ), gettype( $attribute ) ) );
+				$logger->warn( sprintf( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "%s", type %s', var_export( $attribute, true ), gettype( $attribute ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 				continue;
 			}
 			$meta_attribute_names[] = 'attribute_' . sanitize_title( $attribute->get_name() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -940,7 +940,10 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Test find_matching_product_variation.
 	 *
+	 * The following linter rule switches are required because the `return` in `invalid_attributes_callback_strings` is wrongly being detected as breaking the declared return type here.
+	 * phpcs:disable Squiz.Commenting.FunctionComment.InvalidReturnVoid
 	 * @return void
+	 * phpcs:enable Squiz.Commenting.FunctionComment.InvalidReturnVoid
 	 */
 	public function test_find_matching_product_variation() {
 		// Create a fake logger to capture log entries.
@@ -971,10 +974,14 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$match = $data_store->find_matching_product_variation( $product, array() );
 		$this->assertEquals( 0, $match );
 
-		// Simulate a filter that returns void for the product attributes.
-		function invalid_attributes_callback_void( $attributes, $product ) {
-			return;
-		}
+		/**
+		 * Simulate a filter that returns void for the product attributes.
+		 *
+		 * @param array      $attributes The product attributes.
+		 * @param WC_Product $product The product.
+		 * @return void
+		 */
+		function invalid_attributes_callback_void( $attributes, $product ) {}
 		add_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_void', 10, 2 );
 		$match = $data_store->find_matching_product_variation( $product, array() );
 		$this->assertEquals( 0, $match );
@@ -982,7 +989,13 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`', end( $fake_logger->warns )['message'] );
 		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_void', 10 );
 
-		// Simulate a filter that returns an array of strings for the product attributes.
+		/**
+		 * Simulate a filter that returns an array of strings for the product attributes.
+		 *
+		 * @param array      $attributes The product attributes.
+		 * @param WC_Product $product The product.
+		 * @return array
+		 */
 		function invalid_attributes_callback_strings( $attributes, $product ) {
 			return array( 'invalid' );
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -940,7 +940,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Test find_matching_product_variation.
 	 *
-	 * The following linter rule switches are required because the `return` in `invalid_attributes_callback_strings` is wrongly being detected as breaking the declared return type here.
+	 * The following linter rule switches are required because the `return` in `$invalid_attributes_callback_strings` is wrongly being detected as breaking the declared return type here.
 	 * phpcs:disable Squiz.Commenting.FunctionComment.InvalidReturnVoid
 	 * @return void
 	 * phpcs:enable Squiz.Commenting.FunctionComment.InvalidReturnVoid
@@ -981,13 +981,13 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		 * @param WC_Product $product The product.
 		 * @return void
 		 */
-		function invalid_attributes_callback_void( $attributes, $product ) {}
-		add_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_void', 10, 2 );
+		$invalid_attributes_callback_void = function( $attributes, $product ) {};
+		add_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_void, 10, 2 );
 		$match = $data_store->find_matching_product_variation( $product, array() );
 		$this->assertEquals( 0, $match );
 		// Check that the log entry was created.
 		$this->assertEquals( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`', end( $fake_logger->warnings )['message'] );
-		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_void', 10 );
+		remove_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_void, 10 );
 
 		/**
 		 * Simulate a filter that returns an array of strings for the product attributes.
@@ -996,15 +996,15 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		 * @param WC_Product $product The product.
 		 * @return array
 		 */
-		function invalid_attributes_callback_strings( $attributes, $product ) {
+		$invalid_attributes_callback_strings = function( $attributes, $product ) {
 			return array( 'invalid' );
-		}
-		add_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10, 2 );
+		};
+		add_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10, 2 );
 		$match = $data_store->find_matching_product_variation( $product, array() );
 		$this->assertEquals( 0, $match );
 		// Check that the log entry was created.
 		$this->assertEquals( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "\'invalid\'", type string', end( $fake_logger->warnings )['message'] );
-		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10 );
+		remove_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10 );
 
 		$match = $data_store->find_matching_product_variation(
 			$product,

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -949,10 +949,10 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		// Create a fake logger to capture log entries.
 		// phpcs:disable Squiz.Commenting
 		$fake_logger = new class() {
-			public $warns = array();
+			public $warnings = array();
 
-			public function warn( $message, $data = array() ) {
-				$this->warns[] = array(
+			public function warning( $message, $data = array() ) {
+				$this->warnings[] = array(
 					'message' => $message,
 					'data'    => $data,
 				);
@@ -986,7 +986,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$match = $data_store->find_matching_product_variation( $product, array() );
 		$this->assertEquals( 0, $match );
 		// Check that the log entry was created.
-		$this->assertEquals( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`', end( $fake_logger->warns )['message'] );
+		$this->assertEquals( '`$product->get_attributes()` did not return an array in `find_matching_product_variation`', end( $fake_logger->warnings )['message'] );
 		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_void', 10 );
 
 		/**
@@ -1003,7 +1003,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$match = $data_store->find_matching_product_variation( $product, array() );
 		$this->assertEquals( 0, $match );
 		// Check that the log entry was created.
-		$this->assertEquals( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "\'invalid\'", type string', end( $fake_logger->warns )['message'] );
+		$this->assertEquals( 'found a product attribute that is not a `WC_Product_Attribute` in `find_matching_product_variation`: "\'invalid\'", type string', end( $fake_logger->warnings )['message'] );
 		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10 );
 
 		$match = $data_store->find_matching_product_variation(

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -950,6 +950,25 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$match = $data_store->find_matching_product_variation( $product, array() );
 		$this->assertEquals( 0, $match );
 
+		// TODO: add asserts for the log entries
+		// Simulate a filter that returns void for the product attributes.
+		function invalid_attributes_callback_void( $attributes, $product ) {
+			return;
+		}
+		add_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_void', 10, 2 );
+		$match = $data_store->find_matching_product_variation( $product, array() );
+		$this->assertEquals( 0, $match );
+		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_void', 10 );
+
+		// Simulate a filter that returns an array of strings for the product attributes.
+		function invalid_attributes_callback_strings( $attributes, $product ) {
+			return array( 'invalid', 'attributes' );
+		}
+		add_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10, 2 );
+		$match = $data_store->find_matching_product_variation( $product, array() );
+		$this->assertEquals( 0, $match );
+		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10 );
+
 		$match = $data_store->find_matching_product_variation(
 			$product,
 			array(

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -286,8 +286,8 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 
 		$_POST['variable_post_id'] = array( wp_list_pluck( $product->get_available_variations(), 'variation_id' ) );
 		WC_Meta_Box_Product_Data::save_variations( $product->get_id(), get_post( $product->get_id() ) );
-		// We just need to make sure that no error is thrown.
-		$this->assertTrue( true );
+		// Check that the log entry was created.
+		$this->assertEquals( 'found a product attribute that is not a `WC_Product_Attribute` in `prepare_set_attributes`: "\'invalid\'", type string', end( $fake_logger->warnings )['message'] );
 
 		remove_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10 );
 	}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -223,9 +223,9 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox Test the `has_attributes` method to ensure invalid attributes are handled gracefully.
+	 * @testDox Test the `has_attributes` and `update_attributes` methods to ensure invalid attributes are handled gracefully.
 	 */
-	public function test_has_attributes() {
+	public function test_invalid_attributes() {
 		// Create a fake logger to capture log entries.
 		// phpcs:disable Squiz.Commenting
 		$fake_logger = new class() {
@@ -266,6 +266,11 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		$this->assertFalse( $product->has_attributes() );
 		// Check that the log entry was created.
 		$this->assertEquals( 'found a product attribute that is not a `WC_Product_Attribute` in `has_attributes`: "\'invalid\'", type string', end( $fake_logger->warnings )['message'] );
+
+		// This triggers an error in `WC_Product_Data_Store_CPT::update_attributes` when not handled gracefully.
+		$product = WC_Helper_Product::create_variation_product();
+		$this->assertNotNull( $product );
+		$this->assertFalse( $product->has_attributes() );
 
 		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10 );
 	}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -282,6 +282,11 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		ob_end_clean();
 		// We just need to make sure that the `update_attributes` method does not throw an error.
 		$this->assertEquals( '<div id="variable_product_options"', substr( $ob_content, 0, 34 ) );
+		
+		// this makes the test fail, now I can uncomment the fix
+		// but I still have to find a place in the UI for the reproduction steps
+		$_POST['variable_post_id'] = array( wp_list_pluck( $product->get_available_variations(), 'variation_id' ) );
+		WC_Meta_Box_Product_Data::save_variations( $product->get_id(), get_post( $product->get_id() ) );
 
 		remove_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10 );
 	}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -258,10 +258,10 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		 * @param WC_Product $product The product.
 		 * @return array
 		 */
-		function invalid_attributes_callback_strings( $attributes, $product ) {
+		$invalid_attributes_callback_strings = function( $attributes, $product ) {
 			return array( 'invalid' );
-		}
-		add_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10, 2 );
+		};
+		add_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10, 2 );
 
 		$this->assertFalse( $product->has_attributes() );
 		// Check that the log entry was created.
@@ -272,6 +272,6 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		$this->assertNotNull( $product );
 		$this->assertFalse( $product->has_attributes() );
 
-		remove_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_strings', 10 );
+		remove_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10 );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -226,6 +226,8 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	 * @testDox Test the `has_attributes` and `update_attributes` methods to ensure invalid attributes are handled gracefully.
 	 */
 	public function test_invalid_attributes() {
+		// `WC_Meta_Box_Product_Data` uses the `$post` and `$product_object` globals.
+		global $post, $product_object;
 		// Create a fake logger to capture log entries.
 		// phpcs:disable Squiz.Commenting
 		$fake_logger = new class() {
@@ -271,6 +273,15 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		$product = WC_Helper_Product::create_variation_product();
 		$this->assertNotNull( $product );
 		$this->assertFalse( $product->has_attributes() );
+
+		$post = get_post( $product->get_id() );
+		$product_object = $product;
+		ob_start();
+		WC_Meta_Box_Product_Data::output_variations();
+		$ob_content = ob_get_contents();
+		ob_end_clean();
+		// We just need to make sure that the `update_attributes` method does not throw an error.
+		$this->assertEquals( '<div id="variable_product_options"', substr( $ob_content, 0, 34 ) );
 
 		remove_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10 );
 	}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -226,7 +226,7 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	 * @testDox Test the `has_attributes` and `update_attributes` methods to ensure invalid attributes are handled gracefully.
 	 */
 	public function test_invalid_attributes() {
-		// `WC_Meta_Box_Product_Data` uses the `$post` and `$product_object` globals.
+		// `WC_Meta_Box_Product_Data` uses the `$post` and `$product_object` globals. phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		global $post, $product_object;
 		// Create a fake logger to capture log entries.
 		// phpcs:disable Squiz.Commenting
@@ -274,7 +274,8 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		$this->assertNotNull( $product );
 		$this->assertFalse( $product->has_attributes() );
 
-		$post = get_post( $product->get_id() );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post           = get_post( $product->get_id() );
 		$product_object = $product;
 		ob_start();
 		WC_Meta_Box_Product_Data::output_variations();
@@ -282,11 +283,11 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		ob_end_clean();
 		// We just need to make sure that the `update_attributes` method does not throw an error.
 		$this->assertEquals( '<div id="variable_product_options"', substr( $ob_content, 0, 34 ) );
-		
-		// this makes the test fail, now I can uncomment the fix
-		// but I still have to find a place in the UI for the reproduction steps
+
 		$_POST['variable_post_id'] = array( wp_list_pluck( $product->get_available_variations(), 'variation_id' ) );
 		WC_Meta_Box_Product_Data::save_variations( $product->get_id(), get_post( $product->get_id() ) );
+		// We just need to make sure that no error is thrown.
+		$this->assertTrue( true );
 
 		remove_filter( 'woocommerce_product_get_attributes', $invalid_attributes_callback_strings, 10 );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a few checks before we use the results of `$product->get_attributes()` in `find_matching_product_variation`.

Partially addresses #43722 (ignoring the potential REST API occurrence for the sake of this PR).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure CI passes.
2. Read and think about my comments on my own PR. Should we handle this this way, or can you think of a better alternative? Not handling things means that log files contain lots of thrown errors around this in certain environments as probably a plugin is changing attributes in a hook in a way that leaves them as strings, not instances of `WC_Product_Attribute`. 

**For manual reproduction please follow the below instructions:**

1. Install [a snippets plugin](https://wordpress.org/plugins/code-snippets/) and add the following snippet, henceforth referred to as "the snippet":

```
function invalid_attributes_callback_testing( $attributes, $product ) {
	return array( 'invalid' );
}
add_filter( 'woocommerce_product_get_attributes', 'invalid_attributes_callback_testing', 10, 2 );
```

3. Import [the sample products CSV](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/sample-data/sample_products.csv).
4. Visit the product page for the "Hoodie" variable product: `/?product=hoodie`. No option should be displayed under the text "This is a variable product." (and so it cannot be added to the cart), but the product should load without an error. On `trunk`, the following error message would be thrown: "Fatal error: Uncaught Error: Call to a member function get_visible() on string"
5. Edit the "Hoodie" product (adjust ID for your own environment): `/wp-admin/post.php?post=17&action=edit`. Below the row with the "Sold individually" string, there should be no error message. On `trunk`, the following error message would be thrown: "Fatal error: Uncaught Error: Call to a member function get_visible() on string"
6. Go to the "Variations" tab. There should be no error message. On `trunk`, the following error message would be thrown: "Fatal error: Uncaught Error: Call to a member function get_visible() on string"
7. Disable the code snippet by commenting it out (place `//` before each of the lines and save). 
8. Edit the "Hoodie" product (adjust ID for your own environment): `/wp-admin/post.php?post=17&action=edit` 
9. Go to the "Variations" tab. There should be no error message. Different variations should be listed. 
10. Change a dropdown value -- e.g., change a "Yes" to a "No". Do not click save yet. 
11. In a different tab, enable the code snippet again (remove the `//`s and save). 
12. Go back to the tab showing the hoodie. 
13. Now click "Save changes". The save should go through without error, but all variations will now be gone. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
