### PR TITLE
[Experimental] Add `$request` to additional fields validation filter

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -78,6 +78,7 @@ export const getErrorDetails = (
 									message: decodeEntities(
 										additionalError.message
 									),
+									data,
 								},
 							];
 							if ( typeof additionalError.data !== 'undefined' ) {

--- a/plugins/woocommerce/changelog/43789-add-request-to-additional-field-validation-filter
+++ b/plugins/woocommerce/changelog/43789-add-request-to-additional-field-validation-filter
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Skipping changelog because this is behind a feature flag.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -476,27 +476,28 @@ class CheckoutFields {
 	/**
 	 * Validate an additional field against any custom validation rules. The result should be a WP_Error or true.
 	 *
-	 * @param string $key          The key of the field.
-	 * @param mixed  $field_value  The value of the field.
-	 * @param array  $field_schema The schema of the field.
+	 * @param string           $key          The key of the field.
+	 * @param mixed            $field_value  The value of the field.
+	 * @param array            $field_schema The schema of the field.
+	 * @param \WP_REST_Request $request      The current API Request.
 	 *
 	 * @since 8.6.0
 	 */
-	public function validate_field( $key, $field_value, $field_schema ) {
+	public function validate_field( $key, $field_value, $field_schema, $request ) {
 
 		$error = new \WP_Error();
 		try {
 			/**
 			 * Filter the result of validating an additional field.
 			 *
-			 * @param \WP_Error $error A WP_Error that extensions may add errors to.
-			 * @param mixed $field_value The value of the field.
-			 * @param array $field_schema The schema of the field.
-			 * @param string $key The key of the field.
+			 * @param \WP_Error        $error        A WP_Error that extensions may add errors to.
+			 * @param mixed            $field_value  The value of the field.
+			 * @param array            $field_schema The schema of the field.
+			 * @param \WP_REST_Request $request      The current API Request.
 			 *
 			 * @since 8.6.0
 			 */
-			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $error, $field_value, $field_schema, $key );
+			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $error, $field_value, $field_schema, $request );
 
 			if ( $error !== $filtered_result ) {
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -217,7 +217,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
 			// Skip additional validation if the schema validation failed.
 			if ( true === $result && in_array( $key, $additional_keys, true ) ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $properties[ $key ] );
+				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $properties[ $key ], $request );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -373,7 +373,7 @@ class CheckoutSchema extends AbstractSchema {
 
 			// Only allow custom validation on fields that pass the schema validation.
 			if ( true === $result ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $properties[ $key ] );
+				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $properties[ $key ], $request );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/43435 we added a filter to allow further validation on additional checkout fields.

Since then we identified that it would be useful for extensions to know the values of the other fields on the checkout form.

The solution to this is to pass the `WP_Rest_Request` to the filter.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Developer only

Example snippet:

```php

add_action(
	'woocommerce_blocks_loaded',
	function() {
			woocommerce_blocks_register_checkout_field(
				array(
					'id'       => 'plugin-namespace/gov-id',
					'label'    => 'Government ID',
					'location' => 'contact',
					'type'     => 'text',
					'required' => true,
				),
			);
			woocommerce_blocks_register_checkout_field(
				array(
					'id'       => 'plugin-namespace/confirm-gov-id',
					'label'    => 'Confirm Government ID',
					'location' => 'contact',
					'type'     => 'text',
					'required' => true,
				),
			);

			add_filter('woocommerce_blocks_validate_additional_field_plugin-namespace/gov-id', function ( \WP_Error $error, $value, $schema, $request ) {
				$match = preg_match( '/[A-Z0-9]{5}/', $value );

				$confirmed_government_id = $request->get_param( 'additional_fields' )['plugin-namespace/confirm-gov-id'];
				if ( 0 === $match || false === $match ) {
					$error->add( 'invalid_gov_id', 'Please ensure your government ID matches the correct format.' );
				}

				if ( $confirmed_government_id !== $value ) {
					$error->add( 'non_matching_gov_id', 'Your government ID does not match the confirmation.' );
				}
				return $error;
			}, 10, 4);
} );
```


1. Add the snippet to your site.
2. Check out with non-matching Government IDs.
3. Ensure an error shows about non-matching Government IDs.
4. Use ID `12345` in both boxes.
5. Ensure checkout is successful.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
