### PR TITLE
Fix fatal strpos in ComparisonOperation 8.5 branch

### DIFF
--- a/plugins/woocommerce/changelog/fix-strpos-in-ComparisonOperation
+++ b/plugins/woocommerce/changelog/fix-strpos-in-ComparisonOperation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add defensive checks for strpos in ComparisonOperation

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
@@ -36,22 +36,34 @@ class ComparisonOperation {
 				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
 					return in_array( $right_operand, $left_operand, true );
 				}
-				return strpos( $right_operand, $left_operand ) !== false;
+				if ( is_string( $right_operand ) && is_string( $left_operand ) ) {
+					return strpos( $right_operand, $left_operand ) !== false;
+				}
+				break;
 			case '!contains':
 				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
 					return ! in_array( $right_operand, $left_operand, true );
 				}
-				return strpos( $right_operand, $left_operand ) === false;
+				if ( is_string( $right_operand ) && is_string( $left_operand ) ) {
+					return strpos( $right_operand, $left_operand ) === false;
+				}
+				break;
 			case 'in':
 				if ( is_array( $right_operand ) && is_string( $left_operand ) ) {
 					return in_array( $left_operand, $right_operand, true );
 				}
-				return strpos( $left_operand, $right_operand ) !== false;
+				if ( is_string( $left_operand ) && is_string( $right_operand ) ) {
+					return strpos( $left_operand, $right_operand ) !== false;
+				}
+				break;
 			case '!in':
 				if ( is_array( $right_operand ) && is_string( $left_operand ) ) {
 					return ! in_array( $left_operand, $right_operand, true );
 				}
-				return strpos( $left_operand, $right_operand ) === false;
+				if ( is_string( $left_operand ) && is_string( $right_operand ) ) {
+					return strpos( $left_operand, $right_operand ) === false;
+				}
+				break;
 		}
 
 		return false;


### PR DESCRIPTION
### Submission Review Guidelines:

Related to fix in https://github.com/woocommerce/woocommerce/pull/44007

### Changes proposed in this Pull Request:

- Adds defensive checks

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a fresh site
1. Go to WooCommerce Setup Wizard
1. In country step, select Australia (to trigger the RIN rule)
2. Skip plugins step
3. Observe no fatal

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
