### PR TITLE
[Product Block Editor]: use Textarea block in the variation description field

### DIFF
--- a/packages/js/product-editor/changelog/update-add-note-to-text-area-label
+++ b/packages/js/product-editor/changelog/update-add-note-to-text-area-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: use text-area block to handle the variation description field

--- a/packages/js/product-editor/src/blocks/generic/text-area/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/text-area/editor.scss
@@ -1,10 +1,10 @@
 .wp-block-woocommerce-product-text-area-field {	
 	.rich-text {
 		width: 100%;
-		min-height: calc($gap-larger * 3);
+		min-height: calc( $gap-larger * 3 );
 		background-color: $white;
 		box-sizing: border-box;
-		border: 1px solid #757575;
+		border: 1px solid $gray-700;
 		border-radius: 2px;
 		padding: $gap-smaller;
 		margin: 0;
@@ -18,8 +18,8 @@
 		}
 	
 		&:focus {
-			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color-darker-10, --wp-admin-theme-color);
-			border-color: var(--wp-admin-theme-color-darker-10, --wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px var( --wp-admin-theme-color-darker-10, --wp-admin-theme-color );
+			border-color: var( --wp-admin-theme-color-darker-10, --wp-admin-theme-color );
 		}
 	}
 	

--- a/plugins/woocommerce/changelog/update-add-note-to-text-area-label
+++ b/plugins/woocommerce/changelog/update-add-note-to-text-area-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: use text-area block to handle the variation description field

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -133,12 +133,13 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 		$basic_details->add_block(
 			array(
 				'id'         => 'product-variation-note',
-				'blockName'  => 'woocommerce/product-summary-field',
+				'blockName'  => 'woocommerce/product-text-area-field',
 				'order'      => 20,
 				'attributes' => array(
 					'property' => 'description',
-					'label'    => __( 'Note <optional />', 'woocommerce' ),
-					'helpText' => 'Enter an optional note displayed on the product page when customers select this variation.',
+					// Translators: %s defines the field is optional.
+					'label'    => sprintf( esc_html__( 'Note %s', 'woocommerce' ), '<note>(Optional)</note>' ),
+					'help'     => 'Enter an optional note displayed on the product page when customers select this variation.',
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -137,7 +137,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'order'      => 20,
 				'attributes' => array(
 					'property' => 'description',
-					// Translators: %s defines the field is optional.
+					// Translators: %s if the (Optional) text for the product-variation-note field.
 					'label'    => sprintf( esc_html__( 'Note %s', 'woocommerce' ), '<note>(Optional)</note>' ),
 					'help'     => 'Enter an optional note displayed on the product page when customers select this variation.',
 				),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -137,8 +137,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'order'      => 20,
 				'attributes' => array(
 					'property' => 'description',
-					// Translators: %s if the (Optional) text for the product-variation-note field.
-					'label'    => sprintf( esc_html__( 'Note %s', 'woocommerce' ), '<note>(Optional)</note>' ),
+					'label'    => __( 'Note', 'woocommerce' ),
 					'help'     => 'Enter an optional note displayed on the product page when customers select this variation.',
 				),
 			)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

On This PR:

* `product-variation-note` block instance uses the new `woocommerce/product-text-area-field` block
* Remove the `(Optional)` tag from the block label

Follow-up of https://github.com/woocommerce/woocommerce/pull/44104
Closes https://github.com/woocommerce/woocommerce/issues/43128

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new Product Editor
2. Create/edit a product
3. Create/edit the product variation
4. Go to the General View of the variation product
5. Confirm now the `OPTIONAL` label looks as expected

Before (trunk) | After (this branch)
------|------
<img width="705" alt="Screenshot 2024-01-29 at 17 23 32" src="https://github.com/woocommerce/woocommerce/assets/77539/530c71b7-3fe1-4d1b-a5c3-a8174b92ae27"> | <img width="702" alt="Screenshot 2024-01-31 at 08 32 57" src="https://github.com/woocommerce/woocommerce/assets/77539/2325e22b-b762-4cb4-9426-7a7a195990e2">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
