### PR TITLE
Send store address data to the obw subscribe endpoint

### DIFF
--- a/plugins/woocommerce/changelog/43848-update-mailchimp-sync-country
+++ b/plugins/woocommerce/changelog/43848-update-mailchimp-sync-country
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Send store address data to the obw subscribe endpoint

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/MailchimpScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/MailchimpScheduler.php
@@ -64,18 +64,21 @@ class MailchimpScheduler {
 			return false;
 		}
 
-		$country_code  = WC()->countries->get_base_country();
-		$store_country = WC()->countries->country_exists( $country_code ) ? WC()->countries->countries[ $country_code ] : '';
+		$country_code = WC()->countries->get_base_country();
+		$country_name = WC()->countries->countries[ $country_code ] ?? 'N/A';
+
+		$state      = WC()->countries->get_base_state();
+		$state_name = WC()->countries->states[ $country_code ][ $state ] ?? 'N/A';
 
 		$address = array(
-			// Setting N/A for addr1, city, state, and zipcode as they are
+			// Setting N/A for addr1, city, state, zipcode and country as they are
 			// required fields. Setting '' doesn't work.
 			'addr1'   => 'N/A',
 			'addr2'   => '',
 			'city'    => 'N/A',
-			'state'   => 'N/A',
+			'state'   => $state_name,
 			'zip'     => 'N/A',
-			'country' => $store_country,
+			'country' => $country_name,
 		);
 
 		$response = $this->make_request( $profile_data['store_email'], $address );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/pull/19375.

When running MailchimpScheduler, include the store country full name and state name to the API

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Follow the instructions in https://github.com/Automattic/woocommerce.com/pull/19375 to set up local wccom if it is not merged yet


1. Use a fresh site or run `wp option delete woocommerce_onboarding_subscribed_to_mailchimp` 
2. Set `define( 'WP_ENVIRONMENT_TYPE', 'development' );` in your `wp-config.php` (Required only if https://github.com/Automattic/woocommerce.com/pull/19375 is not merged)
3. Go to Core Profiler
4. Choose `Australia — New South Wales` as store country
5. Go to `Tell us a bit about your store` Step
6. Fill an email address that is not yet subscribed to Mailchimp 
7. Opt-in to marketing
8. Complete Core Profiler
9. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper > Tools
10. Click on `Run wc_admin_daily job`
11. Wait for job to be completed
12. Run Mailchimp list member API command (Get the command from https://github.com/Automattic/woocommerce.com/pull/19375)
13. Confirm `ADDRESS` field is set like blew (it seems that Mailchimp automatically convert full country name to country code.
```
  "merge_fields": {
    "FNAME": "",
    "LNAME": "",
    "ADDRESS": {
      "addr1": "N/A",
      "addr2": "",
      "city": "N/A",
      "state": "New South Wales",
      "zip": "N/A",
      "country": "AU"
    },
    "PHONE": "",
    "BIRTHDAY": ""
  },
```
15. Now login to [Klaviyo](https://www.klaviyo.com/dashboard) using credentials from secret store (secret_id 11466)
16. Go to https://www.klaviyo.com/people
17. Confirm the contact is added and that the country/state was recorded 
18. Please test around this issue. 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Send store address data to the obw subscribe endpoint

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
