### PR TITLE
Refactor `get_allowed_countries` and `get_shipping_countries` to make less error prone

### DIFF
--- a/plugins/woocommerce/changelog/44034-fix-countries-settings-43853
+++ b/plugins/woocommerce/changelog/44034-fix-countries-settings-43853
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update `get_shipping_countries` to return no countries when shipping is disabled.

--- a/plugins/woocommerce/changelog/44034-fix-countries-settings-43853
+++ b/plugins/woocommerce/changelog/44034-fix-countries-settings-43853
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Update `get_shipping_countries` to return no countries when shipping is disabled.
+Update `get_shipping_countries` to return an empty list of countries when shipping is disabled.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -323,24 +323,34 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_shipping_countries() {
-		if ( '' === get_option( 'woocommerce_ship_to_countries' ) ) {
-			return $this->get_allowed_countries();
+		// If shipping is disabled, return an empty array.
+		if ( 'disabled' === get_option( 'woocommerce_ship_to_countries' ) ) {
+			return array();
 		}
 
+		// Default to selling countries.
+		$countries = $this->get_allowed_countries();
+
+		// All indicates that all countries are allowed, regardless of where you sell to.
 		if ( 'all' === get_option( 'woocommerce_ship_to_countries' ) ) {
-			return $this->countries;
-		}
+			$countries = $this->countries;
+		} elseif ( 'specific' === get_option( 'woocommerce_ship_to_countries' ) ) {
+			$countries     = array();
+			$raw_countries = get_option( 'woocommerce_specific_ship_to_countries', array() );
 
-		$countries = array();
-
-		$raw_countries = get_option( 'woocommerce_specific_ship_to_countries' );
-
-		if ( $raw_countries ) {
-			foreach ( $raw_countries as $country ) {
-				$countries[ $country ] = $this->countries[ $country ];
+			if ( $raw_countries ) {
+				foreach ( $raw_countries as $country ) {
+					$countries[ $country ] = $this->countries[ $country ];
+				}
 			}
 		}
 
+		/**
+		 * Filter the list of allowed selling countries.
+		 *
+		 * @since 3.3.0
+		 * @param array $countries
+		 */
 		return apply_filters( 'woocommerce_countries_shipping_countries', $countries );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -287,9 +287,10 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_allowed_countries() {
-		$countries = $this->countries;
+		$countries         = $this->countries;
+		$allowed_countries = get_option( 'woocommerce_allowed_countries' );
 
-		if ( 'all_except' === get_option( 'woocommerce_allowed_countries' ) ) {
+		if ( 'all_except' === $allowed_countries ) {
 			$except_countries = get_option( 'woocommerce_all_except_countries', array() );
 
 			if ( $except_countries ) {
@@ -297,7 +298,7 @@ class WC_Countries {
 					unset( $countries[ $country ] );
 				}
 			}
-		} elseif ( 'specific' === get_option( 'woocommerce_allowed_countries' ) ) {
+		} elseif ( 'specific' === $allowed_countries ) {
 			$countries     = array();
 			$raw_countries = get_option( 'woocommerce_specific_allowed_countries', array() );
 

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -287,34 +287,33 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_allowed_countries() {
-		if ( 'all' === get_option( 'woocommerce_allowed_countries' ) ) {
-			return apply_filters( 'woocommerce_countries_allowed_countries', $this->countries );
-		}
+		$countries = $this->countries;
 
 		if ( 'all_except' === get_option( 'woocommerce_allowed_countries' ) ) {
 			$except_countries = get_option( 'woocommerce_all_except_countries', array() );
 
-			if ( ! $except_countries ) {
-				return $this->countries;
-			} else {
-				$all_except_countries = $this->countries;
+			if ( $except_countries ) {
 				foreach ( $except_countries as $country ) {
-					unset( $all_except_countries[ $country ] );
+					unset( $countries[ $country ] );
 				}
-				return apply_filters( 'woocommerce_countries_allowed_countries', $all_except_countries );
+			}
+		} elseif ( 'specific' === get_option( 'woocommerce_allowed_countries' ) ) {
+			$countries     = array();
+			$raw_countries = get_option( 'woocommerce_specific_allowed_countries', array() );
+
+			if ( $raw_countries ) {
+				foreach ( $raw_countries as $country ) {
+					$countries[ $country ] = $this->countries[ $country ];
+				}
 			}
 		}
 
-		$countries = array();
-
-		$raw_countries = get_option( 'woocommerce_specific_allowed_countries', array() );
-
-		if ( $raw_countries ) {
-			foreach ( $raw_countries as $country ) {
-				$countries[ $country ] = $this->countries[ $country ];
-			}
-		}
-
+		/**
+		 * Filter the list of allowed selling countries.
+		 *
+		 * @since 3.3.0
+		 * @param array $countries
+		 */
 		return apply_filters( 'woocommerce_countries_allowed_countries', $countries );
 	}
 
@@ -859,7 +858,7 @@ class WC_Countries {
 						),
 					),
 					'AL' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'County', 'woocommerce' ),
 						),
 					),
@@ -968,7 +967,7 @@ class WC_Countries {
 							'required' => false,
 							'hidden'   => true,
 						),
-						'state' 	=> array(
+						'state'    => array(
 							'required' => false,
 						),
 					),
@@ -1011,7 +1010,7 @@ class WC_Countries {
 						'postcode' => array(
 							'required' => false,
 						),
-						'state' => array(
+						'state'    => array(
 							'label' => __( 'Department', 'woocommerce' ),
 						),
 					),
@@ -1054,12 +1053,12 @@ class WC_Countries {
 						),
 					),
 					'DO' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'Province', 'woocommerce' ),
 						),
 					),
 					'EC' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'Province', 'woocommerce' ),
 						),
 					),
@@ -1097,11 +1096,11 @@ class WC_Countries {
 						),
 					),
 					'GG' => array(
- 						'state' => array(
- 							'required' => false,
- 							'label' => __( 'Parish', 'woocommerce' ),
- 						),
- 					),
+						'state' => array(
+							'required' => false,
+							'label'    => __( 'Parish', 'woocommerce' ),
+						),
+					),
 					'GH' => array(
 						'postcode' => array(
 							'required' => false,
@@ -1147,7 +1146,7 @@ class WC_Countries {
 						),
 					),
 					'HN' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'Department', 'woocommerce' ),
 						),
 					),
@@ -1350,7 +1349,7 @@ class WC_Countries {
 						),
 					),
 					'NI' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'Department', 'woocommerce' ),
 						),
 					),
@@ -1400,7 +1399,7 @@ class WC_Countries {
 						),
 					),
 					'PA' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'Province', 'woocommerce' ),
 						),
 					),
@@ -1430,7 +1429,7 @@ class WC_Countries {
 					),
 					'PY' => array(
 						'state' => array(
-							'label'    => __( 'Department', 'woocommerce' ),
+							'label' => __( 'Department', 'woocommerce' ),
 						),
 					),
 					'RE' => array(
@@ -1497,7 +1496,7 @@ class WC_Countries {
 						),
 					),
 					'SV' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'Department', 'woocommerce' ),
 						),
 					),
@@ -1575,7 +1574,7 @@ class WC_Countries {
 						),
 					),
 					'UY' => array(
-						'state'    => array(
+						'state' => array(
 							'label' => __( 'Department', 'woocommerce' ),
 						),
 					),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While investigating https://github.com/woocommerce/woocommerce/issues/43853 I found some odd behaviours in `get_allowed_countries` and `get_shipping_countries` which should be improved.

## `get_allowed_countries`

This methods returns countries depending on `woocommerce_allowed_countries` setting. It matched against `all` and `all_except`, but left `specific` handling as the default case. Since the `woocommerce_allowed_countries` setting defaults to `all`, this should be the default handling. This protects against corrupted or missing `woocommerce_allowed_countries` setting values.

## `get_shipping_countries`

This lacked handling for `disabled` which meant that if a store disabled shipping and someone consumed this method unaware, it would still return a subset of shipping countries. I think this is related to the issue in #43853 but I've been unable to reproduce since.

I've made it specifically handle `disabled` which then returns no countries. I also updated the code to match `get_allowed_countries`, as well as ensuring `woocommerce_countries_shipping_countries` runs on the return value for all cases.

There are existing legacy unit tests in place for these functions.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Under WC > Settings, set "Selling location" to all and "Shipping location" to "all locations you sell to". Go to checkout and ensure the billing and shipping country dropdowns populate with all countries.
2. Under WC > Settings, set "Shipping location" to "disable shipping calculations". Go to checkout and ensure no shipping is visible, and the billing country dropdown is populated correctly. 
3. Under WC > Settings, set "Selling location" and "Shipping location" to "specific" countries. Choose a subset of countries, then checkout and ensure the country dropdowns match your selection.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update `get_shipping_countries` to return no countries when shipping is disabled.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
