### PR TITLE
Logging: Add details about configuration to SSR

### DIFF
--- a/plugins/woocommerce/changelog/fix-40524-logging-in-ssr
+++ b/plugins/woocommerce/changelog/fix-40524-logging-in-ssr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add details about the logging configuration to the System Status Report

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -816,7 +816,7 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 	<tr>
 		<td data-export-label="Log directory size"><?php esc_html_e( 'Log directory size', 'woocommerce' ); ?></td>
 		<td class="help"><?php echo wc_help_tip( esc_html__( 'The total size of the files in the log directory.', 'woocommerce' ) ); ?></td>
-		<td><?php echo $logging['log_directory_size']; ?></td>
+		<td><?php echo esc_html( $logging['log_directory_size'] ); ?></td>
 	</tr>
 	</tbody>
 </table>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -21,6 +21,7 @@ $dropins_mu_plugins = $report['dropins_mu_plugins'];
 $theme              = $report['theme'];
 $security           = $report['security'];
 $settings           = $report['settings'];
+$logging            = $report['logging'];
 $wp_pages           = $report['pages'];
 $plugin_updates     = new WC_Plugin_Updates();
 $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Constants::get_constant( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' ) );
@@ -768,6 +769,55 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 			<td><?php echo $settings['HPOS_sync_enabled'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>
 
+	</tbody>
+</table>
+<table class="wc_status_table widefat" cellspacing="0">
+	<thead>
+	<tr>
+		<th colspan="3" data-export-label="Logging"><h2><?php esc_html_e( 'Logging', 'woocommerce' ); ?></h2></th>
+	</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td data-export-label="Enabled"><?php esc_html_e( 'Enabled', 'woocommerce' ); ?></td>
+		<td class="help"><?php echo wc_help_tip( esc_html__( 'Is logging enabled?', 'woocommerce' ) ); ?></td>
+		<td><?php echo $logging['logging_enabled'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
+	</tr>
+	<tr>
+		<td data-export-label="Handler"><?php esc_html_e( 'Handler', 'woocommerce' ); ?></td>
+		<td class="help"><?php echo wc_help_tip( esc_html__( 'How log entries are being stored.', 'woocommerce' ) ); ?></td>
+		<td><?php echo esc_html( $logging['default_handler'] ); ?></td>
+	</tr>
+	<tr>
+		<td data-export-label="Retention period"><?php esc_html_e( 'Retention period', 'woocommerce' ); ?></td>
+		<td class="help"><?php echo wc_help_tip( esc_html__( 'How many days log entries will be kept before being auto-deleted.', 'woocommerce' ) ); ?></td>
+		<td>
+			<?php
+			printf(
+				esc_html(
+					// translators: %s is a number of days.
+					_n(
+						'%s day',
+						'%s days',
+						$logging['retention_period_days'],
+						'woocommerce'
+					)
+				),
+				esc_html( number_format_i18n( $logging['retention_period_days'] ) )
+			);
+			?>
+		</td>
+	</tr>
+	<tr>
+		<td data-export-label="Level threshold"><?php esc_html_e( 'Level threshold', 'woocommerce' ); ?></td>
+		<td class="help"><?php echo wc_help_tip( esc_html__( 'The minimum severity level of logs that will be stored.', 'woocommerce' ) ); ?></td>
+		<td><?php echo $logging['level_threshold'] ? esc_html( $logging['level_threshold'] ) : '<mark class="no">&ndash;</mark>'; ?></td>
+	</tr>
+	<tr>
+		<td data-export-label="Log directory size"><?php esc_html_e( 'Log directory size', 'woocommerce' ); ?></td>
+		<td class="help"><?php echo wc_help_tip( esc_html__( 'The total size of the files in the log directory.', 'woocommerce' ) ); ?></td>
+		<td><?php echo $logging['log_directory_size']; ?></td>
+	</tr>
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -665,6 +665,26 @@ class FileController {
 	}
 
 	/**
+	 * Calculate the size, in bytes, of the log directory.
+	 *
+	 * @return int
+	 */
+	public function get_log_directory_size(): int {
+		$bytes = 0;
+		$path  = realpath( $this->log_directory );
+
+		if ( wp_is_writable( $path ) ) {
+			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ) );
+
+			foreach( $iterator as $file ) {
+				$bytes += $file->getSize();
+			}
+		}
+
+		return $bytes;
+	}
+
+	/**
 	 * Invalidate the cache group related to log file data.
 	 *
 	 * @return bool True on successfully invalidating the cache.

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -676,7 +676,7 @@ class FileController {
 		if ( wp_is_writable( $path ) ) {
 			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ) );
 
-			foreach( $iterator as $file ) {
+			foreach ( $iterator as $file ) {
 				$bytes += $file->getSize();
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -256,7 +256,7 @@ class Settings {
 
 		$location_info[] = sprintf(
 			// translators: %s is an amount of computer disk space, e.g. 5 KB.
-			__( 'Directory size: %s' ),
+			__( 'Directory size: %s', 'woocommerce' ),
 			size_format( wc_get_container()->get( FileController::class )->get_log_directory_size() )
 		);
 
@@ -302,8 +302,8 @@ class Settings {
 			),
 			'database_table' => array(
 				'title' => __( 'Location', 'woocommerce' ),
-				'type' => 'info',
-				'text' => $location_info,
+				'type'  => 'info',
+				'text'  => $location_info,
 			),
 			'file_end'       => array(
 				'id'   => self::PREFIX . 'settings',

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -4,10 +4,12 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\File;
 use Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\FileController;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use WC_Admin_Settings;
-use WC_Log_Handler, WC_Log_Handler_DB, WC_Log_Handler_File, WC_Log_Levels;
+use WC_Log_Handler_DB, WC_Log_Handler_File, WC_Log_Levels;
 
 /**
  * Settings class.
@@ -22,11 +24,10 @@ class Settings {
 	 * @const array
 	 */
 	private const DEFAULTS = array(
-		'logging_enabled'           => true,
-		'default_handler'           => LogHandlerFileV2::class,
-		'retention_period_days'     => 30,
-		'level_threshold'           => 'none',
-		'file_entry_collapse_lines' => true,
+		'logging_enabled'       => true,
+		'default_handler'       => LogHandlerFileV2::class,
+		'retention_period_days' => 30,
+		'level_threshold'       => 'none',
 	);
 
 	/**
@@ -77,13 +78,13 @@ class Settings {
 			$settings['default_handler']       = $this->get_default_handler_setting_definition();
 			$settings['retention_period_days'] = $this->get_retention_period_days_setting_definition();
 			$settings['level_threshold']       = $this->get_level_threshold_setting_definition();
-		}
 
-		$default_handler = $this->get_default_handler();
-		if ( in_array( $default_handler, array( LogHandlerFileV2::class, WC_Log_Handler_File::class ), true ) ) {
-			$settings += $this->get_filesystem_settings_definitions();
-		} elseif ( WC_Log_Handler_DB::class === $default_handler ) {
-			$settings += $this->get_database_settings_definitions();
+			$default_handler = $this->get_default_handler();
+			if ( in_array( $default_handler, array( LogHandlerFileV2::class, WC_Log_Handler_File::class ), true ) ) {
+				$settings += $this->get_filesystem_settings_definitions();
+			} elseif ( WC_Log_Handler_DB::class === $default_handler ) {
+				$settings += $this->get_database_settings_definitions();
+			}
 		}
 
 		return $settings;
@@ -231,7 +232,7 @@ class Settings {
 	 */
 	private function get_filesystem_settings_definitions(): array {
 		$location_info = array();
-		$directory     = trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) );
+		$directory     = trailingslashit( Constants::get_constant( 'WC_LOG_DIR' ) );
 
 		$location_info[] = sprintf(
 			// translators: %s is a location in the filesystem.
@@ -253,6 +254,12 @@ class Settings {
 			'<code>wp-config.php</code>'
 		);
 
+		$location_info[] = sprintf(
+			// translators: %s is an amount of computer disk space, e.g. 5 KB.
+			__( 'Directory size: %s' ),
+			size_format( wc_get_container()->get( FileController::class )->get_log_directory_size() )
+		);
+
 		return array(
 			'file_start'    => array(
 				'title' => __( 'File system settings', 'woocommerce' ),
@@ -260,8 +267,9 @@ class Settings {
 				'type'  => 'title',
 			),
 			'log_directory' => array(
-				'type' => 'info',
-				'text' => implode( "\n\n", $location_info ),
+				'title' => __( 'Location', 'woocommerce' ),
+				'type'  => 'info',
+				'text'  => implode( "\n\n", $location_info ),
 			),
 			'entry_format'  => array(),
 			'file_end'      => array(
@@ -293,6 +301,7 @@ class Settings {
 				'type'  => 'title',
 			),
 			'database_table' => array(
+				'title' => __( 'Location', 'woocommerce' ),
 				'type' => 'info',
 				'text' => $location_info,
 			),

--- a/plugins/woocommerce/src/Utilities/LoggingUtil.php
+++ b/plugins/woocommerce/src/Utilities/LoggingUtil.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Utilities;
 
 use Automattic\WooCommerce\Internal\Admin\Logging\{ PageController, Settings };
-use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\File;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ File, FileController };
 
 /**
  * A class of utilities for dealing with logging.
@@ -81,5 +81,14 @@ final class LoggingUtil {
 	 */
 	public static function generate_log_file_hash( string $file_id ): string {
 		return File::generate_hash( $file_id );
+	}
+
+	/**
+	 * Calculate the size, in bytes, of the log directory.
+	 *
+	 * @return int
+	 */
+	public static function get_log_directory_size(): int {
+		return wc_get_container()->get( FileController::class )->get_log_directory_size();
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
@@ -244,7 +244,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 10, count( $properties ) );
+		$this->assertEquals( 11, count( $properties ) );
 		$this->assertArrayHasKey( 'environment', $properties );
 		$this->assertArrayHasKey( 'database', $properties );
 		$this->assertArrayHasKey( 'active_plugins', $properties );
@@ -252,6 +252,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'settings', $properties );
 		$this->assertArrayHasKey( 'security', $properties );
 		$this->assertArrayHasKey( 'pages', $properties );
+		$this->assertArrayHasKey( 'logging', $properties );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
@@ -262,7 +262,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 10, count( $properties ) );
+		$this->assertEquals( 11, count( $properties ) );
 		$this->assertArrayHasKey( 'environment', $properties );
 		$this->assertArrayHasKey( 'database', $properties );
 		$this->assertArrayHasKey( 'active_plugins', $properties );
@@ -270,6 +270,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'settings', $properties );
 		$this->assertArrayHasKey( 'security', $properties );
 		$this->assertArrayHasKey( 'pages', $properties );
+		$this->assertArrayHasKey( 'logging', $properties );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -418,14 +418,14 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$htaccess = wp_filesize( Constants::get_constant( 'WC_LOG_DIR' ) . '.htaccess' );
 		$index    = wp_filesize( Constants::get_constant( 'WC_LOG_DIR' ) . 'index.html' );
 
-		$path = Constants::get_constant( 'WC_LOG_DIR' ) . 'unit-testing-1.log';
+		$path             = Constants::get_constant( 'WC_LOG_DIR' ) . 'unit-testing-1.log';
 		$resource         = fopen( $path, 'a' );
 		$existing_content = random_bytes( 200 );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite
 		fwrite( $resource, $existing_content );
 		fclose( $resource );
 
-		$path = Constants::get_constant( 'WC_LOG_DIR' ) . 'unit-testing-2.log';
+		$path             = Constants::get_constant( 'WC_LOG_DIR' ) . 'unit-testing-2.log';
 		$resource         = fopen( $path, 'a' );
 		$existing_content = random_bytes( 300 );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -409,6 +409,34 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, $match['line_number'] );
 		$this->assertStringContainsString( 'A trip to the food bar', $match['line'] );
 	}
+
+	/**
+	 * @testdox The get_log_directory_size method should return an accurate size of the directory in bytes.
+	 */
+	public function test_get_log_directory_size(): void {
+		// Non-log files that should be in the log directory.
+		$htaccess = wp_filesize( Constants::get_constant( 'WC_LOG_DIR' ) . '.htaccess' );
+		$index    = wp_filesize( Constants::get_constant( 'WC_LOG_DIR' ) . 'index.html' );
+
+		$path = Constants::get_constant( 'WC_LOG_DIR' ) . 'unit-testing-1.log';
+		$resource         = fopen( $path, 'a' );
+		$existing_content = random_bytes( 200 );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite
+		fwrite( $resource, $existing_content );
+		fclose( $resource );
+
+		$path = Constants::get_constant( 'WC_LOG_DIR' ) . 'unit-testing-2.log';
+		$resource         = fopen( $path, 'a' );
+		$existing_content = random_bytes( 300 );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite
+		fwrite( $resource, $existing_content );
+		fclose( $resource );
+
+		$expected_size = $htaccess + $index + 200 + 300;
+
+		$size = $this->sut->get_log_directory_size();
+		$this->assertEquals( $expected_size, $size );
+	}
 }
 
 // phpcs:enable WordPress.WP.AlternativeFunctions.file_system_read_fopen, WordPress.WP.AlternativeFunctions.file_system_read_fclose


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds logs settings values to both the SSR REST API endpoint and to the HTML version of the SSR screen. Also adds a new method for calculating the total size of the log directory, and adds that info to the Logs Settings screen in addition to the SSR.

Fixes #40524

![logging-ssr](https://github.com/woocommerce/woocommerce/assets/916023/7fbf61b3-d8e6-4663-baaf-dfcb220379fd)

### How to test the changes in this Pull Request:

1. In the WP Admin, go to the SSR screen at WooCommerce > Status. Scroll down until you find the "Logging" section.
2. Open a second tab and go to WooCommerce > Status > Logs. Click on the Settings link to view the settings.
3. Now compare the values on the settings screen to the values in the Logging section of the SSR, and make sure they match (the presentation of the values might be slightly different).
4. Try changing various Logs settings, and make sure those changes are reflected properly in the SSR.
5. At the top of the SSR screen, click the "Get system report" button to generate the text-only version of the SSR. In the resulting textarea, scroll to find the Logging section and make sure it looks accurate.