### PR TITLE
Add store notices to the Cart and Checkout block templates

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/style.scss
@@ -151,7 +151,7 @@
 	}
 }
 
-// To fix notice banner width for all themes.
+// To fix notice banner width for all block themes.
 .woocommerce.wc-block-store-notices.alignwide {
 	max-width: var(--wp--style--global--wide-size);
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/style.scss
@@ -150,3 +150,8 @@
 		@extend %info;
 	}
 }
+
+// To fix notice banner width for all themes.
+.woocommerce.wc-block-store-notices.alignwide {
+	max-width: var(--wp--style--global--wide-size);
+}

--- a/plugins/woocommerce/changelog/43753-fix-42787-session-notices-cart-checkout
+++ b/plugins/woocommerce/changelog/43753-fix-42787-session-notices-cart-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add store notices to the Cart and Checkout block templates.

--- a/plugins/woocommerce/templates/templates/blockified/page-cart.html
+++ b/plugins/woocommerce/templates/templates/blockified/page-cart.html
@@ -2,6 +2,7 @@
 <!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
+	<!-- wp:woocommerce/store-notices /-->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
 	<!-- wp:post-content {"align":"wide"} /-->
 </main>

--- a/plugins/woocommerce/templates/templates/blockified/page-checkout.html
+++ b/plugins/woocommerce/templates/templates/blockified/page-checkout.html
@@ -2,6 +2,7 @@
 <!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
+	<!-- wp:woocommerce/store-notices /-->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
 	<!-- wp:post-content {"align":"wide"} /-->
 </main>

--- a/plugins/woocommerce/templates/templates/page-cart.html
+++ b/plugins/woocommerce/templates/templates/page-cart.html
@@ -2,6 +2,7 @@
 <!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
+	<!-- wp:woocommerce/store-notices /-->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
 	<!-- wp:post-content {"align":"wide"} /-->
 </main>

--- a/plugins/woocommerce/templates/templates/page-checkout.html
+++ b/plugins/woocommerce/templates/templates/page-checkout.html
@@ -2,6 +2,7 @@
 <!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
+	<!-- wp:woocommerce/store-notices /-->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
 	<!-- wp:post-content {"align":"wide"} /-->
 </main>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

If the user's session contains a notice, that notice wasn't displayed on the Checkout block or Cart block page on page load. It was happening because we removed `<!-- wp:woocommerce/store-notices /-->` block from the templates. 

In this PR, we're adding store notices back to Checkout block or Cart page templates. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42787.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


```php
add_action('template_redirect', 'add_wc_notice_and_redirect_to_cart');

function add_wc_notice_and_redirect_to_cart() {
    if ( isset( $_GET['debug_notice'] ) ) {
        wc_add_notice( 'This is a debug notice!', 'error' );

        // Redirect to the cart page
        wp_safe_redirect( wc_get_cart_url() );
        exit;
    }
}
```

1. Add the code snippet above to your test site. It will add a notice and redirect you to the Cart page when the `debug_notice` URL parameter is present.
2. Visit `yoursite.com/?debug_notice`
3. You'll be redirected to the Cart page with a notice being displayed.

| Before | After |
|---|---|
|![image](https://github.com/woocommerce/woocommerce/assets/11503784/9cfbd40a-6933-444f-a836-c0b26b843f07)|![image](https://github.com/woocommerce/woocommerce/assets/11503784/2a73ca15-21a7-455d-b4df-f68dd0862c2a)|

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add store notices to the Cart and Checkout block templates. 
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
