### PR TITLE
Fix description toolbar with latest GB version

### DIFF
--- a/packages/js/product-editor/changelog/fix-43676_description_toolbar
+++ b/packages/js/product-editor/changelog/fix-43676_description_toolbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix header toolbar in iframe modal editor to have block toolbar render correctly with latest Gutenberg and WP version.

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -70,6 +70,7 @@
 		"@wordpress/keycodes": "wp-6.0",
 		"@wordpress/media-utils": "wp-6.0",
 		"@wordpress/plugins": "wp-6.0",
+		"@wordpress/preferences": "wp-6.0",
 		"@wordpress/url": "wp-6.0",
 		"classnames": "^2.3.2",
 		"dompurify": "^2.4.7",

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -29,6 +29,56 @@
 
 	&-left {
 		padding-left: $gap-small;
+		align-items: center;
+		display: flex;
+
+		.woocommerce-iframe-editor-document-tools {
+			padding-right: $gap-smaller;
+			margin-right: $gap-smaller;
+		}
+
+		.selected-block-tools-wrapper {
+			overflow-x: hidden;
+			display: flex;
+
+			.block-editor-block-contextual-toolbar {
+				border-bottom: 0;
+			}
+
+			&::after {
+				content: "";
+				width: $border-width;
+				margin-top: $grid-unit + $grid-unit-05;
+				margin-bottom: $grid-unit + $grid-unit-05;
+				background-color: $gray-300;
+				margin-left: $grid-unit;
+			}
+
+			// Modified group borders.
+			.components-toolbar-group,
+			.components-toolbar {
+				border-right: none;
+
+				&::after {
+					content: "";
+					width: $border-width;
+					margin-top: $grid-unit + $grid-unit-05;
+					margin-bottom: $grid-unit + $grid-unit-05;
+					background-color: $gray-300;
+					margin-left: $grid-unit;
+				}
+
+				& .components-toolbar-group.components-toolbar-group {
+					&::after {
+						display: none;
+					}
+				}
+			}
+
+			&.is-collapsed {
+				display: none;
+			}
+		}
 	}
 	&-right {
 		display: flex;

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -12,6 +12,7 @@ import {
 	useContext,
 	useState,
 	Fragment,
+	useEffect,
 } from '@wordpress/element';
 import { MouseEvent } from 'react';
 import {
@@ -106,43 +107,51 @@ export function HeaderToolbar( {
 		}
 	}, [ isInserterOpened, setIsInserterOpened ] );
 
+	useEffect( () => {
+		// If we have a new block selection, show the block tools
+		if ( hasBlockSelection ) {
+			setIsBlockToolsCollapsed( false );
+		}
+	}, [ hasBlockSelection ] );
+
 	return (
 		<NavigableToolbar
 			className="woocommerce-iframe-editor__header-toolbar"
 			aria-label={ toolbarAriaLabel }
 		>
 			<div className="woocommerce-iframe-editor__header-toolbar-left">
-				<ToolbarItem
-					ref={ inserterButton }
-					as={ Button }
-					className="woocommerce-iframe-editor__header-toolbar-inserter-toggle"
-					variant="primary"
-					isPressed={ isInserterOpened }
-					onMouseDown={ (
-						event: MouseEvent< HTMLButtonElement >
-					) => {
-						event.preventDefault();
-					} }
-					onClick={ toggleInserter }
-					disabled={ ! isInserterEnabled }
-					icon={ plus }
-					label={
-						! isInserterOpened
-							? __( 'Add', 'woocommerce' )
-							: __( 'Close', 'woocommerce' )
-					}
-					showTooltip
-				/>
-				{ isLargeViewport && (
+				<div className="woocommerce-iframe-editor-document-tools">
 					<ToolbarItem
-						as={ ToolSelector }
-						disabled={ isTextModeEnabled }
+						ref={ inserterButton }
+						as={ Button }
+						className="woocommerce-iframe-editor__header-toolbar-inserter-toggle"
+						variant="primary"
+						isPressed={ isInserterOpened }
+						onMouseDown={ (
+							event: MouseEvent< HTMLButtonElement >
+						) => {
+							event.preventDefault();
+						} }
+						onClick={ toggleInserter }
+						disabled={ ! isInserterEnabled }
+						icon={ plus }
+						label={
+							! isInserterOpened
+								? __( 'Add', 'woocommerce' )
+								: __( 'Close', 'woocommerce' )
+						}
+						showTooltip
 					/>
-				) }
-				<ToolbarItem as={ EditorHistoryUndo } />
-				<ToolbarItem as={ EditorHistoryRedo } />
-				<ToolbarItem as={ DocumentOverview } />
-
+					{ isLargeViewport && (
+						<ToolbarItem
+							as={ ToolSelector }
+							disabled={ isTextModeEnabled }
+						/>
+					) }
+					<ToolbarItem as={ EditorHistoryUndo } />
+					<ToolbarItem as={ EditorHistoryRedo } />
+					<ToolbarItem as={ DocumentOverview } />
+				</div>
 				{ hasFixedToolbar && isLargeViewport && (
 					<>
 						<div

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -14,23 +14,28 @@ import {
 	Fragment,
 	useEffect,
 } from '@wordpress/element';
+import { isWpVersion } from '@woocommerce/settings';
+import classnames from 'classnames';
 import { MouseEvent } from 'react';
+import {
+	Button,
+	Popover,
+	/* @ts-expect-error missing types. */
+	ToolbarItem,
+} from '@wordpress/components';
+// eslint-disable-next-line @woocommerce/dependency-group
+import {
+	store as preferencesStore,
+	/* @ts-expect-error missing types. */
+} from '@wordpress/preferences';
+// eslint-disable-next-line @woocommerce/dependency-group
 import {
 	NavigableToolbar,
 	store as blockEditorStore,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore ToolSelector exists in WordPress components.
+	// @ts-expect-error ToolSelector exists in WordPress components.
 	ToolSelector,
 	BlockToolbar,
 } from '@wordpress/block-editor';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore ToolbarItem exists in WordPress components.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { Button, Popover, ToolbarItem } from '@wordpress/components';
-// @ts-expect-error missing types.
-import { store as preferencesStore } from '@wordpress/preferences';
-import { isWpVersion } from '@woocommerce/settings';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -29,6 +29,8 @@ import {
 import { Button, Popover, ToolbarItem } from '@wordpress/components';
 // @ts-expect-error missing types.
 import { store as preferencesStore } from '@wordpress/preferences';
+import { isWpVersion } from '@woocommerce/settings';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -39,7 +41,7 @@ import EditorHistoryUndo from './editor-history-undo';
 import { DocumentOverview } from './document-overview';
 import { ShowBlockInspectorPanel } from './show-block-inspector-panel';
 import { MoreMenu } from './more-menu';
-import classnames from 'classnames';
+import { getGutenbergVersion } from '../../../utils/get-gutenberg-version';
 
 type HeaderToolbarProps = {
 	onSave?: () => void;
@@ -114,6 +116,9 @@ export function HeaderToolbar( {
 		}
 	}, [ hasBlockSelection ] );
 
+	const renderBlockToolbar =
+		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.4;
+
 	return (
 		<NavigableToolbar
 			className="woocommerce-iframe-editor__header-toolbar"
@@ -152,7 +157,7 @@ export function HeaderToolbar( {
 					<ToolbarItem as={ EditorHistoryRedo } />
 					<ToolbarItem as={ DocumentOverview } />
 				</div>
-				{ hasFixedToolbar && isLargeViewport && (
+				{ hasFixedToolbar && isLargeViewport && renderBlockToolbar && (
 					<>
 						<div
 							className={ classnames(

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -117,7 +117,7 @@ export function HeaderToolbar( {
 	}, [ hasBlockSelection ] );
 
 	const renderBlockToolbar =
-		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.4;
+		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.3;
 
 	return (
 		<NavigableToolbar

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { createElement, Fragment } from '@wordpress/element';
+import { isWpVersion } from '@woocommerce/settings';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -11,12 +12,17 @@ import { MoreMenuDropdown } from '@wordpress/interface';
  * Internal dependencies
  */
 import { ToolsMenuGroup } from './tools-menu-group';
+import { WritingMenu } from '../writing-menu';
+import { getGutenbergVersion } from '../../../../utils/get-gutenberg-version';
 
 export const MoreMenu = () => {
+	const renderBlockToolbar =
+		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.3;
 	return (
 		<MoreMenuDropdown>
 			{ () => (
 				<>
+					{ renderBlockToolbar && <WritingMenu /> }
 					<ToolsMenuGroup />
 				</>
 			) }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/writing-menu/index.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/writing-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './writing-menu';

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/writing-menu/writing-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/writing-menu/writing-menu.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { MenuGroup } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+import { useViewportMatch } from '@wordpress/compose';
+import { createElement } from '@wordpress/element';
+import {
+	PreferenceToggleMenuItem,
+	store as preferencesStore,
+	// @ts-expect-error missing types.
+} from '@wordpress/preferences';
+
+export function WritingMenu() {
+	// @ts-expect-error missing types.
+	const { set: setPreference } = useDispatch( preferencesStore );
+
+	const turnOffDistractionFree = () => {
+		setPreference( 'core', 'distractionFree', false );
+	};
+
+	const isLargeViewport = useViewportMatch( 'medium' );
+	if ( ! isLargeViewport ) {
+		return null;
+	}
+
+	return (
+		<MenuGroup label={ __( 'View', 'woocommerce' ) }>
+			<PreferenceToggleMenuItem
+				scope="core"
+				name="fixedToolbar"
+				onToggle={ turnOffDistractionFree }
+				label={ __( 'Top toolbar', 'woocommerce' ) }
+				info={ __(
+					'Access all block and document tools in a single place',
+					'woocommerce'
+				) }
+				messageActivated={ __(
+					'Top toolbar activated',
+					'woocommerce'
+				) }
+				messageDeactivated={ __(
+					'Top toolbar deactivated',
+					'woocommerce'
+				) }
+			/>
+		</MenuGroup>
+	);
+}

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/writing-menu/writing-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/writing-menu/writing-menu.tsx
@@ -3,7 +3,7 @@
  */
 import { useDispatch } from '@wordpress/data';
 import { MenuGroup } from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { createElement } from '@wordpress/element';
 import {

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
@@ -24,11 +24,15 @@
 		box-sizing: border-box;
 		flex-grow: 1;
 		background-color: #2f2f2f;
-		padding: 90px 48px 40px;
+		padding: 40px 48px;
 		height: 100%;
 		justify-content: center;
 		display: flex;
 		position: relative;
+
+		&.old-fixed-toolbar-shown {
+			padding: 90px 48px 40px;
+		}
 	}
 
 	&__content-inserter-clipper {

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -22,6 +22,8 @@ import {
 	// @ts-ignore
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import classNames from 'classnames';
+import { isWpVersion } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -34,6 +36,7 @@ import { ResizableEditor } from './resizable-editor';
 import { SecondarySidebar } from './secondary-sidebar/secondary-sidebar';
 import { useEditorHistory } from './hooks/use-editor-history';
 import { store as productEditorUiStore } from '../../store/product-editor-ui';
+import { getGutenbergVersion } from '../../utils/get-gutenberg-version';
 
 type IframeEditorProps = {
 	initialBlocks?: BlockInstance[];
@@ -116,6 +119,9 @@ export function IframeEditor( {
 
 	const settings = __settings || parentEditorSettings;
 
+	const inlineFixedBlockToolbar =
+		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.4;
+
 	return (
 		<div className="woocommerce-iframe-editor">
 			<EditorContext.Provider
@@ -135,7 +141,8 @@ export function IframeEditor( {
 				<BlockEditorProvider
 					settings={ {
 						...settings,
-						hasFixedToolbar,
+						hasFixedToolbar:
+							hasFixedToolbar || ! inlineFixedBlockToolbar,
 						templateLock: false,
 					} }
 					value={ blocks }
@@ -170,7 +177,14 @@ export function IframeEditor( {
 					<div className="woocommerce-iframe-editor__main">
 						<SecondarySidebar />
 						<BlockTools
-							className={ 'woocommerce-iframe-editor__content' }
+							className={ classNames(
+								'woocommerce-iframe-editor__content',
+								{
+									'old-fixed-toolbar-shown':
+										! inlineFixedBlockToolbar &&
+										hasFixedToolbar,
+								}
+							) }
 							onClick={ (
 								event: React.MouseEvent<
 									HTMLDivElement,

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -93,13 +93,18 @@ export function IframeEditor( {
 	const { clearSelectedBlock, updateSettings } =
 		useDispatch( blockEditorStore );
 
-	// @ts-ignore No types for this exist yet.
-	const { setDefaults } = useDispatch( preferencesStore );
-
 	const parentEditorSettings = useSelect( ( select ) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		return select( blockEditorStore ).getSettings();
+	}, [] );
+
+	const { hasFixedToolbar } = useSelect( ( select ) => {
+		// @ts-expect-error These selectors are available in the block data store.
+		const { get: getPreference } = select( preferencesStore );
+		return {
+			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
+		};
 	}, [] );
 
 	useEffect( () => {
@@ -107,10 +112,6 @@ export function IframeEditor( {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		updateSettings( productBlockEditorSettings );
-
-		setDefaults( 'core', {
-			fixedToolbar: true,
-		} );
 	}, [] );
 
 	const settings = __settings || parentEditorSettings;
@@ -134,7 +135,7 @@ export function IframeEditor( {
 				<BlockEditorProvider
 					settings={ {
 						...settings,
-						hasFixedToolbar: true,
+						hasFixedToolbar,
 						templateLock: false,
 					} }
 					value={ blocks }

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -6,6 +6,8 @@ import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
+// @ts-ignore No types for this exist yet.
+import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	BlockEditorProvider,
 	BlockInspector,
@@ -91,6 +93,9 @@ export function IframeEditor( {
 	const { clearSelectedBlock, updateSettings } =
 		useDispatch( blockEditorStore );
 
+	// @ts-ignore No types for this exist yet.
+	const { setDefaults } = useDispatch( preferencesStore );
+
 	const parentEditorSettings = useSelect( ( select ) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
@@ -102,6 +107,10 @@ export function IframeEditor( {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		updateSettings( productBlockEditorSettings );
+
+		setDefaults( 'core', {
+			fixedToolbar: true,
+		} );
 	}, [] );
 
 	const settings = __settings || parentEditorSettings;

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -6,8 +6,13 @@ import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
-// @ts-ignore No types for this exist yet.
-import { store as preferencesStore } from '@wordpress/preferences';
+import classNames from 'classnames';
+import { isWpVersion } from '@woocommerce/settings';
+import {
+	store as preferencesStore,
+	// @ts-expect-error No types for this exist yet.
+} from '@wordpress/preferences';
+// eslint-disable-next-line @woocommerce/dependency-group
 import {
 	BlockEditorProvider,
 	BlockInspector,
@@ -22,8 +27,6 @@ import {
 	// @ts-ignore
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import classNames from 'classnames';
-import { isWpVersion } from '@woocommerce/settings';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -181,8 +181,7 @@ export function IframeEditor( {
 								'woocommerce-iframe-editor__content',
 								{
 									'old-fixed-toolbar-shown':
-										! inlineFixedBlockToolbar &&
-										hasFixedToolbar,
+										! inlineFixedBlockToolbar,
 								}
 							) }
 							onClick={ (

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -120,7 +120,7 @@ export function IframeEditor( {
 	const settings = __settings || parentEditorSettings;
 
 	const inlineFixedBlockToolbar =
-		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.4;
+		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.3;
 
 	return (
 		<div className="woocommerce-iframe-editor">

--- a/packages/js/product-editor/src/utils/get-gutenberg-version.ts
+++ b/packages/js/product-editor/src/utils/get-gutenberg-version.ts
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings';
+
+export function getGutenbergVersion() {
+	const adminSettings: { gutenberg_version?: string } = getSetting( 'admin' );
+	if ( adminSettings.gutenberg_version ) {
+		return parseFloat( adminSettings?.gutenberg_version );
+	}
+	return 0;
+}

--- a/packages/js/product-editor/typings/index.d.ts
+++ b/packages/js/product-editor/typings/index.d.ts
@@ -6,6 +6,10 @@ declare module '@woocommerce/settings' {
 		filter = ( val: unknown, fb: unknown ) =>
 			typeof val !== 'undefined' ? val : fb
 	): T;
+	export declare function isWpVersion(
+		version: string,
+		operator: '>' | '>=' | '=' | '<' | '<='
+	): boolean;
 }
 
 declare module '@wordpress/core-data' {

--- a/plugins/woocommerce/changelog/fix-43676_description_toolbar
+++ b/plugins/woocommerce/changelog/fix-43676_description_toolbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Update admin gutenberg_version setting to more accurately retrieve the Gutenberg version.

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -240,7 +240,19 @@ class Settings {
 
 		$settings['isWooPayEligible'] = WCPayPromotionInit::is_woopay_eligible();
 
-		$settings['gutenberg_version'] = defined( 'GUTENBERG_VERSION' ) ? constant( 'GUTENBERG_VERSION' ) : 0;
+		$has_gutenberg             = is_plugin_active( 'gutenberg/gutenberg.php' );
+		$gutenberg_version = '';
+		if ( $has_gutenberg ) {
+			if ( defined( 'GUTENBERG_VERSION' ) ) {
+				$gutenberg_version = GUTENBERG_VERSION;
+			}
+
+			if ( ! $gutenberg_version ) {
+				$gutenberg_data    = get_plugin_data( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
+				$gutenberg_version = $gutenberg_data['Version'];
+			}
+		}
+		$settings['gutenberg_version'] = $has_gutenberg ? $gutenberg_version : 0;
 
 		return $settings;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -240,7 +240,7 @@ class Settings {
 
 		$settings['isWooPayEligible'] = WCPayPromotionInit::is_woopay_eligible();
 
-		$has_gutenberg             = is_plugin_active( 'gutenberg/gutenberg.php' );
+		$has_gutenberg     = is_plugin_active( 'gutenberg/gutenberg.php' );
 		$gutenberg_version = '';
 		if ( $has_gutenberg ) {
 			if ( defined( 'GUTENBERG_VERSION' ) ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2633,6 +2633,9 @@ importers:
       '@wordpress/plugins':
         specifier: wp-6.0
         version: 4.4.3(react@17.0.2)
+      '@wordpress/preferences':
+        specifier: wp-6.0
+        version: 1.2.5(@types/react@17.0.71)(react-dom@17.0.2)(react-with-direction@1.4.0)(react@17.0.2)
       '@wordpress/url':
         specifier: wp-6.0
         version: 3.7.1
@@ -5686,24 +5689,6 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  /@babel/helper-create-class-features-plugin@7.23.5(@babel/core@7.23.2):
-    resolution: {integrity: sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-    dev: true
-
   /@babel/helper-create-class-features-plugin@7.23.5(@babel/core@7.23.5):
     resolution: {integrity: sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==}
     engines: {node: '>=6.9.0'}
@@ -6310,7 +6295,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.23.2)
+      '@babel/helper-create-class-features-plugin': 7.23.6(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -24186,7 +24171,7 @@ packages:
     peerDependencies:
       react: ^17.0.2
     dependencies:
-      '@babel/runtime': 7.23.5
+      '@babel/runtime': 7.23.6
       '@wordpress/data': 6.6.1(react@17.0.2)
       '@wordpress/element': 4.4.1
       '@wordpress/keycodes': 3.6.1
@@ -24494,11 +24479,11 @@ packages:
       react: ^17.0.2
       react-dom: ^17.0.0
     dependencies:
-      '@babel/runtime': 7.23.5
+      '@babel/runtime': 7.23.6
       '@wordpress/a11y': 3.6.1
       '@wordpress/components': 19.17.0(@types/react@17.0.71)(react-dom@17.0.2)(react-with-direction@1.4.0)(react@17.0.2)
       '@wordpress/data': 6.6.1(react@17.0.2)
-      '@wordpress/i18n': 4.6.1
+      '@wordpress/i18n': 4.47.0
       '@wordpress/icons': 8.4.0
       classnames: 2.3.2
       react: 17.0.2
@@ -46937,7 +46922,6 @@ packages:
       react-is: 16.13.1
       scheduler: 0.19.1
     dev: true
-    bundledDependencies: false
 
   /react-test-renderer@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes use of the new `BlockToolbar` introduced as part of this GB PR: https://github.com/WordPress/gutenberg/pull/55787 & https://github.com/WordPress/gutenberg/pull/56335
In order to accomplish backwards compatibility I had to add some checks for both GB and WP versions, as there was no alternative way of doing this.

Closes #43676 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and enable the new product editor under **Settings > Advanced > Features**
2. Make sure Gutenberg plugin is **not** enabled
3. Go to **Products > Add New** or edit an existing standard product
4. Scroll down to Description field, click the text field and click **Full Editor**
5. Highlight a block the block toolbar should show up in the header as a separate bar
6. Now in a separate tab go to **Posts > Add new post** click the 3 dot menu in the top right and toggle the **Top toolbar** setting
7. Go back to your product editor page, refresh it and open the description block editor again.
8. Click on a block inside the editor, the toolbar should still show as fixed.
9. Now activate/install the latest version of Gutenberg
10. Go back to the **posts** editor and see make sure the **Top toolbar** is selected.
11. Go to your product editor tab and refresh the page and load the description block editor again
12. Select a block and notice how the toolbar now shows inline with the other action menus in the header ( it should look identical to the posts editor toolbar )
13. The toolbar should reflect the different selected blocks
14. Now click the 3 dot menu in the top right and notice the new `Top toolbar` option ( unselect it )
15. Notice when you unselect it it the toolbar renders correctly inline within the description block editor
16. Now go to your **posts** editor tab and refresh it, the toolbar should now also show inline here and reflect the same option as the post editor. If you toggle the one in posts and refresh the product description editor it should also be reflected there.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
