### PR TITLE
[Experimental] Prevent string-based sanitization on non-string field types in additional checkout fields

### DIFF
--- a/plugins/woocommerce/changelog/43999-fix-additional-field-optional-checkboxes
+++ b/plugins/woocommerce/changelog/43999-fix-additional-field-optional-checkboxes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Skipping changelog entry as this is behind a feature flag.
+

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -134,7 +134,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ]  = $rest_sanitized;
 						// Specific sanitization for string types, skipping other types from being coerced to strings.
 						if ( 'string' === $field_schema[ $key ]['type'] ) {
-							$carry[ $key ] = wp_kses( $address[ $key ], [] );
+							$carry[ $key ] = wp_kses( $rest_sanitized, [] );
 						}
 						break;
 				}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -130,7 +130,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
 						break;
 					default:
-						$rest_sanitized = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema, $key );
+						$rest_sanitized = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema[ $key ], $key );
 						$carry[ $key ]  = $rest_sanitized;
 						// Specific sanitization for string types, skipping other types from being coerced to strings.
 						if ( 'string' === $field_schema[ $key ]['type'] ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -130,7 +130,8 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
 						break;
 					default:
-						$carry[ $key ] = $address[ $key ];
+						$rest_sanitized = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema, $key );
+						$carry[ $key ]  = $rest_sanitized;
 						// Specific sanitization for string types, skipping other types from being coerced to strings.
 						if ( 'string' === $field_schema[ $key ]['type'] ) {
 							$carry[ $key ] = wp_kses( $address[ $key ], [] );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -115,9 +115,10 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 	public function sanitize_callback( $address, $request, $param ) {
 		$validation_util = new ValidationUtils();
 		$address         = (array) $address;
+		$field_schema    = $this->get_properties();
 		$address         = array_reduce(
 			array_keys( $address ),
-			function( $carry, $key ) use ( $address, $validation_util ) {
+			function( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
 				switch ( $key ) {
 					case 'country':
 						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
@@ -130,6 +131,10 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						break;
 					default:
 						$carry[ $key ] = $address[ $key ];
+						// Specific sanitization for string types, skipping other types from being coerced to strings.
+						if ( 'string' === $field_schema[ $key ]['type'] ) {
+							$carry[ $key ] = wp_kses( $address[ $key ], [] );
+						}
 						break;
 				}
 				return $carry;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -158,13 +158,14 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$errors          = new \WP_Error();
 		$address         = (array) $address;
 		$validation_util = new ValidationUtils();
+		$schema          = $this->get_properties();
 
 		// The flow is Validate -> Sanitize -> Re-Validate
 		// First validation step is to ensure fields match their schema, then we sanitize to put them in the
 		// correct format, and finally the second validation step is to ensure the correctly-formatted values
 		// match what we expect (postcode etc.).
 		foreach ( $address as $key => $value ) {
-			if ( is_wp_error( rest_validate_value_from_schema( $value, $this->get_properties()[ $key ], $key ) ) ) {
+			if ( is_wp_error( rest_validate_value_from_schema( $value, $schema[ $key ], $key ) ) ) {
 				$errors->add(
 					'invalid_' . $key,
 					sprintf(

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -159,8 +159,10 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$address         = (array) $address;
 		$validation_util = new ValidationUtils();
 
-		// Validate each key manually before sanitizing. The reason we need to sanitize "before" validation is to ensure
-		// the values are in the correct normalized format, e.g. postcode.
+		// The flow is Validate -> Sanitize -> Re-Validate
+		// First validation step is to ensure fields match their schema, then we sanitize to put them in the
+		// correct format, and finally the second validation step is to ensure the correctly-formatted values
+		// match what we expect (postcode etc.).
 		foreach ( $address as $key => $value ) {
 			if ( is_wp_error( rest_validate_value_from_schema( $value, $this->get_properties()[ $key ], $key ) ) ) {
 				$errors->add(

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
@@ -70,7 +70,7 @@ class BillingAddressSchema extends AbstractAddressSchema {
 	 */
 	public function validate_callback( $address, $request, $param ) {
 		$errors  = parent::validate_callback( $address, $request, $param );
-		$address = $this->sanitize_callback( $address, $request, $param );
+		$address = (array) $address;
 		$errors  = is_wp_error( $errors ) ? $errors : new \WP_Error();
 
 		if ( ! empty( $address['email'] ) && ! is_email( $address['email'] ) ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -339,7 +339,12 @@ class CheckoutSchema extends AbstractSchema {
 				}
 				$field_schema   = $properties[ $key ];
 				$rest_sanitized = rest_sanitize_value_from_schema( wp_unslash( $fields[ $key ] ), $field_schema, $key );
-				$carry[ $key ]  = wp_kses( $rest_sanitized, [] );
+				$carry[ $key ]  = $rest_sanitized;
+
+				// Specific sanitization for string types, skipping other types from being coerced to strings.
+				if ( 'string' === $field_schema['type'] ) {
+					$carry[ $key ] = wp_kses( $rest_sanitized, [] );
+				}
 				return $carry;
 			},
 			[]

--- a/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
@@ -13,12 +13,7 @@ class SanitizationUtils {
 	 * @param  array $array The array to run wp_kses on.
 	 * @return mixed       The array, all string keys will have been run through wp_kses.
 	 */
-	public function wp_kses_array( $array ) {
-		if ( ! is_countable( $array ) ) {
-			_doing_it_wrong( __METHOD__, 'This function expects an array.', '8.7.0' );
-			return $array;
-		}
-
+	public function wp_kses_array( array $array ) {
 		foreach ( $array as $key => $value ) {
 			if ( is_array( $value ) ) {
 				$array[ $key ] = $this->wp_kses_array( $value );

--- a/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
@@ -1,0 +1,27 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Utilities;
+
+/**
+ * SanitizationUtils class.
+ * Helper class which sanitizes customer info.
+ */
+class SanitizationUtils {
+
+	/**
+	 * Runs wp_kses on an array. This function runs wp_kses on strings in the array and recurses into arrays.
+	 *
+	 * @param array $array The array to run wp_kses on.
+	 * @return array       The array, all string keys will have been run through wp_kses.
+	 */
+	public function kses_array( $array ) {
+		foreach( $array as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$array[ $key ] = $this->kses_array( $value );
+			}
+			if ( is_string( $value ) ) {
+				$array[ $key ] = wp_kses( $value, [] );
+			}
+		}
+		return $array;
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
@@ -10,13 +10,18 @@ class SanitizationUtils {
 	/**
 	 * Runs wp_kses on an array. This function runs wp_kses on strings in the array and recurses into arrays.
 	 *
-	 * @param array $array The array to run wp_kses on.
-	 * @return array       The array, all string keys will have been run through wp_kses.
+	 * @param  array $array The array to run wp_kses on.
+	 * @return mixed       The array, all string keys will have been run through wp_kses.
 	 */
-	public function kses_array( $array ) {
-		foreach( $array as $key => $value ) {
+	public function wp_kses_array( $array ) {
+		if ( ! is_countable( $array ) ) {
+			_doing_it_wrong( __METHOD__, 'This function expects an array.', '8.7.0' );
+			return $array;
+		}
+
+		foreach ( $array as $key => $value ) {
 			if ( is_array( $value ) ) {
-				$array[ $key ] = $this->kses_array( $value );
+				$array[ $key ] = $this->wp_kses_array( $value );
 			}
 			if ( is_string( $value ) ) {
 				$array[ $key ] = wp_kses( $value, [] );

--- a/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
@@ -16,7 +16,7 @@ class SanitizationUtils {
 	public function wp_kses_array( array $array ) {
 		foreach ( $array as $key => $value ) {
 			if ( empty( $value ) ) {
-				$array[$key] = $value;
+				$array[ $key ] = $value;
 				continue;
 			}
 			if ( is_array( $value ) ) {

--- a/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/SanitizationUtils.php
@@ -15,6 +15,10 @@ class SanitizationUtils {
 	 */
 	public function wp_kses_array( array $array ) {
 		foreach ( $array as $key => $value ) {
+			if ( empty( $value ) ) {
+				$array[$key] = $value;
+				continue;
+			}
 			if ( is_array( $value ) ) {
 				$array[ $key ] = $this->wp_kses_array( $value );
 			}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Utilities;
+
+use Automattic\WooCommerce\StoreApi\Utilities\SanitizationUtils;
+
+/**
+ * A collection of tests for the array utility class.
+ */
+class SanitizationUtilTest extends \WC_Unit_Test_Case {
+
+
+	/**
+	 * @testdox `kses_array` should return an array of the same shape, but strings should be cleaned with `wp_kses`.
+	 */
+	public function test_kses_array() {
+		$sanitization_utils = new SanitizationUtils();
+		$input              = [
+			'a' => true,
+			'b' => [
+				'c' => 'c',
+				'd' => [
+					'e' => 'e',
+				],
+			],
+			'f' => 1,
+			'g' => '<script>alert("hello");</script>',
+		];
+		$expected           = [
+			'a' => 'a',
+			'b' => [
+				'c' => 'c',
+				'd' => [
+					'e' => 'e',
+				],
+			],
+			'f' => 1,
+			'g' => 'alert("hello");',
+		];
+		$this->assertEquals( $expected, $sanitization_utils->wp_kses_array( $input ) );
+	}
+
+	/**
+	 * @testdox `kses_array` should return the same value if passed something not-countable and show a doing_it_wrong message.
+	 */
+	public function test_kses_array_invalid_data() {
+		$sanitization_utils = new SanitizationUtils();
+		$input              = 'hello';
+		$this->assertEquals( $input, $sanitization_utils->wp_kses_array( $input ) );
+		$input = [];
+		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\StoreApi\Utilities\SanitizationUtils::wp_kses_array' );
+		$this->assertEquals( $input, $sanitization_utils->wp_kses_array( $input ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
@@ -39,16 +39,4 @@ class SanitizationUtilTest extends \WC_Unit_Test_Case {
 		];
 		$this->assertEquals( $expected, $sanitization_utils->wp_kses_array( $input ) );
 	}
-
-	/**
-	 * @testdox `kses_array` should return the same value if passed something not-countable and show a doing_it_wrong message.
-	 */
-	public function test_kses_array_invalid_data() {
-		$sanitization_utils = new SanitizationUtils();
-		$input              = 'hello';
-		$this->assertEquals( $input, $sanitization_utils->wp_kses_array( $input ) );
-		$input = [];
-		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\StoreApi\Utilities\SanitizationUtils::wp_kses_array' );
-		$this->assertEquals( $input, $sanitization_utils->wp_kses_array( $input ) );
-	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
@@ -25,6 +25,9 @@ class SanitizationUtilTest extends \WC_Unit_Test_Case {
 			],
 			'f' => 1,
 			'g' => '<script>alert("hello");</script>',
+			'h' => [
+				'i' => '<script>alert("i");</script>',
+			],
 		];
 		$expected           = [
 			'a' => 'a',
@@ -36,6 +39,9 @@ class SanitizationUtilTest extends \WC_Unit_Test_Case {
 			],
 			'f' => 1,
 			'g' => 'alert("hello");',
+			'h' => [
+				'i' => 'alert("i");',
+			],
 		];
 		$this->assertEquals( $expected, $sanitization_utils->wp_kses_array( $input ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
@@ -30,6 +30,13 @@ class SanitizationUtilTest extends \WC_Unit_Test_Case {
 				'j' => '&lt;script&gt;alert("i");&lt;/script&gt;',
 				'k' => '<div <script>alert("malformed HTML");</s<div>cript><img src= />',
 			],
+			'l' => false,
+			'm' => null,
+			'n' => 0,
+			'o' => [],
+			'p' => [ [ [ [ [ [ [ [ [] ] ] ] ] ] ] ] ],
+			'q' => [ [ [ [ [ [ [ [ [ 'really_nested' => 'boo' ] ] ] ] ] ] ] ] ],
+			'r' => '',
 		];
 		$expected           = [
 			'a' => 'a',
@@ -46,6 +53,13 @@ class SanitizationUtilTest extends \WC_Unit_Test_Case {
 				'j' => '&lt;script&gt;alert("i");&lt;/script&gt;',
 				'k' => '&lt;div alert("malformed HTML");&lt;/script&gt;',
 			],
+			'l' => false,
+			'm' => null,
+			'n' => 0,
+			'o' => [],
+			'p' => [ [ [ [ [ [ [ [ [] ] ] ] ] ] ] ] ],
+			'q' => [ [ [ [ [ [ [ [ [ 'really_nested' => 'boo' ] ] ] ] ] ] ] ] ],
+			'r' => '',
 		];
 		$this->assertEquals( $expected, $sanitization_utils->wp_kses_array( $input ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/SanitizationUtilTest.php
@@ -27,6 +27,8 @@ class SanitizationUtilTest extends \WC_Unit_Test_Case {
 			'g' => '<script>alert("hello");</script>',
 			'h' => [
 				'i' => '<script>alert("i");</script>',
+				'j' => '&lt;script&gt;alert("i");&lt;/script&gt;',
+				'k' => '<div <script>alert("malformed HTML");</s<div>cript><img src= />',
 			],
 		];
 		$expected           = [
@@ -41,6 +43,8 @@ class SanitizationUtilTest extends \WC_Unit_Test_Case {
 			'g' => 'alert("hello");',
 			'h' => [
 				'i' => 'alert("i");',
+				'j' => '&lt;script&gt;alert("i");&lt;/script&gt;',
+				'k' => '&lt;div alert("malformed HTML");&lt;/script&gt;',
 			],
 		];
 		$this->assertEquals( $expected, $sanitization_utils->wp_kses_array( $input ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#### Main changes

- Sanitize address fields based on their schema type.
- Add a new class `SanitizationUtils` which contains a `wp_kses_array` function. After all sanitization is complete in the `AbstractAddressSchema` and `CheckoutSchema`, do a final pass over the array recursively running `wp_kses` on any string key.

#### Required changes because of the above

- Update the `BillingAddressSchema` and `AbstractAddressSchema` to run _validation_ before sanitization. This is required because of the main change.
  - In `BillingAddressSchema`, the address was sanitized in the `validate_callback` function. This meant that things were sanitized _before_ validation had finished. The issue was that this could potentially result in casting invalid values (e.g. arrays) to strings. The `BillingAddressSchema` does not need to sanitize fields before validating them because it only validates the email, which had no special sanitization in place anyway.
  - In `AbstractAddressSchema` we still need to sanitize before validation because we want the keys to be normalized, e.g. state to upper case. however we need to prevent values being cast incorrectly. To achieve this, each key is validated against its schema definition first, then sanitized after they all pass, then validated.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

```php
add_action(
	'woocommerce_blocks_loaded',
	function() {

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/email-opt-in',
				'label'    => 'Sign up to our mailing list?',
				'location' => 'contact',
				'type'     => 'checkbox',
			),
		);
    }
);
```

1. Add a checkout field to your store using the snippet above
2. Add an item to your cart, then go to the Checkout block.
4. Check and uncheck the box
5. Place the order succesfully.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Skipping changelog entry as this is behind a feature flag.

</details>
