### PR TITLE
Add e2e tests to verify specific theme templates have priority over user-modified Product Catalog template

### DIFF
--- a/plugins/woocommerce/changelog/43750-add-theme-block-template-customization-ii
+++ b/plugins/woocommerce/changelog/43750-add-theme-block-template-customization-ii
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Add e2e tests to verify specific theme templates have priority over user-modified Product Catalog template
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Based on https://github.com/woocommerce/woocommerce/pull/43650.

Part of https://github.com/woocommerce/woocommerce/issues/43416.

This PR adds some tests to verify that if the theme has a specific template for Products by Category/Tag/Attribute, that one has priority over a Product Catalog template edited by the user.

(For context: if the theme doesn't have a specific template for Products by Category/Tag/Attribute and the user hasn't modified those templates, they default to the Product Catalog template, tests for this were added in https://github.com/woocommerce/woocommerce/pull/43471)

### How to test the changes in this Pull Request:

Note: no need to test this for the release.

1. Verify Playwright e2e tests pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Add e2e tests to verify specific theme templates have priority over user-modified Product Catalog template

</details>
