### PR TITLE
[Experimental] Update args for `woocommerce_blocks_validate_additional_field_{key}` filter

### DIFF
--- a/plugins/woocommerce/changelog/remove-schema-from-additional-fields-filter
+++ b/plugins/woocommerce/changelog/remove-schema-from-additional-fields-filter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: This is behind a feature flag for now.
+
+

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -539,10 +539,11 @@ class CheckoutFields {
 	 * @param string           $key          The key of the field.
 	 * @param mixed            $field_value  The value of the field.
 	 * @param \WP_REST_Request $request      The current API Request.
+	 * @param string|null      $address_type The type of address (billing, shipping, or null if the field is a contact/additional field).
 	 *
 	 * @since 8.6.0
 	 */
-	public function validate_field( $key, $field_value, $request ) {
+	public function validate_field( $key, $field_value, $request, $address_type ) {
 
 		$error = new \WP_Error();
 		try {
@@ -552,10 +553,11 @@ class CheckoutFields {
 			 * @param \WP_Error        $error        A WP_Error that extensions may add errors to.
 			 * @param mixed            $field_value  The value of the field.
 			 * @param \WP_REST_Request $request      The current API Request.
+			 * @param string|null      $address_type The type of address (billing, shipping, or null if the field is a contact/additional field).
 			 *
 			 * @since 8.6.0
 			 */
-			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $error, $field_value, $request );
+			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $error, $field_value, $request, $address_type );
 
 			if ( $error !== $filtered_result ) {
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -543,7 +543,7 @@ class CheckoutFields {
 	 *
 	 * @since 8.6.0
 	 */
-	public function validate_field( $key, $field_value, $request, $address_type ) {
+	public function validate_field( $key, $field_value, $request, $address_type = null ) {
 
 		$error = new \WP_Error();
 		try {

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -538,12 +538,11 @@ class CheckoutFields {
 	 *
 	 * @param string           $key          The key of the field.
 	 * @param mixed            $field_value  The value of the field.
-	 * @param array            $field_schema The schema of the field.
 	 * @param \WP_REST_Request $request      The current API Request.
 	 *
 	 * @since 8.6.0
 	 */
-	public function validate_field( $key, $field_value, $field_schema, $request ) {
+	public function validate_field( $key, $field_value, $request ) {
 
 		$error = new \WP_Error();
 		try {
@@ -552,12 +551,11 @@ class CheckoutFields {
 			 *
 			 * @param \WP_Error        $error        A WP_Error that extensions may add errors to.
 			 * @param mixed            $field_value  The value of the field.
-			 * @param array            $field_schema The schema of the field.
 			 * @param \WP_REST_Request $request      The current API Request.
 			 *
 			 * @since 8.6.0
 			 */
-			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $error, $field_value, $field_schema, $request );
+			$filtered_result = apply_filters( 'woocommerce_blocks_validate_additional_field_' . $key, $error, $field_value, $request );
 
 			if ( $error !== $filtered_result ) {
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -222,7 +222,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {
-				$errors->add( $result->get_error_code(), $result->get_error_message() );
+				$errors->merge_from( $result );
 			}
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -217,7 +217,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
 			// Skip additional validation if the schema validation failed.
 			if ( true === $result && in_array( $key, $additional_keys, true ) ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $properties[ $key ], $request );
+				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $request );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -217,7 +217,8 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
 			// Skip additional validation if the schema validation failed.
 			if ( true === $result && in_array( $key, $additional_keys, true ) ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $request );
+				$address_type = 'shipping_address' === $this->title ? 'shipping' : 'billing';
+				$result       = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $request, $address_type );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -373,7 +373,7 @@ class CheckoutSchema extends AbstractSchema {
 
 			// Only allow custom validation on fields that pass the schema validation.
 			if ( true === $result ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $request );
+				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $request, null );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -373,7 +373,7 @@ class CheckoutSchema extends AbstractSchema {
 
 			// Only allow custom validation on fields that pass the schema validation.
 			if ( true === $result ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $properties[ $key ], $request );
+				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $request );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -373,7 +373,7 @@ class CheckoutSchema extends AbstractSchema {
 
 			// Only allow custom validation on fields that pass the schema validation.
 			if ( true === $result ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $request, null );
+				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $request );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the `$field_schema` arg from the `woocommerce_blocks_validate_additional_field_{key}` filters - this is because we didn't find a lot of value in having that arg available to the filter and it is safer to add it later if needed than remove it later if it becomes problematic.

We will assess any use-cases that arise when this feature is released and if legit use cases for knowing the additional checkout field's schema are raised we will consider adding it back.

It also adds the `$address_type` arg to this filter. This is required because any validation callbacks for fields rendered in the `address` location would not know which address they're validating for. These callbacks will be called twice, once for billing, once for shipping, so it is important that the type can be distinguished.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Add the following snippet to your site:

```php
add_action( 'woocommerce_blocks_loaded', function() {
	woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/gov-id',
				'label'    => 'Government ID',
				'location' => 'address',
				'type'     => 'text',
				'required' => true,
			),
		);

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/confirm-gov-id',
				'label'    => 'Confirm Government ID',
				'location' => 'address',
				'type'     => 'text',
				'required' => true,
			),
		);

		add_filter( 'woocommerce_blocks_validate_additional_field_plugin-namespace/gov-id', function ( \WP_Error $error, $value, $request, $address_type ) {
			$match = preg_match( '/[A-Z0-9]{5}/', $value );
			if ( 0 === $match || false === $match ) {
				$error->add( 'invalid_gov_id', 'Please ensure your government ID matches the correct format.' );
			}
			$address_key = 'shipping' === $address_type ? 'shipping_address' : 'billing_address';
			if ( $value !== $request->get_params()[ $address_key ]['plugin-namespace/confirm-gov-id'] ) {
				$error->add( 'gov_id_mismatch', 'Please ensure your government ID matches the confirmation.' );
			}
			return $error;
		}, 10, 4 );
} );
```

1. Add an item to your cart and go to the Checkout block
3. Check the Government ID inputs show up in the address form.
4. Enter `abcde` into both fields and submit the form.
5. Ensure an error shows up saying: `Please ensure your government ID matches the correct format.`
7. Enter `12345` into the first field and `abcde` into the second field. Ensure two errors show up. One saying: `Please ensure your government ID matches the correct format.` and one saying `Please ensure your government ID matches the confirmation.'`.
8. Change both fields to `12345` and ensure you can check out successfully.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
