### PR TITLE
correct the command for generating the docs manifest

### DIFF
--- a/docs/contributing-docs/contributing-docs.md
+++ b/docs/contributing-docs/contributing-docs.md
@@ -121,7 +121,7 @@ You don't need to regenerate the manifest if you only make changes to a page's c
 These instructions presume you're currently have your `docs/` branch open and you've made your required changes to any files.
 
 1. In your command line, navigate to your repo's folder.
-2. Run `pnpm utils md-docs create docs woocommerce -o docs/manifest.json`.
+2. Run `pnpm utils md-docs create docs woocommerce -o docs/docs-manifest.json`.
 3. The `docs-manifest.json` file in the `/docs` folder of your repo will be updated. Verify that the changes to the manifest reflect the changes that you made to the docs.
 
 If you are a non-technical contributor who isn't experienced with command line tools, we're still happy to receive your contributions. If you're unable to include an updated manifest, please ensure that you mention this in your pull request's description.


### PR DESCRIPTION

### Changes proposed in this Pull Request:

The contributing docs doc was updated in #43802. I had misquoted the command to generate to docs manifest. This PR updates it to the correct command.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm utils md-docs create docs woocommerce -o docs/docs-manifest.json` in the root of the repo
2. Run `ls -l docs/docs-manifest.json`
3. the datestamp on the file should be the current time

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
