### PR TITLE
Build path info directly instead of loading REST API.

### DIFF
--- a/plugins/woocommerce/changelog/fix-43879
+++ b/plugins/woocommerce/changelog/fix-43879
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Don't load REST API when generating possible routes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -463,6 +463,18 @@ abstract class AbstractBlock {
 	 * @return array
 	 */
 	protected function get_routes_from_namespace( $namespace ) {
+
+		$routes = apply_filters(
+			'woocommerce_blocks_pre_get_routes_from_namespace',
+			[],
+			$namespace,
+			'view'
+		);
+
+		if ( ! empty( $routes ) ) {
+			return $routes;
+		}
+
 		$rest_server     = rest_get_server();
 		$namespace_index = $rest_server->get_namespace_index(
 			[

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -466,7 +466,7 @@ abstract class AbstractBlock {
 		/**
 		 * Gives opportunity to return routes without invoking the compute intensive REST API.
 		 *
-		 * @since 8.6.0
+		 * @since 8.7.0
 		 * @param array  $routes    Array of routes.
 		 * @param string $namespace Namespace for routes.
 		 * @param string $context   Context, can be edit or view.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -463,7 +463,14 @@ abstract class AbstractBlock {
 	 * @return array
 	 */
 	protected function get_routes_from_namespace( $namespace ) {
-
+		/**
+		 * Gives opportunity to return routes without invoking the compute intensive REST API.
+		 *
+		 * @since 8.6.0
+		 * @param array  $routes    Array of routes.
+		 * @param string $namespace Namespace for routes.
+		 * @param string $context   Context, can be edit or view.
+		 */
 		$routes = apply_filters(
 			'woocommerce_blocks_pre_get_routes_from_namespace',
 			[],

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -2,6 +2,8 @@
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\StoreApi\RoutesController;
+use Automattic\WooCommerce\StoreApi\StoreApi;
 
 /**
  * Service class that handles hydration of API data for blocks.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -48,6 +48,13 @@ class Hydration {
 		$available_routes = StoreApi::container()->get( RoutesController::class )->get_all_routes( 'v1', true );
 		$controller_class = $this->match_route_to_handler( $path, $available_routes );
 
+		/**
+		 * We disable nonce check to support endpoints such as checkout. The caveat here is that we need to be careful to only support GET requests. No other request type should be processed without nonce check. Additionally, no GET request can modify data as part of hydration request, for example adding items to cart.
+		 *
+		 * Long term, we should consider validating nonce here, instead of disabling it temporarily.
+		 */
+		$this->disable_nonce_check();
+
 		if ( null !== $controller_class ) {
 			$request           = new \WP_REST_Request( 'GET', $path );
 			$schema_controller = StoreApi::container()->get( SchemaController::class );
@@ -64,7 +71,6 @@ class Hydration {
 		}
 
 		$this->cache_store_notices();
-		$this->disable_nonce_check();
 
 		// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
 		$preloaded_requests = rest_preload_api_request( [], $path );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -55,6 +55,8 @@ class Hydration {
 		 */
 		$this->disable_nonce_check();
 
+		$this->cache_store_notices();
+
 		if ( null !== $controller_class ) {
 			$request           = new \WP_REST_Request( 'GET', $path );
 			$schema_controller = StoreApi::container()->get( SchemaController::class );
@@ -69,8 +71,6 @@ class Hydration {
 				'headers' => $response->get_headers(),
 			);
 		}
-
-		$this->cache_store_notices();
 
 		// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
 		$preloaded_requests = rest_preload_api_request( [], $path );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\StoreApi\RoutesController;
+use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 
 /**
@@ -40,6 +41,28 @@ class Hydration {
 	 * @return array Response data.
 	 */
 	public function get_rest_api_response_data( $path = '' ) {
+		if ( ! str_starts_with( $path, '/wc/store' ) ) {
+			return [];
+		}
+
+		$available_routes = StoreApi::container()->get( RoutesController::class )->get_all_routes( 'v1', true );
+		$controller_class = $this->match_route_to_handler( $path, $available_routes );
+
+		if ( null !== $controller_class ) {
+			$request           = new \WP_REST_Request( 'GET', $path );
+			$schema_controller = StoreApi::container()->get( SchemaController::class );
+			$controller        = new $controller_class(
+				$schema_controller,
+				$schema_controller->get( $controller_class::SCHEMA_TYPE, $controller_class::SCHEMA_VERSION )
+			);
+
+			$response = $controller->get_response( $request );
+			return array(
+				'body'    => $response->get_data(),
+				'headers' => $response->get_headers(),
+			);
+		}
+
 		$this->cache_store_notices();
 		$this->disable_nonce_check();
 
@@ -51,6 +74,27 @@ class Hydration {
 
 		// Returns just the single preloaded request, or an empty array if it doesn't exist.
 		return $preloaded_requests[ $path ] ?? [];
+	}
+
+	/**
+	 * Inspired from WP core's `match_request_to_handler`, this matches a given path from available route regexes.
+	 * However, unlike WP core, this does not check against query params, request method etc.
+	 *
+	 * @param string $path The path to match.
+	 * @param array  $available_routes Available routes in { $regex1 => $contoller_class1, ... } format.
+	 *
+	 * @return string|null
+	 */
+	private function match_route_to_handler( $path, $available_routes ) {
+		$matched_route = null;
+		foreach ( $available_routes as $route_path => $controller ) {
+			$match = preg_match( '@^' . $route_path . '$@i', $path );
+			if ( $match ) {
+				$matched_route = $controller;
+				break;
+			}
+		}
+		return $matched_route;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
@@ -30,6 +30,15 @@ class BusinessDescription extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/ai/business-description';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
@@ -30,7 +30,7 @@ class BusinessDescription extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -38,7 +38,7 @@ class BusinessDescription extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/ai/business-description';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
@@ -30,6 +30,15 @@ class Images extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/ai/images';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
@@ -30,7 +30,7 @@ class Images extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -38,7 +38,7 @@ class Images extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/ai/images';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
@@ -34,6 +34,15 @@ class Patterns extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/ai/patterns';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
@@ -34,7 +34,7 @@ class Patterns extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -42,7 +42,7 @@ class Patterns extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/ai/patterns';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
@@ -31,6 +31,15 @@ class Product extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/ai/product';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
@@ -31,7 +31,7 @@ class Product extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -39,7 +39,7 @@ class Product extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/ai/product';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
@@ -32,6 +32,15 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/ai/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
@@ -32,7 +32,7 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Products extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/ai/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
@@ -32,6 +32,15 @@ class StoreInfo extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/ai/store-info';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
@@ -32,7 +32,7 @@ class StoreInfo extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -40,7 +40,7 @@ class StoreInfo extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/ai/store-info';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
@@ -45,6 +45,15 @@ class StoreTitle extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/ai/store-title';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
@@ -45,7 +45,7 @@ class StoreTitle extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -53,7 +53,7 @@ class StoreTitle extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/ai/store-title';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -30,6 +30,15 @@ class Batch extends AbstractRoute implements RouteInterface {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/batch';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -30,7 +30,7 @@ class Batch extends AbstractRoute implements RouteInterface {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -38,7 +38,7 @@ class Batch extends AbstractRoute implements RouteInterface {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/batch';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
@@ -18,6 +18,15 @@ class Cart extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
@@ -18,7 +18,7 @@ class Cart extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -26,7 +26,7 @@ class Cart extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -20,6 +20,15 @@ class CartAddItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/add-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -20,7 +20,7 @@ class CartAddItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -28,7 +28,7 @@ class CartAddItem extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/add-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
@@ -20,6 +20,15 @@ class CartApplyCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/apply-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
@@ -20,7 +20,7 @@ class CartApplyCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -28,7 +28,7 @@ class CartApplyCoupon extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/apply-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
@@ -27,6 +27,15 @@ class CartCoupons extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/coupons';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
@@ -27,7 +27,7 @@ class CartCoupons extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class CartCoupons extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/coupons';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
@@ -27,6 +27,15 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/coupons/(?P<code>[\w-]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
@@ -27,7 +27,7 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/coupons/(?P<code>[\w-]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
@@ -27,6 +27,15 @@ class CartExtensions extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/extensions';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
@@ -27,7 +27,7 @@ class CartExtensions extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class CartExtensions extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/extensions';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
@@ -27,6 +27,15 @@ class CartItems extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/items';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
@@ -27,7 +27,7 @@ class CartItems extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class CartItems extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/items';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
@@ -27,6 +27,15 @@ class CartItemsByKey extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/items/(?P<key>[\w-]{32})';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
@@ -27,7 +27,7 @@ class CartItemsByKey extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class CartItemsByKey extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/items/(?P<key>[\w-]{32})';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
@@ -20,6 +20,15 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/remove-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
@@ -20,7 +20,7 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -28,7 +28,7 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/remove-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -23,6 +23,15 @@ class CartRemoveItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/remove-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -23,7 +23,7 @@ class CartRemoveItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -31,7 +31,7 @@ class CartRemoveItem extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/remove-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -20,6 +20,15 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/select-shipping-rate';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -20,7 +20,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -28,7 +28,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/select-shipping-rate';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -25,6 +25,15 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/update-customer';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -25,7 +25,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -33,7 +33,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/update-customer';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -18,6 +18,15 @@ class CartUpdateItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/cart/update-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -18,7 +18,7 @@ class CartUpdateItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -26,7 +26,7 @@ class CartUpdateItem extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/cart/update-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -48,6 +48,15 @@ class Checkout extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/checkout';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -48,7 +48,7 @@ class Checkout extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -56,7 +56,7 @@ class Checkout extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/checkout';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -41,6 +41,15 @@ class CheckoutOrder extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/checkout/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -41,7 +41,7 @@ class CheckoutOrder extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -49,7 +49,7 @@ class CheckoutOrder extends AbstractCartRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/checkout/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
@@ -51,6 +51,15 @@ class Order extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/order/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
@@ -51,7 +51,7 @@ class Order extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Order extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/order/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -20,6 +20,15 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/attributes/(?P<attribute_id>[\d]+)/terms';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -20,7 +20,7 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -28,7 +28,7 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/attributes/(?P<attribute_id>[\d]+)/terms';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
@@ -25,6 +25,15 @@ class ProductAttributes extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/attributes';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
@@ -25,7 +25,7 @@ class ProductAttributes extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -33,7 +33,7 @@ class ProductAttributes extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/attributes';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
@@ -27,6 +27,15 @@ class ProductAttributesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/attributes/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
@@ -27,7 +27,7 @@ class ProductAttributesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class ProductAttributesById extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/attributes/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
@@ -25,6 +25,15 @@ class ProductCategories extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/categories';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
@@ -25,7 +25,7 @@ class ProductCategories extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -33,7 +33,7 @@ class ProductCategories extends AbstractTermsRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/categories';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
@@ -27,6 +27,15 @@ class ProductCategoriesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/categories/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
@@ -27,7 +27,7 @@ class ProductCategoriesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class ProductCategoriesById extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/categories/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -30,6 +30,15 @@ class ProductCollectionData extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/collection-data';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -30,7 +30,7 @@ class ProductCollectionData extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -38,7 +38,7 @@ class ProductCollectionData extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/collection-data';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -28,6 +28,15 @@ class ProductReviews extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/reviews';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -28,7 +28,7 @@ class ProductReviews extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -36,7 +36,7 @@ class ProductReviews extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/reviews';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
@@ -18,6 +18,15 @@ class ProductTags extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/tags';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
@@ -18,7 +18,7 @@ class ProductTags extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -26,7 +26,7 @@ class ProductTags extends AbstractTermsRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/tags';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
@@ -28,6 +28,15 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
@@ -28,7 +28,7 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -36,7 +36,7 @@ class Products extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -27,6 +27,15 @@ class ProductsById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -27,7 +27,7 @@ class ProductsById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class ProductsById extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -27,6 +27,15 @@ class ProductsBySlug extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::_get_path();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function _get_path() {
 		return '/products/(?P<slug>[\S]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -27,7 +27,7 @@ class ProductsBySlug extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::_get_path();
+		return self::get_path_regex();
 	}
 
 	/**
@@ -35,7 +35,7 @@ class ProductsBySlug extends AbstractRoute {
 	 *
 	 * @return string
 	 */
-	public static function _get_path() {
+	public static function get_path_regex() {
 		return '/products/(?P<slug>[\S]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -105,6 +105,30 @@ class RoutesController {
 	}
 
 	/**
+	 * Get a route path without instantiating the corresponding RoutesController object.
+	 *
+	 * @throws \Exception If the schema does not exist.
+	 *
+	 * @param string $version API Version being requested.
+	 *
+	 * @return string[] List of route paths.
+	 */
+	public function get_all_routes( $version = 'v1' ) {
+		$routes = [];
+
+		foreach ( $this->routes[ $version ] as $key => $route_class ) {
+
+			if ( ! method_exists( $route_class, '_get_path' ) ) {
+				throw new \Exception( "{$route_class} route does not have a _get_path method" );
+			}
+
+			$routes[$key] = $route_class::_get_path();
+		}
+
+		return $routes;
+	}
+
+	/**
 	 * Register defined list of routes with WordPress.
 	 *
 	 * @param string $version API Version being registered..

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -21,6 +21,8 @@ class RoutesController {
 	 */
 	protected $routes = [];
 
+	private static $api_namespace = 'wc/store';
+
 	/**
 	 * Constructor.
 	 *
@@ -76,8 +78,8 @@ class RoutesController {
 	 * Register all Store API routes. This includes routes under specific version namespaces.
 	 */
 	public function register_all_routes() {
-		$this->register_routes( 'v1', 'wc/store' );
-		$this->register_routes( 'v1', 'wc/store/v1' );
+		$this->register_routes( 'v1', self::$api_namespace );
+		$this->register_routes( 'v1', self::$api_namespace . 'v1' );
 		$this->register_routes( 'private', 'wc/private' );
 	}
 
@@ -122,7 +124,9 @@ class RoutesController {
 				throw new \Exception( "{$route_class} route does not have a _get_path method" );
 			}
 
-			$routes[$key] = $route_class::_get_path();
+			$route_path = '/' . trailingslashit( self::$api_namespace ) . $version . $route_class::_get_path();
+
+			$routes[ $route_path ] = array();
 		}
 
 		return $routes;

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -21,6 +21,11 @@ class RoutesController {
 	 */
 	protected $routes = [];
 
+	/**
+	 * Namespace for the API.
+	 *
+	 * @var string
+	 */
 	private static $api_namespace = 'wc/store';
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -117,10 +117,13 @@ class RoutesController {
 	 * @throws \Exception If the schema does not exist.
 	 *
 	 * @param string $version API Version being requested.
+	 * @param string $controller Whether to return controller name. If false, returns empty array. Note:
+	 * When $controller param is true, the output should not be used directly in front-end code, to prevent class names from leaking. It's not a security issue necessarily, but it's not a good practice.
+	 * When $controller param is false, it currently returns and empty array. But it can be modified in future to return include more details about the route info that can be used in frontend.
 	 *
 	 * @return string[] List of route paths.
 	 */
-	public function get_all_routes( $version = 'v1' ) {
+	public function get_all_routes( $version = 'v1', $controller = false ) {
 		$routes = [];
 
 		foreach ( $this->routes[ $version ] as $key => $route_class ) {
@@ -131,7 +134,7 @@ class RoutesController {
 
 			$route_path = '/' . trailingslashit( self::$api_namespace ) . $version . $route_class::_get_path();
 
-			$routes[ $route_path ] = array();
+			$routes[ $route_path ] = $controller ? $route_class : array();
 		}
 
 		return $routes;

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -128,11 +128,11 @@ class RoutesController {
 
 		foreach ( $this->routes[ $version ] as $key => $route_class ) {
 
-			if ( ! method_exists( $route_class, '_get_path' ) ) {
-				throw new \Exception( "{$route_class} route does not have a _get_path method" );
+			if ( ! method_exists( $route_class, 'get_path_regex' ) ) {
+				throw new \Exception( "{$route_class} route does not have a get_path_regex method" );
 			}
 
-			$route_path = '/' . trailingslashit( self::$api_namespace ) . $version . $route_class::_get_path();
+			$route_path = '/' . trailingslashit( self::$api_namespace ) . $version . $route_class::get_path_regex();
 
 			$routes[ $route_path ] = $controller ? $route_class : array();
 		}

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -84,7 +84,7 @@ class RoutesController {
 	 */
 	public function register_all_routes() {
 		$this->register_routes( 'v1', self::$api_namespace );
-		$this->register_routes( 'v1', self::$api_namespace . 'v1' );
+		$this->register_routes( 'v1', self::$api_namespace . '/v1' );
 		$this->register_routes( 'private', 'wc/private' );
 	}
 

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -35,6 +35,24 @@ final class StoreApi {
 			},
 			11
 		);
+
+		add_action(
+			'woocommerce_blocks_pre_get_routes_from_namespace',
+			function( $routes, $namespace, $context ) {
+				if ( 'wc/store/v1' !==  $namespace ) {
+					return array();
+				}
+
+				$routes = array_merge(
+					$routes,
+					self::container()->get( RoutesController::class )->get_all_routes( 'v1' )
+				);
+
+				return $routes;
+			},
+			10,
+			3
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -39,7 +39,7 @@ final class StoreApi {
 		add_action(
 			'woocommerce_blocks_pre_get_routes_from_namespace',
 			function( $routes, $namespace, $context ) {
-				if ( 'wc/store/v1' !==  $namespace ) {
+				if ( 'wc/store/v1' !== $namespace ) {
 					return array();
 				}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While loading blocks, we also load the entire REST API as part of the Store API's initialization since they are powered by store API. We also hydrate responses from several store API endpoints in the first page load itself to prevent having to make requests multiple times.

Unfortunately, when loading REST API, we load the entirety of all REST API available on a site, and not just the controllers required to power blocks. This can cause a significant performance degradation especially if the site has few plugins that provide extensive REST API support (such as WooCommerce). 

With WC 8.5.x we are now loading blocks with many themes by default (via the mini cart block), and this has exacerbated problems for many sites because of this extra loading.

In this PR, we are going to skip loading REST API both for building routes as well as for data hydration. Instead, we will call the controller directly which we need to build our response array for the mini cart (and other blocks). We do this, by introducing a function that can find the controller that we need based on the regex that the controller provides and then matching it against the API path that we want to load.

In my testing, this prevents loading REST API and provides significant performance improvements, especially on sites that have lots of plugins enabled which provide REST API routes.

Towards #43879

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR needs exploration testing of blocks features, I recommend exploration testing following blocks:

1. Mini cart block.
2. Cart and checkout block (perform a checkout entirely using WC blocks).
3. Product list and filters blocks.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
