### PR TITLE
[CYS] Proceed with product creation when their images fail to upload

### DIFF
--- a/plugins/woocommerce/changelog/44031-44005-handle-products-error
+++ b/plugins/woocommerce/changelog/44031-44005-handle-products-error
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-CYS: Handle errors when the product creation fails.
+CYS: Proceed with product creation when their images fails to upload.

--- a/plugins/woocommerce/changelog/44031-44005-handle-products-error
+++ b/plugins/woocommerce/changelog/44031-44005-handle-products-error
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-CYS: Proceed with product creation when their images fails to upload.
+CYS: Handle errors when the product creation fails.

--- a/plugins/woocommerce/changelog/44031-44005-handle-products-error
+++ b/plugins/woocommerce/changelog/44031-44005-handle-products-error
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-CYS: Proceed with product creation when their images fails to upload.
+CYS: Proceed with product creation when their images fail to upload.

--- a/plugins/woocommerce/changelog/44031-44005-handle-products-error
+++ b/plugins/woocommerce/changelog/44031-44005-handle-products-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS: Handle errors when the product creation fails.

--- a/plugins/woocommerce/src/Admin/API/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProducts.php
@@ -62,7 +62,7 @@ class OnboardingProducts extends \WC_REST_Data_Controller {
 		$products = $update_products->fetch_dummy_products_to_update();
 
 		if ( is_wp_error( $products ) ) {
-			return rest_ensure_response( array( 'success' => false ) );
+			return rest_ensure_response( $products );
 		}
 
 		return rest_ensure_response( array( 'success' => true ) );

--- a/plugins/woocommerce/src/Admin/API/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProducts.php
@@ -62,7 +62,7 @@ class OnboardingProducts extends \WC_REST_Data_Controller {
 		$products = $update_products->fetch_dummy_products_to_update();
 
 		if ( is_wp_error( $products ) ) {
-			return rest_ensure_response( $products );
+			return rest_ensure_response( array( 'success' => false ) );
 		}
 
 		return rest_ensure_response( array( 'success' => true ) );

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
@@ -112,7 +112,11 @@ class UpdateProducts {
 		$dummy_products_count = count( $dummy_products );
 		$products_to_create   = max( 0, 6 - $real_products_count - $dummy_products_count );
 		while ( $products_to_create > 0 ) {
-			$this->create_new_product( self::DUMMY_PRODUCTS[ $products_to_create - 1 ] );
+			$product_created = $this->create_new_product( self::DUMMY_PRODUCTS[ $products_to_create - 1 ] );
+			if ( is_wp_error( $product_created ) ) {
+				return $product_created;
+			}
+
 			$products_to_create--;
 		}
 

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
@@ -112,11 +112,7 @@ class UpdateProducts {
 		$dummy_products_count = count( $dummy_products );
 		$products_to_create   = max( 0, 6 - $real_products_count - $dummy_products_count );
 		while ( $products_to_create > 0 ) {
-			$product_created = $this->create_new_product( self::DUMMY_PRODUCTS[ $products_to_create - 1 ] );
-			if ( is_wp_error( $product_created ) ) {
-				return $product_created;
-			}
-
+			$this->create_new_product( self::DUMMY_PRODUCTS[ $products_to_create - 1 ] );
 			$products_to_create--;
 		}
 

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
@@ -197,10 +197,6 @@ class UpdateProducts {
 		$image_alt        = $product_data['title'];
 		$product_image_id = $this->product_image_upload( $product->get_id(), $image_src, $image_alt );
 
-		if ( is_wp_error( $product_image_id ) ) {
-			return new \WP_Error( 'error_uploading_image', $product_image_id->get_error_message() );
-		}
-
 		$saved_product = $this->product_update( $product, $product_image_id, $product_data['title'], $product_data['description'], $product_data['price'] );
 
 		if ( is_wp_error( $saved_product ) ) {
@@ -297,10 +293,6 @@ class UpdateProducts {
 		}
 
 		$product_image_id = $this->product_image_upload( $product->get_id(), $ai_generated_product_content['image']['src'], $ai_generated_product_content['image']['alt'] );
-
-		if ( is_wp_error( $product_image_id ) ) {
-			return new \WP_Error( 'error_uploading_image', $product_image_id->get_error_message() );
-		}
 
 		$this->product_update( $product, $product_image_id, $ai_generated_product_content['title'], $ai_generated_product_content['description'], $ai_generated_product_content['price'] );
 	}
@@ -474,10 +466,6 @@ class UpdateProducts {
 			$image_alt        = self::DUMMY_PRODUCTS[ $i ]['title'];
 			$product_image_id = $this->product_image_upload( $product->get_id(), $image_src, $image_alt );
 
-			if ( is_wp_error( $product_image_id ) ) {
-				continue;
-			}
-
 			$this->product_update( $product, $product_image_id, self::DUMMY_PRODUCTS[ $i ]['title'], self::DUMMY_PRODUCTS[ $i ]['description'], self::DUMMY_PRODUCTS[ $i ]['price'] );
 
 			$i++;
@@ -500,7 +488,9 @@ class UpdateProducts {
 			return new WP_Error( 'invalid_product', __( 'Invalid product.', 'woocommerce' ) );
 		}
 
-		$product->set_image_id( $product_image_id );
+		if ( ! is_wp_error( $product_image_id ) ) {
+			$product->set_image_id( $product_image_id );
+		}
 		$product->set_name( $product_title );
 		$product->set_description( $product_description );
 		$product->set_price( $product_price );

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
@@ -486,6 +486,14 @@ class UpdateProducts {
 
 		if ( ! is_wp_error( $product_image_id ) ) {
 			$product->set_image_id( $product_image_id );
+		} else {
+			wc_get_logger()->warning(
+				sprintf(
+					// translators: %s is a generated error message.
+					__( 'The image upload failed: "%s", creating the product without image', 'woocommerce' ),
+					$product_image_id->get_error_message()
+				),
+			);
 		}
 		$product->set_name( $product_title );
 		$product->set_description( $product_description );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR avoids returning an error when the `product_image_upload` function fails. The error is now handled in the `product_update` function before associating the image to the product. That way we ensure products are created even when the image upload fails.

Closes https://github.com/woocommerce/woocommerce/issues/44005

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
2. Go to `WooCommerce > Home`, click on the `Start Customizing` button, and finish the CYS flow.
3. Make sure all products are created correctly and have images associated with them.
4. Update the code in https://github.com/woocommerce/woocommerce/blob/97dca87e7ae2f24a10be3ac9ddc27598952764ab/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php#L305 👇 to simulate an error when uploading product images:
```
	private function product_image_upload( $product_id, $image_src, $image_alt ) {
		return new \WP_Error( 'error_uploading_image' );
```
5. Go to `wp-admin/tools.php?page=woocommerce-admin-test-helper` and click on `Reset Customize Your Store` and `Delete all products`.
6. Go to `WooCommerce > Home`, click on the `Start Customizing` button, and finish the CYS flow.
7. Go to `Products` in the admin and make sure all dummy products are created with a placeholder image.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: Proceed with product creation when their images fail to upload.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
