### PR TITLE
Add rudimentary try catch for all remote endpoint spec evaluators

### DIFF
--- a/plugins/woocommerce/changelog/fix-8.5-rudimentary-trycatch-remote-apis
+++ b/plugins/woocommerce/changelog/fix-8.5-rudimentary-trycatch-remote-apis
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add rudimentary try catch for all remote endpoint spec evaluators

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -44,7 +44,10 @@ class Init {
 			try {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
-			} catch (\Throwable $e) {}
+				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			} catch ( \Throwable $e ) {
+				// Ignore errors.
+			}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -41,8 +41,10 @@ class Init {
 		}
 
 		foreach ( $specs as $spec ) {
-			$suggestion    = EvaluateSuggestion::evaluate( $spec );
-			$suggestions[] = $suggestion;
+			try {
+				$suggestion    = EvaluateSuggestion::evaluate( $spec );
+				$suggestions[] = $suggestion;
+			} catch (\Throwable $e) {}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -37,12 +37,14 @@ class SpecRunner {
 
 		// Evaluate the spec and get the new note status.
 		$previous_status = $note->get_status();
-		$status          = EvaluateAndGetStatus::evaluate(
-			$spec,
-			$previous_status,
-			$stored_state,
-			new RuleEvaluator()
-		);
+		try {
+			$status          = EvaluateAndGetStatus::evaluate(
+				$spec,
+				$previous_status,
+				$stored_state,
+				new RuleEvaluator()
+			);
+		} catch (\Throwable $e) { return; }
 
 		// If the status is changing, update the created date to now.
 		if ( $previous_status !== $status ) {

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -38,13 +38,15 @@ class SpecRunner {
 		// Evaluate the spec and get the new note status.
 		$previous_status = $note->get_status();
 		try {
-			$status          = EvaluateAndGetStatus::evaluate(
+			$status = EvaluateAndGetStatus::evaluate(
 				$spec,
 				$previous_status,
 				$stored_state,
 				new RuleEvaluator()
 			);
-		} catch (\Throwable $e) { return; }
+		} catch ( \Throwable $e ) {
+			return;
+		}
 
 		// If the status is changing, update the created date to now.
 		if ( $previous_status !== $status ) {

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
@@ -42,11 +42,12 @@ class Init {
 			}
 
 			foreach ( $spec->plugins as $plugin ) {
-				$extension = EvaluateExtension::evaluate( (object) $plugin );
-
-				if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
-					$bundle['plugins'][] = $extension;
-				}
+				try {
+					$extension = EvaluateExtension::evaluate( (object) $plugin );
+					if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
+						$bundle['plugins'][] = $extension;
+					}
+				} catch (\Throwable $e) {}
 			}
 
 			$bundles[] = $bundle;

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
@@ -47,7 +47,10 @@ class Init {
 					if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
 						$bundle['plugins'][] = $extension;
 					}
-				} catch (\Throwable $e) {}
+					// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				} catch ( \Throwable $e ) {
+					// Ignore errors.
+				}
 			}
 
 			$bundles[] = $bundle;

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -129,7 +129,10 @@ class Init {
 			try {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
-			} catch (\Throwable $e) {}
+				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			} catch (\Throwable $e) {
+				// Ignore errors.
+			}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -126,8 +126,10 @@ class Init {
 		$specs       = self::get_specs();
 
 		foreach ( $specs as $spec ) {
-			$suggestion    = EvaluateSuggestion::evaluate( $spec );
-			$suggestions[] = $suggestion;
+			try {
+				$suggestion    = EvaluateSuggestion::evaluate( $spec );
+				$suggestions[] = $suggestion;
+			} catch (\Throwable $e) {}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -130,7 +130,7 @@ class Init {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
 				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			} catch (\Throwable $e) {
+			} catch ( \Throwable $e ) {
 				// Ignore errors.
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In light of a recent fatal due to faulty rule in PaymentGatewaySuggestions, this PR aims to add rudimentary and broad try-catch in order to prevent future fatals. 

### How to test the changes in this Pull Request:

#### In order to simulate errors either:
1. Cherry-pick the commit 52f8fa8e681cf0932996e5921cf51dc840939ba8 from [this branch](https://github.com/woocommerce/woocommerce/compare/release/8.5...tempfixtestbrokenapi?expand=1)
2. Or manually set the following APIs
    - PaymentGatewaySuggestionsDataSourcePoller ([file](https://github.com/woocommerce/woocommerce/blob/0aebb139c2b1004879dca63825dc6654c4f46bea/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaySuggestionsDataSourcePoller.php#L21)): https://api.npoint.io/83d63d29d478ececdbc5
    - DataSourcePoller ([file](https://github.com/woocommerce/woocommerce/blob/0aebb139c2b1004879dca63825dc6654c4f46bea/plugins/woocommerce/src/Admin/RemoteInboxNotifications/DataSourcePoller.php#L18)): https://api.npoint.io/099094352a530a673fef
    - RemoteFreeExtensionsDataSourcePoller ([file](https://github.com/woocommerce/woocommerce/blob/0aebb139c2b1004879dca63825dc6654c4f46bea/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php#L13)): https://api.npoint.io/34e72d8b75957e47ff1e
    - WCPayPromotionDataSourcePoller ([file](https://github.com/woocommerce/woocommerce/blob/0aebb139c2b1004879dca63825dc6654c4f46bea/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPayPromotionDataSourcePoller.php#L17)): https://api.npoint.io/6eed3f7093fa2ca8fd1f

#### Testing

1. In your environment, use PHP 8.1+
1. If using an existing site, clear transients by running `wp transient delete --all`
2. Ensure WooCommerce > Settings > Advanced > Woo.com > `Display suggestions within WooCommerce` is checked
3. Go to Setup Wizard, `/wp-admin/admin.php?page=wc-admin&path=/setup-wizard`
4. Click continue
5. Select `I'm just starting my business` and continue
6. Select `Australia — Australian Capital Territory` and continue
7. Skip plugin installation
8. Observe no fatal when loading homescreen
9. Go to Tools > WCA Test Helper > Tools > Run wc_admin_daily job
10. Ensure the job is run successfully

