### PR TITLE
Hide Downloads section under Toggle for product variations

### DIFF
--- a/packages/js/product-editor/changelog/add-43807-variations
+++ b/packages/js/product-editor/changelog/add-43807-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Unlink downloads and downloadable product props so they can be managed separately

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -52,11 +52,6 @@ export function DownloadBlockEdit( {
 	context: { postType },
 }: ProductEditorBlockEditProps< UploadsBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const [ , setDownloadable ] = useEntityProp< Product[ 'downloadable' ] >(
-		'postType',
-		postType,
-		'downloadable'
-	);
 	const [ downloads, setDownloads ] = useEntityProp< Product[ 'downloads' ] >(
 		'postType',
 		postType,
@@ -122,10 +117,6 @@ export function DownloadBlockEdit( {
 		}
 
 		if ( newFiles.length ) {
-			if ( ! downloads.length ) {
-				setDownloadable( true );
-			}
-
 			const uploadedFiles = newFiles.map( ( file ) => ( {
 				id: stringifyId( file.id ),
 				file: file.url,
@@ -151,10 +142,6 @@ export function DownloadBlockEdit( {
 			files[ 0 ]?.id === undefined
 		) {
 			return;
-		}
-
-		if ( ! downloads.length ) {
-			setDownloadable( true );
 		}
 
 		const uploadedFile = {
@@ -190,10 +177,6 @@ export function DownloadBlockEdit( {
 			},
 			[]
 		);
-
-		if ( ! otherDownloads.length ) {
-			setDownloadable( false );
-		}
 
 		setDownloads( otherDownloads );
 	}

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/editor.scss
@@ -8,6 +8,10 @@ $fixed-section-height: 224px;
 .wp-block-woocommerce-product-downloads-field {
 	&__body {
 		position: relative;
+
+		.woocommerce-media-uploader .woocommerce-media-uploader__label {
+			margin-bottom: 0;
+		}
 	}
 
 	&__table {

--- a/plugins/woocommerce/changelog/add-43807-variations
+++ b/plugins/woocommerce/changelog/add-43807-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Hide Downloads section under Toggle for product variations

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -69,7 +69,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * Get the downloads for a product variation.
 	 *
 	 * @param WC_Product_Variation $product Product variation instance.
-	 * @param string $context Context of the request: 'view' or 'edit'.
+	 * @param string               $context Context of the request: 'view' or 'edit'.
 	 *
 	 * @return array
 	 */

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -66,6 +66,30 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	}
 
 	/**
+	 * Get the downloads for a product variation.
+	 *
+	 * @param WC_Product_Variation $product Product variation instance.
+	 * @param string $context Context of the request: 'view' or 'edit'.
+	 *
+	 * @return array
+	 */
+	protected function get_downloads( $product, $context = 'view' ) {
+		$downloads = array();
+
+		if ( $product->is_downloadable() || 'edit' === $context ) {
+			foreach ( $product->get_downloads() as $file_id => $file ) {
+				$downloads[] = array(
+					'id'   => $file_id, // MD5 hash.
+					'name' => $file['name'],
+					'file' => $file['file'],
+				);
+			}
+		}
+
+		return $downloads;
+	}
+
+	/**
 	 * Prepare a single variation output for response.
 	 *
 	 * @param  WC_Data         $object  Object data.
@@ -95,7 +119,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'purchasable'           => $object->is_purchasable(),
 			'virtual'               => $object->is_virtual(),
 			'downloadable'          => $object->is_downloadable(),
-			'downloads'             => $this->get_downloads( $object ),
+			'downloads'             => $this->get_downloads( $object, $context ),
 			'download_limit'        => '' !== $object->get_download_limit() ? (int) $object->get_download_limit() : -1,
 			'download_expiry'       => '' !== $object->get_download_expiry() ? (int) $object->get_download_expiry() : -1,
 			'tax_status'            => $object->get_tax_status(),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/DownloadableProductTrait.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/DownloadableProductTrait.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * DownloadableProductTrait
+ */
+namespace Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates;
+
+use Automattic\WooCommerce\Admin\Features\Features;
+
+/**
+ * Downloadable Product Trait.
+ */
+trait DownloadableProductTrait {
+	/**
+	 * Adds the general group blocks to the template.
+	 */
+	private function add_downloadable_product_blocks( $parent_block ) {
+		// Downloads section.
+		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
+			$product_downloads_section_group = $parent_block->add_section(
+				array(
+					'id'             => 'product-downloads-section-group',
+					'order'          => 50,
+					'attributes'     => array(
+						'blockGap' => 'unit-40',
+					),
+					'hideConditions' => array(
+						array(
+							'expression' => 'postType === "product" && editedProduct.type !== "simple"',
+						),
+					),
+				)
+			);
+
+			$product_downloads_section_group->add_block(
+				array(
+					'id'         => 'product-downloadable',
+					'blockName'  => 'woocommerce/product-checkbox-field',
+					'order'      => 10,
+					'attributes' => array(
+						'property' => 'downloadable',
+						'label'    => __( 'Include downloads', 'woocommerce' ),
+					),
+				)
+			);
+
+			$product_downloads_section_group->add_section(
+				array(
+					'id'             => 'product-downloads-section',
+					'order'          => 20,
+					'attributes'     => array(
+						'title'       => __( 'Downloads', 'woocommerce' ),
+						'description' => sprintf(
+							/* translators: %1$s: Downloads settings link opening tag. %2$s: Downloads settings link closing tag. */
+							__( 'Add any files you\'d like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your %1$sproduct settings%2$s.', 'woocommerce' ),
+							'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=products&section=downloadable' ) . '" target="_blank" rel="noreferrer">',
+							'</a>'
+						),
+					),
+					'hideConditions' => array(
+						array(
+							'expression' => 'editedProduct.downloadable !== true',
+						),
+					),
+				)
+			)->add_block(
+				array(
+					'id'        => 'product-downloads',
+					'blockName' => 'woocommerce/product-downloads-field',
+					'order'     => 10,
+				)
+			);
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/DownloadableProductTrait.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/DownloadableProductTrait.php
@@ -2,16 +2,20 @@
 /**
  * DownloadableProductTrait
  */
+
 namespace Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates;
 
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\GroupInterface;
 
 /**
  * Downloadable Product Trait.
  */
 trait DownloadableProductTrait {
 	/**
-	 * Adds the general group blocks to the template.
+	 * Adds downloadable blocks to the given parent block.
+	 *
+	 * @param GroupInterface $parent_block The parent block.
 	 */
 	private function add_downloadable_product_blocks( $parent_block ) {
 		// Downloads section.

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -7,11 +7,14 @@ namespace Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\Prod
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\ProductFormTemplateInterface;
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\DownloadableProductTrait;
 
 /**
  * Product Variation Template.
  */
 class ProductVariationTemplate extends AbstractProductFormTemplate implements ProductFormTemplateInterface {
+	use DownloadableProductTrait;
+
 	/**
 	 * The context name used to identify the editor.
 	 */
@@ -185,29 +188,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 		);
 
 		// Downloads section.
-		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
-			$general_group->add_section(
-				array(
-					'id'         => 'product-variation-downloads-section',
-					'order'      => 40,
-					'attributes' => array(
-						'title'       => __( 'Downloads', 'woocommerce' ),
-						'description' => sprintf(
-						/* translators: %1$s: Downloads settings link opening tag. %2$s: Downloads settings link closing tag. */
-							__( 'Add any files you\'d like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your %1$sproduct settings%2$s.', 'woocommerce' ),
-							'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=products&section=downloadable' ) . '" target="_blank" rel="noreferrer">',
-							'</a>'
-						),
-					),
-				)
-			)->add_block(
-				array(
-					'id'        => 'product-variation-downloads',
-					'blockName' => 'woocommerce/product-downloads-field',
-					'order'     => 10,
-				)
-			);
-		}
+		$this->add_downloadable_product_blocks( $general_group );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -7,11 +7,14 @@ namespace Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\Prod
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\ProductFormTemplateInterface;
+use Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\DownloadableProductTrait;
 
 /**
  * Simple Product Template.
  */
 class SimpleProductTemplate extends AbstractProductFormTemplate implements ProductFormTemplateInterface {
+	use DownloadableProductTrait;
+
 	/**
 	 * The context name used to identify the editor.
 	 */
@@ -459,62 +462,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				),
 			)
 		);
+
 		// Downloads section.
-		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
-			$product_downloads_section_group = $general_group->add_section(
-				array(
-					'id'             => 'product-downloads-section-group',
-					'order'          => 50,
-					'attributes'     => array(
-						'blockGap' => 'unit-40',
-					),
-					'hideConditions' => array(
-						array(
-							'expression' => 'editedProduct.type !== "simple"',
-						),
-					),
-				)
-			);
-
-			$product_downloads_section_group->add_block(
-				array(
-					'id'         => 'product-downloadable',
-					'blockName'  => 'woocommerce/product-checkbox-field',
-					'order'      => 10,
-					'attributes' => array(
-						'property' => 'downloadable',
-						'label'    => __( 'Include downloads', 'woocommerce' ),
-					),
-				)
-			);
-
-			$product_downloads_section_group->add_section(
-				array(
-					'id'             => 'product-downloads-section',
-					'order'          => 20,
-					'attributes'     => array(
-						'title'       => __( 'Downloads', 'woocommerce' ),
-						'description' => sprintf(
-							/* translators: %1$s: Downloads settings link opening tag. %2$s: Downloads settings link closing tag. */
-							__( 'Add any files you\'d like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your %1$sproduct settings%2$s.', 'woocommerce' ),
-							'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=products&section=downloadable' ) . '" target="_blank" rel="noreferrer">',
-							'</a>'
-						),
-					),
-					'hideConditions' => array(
-						array(
-							'expression' => 'editedProduct.downloadable !== true',
-						),
-					),
-				)
-			)->add_block(
-				array(
-					'id'        => 'product-downloads',
-					'blockName' => 'woocommerce/product-downloads-field',
-					'order'     => 10,
-				)
-			);
-		}
+		$this->add_downloadable_product_blocks( $general_group );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43807

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-virtual-downloadable` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
4. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
5. Add some variations to that product to convert it into a variable one and publish the product.
6. Then under the variations list click to `Edit` any generated variation from the list.
7. You should be redirected to the specific variation edition page.
8. Under `General` tab at the bottom of the page the `Downloads` section should be shown only when the `Include downloads` checkbox is checked.
9. If the user uploads a file, then toggles off `Include downloads`, then Saves or Updates the product, then toggles on `Include downloads`, the previously uploaded file should re-appear. (This aligns with how it currently works in our legacy editor, gif below.)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
