### PR TITLE
Add filters for customer email and order id for performance.

### DIFF
--- a/plugins/woocommerce/changelog/fix-41454-2
+++ b/plugins/woocommerce/changelog/fix-41454-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+HPOS: Add more select options when searching orders for Order ID and Customer email.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1580,6 +1580,8 @@ class ListTable extends WP_List_Table {
 	 */
 	private function search_filter() {
 		$options = array(
+			'order_id'  => __( 'Order ID', 'woocommerce' ),
+			'customer_email' => __( 'Customer Email', 'woocommerce' ),
 			'customers' => __( 'Customers', 'woocommerce' ),
 			'products'  => __( 'Products', 'woocommerce' ),
 			'all'       => __( 'All', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1580,11 +1580,11 @@ class ListTable extends WP_List_Table {
 	 */
 	private function search_filter() {
 		$options = array(
-			'order_id'  => __( 'Order ID', 'woocommerce' ),
+			'order_id'       => __( 'Order ID', 'woocommerce' ),
 			'customer_email' => __( 'Customer Email', 'woocommerce' ),
-			'customers' => __( 'Customers', 'woocommerce' ),
-			'products'  => __( 'Products', 'woocommerce' ),
-			'all'       => __( 'All', 'woocommerce' ),
+			'customers'      => __( 'Customers', 'woocommerce' ),
+			'products'       => __( 'Products', 'woocommerce' ),
+			'all'            => __( 'All', 'woocommerce' ),
 		);
 		?>
 		<select name="search-filter" id="order-search-filter">

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -53,6 +53,8 @@ class OrdersTableSearchQuery {
 	 */
 	private function sanitize_search_filters( string $search_filter ) : array {
 		$available_filters = array(
+			'order_id',
+			'customer_email',
 			'customers', // customers also searches in meta.
 			'products',
 		);
@@ -158,6 +160,20 @@ class OrdersTableSearchQuery {
 
 		$order_table = $this->query->get_table_name( 'orders' );
 
+		if( 'customer_email' === $search_filter ) {
+			return $wpdb->prepare(
+				"`$order_table`.billing_email LIKE %s",
+				$wpdb->esc_like( $this->search_term )
+			);
+		}
+
+		if( 'order_id' === $search_filter && is_numeric( $this->search_term ) ) {
+			return $wpdb->prepare(
+				"`$order_table`.id = %d",
+				absint( $this->search_term )
+			);
+		}
+
 		if ( 'products' === $search_filter ) {
 			return $wpdb->prepare(
 				'search_query_items.order_item_name LIKE %s',
@@ -169,6 +185,7 @@ class OrdersTableSearchQuery {
 			$meta_sub_query = $this->generate_where_for_meta_table();
 			return "`$order_table`.id IN ( $meta_sub_query ) ";
 		}
+
 		return '';
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -140,7 +140,10 @@ class OrdersTableSearchQuery {
 		}
 
 		foreach ( $this->search_filters as $search_filter ) {
-			$where[] = $this->generate_where_for_search_filter( $search_filter );
+			$search_where = $this->generate_where_for_search_filter( $search_filter );
+			if ( ! empty( $search_where ) ) {
+				$where[] = $search_where;
+			}
 		}
 
 		$where_statement = implode( ' OR ', $where );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -164,7 +164,6 @@ class OrdersTableSearchQuery {
 		$order_table = $this->query->get_table_name( 'orders' );
 
 		if ( 'customer_email' === $search_filter ) {
-
 			return $wpdb->prepare(
 				"`$order_table`.billing_email LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
 				$wpdb->esc_like( $this->search_term ) . '%'

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -167,7 +167,7 @@ class OrdersTableSearchQuery {
 
 			return $wpdb->prepare(
 				"`$order_table`.billing_email LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
-				$wpdb->esc_like( $this->search_term )
+				$wpdb->esc_like( $this->search_term ) . '%'
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -163,16 +163,17 @@ class OrdersTableSearchQuery {
 
 		$order_table = $this->query->get_table_name( 'orders' );
 
-		if( 'customer_email' === $search_filter ) {
+		if ( 'customer_email' === $search_filter ) {
+
 			return $wpdb->prepare(
-				"`$order_table`.billing_email LIKE %s",
+				"`$order_table`.billing_email LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
 				$wpdb->esc_like( $this->search_term )
 			);
 		}
 
-		if( 'order_id' === $search_filter && is_numeric( $this->search_term ) ) {
+		if ( 'order_id' === $search_filter && is_numeric( $this->search_term ) ) {
 			return $wpdb->prepare(
-				"`$order_table`.id = %d",
+				"`$order_table`.id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
 				absint( $this->search_term )
 			);
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -523,7 +523,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 			'return' => 'ids',
 		);
 
-		$query_args['search_filter'] = 'all';
+		// Default search filter is all, so we don't need to set it explicitly.
 
 		$query_args['s'] = 'Product';
 		$query           = new OrdersTableQuery( $query_args );
@@ -536,5 +536,43 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$query_args['s'] = 'name';
 		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( $orders, $query->orders );
+	}
+
+	/**
+	 * @testDox The 'search_filter' argument works with an 'order_id' param passed in.
+	 */
+	public function test_query_s_filters_order_id() {
+		$orders = $this->setup_dummy_orders_for_search_filter();
+
+		$query_args = array(
+			's'      => $orders[0],
+			'return' => 'ids',
+		);
+
+		$query_args['search_filter'] = 'order_id';
+
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $orders[0] ), $query->orders );
+
+		$query_args['s'] = $orders[1];
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $orders[1] ), $query->orders );
+	}
+
+	/**
+	 * @testDox The 'search_filter' argument works with an 'customer_email' param passed in.
+	 */
+	public function test_query_s_filters_customer_email() {
+		$orders = $this->setup_dummy_orders_for_search_filter();
+
+		$query_args = array(
+			's'      => 'customer@woo.test',
+			'return' => 'ids',
+		);
+
+		$query_args['search_filter'] = 'customer_email';
+
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $orders[0] ), $query->orders );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -566,7 +566,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$orders = $this->setup_dummy_orders_for_search_filter();
 
 		$query_args = array(
-			's'      => 'customer@woo.test',
+			's'      => 'customer@woo.t',
 			'return' => 'ids',
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41454 

This PR adds two more options to the search filter. Most likely we would need another PR to add filter so that folks can add their own custom search boxes, but before we do that I want to wait and see how these changes are received. 

We added an order ID filter and customer email filter, which as named, will limit the search to only those fields. They also remove wildcard, and both are indexed fields with HPOS (ID was already an indexed field with posts as well, but now billing email is also indexed).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With HPOS authoritative, create a few orders (at least 3). In at least one of the orders, use a unique email, make sure to note that email.
2. Go to admin orders on `wp-admin/admin.php?page=wc-orders`
3. Select `Customer Email` as the search option, and enter the unique email used in step 1 to search. Check that the order with that email shows up.
4. Similarly, add any order ID in the search box, select order ID in the search dropdown and search. Check that order with that ID shows up.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
