### PR TITLE
[Experimental] Utilize WP generated class names when styling new active filters block.

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/components/inspector.tsx
@@ -30,7 +30,6 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 							displayStyle: value,
 						} )
 					}
-					className="wc-block-active-filter__style-toggle"
 				>
 					<ToggleGroupControlOption
 						value="list"

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/components/removable-list-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/components/removable-list-item.tsx
@@ -39,14 +39,9 @@ export const RemovableListItem = ( {
 	);
 
 	return (
-		<li
-			className="wc-block-active-filters__list-item"
-			key={ `${ type }: ${ name }` }
-		>
+		<li className="list-item" key={ `${ type }: ${ name }` }>
 			{ showLabel && (
-				<span className="wc-block-active-filters__list-item-type">
-					{ `${ type }: ` }
-				</span>
+				<span className="list-item-type">{ `${ type }: ` }</span>
 			) }
 			{ displayStyle === 'chips' ? (
 				<RemovableChip
@@ -57,9 +52,9 @@ export const RemovableListItem = ( {
 					ariaLabel={ removeText }
 				/>
 			) : (
-				<span className="wc-block-active-filters__list-item-name">
+				<span className="list-item-name">
 					<button
-						className="wc-block-active-filters__list-item-remove"
+						className="list-item-remove"
 						onClick={ removeCallback }
 					>
 						<Icon

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/edit.tsx
@@ -25,9 +25,8 @@ const Edit = ( props: EditProps ) => {
 			<Inspector { ...props } />
 			<Disabled>
 				<ul
-					className={ classNames( 'wc-block-active-filters__list', {
-						'wc-block-active-filters__list--chips':
-							displayStyle === 'chips',
+					className={ classNames( 'filter-list', {
+						'list-chips': displayStyle === 'chips',
 					} ) }
 				>
 					<RemovableListItem

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/style.scss
@@ -1,8 +1,8 @@
-.wc-block-active-filters {
+.wp-block-woocommerce-product-filter-active {
 	margin-bottom: $gap-large;
 	overflow: hidden;
 
-	.wc-block-active-filters__clear-all {
+	.clear-all {
 		@include filter-link-button();
 		@include font-size(small);
 		border: none;
@@ -20,34 +20,11 @@
 		}
 	}
 
-	.wc-block-active-filters__clear-all-placeholder {
-		@include placeholder();
-		display: inline-block;
-		width: 80px;
-		height: 1em;
-		float: right;
-		border-radius: 0;
-	}
-
-	.wc-block-active-filters__list {
+	.filter-list {
 		margin: 0 0 $gap-smallest;
 		padding: 0;
 		list-style: none outside;
 		clear: both;
-
-		&.wc-block-active-filters--loading {
-			margin-top: $gap-small;
-			display: flex;
-			flex-direction: column;
-			flex-wrap: nowrap;
-
-			&.wc-block-active-filters__list--chips {
-				flex-direction: row;
-				flex-wrap: wrap;
-				align-items: flex-end;
-				gap: 0 10px;
-			}
-		}
 
 		li {
 			margin: 9px 0 0;
@@ -61,57 +38,22 @@
 			}
 
 			&:first-child {
-				.wc-block-active-filters__list-item-type {
+				.list-item-type {
 					margin: 0;
 				}
 			}
 		}
+
 		> li:first-child {
 			margin: 0;
 		}
-		li.show-loading-state-list {
-			display: inline-block;
 
-			> span {
-				@include placeholder();
-				display: inline-block;
-				box-shadow: none;
-				border-radius: 0;
-				height: 1em;
-				width: 100%;
-			}
-		}
-
-		li.show-loading-state-chips {
-			display: inline-block;
-
-			> span {
-				@include placeholder();
-				display: inline-block;
-				box-shadow: none;
-				border-radius: 13px;
-				height: 1em;
-				width: 100%;
-				min-width: 70px;
-				margin-right: 15px !important;
-			}
-
-			&:last-of-type > span {
-				margin-right: 0 !important;
-			}
-
-			&:nth-child(3) {
-				flex-grow: 1;
-				max-width: 200px;
-			}
-		}
-
-		> .wc-block-active-filters__list-item .wc-block-active-filters__list-item-name {
+		> .list-item .list-item-name {
 			margin: 9px 0 0;
 		}
 	}
 
-	.wc-block-active-filters__list-item-type {
+	.list-item-type {
 		@include font-size(smaller);
 		font-weight: bold;
 		text-transform: uppercase;
@@ -120,12 +62,7 @@
 		display: block;
 	}
 
-	.wc-block-active-filters__list-item-operator {
-		font-weight: normal;
-		font-style: italic;
-	}
-
-	.wc-block-active-filters__list-item-name {
+	.list-item-name {
 		@include font-size(small);
 		display: flex;
 		align-items: center;
@@ -133,8 +70,9 @@
 		padding: 0;
 	}
 
-	.wc-block-active-filters__list-item-remove {
+	.list-item-remove {
 		@include font-size(smaller);
+		cursor: pointer;
 		background: $gray-200;
 		border: 0;
 		border-radius: 25px;
@@ -161,13 +99,13 @@
 		}
 	}
 
-	.wc-block-active-filters__list--chips {
+	.list-chips {
 		ul,
 		li {
 			display: inline;
 		}
 
-		.wc-block-active-filters__list-item-type {
+		.list-item-type {
 			display: none;
 		}
 

--- a/plugins/woocommerce/changelog/44069-dev-unify-class-naming-active-filters
+++ b/plugins/woocommerce/changelog/44069-dev-unify-class-naming-active-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+[Experimental] Utilize WP generated class names when styling new active filters block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
@@ -55,7 +55,6 @@ final class ProductFilterActive extends AbstractBlock {
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'class'               => 'wc-block-active-filters',
 				'data-wc-interactive' => wp_json_encode( array( 'namespace' => $this->get_full_block_name() ) ),
 				'data-wc-context'     => wp_json_encode( $context ),
 				'data-has-filter'     => empty( $active_filters ) ? 'no' : 'yes',
@@ -67,17 +66,17 @@ final class ProductFilterActive extends AbstractBlock {
 
 		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php if ( ! empty( $active_filters ) ) : ?>
-				<ul class="wc-block-active-filters__list %3$s">
+				<ul class="filter-list">
 					<?php foreach ( $active_filters as $filter ) : ?>
 					<li>
-						<span class="wc-block-active-filters__list-item-type"><?php echo esc_html( $filter['type'] ); ?>: </span>
+						<span class="list-item-type"><?php echo esc_html( $filter['type'] ); ?>: </span>
 						<ul>
 							<?php $this->render_items( $filter['items'], $attributes['displayStyle'] ); ?>
 						</ul>
 					</li>
 					<?php endforeach; ?>
 				</ul>
-				<button class="wc-block-active-filters__clear-all" data-wc-on--click="actions.clearAll">
+				<button class="clear-all" data-wc-on--click="actions.clearAll">
 					<span aria-hidden="true"><?php echo esc_html__( 'Clear All', 'woocommerce' ); ?></span>
 					<span class="screen-reader-text"><?php echo esc_html__( 'Clear All Filters', 'woocommerce' ); ?></span>
 				</button>
@@ -125,10 +124,10 @@ final class ProductFilterActive extends AbstractBlock {
 
 		$remove_label = sprintf( 'Remove %s filter', wp_strip_all_tags( $title ) );
 		?>
-		<li class="wc-block-active-filters__list-item">
-			<span class="wc-block-active-filters__list-item-name">
+		<li class="list-item">
+			<span class="list-item-name">
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<button class="wc-block-active-filters__list-item-remove"  <?php echo $this->get_html_attributes( $attributes ); ?>>
+				<button class="list-item-remove"  <?php echo $this->get_html_attributes( $attributes ); ?>>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" class="wc-block-components-chip__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
 					<span class="screen-reader-text"><?php echo esc_html( $remove_label ); ?></span>
 				</button>
@@ -159,7 +158,7 @@ final class ProductFilterActive extends AbstractBlock {
 
 		$remove_label = sprintf( 'Remove %s filter', wp_strip_all_tags( $title ) );
 		?>
-		<li class="wc-block-active-filters__list-item">
+		<li class="list-item">
 			<span class="is-removable wc-block-components-chip wc-block-components-chip--radius-large">
 				<span aria-hidden="false" class="wc-block-components-chip__text"><?php echo wp_kses_post( $title ); ?></span>
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>


### PR DESCRIPTION

### Changes proposed in this Pull Request:

@dinhtungdu and I agreed that we don't need to create our own unique class names or use bem style syntax, its overly verbose and doesn't add anything.

Instead we scope all styles to the class name generated for the block by WP, and also remove the BEM style prefix from any scoped class names. (To keep PR's small and testable I'm addressing one block at a time.)

Additionally, I noticed a lot of copy pasted styles from the old block that we don't use or need. 

This is part of https://github.com/woocommerce/woocommerce/issues/43167

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Create a page (or edit the product catalog template) and add the new active filters block along with some of the other new blocks.
2. Try adding some filters and clearing some, Check that the styling and behaviour still looks correct for one or 2 filters or many filters. 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

[Experimental] Utilize WP generated class names when styling new active filters block.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
