### PR TITLE
Improve the logging/noticing of Legacy REST API usages

### DIFF
--- a/plugins/woocommerce/changelog/43851-improve-legacy-rest-api-usage-logging
+++ b/plugins/woocommerce/changelog/43851-improve-legacy-rest-api-usage-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve the logging/noticing of Legacy REST API usages

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -149,7 +149,7 @@ class WC_Admin_Notices {
 					// translators: Placeholders are URLs.
 						wpautop( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. <a target="_blank" href="%2$s">A separate WooCommerce extension is available</a> to keep it enabled. <b><a target="_blank" href="%3$s">Learn more about this change.</a></b>', 'woocommerce' ) ),
 						admin_url( 'admin.php?page=wc-settings&tab=advanced&section=legacy_api' ),
-                        'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
+						'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
 						'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 					)
 				)
@@ -169,8 +169,8 @@ class WC_Admin_Notices {
 					// translators: Placeholders are URLs.
 						wpautop( __( 'The WooCommerce Legacy REST API will be removed in WooCommerce 9.0, and this will cause <a href="%1$s">webhooks on this site that are configured to use the Legacy REST API</a> to stop working. <a target="_blank" href="%2$s">A separate WooCommerce extension is available</a> to allow these webhooks to keep using the Legacy REST API without interruption. You can also edit these webhooks to use the current REST API version to generate the payload instead. <b><a target="_blank" href="%3$s">Learn more about this change.</a></b>', 'woocommerce' ) ),
 						admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks&legacy=true' ),
-                        'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
-                        'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
+						'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
+						'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 					)
 				)
 			);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -147,8 +147,9 @@ class WC_Admin_Notices {
 					),
 					sprintf(
 					// translators: Placeholders are URLs.
-						wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to keep it enabled. <b><a target="_blank" href="%2$s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
+						wpautop( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. <a target="_blank" href="%2$s">A separate WooCommerce extension is available</a> to keep it enabled. <b><a target="_blank" href="%3$s">Learn more about this change.</a></b>', 'woocommerce' ) ),
 						admin_url( 'admin.php?page=wc-settings&tab=advanced&section=legacy_api' ),
+                        'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
 						'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 					)
 				)
@@ -166,9 +167,10 @@ class WC_Admin_Notices {
 					),
 					sprintf(
 					// translators: Placeholders are URLs.
-						wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API will be removed in WooCommerce 9.0, and this will cause <a href="%1$s">webhooks on this site that are configured to use the Legacy REST API</a> to stop working. A separate WooCommerce extension will be available to allow these webhooks to keep using the Legacy REST API without interruption. You can also edit these webhooks to use the current REST API version to generate the payload instead. <b><a target="_blank" href="%2$s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
+						wpautop( __( 'The WooCommerce Legacy REST API will be removed in WooCommerce 9.0, and this will cause <a href="%1$s">webhooks on this site that are configured to use the Legacy REST API</a> to stop working. <a target="_blank" href="%2$s">A separate WooCommerce extension is available</a> to allow these webhooks to keep using the Legacy REST API without interruption. You can also edit these webhooks to use the current REST API version to generate the payload instead. <b><a target="_blank" href="%3$s">Learn more about this change.</a></b>', 'woocommerce' ) ),
 						admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks&legacy=true' ),
-						'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
+                        'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
+                        'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 					)
 				)
 			);

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -398,7 +398,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> <a target="_blank" href="%1$s">A separate WooCommerce extension is available</a> to keep it enabled. You can check Legacy REST API usages in <b><a target="_blank" href="%2$s">the WooCommerce log files</a></b> (file names start with <code>legacy_rest_api_usages</code>). <b><a target="_blank" href="%3$s">Learn more about this change.</a></b>',
 					'woocommerce'
 				),
-                'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
+				'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
 				admin_url( 'admin.php?page=wc-status&tab=logs' ),
 				'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 			);

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -395,9 +395,10 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			$enable_legacy_api_setting['desc_tip'] = sprintf(
 			// translators: Placeholders are URLs.
 				__(
-					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. You can check Legacy REST API usages in <b><a target="_blank" href="%1$s">the WooCommerce log files</a></b> (file names start with <code>legacy_rest_api_usages</code>). <b><a target="_blank" href="%2$s">Learn more about this change.</a></b>',
+					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> <a target="_blank" href="%1$s">A separate WooCommerce extension is available</a> to keep it enabled. You can check Legacy REST API usages in <b><a target="_blank" href="%2$s">the WooCommerce log files</a></b> (file names start with <code>legacy_rest_api_usages</code>). <b><a target="_blank" href="%3$s">Learn more about this change.</a></b>',
 					'woocommerce'
 				),
+                'https://wordpress.org/plugins/woocommerce-legacy-rest-api/',
 				admin_url( 'admin.php?page=wc-status&tab=logs' ),
 				'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 			);

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
@@ -116,7 +116,7 @@ class WC_Legacy_API {
 		if ( apply_filters( 'woocommerce_log_legacy_rest_api_usages', true ) ) {
             $info = 'Version: ' . WC_API_REQUEST_VERSION . ", Route: $route, User agent: $user_agent";
             $ip_address = WC_Geolocation::get_ip_address();
-            if('' !== $ip_address) {
+            if( '' !== $ip_address ) {
                 $info .= ", IP: $ip_address";
             }
 			wc_get_logger()->info( $info, array( 'source' => 'legacy_rest_api_usages' ) );

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
@@ -114,7 +114,12 @@ class WC_Legacy_API {
 		 * @since 8.5.0
 		 */
 		if ( apply_filters( 'woocommerce_log_legacy_rest_api_usages', true ) ) {
-			wc_get_logger()->info( 'Version: ' . WC_API_REQUEST_VERSION . ", Route: $route, User agent: $user_agent", array( 'source' => 'legacy_rest_api_usages' ) );
+            $info = 'Version: ' . WC_API_REQUEST_VERSION . ", Route: $route, User agent: $user_agent";
+            $ip_address = WC_Geolocation::get_ip_address();
+            if('' !== $ip_address) {
+                $info .= ", IP: $ip_address";
+            }
+			wc_get_logger()->info( $info, array( 'source' => 'legacy_rest_api_usages' ) );
 		}
 	}
 

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
@@ -114,6 +114,8 @@ class WC_Legacy_API {
 		 * @since 8.5.0
 		 */
 		if ( apply_filters( 'woocommerce_log_legacy_rest_api_usages', true ) ) {
+            $user_agent = sanitize_text_field( wp_unslash( $user_agent ) );
+            $route = sanitize_text_field( wp_unslash( $route ) );
             $info = 'Version: ' . WC_API_REQUEST_VERSION . ", Route: $route, User agent: $user_agent";
             $ip_address = WC_Geolocation::get_ip_address();
             if( '' !== $ip_address ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull request expands on https://github.com/woocommerce/woocommerce/pull/40535, https://github.com/woocommerce/woocommerce/pull/40866 and https://github.com/woocommerce/woocommerce/pull/41804 by adding the following improvements:

* Add the IP address of the requester to the generated log entries.

* Replace the "an extension will be available" text with "an extension is available", including a link to the extension in the WordPress.org plugins directory, in the usages detected notices and in the Legacy REST API settings page notices:

![image](https://github.com/woocommerce/woocommerce/assets/937723/192f2c65-dca3-4b4c-8b49-1bc3d61af6fc)

### How to test the changes in this Pull Request:

First, if you have tested the pull requests mentioned above, you'll probably have dismissed the relevant notices; you'll need to undo the dismissals first:

```
wp user meta delete <your user id> "dismissed_legacy_api_usages_detected_notice"
wp user meta delete <your user id> "dismissed_legacy_api_removed_in_woo_90_notice"
wp user meta delete <your user id> "dismissed_legacy_webhooks_unsupported_in_woo_90_notice"
```

If you have the separate Legacy REST API extension installed, you need to at least disable (or uninstall if you prefer) it.

Make sure to have the Legacy REST API activated in settings, and to have webhooks that depend on the Legacy REST API (see the testing instructions in the other pull requests welcome); and force the recreation of the notices: `wp eval 'WC_Admin_Notices::reset_admin_notices();'`

Now go to the Legacy REST API settings page, you should see three Legacy REST API warnings (two dismissable notices, and one paragraph under the setting, as in the screenshot above); verify that all the links in those work as expected.

Finally, repeat the testing instructions of https://github.com/woocommerce/woocommerce/pull/41804 and verify that the log entries contain the IP address of the requester.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Improve the logging/noticing of Legacy REST API usages

#### Comment

</details>
