### PR TITLE
Hide Downloads section under Toggle

### DIFF
--- a/packages/js/product-editor/changelog/add-43807
+++ b/packages/js/product-editor/changelog/add-43807
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Fix margin top for none first child nested sections

--- a/packages/js/product-editor/src/blocks/generic/section/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/section/editor.scss
@@ -53,7 +53,9 @@
 		}
 
 		.wp-block-woocommerce-product-section {
-			margin-top: 0;
+			&:first-child {
+				margin-top: 0;
+			}
 			padding-bottom: 0;
 			border-bottom: none;
 		}
@@ -74,9 +76,15 @@
 		 * Core removes the "loading" animation styles
 		 * from the button when it's disabled, so we
 		 * let's add them back.
-		 */ 
+		 */
 		.components-button.is-tertiary.is-busy:disabled {
-			background-image: linear-gradient( -45deg, #fafafa 33%, #e0e0e0 0, #e0e0e0 70%, #fafafa 0 );
+			background-image: linear-gradient(
+				-45deg,
+				#fafafa 33%,
+				#e0e0e0 0,
+				#e0e0e0 70%,
+				#fafafa 0
+			);
 			background-size: 100px 100%;
 			opacity: 1;
 		}

--- a/plugins/woocommerce/changelog/add-43807
+++ b/plugins/woocommerce/changelog/add-43807
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Include downloads to show/hide the Downloads section

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -452,10 +452,37 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		);
 		// Downloads section.
 		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
-			$general_group->add_section(
+			$product_downloads_section_group = $general_group->add_section(
+				array(
+					'id'             => 'product-downloads-section-group',
+					'order'          => 50,
+					'attributes'     => array(
+						'blockGap' => 'unit-40',
+					),
+					'hideConditions' => array(
+						array(
+							'expression' => 'editedProduct.type !== "simple"',
+						),
+					),
+				)
+			);
+			
+			$product_downloads_section_group->add_block(
+				array(
+					'id'         => 'product-downloadable',
+					'blockName'  => 'woocommerce/product-checkbox-field',
+					'order'      => 10,
+					'attributes' => array(
+						'property' => 'downloadable',
+						'label'    => __( 'Include downloads', 'woocommerce'),
+					),
+				)
+			);
+
+			$product_downloads_section_group->add_section(
 				array(
 					'id'             => 'product-downloads-section',
-					'order'          => 50,
+					'order'          => 20,
 					'attributes'     => array(
 						'title'       => __( 'Downloads', 'woocommerce' ),
 						'description' => sprintf(
@@ -467,7 +494,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					),
 					'hideConditions' => array(
 						array(
-							'expression' => 'editedProduct.type !== "simple"',
+							'expression' => 'editedProduct.downloadable !== true',
 						),
 					),
 				)

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -466,7 +466,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					),
 				)
 			);
-			
+
 			$product_downloads_section_group->add_block(
 				array(
 					'id'         => 'product-downloadable',
@@ -474,7 +474,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'order'      => 10,
 					'attributes' => array(
 						'property' => 'downloadable',
-						'label'    => __( 'Include downloads', 'woocommerce'),
+						'label'    => __( 'Include downloads', 'woocommerce' ),
 					),
 				)
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43807

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-virtual-downloadable` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and the bottom of the page a new `Downloads` section should be shown only when the `Include downloads` checkbox is checked.
5. The `Include downloads` checkbox should be unchecked by default.
6. When loading the page, if the `Download` section has no files, then the `Include downloads` checkbox should be unchecked.
7. When loading the page, if the `Download` section has files, then the `Include downloads` checkbox should be checked.
8. Any change to the download list should remains when saving the product and refreshing the page for the given product.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
