### PR TITLE
Fix a link typo in adding-a-section-to-a-settings-tab.md

### DIFF
--- a/docs/extension-development/adding-a-section-to-a-settings-tab.md
+++ b/docs/extension-development/adding-a-section-to-a-settings-tab.md
@@ -136,4 +136,4 @@ You would now just use your newly created settings like you would any other Word
 
 ## Conclusion
 
-When creating an extension for WooCommerce, think about where your settings belong before you create them. The key to building a useful product is making it easy to use for the end user, so appropriate setting placement is crucially important. For more specific information on adding settings to WooCommerce, check out the  [**Settings API documentation**](https://github.com/woocommerce/woocommerce/blob/trunk/docs/extesion-developlment/settings-api/).
+When creating an extension for WooCommerce, think about where your settings belong before you create them. The key to building a useful product is making it easy to use for the end user, so appropriate setting placement is crucially important. For more specific information on adding settings to WooCommerce, check out the  [**Settings API documentation**](https://github.com/woocommerce/woocommerce/blob/trunk/docs/extension-development/settings-api.md).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

#### Significance

<!-- Choose only one -->

-   [x] Patch

#### Type

<!-- Choose only one -->

-   [x] Tweak - A minor adjustment to the codebase

#### Comment

This just fixes a typo in a link that I noticed when reading the docs. Thanks!