### PR TITLE
Initialise customer sessions on the order pay page

### DIFF
--- a/plugins/woocommerce/changelog/43858-fix-23902-create-session-on-page-page
+++ b/plugins/woocommerce/changelog/43858-fix-23902-create-session-on-page-page
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix to ensure all customers have a session when visiting the order pay page.
+Ensure all customers have a session when visiting the order pay page.

--- a/plugins/woocommerce/changelog/43858-fix-23902-create-session-on-page-page
+++ b/plugins/woocommerce/changelog/43858-fix-23902-create-session-on-page-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix to ensure all customers have a session when visiting the order pay page.

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -71,6 +71,7 @@ class WC_Session_Handler extends WC_Session {
 		$this->init_session_cookie();
 
 		add_action( 'woocommerce_set_cart_cookies', array( $this, 'set_customer_session_cookie' ), 10 );
+		add_action( 'wp', array( $this, 'maybe_set_customer_session_cookie' ), 99 );
 		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
 
@@ -137,12 +138,24 @@ class WC_Session_Handler extends WC_Session {
 			return false;
 		}
 
-		// Session from a different user is not valid. (Although from a guest user will be valid)
+		// Session from a different user is not valid. (Although from a guest user will be valid).
 		if ( is_user_logged_in() && ! $this->is_customer_guest( $this->_customer_id ) && strval( get_current_user_id() ) !== $this->_customer_id ) {
 			return false;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Hooks into the wp action to maybe set the session cookie if the user is on a certain page e.g. a checkout endpoint.
+	 *
+	 * Certain gateways may rely on sessions and this ensures a session is present even if the customer does not have a
+	 * cart.
+	 */
+	public function maybe_set_customer_session_cookie() {
+		if ( is_wc_endpoint_url( 'order-pay' ) ) {
+			$this->set_customer_session_cookie( true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Logged-out customers only have a WooCommerce session initialised when they have a cart. Some pages, such as the order pay page, may require a session outside of the regular cart flow.

To negate the need for extensions to handle this case themselves, this PR sets the session on the order pay page.

Closes #23902 

Because I'm not certain what payment gateways/extensions need this, I tested using a small snippet instead to ensure a session was set. 

```php
add_action(
	'wp_head',
	function () {
		var_dump( WC()->session->get( 'test_session_data' ) );
	}
);
add_action(
	'wp_footer',
	function () {

		WC()->session->set( 'test_session_data', 'Hello' );
	}
);
```

This will output `Hello` in the header after refreshing the page only if a session is set. Otherwise it will show `NULL`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testers only need to test for regressions. Run through the checkout flow as a logged out guest user and ensure there are no errors.

**Developer testing**

1. Use the snippet above.
2. As a logged out guest with no cart (use private browser window if possible) visit the website. You should see `NULL` at the top of the page indicating there is no session.
3. Visit the pay page. It can be an invalid link, it doesn't matter. e.g. `https://store.local/checkout/order-pay/18/?pay_for_order=true&key=123);`
4. Now refresh or visit another page. See `hello` in the header instead of `null`. This means you now have a session.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix to ensure all customers have a session when visiting the order pay page.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
