### PR TITLE
Update WC Blocks Playwright tests docs so we pass parameters correctly to PNPM scripts

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/README.md
+++ b/plugins/woocommerce-blocks/tests/e2e/README.md
@@ -101,19 +101,19 @@ pnpm run test:e2e
 Interactive UI mode:
 
 ```sh
-pnpm run test:e2e -- --ui
+pnpm run test:e2e --ui
 ```
 
 Headed mode:
 
 ```sh
-pnpm run test:e2e -- --headed
+pnpm run test:e2e --headed
 ```
 
 Debug mode:
 
 ```sh
-pnpm run test:e2e -- --debug
+pnpm run test:e2e --debug
 ```
 
 Running a single test:

--- a/plugins/woocommerce/changelog/43779-fix-blocks-e2e-pnpm-parameters
+++ b/plugins/woocommerce/changelog/43779-fix-blocks-e2e-pnpm-parameters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Update docs on how to run Playwright e2e commands for WC Blocks.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/43650 we updated the WC Blocks Playwright docs to use `pnpm` instead of `npm`, but I didn't update how the parameters are passed, so they were ignored. I needed to change from:

`pnpm run test:e2e -- --headed`

to:

`pnpm run test:e2e --headed`

This PR fixes that.

### How to test the changes in this Pull Request:

Note: no need to test this for the release.

1. Inside the `plugins/woocommerce-blocks` folder, run `pnpm run test:e2e --ui`, `pnpm run test:e2e --headed`, `pnpm run test:e2e --debug` and verify all of them work as expected. Tip: no need to run all tests to verify the commands work, you can simply run one of them. Ie:

* `pnpm run test:e2e mini-cart-template-part.block_theme.spec.ts --ui`
* `pnpm run test:e2e mini-cart-template-part.block_theme.spec.ts --headed`
* `pnpm run test:e2e mini-cart-template-part.block_theme.spec.ts --debug`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Update docs on how to run Playwright e2e commands for WC Blocks.

</details>
