### PR TITLE
Add rudimentary try catch for all remote endpoint spec evaluators 8.5 branch

### DIFF
--- a/plugins/woocommerce/changelog/fix-8.5-rudimentary-trycatch-remote-apis
+++ b/plugins/woocommerce/changelog/fix-8.5-rudimentary-trycatch-remote-apis
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add rudimentary try catch for all remote endpoint spec evaluators

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -44,7 +44,10 @@ class Init {
 			try {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
-			} catch (\Throwable $e) {}
+				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			} catch ( \Throwable $e ) {
+				// Ignore errors.
+			}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -41,8 +41,10 @@ class Init {
 		}
 
 		foreach ( $specs as $spec ) {
-			$suggestion    = EvaluateSuggestion::evaluate( $spec );
-			$suggestions[] = $suggestion;
+			try {
+				$suggestion    = EvaluateSuggestion::evaluate( $spec );
+				$suggestions[] = $suggestion;
+			} catch (\Throwable $e) {}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -37,12 +37,14 @@ class SpecRunner {
 
 		// Evaluate the spec and get the new note status.
 		$previous_status = $note->get_status();
-		$status          = EvaluateAndGetStatus::evaluate(
-			$spec,
-			$previous_status,
-			$stored_state,
-			new RuleEvaluator()
-		);
+		try {
+			$status          = EvaluateAndGetStatus::evaluate(
+				$spec,
+				$previous_status,
+				$stored_state,
+				new RuleEvaluator()
+			);
+		} catch (\Throwable $e) { return; }
 
 		// If the status is changing, update the created date to now.
 		if ( $previous_status !== $status ) {

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -38,13 +38,15 @@ class SpecRunner {
 		// Evaluate the spec and get the new note status.
 		$previous_status = $note->get_status();
 		try {
-			$status          = EvaluateAndGetStatus::evaluate(
+			$status = EvaluateAndGetStatus::evaluate(
 				$spec,
 				$previous_status,
 				$stored_state,
 				new RuleEvaluator()
 			);
-		} catch (\Throwable $e) { return; }
+		} catch ( \Throwable $e ) {
+			return;
+		}
 
 		// If the status is changing, update the created date to now.
 		if ( $previous_status !== $status ) {

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
@@ -42,11 +42,12 @@ class Init {
 			}
 
 			foreach ( $spec->plugins as $plugin ) {
-				$extension = EvaluateExtension::evaluate( (object) $plugin );
-
-				if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
-					$bundle['plugins'][] = $extension;
-				}
+				try {
+					$extension = EvaluateExtension::evaluate( (object) $plugin );
+					if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
+						$bundle['plugins'][] = $extension;
+					}
+				} catch (\Throwable $e) {}
 			}
 
 			$bundles[] = $bundle;

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
@@ -47,7 +47,10 @@ class Init {
 					if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
 						$bundle['plugins'][] = $extension;
 					}
-				} catch (\Throwable $e) {}
+					// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				} catch ( \Throwable $e ) {
+					// Ignore errors.
+				}
 			}
 
 			$bundles[] = $bundle;

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -129,7 +129,10 @@ class Init {
 			try {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
-			} catch (\Throwable $e) {}
+				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			} catch (\Throwable $e) {
+				// Ignore errors.
+			}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -126,8 +126,10 @@ class Init {
 		$specs       = self::get_specs();
 
 		foreach ( $specs as $spec ) {
-			$suggestion    = EvaluateSuggestion::evaluate( $spec );
-			$suggestions[] = $suggestion;
+			try {
+				$suggestion    = EvaluateSuggestion::evaluate( $spec );
+				$suggestions[] = $suggestion;
+			} catch (\Throwable $e) {}
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -130,7 +130,7 @@ class Init {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
 				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			} catch (\Throwable $e) {
+			} catch ( \Throwable $e ) {
 				// Ignore errors.
 			}
 		}


### PR DESCRIPTION
Same exact changes from [this PR](https://github.com/woocommerce/woocommerce/pull/44037), cherry-picked into 8.5 branch. Please refer to the original PR for instructions.