### PR TITLE
Add tracking to non-WooCommerce commands re-registering the commands

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -17,6 +17,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { registerCommandWithTracking } from './register-command-with-tracking';
 import { useEditedPostType } from './use-edited-post-type';
+import { useAddTrackingToExternalCommands } from './use-add-tracking-to-external-commands';
 
 const registerWooCommerceSettingsCommand = ( { label, tab, origin } ) => {
 	registerCommandWithTracking( {
@@ -95,6 +96,7 @@ function useProductCommandLoader( { search } ) {
 				callback: ( { close } ) => {
 					queueRecordEvent( 'woocommerce_command_palette_submit', {
 						name: 'woocommerce/product',
+						title: record.title.raw,
 						origin,
 					} );
 
@@ -119,6 +121,7 @@ function useProductCommandLoader( { search } ) {
 const WooCommerceCommands = () => {
 	const { editedPostType } = useEditedPostType();
 	const origin = editedPostType ? editedPostType + '-editor' : null;
+	useAddTrackingToExternalCommands( origin );
 	const { isCommandPaletteOpen } = useSelect( ( select ) => {
 		const { isOpen } = select( commandsStore );
 		return {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -96,7 +96,7 @@ function useProductCommandLoader( { search } ) {
 				callback: ( { close } ) => {
 					queueRecordEvent( 'woocommerce_command_palette_submit', {
 						name: 'woocommerce/product',
-						title: record.title.raw,
+						label: record.title.raw,
 						origin,
 					} );
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/register-command-with-tracking.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/register-command-with-tracking.js
@@ -20,6 +20,7 @@ export const registerCommandWithTracking = ( {
 		callback: ( ...args ) => {
 			queueRecordEvent( 'woocommerce_command_palette_submit', {
 				name,
+				label,
 				origin,
 			} );
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-add-tracking-to-external-commands.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-add-tracking-to-external-commands.js
@@ -43,6 +43,7 @@ export const useAddTrackingToExternalCommands = ( origin ) => {
 					callback: ( ...args ) => {
 						recordEvent( 'woocommerce_command_palette_submit', {
 							name: command.name,
+							label: command.label,
 							origin: originRef.current,
 						} );
 						command.callback( ...args );
@@ -72,7 +73,7 @@ export const useAddTrackingToExternalCommands = ( origin ) => {
 											'woocommerce_command_palette_submit',
 											{
 												name: commandLoader.name,
-												title:
+												label:
 													command.label ??
 													command.name,
 												origin: originRef.current,

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-add-tracking-to-external-commands.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-add-tracking-to-external-commands.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { dispatch, useSelect } from '@wordpress/data';
+import { recordEvent, queueRecordEvent } from '@woocommerce/tracks';
+import { store as commandsStore } from '@wordpress/commands';
+
+// Hook to add tracking to non-WooCommerce commands.
+export const useAddTrackingToExternalCommands = ( origin ) => {
+	const wasTrackingAdded = useRef( false );
+	const { commands, commandLoaders } = useSelect( ( select ) => {
+		const { getCommands, getCommandLoaders } = select( commandsStore );
+		return {
+			commands: getCommands(),
+			commandLoaders: getCommandLoaders(),
+		};
+	}, [] );
+
+	useEffect( () => {
+		if ( wasTrackingAdded.current === false ) {
+			commands.forEach( ( command ) => {
+				dispatch( commandsStore ).registerCommand( {
+					...command,
+					callback: ( ...args ) => {
+						recordEvent( 'woocommerce_command_palette_submit', {
+							name: command.name,
+							origin,
+						} );
+						command.callback( ...args );
+					},
+				} );
+			} );
+			commandLoaders.forEach( ( commandLoader ) => {
+				dispatch( commandsStore ).registerCommandLoader( {
+					...commandLoader,
+					hook: ( ...args ) => {
+						const commandLoaderProps = commandLoader.hook(
+							...args
+						);
+						const commandsWithTracking =
+							commandLoaderProps.commands.map( ( command ) => {
+								return {
+									...command,
+									callback: ( ...callbackArgs ) => {
+										queueRecordEvent(
+											'woocommerce_command_palette_submit',
+											{
+												name: commandLoader.name,
+												title:
+													command.label ??
+													command.name,
+												origin,
+											}
+										);
+										command.callback( ...callbackArgs );
+									},
+								};
+							} );
+						return {
+							...commandLoaderProps,
+							commands: commandsWithTracking,
+						};
+					},
+				} );
+			} );
+			wasTrackingAdded.current = true;
+		}
+	}, [ commands, commandLoaders, origin ] );
+};

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-add-tracking-to-external-commands.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-add-tracking-to-external-commands.js
@@ -8,6 +8,7 @@ import { store as commandsStore } from '@wordpress/commands';
 
 // Hook to add tracking to non-WooCommerce commands.
 export const useAddTrackingToExternalCommands = ( origin ) => {
+	const originRef = useRef( origin );
 	const commandsWithTracking = useRef( [] );
 	const commandLoadersWithTracking = useRef( [] );
 	const { commands, commandLoaders, isCommandPaletteOpen } = useSelect(
@@ -24,6 +25,10 @@ export const useAddTrackingToExternalCommands = ( origin ) => {
 	);
 
 	useEffect( () => {
+		originRef.current = origin;
+	}, [ origin ] );
+
+	useEffect( () => {
 		if ( ! isCommandPaletteOpen ) {
 			commandsWithTracking.current = [];
 			commandLoadersWithTracking.current = [];
@@ -38,7 +43,7 @@ export const useAddTrackingToExternalCommands = ( origin ) => {
 					callback: ( ...args ) => {
 						recordEvent( 'woocommerce_command_palette_submit', {
 							name: command.name,
-							origin,
+							origin: originRef.current,
 						} );
 						command.callback( ...args );
 					},
@@ -70,7 +75,7 @@ export const useAddTrackingToExternalCommands = ( origin ) => {
 												title:
 													command.label ??
 													command.name,
-												origin,
+												origin: originRef.current,
 											}
 										);
 										command.callback( ...callbackArgs );
@@ -86,5 +91,5 @@ export const useAddTrackingToExternalCommands = ( origin ) => {
 				commandLoadersWithTracking.current.push( commandLoader.name );
 			}
 		} );
-	}, [ commands, commandLoaders, origin ] );
+	}, [ commands, commandLoaders ] );
 };

--- a/plugins/woocommerce/changelog/44032-update-command-palette-external-commands-tracking-ii
+++ b/plugins/woocommerce/changelog/44032-update-command-palette-external-commands-tracking-ii
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add tracking to non-WooCommerce commands in the Command Palette.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Supersedes https://github.com/woocommerce/woocommerce/pull/43265.

This PR is a follow-up of https://github.com/woocommerce/woocommerce/pull/41605 and https://github.com/woocommerce/woocommerce/pull/41838, with the goal to add tracking when the user triggers a non-WooCommerce Command.

This PR also adds a `label` property to the `woocommerce_command_palette_submit` event when triggered in a WooCommerce-command, so make it consistent with the new tracking events introduced in this PR.

The `label` property is important because some commands are loaded differently depending on the editor. Ie, the "Toggle breadcrumbs" command is loaded by a command loader in the site editor, but it's a regular command in the post/page editor, resulting in the tracking event having a different `name` property.

### How to test the changes in this Pull Request:

0. To test tracking, open the browser console (<kbd>F12</kbd>) and run `localStorage.setItem( 'debug', 'wc-admin:*' );`.
1. Go to the post editor (Posts > Add New).
2. Press <kbd>Ctrl</kbd>+<kbd>K</kbd> to open the Command Palette.
3. Type `breadcrumbs` as the search term in the Command Palette.
4. Click on the first command that appears.
5. Verify an event has been triggered  (in the browser console you will see something like `wc-admin:tracks recordevent wcadmin_woocommerce_command_palette_submit 
{ name: "core/toggle-breadcrumbs", label: "Show block breadcrumbs", origin: "post-editor" }`).
6. Now repeat steps 2-5, but with a command loader instruction (ie: search for a page name like _My Account_ in the command palette).
7. Repeat steps 2-6 in the Site Editor.
8. Feel free to take other actions to try to "break it". Ie: closing and opening the command palette, navigating between templates and template parts in the Site Editor, etc. There should always be one (and only one) `wcadmin_woocommerce_command_palette_submit` tracking event for each command that you trigger.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add tracking to non-WooCommerce commands in the Command Palette.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
