### PR TITLE
Avoid duplicate templates appearing on the Site Editor when the WooCommerce template and the theme template have been customized by the user

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import type { Page, Response } from '@playwright/test';
+import type { FrontendUtils } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { SIMPLE_VIRTUAL_PRODUCT_NAME } from '../checkout/constants';
+import { CheckoutPage } from '../checkout/checkout.page';
+
+type TemplateCustomizationTest = {
+	visitPage: ( props: {
+		frontendUtils: FrontendUtils;
+		page: Page;
+	} ) => Promise< void | Response | null >;
+	templateName: string;
+	templatePath: string;
+	templateType: string;
+	defaultTemplate?: {
+		templateName: string;
+		templatePath: string;
+	};
+};
+
+export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
+	{
+		visitPage: async ( { frontendUtils } ) =>
+			await frontendUtils.goToShop(),
+		templateName: 'Product Catalog',
+		templatePath: 'archive-product',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { page } ) =>
+			await page.goto( '/?s=shirt&post_type=product' ),
+		templateName: 'Product Search Results',
+		templatePath: 'product-search-results',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { page } ) => await page.goto( '/color/blue' ),
+		templateName: 'Products by Attribute',
+		templatePath: 'taxonomy-product_attribute',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { page } ) =>
+			await page.goto( '/product-category/clothing' ),
+		templateName: 'Products by Category',
+		templatePath: 'taxonomy-product_cat',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { page } ) =>
+			await page.goto( '/product-tag/recommended/' ),
+		templateName: 'Products by Tag',
+		templatePath: 'taxonomy-product_tag',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { page } ) => await page.goto( '/product/hoodie' ),
+		templateName: 'Single Product',
+		templatePath: 'single-product',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { frontendUtils } ) =>
+			await frontendUtils.goToCart(),
+		templateName: 'Page: Cart',
+		templatePath: 'page-cart',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { frontendUtils } ) => {
+			await frontendUtils.goToShop();
+			await frontendUtils.addToCart();
+			await frontendUtils.goToCheckout();
+		},
+		templateName: 'Page: Checkout',
+		templatePath: 'page-checkout',
+		templateType: 'wp_template',
+	},
+	{
+		visitPage: async ( { frontendUtils, page } ) => {
+			const checkoutPage = new CheckoutPage( { page } );
+			await frontendUtils.goToShop();
+			await frontendUtils.addToCart( SIMPLE_VIRTUAL_PRODUCT_NAME );
+			await frontendUtils.goToCheckout();
+			await checkoutPage.fillInCheckoutWithTestData();
+			await checkoutPage.placeOrder();
+		},
+		templateName: 'Order Confirmation',
+		templatePath: 'order-confirmation',
+		templateType: 'wp_template',
+	},
+];
+
+export const WC_TEMPLATES_SLUG = 'woocommerce/woocommerce';

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -19,6 +19,10 @@ const woocommerceTemplateUserText = 'Hello World in the WooCommerce template';
 
 CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 	test.describe( `${ testData.templateName } template`, async () => {
+		test.afterAll( async () => {
+			await deleteAllTemplates( 'wp_template' );
+		} );
+
 		test( `user-modified ${ testData.templateName } template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {
 			admin,
 			frontendUtils,
@@ -84,7 +88,6 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			await cli(
 				`npm run wp-env run tests-cli -- wp theme activate ${ BLOCK_THEME_SLUG }`
 			);
-			deleteAllTemplates( 'wp_template' );
 		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { deleteAllTemplates } from '@wordpress/e2e-test-utils';
+import {
+	BLOCK_THEME_SLUG,
+	BLOCK_THEME_WITH_TEMPLATES_SLUG,
+	cli,
+} from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { CUSTOMIZABLE_WC_TEMPLATES, WC_TEMPLATES_SLUG } from './constants';
+
+const userText = 'Hello World in the template';
+const woocommerceTemplateUserText = 'Hello World in the WooCommerce template';
+
+CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
+	test.describe( `${ testData.templateName } template`, async () => {
+		test( `user-modified ${ testData.templateName } template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {
+			admin,
+			frontendUtils,
+			editorUtils,
+			page,
+		} ) => {
+			// Edit the WooCommerce default template
+			await admin.visitSiteEditor( {
+				postId: `${ WC_TEMPLATES_SLUG }//${ testData.templatePath }`,
+				postType: testData.templateType,
+			} );
+			await editorUtils.enterEditMode();
+			await editorUtils.closeWelcomeGuideModal();
+			await editorUtils.editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: woocommerceTemplateUserText },
+			} );
+			await editorUtils.saveTemplate();
+
+			await cli(
+				`npm run wp-env run tests-cli -- wp theme activate ${ BLOCK_THEME_WITH_TEMPLATES_SLUG }`
+			);
+
+			// Edit the theme template.
+			await admin.visitSiteEditor( {
+				postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
+				postType: testData.templateType,
+			} );
+			await editorUtils.enterEditMode();
+			await editorUtils.closeWelcomeGuideModal();
+			await editorUtils.editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: userText },
+			} );
+			await editorUtils.saveTemplate();
+
+			// Verify the template is the one modified by the user based on the theme.
+			await testData.visitPage( { frontendUtils, page } );
+			await expect( page.getByText( userText ).first() ).toBeVisible();
+			await expect(
+				page.getByText( woocommerceTemplateUserText )
+			).toHaveCount( 0 );
+
+			// Revert edition and verify the user-modified WC template is used.
+			// Note: we need to revert it from the admin (instead of calling
+			// `deleteAllTemplates()`). This way, we verify there are no
+			// duplicate templates with the same name.
+			// See: https://github.com/woocommerce/woocommerce/issues/42220
+			await admin.visitAdminPage(
+				'site-editor.php',
+				`path=/${ testData.templateType }/all`
+			);
+			await editorUtils.revertTemplateCustomizations(
+				testData.templateName
+			);
+			await testData.visitPage( { frontendUtils, page } );
+
+			await expect(
+				page.getByText( woocommerceTemplateUserText ).first()
+			).toBeVisible();
+			await expect( page.getByText( userText ) ).toHaveCount( 0 );
+
+			await cli(
+				`npm run wp-env run tests-cli -- wp theme activate ${ BLOCK_THEME_SLUG }`
+			);
+			deleteAllTemplates( 'wp_template' );
+		} );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -29,10 +29,10 @@ export class FrontendUtils {
 	async addToCart( itemName = '' ) {
 		await this.page.waitForLoadState( 'domcontentloaded' );
 		if ( itemName !== '' ) {
+			// We can't use `getByRole()` here because the Add to Cart button
+			// might be a button (in blocks) or a link (in the legacy template).
 			await this.page
-				.getByRole( 'button', {
-					name: `Add to cart: “${ itemName }”`,
-				} )
+				.getByLabel( `Add to cart: “${ itemName }”` )
 				.click();
 		} else {
 			await this.page.click( 'text=Add to cart' );

--- a/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/order-confirmation.html
+++ b/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/order-confirmation.html
@@ -1,0 +1,57 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:paragraph -->
+<p>Order Confirmation template loaded from theme</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:woocommerce/order-confirmation-status {"fontSize":"large"} /-->
+
+	<!-- wp:woocommerce/order-confirmation-summary /-->
+
+	<!-- wp:woocommerce/order-confirmation-totals-wrapper {"align":"wide"} -->
+	<!-- wp:pattern {"slug":"woocommerce/order-confirmation-totals-heading"} /-->
+
+	<!-- wp:woocommerce/order-confirmation-totals {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/order-confirmation-totals-wrapper -->
+
+	<!-- wp:woocommerce/order-confirmation-downloads-wrapper {"align":"wide"} -->
+	<!-- wp:pattern {"slug":"woocommerce/order-confirmation-downloads-heading"} /-->
+
+	<!-- wp:woocommerce/order-confirmation-downloads {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/order-confirmation-downloads-wrapper -->
+
+	<!-- wp:columns {"align":"wide","className":"woocommerce-order-confirmation-address-wrapper"} -->
+	<div class="wp-block-columns alignwide woocommerce-order-confirmation-address-wrapper">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:woocommerce/order-confirmation-shipping-wrapper {"align":"wide"} -->
+			<!-- wp:pattern {"slug":"woocommerce/order-confirmation-shipping-heading"} /-->
+
+			<!-- wp:woocommerce/order-confirmation-shipping-address {"lock":{"remove":true}} /-->
+			<!-- /wp:woocommerce/order-confirmation-shipping-wrapper -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:woocommerce/order-confirmation-billing-wrapper {"align":"wide"} -->
+			<!-- wp:pattern {"slug":"woocommerce/order-confirmation-billing-heading"} /-->
+
+			<!-- wp:woocommerce/order-confirmation-billing-address {"lock":{"remove":true}} /-->
+			<!-- /wp:woocommerce/order-confirmation-billing-wrapper -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:woocommerce/order-confirmation-additional-fields-wrapper {"align":"wide"} -->
+	<!-- wp:pattern {"slug":"woocommerce/order-confirmation-additional-fields-heading"} /-->
+	<!-- wp:woocommerce/order-confirmation-additional-fields /-->
+	<!-- /wp:woocommerce/order-confirmation-additional-fields-wrapper -->
+
+	<!-- wp:woocommerce/order-confirmation-additional-information /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/page-cart.html
+++ b/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/page-cart.html
@@ -1,0 +1,13 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:paragraph -->
+<p>Page: Cart template loaded from theme</p>
+<!-- /wp:paragraph -->
+<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:post-title {"align":"wide", "level":1} /-->
+	<!-- wp:post-content {"align":"wide"} /-->
+</main>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/page-checkout.html
+++ b/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/page-checkout.html
@@ -1,0 +1,12 @@
+<!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->
+<!-- wp:paragraph -->
+<p>Page: Checkout template loaded from theme</p>
+<!-- /wp:paragraph -->
+<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:post-title {"align":"wide", "level":1} /-->
+	<!-- wp:post-content {"align":"wide"} /-->
+</main>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->

--- a/plugins/woocommerce/changelog/44000-fix-42220-duplicate-templates-when-both-modified
+++ b/plugins/woocommerce/changelog/44000-fix-42220-duplicate-templates-when-both-modified
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid duplicate templates appearing on the Site Editor when the WooCommerce template and the theme template have been customized by the user

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -418,8 +418,8 @@ class BlockTemplatesController {
 		$query_result = BlockTemplateUtils::remove_theme_templates_with_custom_alternative( $query_result );
 
 		// There is the chance that the user customized the default template, installed a theme with a custom template
-		// and customized that one as well. When that happens, duplicates might appear in the list. See:
-		// https://github.com/woocommerce/woocommerce/issues/42220
+		// and customized that one as well. When that happens, duplicates might appear in the list.
+		// See: https://github.com/woocommerce/woocommerce/issues/42220.
 		$query_result = BlockTemplateUtils::remove_duplicate_customized_templates( $query_result, $theme_slug );
 
 		/**

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -691,9 +691,8 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Removes customized templates that shouldn't be available. That means customized templates from other themes or
-	 * customized templates based on the WooCommerce default templates when there is a customized template based on the
-	 * theme one.
+	 * Removes customized templates that shouldn't be available. That means customized templates based on the
+	 * WooCommerce default template when there is a customized template based on the theme template.
 	 *
 	 * @param \WP_Block_Template[]|\stdClass[] $templates  List of templates to run the filter on.
 	 * @param string                           $theme_slug Slug of the theme currently active.
@@ -707,9 +706,6 @@ class BlockTemplateUtils {
 				if ( $template->theme === $theme_slug ) {
 					// This is a customized template based on the theme template, so it should be returned.
 					return true;
-				} elseif ( self::PLUGIN_SLUG !== $template->theme && self::DEPRECATED_PLUGIN_SLUG !== $template->theme ) {
-					// This is a customized template from a different theme, so it shouldn't be returned.
-					return false;
 				}
 				// This is a template customized from the WooCommerce default template.
 				// Only return it if there isn't a customized version of the theme template.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -691,6 +691,45 @@ class BlockTemplateUtils {
 	}
 
 	/**
+	 * Removes customized templates that shouldn't be available. That means customized templates from other themes or
+	 * customized templates based on the WooCommerce default templates when there is a customized template based on the
+	 * theme one.
+	 *
+	 * @param \WP_Block_Template[]|\stdClass[] $templates  List of templates to run the filter on.
+	 * @param string                           $theme_slug Slug of the theme currently active.
+	 *
+	 * @return array Filtered list of templates with only relevant templates available.
+	 */
+	public static function remove_duplicate_customized_templates( $templates, $theme_slug ) {
+		$filtered_templates = array_filter(
+			$templates,
+			function( $template ) use ( $templates, $theme_slug ) {
+				if ( $template->theme === $theme_slug ) {
+					// This is a customized template based on the theme template, so it should be returned.
+					return true;
+				} elseif ( self::PLUGIN_SLUG !== $template->theme && self::DEPRECATED_PLUGIN_SLUG !== $template->theme ) {
+					// This is a customized template from a different theme, so it shouldn't be returned.
+					return false;
+				}
+				// This is a template customized from the WooCommerce default template.
+				// Only return it if there isn't a customized version of the theme template.
+				$is_there_a_customized_theme_template = array_filter(
+					$templates,
+					function( $theme_template ) use ( $template, $theme_slug ) {
+						return $theme_template->slug === $template->slug && $theme_template->theme === $theme_slug;
+					}
+				);
+				if ( $is_there_a_customized_theme_template ) {
+					return false;
+				}
+				return true;
+			},
+		);
+
+		return $filtered_templates;
+	}
+
+	/**
 	 * Returns whether the blockified templates should be used or not.
 	 * First, we need to make sure WordPress version is higher than 6.1 (lowest that supports Products block).
 	 * Then, if the option is not stored on the db, we need to check if the current theme is a block one or not.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/42220.

Blocks https://github.com/woocommerce/woocommerce/pull/43794.

As mentioned in #42220, if the user modified a WooCommerce templates twice, once using the WooCommerce template as the base and the other time using the theme templates as the base, we ended up with duplicate templates on the list.

This PR fixes that and adds some tests to verify we don't introduce regressions in the future.

### How to test the changes in this Pull Request:

1. Activate a theme without WooCommerce templates (ie: Twenty Twenty Four).
2. Make a modification to a WooCommerce template. Ie: add a "Hello world" paragraph somewhere in the Single Product template.
3. Now, switch your theme to a theme with WooCommerce templates (ie: Tsubaki).
4. Make a modification to the same template from step 2. You will probably need to access it via the URL. Ie: `/wp-admin/site-editor.php?postId=theme-tsubaki%2F%2Fsingle-product&postType=wp_template&canvas=edit`. Note: the `theme-tsubaki` part of the URL might change depending on the ZIP file name that you uploaded. In case of doubt, go to Appearance > Editor > Templates > Template Catalog and look at the URL.
5. Load the templates list: `/wp-admin/site-editor.php?path=%2Fwp_template%2Fall`.
6. Verify there is only one template named "Single Product".

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Avoid duplicate templates appearing on the Site Editor when the WooCommerce template and the theme template have been customized by the user

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
