### PR TITLE
Fix product editor UI misbehaving in Calypso

### DIFF
--- a/packages/js/admin-layout/changelog/fix-calypso-adminmenu
+++ b/packages/js/admin-layout/changelog/fix-calypso-adminmenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add useAdminSidebarWidth hook

--- a/packages/js/admin-layout/src/hooks/index.ts
+++ b/packages/js/admin-layout/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-admin-sidebar-width';

--- a/packages/js/admin-layout/src/hooks/use-admin-sidebar-width.ts
+++ b/packages/js/admin-layout/src/hooks/use-admin-sidebar-width.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * the admin menu can have different widths in certain scenarios, like when using calypso
+ * so we need to observe it and adjust the header width and position accordingly
+ */
+export function useAdminSidebarWidth() {
+	const [ width, setWidth ] = useState( 0 );
+	useEffect( () => {
+		const resizeObserver = new ResizeObserver( ( entries ) => {
+			setWidth( entries[ 0 ].contentRect.width );
+		} );
+		const adminMenu = document.getElementById( 'adminmenu' );
+		if ( adminMenu ) {
+			resizeObserver.observe( adminMenu );
+		}
+		return () => {
+			if ( adminMenu ) {
+				resizeObserver.unobserve( adminMenu );
+			}
+		};
+	}, [] );
+	return width;
+}

--- a/packages/js/admin-layout/src/index.ts
+++ b/packages/js/admin-layout/src/index.ts
@@ -1,2 +1,3 @@
 export * from './plugins';
 export * from './components';
+export * from './hooks';

--- a/packages/js/product-editor/changelog/fix-calypso-adminmenu
+++ b/packages/js/product-editor/changelog/fix-calypso-adminmenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product editor UI misbehaving in custom adminmenu widths (e.g. Calypso)

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -4,7 +4,7 @@
 import { WooHeaderItem } from '@woocommerce/admin-layout';
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { createElement } from '@wordpress/element';
+import { createElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/components';
 import { chevronLeft, group, Icon } from '@wordpress/icons';
@@ -55,6 +55,35 @@ export function Header( {
 		productType,
 		'name'
 	);
+
+	/**
+	 * the admin menu can have different widths in certain scenarios, like when using calypso
+	 * so we need to observe it and adjust the header width and position accordingly */
+	useEffect( () => {
+		const resizeObserver = new ResizeObserver( ( entries ) => {
+			for ( const entry of entries ) {
+				const width = entry.contentRect.width;
+				document
+					.querySelectorAll( '.interface-interface-skeleton__header' )
+					.forEach( ( el ) => {
+						if ( ( el as HTMLElement ).style ) {
+							( el as HTMLElement ).style.width =
+								'calc(100% - ' + width + 'px)';
+							( el as HTMLElement ).style.left = width + 'px';
+						}
+					} );
+			}
+		} );
+		const adminMenu = document.getElementById( 'adminmenu' );
+		if ( adminMenu ) {
+			resizeObserver.observe( adminMenu );
+		}
+		return () => {
+			if ( adminMenu ) {
+				resizeObserver.unobserve( adminMenu );
+			}
+		};
+	}, [] );
 
 	if ( ! productId ) {
 		return null;

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { WooHeaderItem } from '@woocommerce/admin-layout';
+import { WooHeaderItem, useAdminSidebarWidth } from '@woocommerce/admin-layout';
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { createElement, useEffect } from '@wordpress/element';
@@ -56,34 +56,19 @@ export function Header( {
 		'name'
 	);
 
-	/**
-	 * the admin menu can have different widths in certain scenarios, like when using calypso
-	 * so we need to observe it and adjust the header width and position accordingly */
+	const sidebarWidth = useAdminSidebarWidth();
+
 	useEffect( () => {
-		const resizeObserver = new ResizeObserver( ( entries ) => {
-			for ( const entry of entries ) {
-				const width = entry.contentRect.width;
-				document
-					.querySelectorAll( '.interface-interface-skeleton__header' )
-					.forEach( ( el ) => {
-						if ( ( el as HTMLElement ).style ) {
-							( el as HTMLElement ).style.width =
-								'calc(100% - ' + width + 'px)';
-							( el as HTMLElement ).style.left = width + 'px';
-						}
-					} );
-			}
-		} );
-		const adminMenu = document.getElementById( 'adminmenu' );
-		if ( adminMenu ) {
-			resizeObserver.observe( adminMenu );
-		}
-		return () => {
-			if ( adminMenu ) {
-				resizeObserver.unobserve( adminMenu );
-			}
-		};
-	}, [] );
+		document
+			.querySelectorAll( '.interface-interface-skeleton__header' )
+			.forEach( ( el ) => {
+				if ( ( el as HTMLElement ).style ) {
+					( el as HTMLElement ).style.width =
+						'calc(100% - ' + sidebarWidth + 'px)';
+					( el as HTMLElement ).style.left = sidebarWidth + 'px';
+				}
+			} );
+	}, [ sidebarWidth ] );
 
 	if ( ! productId ) {
 		return null;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix product editor UI misbehaving in custom adminmenu widths (e.g. Calypso)

Closes https://github.com/woocommerce/woocommerce/issues/44155

Before:
<img width="1286" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13437655/233237f3-ef4e-43a2-902f-11213926a5b4">

After:
<img width="1429" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13437655/812564dd-1980-41dd-b0c4-667133d65281">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. You need to test this in WordPress.com somehow to test with calypso's admin menu bar. My suggestion is to build the plugin with `pnpm run build` and `pnpm --filter="*plugin-woocommerce" build:zip` and install it on a website hosted on WordPress.com
2. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
3. Go to Products > Add
4. Create a Variable product: go to the Variations tab, add variation options, and go inside a variation clicking on "Edit"
5. Check that button from the screenshot looks correct, like the screenshot.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
