### PR TITLE
Remember downloadable files

### DIFF
--- a/plugins/woocommerce/changelog/add-43807-remember-downloadable-files
+++ b/plugins/woocommerce/changelog/add-43807-remember-downloadable-files
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+The previously uploaded file should re-appear when the product changes from downloadable to not and then back again

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1562,6 +1562,31 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	}
 
 	/**
+	 * Get the downloads for a product.
+	 *
+	 * @param WC_Product $product Product instance.
+	 *
+	 * @return array
+	 */
+	protected function get_downloads( $product ) {
+		$downloads = array();
+
+		$context = isset( $this->request ) && isset( $this->request['context'] ) ? $this->request['context'] : 'view';
+
+		if ( $product->is_downloadable() || $context === 'edit' ) {
+			foreach ( $product->get_downloads() as $file_id => $file ) {
+				$downloads[] = array(
+					'id'   => $file_id, // MD5 hash.
+					'name' => $file['name'],
+					'file' => $file['file'],
+				);
+			}
+		}
+
+		return $downloads;
+	}
+
+	/**
 	 * Get product data.
 	 *
 	 * @param WC_Product $product Product instance.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1573,7 +1573,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		$context = isset( $this->request ) && isset( $this->request['context'] ) ? $this->request['context'] : 'view';
 
-		if ( $product->is_downloadable() || $context === 'edit' ) {
+		if ( $product->is_downloadable() || 'edit' === $context ) {
 			foreach ( $product->get_downloads() as $file_id => $file ) {
 				$downloads[] = array(
 					'id'   => $file_id, // MD5 hash.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43807

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-virtual-downloadable` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and the bottom of the page a new `Downloads` section should be shown only when the `Include downloads` checkbox is checked.
5. If the user uploads a file, then toggles off `Include downloads`, then Saves or Updates the product, then toggles on `Include downloads`, the previously uploaded file should re-appear. (This aligns with how it currently works in our legacy editor, gif below.)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
