### PR TITLE
Variations tab should be moved to the second tab, after General

### DIFF
--- a/plugins/woocommerce/changelog/add-43808
+++ b/plugins/woocommerce/changelog/add-43808
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Move variations tab to position 2 so it will appear right next to the general tab

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -73,10 +73,37 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				),
 			)
 		);
+
+		// Variations tab.
+		if ( Features::is_enabled( 'product-variation-management' ) ) {
+			$variations_hide_conditions = array();
+			if ( Features::is_enabled( 'product-grouped' ) ) {
+				$variations_hide_conditions[] = array(
+					'expression' => 'editedProduct.type === "grouped"',
+				);
+			}
+			if ( Features::is_enabled( 'product-external-affiliate' ) ) {
+				$variations_hide_conditions[] = array(
+					'expression' => 'editedProduct.type === "external"',
+				);
+			}
+
+			$this->add_group(
+				array(
+					'id'             => $this::GROUP_IDS['VARIATIONS'],
+					'order'          => 20,
+					'attributes'     => array(
+						'title' => __( 'Variations', 'woocommerce' ),
+					),
+					'hideConditions' => $variations_hide_conditions,
+				)
+			);
+		}
+
 		$this->add_group(
 			array(
 				'id'         => $this::GROUP_IDS['ORGANIZATION'],
-				'order'      => 15,
+				'order'      => 30,
 				'attributes' => array(
 					'title' => __( 'Organization', 'woocommerce' ),
 				),
@@ -85,7 +112,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		$this->add_group(
 			array(
 				'id'             => $this::GROUP_IDS['PRICING'],
-				'order'          => 20,
+				'order'          => 40,
 				'attributes'     => array(
 					'title' => __( 'Pricing', 'woocommerce' ),
 				),
@@ -99,7 +126,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		$this->add_group(
 			array(
 				'id'         => $this::GROUP_IDS['INVENTORY'],
-				'order'      => 30,
+				'order'      => 50,
 				'attributes' => array(
 					'title' => __( 'Inventory', 'woocommerce' ),
 				),
@@ -120,44 +147,20 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		$this->add_group(
 			array(
 				'id'             => $this::GROUP_IDS['SHIPPING'],
-				'order'          => 40,
+				'order'          => 60,
 				'attributes'     => array(
 					'title' => __( 'Shipping', 'woocommerce' ),
 				),
 				'hideConditions' => $shipping_hide_conditions,
 			)
 		);
-		if ( Features::is_enabled( 'product-variation-management' ) ) {
-			$variations_hide_conditions = array();
-			if ( Features::is_enabled( 'product-grouped' ) ) {
-				$variations_hide_conditions[] = array(
-					'expression' => 'editedProduct.type === "grouped"',
-				);
-			}
-			if ( Features::is_enabled( 'product-external-affiliate' ) ) {
-				$variations_hide_conditions[] = array(
-					'expression' => 'editedProduct.type === "external"',
-				);
-			}
-
-			$this->add_group(
-				array(
-					'id'             => $this::GROUP_IDS['VARIATIONS'],
-					'order'          => 50,
-					'attributes'     => array(
-						'title' => __( 'Variations', 'woocommerce' ),
-					),
-					'hideConditions' => $variations_hide_conditions,
-				)
-			);
-		}
 
 		// Linked Products tab.
 		if ( Features::is_enabled( 'product-linked' ) ) {
 			$this->add_group(
 				array(
 					'id'         => $this::GROUP_IDS['LINKED_PRODUCTS'],
-					'order'      => 60,
+					'order'      => 70,
 					'attributes' => array(
 						'title' => __( 'Linked products', 'woocommerce' ),
 					),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43808

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. The `Variations` tab should be located at the second position right next to the `General` tab. 
<img width="691" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/5d760d03-6217-41d9-abea-376807c6060c">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
