### PR TITLE
Allow providing meta fields starting with "meta_data_" as regular fields on the REST API

### DIFF
--- a/plugins/woocommerce/changelog/poc-metadata_fields
+++ b/plugins/woocommerce/changelog/poc-metadata_fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow providing meta fields starting with "meta_data_" as regular fields on the REST API

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -780,14 +780,14 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		$metadata_fields = array_filter(
 			$request->get_params(),
 			function( $k ) {
-				return str_starts_with( $k, 'meta_data_' );
+				return str_starts_with( $k, '__meta_data_' );
 			},
 			ARRAY_FILTER_USE_KEY
 		);
 
 		if ( ! empty( $metadata_fields ) ) {
 			foreach ( $metadata_fields as $key => $value ) {
-				$product->update_meta_data( str_replace( 'meta_data_', '', $key ), $value );
+				$product->update_meta_data( str_replace( '__meta_data_', '', $key ), $value );
 			}
 		}
 
@@ -1527,7 +1527,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 			if ( in_array( 'meta_data', $fields, true ) ) {
 				foreach ( $data['meta_data'] as $meta ) {
-					$data[ 'meta_data_' . $meta->key ] = $meta->value;
+					$data[ '__meta_data_' . $meta->key ] = $meta->value;
 				}
 			}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1450,7 +1450,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 						),
 					),
 				),
-				'__meta_data_*' => array(
+				'__meta_data_*'         => array(
 					'description' => __( 'Meta data can be added to the product by providing properties with the "__meta_data_" prefix', 'woocommerce' ),
 					'type'        => 'mixed',
 					'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1450,6 +1450,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 						),
 					),
 				),
+				'__meta_data_*' => array(
+					'description' => __( 'Meta data can be added to the product by providing properties with the "__meta_data_" prefix', 'woocommerce' ),
+					'type'        => 'mixed',
+					'context'     => array( 'view', 'edit' ),
+				),
 			),
 		);
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -787,7 +787,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		if ( ! empty( $metadata_fields ) ) {
 			foreach ( $metadata_fields as $key => $value ) {
-				$product->update_meta_data( str_replace( '__meta_data_', '', $key ), $value );
+				if ( is_array( $value ) && isset( $value['key'] ) && isset( $value['value'] ) ) {
+					$product->update_meta_data( str_replace( '__meta_data_', '', $value['key'] ), $value['value'], isset( $value['id'] ) ? $value['id'] : '' );
+				} else {
+					$product->update_meta_data( str_replace( '__meta_data_', '', $key ), $value );
+				}
 			}
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -649,7 +649,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 70, count( $properties ) );
+		$this->assertEquals( 71, count( $properties ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -323,6 +323,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertArrayHasKey( 'meta_data_test1', $order );
+			$this->assertArrayNotHasKey( 'meta_data_test2', $order );
 			$this->assertEquals( 1, count( $order['meta_data'] ) );
 			$meta_keys = array_map(
 				function( $meta_item ) {
@@ -348,6 +350,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertArrayHasKey( 'meta_data_test1', $order );
+			$this->assertArrayHasKey( 'meta_data_test2', $order );
 			$meta_keys = array_map(
 				function( $meta_item ) {
 					return $meta_item->get_data()['key'];
@@ -373,6 +377,9 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertArrayNotHasKey( 'meta_data_test1', $order );
+			$this->assertArrayHasKey( 'meta_data_test2', $order );
+
 			$meta_keys = array_map(
 				function( $meta_item ) {
 					return $meta_item->get_data()['key'];
@@ -399,6 +406,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertArrayHasKey( 'meta_data_test1', $order );
+			$this->assertArrayNotHasKey( 'meta_data_test2', $order );
 			$this->assertEquals( 1, count( $order['meta_data'] ) );
 			$meta_keys = array_map(
 				function( $meta_item ) {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -323,8 +323,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertArrayHasKey( 'meta_data_test1', $order );
-			$this->assertArrayNotHasKey( 'meta_data_test2', $order );
+			$this->assertArrayHasKey( '__meta_data_test1', $order );
+			$this->assertArrayNotHasKey( '__meta_data_test2', $order );
 			$this->assertEquals( 1, count( $order['meta_data'] ) );
 			$meta_keys = array_map(
 				function( $meta_item ) {
@@ -350,8 +350,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertArrayHasKey( 'meta_data_test1', $order );
-			$this->assertArrayHasKey( 'meta_data_test2', $order );
+			$this->assertArrayHasKey( '__meta_data_test1', $order );
+			$this->assertArrayHasKey( '__meta_data_test2', $order );
 			$meta_keys = array_map(
 				function( $meta_item ) {
 					return $meta_item->get_data()['key'];
@@ -377,8 +377,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertArrayNotHasKey( 'meta_data_test1', $order );
-			$this->assertArrayHasKey( 'meta_data_test2', $order );
+			$this->assertArrayNotHasKey( '__meta_data_test1', $order );
+			$this->assertArrayHasKey( '__meta_data_test2', $order );
 
 			$meta_keys = array_map(
 				function( $meta_item ) {
@@ -406,8 +406,8 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertArrayHasKey( 'meta_data_test1', $order );
-			$this->assertArrayNotHasKey( 'meta_data_test2', $order );
+			$this->assertArrayHasKey( '__meta_data_test1', $order );
+			$this->assertArrayNotHasKey( '__meta_data_test2', $order );
 			$this->assertEquals( 1, count( $order['meta_data'] ) );
 			$meta_keys = array_map(
 				function( $meta_item ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Allow providing meta fields starting with "meta_data_" as regular fields on the REST API

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Add the following to your `mu-plugins` or using the Code Snippets plugin:
```php
<?php

function add_meta_fields( $basic_details_section )
{
	$general_group = $basic_details_section->get_parent();
	$section = $general_group->add_section(
		[
			'id'         => 'YOUR-PREFIX-section',
			'order'      => $basic_details_section->get_order() + 5,
			'attributes' => [
				'title' => __('My Meta Fields', 'woocommerce'),
				'description' => __('This is a description', 'woocommerce'),
			],
		]
	);

	$section->add_block(
		[
			'id'         => 'example-taxonomy-meta',
			'blockName'  => 'woocommerce/product-taxonomy-field',
			'order'      => 11,
			'attributes' => [
					'label' => 'Taxonomy',
					'property' => '__meta_data_taxonomy',
					'slug' => 'product_cat',
			],
		]
	);
	$section->add_block(
		[
			'id'         => 'example-checkbox-meta',
			'blockName'  => 'woocommerce/product-checkbox-field',
			'order'      => 12,
			'attributes' => [
					'label' => 'Checkbox',
					'property' => '__meta_data_checkbox',
					'checkedValue'   => 'yes',
					'uncheckedValue' => 'no',
					'tooltip' => 'Hello'
			],
		]
	);
	$section->add_block(
		[
			'id'         => 'example-text-meta',
			'blockName'  => 'woocommerce/product-text-field',
			'order'      => 13,
			'attributes' => [
				'label' => 'Text',
				'property' => '__meta_data_text',
				'placeholder' => 'Placeholder',
				'help' => 'Add additional information here',
				'tooltip' => 'My tooltip'
			],
		]
	);
	$section->add_block(
		[
			'id'         => 'example-toggle-meta',
			'blockName'  => 'woocommerce/product-toggle-field',
			'order'      => 14,
			'attributes' => [
				'label' => 'Toggle',
				'property' => '__meta_data_toggle',
			],
		]
	);
	$section->add_block(
		[
			'id'         => 'example-radio-meta',
			'blockName'  => 'woocommerce/product-radio-field',
			'order'      => 15,
			'attributes' => [
				'title' => 'Radio',
				'property' => '__meta_data_radio',
				'options' => [
					[
						'label' => 'Option 1',
						'value' => 'option_1',
					],
					[
						'label' => 'Option 2',
						'value' => 'option_2',
					],
				],
			]
		],
	);

	$section->add_block(
		[
			'id'         => 'example-number-meta',
			'blockName'  => 'woocommerce/product-number-field',
			'order'      => 16,
			'attributes' => [
				'label' => 'Label',
				'property' => '__meta_data_number',
				'suffix' => 'suffix',
				'placeholder' => 'Placeholder',
				'required' => true,
				'help' => 'Add additional information here',
				'tooltip' => 'My tooltip'
			]
		],
	);

	$section->add_block(
		[
			'id'         => 'example-points-earned',
			'blockName'  => 'woocommerce/product-pricing-field',
			'order'      => 16,
			'attributes' => [
				'label' => 'Pricing',
				'property' => '__meta_data_pricing',
			]
		],
	);

}

function example_hook_meta_field()
{
	add_action(
		'woocommerce_block_template_area_product-form_after_add_block_basic-details',
		'add_meta_fields'
	);
}


add_action('init', 'example_hook_meta_field', 0);
```
1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Check the new section added to the General tab
4. Fill all the fields from the section, along with the Name field, and save the product. 
5. Test if all values are persisted correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
