### PR TITLE
Simplify the applied coupon data that gets stored as line item meta

### DIFF
--- a/plugins/woocommerce/changelog/pr-44113
+++ b/plugins/woocommerce/changelog/pr-44113
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Simplify the applied coupon data that gets stored as line item meta

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1365,8 +1365,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			} else {
 
 				// If we do not have a coupon ID (was it virtual? has it been deleted?) we must create a temporary coupon using what data we have stored during checkout.
-				$coupon_object = new WC_Coupon();
-				$coupon_object->set_props( (array) $coupon_item->get_meta( 'coupon_data', true ) );
+				$coupon_object = $this->get_temporary_coupon( $coupon_item );
 				$coupon_object->set_code( $coupon_code );
 				$coupon_object->set_virtual( true );
 
@@ -1400,6 +1399,35 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Recalculate totals and taxes.
 		$this->calculate_totals( true );
+	}
+
+	/**
+	 * Get a coupon object populated from order line item metadata, to be used when reapplying coupons
+	 * if the original coupon no longer exists.
+	 *
+	 * @since 8.7.0
+	 *
+	 * @param WC_Order_Item_Coupon $coupon_item The order item corresponding to the coupon to reapply.
+	 * @returns WC_Coupon Coupon object populated from order line item metadata, or empty if no such metadata exists (should never happen).
+	 */
+	private function get_temporary_coupon( WC_Order_Item_Coupon $coupon_item ): WC_Coupon {
+		$coupon_object = new WC_Coupon();
+
+		// Since WooCommerce 8.7 a succint 'coupon_reapply_info' line item meta entry is created
+		// whenever a coupon is applied to an order. Previously a more verbose 'coupon_data' was created.
+
+		$coupon_info = $coupon_item->get_meta( 'coupon_reapply_info', true );
+		if ( $coupon_info ) {
+			$coupon_object->set_reapply_info( $coupon_info );
+			return $coupon_object;
+		}
+
+		$coupon_data = $coupon_item->get_meta( 'coupon_data', true );
+		if ( $coupon_data ) {
+			$coupon_object->set_props( (array) $coupon_data );
+		}
+
+		return $coupon_object;
 	}
 
 	/**
@@ -1461,11 +1489,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$coupon_id = wc_get_coupon_id_by_code( $coupon_code );
 					$coupon    = new WC_Coupon( $coupon_id );
 
-					// Avoid storing used_by - it's not needed and can get large.
-					$coupon_data = $coupon->get_data();
-					unset( $coupon_data['used_by'] );
-
-					$coupon_item->add_meta_data( 'coupon_data', $coupon_data );
+					$coupon_info = $coupon->get_reapply_info();
+					$coupon_item->add_meta_data( 'coupon_reapply_info', $coupon_info );
 				} else {
 					$coupon_item = $this->get_item( $item_id, false );
 				}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1413,12 +1413,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	private function get_temporary_coupon( WC_Order_Item_Coupon $coupon_item ): WC_Coupon {
 		$coupon_object = new WC_Coupon();
 
-		// Since WooCommerce 8.7 a succint 'coupon_reapply_info' line item meta entry is created
+		// Since WooCommerce 8.7 a succint 'coupon_info' line item meta entry is created
 		// whenever a coupon is applied to an order. Previously a more verbose 'coupon_data' was created.
 
-		$coupon_info = $coupon_item->get_meta( 'coupon_reapply_info', true );
+		$coupon_info = $coupon_item->get_meta( 'coupon_info', true );
 		if ( $coupon_info ) {
-			$coupon_object->set_reapply_info( $coupon_info );
+			$coupon_object->set_short_info( $coupon_info );
 			return $coupon_object;
 		}
 
@@ -1489,8 +1489,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$coupon_id = wc_get_coupon_id_by_code( $coupon_code );
 					$coupon    = new WC_Coupon( $coupon_id );
 
-					$coupon_info = $coupon->get_reapply_info();
-					$coupon_item->add_meta_data( 'coupon_reapply_info', $coupon_info );
+					$coupon_info = $coupon->get_short_info();
+					$coupon_item->add_meta_data( 'coupon_info', $coupon_info );
 				} else {
 					$coupon_item = $this->get_item( $item_id, false );
 				}

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -695,10 +695,8 @@ class WC_Checkout {
 				)
 			);
 
-			// Avoid storing used_by - it's not needed and can get large.
-			$coupon_data = $coupon->get_data();
-			unset( $coupon_data['used_by'] );
-			$item->add_meta_data( 'coupon_data', $coupon_data );
+			$coupon_reapply_info = $coupon->get_reapply_info();
+			$item->add_meta_data( 'coupon_reapply_info', $coupon_reapply_info );
 
 			/**
 			 * Action hook to adjust item before save.
@@ -751,7 +749,7 @@ class WC_Checkout {
 		);
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-		$skipped = array();
+		$skipped        = array();
 		$form_was_shown = isset( $_POST['woocommerce-process-checkout-nonce'] ); // phpcs:disable WordPress.Security.NonceVerification.Missing
 
 		foreach ( $this->get_checkout_fields() as $fieldset_key => $fieldset ) {

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -695,8 +695,8 @@ class WC_Checkout {
 				)
 			);
 
-			$coupon_reapply_info = $coupon->get_reapply_info();
-			$item->add_meta_data( 'coupon_reapply_info', $coupon_reapply_info );
+			$coupon_info = $coupon->get_short_info();
+			$item->add_meta_data( 'coupon_info', $coupon_info );
 
 			/**
 			 * Action hook to adjust item before save.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -1100,7 +1100,8 @@ class WC_Coupon extends WC_Legacy_Coupon {
 
 	/**
 	 * Get the coupon information that is needed to reapply the coupon to an existing order.
-	 * This information is intended to be stored as a meta value in the order line item corresponding to the coupon.
+	 * This information is intended to be stored as a meta value in the order line item corresponding to the coupon
+	 * and should NOT be modified or extended (additional/custom data should go in a separate metadata entry).
 	 *
 	 * The information returned is a JSON-encoded string of an array with the following coupon information:
 	 *

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -1108,7 +1108,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * 0: Id
 	 * 1: Code
 	 * 2: Type, null is equivalent to 'fixed_cart'
-	 * 3: Amount
+	 * 3: Nominal amount (either a fixed amount or a percent, depending on the coupon type)
 	 * 4: The coupon grants free shipping? (present only if true)
 	 *
 	 * @return string A JSON string with information that allows the coupon to be reapplied to an existing order.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -1112,7 +1112,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 *
 	 * @return string A JSON string with information that allows the coupon to be reapplied to an existing order.
 	 */
-	public function get_reapply_info(): string {
+	public function get_short_info(): string {
 		$type = $this->get_discount_type();
 		$info = array(
 			$this->get_id(),
@@ -1129,11 +1129,11 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Sets the coupon parameters from a reapply information set generated with 'get_reapply_info'.
+	 * Sets the coupon parameters from a reapply information set generated with 'get_short_info'.
 	 *
-	 * @param string $info JSON string with reapply information as returned by 'get_reapply_info'.
+	 * @param string $info JSON string with reapply information as returned by 'get_short_info'.
 	 */
-	public function set_reapply_info( string $info ) {
+	public function set_short_info( string $info ) {
 		$info = json_decode( $info, true );
 
 		$this->set_id( $info[0] ?? 0 );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -289,6 +289,25 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			);
 		}
 
+		// Add additional applied coupon information.
+		if ( $item instanceof WC_Order_Item_Coupon ) {
+			$temp_coupon         = new WC_Coupon();
+			$coupon_reapply_info = $item->get_meta( 'coupon_reapply_info', true );
+			if ( $coupon_reapply_info ) {
+				$temp_coupon->set_reapply_info( $coupon_reapply_info );
+			} else {
+				$coupon_meta = $item->get_meta( 'coupon_data', true );
+				if ( $coupon_meta ) {
+					$temp_coupon->set_props( (array) $coupon_meta );
+
+				}
+			}
+
+			$data['discount_type']  = $temp_coupon->get_discount_type();
+			$data['nominal_amount'] = (float) $temp_coupon->get_amount();
+			$data['free_shipping']  = $temp_coupon->get_free_shipping();
+		}
+
 		$data['meta_data'] = array_map(
 			array( $this, 'merge_meta_item_with_formatted_meta_display_attributes' ),
 			$data['meta_data'],
@@ -1849,29 +1868,47 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'id'           => array(
+							'id'             => array(
 								'description' => __( 'Item ID.', 'woocommerce' ),
 								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'code'         => array(
+							'code'           => array(
 								'description' => __( 'Coupon code.', 'woocommerce' ),
 								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
-							'discount'     => array(
+							'discount'       => array(
 								'description' => __( 'Discount total.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 							),
-							'discount_tax' => array(
+							'discount_tax'   => array(
 								'description' => __( 'Discount total tax.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'meta_data'    => array(
+							'discount_type'  => array(
+								'description' => __( 'Discount type.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'nominal_amount' => array(
+								'description' => __( 'Discount amount as defined in the coupon (absolute value or a percent, depending on the discount type).', 'woocommerce' ),
+								'type'        => 'number',
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'free_shipping'  => array(
+								'description' => __( 'Whether the coupon grants free shipping or not.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'meta_data'      => array(
 								'description' => __( 'Meta data.', 'woocommerce' ),
 								'type'        => 'array',
 								'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -292,9 +292,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		// Add additional applied coupon information.
 		if ( $item instanceof WC_Order_Item_Coupon ) {
 			$temp_coupon         = new WC_Coupon();
-			$coupon_reapply_info = $item->get_meta( 'coupon_reapply_info', true );
-			if ( $coupon_reapply_info ) {
-				$temp_coupon->set_reapply_info( $coupon_reapply_info );
+			$coupon_info = $item->get_meta( 'coupon_info', true );
+			if ( $coupon_info ) {
+				$temp_coupon->set_short_info( $coupon_info );
 			} else {
 				$coupon_meta = $item->get_meta( 'coupon_data', true );
 				if ( $coupon_meta ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -291,7 +291,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 
 		// Add additional applied coupon information.
 		if ( $item instanceof WC_Order_Item_Coupon ) {
-			$temp_coupon         = new WC_Coupon();
+			$temp_coupon = new WC_Coupon();
 			$coupon_info = $item->get_meta( 'coupon_info', true );
 			if ( $coupon_info ) {
 				$temp_coupon->set_short_info( $coupon_info );

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
@@ -64,8 +64,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 	/**
 	 * Set up all the hooks for maintaining and populating table data.
+	 *
+	 * @internal
 	 */
-	public static function init() {
+	final public static function init() {
 		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 5 );
 	}
 
@@ -339,6 +341,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function get_coupon_id( \WC_Order_Item_Coupon $coupon_item ) {
 		// First attempt to get coupon ID from order item data.
+		$coupon_reapply_info = $coupon_item->get_meta( 'coupon_reapply_info', true );
+		if ( $coupon_reapply_info ) {
+			return json_decode( $coupon_reapply_info, true )[0];
+		}
+
 		$coupon_data = $coupon_item->get_meta( 'coupon_data', true );
 
 		// Normal checkout orders should have this data.

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
@@ -62,14 +62,19 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		);
 	}
 
+	// This method was already available as non-final, marking it as final now would make it backwards-incompatible.
+	// phpcs:disable WooCommerce.Functions.InternalInjectionMethod.MissingFinal
+
 	/**
 	 * Set up all the hooks for maintaining and populating table data.
 	 *
 	 * @internal
 	 */
-	final public static function init() {
+	public static function init() {
 		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 5 );
 	}
+
+	// phpcs:enable WooCommerce.Functions.InternalInjectionMethod.MissingFinal
 
 	/**
 	 * Returns an array of ids of included coupons, based on query arguments from the user.

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
@@ -341,9 +341,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function get_coupon_id( \WC_Order_Item_Coupon $coupon_item ) {
 		// First attempt to get coupon ID from order item data.
-		$coupon_reapply_info = $coupon_item->get_meta( 'coupon_reapply_info', true );
-		if ( $coupon_reapply_info ) {
-			return json_decode( $coupon_reapply_info, true )[0];
+		$coupon_info = $coupon_item->get_meta( 'coupon_info', true );
+		if ( $coupon_info ) {
+			return json_decode( $coupon_info, true )[0];
 		}
 
 		$coupon_data = $coupon_item->get_meta( 'coupon_data', true );

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/BatchProcessingServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/BatchProcessingServiceProvider.php
@@ -1,19 +1,20 @@
 <?php
 /**
- * Service provider for ActionUpdateController class.
+ * Service provider for the batch processing classes.
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
+use Automattic\WooCommerce\Internal\OrderCouponDataMigrator;
 
 /**
  * Class BatchProcessingServiceProvider
  *
  * @package Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders
  */
-class BatchProcessingServiceProvider extends AbstractServiceProvider {
+class BatchProcessingServiceProvider extends AbstractInterfaceServiceProvider {
 
 	/**
 	 * Services provided by this provider.
@@ -22,6 +23,7 @@ class BatchProcessingServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = array(
 		BatchProcessingController::class,
+		OrderCouponDataMigrator::class,
 	);
 
 	/**
@@ -33,5 +35,6 @@ class BatchProcessingServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register() {
 		$this->share( BatchProcessingController::class, new BatchProcessingController() );
+		$this->share_with_implements_tags( OrderCouponDataMigrator::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
+++ b/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
@@ -2,7 +2,9 @@
 
 namespace Automattic\WooCommerce\Internal;
 
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
+use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Utilities\StringUtil;
 use \Exception;
 
@@ -10,8 +12,21 @@ use \Exception;
  * This class is intended to be used with BatchProcessingController and converts verbose
  * 'coupon_data' metadata entries in coupon line items (corresponding to coupons applied to orders)
  * into simplified 'coupon_reapply_info' entries. See WC_Coupon::get_reapply_info.
+ *
+ * Additionally, this class manages the "Convert order coupon data" tool.
  */
-class OrderCouponDataMigrator implements BatchProcessorInterface {
+class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksInterface {
+
+	use AccessiblePrivateMethods;
+
+	/**
+	 * Register hooks for the class.
+	 */
+	public function register() {
+		self::add_filter( 'woocommerce_debug_tools', array( $this, 'handle_woocommerce_debug_tools' ), 999, 1 );
+		self::mark_method_as_accessible( 'enqueue' );
+		self::mark_method_as_accessible( 'dequeue' );
+	}
 
 	/**
 	 * Get a user-friendly name for this processor.
@@ -141,5 +156,76 @@ class OrderCouponDataMigrator implements BatchProcessorInterface {
 	 */
 	public function get_default_batch_size(): int {
 		return 1000;
+	}
+
+	/**
+	 * Add the tool to start or stop the background process that converts order coupon metadata entries.
+	 *
+	 * @param array $tools Old tools array.
+	 * @return array Updated tools array.
+	 */
+	private function handle_woocommerce_debug_tools( array $tools ): array {
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+
+		$pending_count = $this->get_total_pending_count();
+
+		if ( 0 === $pending_count ) {
+			$tools['start_convert_order_coupon_data'] = array(
+				'name'     => __( 'Start converting order coupon data to the simplified format', 'woocommerce' ),
+				'button'   => __( 'Start converting', 'woocommerce' ),
+				'disabled' => true,
+				'desc'     => __( 'This will convert <code>coupon_data</code> order item meta entries to simplified <code>coupon_reapply_info</code> entries. The conversion will happen overtime in the background (via Action Scheduler). There are currently no entries to convert.', 'woocommerce' ),
+			);
+		} elseif ( $batch_processor->is_enqueued( self::class ) ) {
+			$tools['stop_convert_order_coupon_data'] = array(
+				'name'     => __( 'Stop converting order coupon data to the simplified format', 'woocommerce' ),
+				'button'   => __( 'Stop converting', 'woocommerce' ),
+				'desc'     =>
+					/* translators: %d=count of entries pending conversion */
+					sprintf( __( 'This will stop the background process that converts <code>coupon_data</code> order item meta entries to simplified <code>coupon_reapply_info</code> entries. There are currently %d entries that can be converted.', 'woocommerce' ), $pending_count ),
+				'callback' => array( $this, 'dequeue' ),
+			);
+		} else {
+			$tools['start_converting_order_coupon_data'] = array(
+				'name'     => __( 'Convert order coupon data to the simplified format', 'woocommerce' ),
+				'button'   => __( 'Start converting', 'woocommerce' ),
+				'desc'     =>
+					/* translators: %d=count of entries pending conversion */
+					sprintf( __( 'This will convert <code>coupon_data</code> order item meta entries to simplified <code>coupon_reapply_info</code> entries. The conversion will happen overtime in the background (via Action Scheduler). There are currently %d entries that can be converted.', 'woocommerce' ), $pending_count ),
+				'callback' => array( $this, 'enqueue' ),
+			);
+		}
+
+		return $tools;
+	}
+
+	/**
+	 * Start the background process for coupon data conversion.
+	 *
+	 * @return string Informative string to show after the tool is triggered in UI.
+	 */
+	private function enqueue(): string {
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		if ( $batch_processor->is_enqueued( self::class ) ) {
+			return __( 'Background process for coupon meta conversion already started, nothing done.', 'woocommerce' );
+		}
+
+		$batch_processor->enqueue_processor( self::class );
+		return __( 'Background process for coupon meta conversion started', 'woocommerce' );
+	}
+
+	/**
+	 * Stop the background process for coupon data conversion.
+	 *
+	 * @return string Informative string to show after the tool is triggered in UI.
+	 */
+	private function dequeue(): string {
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		if ( ! $batch_processor->is_enqueued( self::class ) ) {
+			return __( 'Background process for coupon meta conversion not started, nothing done.', 'woocommerce' );
+		}
+
+		$batch_processor->remove_processor( self::class );
+		return __( 'Background process for coupon meta conversion stopped', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
+++ b/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal;
+
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
+use Automattic\WooCommerce\Utilities\StringUtil;
+use \Exception;
+
+/**
+ * This class is intended to be used with BatchProcessingController and converts verbose
+ * 'coupon_data' metadata entries in coupon line items (corresponding to coupons applied to orders)
+ * into simplified 'coupon_reapply_info' entries. See WC_Coupon::get_reapply_info.
+ */
+class OrderCouponDataMigrator implements BatchProcessorInterface {
+
+	/**
+	 * Get a user-friendly name for this processor.
+	 *
+	 * @return string Name of the processor.
+	 */
+	public function get_name(): string {
+		return "Coupon line item 'coupon_data' to 'coupon_reapply_info' metadata migrator";
+	}
+
+	/**
+	 * Get a user-friendly description for this processor.
+	 *
+	 * @return string Description of what this processor does.
+	 */
+	public function get_description(): string {
+		return "Migrates verbose metadata about coupons applied to an order ('coupon_data' metadata key in coupon line items) to simplified metadata ('coupon_reapply_info' keys)";
+	}
+
+	/**
+	 * Get the total number of pending items that require processing.
+	 *
+	 * @return int Number of items pending processing.
+	 */
+	public function get_total_pending_count(): int {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_key=%s",
+				'coupon_data'
+			)
+		);
+	}
+
+	/**
+	 * Returns the next batch of items that need to be processed.
+	 * A batch in this context is a list of 'meta_id' values from the wp_woocommerce_order_itemmeta table.
+	 *
+	 * @param int $size Maximum size of the batch to be returned.
+	 *
+	 * @return array Batch of items to process, containing $size or less items.
+	 */
+	public function get_next_batch_to_process( int $size ): array {
+		global $wpdb;
+
+		$meta_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT meta_id FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_key=%s ORDER BY meta_id ASC LIMIT %d",
+				'coupon_data',
+				$size
+			)
+		);
+
+		return array_map( 'absint', $meta_ids );
+	}
+
+	/**
+	 * Process data for the supplied batch. See the convert_item method.
+	 *
+	 * @throw \Exception Something went wrong while processing the batch.
+	 *
+	 * @param array $batch Batch to process, as returned by 'get_next_batch_to_process'.
+	 */
+	public function process_batch( array $batch ): void {
+		global $wpdb;
+
+		if ( empty( $batch ) ) {
+			return;
+		}
+
+		$meta_ids = StringUtil::to_sql_list( $batch );
+
+		$meta_ids_and_values = $wpdb->get_results(
+			//phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT meta_id,meta_value FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_id IN $meta_ids",
+			ARRAY_N
+		);
+
+		foreach ( $meta_ids_and_values as $meta_id_and_value ) {
+			try {
+				$this->convert_item( (int) $meta_id_and_value[0], $meta_id_and_value[1] );
+			} catch ( Exception $ex ) {
+				wc_get_logger()->error( StringUtil::class_name_without_namespace( self::class ) . ": when converting meta row with id {$meta_id_and_value[0]}: {$ex->getMessage()}" );
+			}
+		}
+	}
+
+	/**
+	 * Convert one verbose 'coupon_data' entry into a simplified 'coupon_reapply_info' entry.
+	 *
+	 * The existing database row is updated in place, both the 'meta_key' and the 'meta_value' columns.
+	 *
+	 * @param int    $meta_id Value of 'meta_id' of the row being converted.
+	 * @param string $meta_value Value of 'meta_value' of the row being converted.
+	 * @throws Exception Database error.
+	 */
+	private function convert_item( int $meta_id, string $meta_value ) {
+		global $wpdb;
+
+		//phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+		$coupon_data = unserialize( $meta_value );
+
+		$temp_coupon = new \WC_Coupon();
+		$temp_coupon->set_props( $coupon_data );
+
+		//phpcs:disable WordPress.DB.SlowDBQuery
+		$wpdb->update(
+			"{$wpdb->prefix}woocommerce_order_itemmeta",
+			array(
+				'meta_key'   => 'coupon_reapply_info',
+				'meta_value' => $temp_coupon->get_reapply_info(),
+			),
+			array( 'meta_id' => $meta_id )
+		);
+		//phpcs:enable WordPress.DB.SlowDBQuery
+
+		if ( $wpdb->last_error ) {
+			throw new Exception( $wpdb->last_error );
+		}
+	}
+
+	/**
+	 * Default (preferred) batch size to pass to 'get_next_batch_to_process'.
+	 *
+	 * @return int Default batch size.
+	 */
+	public function get_default_batch_size(): int {
+		return 1000;
+	}
+}

--- a/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
+++ b/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
@@ -166,7 +166,7 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 	 */
 	private function handle_woocommerce_debug_tools( array $tools ): array {
 		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
-		$pending_count = $this->get_total_pending_count();
+		$pending_count   = $this->get_total_pending_count();
 
 		if ( 0 === $pending_count ) {
 			$tools['start_convert_order_coupon_data'] = array(

--- a/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
+++ b/plugins/woocommerce/src/Internal/OrderCouponDataMigrator.php
@@ -11,7 +11,7 @@ use \Exception;
 /**
  * This class is intended to be used with BatchProcessingController and converts verbose
  * 'coupon_data' metadata entries in coupon line items (corresponding to coupons applied to orders)
- * into simplified 'coupon_reapply_info' entries. See WC_Coupon::get_reapply_info.
+ * into simplified 'coupon_info' entries. See WC_Coupon::get_short_info.
  *
  * Additionally, this class manages the "Convert order coupon data" tool.
  */
@@ -34,7 +34,7 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 	 * @return string Name of the processor.
 	 */
 	public function get_name(): string {
-		return "Coupon line item 'coupon_data' to 'coupon_reapply_info' metadata migrator";
+		return "Coupon line item 'coupon_data' to 'coupon_info' metadata migrator";
 	}
 
 	/**
@@ -43,7 +43,7 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 	 * @return string Description of what this processor does.
 	 */
 	public function get_description(): string {
-		return "Migrates verbose metadata about coupons applied to an order ('coupon_data' metadata key in coupon line items) to simplified metadata ('coupon_reapply_info' keys)";
+		return "Migrates verbose metadata about coupons applied to an order ('coupon_data' metadata key in coupon line items) to simplified metadata ('coupon_info' keys)";
 	}
 
 	/**
@@ -116,7 +116,7 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 	}
 
 	/**
-	 * Convert one verbose 'coupon_data' entry into a simplified 'coupon_reapply_info' entry.
+	 * Convert one verbose 'coupon_data' entry into a simplified 'coupon_info' entry.
 	 *
 	 * The existing database row is updated in place, both the 'meta_key' and the 'meta_value' columns.
 	 *
@@ -137,8 +137,8 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 		$wpdb->update(
 			"{$wpdb->prefix}woocommerce_order_itemmeta",
 			array(
-				'meta_key'   => 'coupon_reapply_info',
-				'meta_value' => $temp_coupon->get_reapply_info(),
+				'meta_key'   => 'coupon_info',
+				'meta_value' => $temp_coupon->get_short_info(),
 			),
 			array( 'meta_id' => $meta_id )
 		);
@@ -166,7 +166,6 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 	 */
 	private function handle_woocommerce_debug_tools( array $tools ): array {
 		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
-
 		$pending_count = $this->get_total_pending_count();
 
 		if ( 0 === $pending_count ) {
@@ -174,7 +173,7 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 				'name'     => __( 'Start converting order coupon data to the simplified format', 'woocommerce' ),
 				'button'   => __( 'Start converting', 'woocommerce' ),
 				'disabled' => true,
-				'desc'     => __( 'This will convert <code>coupon_data</code> order item meta entries to simplified <code>coupon_reapply_info</code> entries. The conversion will happen overtime in the background (via Action Scheduler). There are currently no entries to convert.', 'woocommerce' ),
+				'desc'     => __( 'This will convert <code>coupon_data</code> order item meta entries to simplified <code>coupon_info</code> entries. The conversion will happen overtime in the background (via Action Scheduler). There are currently no entries to convert.', 'woocommerce' ),
 			);
 		} elseif ( $batch_processor->is_enqueued( self::class ) ) {
 			$tools['stop_convert_order_coupon_data'] = array(
@@ -182,7 +181,7 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 				'button'   => __( 'Stop converting', 'woocommerce' ),
 				'desc'     =>
 					/* translators: %d=count of entries pending conversion */
-					sprintf( __( 'This will stop the background process that converts <code>coupon_data</code> order item meta entries to simplified <code>coupon_reapply_info</code> entries. There are currently %d entries that can be converted.', 'woocommerce' ), $pending_count ),
+					sprintf( __( 'This will stop the background process that converts <code>coupon_data</code> order item meta entries to simplified <code>coupon_info</code> entries. There are currently %d entries that can be converted.', 'woocommerce' ), $pending_count ),
 				'callback' => array( $this, 'dequeue' ),
 			);
 		} else {
@@ -191,7 +190,7 @@ class OrderCouponDataMigrator implements BatchProcessorInterface, RegisterHooksI
 				'button'   => __( 'Start converting', 'woocommerce' ),
 				'desc'     =>
 					/* translators: %d=count of entries pending conversion */
-					sprintf( __( 'This will convert <code>coupon_data</code> order item meta entries to simplified <code>coupon_reapply_info</code> entries. The conversion will happen overtime in the background (via Action Scheduler). There are currently %d entries that can be converted.', 'woocommerce' ), $pending_count ),
+					sprintf( __( 'This will convert <code>coupon_data</code> order item meta entries to simplified <code>coupon_info</code> entries. The conversion will happen overtime in the background (via Action Scheduler). There are currently %d entries that can be converted.', 'woocommerce' ), $pending_count ),
 				'callback' => array( $this, 'enqueue' ),
 			);
 		}

--- a/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
@@ -388,10 +388,8 @@ test.describe( 'Add coupon to order', () => {
 		expect( responseJSON.coupon_lines[ 0 ].meta_data ).toEqual(
 			expect.arrayContaining( [
 				expect.objectContaining( {
-					key: 'coupon_data',
-					value: expect.objectContaining( {
-						code: testCoupon.code,
-					} ),
+					key: 'coupon_info',
+					value: `[${ testCoupon.id },"${ testCoupon.code }","${ testCoupon.discount_type }",${ testCoupon.amount }]`,
 				} ),
 			] )
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/coupon.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/coupon.php
@@ -346,4 +346,47 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		// Test if the cart total amount is equal 39.5 (coupon only applying to one item).
 		$this->assertEquals( 39.5, WC()->cart->total );
 	}
+
+	/**
+	 * @testdox 'get_reapply_info' returns JSON-encoded information that allows to reapply the coupon on an existing order.
+	 *
+	 * @testWith ["fixed_cart", true, "[1234,\"the_coupon\",null,56.78,true]"]
+	 *           ["percent", false, "[1234,\"the_coupon\",\"percent\",56.78]"]
+	 *
+	 * @param string $type Coupon type to test.
+	 * @param bool   $free_shipping Value of 'free shipping' to test.
+	 * @param string $expected_json Expected JSON string generated.
+	 */
+	public function test_get_reapply_info( string $type, bool $free_shipping, string $expected_json ) {
+		$coupon = new WC_Coupon();
+		$coupon->set_id( 1234 );
+		$coupon->set_code( 'the_coupon' );
+		$coupon->set_discount_type( $type );
+		$coupon->set_amount( 56.78 );
+		$coupon->set_free_shipping( $free_shipping );
+
+		$actual_json = $coupon->get_reapply_info();
+		$this->assertEquals( $expected_json, $actual_json );
+	}
+
+	/**
+	 * @testdox 'set_reapply_info' sets coupon parameters from a set of JSON-encoded information returned by 'get_reapply_info'.
+	 *
+	 * @testWith ["[1234,\"the_coupon\",null,56.78,true]", "fixed_cart", true]
+	 *           ["[1234,\"the_coupon\",\"percent\",56.78]", "percent", false]
+	 *
+	 * @param string $json Input JSON string to use.
+	 * @param string $expected_type Expected coupon type set.
+	 * @param bool   $expected_free_shipping Expected value of 'free shipping' set.
+	 */
+	public function test_set_reapply_info( string $json, string $expected_type, bool $expected_free_shipping ) {
+		$coupon = new WC_Coupon();
+		$coupon->set_reapply_info( $json );
+
+		$this->assertEquals( 1234, $coupon->get_id() );
+		$this->assertEquals( 'the_coupon', $coupon->get_code() );
+		$this->assertEquals( $expected_type, $coupon->get_discount_type() );
+		$this->assertEquals( 56.78, (float) $coupon->get_amount() );
+		$this->assertEquals( $expected_free_shipping, $coupon->get_free_shipping() );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/coupon.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/coupon.php
@@ -348,7 +348,7 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'get_reapply_info' returns JSON-encoded information that allows to reapply the coupon on an existing order.
+	 * @testdox 'get_short_info' returns JSON-encoded information that allows to reapply the coupon on an existing order.
 	 *
 	 * @testWith ["fixed_cart", true, "[1234,\"the_coupon\",null,56.78,true]"]
 	 *           ["percent", false, "[1234,\"the_coupon\",\"percent\",56.78]"]
@@ -357,7 +357,7 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 * @param bool   $free_shipping Value of 'free shipping' to test.
 	 * @param string $expected_json Expected JSON string generated.
 	 */
-	public function test_get_reapply_info( string $type, bool $free_shipping, string $expected_json ) {
+	public function test_get_short_info( string $type, bool $free_shipping, string $expected_json ) {
 		$coupon = new WC_Coupon();
 		$coupon->set_id( 1234 );
 		$coupon->set_code( 'the_coupon' );
@@ -365,12 +365,12 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		$coupon->set_amount( 56.78 );
 		$coupon->set_free_shipping( $free_shipping );
 
-		$actual_json = $coupon->get_reapply_info();
+		$actual_json = $coupon->get_short_info();
 		$this->assertEquals( $expected_json, $actual_json );
 	}
 
 	/**
-	 * @testdox 'set_reapply_info' sets coupon parameters from a set of JSON-encoded information returned by 'get_reapply_info'.
+	 * @testdox 'set_short_info' sets coupon parameters from a set of JSON-encoded information returned by 'get_short_info'.
 	 *
 	 * @testWith ["[1234,\"the_coupon\",null,56.78,true]", "fixed_cart", true]
 	 *           ["[1234,\"the_coupon\",\"percent\",56.78]", "percent", false]
@@ -379,9 +379,9 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 * @param string $expected_type Expected coupon type set.
 	 * @param bool   $expected_free_shipping Expected value of 'free shipping' set.
 	 */
-	public function test_set_reapply_info( string $json, string $expected_type, bool $expected_free_shipping ) {
+	public function test_set_short_info( string $json, string $expected_type, bool $expected_free_shipping ) {
 		$coupon = new WC_Coupon();
-		$coupon->set_reapply_info( $json );
+		$coupon->set_short_info( $json );
 
 		$this->assertEquals( 1234, $coupon->get_id() );
 		$this->assertEquals( 'the_coupon', $coupon->get_code() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons.php
@@ -367,9 +367,8 @@ class WC_Admin_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 				continue;
 			}
 
-			$coupon_2_data = $coupon_2->get_data();
-			unset( $coupon_2_data['used_by'] );
-			$coupon_item->add_meta_data( 'coupon_data', $coupon_2_data );
+			$coupon_2_reapply_info = $coupon_2->get_reapply_info();
+			$coupon_item->add_meta_data( 'coupon_reapply_info', $coupon_2_reapply_info );
 			$coupon_item->save();
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons.php
@@ -367,8 +367,8 @@ class WC_Admin_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 				continue;
 			}
 
-			$coupon_2_reapply_info = $coupon_2->get_reapply_info();
-			$coupon_item->add_meta_data( 'coupon_reapply_info', $coupon_2_reapply_info );
+			$coupon_2_short_info = $coupon_2->get_short_info();
+			$coupon_item->add_meta_data( 'coupon_info', $coupon_2_short_info );
 			$coupon_item->save();
 		}
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -262,12 +262,11 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$coupon_items = $order->get_items( 'coupon' );
 		$this->assertCount( 1, $coupon_items );
 
-		$coupon_data = ( current( $coupon_items ) )->get_meta( 'coupon_data' );
-		$this->assertNotEmpty( $coupon_data, 'WC_Order_Item_Coupon missing `coupon_data` meta.' );
-		$this->assertArrayHasKey( 'id', $coupon_data );
-		$this->assertArrayHasKey( 'code', $coupon_data );
-		$this->assertEquals( $coupon->get_id(), $coupon_data['id'] );
-		$this->assertEquals( $coupon_code, $coupon_data['code'] );
+		$coupon_reapply_info = ( current( $coupon_items ) )->get_meta( 'coupon_reapply_info' );
+		$this->assertNotEmpty( $coupon_reapply_info, 'WC_Order_Item_Coupon missing `coupon_reapply_info` meta.' );
+		$coupon_reapply_info = json_decode( $coupon_reapply_info, true );
+		$this->assertEquals( $coupon->get_id(), $coupon_reapply_info[0] );
+		$this->assertEquals( $coupon_code, $coupon_reapply_info[1] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -262,11 +262,11 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$coupon_items = $order->get_items( 'coupon' );
 		$this->assertCount( 1, $coupon_items );
 
-		$coupon_reapply_info = ( current( $coupon_items ) )->get_meta( 'coupon_reapply_info' );
-		$this->assertNotEmpty( $coupon_reapply_info, 'WC_Order_Item_Coupon missing `coupon_reapply_info` meta.' );
-		$coupon_reapply_info = json_decode( $coupon_reapply_info, true );
-		$this->assertEquals( $coupon->get_id(), $coupon_reapply_info[0] );
-		$this->assertEquals( $coupon_code, $coupon_reapply_info[1] );
+		$coupon_info = ( current( $coupon_items ) )->get_meta( 'coupon_info' );
+		$this->assertNotEmpty( $coupon_info, 'WC_Order_Item_Coupon missing `coupon_info` meta.' );
+		$coupon_info = json_decode( $coupon_info, true );
+		$this->assertEquals( $coupon->get_id(), $coupon_info[0] );
+		$this->assertEquals( $coupon_code, $coupon_info[1] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Context: https://github.com/woocommerce/woocommerce/discussions/41040

Short version of the issue: whenever a coupon is applied to an order a `coupon_data` metadata entry is created for the corresponding discount line item, which contains an almost entire copy of the coupon object; https://github.com/woocommerce/woocommerce/pull/19669 removed the coupon usage data from the data that gets stored, but still, the stored data is too big and is causing issues in large stores.

This pull request introduces the following changes:

1. Instead of the verbose `coupon_data` entry, a simplified `coupon_info` entry is created when a coupon is applied to an order. It contains a JSON encoded array with the following information about the coupon: id, code, discount type (`fixed_cart` is considered the default and stored as `null`), nominal amount, and whether the coupon grants free shipping (this is added to the array only if the value is `true`).
2. The `WC_Coupon` class gets the `get_short_info` method that gets the data for `coupon_info` ready to use (already JSON encoded), and the corresponding `set_short_info` method. 
3. When the discounts for an order are recalculated because a coupon is added or removed, **and** a coupon that had been previously applied to the order no longer exists, the `coupon_info` entry of the corresponding discount line item will be used if available; otherwise the old `coupon_data` will be used (one of the two should always exist for a discount line item).
4. The following items are added to the discount line items entries (`coupon_lines` item) in the data returned by the order details REST API endpoint (`/wp-json/wc/v3/orders/<order id>`): `discount_type` (string), `nominal_amount` (float) and `free_shipping` (boolean). Previously this information had to be extracted from the item metadata.
5. A tool (in WooCommerce - Status - Tools) is added to convert existing `coupon_data` entries into simplified `coupon_info` entries in a background process.

Note that the discussion starter post incorrectly states that `coupon_data` entries are used only to be returned as part of the order detail in the REST API endpoint: actually, they are also used to recalculate discounts when the original coupon no longer exists.

Closes #36295.

### How to test the changes in this Pull Request:

#### Initial setup

First you need a WooCommerce site **without** the changes applied to this pull request (you can use the latest released WooCommerce). Once you have it:

1. Create a couple of coupons, one of type "fixed cart discount" and another of type "percent discount".
2. Create a bunch of orders. You can use [smooth generator](https://github.com/woocommerce/wc-smooth-generator) for that.
3. Apply both coupons to all orders. You can run the following code from `wp shell` for that (adjust query limit and coupon codes accordingly):

```php
$orders=wc_get_orders(['limit'=>1000]);
foreach($orders as $order) {$order->apply_coupon('coupon1'); $order->apply_coupon('coupon2'); $order->save();}
```

Verify that you actually have 2000 coupon meta entries:

```
wp db query "select count(*) from wp_woocommerce_order_itemmeta where meta_key='coupon_data'"
```

And **now** is when you upgrade to a WooCommerce version that has this pull request applied.

#### (Re)applying coupons

Create a new order and apply the two coupons, verify that two `coupon_info` entries have been created but there's no trace of `coupon_data`:

```
wp db query "select * from wp_woocommerce_order_itemmeta where meta_key like 'coupon_%' and order_item_id in (select order_item_id from wp_woocommerce_order_items where order_id=<order id>)"
```

Now open one of the old orders, remove the coupons and add them again. The query above will show two `coupon_info` entries this time too, and the query before that (the `select count(*)` one) this time will yield a value of 1998 (the old `coupon_data` entries were deleted when the coupons were removed).

Now delete one of the coupons, go back to the order, remove _the other_ coupon (not the one you just deleted) and add it again. Verify that discounts are recalculated properly, including the one for the deleted coupon.

#### REST API additions

Perform an order details REST API query (`/wp-json/wc/v3/orders/<order id>` endpoint) for both the new order (having `coupon_info` entries) and one of the old ones (still having `coupon_data` entries) and verify that in both cases the items listed in `coupon_lines` have three new keys: `discount_type`, `nominal_amount` and `free_shipping`.

#### Metadata conversion tool

Go to WooCommerce - Status - Tools and locate the _"Start converting order coupon data to the simplified format"_ entry at the bottom. Click the "Start converting" button. (If you have created a big enough number of orders -batch step size is 1000- you'll be able to see how upon page reload the button text has changed to "Stop converting", clicking it will do what it says).

Once the process finishes verify that no `coupon_data` entries exist, all have been converted to `coupon_info`:

```
wp db query "select count(*) from wp_woocommerce_order_itemmeta where meta_key='coupon_data'"
wp db query "select count(*) from wp_woocommerce_order_itemmeta where meta_key='coupon_info'"
```

Additionally, the "Start converting" button of the tool now appears grayed out.

You can repeat the "reapply the non-deleted coupon" step in any of the old orders to verify that order discounts are still recalculated properly.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>