### PR TITLE
43813 hpos add missing filters on order listtable

### DIFF
--- a/plugins/woocommerce/changelog/43813-hpos-add-missing-filters-on-order-listtable
+++ b/plugins/woocommerce/changelog/43813-hpos-add-missing-filters-on-order-listtable
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-HPOS add missing filters on order list table class.
+HPOS: add missing filters on order list table class.

--- a/plugins/woocommerce/changelog/43813-hpos-add-missing-filters-on-order-listtable
+++ b/plugins/woocommerce/changelog/43813-hpos-add-missing-filters-on-order-listtable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+HPOS add missing filters on order list table class.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -546,20 +546,20 @@ class ListTable extends WP_List_Table {
 	 * @return array
 	 */
 	public function get_views() {
-		$view_links  = array();
+		$view_links = array();
 
-        /**
-         * Filters the list of available list table views link
-         * before the actual query runs so gives the opportunity to remove counts from the links
-         *
-         * @since x.x.x
-         *
-         * @param string[] $views An array of available list table views links.
-         */
-        $view_links = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_view_links', $view_links );
-        if ( !empty($view_links) ) {
-            return $view_links;
-        }
+		/**
+		 * Filters the list of available list table views link
+		 * before the actual query runs so gives the opportunity to remove counts from the links
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string[] $views An array of available list table views links.
+		 */
+		$view_links = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_view_links', $view_links );
+		if ( ! empty($view_links) ) {
+			return $view_links;
+		}
 
         $view_counts = array();
 		$statuses    = $this->get_visible_statuses();
@@ -639,23 +639,23 @@ class ListTable extends WP_List_Table {
 	 * @return boolean TRUE when the blank state should be rendered, FALSE otherwise.
 	 */
     private function should_render_blank_state(): bool {
-        /**
-         * Filters if we should render blank state, allowing for custom count queries to be used
-         *
-         * @since x.x.x
-         *
-         * @param null           $should_render_blank_state null will use the build in counts, and sending a boolean will overwrite it
-         * @param object         ListTable The current instance of the class.
-        */
-        $should_render_blank_state = apply_filters(
-            'woocommerce_' . $this->order_type . '_list_table_render_blank_state',
-            null,
-            $this
-        );
+		/**
+		 * Filters if we should render blank state, allowing for custom count queries to be used
+		 *
+		 * @since x.x.x
+		 *
+		 * @param null           $should_render_blank_state null will use the build in counts, and sending a boolean will overwrite it
+		 * @param object         ListTable The current instance of the class.
+		*/
+		$should_render_blank_state = apply_filters(
+			'woocommerce_' . $this->order_type . '_list_table_render_blank_state',
+			null,
+			$this
+		);
 
-        if ( is_bool($should_render_blank_state) ) {
-            return $should_render_blank_state;
-        }
+		if ( is_bool($should_render_blank_state) ) {
+			return $should_render_blank_state;
+		}
 
         return ( ! $this->has_filter ) && 0 === $this->count_orders_by_status( array_keys( $this->get_visible_statuses() ) );
  	}
@@ -756,16 +756,16 @@ class ListTable extends WP_List_Table {
 	private function months_filter() {
 		// XXX: [review] we may prefer to move this logic outside of the ListTable class.
 
-        /**
-         * Filters whether to remove the 'Months' drop-down from the order list table.
-         *
-         * @since x.x.x
-         *
-         * @param bool   $disable   Whether to disable the drop-down. Default false.
-         */
-        if ( apply_filters( 'woocommerce_order_list_table_disable_months_filter', false ) ) {
-            return;
-        }
+		/**
+		 * Filters whether to remove the 'Months' drop-down from the order list table.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool   $disable   Whether to disable the drop-down. Default false.
+		 */
+		if ( apply_filters( 'woocommerce_order_list_table_disable_months_filter', false ) ) {
+			return;
+		}
 
 		global $wp_locale;
 		global $wpdb;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -639,7 +639,19 @@ class ListTable extends WP_List_Table {
 	 * @return boolean TRUE when the blank state should be rendered, FALSE otherwise.
 	 */
 	private function should_render_blank_state(): bool {
-		return ( ! $this->has_filter ) && 0 === $this->count_orders_by_status( array_keys( $this->get_visible_statuses() ) );
+        /**
+         * Filters if we should render blank state, allowing for custom count queries to be used
+         *
+         * @since x.x.x
+         *
+         * @param boolean           $should_render_blank_state
+         * @param object            ListTable The current instance of the class.
+         */
+         return apply_filters(
+ 			'woocommerce_' . $this->order_type . '_list_table_render_blank_state',
+            ( ! $this->has_filter ) && 0 === $this->count_orders_by_status( array_keys( $this->get_visible_statuses() ) ),
+            $this
+ 		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -557,11 +557,11 @@ class ListTable extends WP_List_Table {
 		 * @param string[] $views An array of available list table views links.
 		 */
 		$view_links = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_view_links', $view_links );
-		if ( ! empty($view_links) ) {
+		if ( ! empty( $view_links ) ) {
 			return $view_links;
 		}
 
-        $view_counts = array();
+		$view_counts = array();
 		$statuses    = $this->get_visible_statuses();
 		$current     = ! empty( $this->request['status'] ) ? sanitize_text_field( $this->request['status'] ) : 'all';
 		$all_count   = 0;
@@ -638,7 +638,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return boolean TRUE when the blank state should be rendered, FALSE otherwise.
 	 */
-    private function should_render_blank_state(): bool {
+	private function should_render_blank_state(): bool {
 		/**
 		 * Filters if we should render blank state, allowing for custom count queries to be used
 		 *
@@ -653,12 +653,12 @@ class ListTable extends WP_List_Table {
 			$this
 		);
 
-		if ( is_bool($should_render_blank_state) ) {
+		if ( is_bool( $should_render_blank_state ) ) {
 			return $should_render_blank_state;
 		}
 
-        return ( ! $this->has_filter ) && 0 === $this->count_orders_by_status( array_keys( $this->get_visible_statuses() ) );
- 	}
+		return ( ! $this->has_filter ) && 0 === $this->count_orders_by_status( array_keys( $this->get_visible_statuses() ) );
+	}
 
 	/**
 	 * Returns a list of slug and labels for order statuses that should be visible in the status list.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -549,12 +549,12 @@ class ListTable extends WP_List_Table {
 		$view_links = array();
 
 		/**
-		 * Filters the list of available list table views link
-		 * before the actual query runs so gives the opportunity to remove counts from the links
+		 * Filters the list of available list table view links before the actual query runs.
+		 * This can be used to, e.g., remove counts from the links.
 		 *
-		 * @since x.x.x
+		 * @since 8.6.0
 		 *
-		 * @param string[] $views An array of available list table views links.
+		 * @param string[] $views An array of available list table view links.
 		 */
 		$view_links = apply_filters( 'woocommerce_before_' . $this->order_type . '_list_table_view_links', $view_links );
 		if ( ! empty( $view_links ) ) {
@@ -640,11 +640,11 @@ class ListTable extends WP_List_Table {
 	 */
 	private function should_render_blank_state(): bool {
 		/**
-		 * Filters if we should render blank state, allowing for custom count queries to be used
+		 * Whether we should render a blank state so that custom count queries can be used.
 		 *
-		 * @since x.x.x
+		 * @since 8.6.0
 		 *
-		 * @param null           $should_render_blank_state null will use the build in counts, and sending a boolean will overwrite it
+		 * @param null           $should_render_blank_state `null` will use the built-in counts. Sending a boolean will short-circuit that path.
 		 * @param object         ListTable The current instance of the class.
 		*/
 		$should_render_blank_state = apply_filters(
@@ -759,7 +759,7 @@ class ListTable extends WP_List_Table {
 		/**
 		 * Filters whether to remove the 'Months' drop-down from the order list table.
 		 *
-		 * @since x.x.x
+		 * @since 8.6.0
 		 *
 		 * @param bool   $disable   Whether to disable the drop-down. Default false.
 		 */

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -763,7 +763,7 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @param bool   $disable   Whether to disable the drop-down. Default false.
 		 */
-		if ( apply_filters( 'woocommerce_order_list_table_disable_months_filter', false ) ) {
+		if ( apply_filters( 'woocommerce_' . $this->order_type . '_list_table_disable_months_filter', false ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -546,8 +546,22 @@ class ListTable extends WP_List_Table {
 	 * @return array
 	 */
 	public function get_views() {
-		$view_counts = array();
 		$view_links  = array();
+
+        /**
+         * Filters the list of available list table views link
+         * before the actual query runs so gives the opportunity to remove counts from the links
+         *
+         * @since x.x.x
+         *
+         * @param string[] $views An array of available list table views links.
+         */
+        $view_links = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_view_links', $view_links );
+        if ( !empty($view_links) ) {
+            return $view_links;
+        }
+
+        $view_counts = array();
 		$statuses    = $this->get_visible_statuses();
 		$current     = ! empty( $this->request['status'] ) ? sanitize_text_field( $this->request['status'] ) : 'all';
 		$all_count   = 0;
@@ -723,6 +737,17 @@ class ListTable extends WP_List_Table {
 	 */
 	private function months_filter() {
 		// XXX: [review] we may prefer to move this logic outside of the ListTable class.
+
+        /**
+         * Filters whether to remove the 'Months' drop-down from the order list table.
+         *
+         * @since 4.2.0
+         *
+         * @param bool   $disable   Whether to disable the drop-down. Default false.
+         */
+        if ( apply_filters( 'woocommerce_order_list_table_disable_months_filter', false ) ) {
+            return;
+        }
 
 		global $wp_locale;
 		global $wpdb;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -638,21 +638,27 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return boolean TRUE when the blank state should be rendered, FALSE otherwise.
 	 */
-	private function should_render_blank_state(): bool {
+    private function should_render_blank_state(): bool {
         /**
          * Filters if we should render blank state, allowing for custom count queries to be used
          *
          * @since x.x.x
          *
-         * @param boolean           $should_render_blank_state
-         * @param object            ListTable The current instance of the class.
-         */
-         return apply_filters(
- 			'woocommerce_' . $this->order_type . '_list_table_render_blank_state',
-            ( ! $this->has_filter ) && 0 === $this->count_orders_by_status( array_keys( $this->get_visible_statuses() ) ),
+         * @param null           $should_render_blank_state null will use the build in counts, and sending a boolean will overwrite it
+         * @param object         ListTable The current instance of the class.
+        */
+        $should_render_blank_state = apply_filters(
+            'woocommerce_' . $this->order_type . '_list_table_render_blank_state',
+            null,
             $this
- 		);
-	}
+        );
+
+        if ( is_bool($should_render_blank_state) ) {
+            return $should_render_blank_state;
+        }
+
+        return ( ! $this->has_filter ) && 0 === $this->count_orders_by_status( array_keys( $this->get_visible_statuses() ) );
+ 	}
 
 	/**
 	 * Returns a list of slug and labels for order statuses that should be visible in the status list.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -556,7 +556,7 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @param string[] $views An array of available list table views links.
 		 */
-		$view_links = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_view_links', $view_links );
+		$view_links = apply_filters( 'woocommerce_before_' . $this->order_type . '_list_table_view_links', $view_links );
 		if ( ! empty( $view_links ) ) {
 			return $view_links;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -648,7 +648,7 @@ class ListTable extends WP_List_Table {
 		 * @param object         ListTable The current instance of the class.
 		*/
 		$should_render_blank_state = apply_filters(
-			'woocommerce_' . $this->order_type . '_list_table_render_blank_state',
+			'woocommerce_' . $this->order_type . '_list_table_should_render_blank_state',
 			null,
 			$this
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -741,7 +741,7 @@ class ListTable extends WP_List_Table {
         /**
          * Filters whether to remove the 'Months' drop-down from the order list table.
          *
-         * @since 4.2.0
+         * @since x.x.x
          *
          * @param bool   $disable   Whether to disable the drop-down. Default false.
          */

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -928,14 +928,14 @@ class OrdersTableQuery {
 		     *
 		     * @param string           $sql   The count SQL query.
 		     * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
-		     * @param array 		   $args  Query args.
-		     * @param string 		   $fields Prepared fields for SELECT clause.
-		     * @param string 		   $join Prepared JOIN clause.
-		     * @param string 		   $where Prepared WHERE clause.
-		     * @param string 		   $groupby Prepared GROUP BY clause.	
+		     * @param array            $args  Query args.
+		     * @param string           $fields Prepared fields for SELECT clause.
+		     * @param string           $join Prepared JOIN clause.
+		     * @param string           $where Prepared WHERE clause.
+		     * @param string           $groupby Prepared GROUP BY clause.
 		     */
 		    $this->count_sql = apply_filters_ref_array( 'woocommerce_orders_table_query_count_sql', array( $this->count_sql, &$this, $this->args, $fields, $join, $where, $groupby ) );
-		}		
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -921,20 +921,20 @@ class OrdersTableQuery {
 		$this->count_sql = "SELECT COUNT(DISTINCT $fields) FROM  $orders_table $join WHERE $where";
 
 		if ( ! $this->suppress_filters ) {
-		    /**
-		     * Filters the count SQL query.
-		     *
-		     * @since x.x.x
-		     *
-		     * @param string           $sql   The count SQL query.
-		     * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
-		     * @param array            $args  Query args.
-		     * @param string           $fields Prepared fields for SELECT clause.
-		     * @param string           $join Prepared JOIN clause.
-		     * @param string           $where Prepared WHERE clause.
-		     * @param string           $groupby Prepared GROUP BY clause.
-		     */
-		    $this->count_sql = apply_filters_ref_array( 'woocommerce_orders_table_query_count_sql', array( $this->count_sql, &$this, $this->args, $fields, $join, $where, $groupby ) );
+			/**
+			 * Filters the count SQL query.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param string           $sql   The count SQL query.
+			 * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
+			 * @param array            $args  Query args.
+			 * @param string           $fields Prepared fields for SELECT clause.
+			 * @param string           $join Prepared JOIN clause.
+			 * @param string           $where Prepared WHERE clause.
+			 * @param string           $groupby Prepared GROUP BY clause.
+			 */
+			$this->count_sql = apply_filters_ref_array( 'woocommerce_orders_table_query_count_sql', array( $this->count_sql, &$this, $this->args, $fields, $join, $where, $groupby ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -919,6 +919,23 @@ class OrdersTableQuery {
 		}
 		$orders_table    = $this->tables['orders'];
 		$this->count_sql = "SELECT COUNT(DISTINCT $fields) FROM  $orders_table $join WHERE $where";
+
+		if ( ! $this->suppress_filters ) {
+		    /**
+		     * Filters the count SQL query.
+		     *
+		     * @since x.x.x
+		     *
+		     * @param string           $sql   The count SQL query.
+		     * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
+		     * @param array 		   $args  Query args.
+		     * @param string 		   $fields Prepared fields for SELECT clause.
+		     * @param string 		   $join Prepared JOIN clause.
+		     * @param string 		   $where Prepared WHERE clause.
+		     * @param string 		   $groupby Prepared GROUP BY clause.	
+		     */
+		    $this->count_sql = apply_filters_ref_array( 'woocommerce_orders_table_query_count_sql', array( $this->count_sql, &$this, $this->args, $fields, $join, $where, $groupby ) );
+		}		
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -924,7 +924,7 @@ class OrdersTableQuery {
 			/**
 			 * Filters the count SQL query.
 			 *
-			 * @since x.x.x
+			 * @since 8.6.0
 			 *
 			 * @param string           $sql   The count SQL query.
 			 * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43813 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Since there are multiple filters added in the PR, we will test them separately.

All of the test should have HPOS authoritative.

### For `woocommerce_before_' . $this->order_type . '_list_table_view_links`
1. Add this code snippet to trigger the filter:
```php
add_filter( 'woocommerce_before_shop_order_list_table_view_links', function () {
	return array('test' => 'Filter is overriding all pages link.');
});
```
2. Go to `/wp-admin/admin.php?page=wc-orders`. Instead of link to different sub pages, you will see a line `Filter is overriding all pages link.` like so:
<img width="762" alt="Screenshot 2024-01-25 at 1 54 29 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/88b3454a-d5f1-4267-b38b-180eb7ebf73d">

### For `_should_render_blank_state` filter:
0. Make sure you have at least one order in the test site.
1. Add this snippet to trigger the filter:
```php
add_filter( 'woocommerce_shop_order_list_table_should_render_blank_state', '__return_true' );
```
2. Go to `/wp-admin/admin.php?page=wc-orders`, you will see a blank order screen, as if there are no orders in the site at all.

### For `_list_table_disable_months_filter`:
1. Remove both the snippets added in the above steps to restore normal functioning.
2. Add the following snippet to disable the months filter:
```php
add_filter('woocommerce_shop_order_list_table_disable_months_filter', '__return_true');
```
3. Go to `/wp-admin/admin.php?page=wc-orders`. You will see that months filter is not added to UX any more like so:
<img width="804" alt="Screenshot 2024-01-25 at 2 01 23 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/86b1fd44-f5e1-4ca1-b4ea-8cd0a2ffa561">

### For `woocommerce_orders_table_query_count_sql` filter:
1. Add the following snippet to trigger, this snippet will force the order count to always return 32
```php
add_filter( 'woocommerce_orders_table_query_count_sql', function () {
	return 'SELECT 32 FROM dual';
});
```
2. Go to `/wp-admin/admin.php?page=wc-orders`., and see the order count listed. It should be 32 regardless of the number of orders there in the site like so:

<img width="335" alt="Screenshot 2024-01-25 at 2 07 22 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/fb3cd5ac-1a83-49d3-9217-829ab5c27217">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
