### PR TITLE
Settings: Ensure row attributes don't have HTML entities

### DIFF
--- a/plugins/woocommerce/changelog/update-settings-row-class
+++ b/plugins/woocommerce/changelog/update-settings-row-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure table rows on settings pages don't have invalid HTML

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -253,11 +253,6 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					$value['value'] = self::get_option( $value['id'], $value['default'] );
 				}
 
-				$row_class_attribute = '';
-				if ( $value['row_class'] ) {
-					$row_class_attribute = " class=\"{$value['row_class']}\"";
-				}
-
 				// Custom attribute handling.
 				$custom_attributes = array();
 
@@ -292,7 +287,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						break;
 
 					case 'info':
-						?><tr<?php echo esc_html( $row_class_attribute ); ?>>
+						?><tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
 							<td style="<?php echo esc_attr( $value['css'] ); ?>">
 						<?php
@@ -327,7 +322,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -352,7 +347,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -380,7 +375,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -406,7 +401,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -449,7 +444,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$show_desc_at_end = $value['desc_at_end'] ?? false;
 
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -516,18 +511,14 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							$visibility_class[] = $value['row_class'];
 						}
 
-						$container_class_attribute = '';
-						if ( count( $visibility_class ) > 0 ) {
-							$container_class_attribute = ' class="' . implode( ' ', $visibility_class ) . '"';
-						}
-
-						$must_disable = $value['disabled'] ?? false;
+						$container_class = implode( ' ', $visibility_class );
+						$must_disable    = $value['disabled'] ?? false;
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
 							$has_tooltip             = isset( $value['tooltip'] ) && '' !== $value['tooltip'];
 							$tooltip_container_class = $has_tooltip ? 'with-tooltip' : '';
 							?>
-								<tr<?php echo esc_html( $container_class_attribute ); ?>>
+								<tr class="<?php echo esc_attr( $container_class ); ?>">
 									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
 									<td class="forminp forminp-checkbox <?php echo esc_html( $tooltip_container_class ); ?>">
 										<?php if ( $has_tooltip ) : ?>
@@ -537,7 +528,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							<?php
 						} else {
 							?>
-								<fieldset<?php echo esc_html( $container_class_attribute ); ?>>
+								<fieldset class="<?php echo esc_attr( $container_class ); ?>">
 							<?php
 						}
 
@@ -592,7 +583,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 							<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html . $disabled_message; // WPCS: XSS ok. ?></label>
 						</th>
@@ -691,7 +682,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							$state   = '*';
 						}
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -715,7 +706,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 						asort( $countries );
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -744,7 +735,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						);
 						$option_value = wc_parse_relative_date_option( $value['value'] );
 						?>
-						<tr<?php echo esc_html( $row_class_attribute ); ?>>
+						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #43166 I changed the way that row classes are added on settings fields. However, by using `esc_html`, it's actually outputting invalid HTML, where the double quote wrappers are getting converted to HTML entities. This simply switches back to escaping only the attribute value and not worrying if the tr element contains an empty class attribute.

### How to test the changes in this Pull Request:

1. Go to the Features settings screen, WooCommerce > Settings > Advanced > Features.
2. View the document source, and search for the string `tr class=`. This will find the instances of settings that have a `row_class` property set.
3. On `trunk`, you should see something like this: `<tr class=&quot;wc-settings-row-woocommerce_custom_orders_table_enabled&quot;>`
4. On this branch, you should instead see this: `<tr class="wc-settings-row-woocommerce_custom_orders_table_enabled">`