### PR TITLE
Fix fatal strpos in ComparisonOperation 8.4 branch

### DIFF
--- a/plugins/woocommerce/changelog/fix-strpos-in-ComparisonOperation
+++ b/plugins/woocommerce/changelog/fix-strpos-in-ComparisonOperation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add defensive checks for strpos in ComparisonOperation

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
@@ -36,22 +36,34 @@ class ComparisonOperation {
 				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
 					return in_array( $right_operand, $left_operand, true );
 				}
-				return strpos( $right_operand, $left_operand ) !== false;
+				if ( is_string( $right_operand ) && is_string( $left_operand ) ) {
+					return strpos( $right_operand, $left_operand ) !== false;
+				}
+				break;
 			case '!contains':
 				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
 					return ! in_array( $right_operand, $left_operand, true );
 				}
-				return strpos( $right_operand, $left_operand ) === false;
+				if ( is_string( $right_operand ) && is_string( $left_operand ) ) {
+					return strpos( $right_operand, $left_operand ) === false;
+				}
+				break;
 			case 'in':
 				if ( is_array( $right_operand ) && is_string( $left_operand ) ) {
 					return in_array( $left_operand, $right_operand, true );
 				}
-				return strpos( $left_operand, $right_operand ) !== false;
+				if ( is_string( $left_operand ) && is_string( $right_operand ) ) {
+					return strpos( $left_operand, $right_operand ) !== false;
+				}
+				break;
 			case '!in':
 				if ( is_array( $right_operand ) && is_string( $left_operand ) ) {
 					return ! in_array( $left_operand, $right_operand, true );
 				}
-				return strpos( $left_operand, $right_operand ) === false;
+				if ( is_string( $left_operand ) && is_string( $right_operand ) ) {
+					return strpos( $left_operand, $right_operand ) === false;
+				}
+				break;
 		}
 
 		return false;


### PR DESCRIPTION
This is an exact replica of https://github.com/woocommerce/woocommerce/pull/44033, but created from `release/8.4` branch.

## Test Instructions

1. Set up a fresh site
1. Go to WooCommerce Setup Wizard
1. In country step, select Australia (to trigger the RIN rule)
2. Skip plugins step
3. Observe no fatal