### PR TITLE
Fix default shipping method selection after rate changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-41831-default-shipping-selection
+++ b/plugins/woocommerce/changelog/fix-41831-default-shipping-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix default shipping method selection after rate changes.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -441,24 +442,54 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
  * @since  3.2.0
  * @param  int    $key Key of package.
  * @param  array  $package Package data array.
- * @param  string $chosen_method Chosen method id.
+ * @param  string $chosen_method Chosen shipping method. e.g. flat_rate:1.
  * @return string
  */
 function wc_get_default_shipping_method_for_package( $key, $package, $chosen_method ) {
-	$rate_keys = array_keys( $package['rates'] );
-	$default   = current( $rate_keys );
-	$coupons   = WC()->cart->get_coupons();
-	foreach ( $coupons as $coupon ) {
-		if ( $coupon->get_free_shipping() ) {
-			foreach ( $rate_keys as $rate_key ) {
-				if ( 0 === stripos( $rate_key, 'free_shipping' ) ) {
-					$default = $rate_key;
-					break;
+	$chosen_method_id     = current( explode( ':', $chosen_method ) );
+	$rate_keys            = array_keys( $package['rates'] );
+	$chosen_method_exists = in_array( $chosen_method, $rate_keys, true );
+
+	/**
+	 * If the customer has selected local pickup, keep it selected if it's still in the package. We don't want to auto
+	 * toggle between shipping and pickup even if available shipping methods are changed.
+	 *
+	 * This is important for block based checkout where there is an explicit toggle between shipping and pickup.
+	 */
+	$local_pickup_method_ids = LocalPickupUtils::get_local_pickup_method_ids();
+	$is_local_pickup_chosen  = in_array( $chosen_method_id, $local_pickup_method_ids, true );
+
+	// Default to the first method in the package. This can be sorted in the backend by the merchant.
+	$default = current( $rate_keys );
+
+	// Default to local pickup if its chosen already.
+	if ( $chosen_method_exists && $is_local_pickup_chosen ) {
+		$default = $chosen_method;
+
+	} else {
+		// Check coupons to see if free shipping is available. If it is, we'll use that method as the default.
+		$coupons = WC()->cart->get_coupons();
+		foreach ( $coupons as $coupon ) {
+			if ( $coupon->get_free_shipping() ) {
+				foreach ( $rate_keys as $rate_key ) {
+					if ( 0 === stripos( $rate_key, 'free_shipping' ) ) {
+						$default = $rate_key;
+						break;
+					}
 				}
+				break;
 			}
-			break;
 		}
 	}
+
+	/**
+	 * Filters the default shipping method for a package.
+	 *
+	 * @since 3.2.0
+	 * @param string $default Default shipping method.
+	 * @param array  $rates   Shipping rates.
+	 * @param string $chosen_method Chosen method id.
+	 */
 	return apply_filters( 'woocommerce_shipping_chosen_method', $default, $package['rates'], $chosen_method );
 }
 

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -77,36 +77,12 @@ class ShippingController {
 		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
 		add_filter( 'wc_shipping_enabled', array( $this, 'force_shipping_enabled' ), 100, 1 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
-		add_filter( 'woocommerce_shipping_chosen_method', array( $this, 'prevent_shipping_method_selection_changes' ), 20, 3 );
 
 		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
 		// returns based on the option's value in the DB and we can't override it any other way.
 		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 
 		add_action( 'rest_pre_serve_request', array( $this, 'track_local_pickup' ), 10, 4 );
-	}
-
-	/**
-	 * Prevent changes in the selected shipping method when new rates are added or removed.
-	 *
-	 * If the chosen method exists within package rates, it is returned to maintain the selection.
-	 * Otherwise, the default rate is returned.
-	 *
-	 * @param string $default        Default shipping method.
-	 * @param array  $package_rates  Associative array of available package rates.
-	 * @param string $chosen_method  Previously chosen shipping method.
-	 *
-	 * @return string                Chosen shipping method or default.
-	 */
-	public function prevent_shipping_method_selection_changes( $default, $package_rates, $chosen_method ) {
-
-		// If the chosen method exists in the package rates, return it.
-		if ( $chosen_method && isset( $package_rates[ $chosen_method ] ) ) {
-			return $chosen_method;
-		}
-
-		// Otherwise, return the default method.
-		return $default;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When rates change (either through updating addresses, or applying free shipping coupons) the selected method is supposed to change to "default". That is, either the first method in the list, or free shipping if a free shipping coupon was allowed.

Block checkout however disabled this to prevent shipping toggling between Pickup and Shipping (something explicitly selected during checkout).

Due to the mono repo merge, this logic became default and thus broke free shipping selection.

The solution in this PR is to:

1. See if local pickup is selected. If it is, maintain that selection.
2. Otherwise default to the first method, or free shipping if a coupon was added

This consolidates the needs of both use cases. I've documented this inline.

Closes #41831

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Setup free shipping in your shipping zones with a minimum spend of 50. Ensure it is not first in the list of shipping methods. Also add a flat rate. Free shipping should be at the top of the list.
2. In WC > Settings > Shipping > Local pickup, enable local pickup
3. Add an item that costs lest than 50 to the cart and go to the cart page.
4. Select flat rate shipping
5. Increase the qty of the item in the cart  until it exceeds 50
6. Confirm shipping changes to free shipping
7. Reduce the cart item qty again
8. Confirm shipping changes to flat rate
9. Select local pickup
10. Increase the qty of the item in the cart  until it exceeds 50
11. Local pickup should still be selected.
12. Reduce the cart item qty again
13. Local pickup should still be selected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
