### PR TITLE
[Product Block Editor]: improve getting suggested products from linked product section

### DIFF
--- a/packages/js/product-editor/changelog/update-improve-getting-fresh-product-suggestions
+++ b/packages/js/product-editor/changelog/update-improve-getting-fresh-product-suggestions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: improve getting suggested products from linked product section

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/edit.tsx
@@ -41,7 +41,7 @@ import {
 	LinkedProductListBlockAttributes,
 	LinkedProductListBlockEmptyState,
 } from './types';
-import getRelatedProducts from '../../../utils/get-related-products';
+import { getSuggestedProductsFor } from '../../../utils/get-related-products';
 import { SectionActions } from '../../../components/block-slot-fill';
 
 export function EmptyStateImage( {
@@ -182,8 +182,8 @@ export function LinkedProductListBlockEdit( {
 
 		setIsChoosingProducts( true );
 
-		const relatedProducts = ( await getRelatedProducts( productId, {
-			fallbackToRandomProducts: true,
+		const linkedProducts = ( await getSuggestedProductsFor( {
+			postId: productId,
 		} ) ) as Product[];
 
 		dispatch( {
@@ -195,12 +195,12 @@ export function LinkedProductListBlockEdit( {
 
 		setIsChoosingProducts( false );
 
-		if ( ! relatedProducts ) {
+		if ( ! linkedProducts ) {
 			return;
 		}
 
 		const newLinkedProducts = selectSearchedProductDispatcher(
-			relatedProducts,
+			linkedProducts,
 			[]
 		);
 

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -2,12 +2,8 @@
  * External dependencies
  */
 import { select, resolveSelect } from '@wordpress/data';
+import { PRODUCTS_STORE_NAME } from '@woocommerce/data';
 import type { Product } from '@woocommerce/data';
-/**
- * Internal dependencies
- */
-import { GetSuggestedProductsOptions } from '../../store/data/types';
-import { store as wooProductEditorDataStore } from '../../store/data/constants';
 
 type getRelatedProductsOptions = {
 	// If true, return random products if no related products are found.
@@ -78,16 +74,16 @@ type getSuggestedProductsForOptions = {
 	postType?: 'product' | 'post' | 'page';
 };
 
-type ProductTaxonomyItemProps = {
-	id: number;
-	name: string;
-	slug: string;
-};
-
+/**
+ * Get suggested products for a given post ID.
+ *
+ * @param { getSuggestedProductsForOptions } options - Options.
+ * @return { Promise<Product[] | undefined> } Suggested products.
+ */
 export async function getSuggestedProductsFor( {
 	postId,
 	postType = 'product',
-}: getSuggestedProductsForOptions ) {
+}: getSuggestedProductsForOptions ): Promise< Product[] | undefined > {
 	// @ts-expect-error There are no types for this.
 	const { getEditedEntityRecord } = select( 'core' );
 
@@ -95,14 +91,12 @@ export async function getSuggestedProductsFor( {
 
 	const options = {
 		categories: data?.categories
-			? data.categories.map( ( cat: ProductTaxonomyItemProps ) => cat.id )
+			? data.categories.map( ( cat ) => cat.id )
 			: [],
-		tags: data?.tags
-			? data.tags.map( ( tag: ProductTaxonomyItemProps ) => tag.id )
-			: [],
+		tags: data?.tags ? data.tags.map( ( tag ) => tag.id ) : [],
 	};
 
-	return await resolveSelect(
-		wooProductEditorDataStore
-	).getSuggestedProducts( options );
+	return await resolveSelect( PRODUCTS_STORE_NAME ).getSuggestedProducts(
+		options
+	);
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the way to suggest products when the user clicks on clicks on the `Choose products for me` from the Linked Products section of the new Product Editor app.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR returns a fresh list of products when the user clicks on the `Choose products for me` button.

Follow-up of https://github.com/woocommerce/woocommerce/pull/44043
Closes https://github.com/woocommerce/woocommerce/issues/44049

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Product Editor
2. Ensure to have a few products to test 
3. Go to the Linked Products section 
4. Click on the `Choose products for me` button
5. Confirm the app returns a product list
6. Confirm when clicking on it again doesn't perform a new request
(there is an UI https://github.com/woocommerce/woocommerce/issues/43845)
7. Change product organization
8. Repeat from (3) as many times as you want

# 🍿 

https://github.com/woocommerce/woocommerce/assets/77539/eaa07b8c-3d39-40c3-8264-baafdd22ea45

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
