### PR TITLE
Fix beta test plugin deprecated creation dynamic property

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/fix-deprecated-creation-dynamic-property
+++ b/plugins/woocommerce-beta-tester/changelog/fix-deprecated-creation-dynamic-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix beta test plugin deprecated creation dynamic property

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
@@ -20,6 +20,13 @@ class WC_Beta_Tester {
 	private $plugin_config;
 
 	/**
+	 * Plugin name.
+	 *
+	 * @var string
+	 */
+	private $plugin_name;
+
+	/**
 	 * Plugin instance.
 	 *
 	 * @var WC_Beta_Tester


### PR DESCRIPTION
### Submission Review Guidelines:

When using `woocommerce-beta-tester` plugin with PHP 8.2, there's a deprecated warning:

`Deprecated: Creation of dynamic property WC_Beta_Tester::$plugin_name is deprecated in /var/www/html/wp-content/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php on line 79`

<img width="1222" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/a56e20e8-792d-45e6-8bba-b0a6520886bc">

### How to test the changes in this Pull Request:

1. Ensure you're using PHP 8.2+
2. Ensure you've enabled debugging by having `define('WP_DEBUG', true);` and `define('WP_DEBUG_DISPLAY', true);` in `wp-config.php`
3. Ensure `woocommerce-beta-tester` plugin is installed, activated, and linked from this repository
4. Go to WordPress dashboard
5. Observe no deprecated warning `Deprecated: Creation of dynamic property WC_Beta_Tester::$plugin_name`

