### PR TITLE
[Product Editor] Support for variable product and variations in product templates

### DIFF
--- a/packages/js/product-editor/changelog/update-product-templates-for-variable-and-variation
+++ b/packages/js/product-editor/changelog/update-product-templates-for-variable-and-variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove special handling of product template and layout template for variable products and variations

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -59,10 +59,12 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 	const [ supportedProductTemplates, unsupportedProductTemplates ] =
 		productTemplates.reduce< [ ProductTemplate[], ProductTemplate[] ] >(
 			( [ supported, unsupported ], productTemplate ) => {
-				if ( productTemplate.layoutTemplateId ) {
-					supported.push( productTemplate );
-				} else {
-					unsupported.push( productTemplate );
+				if ( productTemplate.isSelectableByUser ) {
+					if ( productTemplate.layoutTemplateId ) {
+						supported.push( productTemplate );
+					} else {
+						unsupported.push( productTemplate );
+					}
 				}
 				return [ supported, unsupported ];
 			},

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -45,23 +45,7 @@ import { store as productEditorUiStore } from '../../store/product-editor-ui';
 import { ModalEditor } from '../modal-editor';
 import { ProductEditorSettings } from '../editor';
 import { BlockEditorProps } from './types';
-import { ProductTemplate } from '../../types';
 
-function getLayoutTemplateId(
-	productTemplate: ProductTemplate | undefined,
-	postType: string
-) {
-	if ( productTemplate?.layoutTemplateId ) {
-		return productTemplate.layoutTemplateId;
-	}
-
-	if ( postType === 'product_variation' ) {
-		return 'product-variation';
-	}
-
-	// Fallback to simple product if no layout template is set.
-	return 'simple-product';
-}
 export function BlockEditor( {
 	context,
 	settings: _settings,
@@ -127,11 +111,12 @@ export function BlockEditor( {
 
 	const { productTemplate } = useProductTemplate(
 		productTemplateId,
-		productType
+		productType,
+		postType
 	);
 
 	const { layoutTemplate } = useLayoutTemplate(
-		getLayoutTemplateId( productTemplate, postType )
+		productTemplate?.layoutTemplateId
 	);
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -28,6 +28,18 @@ describe( 'useProductTemplate', () => {
 					},
 				},
 				{
+					id: 'template-2a',
+					title: 'Template 2a',
+					description: 'Template 2a description',
+					icon: 'icon',
+					order: 999,
+					layoutTemplateId: 'layout-template-2a',
+					postType: 'custom_product',
+					productData: {
+						type: 'grouped',
+					},
+				},
+				{
 					id: 'template-2',
 					title: 'Template 2',
 					description: 'Template 2 description',
@@ -49,6 +61,18 @@ describe( 'useProductTemplate', () => {
 					postType: 'product',
 					productData: {
 						type: 'simple',
+					},
+				},
+				{
+					id: 'template-4',
+					title: 'Template 4',
+					description: 'Template 4 description',
+					icon: 'icon',
+					layoutTemplateId: 'layout-template-4',
+					order: 4,
+					postType: 'product_variation',
+					productData: {
+						type: undefined,
 					},
 				},
 			],
@@ -84,9 +108,33 @@ describe( 'useProductTemplate', () => {
 		expect( result.current.productTemplate?.id ).toEqual( 'template-2' );
 	} );
 
+	it( 'should return the first product template with a matching post type when no product template id or product type is set', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( undefined, undefined, 'product_variation' )
+		);
+
+		expect( result.current.productTemplate?.id ).toEqual( 'template-4' );
+	} );
+
 	it( 'should return undefined if no matching product template by id or type', () => {
 		const { result } = renderHook( () =>
 			useProductTemplate( 'invalid-template-id', 'external', 'product' )
+		);
+
+		expect( result.current.productTemplate ).toBeUndefined();
+	} );
+
+	it( 'should return undefined if post type is not set', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( 'template-1', 'simple', undefined )
+		);
+
+		expect( result.current.productTemplate ).toBeUndefined();
+	} );
+
+	it( 'should return undefined if post type does not match', () => {
+		const { result } = renderHook( () =>
+			useProductTemplate( 'template-1', 'simple', 'product_variation' )
 		);
 
 		expect( result.current.productTemplate ).toBeUndefined();

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -26,6 +26,7 @@ describe( 'useProductTemplate', () => {
 					productData: {
 						type: 'simple',
 					},
+					isSelectableByUser: true,
 				},
 				{
 					id: 'template-2a',
@@ -38,6 +39,7 @@ describe( 'useProductTemplate', () => {
 					productData: {
 						type: 'grouped',
 					},
+					isSelectableByUser: true,
 				},
 				{
 					id: 'template-2',
@@ -50,6 +52,7 @@ describe( 'useProductTemplate', () => {
 					productData: {
 						type: 'grouped',
 					},
+					isSelectableByUser: true,
 				},
 				{
 					id: 'template-3',
@@ -62,6 +65,7 @@ describe( 'useProductTemplate', () => {
 					productData: {
 						type: 'simple',
 					},
+					isSelectableByUser: true,
 				},
 				{
 					id: 'template-4',
@@ -74,6 +78,7 @@ describe( 'useProductTemplate', () => {
 					productData: {
 						type: undefined,
 					},
+					isSelectableByUser: false,
 				},
 			],
 		};

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -22,6 +22,7 @@ describe( 'useProductTemplate', () => {
 					icon: 'icon',
 					order: 1,
 					layoutTemplateId: 'layout-template-1',
+					postType: 'product',
 					productData: {
 						type: 'simple',
 					},
@@ -33,6 +34,7 @@ describe( 'useProductTemplate', () => {
 					icon: 'icon',
 					layoutTemplateId: 'layout-template-2',
 					order: 2,
+					postType: 'product',
 					productData: {
 						type: 'grouped',
 					},
@@ -44,6 +46,7 @@ describe( 'useProductTemplate', () => {
 					icon: 'icon',
 					layoutTemplateId: 'layout-template-3',
 					order: 3,
+					postType: 'product',
 					productData: {
 						type: 'simple',
 					},
@@ -55,6 +58,7 @@ describe( 'useProductTemplate', () => {
 					icon: 'icon',
 					layoutTemplateId: 'layout-template-4',
 					order: 4,
+					postType: 'product',
 					productData: {
 						type: 'simple',
 					},
@@ -70,7 +74,7 @@ describe( 'useProductTemplate', () => {
 
 	it( 'should return the product template if it exists', () => {
 		const { result } = renderHook( () =>
-			useProductTemplate( 'template-3', 'simple' )
+			useProductTemplate( 'template-3', 'simple', 'product' )
 		);
 
 		expect( result.current.productTemplate?.id ).toEqual( 'template-3' );
@@ -78,7 +82,7 @@ describe( 'useProductTemplate', () => {
 
 	it( 'should return the first product template with a matching type in the productData if no matching product template by id', () => {
 		const { result } = renderHook( () =>
-			useProductTemplate( 'invalid-template-id', 'grouped' )
+			useProductTemplate( 'invalid-template-id', 'grouped', 'product' )
 		);
 
 		expect( result.current.productTemplate?.id ).toEqual( 'template-2' );
@@ -86,7 +90,7 @@ describe( 'useProductTemplate', () => {
 
 	it( 'should return the first product template with a matching type in the productData if no product template id is set', () => {
 		const { result } = renderHook( () =>
-			useProductTemplate( undefined, 'grouped' )
+			useProductTemplate( undefined, 'grouped', 'product' )
 		);
 
 		expect( result.current.productTemplate?.id ).toEqual( 'template-2' );
@@ -94,7 +98,7 @@ describe( 'useProductTemplate', () => {
 
 	it( 'should return undefined if no matching product template by id or type', () => {
 		const { result } = renderHook( () =>
-			useProductTemplate( 'invalid-template-id', 'external' )
+			useProductTemplate( 'invalid-template-id', 'external', 'product' )
 		);
 
 		expect( result.current.productTemplate ).toBeUndefined();
@@ -102,7 +106,7 @@ describe( 'useProductTemplate', () => {
 
 	it( 'should use the standard product template if the product type is variable', () => {
 		const { result } = renderHook( () =>
-			useProductTemplate( 'template-1', 'variable' )
+			useProductTemplate( 'template-1', 'variable', 'product' )
 		);
 
 		expect( result.current.productTemplate?.id ).toEqual(
@@ -112,7 +116,7 @@ describe( 'useProductTemplate', () => {
 
 	it( 'should use the product type to match if the product template id matches a template with a different product type', () => {
 		const { result } = renderHook( () =>
-			useProductTemplate( 'template-2', 'simple' )
+			useProductTemplate( 'template-2', 'simple', 'product' )
 		);
 
 		expect( result.current.productTemplate?.id ).toEqual( 'template-1' );

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -51,18 +51,6 @@ describe( 'useProductTemplate', () => {
 						type: 'simple',
 					},
 				},
-				{
-					id: 'standard-product-template',
-					title: 'Standard Product Template',
-					description: 'Standard Product Template description',
-					icon: 'icon',
-					layoutTemplateId: 'layout-template-4',
-					order: 4,
-					postType: 'product',
-					productData: {
-						type: 'simple',
-					},
-				},
 			],
 		};
 	} );
@@ -102,16 +90,6 @@ describe( 'useProductTemplate', () => {
 		);
 
 		expect( result.current.productTemplate ).toBeUndefined();
-	} );
-
-	it( 'should use the standard product template if the product type is variable', () => {
-		const { result } = renderHook( () =>
-			useProductTemplate( 'template-1', 'variable', 'product' )
-		);
-
-		expect( result.current.productTemplate?.id ).toEqual(
-			'standard-product-template'
-		);
 	} );
 
 	it( 'should use the product type to match if the product template id matches a template with a different product type', () => {

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -18,8 +18,22 @@ declare global {
 
 function isProductTypeSupported(
 	productTemplate: ProductTemplate,
-	productType: ProductType | undefined
+	productType: ProductType | undefined,
+	postType: string | undefined
 ) {
+	if ( productTemplate.postType !== postType ) {
+		return false;
+	}
+
+	// consider null and undefined to be the same for product type
+	if (
+		( productTemplate.productData.type === null ||
+			productTemplate.productData.type === undefined ) &&
+		( productType === null || productType === undefined )
+	) {
+		return true;
+	}
+
 	if ( productTemplate.productData.type === productType ) {
 		return true;
 	}
@@ -37,7 +51,8 @@ function isProductTypeSupported(
 
 export const useProductTemplate = (
 	productTemplateId: string | undefined,
-	productType: ProductType | undefined
+	productType: ProductType | undefined,
+	postType: string | undefined = 'product'
 ) => {
 	const productTemplates =
 		window.productBlockEditorSettings?.productTemplates ?? [];
@@ -45,13 +60,13 @@ export const useProductTemplate = (
 	let matchingProductTemplate = productTemplates.find(
 		( productTemplate ) =>
 			productTemplate.id === productTemplateId &&
-			isProductTypeSupported( productTemplate, productType )
+			isProductTypeSupported( productTemplate, productType, postType )
 	);
 
 	if ( ! matchingProductTemplate ) {
 		// Fallback to the first template with the same product type.
 		matchingProductTemplate = productTemplates.find( ( productTemplate ) =>
-			isProductTypeSupported( productTemplate, productType )
+			isProductTypeSupported( productTemplate, productType, postType )
 		);
 	}
 

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -16,6 +16,25 @@ declare global {
 	}
 }
 
+function isProductTypeSupported(
+	productTemplate: ProductTemplate,
+	productType: ProductType | undefined
+) {
+	if ( productTemplate.productData.type === productType ) {
+		return true;
+	}
+
+	const alternateProductDatas = productTemplate.alternateProductDatas;
+	if ( alternateProductDatas ) {
+		return alternateProductDatas.some(
+			( alternateProductData ) =>
+				alternateProductData.type === productType
+		);
+	}
+
+	return false;
+}
+
 export const useProductTemplate = (
 	productTemplateId: string | undefined,
 	productType: ProductType | undefined
@@ -23,25 +42,16 @@ export const useProductTemplate = (
 	const productTemplates =
 		window.productBlockEditorSettings?.productTemplates ?? [];
 
-	const productTemplateIdToFind =
-		productType === 'variable'
-			? 'standard-product-template'
-			: productTemplateId;
-
-	const productTypeToFind =
-		productType === 'variable' ? 'simple' : productType;
-
 	let matchingProductTemplate = productTemplates.find(
 		( productTemplate ) =>
-			productTemplate.id === productTemplateIdToFind &&
-			productTemplate.productData.type === productTypeToFind
+			productTemplate.id === productTemplateId &&
+			isProductTypeSupported( productTemplate, productType )
 	);
 
 	if ( ! matchingProductTemplate ) {
 		// Fallback to the first template with the same product type.
-		matchingProductTemplate = productTemplates.find(
-			( productTemplate ) =>
-				productTemplate.productData.type === productTypeToFind
+		matchingProductTemplate = productTemplates.find( ( productTemplate ) =>
+			isProductTypeSupported( productTemplate, productType )
 		);
 	}
 

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -52,7 +52,7 @@ function isProductTypeSupported(
 export const useProductTemplate = (
 	productTemplateId: string | undefined,
 	productType: ProductType | undefined,
-	postType: string | undefined = 'product'
+	postType: string | undefined
 ) => {
 	const productTemplates =
 		window.productBlockEditorSettings?.productTemplates ?? [];

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -25,28 +25,16 @@ function isProductTypeSupported(
 		return false;
 	}
 
-	// consider null and undefined to be the same for product type
 	if (
-		( productTemplate.productData.type === null ||
-			productTemplate.productData.type === undefined ) &&
-		( productType === null || productType === undefined )
+		( productTemplate.productData.type ?? null ) === ( productType ?? null )
 	) {
 		return true;
 	}
 
-	if ( productTemplate.productData.type === productType ) {
-		return true;
-	}
-
-	const alternateProductDatas = productTemplate.alternateProductDatas;
-	if ( alternateProductDatas ) {
-		return alternateProductDatas.some(
-			( alternateProductData ) =>
-				alternateProductData.type === productType
-		);
-	}
-
-	return false;
+	return productTemplate.alternateProductDatas?.some(
+		( alternateProductData ) =>
+			( alternateProductData.type ?? null ) === ( productType ?? null )
+	);
 }
 
 export const useProductTemplate = (

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -12,6 +12,7 @@ export type ProductTemplate = {
 	order: number;
 	layoutTemplateId: string;
 	productData: Partial< Product >;
+	alternateProductDatas?: Partial< Product >[];
 };
 
 export interface ProductEditorContext {

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -14,6 +14,7 @@ export type ProductTemplate = {
 	postType: string;
 	productData: Partial< Product >;
 	alternateProductDatas?: Partial< Product >[];
+	isSelectableByUser: boolean;
 };
 
 export interface ProductEditorContext {

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -11,6 +11,7 @@ export type ProductTemplate = {
 	icon: string | null;
 	order: number;
 	layoutTemplateId: string;
+	postType: string;
 	productData: Partial< Product >;
 	alternateProductDatas?: Partial< Product >[];
 };

--- a/plugins/woocommerce/changelog/update-product-templates-for-variable-and-variation
+++ b/plugins/woocommerce/changelog/update-product-templates-for-variable-and-variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Allow product templates to support alternate product types, as well as post types, and marking as unselectable

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -240,14 +240,19 @@ class Init {
 		$templates   = array();
 		$templates[] = new ProductTemplate(
 			array(
-				'id'                 => 'standard-product-template',
-				'title'              => __( 'Standard product', 'woocommerce' ),
-				'description'        => __( 'A single physical or virtual product, e.g. a t-shirt or an eBook.', 'woocommerce' ),
-				'order'              => 10,
-				'icon'               => 'shipping',
-				'layout_template_id' => 'simple-product',
-				'product_data'       => array(
+				'id'                      => 'standard-product-template',
+				'title'                   => __( 'Standard product', 'woocommerce' ),
+				'description'             => __( 'A single physical or virtual product, e.g. a t-shirt or an eBook.', 'woocommerce' ),
+				'order'                   => 10,
+				'icon'                    => 'shipping',
+				'layout_template_id'      => 'simple-product',
+				'product_data'            => array(
 					'type' => 'simple',
+				),
+				'alternate_product_datas' => array(
+					array(
+						'type' => 'variable',
+					),
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -258,6 +258,18 @@ class Init {
 		);
 		$templates[] = new ProductTemplate(
 			array(
+				'id'                 => 'variation-product-template',
+				'title'              => __( 'Variation product', 'woocommerce' ),
+				'description'        => __( 'A variation of a variable product.', 'woocommerce' ),
+				'layout_template_id' => 'product-variation',
+				'post_type'          => 'product_variation',
+				'product_data'       => array(
+					'type' => null,
+				),
+			)
+		);
+		$templates[] = new ProductTemplate(
+			array(
 				'id'                 => 'grouped-product-template',
 				'title'              => __( 'Grouped product', 'woocommerce' ),
 				'description'        => __( 'A set of products that go well together, e.g. camera kit.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -258,14 +258,15 @@ class Init {
 		);
 		$templates[] = new ProductTemplate(
 			array(
-				'id'                 => 'variation-product-template',
-				'title'              => __( 'Variation product', 'woocommerce' ),
-				'description'        => __( 'A variation of a variable product.', 'woocommerce' ),
-				'layout_template_id' => 'product-variation',
-				'post_type'          => 'product_variation',
-				'product_data'       => array(
+				'id'                    => 'variation-product-template',
+				'title'                 => __( 'Variation product', 'woocommerce' ),
+				'description'           => __( 'A variation of a variable product.', 'woocommerce' ),
+				'layout_template_id'    => 'product-variation',
+				'post_type'             => 'product_variation',
+				'product_data'          => array(
 					'type' => null,
 				),
+				'is_selectable_by_user' => false,
 			)
 		);
 		$templates[] = new ProductTemplate(

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -34,6 +34,13 @@ class ProductTemplate {
 	private $product_data;
 
 	/**
+	 * Alternate product datas.
+	 *
+	 * @var array
+	 */
+	private $alternate_product_datas = array();
+
+	/**
 	 * The template order.
 	 *
 	 * @var Integer
@@ -86,6 +93,10 @@ class ProductTemplate {
 		if ( isset( $data['icon'] ) ) {
 			$this->icon = $data['icon'];
 		}
+
+		if ( isset( $data['alternate_product_datas'] ) ) {
+			$this->alternate_product_datas = $data['alternate_product_datas'];
+		}
 	}
 
 	/**
@@ -131,6 +142,15 @@ class ProductTemplate {
 	 */
 	public function get_product_data() {
 		return $this->product_data;
+	}
+
+	/**
+	 * Get the alternate product datas.
+	 *
+	 * @return array The alternate product datas.
+	 */
+	public function get_alternate_product_datas() {
+		return $this->alternate_product_datas;
 	}
 
 	/**
@@ -196,13 +216,41 @@ class ProductTemplate {
 	 */
 	public function to_json() {
 		return array(
-			'id'               => $this->get_id(),
-			'title'            => $this->get_title(),
-			'description'      => $this->get_description(),
-			'icon'             => $this->get_icon(),
-			'order'            => $this->get_order(),
-			'layoutTemplateId' => $this->get_layout_template_id(),
-			'productData'      => $this->get_product_data(),
+			'id'                    => $this->get_id(),
+			'title'                 => $this->get_title(),
+			'description'           => $this->get_description(),
+			'icon'                  => $this->get_icon(),
+			'order'                 => $this->get_order(),
+			'layoutTemplateId'      => $this->get_layout_template_id(),
+			'productData'           => $this->get_product_data(),
+			'alternateProductDatas' => $this->get_alternate_product_datas(),
 		);
+	}
+
+	/**
+	 * Check if a product type is supported by the template.
+	 *
+	 * @param string $product_type The product type.
+	 * @return bool True if the product type is supported.
+	 */
+	public function is_product_type_supported( string $product_type ) {
+		$product_data_type = $this->product_data['type'];
+
+		if ( $product_data_type === $product_type ) {
+			return true;
+		}
+
+		$alternate_product_datas = $this->get_alternate_product_datas();
+		if ( ! empty( $alternate_product_datas ) ) {
+			foreach ( $alternate_product_datas as $alternate_product_data ) {
+				$alternate_product_data_type = $alternate_product_data['type'];
+
+				if ( $alternate_product_data_type === $product_type ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -273,26 +273,25 @@ class ProductTemplate {
 	 * Check if a product type is supported by the template.
 	 *
 	 * @param string $product_type The product type.
+	 * @param string $post_type    The post type.
 	 * @return bool True if the product type is supported.
 	 */
-	public function is_product_type_supported( string $product_type ) {
-		$product_data_type = $this->product_data['type'];
+	public function is_product_type_supported( string $product_type, string $post_type ) {
+		if ( $this->post_type !== $post_type ) {
+			return false;
+		}
 
-		if ( $product_data_type === $product_type ) {
+		if ( ( $this->product_data['type'] ?? null ) === ( $product_type ?? null ) ) {
 			return true;
 		}
 
-		$alternate_product_datas = $this->get_alternate_product_datas();
-		if ( ! empty( $alternate_product_datas ) ) {
-			foreach ( $alternate_product_datas as $alternate_product_data ) {
-				$alternate_product_data_type = $alternate_product_data['type'];
-
-				if ( $alternate_product_data_type === $product_type ) {
-					return true;
+		return count(
+			array_filter(
+				$this->get_alternate_product_datas(),
+				function( $alternate_product_data ) use ( $product_type ) {
+					return ( $alternate_product_data['type'] ?? null ) === ( $product_type ?? null );
 				}
-			}
-		}
-
-		return false;
+			)
+		) > 0;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -27,6 +27,13 @@ class ProductTemplate {
 	private $title;
 
 	/**
+	 * The post type.
+	 *
+	 * @var string
+	 */
+	private $post_type = 'product';
+
+	/**
 	 * The product data.
 	 *
 	 * @var array
@@ -94,6 +101,10 @@ class ProductTemplate {
 			$this->icon = $data['icon'];
 		}
 
+		if ( isset( $data['post_type'] ) ) {
+			$this->post_type = $data['post_type'];
+		}
+
 		if ( isset( $data['alternate_product_datas'] ) ) {
 			$this->alternate_product_datas = $data['alternate_product_datas'];
 		}
@@ -133,6 +144,15 @@ class ProductTemplate {
 	 */
 	public function set_layout_template_id( string $layout_template_id ) {
 		$this->layout_template_id = $layout_template_id;
+	}
+
+	/**
+	 * Get the post type.
+	 *
+	 * @return string The post type.
+	 */
+	public function get_post_type() {
+		return $this->post_type;
 	}
 
 	/**
@@ -222,6 +242,7 @@ class ProductTemplate {
 			'icon'                  => $this->get_icon(),
 			'order'                 => $this->get_order(),
 			'layoutTemplateId'      => $this->get_layout_template_id(),
+			'postType'              => $this->get_post_type(),
 			'productData'           => $this->get_product_data(),
 			'alternateProductDatas' => $this->get_alternate_product_datas(),
 		);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -38,7 +38,7 @@ class ProductTemplate {
 	 *
 	 * @var array
 	 */
-	private $product_data;
+	private $product_data = array();
 
 	/**
 	 * Alternate product datas.
@@ -88,9 +88,12 @@ class ProductTemplate {
 	 * @param array $data The data.
 	 */
 	public function __construct( array $data ) {
-		$this->id           = $data['id'];
-		$this->title        = $data['title'];
-		$this->product_data = $data['product_data'];
+		$this->id    = $data['id'];
+		$this->title = $data['title'];
+
+		if ( isset( $data['product_data'] ) ) {
+			$this->product_data = $data['product_data'];
+		}
 
 		if ( isset( $data['order'] ) ) {
 			$this->order = $data['order'];

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -276,7 +276,7 @@ class ProductTemplate {
 	 * @param string $post_type    The post type.
 	 * @return bool True if the product type is supported.
 	 */
-	public function is_product_type_supported( string $product_type, string $post_type ) {
+	public function is_product_type_supported( ?string $product_type, string $post_type ) {
 		if ( $this->post_type !== $post_type ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplate.php
@@ -76,6 +76,13 @@ class ProductTemplate {
 	private $icon = null;
 
 	/**
+	 * If the template is selectable by the user.
+	 *
+	 * @var bool
+	 */
+	private $is_selectable_by_user = true;
+
+	/**
 	 * ProductTemplate constructor
 	 *
 	 * @param array $data The data.
@@ -107,6 +114,10 @@ class ProductTemplate {
 
 		if ( isset( $data['alternate_product_datas'] ) ) {
 			$this->alternate_product_datas = $data['alternate_product_datas'];
+		}
+
+		if ( isset( $data['is_selectable_by_user'] ) ) {
+			$this->is_selectable_by_user = $data['is_selectable_by_user'];
 		}
 	}
 
@@ -230,6 +241,15 @@ class ProductTemplate {
 	}
 
 	/**
+	 * Check if the template is selectable by the user.
+	 *
+	 * @return bool True if the template is selectable by the user.
+	 */
+	public function is_selectable_by_user() {
+		return $this->is_selectable_by_user;
+	}
+
+	/**
 	 * Get the product template as JSON like.
 	 *
 	 * @return array The JSON.
@@ -245,6 +265,7 @@ class ProductTemplate {
 			'postType'              => $this->get_post_type(),
 			'productData'           => $this->get_product_data(),
 			'alternateProductDatas' => $this->get_alternate_product_datas(),
+			'isSelectableByUser'    => $this->is_selectable_by_user(),
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -99,7 +99,7 @@ class RedirectionController {
 	/**
 	 * Check if a product is supported by the new experience.
 	 *
-	 * @param array $product_templates The registered product teamplates.
+	 * @param array $product_templates The registered product templates.
 	 */
 	public function set_product_templates( array $product_templates ): void {
 		$this->product_templates = $product_templates;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -70,13 +70,7 @@ class RedirectionController {
 				continue;
 			}
 
-			$product_data      = $product_template->get_product_data();
-			$product_data_type = $product_data['type'];
-			// Treat a variable product as a simple product since there is not a product template
-			// for variable products.
-			$product_type = $product->get_type() === 'variable' ? 'simple' : $product->get_type();
-
-			if ( isset( $product_data_type ) && $product_data_type !== $product_type ) {
+			if ( ! $product_template->is_product_type_supported( $product->get_type() ) ) {
 				continue;
 			}
 
@@ -84,12 +78,11 @@ class RedirectionController {
 				return true;
 			}
 
-			if ( isset( $product_data_type ) ) {
-				if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
-					return true;
-				}
-				return ! $digital_product;
+			if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
+				return true;
 			}
+
+			return ! $digital_product;
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -57,9 +57,10 @@ class RedirectionController {
 	 * @param integer $product_id Product ID.
 	 */
 	protected function is_product_supported( $product_id ): bool {
-		$product = $product_id ? wc_get_product( $product_id ) : null;
+		$product   = $product_id ? wc_get_product( $product_id ) : null;
+		$post_type = get_post_type( $product_id );
 
-		if ( is_null( $product ) ) {
+		if ( is_null( $product ) || ! $post_type ) {
 			return false;
 		}
 
@@ -71,8 +72,7 @@ class RedirectionController {
 				continue;
 			}
 
-			// TODO: how to get post type from product?
-			if ( ! $product_template->is_product_type_supported( $product->get_type(), 'product' ) ) {
+			if ( ! $product_template->is_product_type_supported( $product->get_type(), $post_type ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -6,7 +6,6 @@
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 
 /**
  * Handle redirecting to the old or new editor based on features and support.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplate;
 
 /**
  * Handle redirecting to the old or new editor based on features and support.
@@ -14,7 +15,7 @@ class RedirectionController {
 	/**
 	 * Registered product templates.
 	 *
-	 * @var array
+	 * @var ProductTemplate[]
 	 */
 	private $product_templates = array();
 
@@ -70,7 +71,8 @@ class RedirectionController {
 				continue;
 			}
 
-			if ( ! $product_template->is_product_type_supported( $product->get_type() ) ) {
+			// TODO: how to get post type from product?
+			if ( ! $product_template->is_product_type_supported( $product->get_type(), 'product' ) ) {
 				continue;
 			}
 
@@ -91,7 +93,7 @@ class RedirectionController {
 	/**
 	 * Check if a product is supported by the new experience.
 	 *
-	 * @param array $product_templates The registered product templates.
+	 * @param ProductTemplate[] $product_templates The registered product templates.
 	 */
 	public function set_product_templates( array $product_templates ): void {
 		$this->product_templates = $product_templates;

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/ProductTemplates/ProductTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/ProductTemplates/ProductTemplateTest.php
@@ -16,6 +16,8 @@ class ProductTemplateTest extends WC_Unit_Test_Case {
 	public function test_is_product_type_supported_post_type_mismatch() {
 		$template = new ProductTemplate(
 			array(
+				'id'        => 'test-product-template',
+				'title'     => 'Test Product Template',
 				'post_type' => 'post',
 			)
 		);
@@ -29,6 +31,8 @@ class ProductTemplateTest extends WC_Unit_Test_Case {
 	public function test_is_product_type_supported_product_type_mismatch() {
 		$template = new ProductTemplate(
 			array(
+				'id'           => 'test-product-template',
+				'title'        => 'Test Product Template',
 				'post_type'    => 'product',
 				'product_data' => array(
 					'type' => 'variable',
@@ -45,6 +49,8 @@ class ProductTemplateTest extends WC_Unit_Test_Case {
 	public function test_is_product_type_supported_product_type_match() {
 		$template = new ProductTemplate(
 			array(
+				'id'           => 'test-product-template',
+				'title'        => 'Test Product Template',
 				'post_type'    => 'product',
 				'product_data' => array(
 					'type' => 'simple',
@@ -61,6 +67,8 @@ class ProductTemplateTest extends WC_Unit_Test_Case {
 	public function test_is_product_type_supported_product_type_null_match() {
 		$template = new ProductTemplate(
 			array(
+				'id'           => 'test-product-template',
+				'title'        => 'Test Product Template',
 				'post_type'    => 'product_variation',
 				'product_data' => array(
 					'type' => null,
@@ -77,6 +85,8 @@ class ProductTemplateTest extends WC_Unit_Test_Case {
 	public function test_is_product_type_supported_product_type_match_with_alternate_product_data() {
 		$template = new ProductTemplate(
 			array(
+				'id'                      => 'test-product-template',
+				'title'                   => 'Test Product Template',
 				'post_type'               => 'product',
 				'product_data'            => array(
 					'type' => 'simple',
@@ -98,6 +108,8 @@ class ProductTemplateTest extends WC_Unit_Test_Case {
 	public function test_is_product_type_supported_product_type_mismatch_with_alternate_product_data() {
 		$template = new ProductTemplate(
 			array(
+				'id'                      => 'test-product-template',
+				'title'                   => 'Test Product Template',
 				'post_type'               => 'product',
 				'product_data'            => array(
 					'type' => 'simple',

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/ProductTemplates/ProductTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/ProductTemplates/ProductTemplateTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Admin\ProductBlockEditor\ProductTemplates;
+
+use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplate;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the ProductTemplate class.
+ */
+class ProductTemplateTest extends WC_Unit_Test_Case {
+	/**
+	 * Test is_product_type_supported() with a mismatched post type.
+	 */
+	public function test_is_product_type_supported_post_type_mismatch() {
+		$template = new ProductTemplate(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		$this->assertFalse( $template->is_product_type_supported( 'simple', 'product' ) );
+	}
+
+	/**
+	 * Test is_product_type_supported() with a mismatched product type.
+	 */
+	public function test_is_product_type_supported_product_type_mismatch() {
+		$template = new ProductTemplate(
+			array(
+				'post_type'    => 'product',
+				'product_data' => array(
+					'type' => 'variable',
+				),
+			)
+		);
+
+		$this->assertFalse( $template->is_product_type_supported( 'simple', 'product' ) );
+	}
+
+	/**
+	 * Test is_product_type_supported() with a matching product type.
+	 */
+	public function test_is_product_type_supported_product_type_match() {
+		$template = new ProductTemplate(
+			array(
+				'post_type'    => 'product',
+				'product_data' => array(
+					'type' => 'simple',
+				),
+			)
+		);
+
+		$this->assertTrue( $template->is_product_type_supported( 'simple', 'product' ) );
+	}
+
+	/**
+	 * Test is_product_type_supported() with a null product type and matching post type.
+	 */
+	public function test_is_product_type_supported_product_type_null_match() {
+		$template = new ProductTemplate(
+			array(
+				'post_type'    => 'product_variation',
+				'product_data' => array(
+					'type' => null,
+				),
+			)
+		);
+
+		$this->assertTrue( $template->is_product_type_supported( null, 'product_variation' ) );
+	}
+
+	/**
+	 * Test is_product_type_supported() with a matching alternate product type.
+	 */
+	public function test_is_product_type_supported_product_type_match_with_alternate_product_data() {
+		$template = new ProductTemplate(
+			array(
+				'post_type'               => 'product',
+				'product_data'            => array(
+					'type' => 'simple',
+				),
+				'alternate_product_datas' => array(
+					array(
+						'type' => 'variable',
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $template->is_product_type_supported( 'variable', 'product' ) );
+	}
+
+	/**
+	 * Test is_product_type_supported() with a mismatched alternate product type.
+	 */
+	public function test_is_product_type_supported_product_type_mismatch_with_alternate_product_data() {
+		$template = new ProductTemplate(
+			array(
+				'post_type'               => 'product',
+				'product_data'            => array(
+					'type' => 'simple',
+				),
+				'alternate_product_datas' => array(
+					array(
+						'type' => 'variable',
+					),
+				),
+			)
+		);
+
+		$this->assertFalse( $template->is_product_type_supported( 'grouped', 'product' ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR came out of work I was doing on #43840.

I found myself tripping up with the special casing we were doing client-side to handle product templates and layout templates with variable products and variations. This special casing made writing other code that depended on whether those were set fragile and error-prone.

This PR changes adds actual product templates for variable products and variations.

For variable products, I introduced the concept of "alternate product data", so that we get the correct matching product template for situations where the product type can be multiple values. For example, we were in essence using the `standard-product-template` for `variable` products with our special-casing client-side (since we were hard-coding that the `simple-product` layout template should be used, and the `standard-product-template` should show as the selected product template in the "Change product type" menu).

For variations, I introduced the concept of product templates that can't be selected by the user, and also gave product templates a `post_type` property. This is because we do not show the "Variation" type in the "Change product type" menu, and variations do not have a (product) `type` value to match against.

With these changes in place, the handling of product templates and layout templates is consistent. If a product is to be handled in the new product editor, it will always have a matching product template, and therefore also a matching layout template by association.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Automated testing

1. Make sure unit tests pass...

JS:
```bash
pnpm --filter=@woocommerce/product-editor test:js
```

PHP:
```bash
cd plugins/woocommerce
pnpm env:test
pnpm test:unit:env --filter 'Automattic\\WooCommerce\\Tests\\Admin\\ProductBlockEditor\\ProductTemplates'
```

#### Manual testing

_**Note: This PR should not result in any visible/functional changes to the product editor. What follows is a recommended set of regression tests to run...**_

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Verify that the **Change product type** menu does not show **Variation** as a selectable option.

<img width="1095" alt="Screenshot 2024-01-24 at 16 32 04" src="https://github.com/woocommerce/woocommerce/assets/2098816/49037836-1895-4038-bf8e-348f84992668">

3. Add some variations on the **Variations** tab.
4. Click **Edit** on a variation in the list and verify that the editor loads the variation correctly.
5. Click **< Main product**  
6. Verify that the **Change product type** menu shows **Standard product** as selected.
7. Use the  **Change product type** menu to change the product type to something else. Verify the product is saved properly and the editor shows the correct form.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
