### PR TITLE
Create a dedicated survey and tracking events for the CYS flow on core

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -52,6 +52,7 @@ import { AiOfflineModal } from '~/customize-store/assembler-hub/onboarding-tour/
 import { useQuery } from '@woocommerce/navigation';
 import { FlowType } from '../types';
 import { isOfflineAIFlow } from '../guards';
+import { isWooExpress } from '~/utils/is-woo-express';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
@@ -128,6 +129,7 @@ export const Layout = () => {
 					<Transitional
 						sendEvent={ sendEvent }
 						editor={ editor }
+						isWooExpress={ isWooExpress() }
 						isSurveyOpen={ isSurveyOpen }
 						setSurveyOpen={ setSurveyOpen }
 						hasCompleteSurvey={

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -59,7 +59,6 @@ export const Transitional = ( {
 	const showSurveyButton = ! hasCompleteSurvey;
 	const showAISurvey = isWooExpress && aiOnline;
 
-	console.log( { showSurveyButton, showAISurvey } );
 	return (
 		<div className="woocommerce-customize-store__transitional">
 			{ isSurveyOpen && (

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -56,12 +56,13 @@ export const Transitional = ( {
 		setSurveyOpen( false );
 	};
 
-	const showSurveyButton =
-		( ! hasCompleteSurvey && aiOnline ) || ! isWooExpress;
+	const showSurveyButton = ! hasCompleteSurvey;
+	const showAISurvey = isWooExpress && aiOnline;
 
+	console.log( { showSurveyButton, showAISurvey } );
 	return (
 		<div className="woocommerce-customize-store__transitional">
-			{ isSurveyOpen && aiOnline && (
+			{ isSurveyOpen && (
 				<Modal
 					title={ __( 'Share feedback', 'woocommerce' ) }
 					onRequestClose={ () => closeSurvey() }
@@ -69,7 +70,7 @@ export const Transitional = ( {
 					className="woocommerce-ai-survey-modal"
 				>
 					<SurveyForm
-						isWooExpress={ isWooExpress }
+						showAISurvey={ showAISurvey }
 						onSend={ () => {
 							sendEvent( {
 								type: 'COMPLETE_SURVEY',

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -37,6 +37,7 @@ export const Transitional = ( {
 	editor,
 	sendEvent,
 	hasCompleteSurvey,
+	isWooExpress,
 	isSurveyOpen,
 	setSurveyOpen,
 	aiOnline,
@@ -44,6 +45,7 @@ export const Transitional = ( {
 	editor: React.ReactNode;
 	sendEvent: ( event: events ) => void;
 	hasCompleteSurvey: boolean;
+	isWooExpress: boolean;
 	isSurveyOpen: boolean;
 	setSurveyOpen: ( isOpen: boolean ) => void;
 	aiOnline: boolean;
@@ -53,6 +55,9 @@ export const Transitional = ( {
 	const closeSurvey = () => {
 		setSurveyOpen( false );
 	};
+
+	const showSurveyButton =
+		( ! hasCompleteSurvey && aiOnline ) || ! isWooExpress;
 
 	return (
 		<div className="woocommerce-customize-store__transitional">
@@ -64,6 +69,7 @@ export const Transitional = ( {
 					className="woocommerce-ai-survey-modal"
 				>
 					<SurveyForm
+						isWooExpress={ isWooExpress }
 						onSend={ () => {
 							sendEvent( {
 								type: 'COMPLETE_SURVEY',
@@ -88,22 +94,29 @@ export const Transitional = ( {
 					{ __( 'Your store looks great!', 'woocommerce' ) }
 				</h1>
 				<h2 className="woocommerce-customize-store__transitional-subheading">
-					{ __(
-						"You're one step closer to launching your online business — we can't wait to see it come to life.",
-						'woocommerce'
-					) }
+					{ isWooExpress
+						? __(
+								"You're one step closer to launching your online business — we can't wait to see it come to life.",
+								'woocommerce'
+						  )
+						: __(
+								'Your store is a reflection of your unique style and personality, and we are thrilled to see it come to life.',
+								'woocommerce'
+						  ) }
 				</h2>
 
 				<div className="woocommerce-customize-store__transitional-main-actions">
 					<WooCYSSecondaryButtonSlot />
 
-					{ ! hasCompleteSurvey && aiOnline && (
+					{ showSurveyButton && (
 						<Button
 							className="woocommerce-customize-store__transitional-preview-button"
 							variant="secondary"
 							onClick={ () => {
 								recordEvent(
-									'customize_your_store_transitional_survey_click'
+									isWooExpress
+										? 'customize_your_store_transitional_survey_click'
+										: 'customize_your_store_on_core_transitional_survey_click'
 								);
 								setSurveyOpen( true );
 							} }

--- a/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
@@ -212,6 +212,11 @@
 		line-height: 16px; /* 123.077% */
 		margin-top: 0;
 		margin-bottom: 12px;
+
+		span {
+			color: #CC1818;
+			margin-left: 3px;
+		}
 	}
 
 	.woocommerce-survey-star-rating {

--- a/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
@@ -214,7 +214,7 @@
 		margin-bottom: 12px;
 
 		span {
-			color: #CC1818;
+			color: #cc1818;
 			margin-left: 3px;
 		}
 	}

--- a/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
@@ -60,9 +60,11 @@ const StarRating = ( {
 };
 
 export const SurveyForm = ( {
+	isWooExpress,
 	onSend,
 	closeFunction,
 }: {
+	isWooExpress: boolean;
 	onSend: () => void;
 	closeFunction: CloseSurveyFunction;
 } ): JSX.Element => {
@@ -76,7 +78,10 @@ export const SurveyForm = ( {
 	const [ rating, setRating ] = useState( 0 );
 
 	const sendData = () => {
-		recordEvent( 'customize_your_store_transitional_survey_complete', {
+		const surveyCompleteEvent = isWooExpress
+			? 'customize_your_store_transitional_survey_complete'
+			: 'customize_your_store_on_core_transitional_survey_complete';
+		recordEvent( surveyCompleteEvent, {
 			rating,
 			choose_streamline: isStreamlineChecked,
 			choose_dislike_themes: isDislikeThemesChecked,
@@ -119,16 +124,28 @@ export const SurveyForm = ( {
 				<hr />
 
 				<h4>
-					{ __(
-						'What motivated you to choose the “Design with AI” option?',
-						'woocommerce'
-					) }
+					{ isWooExpress
+						? __(
+								'What motivated you to choose the “Design with AI” option?',
+								'woocommerce'
+						  )
+						: __(
+								'What motivated you to choose the "Design your own theme" option?',
+								'woocommerce'
+						  ) }
 				</h4>
 				<CheckboxControl
-					label={ __(
-						'I wanted to see how AI could help me streamline the process.',
-						'woocommerce'
-					) }
+					label={
+						isWooExpress
+							? __(
+									'I wanted to see how AI could help me streamline the process.',
+									'woocommerce'
+							  )
+							: __(
+									'I wanted to design my own theme.',
+									'woocommerce'
+							  )
+					}
 					checked={ isStreamlineChecked }
 					onChange={ setStreamlineChecked }
 				/>
@@ -168,10 +185,15 @@ export const SurveyForm = ( {
 				/>
 
 				<h4>
-					{ __(
-						'Feel free to spill the beans here. All suggestions, feedback, or comments about the AI-generated store experience are welcome.',
-						'woocommerce'
-					) }
+					{ isWooExpress
+						? __(
+								'Feel free to spill the beans here. All suggestions, feedback, or comments about the AI-generated store experience are welcome.',
+								'woocommerce'
+						  )
+						: __(
+								'Feel free to spill the beans here. All suggestions, feedback, or comments about the "Design your own theme" experience are welcome.',
+								'woocommerce'
+						  ) }
 				</h4>
 				<TextareaControl
 					value={ spillBeansText }

--- a/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
@@ -77,6 +77,14 @@ export const SurveyForm = ( {
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
 	const [ rating, setRating ] = useState( 0 );
 
+	const disableSendButton =
+		rating === 0 ||
+		feedbackText === '' ||
+		( ! isStreamlineChecked &&
+			! isDislikeThemesChecked &&
+			! isThemeNoMatchChecked &&
+			! isOtherChecked );
+
 	const sendData = () => {
 		const surveyCompleteEvent = showAISurvey
 			? 'customize_your_store_transitional_survey_complete'
@@ -115,9 +123,10 @@ export const SurveyForm = ( {
 
 				<h4>
 					{ __(
-						'On a scale of 1 = difficult to 5 = very easy, how would you rate the overall experience? *',
+						'On a scale of 1 = difficult to 5 = very easy, how would you rate the overall experience?',
 						'woocommerce'
 					) }
+					<span>*</span>
 				</h4>
 				<StarRating value={ rating } onChange={ setRating } />
 
@@ -133,6 +142,7 @@ export const SurveyForm = ( {
 								'What motivated you to choose the "Design your own theme" option?',
 								'woocommerce'
 						  ) }
+					<span>*</span>
 				</h4>
 				<CheckboxControl
 					label={
@@ -151,7 +161,7 @@ export const SurveyForm = ( {
 				/>
 				<CheckboxControl
 					label={ __(
-						'I didn’t like any of the available themes.',
+						"I didn't like any of the available themes.",
 						'woocommerce'
 					) }
 					checked={ isDislikeThemesChecked }
@@ -159,7 +169,7 @@ export const SurveyForm = ( {
 				/>
 				<CheckboxControl
 					label={ __(
-						'I didn’t find a theme that matched my needs.',
+						"I didn't find a theme that matched my needs.",
 						'woocommerce'
 					) }
 					checked={ isThemeNoMatchChecked }
@@ -178,6 +188,7 @@ export const SurveyForm = ( {
 						'Did you find anything confusing, irrelevant, or not useful?',
 						'woocommerce'
 					) }
+					<span>*</span>
 				</h4>
 				<TextareaControl
 					value={ feedbackText }
@@ -212,7 +223,7 @@ export const SurveyForm = ( {
 					<Button
 						variant="primary"
 						onClick={ sendData }
-						disabled={ rating === 0 }
+						disabled={ disableSendButton }
 					>
 						{ __( 'Send', 'woocommerce' ) }
 					</Button>

--- a/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
@@ -60,11 +60,11 @@ const StarRating = ( {
 };
 
 export const SurveyForm = ( {
-	isWooExpress,
+	showAISurvey,
 	onSend,
 	closeFunction,
 }: {
-	isWooExpress: boolean;
+	showAISurvey: boolean;
 	onSend: () => void;
 	closeFunction: CloseSurveyFunction;
 } ): JSX.Element => {
@@ -78,7 +78,7 @@ export const SurveyForm = ( {
 	const [ rating, setRating ] = useState( 0 );
 
 	const sendData = () => {
-		const surveyCompleteEvent = isWooExpress
+		const surveyCompleteEvent = showAISurvey
 			? 'customize_your_store_transitional_survey_complete'
 			: 'customize_your_store_on_core_transitional_survey_complete';
 		recordEvent( surveyCompleteEvent, {
@@ -124,7 +124,7 @@ export const SurveyForm = ( {
 				<hr />
 
 				<h4>
-					{ isWooExpress
+					{ showAISurvey
 						? __(
 								'What motivated you to choose the “Design with AI” option?',
 								'woocommerce'
@@ -136,7 +136,7 @@ export const SurveyForm = ( {
 				</h4>
 				<CheckboxControl
 					label={
-						isWooExpress
+						showAISurvey
 							? __(
 									'I wanted to see how AI could help me streamline the process.',
 									'woocommerce'
@@ -185,7 +185,7 @@ export const SurveyForm = ( {
 				/>
 
 				<h4>
-					{ isWooExpress
+					{ showAISurvey
 						? __(
 								'Feel free to spill the beans here. All suggestions, feedback, or comments about the AI-generated store experience are welcome.',
 								'woocommerce'

--- a/plugins/woocommerce/changelog/43862-43667-update-survey-on-woo-core
+++ b/plugins/woocommerce/changelog/43862-43667-update-survey-on-woo-core
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Create a dedicated survey and tracking events for the CYS flow on core.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR:
- Changes the logic to show the survey button: it should always show unless the survey has already been completed.
- Updates the transitional page and survey copy when on Core or the AI is not available on WooExpress.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/43667

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Local/JN site**
1. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
2. Go to `WooCommerce > Home`, click on the `Start Customizing` button, finish the CYS process, and click on `Done` to go to the `transitional` page.
3. Make sure the copy looks like this 👇 and you see the `Share feedback` button.
![core](https://github.com/woocommerce/woocommerce/assets/186112/0461f843-c6b5-494d-abf6-44852c420d96)
4. Click on the `Share feedback` button and check the survey looks like this:
<img width="449" alt="surveycore" src="https://github.com/woocommerce/woocommerce/assets/186112/057f0f72-2102-4773-85b2-b63e1aad76b1">

5. Complete the survey with some test data and send it, make sure the `Share feedback` button disappears.

------------------------------------------------------------------------

**WooExpress site**
1. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
2. Go to `WooCommerce > Home`, click on the `Start Customizing` button, finish the CYS process, and click on `Done` to go to the `transitional` page.
3. Make sure the copy looks like this 👇 and you see the `Share feedback` button.
<img width="588" alt="express" src="https://github.com/woocommerce/woocommerce/assets/186112/bd596ab9-29cf-49c7-bb0a-c4a45b18f5ab">

4. Click on the `Share feedback` button and check the survey looks like this:
<img width="497" alt="Screenshot 2024-01-25 at 14 49 43" src="https://github.com/woocommerce/woocommerce/assets/186112/5a681374-fbec-49ab-a2ae-0fa5a3bb84fa">

5. Go back to `admin.php?page=wc-admin&path=%2Fcustomize-store`.
6. Open your browser's inspector and use Chrome's content override feature to change the content of `https://status.openai.com/api/v2/status.json` call. Change `status.indicator` to `major`.
7. Refresh the page, go through the process again, and click on `Done`.
8. Click on the `Share feedback` button and check the survey looks like the Core one:
<img width="449" alt="surveycore" src="https://github.com/woocommerce/woocommerce/assets/186112/057f0f72-2102-4773-85b2-b63e1aad76b1">

9. Complete the survey with some test data and send it, make sure the `Share feedback` button disappears.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Create a dedicated survey and tracking events for the CYS flow on core.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
