### PR TITLE
Enable WooCommerce feature plugin - set WOOCOMMERCE_BLOCKS_PHASE to 2

### DIFF
--- a/plugins/woocommerce/bin/build-zip.sh
+++ b/plugins/woocommerce/bin/build-zip.sh
@@ -6,7 +6,7 @@ BUILD_PATH="${PROJECT_PATH}/build"
 DEST_PATH="$BUILD_PATH/$PLUGIN_SLUG"
 
 if [ -z "${WOOCOMMERCE_BLOCKS_PHASE}" ]; then
-    export WOOCOMMERCE_BLOCKS_PHASE=1
+    export WOOCOMMERCE_BLOCKS_PHASE=2
 fi
 
 echo "Generating build directory..."

--- a/plugins/woocommerce/changelog/fix-enable-feature-plugin
+++ b/plugins/woocommerce/changelog/fix-enable-feature-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Enable feature plugin in the production build


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/43074 we bumped the WOOCOMMERCE_BLOCKS_PHASE to 1 (Core flag) which was a reaction to experimental features being exposed in a production build. But that means we also disabled plugin features and basically after merge with Core and WooCommerce 8.5 release there’s no way from user perspective to use plugin features. Example:

Example: Product Price styling

WooCommerce 8.4 with Blocks active users had all plugin features | After bump to WooCommerce 8.5
-- | --
![image](https://github.com/woocommerce/woocommerce/assets/20098064/d4b8581b-3d3b-4f52-91f4-bbd14937ec9f) | ![image](https://github.com/woocommerce/woocommerce/assets/20098064/4633ce2a-c7a8-488c-9d42-fca3515305f9)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

_Note: Steps 0 and 1 are only for developers. Skip it if you're testing final build._
0. Build a plugin ZIP `pnpm --filter=@woocommerce/plugin-woocommerce build:zip`
1. Add plugin to your page

Steps for everyone to follow:
2. Go to Editor
3. Add Product Collection block
4. Focus on Product Price block
5. Verify the following features are available in the inspector controls like in the screenshot:
  - Color
  - Typography
  - Dimensions
<img width="285" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/df52d148-adfa-4197-8f8f-4e3624519095">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>