### PR TITLE
Remove wp-data & wc-blocks-checkout dependencies from OA script

### DIFF
--- a/plugins/woocommerce/changelog/fix-43829-oa-blocks
+++ b/plugins/woocommerce/changelog/fix-43829-oa-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove wp-data & wc-blocks-checkout dependencies from Order Attribution script.

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -122,12 +122,10 @@
 		if (
 			window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function'
 		) {
+			// Update checkout block data once more if the checkout store was loaded after this script.
 			const unsubscribe = wp.data.subscribe( function () {
-				const checkoutDataStore = wp.data.select( CHECKOUT_STORE_KEY );
-				if ( undefined !== checkoutDataStore && checkoutDataStore.getOrderId() !== 0 ) {
-					unsubscribe();
-					updateCheckoutBlockData( getData() );
-				}
+				unsubscribe();
+				updateCheckoutBlockData( getData() );
 			}, CHECKOUT_STORE_KEY );
 		}
 	};

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -123,7 +123,7 @@
 			window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function'
 		) {
 			// Update checkout block data once more if the checkout store was loaded after this script.
-			const unsubscribe = wp.data.subscribe( function () {
+			const unsubscribe = window.wp.data.subscribe( function () {
 				unsubscribe();
 				updateCheckoutBlockData( getData() );
 			}, CHECKOUT_STORE_KEY );

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -118,9 +118,10 @@
 		if (
 			window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function'
 		) {
-			wp.data.subscribe( function () {
+			const unsubscribe = wp.data.subscribe( function () {
 				const checkoutDataStore = wp.data.select( 'wc/store/checkout' );
 				if ( undefined !== checkoutDataStore && checkoutDataStore.getOrderId() !== 0 ) {
+					unsubscribe();
 					updateCheckoutBlockData( getData() );
 				}
 			} );

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -110,5 +110,27 @@
 			previousInitCheckout && previousInitCheckout();
 		};
 	}
+	// Work around the lack of explicit script dependency for the checkout block.
+	// Conditionally, wait for and use 'wp-data' & 'wc-blocks-checkout.
+
+	// Wait for (async) block checkout initialization and set source values once loaded.
+	function eventuallyInitializeCheckoutBlock() {
+		if (
+			window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function'
+		) {
+			wp.data.subscribe( function () {
+				const checkoutDataStore = wp.data.select( 'wc/store/checkout' );
+				if ( undefined !== checkoutDataStore && checkoutDataStore.getOrderId() !== 0 ) {
+					updateCheckoutBlockData( getData() );
+				}
+			} );
+		}
+	};
+	// Wait for DOMContentLoaded to make sure wp.data is in place, if applicable for the page.
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", eventuallyInitializeCheckoutBlock);
+	} else {
+		eventuallyInitializeCheckoutBlock();
+	}
 
 }( window.wc_order_attribution ) );

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -8,6 +8,9 @@
 	const propertyAccessor = ( obj, path ) => path.split( '.' ).reduce( ( acc, part ) => acc && acc[ part ], obj );
 	const returnNull = () => null;
 
+	// Hardcode Checkout store key (`wc.wcBlocksData.CHECKOUT_STORE_KEY`), as we no longer have `wc-blocks-checkout` as a dependency.
+	const CHECKOUT_STORE_KEY = 'wc/store/checkout';
+
 	/**
 	 * Get the order attribution data.
 	 *
@@ -110,6 +113,7 @@
 			previousInitCheckout && previousInitCheckout();
 		};
 	}
+
 	// Work around the lack of explicit script dependency for the checkout block.
 	// Conditionally, wait for and use 'wp-data' & 'wc-blocks-checkout.
 
@@ -119,12 +123,12 @@
 			window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function'
 		) {
 			const unsubscribe = wp.data.subscribe( function () {
-				const checkoutDataStore = wp.data.select( 'wc/store/checkout' );
+				const checkoutDataStore = wp.data.select( CHECKOUT_STORE_KEY );
 				if ( undefined !== checkoutDataStore && checkoutDataStore.getOrderId() !== 0 ) {
 					unsubscribe();
 					updateCheckoutBlockData( getData() );
 				}
-			} );
+			}, CHECKOUT_STORE_KEY );
 		}
 	};
 	// Wait for DOMContentLoaded to make sure wp.data is in place, if applicable for the page.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -226,9 +226,10 @@ class OrderAttributionController implements RegisterHooksInterface {
 		wp_enqueue_script(
 			'wc-order-attribution',
 			plugins_url( "assets/js/frontend/order-attribution{$this->get_script_suffix()}.js", WC_PLUGIN_FILE ),
-			// Technically, we do not need 'wp-data', 'wc-blocks-checkout' for classic checkout,
-			// but we do not seem to distingush and load blocks scripts there anyway.
-			array( 'sourcebuster-js', 'wp-data', 'wc-blocks-checkout' ),
+			// Technically we do depend on 'wp-data', 'wc-blocks-checkout' for blocks checkout,
+			// but as implementing conditional dependency on the server-side would be too complex,
+			// we resolve this condition at the client-side.
+			array( 'sourcebuster-js' ),
 			Constants::get_constant( 'WC_VERSION' ),
 			true
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Remove wp-data & wc-blocks-checkout dependencies from OA script
   Resolve conditional dependency in JS.

Closes: https://github.com/woocommerce/woocommerce/issues/43829


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. (developer only) Check that order-attribution js does not have `'wp-data', 'wc-blocks-checkout'` as dependencies.
1. Check live site:
   1. Ensure the mini-cart block is removed from your header.
      ![image](https://github.com/woocommerce/woocommerce/assets/17435/606978de-6f2b-4e3d-a5e2-bf29283800de)

   2. Load the page and ensure the `wc-blocks-checkout` script is not loaded.
      Call from the browser dev tools `document.querySelector('script#wc-blocks-checkout-js')` - should return `null`
2. Check testing instructions for the following for the regression:
   1. https://github.com/woocommerce/woocommerce/pull/39701
   3. https://github.com/woocommerce/woocommerce/pull/43012
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>