### PR TITLE
[Experimental] Fix a bug where the editor for attribute selector would flicker and re-render constantly.

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/edit.tsx
@@ -189,7 +189,7 @@ const Edit = ( props: EditProps ) => {
 			</Wrapper>
 		);
 
-	if ( isEditing ) {
+	if ( isEditing )
 		return (
 			<Wrapper
 				onClickToolbarEdit={ toggleEditing }
@@ -203,7 +203,6 @@ const Edit = ( props: EditProps ) => {
 				/>
 			</Wrapper>
 		);
-	}
 
 	if ( ! attributeId || ! attributeObject )
 		return (

--- a/plugins/woocommerce/changelog/44147-dev-fix-flickering-attribute-editor
+++ b/plugins/woocommerce/changelog/44147-dev-fix-flickering-attribute-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+[Experimental] Fix a bug where the editor for attribute selector would flicker and re-render constantly.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/44061

We declare a number of components and callbacks inline in the editor component for attribute filter. I found I needed to memoize all the callbacks and externalize component declarations to ensure the editor stopped flickering. 

I would have liked to refactor this component more because this solution still feels like the code needs more clean-up, but we could address that in future.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

On trunk, this component can be triggered to continuously flicker simply by

1. Adding new attribute filter block to a page or template
2. click the block to focus it, then click outside it to unfocus
3. You'll notice it flickers the content as it re-renders it

On this branch doing the same actions should not cause the block to flicker.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

[Experimental] Fix a bug where the editor for attribute selector would flicker and re-render constantly.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
