### PR TITLE
Try: Add product editor hooks

### DIFF
--- a/packages/js/data/src/product-variations/actions.ts
+++ b/packages/js/data/src/product-variations/actions.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
-import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,7 +16,6 @@ import type {
 	GenerateRequest,
 } from './types';
 import CRUD_ACTIONS from './crud-actions';
-import { ProductAttribute, ProductDefaultAttribute } from '../products/types';
 
 export function generateProductVariationsError( key: IdType, error: unknown ) {
 	return {
@@ -44,13 +42,7 @@ export function generateProductVariationsSuccess( key: IdType ) {
 
 export const generateProductVariations = function* (
 	idQuery: IdQuery,
-	productData: {
-		type?: string;
-		attributes: ProductAttribute[];
-		default_attributes?: ProductDefaultAttribute[];
-	},
 	data: GenerateRequest,
-	saveAttributes = true
 ) {
 	const urlParameters = getUrlParameters(
 		WC_PRODUCT_VARIATIONS_NAMESPACE,
@@ -58,24 +50,6 @@ export const generateProductVariations = function* (
 	);
 	const { key } = parseId( idQuery, urlParameters );
 	yield generateProductVariationsRequest( key );
-
-	if ( saveAttributes ) {
-		try {
-			yield controls.dispatch(
-				'core',
-				'saveEntityRecord',
-				'postType',
-				'product',
-				{
-					id: urlParameters[ 0 ],
-					...productData,
-				}
-			);
-		} catch ( error ) {
-			yield generateProductVariationsError( key, error );
-			throw error;
-		}
-	}
 
 	try {
 		const result: Item = yield apiFetch( {

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -16,6 +16,7 @@ import {
  * Internal dependencies
  */
 import { EnhancedProductAttribute } from './use-product-attributes';
+import { useProduct } from './use-product';
 
 async function getDefaultVariationValues(
 	productId: number
@@ -58,6 +59,7 @@ export function useProductVariationsHelper() {
 		'product',
 		'id'
 	);
+	const { editProduct, saveProduct } = useProduct();
 	const [ _isGenerating, setIsGenerating ] = useState( false );
 
 	const { isGeneratingVariations, generateError } = useSelect(
@@ -117,6 +119,11 @@ export function useProductVariationsHelper() {
 			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
 		).invalidateResolutionForStore();
 
+		await saveProduct( {
+			type: hasVariableAttribute ? 'variable' : 'simple',
+			default_attributes: defaultAttributes,
+		} );
+
 		return dispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME )
 			.generateProductVariations< {
 				count: number;
@@ -126,28 +133,11 @@ export function useProductVariationsHelper() {
 					product_id: productId,
 				},
 				{
-					type: hasVariableAttribute ? 'variable' : 'simple',
-					attributes,
-					default_attributes: defaultAttributes,
-				},
-				{
 					delete: true,
 					default_values: defaultVariationValues,
 				}
 			)
 			.then( async ( response ) => {
-				// @ts-expect-error There are no types for this.
-				await dispatch( 'core' ).invalidateResolution(
-					'getEntityRecord',
-					[ 'postType', 'product', productId ]
-				);
-
-				await resolveSelect( 'core' ).getEntityRecord(
-					'postType',
-					'product',
-					productId
-				);
-
 				await dispatch(
 					EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
 				).invalidateResolutionForStore();

--- a/packages/js/product-editor/src/hooks/use-product.ts
+++ b/packages/js/product-editor/src/hooks/use-product.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { Product, ReadOnlyProperties } from '@woocommerce/data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityId } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+
+
+export function useProduct() {
+	const { editEntityRecord, saveEntityRecord } = useDispatch( 'core' );
+
+	const productId = useEntityId( 'postType', 'product' );
+
+    function editProduct( data: Omit< Product, ReadOnlyProperties > ) {
+        return editEntityRecord(
+            'postType',
+            'product',
+            productId,
+            applyFilters(
+                'woocommerce_edit_product_data',
+                data,
+                productId
+            )
+        );
+    }
+
+    function saveProduct( data: Omit< Product, ReadOnlyProperties > ) {
+        return saveEntityRecord( 'postType', 'product', {
+            id: productId,
+            ...( applyFilters(
+                'woocommerce_save_product_data',
+                data,
+                productId
+            ) as Omit< Product, ReadOnlyProperties > )
+        } );
+    }
+
+    return {
+        editProduct,
+        saveProduct,
+    }
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<img width="536" alt="Screenshot 2024-01-29 at 3 26 14 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/cade2618-0123-4a8c-93a0-acc14a3de94d">
<img width="521" alt="Screenshot 2024-01-29 at 3 24 54 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/fd13acac-57c9-4f4e-8eb7-a770365f9cb5">


#### Use case

This PR is a concept to cover cases where product data is modified by a block, but that data needs to be modified by a third party extension.

In this specific scenario, the variations block automatically handles updating the product type to `variable` when variations are added, but this conflicts with variable subscription product types which also use variations.  Allowing the data to be filtered prior to edit or save allows extensions to modify data and handle conflict resolution or update other fields when a value has been changed.

**Alternatives**

* Server-side filtering - This is certainly an option, but relies on all transient edits in the product to be saved.  In the current case of variations, we bypass saving transient edits which would not provide enough information to the server filter to update the product type respectively.
* `useEffect` - We could react to changes in the data in individual blocks, but this would occur after updates to the product are made and sometimes persisted, resulting in duplicate update calls at best and unexpected side effects at worst.

#### Benefits

This PR introduces a wrapper around entity hooks which gives us a few benefits:

* Allows us to add custom hooks or filter data for entities
* Provides a backwards compatible way for us to change underlying data stores or endpoints
* Gives more intuitive hooks and naming to 3PDs building in the product editor

#### Follow-ups needed

We have a lot of hooks that do very similar things and probably need to be consolidated.

* `useProductMetadata`
* `useProductHelper`
* `useProductEntityProp`
* `useProductEdits`
* `useProductAttributes`

There may be reasons to keep some of these separate, but at first glance it's not clear by the naming why each of these needs separate hooks and adds overhead to learning how to work with this new system.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you've enable the new product editing experience under WC -> Settings -> Advanced -> Features.
2. Install WC Subscriptions and this branch of WC Subscriptions Core - https://github.com/Automattic/woocommerce-subscriptions-core/pull/562
3. Add some variations
4. Note in the Network tab of your developer console that the request to the product endpoint includes `type` of `variable`
5. Remove the variations
6. Under the "Pricing" tab check the "Subscribeable" checkbox
7. Add some variations
8. Note in the Network tab of your developer console that the request to the product endpoint includes `type` of `variable-subscription`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>