### PR TITLE
[Product Block Editor]: introduce TextArea field block

### DIFF
--- a/packages/js/product-editor/changelog/update-introduce-text-area-block
+++ b/packages/js/product-editor/changelog/update-introduce-text-area-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: introduce TextArea field block

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -5,7 +5,7 @@
 	"title": "Product textarea block",
 	"category": "woocommerce",
 	"description": "A text-area field for use in the product editor.",
-	"keywords": [ "products", "description" ],
+	"keywords": [ "textarea", "rich-text" ],
 	"textdomain": "default",
 	"attributes": {
 		"property": {

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -34,10 +34,6 @@
 			"type": "string",
 			"enum": [ "left", "center", "right", "justify" ]
 		},
-		"direction": {
-			"type": "string",
-			"enum": [ "ltr", "rtl" ]
-		},
 		"allowedFormats": {
 			"type": "array",
 			"default": [
@@ -52,6 +48,10 @@
 				"core/superscript",
 				"core/unknown"
 			]
+		},
+		"direction": {
+			"type": "string",
+			"enum": [ "ltr", "rtl" ]
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -21,9 +21,6 @@
 		"help": {
 			"type": "string"
 		},
-		"tooltip": {
-			"type": "string"
-		},
 		"required": {
 			"type": "string"
 		},

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -1,0 +1,56 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-text-area-field",
+	"title": "Product textarea block",
+	"category": "woocommerce",
+	"description": "A text-area field for use in the product editor.",
+	"keywords": [ "products", "description" ],
+	"textdomain": "default",
+	"attributes": {
+		"property": {
+			"type": "string"
+		},
+		"align": {
+			"type": "string"
+		},
+		"allowedFormats": {
+			"type": "array",
+			"default": [
+				"core/bold",
+				"core/code",
+				"core/italic",
+				"core/link",
+				"core/strikethrough",
+				"core/underline",
+				"core/text-color",
+				"core/subscript",
+				"core/superscript",
+				"core/unknown"
+			]
+		},
+		"direction": {
+			"type": "string",
+			"enum": [ "ltr", "rtl" ]
+		},
+		"label": {
+			"type": "string"
+		},
+		"helpText": {
+			"type": "string"
+		},
+		"content": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": true
+	}
+}

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -11,8 +11,32 @@
 		"property": {
 			"type": "string"
 		},
-		"align": {
+		"label": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"placeholder": {
 			"type": "string"
+		},
+		"help": {
+			"type": "string"
+		},
+		"tooltip": {
+			"type": "string"
+		},
+		"required": {
+			"type": "string"
+		},
+		"disabled": {
+			"type": "boolean"
+		},
+		"align": {
+			"type": "string",
+			"enum": [ "left", "center", "right", "justify" ]
+		},
+		"direction": {
+			"type": "string",
+			"enum": [ "ltr", "rtl" ]
 		},
 		"allowedFormats": {
 			"type": "array",
@@ -28,20 +52,6 @@
 				"core/superscript",
 				"core/unknown"
 			]
-		},
-		"direction": {
-			"type": "string",
-			"enum": [ "ltr", "rtl" ]
-		},
-		"label": {
-			"type": "string"
-		},
-		"helpText": {
-			"type": "string"
-		},
-		"content": {
-			"type": "string",
-			"__experimentalRole": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -14,15 +14,17 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { RTLToolbarButton } from './toolbar/toolbar-button-rtl';
-import type { TextAreaBlockEdit } from './types';
-import { ProductEditorBlockEditProps } from '../../../types';
+import type {
+	TextAreaBlockEditAttributes,
+	TextAreaBlockEditProps,
+} from './types';
 import AligmentToolbarButton from './toolbar/toolbar-button-alignment';
 
 export function TextAreaBlockEdit( {
 	attributes,
 	setAttributes,
 	context,
-}: ProductEditorBlockEditProps< TextAreaBlockEdit > ) {
+}: TextAreaBlockEditProps ) {
 	const { align, allowedFormats, direction, label, helpText } = attributes;
 	const blockProps = useWooBlockProps( attributes, {
 		style: { direction },
@@ -47,11 +49,13 @@ export function TextAreaBlockEdit( {
 		property
 	);
 
-	function setAligment( value: TextAreaBlockEdit[ 'align' ] ) {
+	function setAlignment( value: TextAreaBlockEditAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );
 	}
 
-	function changeDirection( value: TextAreaBlockEdit[ 'direction' ] ) {
+	function changeDirection(
+		value: TextAreaBlockEditAttributes[ 'direction' ]
+	) {
 		setAttributes( { direction: value } );
 	}
 
@@ -62,7 +66,7 @@ export function TextAreaBlockEdit( {
 			<BlockControls { ...blockControlsProps }>
 				<AligmentToolbarButton
 					align={ align }
-					setAligment={ setAligment }
+					setAlignment={ setAlignment }
 				/>
 
 				<RTLToolbarButton

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -25,7 +25,8 @@ export function TextAreaBlockEdit( {
 	setAttributes,
 	context,
 }: TextAreaBlockEditProps ) {
-	const { align, allowedFormats, direction, label, helpText } = attributes;
+	const { align, allowedFormats, direction, label, helpText, placeholder } =
+		attributes;
 	const blockProps = useWooBlockProps( attributes, {
 		style: { direction },
 	} );
@@ -93,6 +94,7 @@ export function TextAreaBlockEdit( {
 						} ) }
 						dir={ direction }
 						allowedFormats={ allowedFormats }
+						placeholder={ placeholder }
 					/>
 				</div>
 			</BaseControl>

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -92,7 +92,7 @@ export function TextAreaBlockEdit( {
 						id={ contentId.toString() }
 						identifier="content"
 						tagName="p"
-						value={ content }
+						value={ content || '' }
 						onChange={ setContent }
 						data-empty={ Boolean( content ) }
 						className={ classNames( 'components-content-control', {

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -95,7 +95,7 @@ export function TextAreaBlockEdit( {
 						value={ content || '' }
 						onChange={ setContent }
 						data-empty={ Boolean( content ) }
-						className={ classNames( 'components-content-control', {
+						className={ classNames( {
 							[ `has-text-align-${ align }` ]: align,
 						} ) }
 						dir={ direction }

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { createElement } from '@wordpress/element';
+import { BaseControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useInstanceId } from '@wordpress/compose';
+import { BlockControls, RichText } from '@wordpress/block-editor';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { RTLToolbarButton } from './toolbar/toolbar-button-rtl';
+import type { TextAreaBlockEdit } from './types';
+import { ProductEditorBlockEditProps } from '../../../types';
+import AligmentToolbarButton from './toolbar/toolbar-button-alignment';
+
+export function TextAreaBlockEdit( {
+	attributes,
+	setAttributes,
+	context,
+}: ProductEditorBlockEditProps< TextAreaBlockEdit > ) {
+	const { align, allowedFormats, direction, label, helpText } = attributes;
+	const blockProps = useWooBlockProps( attributes, {
+		style: { direction },
+	} );
+
+	const contentId = useInstanceId(
+		TextAreaBlockEdit,
+		'wp-block-woocommerce-product-content-field__content'
+	);
+
+	// `property` attribute is required.
+	const { property } = attributes;
+	if ( ! property ) {
+		throw new Error(
+			__( 'Property attribute is required.', 'woocommerce' )
+		);
+	}
+
+	const [ content, setContent ] = useEntityProp< string >(
+		'postType',
+		context.postType || 'product',
+		property
+	);
+
+	function setAligment( value: TextAreaBlockEdit[ 'align' ] ) {
+		setAttributes( { align: value } );
+	}
+
+	function changeDirection( value: TextAreaBlockEdit[ 'direction' ] ) {
+		setAttributes( { direction: value } );
+	}
+
+	const blockControlsProps = { group: 'block' };
+
+	return (
+		<div className={ 'wp-block-woocommerce-product-text-area-field' }>
+			<BlockControls { ...blockControlsProps }>
+				<AligmentToolbarButton
+					align={ align }
+					setAligment={ setAligment }
+				/>
+
+				<RTLToolbarButton
+					direction={ direction }
+					onChange={ changeDirection }
+				/>
+			</BlockControls>
+
+			<BaseControl
+				id={ contentId.toString() }
+				label={ label }
+				help={ helpText }
+			>
+				<div { ...blockProps }>
+					<RichText
+						id={ contentId.toString() }
+						identifier="content"
+						tagName="p"
+						value={ content }
+						onChange={ setContent }
+						data-empty={ Boolean( content ) }
+						className={ classNames( 'components-content-control', {
+							[ `has-text-align-${ align }` ]: align,
+						} ) }
+						dir={ direction }
+						allowedFormats={ allowedFormats }
+					/>
+				</div>
+			</BaseControl>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { createElement } from '@wordpress/element';
 import { BaseControl } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
 import { useInstanceId } from '@wordpress/compose';
 import { BlockControls, RichText } from '@wordpress/block-editor';
 import classNames from 'classnames';
@@ -19,11 +18,12 @@ import type {
 	TextAreaBlockEditProps,
 } from './types';
 import AligmentToolbarButton from './toolbar/toolbar-button-alignment';
+import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 
 export function TextAreaBlockEdit( {
 	attributes,
 	setAttributes,
-	context,
+	context: { postType },
 }: TextAreaBlockEditProps ) {
 	const {
 		property,
@@ -52,11 +52,9 @@ export function TextAreaBlockEdit( {
 		);
 	}
 
-	const [ content, setContent ] = useEntityProp< string >(
-		'postType',
-		context.postType || 'product',
-		property
-	);
+	const [ content, setContent ] = useProductEntityProp< string >( property, {
+		postType,
+	} );
 
 	function setAlignment( value: TextAreaBlockEditAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -30,12 +30,11 @@ export function TextAreaBlockEdit( {
 		label,
 		placeholder,
 		help,
-		align,
-		tooltip,
 		required,
+		disabled,
+		align,
 		allowedFormats,
 		direction,
-		disabled,
 	} = attributes;
 	const blockProps = useWooBlockProps( attributes, {
 		style: { direction },

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -27,13 +27,14 @@ export function TextAreaBlockEdit( {
 }: TextAreaBlockEditProps ) {
 	const {
 		property,
+		label,
+		placeholder,
+		help,
 		align,
+		tooltip,
+		required,
 		allowedFormats,
 		direction,
-		label,
-		help,
-		placeholder,
-		required,
 		disabled,
 	} = attributes;
 	const blockProps = useWooBlockProps( attributes, {

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -25,8 +25,17 @@ export function TextAreaBlockEdit( {
 	setAttributes,
 	context,
 }: TextAreaBlockEditProps ) {
-	const { align, allowedFormats, direction, label, helpText, placeholder } =
-		attributes;
+	const {
+		property,
+		align,
+		allowedFormats,
+		direction,
+		label,
+		help,
+		placeholder,
+		required,
+		disabled,
+	} = attributes;
 	const blockProps = useWooBlockProps( attributes, {
 		style: { direction },
 	} );
@@ -37,7 +46,6 @@ export function TextAreaBlockEdit( {
 	);
 
 	// `property` attribute is required.
-	const { property } = attributes;
 	if ( ! property ) {
 		throw new Error(
 			__( 'Property attribute is required.', 'woocommerce' )
@@ -79,7 +87,7 @@ export function TextAreaBlockEdit( {
 			<BaseControl
 				id={ contentId.toString() }
 				label={ label }
-				help={ helpText }
+				help={ help }
 			>
 				<div { ...blockProps }>
 					<RichText
@@ -95,6 +103,8 @@ export function TextAreaBlockEdit( {
 						dir={ direction }
 						allowedFormats={ allowedFormats }
 						placeholder={ placeholder }
+						required={ required }
+						disabled={ disabled }
 					/>
 				</div>
 			</BaseControl>

--- a/packages/js/product-editor/src/blocks/generic/text-area/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/text-area/editor.scss
@@ -1,0 +1,32 @@
+.wp-block-woocommerce-product-text-area-field {	
+	.rich-text {
+		width: 100%;
+		min-height: calc($gap-larger * 3);
+		background-color: $white;
+		box-sizing: border-box;
+		border: 1px solid #757575;
+		border-radius: 2px;
+		padding: $gap-smaller;
+		margin: 0;
+		appearance: textarea;
+		resize: vertical;
+		overflow: hidden;
+	
+		&.rich-text [data-rich-text-placeholder]:after {
+			color: $gray-700;
+			opacity: 1;
+		}
+	
+		&:focus {
+			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color-darker-10, --wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color-darker-10, --wp-admin-theme-color);
+		}
+	}
+	
+	// This alignment class does not exists in
+	// https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/common.scss
+	.has-text-align-justify {
+		/*rtl:ignore*/
+		text-align: justify;
+	}	
+}

--- a/packages/js/product-editor/src/blocks/generic/text-area/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/index.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { postContent } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { TextAreaBlockEdit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
+
+const { name, ...metadata } = blockConfiguration;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: TextAreaBlockEdit,
+	icon: postContent,
+};
+
+export const init = () =>
+	registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );

--- a/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-alignment/index.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-alignment/index.tsx
@@ -40,13 +40,13 @@ export const ALIGNMENT_CONTROLS = [
 
 export default function AligmentToolbarButton( {
 	align,
-	setAligment,
+	setAlignment,
 }: AlignmentControl ) {
 	return (
 		<AlignmentControl
 			alignmentControls={ ALIGNMENT_CONTROLS }
 			value={ align }
-			onChange={ setAligment }
+			onChange={ setAlignment }
 		/>
 	);
 }

--- a/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-alignment/index.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-alignment/index.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	alignCenter,
+	alignJustify,
+	alignLeft,
+	alignRight,
+} from '@wordpress/icons';
+import {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	AlignmentControl,
+} from '@wordpress/block-editor';
+
+export const ALIGNMENT_CONTROLS = [
+	{
+		icon: alignLeft,
+		title: __( 'Align text left', 'woocommerce' ),
+		align: 'left',
+	},
+	{
+		icon: alignCenter,
+		title: __( 'Align text center', 'woocommerce' ),
+		align: 'center',
+	},
+	{
+		icon: alignRight,
+		title: __( 'Align text right', 'woocommerce' ),
+		align: 'right',
+	},
+	{
+		icon: alignJustify,
+		title: __( 'Align text justify', 'woocommerce' ),
+		align: 'justify',
+	},
+];
+
+export default function AligmentToolbarButton( {
+	align,
+	setAligment,
+}: AlignmentControl ) {
+	return (
+		<AlignmentControl
+			alignmentControls={ ALIGNMENT_CONTROLS }
+			value={ align }
+			onChange={ setAligment }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-rtl/index.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-rtl/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { ToolbarButton } from '@wordpress/components';
+import { _x, isRTL } from '@wordpress/i18n';
+import { formatLtr } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { RTLToolbarButtonProps } from './types';
+
+export function RTLToolbarButton( {
+	direction,
+	onChange,
+}: RTLToolbarButtonProps ) {
+	if ( ! isRTL() ) {
+		return null;
+	}
+
+	return (
+		<ToolbarButton
+			icon={ formatLtr }
+			title={ _x( 'Left to right', 'editor button', 'woocommerce' ) }
+			isActive={ direction === 'ltr' }
+			onClick={ () =>
+				onChange?.( direction === 'ltr' ? undefined : 'ltr' )
+			}
+		/>
+	);
+}

--- a/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-rtl/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-rtl/types.ts
@@ -1,8 +1,18 @@
 /**
  * Internal dependencies
  */
-import type { TextAreaBlockEdit } from '../../types';
+import type { TextAreaBlockEditAttributes } from '../../types';
 
-export type RTLToolbarButtonProps = Pick< TextAreaBlockEdit, 'direction' > & {
-	onChange( direction?: TextAreaBlockEdit[ 'direction' ] ): void;
+type DirectionProp = TextAreaBlockEditAttributes[ 'direction' ];
+
+export type RTLToolbarButtonProps = {
+	/**
+	 * Current direction.
+	 */
+	direction: DirectionProp;
+
+	/**
+	 * Callback to update the direction.
+	 */
+	onChange( direction?: DirectionProp ): void;
 };

--- a/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-rtl/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/toolbar/toolbar-button-rtl/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import type { TextAreaBlockEdit } from '../../types';
+
+export type RTLToolbarButtonProps = Pick< TextAreaBlockEdit, 'direction' > & {
+	onChange( direction?: TextAreaBlockEdit[ 'direction' ] ): void;
+};

--- a/packages/js/product-editor/src/blocks/generic/text-area/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/types.ts
@@ -7,10 +7,10 @@ import {
 } from '../../../types';
 
 export type TextAreaBlockEditAttributes = ProductEditorBlockAttributes & {
-	align: 'left' | 'center' | 'right' | 'justify';
+	align?: 'left' | 'center' | 'right' | 'justify';
 	allowedFormats?: string[];
-	direction: 'ltr' | 'rtl';
-	label: string;
+	direction?: 'ltr' | 'rtl';
+	label?: string;
 	property: string;
 	helpText?: string;
 	placeholder?: string;

--- a/packages/js/product-editor/src/blocks/generic/text-area/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/types.ts
@@ -1,4 +1,12 @@
-export type TextAreaBlockEdit = {
+/**
+ * Internal dependencies
+ */
+import {
+	ProductEditorBlockAttributes,
+	ProductEditorBlockEditProps,
+} from '../../../types';
+
+export type TextAreaBlockEditAttributes = ProductEditorBlockAttributes & {
 	align: 'left' | 'center' | 'right' | 'justify';
 	allowedFormats?: string[];
 	direction: 'ltr' | 'rtl';
@@ -6,3 +14,6 @@ export type TextAreaBlockEdit = {
 	property: string;
 	helpText?: string;
 };
+
+export type TextAreaBlockEditProps =
+	ProductEditorBlockEditProps< TextAreaBlockEditAttributes >;

--- a/packages/js/product-editor/src/blocks/generic/text-area/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/types.ts
@@ -13,6 +13,7 @@ export type TextAreaBlockEditAttributes = ProductEditorBlockAttributes & {
 	label: string;
 	property: string;
 	helpText?: string;
+	placeholder?: string;
 };
 
 export type TextAreaBlockEditProps =

--- a/packages/js/product-editor/src/blocks/generic/text-area/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/types.ts
@@ -1,0 +1,8 @@
+export type TextAreaBlockEdit = {
+	align: 'left' | 'center' | 'right' | 'justify';
+	allowedFormats?: string[];
+	direction: 'ltr' | 'rtl';
+	label: string;
+	property: string;
+	helpText?: string;
+};

--- a/packages/js/product-editor/src/blocks/generic/text-area/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/types.ts
@@ -6,14 +6,29 @@ import {
 	ProductEditorBlockEditProps,
 } from '../../../types';
 
+type AllowedFormat =
+	| 'core/bold'
+	| 'core/code'
+	| 'core/italic'
+	| 'core/link'
+	| 'core/strikethrough'
+	| 'core/underline'
+	| 'core/text-color'
+	| 'core/subscript'
+	| 'core/superscript'
+	| 'core/unknown';
+
 export type TextAreaBlockEditAttributes = ProductEditorBlockAttributes & {
-	align?: 'left' | 'center' | 'right' | 'justify';
-	allowedFormats?: string[];
-	direction?: 'ltr' | 'rtl';
-	label?: string;
 	property: string;
-	helpText?: string;
+	label?: string;
 	placeholder?: string;
+	help?: string;
+	tooltip?: string;
+	required?: boolean;
+	disabled?: boolean;
+	align?: 'left' | 'center' | 'right' | 'justify';
+	allowedFormats?: AllowedFormat[];
+	direction?: 'ltr' | 'rtl';
 };
 
 export type TextAreaBlockEditProps =

--- a/packages/js/product-editor/src/blocks/generic/text-area/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/types.ts
@@ -23,7 +23,6 @@ export type TextAreaBlockEditAttributes = ProductEditorBlockAttributes & {
 	label?: string;
 	placeholder?: string;
 	help?: string;
-	tooltip?: string;
 	required?: boolean;
 	disabled?: boolean;
 	align?: 'left' | 'center' | 'right' | 'justify';

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -35,3 +35,4 @@ export { init as initTaxonomy } from './generic/taxonomy';
 export { init as initText } from './generic/text';
 export { init as initNumber } from './generic/number';
 export { init as initLinkedProductList } from './generic/linked-product-list';
+export { init as initTextArea } from './generic/text-area';

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -25,3 +25,4 @@
 @import "generic/toggle/editor.scss";
 @import "generic/number/editor.scss";
 @import "generic/linked-product-list/editor.scss";
+@import "generic/text-area/editor.scss";

--- a/plugins/woocommerce/changelog/update-introduce-text-area-block
+++ b/plugins/woocommerce/changelog/update-introduce-text-area-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Use the new text area block in the summary field

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -36,6 +36,7 @@ class BlockRegistry {
 		'woocommerce/product-toggle-field',
 		'woocommerce/product-taxonomy-field',
 		'woocommerce/product-text-field',
+		'woocommerce/product-text-area-field',
 		'woocommerce/product-number-field',
 		'woocommerce/product-linked-list-field',
 	);

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -330,7 +330,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				),
 			)
 		);
- 
+
 		// External/Affiliate section.
 		if ( Features::is_enabled( 'product-external-affiliate' ) ) {
 			$buy_button_section = $general_group->add_section(

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -223,7 +223,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'order'      => 20,
 				'attributes' => array(
 					'label'    => __( 'Summary', 'woocommerce' ),
-					'help' => __(
+					'help'     => __(
 						"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
 						'woocommerce'
 					),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -223,7 +223,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'order'      => 20,
 				'attributes' => array(
 					'label'    => __( 'Summary', 'woocommerce' ),
-					'helpText' => __(
+					'help' => __(
 						"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
 						'woocommerce'
 					),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -215,12 +215,18 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				),
 			)
 		);
+
 		$basic_details->add_block(
 			array(
 				'id'         => 'product-summary',
-				'blockName'  => 'woocommerce/product-summary-field',
+				'blockName'  => 'woocommerce/product-text-area-field',
 				'order'      => 20,
 				'attributes' => array(
+					'label'    => __( 'Summary', 'woocommerce' ),
+					'helpText' => __(
+						"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
+						'woocommerce'
+					),
 					'property' => 'short_description',
 				),
 			)
@@ -324,7 +330,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				),
 			)
 		);
-
+ 
 		// External/Affiliate section.
 		if ( Features::is_enabled( 'product-external-affiliate' ) ) {
 			$buy_button_section = $general_group->add_section(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a new Textarea block. This block is used for the Summary product field. In a follow-up were going to update the Description field too.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce/issues/42736
Closes 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Product Editor
2. Go to the General Tab
3. Take a look at the summary field
4. Confirm it looks as expected
5. Edit the summary content
6. Confirm it works as expected. Use the alignment and format options provided by the block toolbar

<img width="711" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/edb8438a-9114-4009-bc39-c57c383fa2ba">

### Use the React Dev Tool to inspect the block instance 

1. Open the components tab
2. search instances by TextAreaBlockEdit, which is the react component used to represent the block in the editor dashboard
3. Confirm the props and attributes are okay

<img width="900" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/7f746972-da66-44c0-ad5a-15569d2d1ec3">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>