### PR TITLE
Add an empty state to the variations table when there are no options added yet

### DIFF
--- a/packages/js/product-editor/changelog/add-43808-variations-empty-state
+++ b/packages/js/product-editor/changelog/add-43808-variations-empty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create variation empty state when no variable attributes are asigned to the product

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/edit.tsx
@@ -22,11 +22,13 @@ import { useEntityId, useEntityProp } from '@wordpress/core-data';
  */
 import { VariationsTable } from '../../../components/variations-table';
 import { useValidation } from '../../../contexts/validation-context';
+import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { VariationOptionsBlockAttributes } from './types';
 import { VariableProductTour } from './variable-product-tour';
 import { TRACKS_SOURCE } from '../../../constants';
 import { handlePrompt } from '../../../utils/handle-prompt';
 import { ProductEditorBlockEditProps } from '../../../types';
+import { EmptyState } from './empty-state';
 
 export function Edit( {
 	attributes,
@@ -46,6 +48,17 @@ export function Edit( {
 		'postType',
 		'product',
 		'status'
+	);
+	const [ productAttributes ] =
+		useProductEntityProp< Product[ 'attributes' ] >( 'attributes' );
+
+	const hasVariationOptions = useMemo(
+		function hasAttributesUsedForVariations() {
+			return productAttributes?.some(
+				( productAttribute ) => productAttribute.variation
+			);
+		},
+		[ productAttributes ]
 	);
 
 	const totalCountWithoutPriceRequestParams = useMemo(
@@ -161,6 +174,10 @@ export function Edit( {
 					totalCountWithoutPrice
 			  )
 			: '';
+
+	if ( ! hasVariationOptions ) {
+		return <EmptyState />;
+	}
 
 	return (
 		<div { ...blockProps }>

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/editor.scss
@@ -1,3 +1,5 @@
+@import "empty-state/style.scss";
+
 .wp-block-woocommerce-product-variation-items-field {
 	@media ( min-width: #{ ($break-medium) } ) {
 		min-height: 420px;

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/empty-state/empty-state.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/empty-state/empty-state.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+export function EmptyState(
+	props: React.DetailedHTMLProps<
+		React.HTMLAttributes< HTMLDivElement >,
+		HTMLDivElement
+	>
+) {
+	return (
+		<div
+			{ ...props }
+			role="none"
+			className="wp-block-woocommerce-product-variation-items-field__empty-state"
+		>
+			<div className="wp-block-woocommerce-product-variation-items-field__empty-state-row">
+				<div>{ __( 'Variation', 'woocommerce' ) }</div>
+				<div>
+					<div className="wp-block-woocommerce-product-variation-items-field__empty-state-name" />
+				</div>
+				<div>
+					<div className="wp-block-woocommerce-product-variation-items-field__empty-state-actions" />
+				</div>
+			</div>
+
+			<div className="wp-block-woocommerce-product-variation-items-field__empty-state-row">
+				<div>{ __( 'Colors', 'woocommerce' ) }</div>
+				<div>
+					<div className="wp-block-woocommerce-product-variation-items-field__empty-state-name" />
+				</div>
+				<div>
+					<div className="wp-block-woocommerce-product-variation-items-field__empty-state-actions" />
+				</div>
+			</div>
+
+			<div className="wp-block-woocommerce-product-variation-items-field__empty-state-row">
+				<div>{ __( 'Sizes', 'woocommerce' ) }</div>
+				<div>
+					<div className="wp-block-woocommerce-product-variation-items-field__empty-state-name" />
+				</div>
+				<div>
+					<div className="wp-block-woocommerce-product-variation-items-field__empty-state-actions" />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/empty-state/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/empty-state/index.ts
@@ -1,0 +1,1 @@
+export * from './empty-state';

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/empty-state/style.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/empty-state/style.scss
@@ -1,0 +1,59 @@
+.wp-block-woocommerce-product-variation-items-field__empty-state {
+	@mixin skeleton {
+		@include placeholder();
+		background-color: $gray-200;
+		border-radius: $grid-unit-05;
+		width: $grid-unit-30;
+		height: $grid-unit;
+	}
+
+	border: 1px dashed $gray-400;
+	padding: 0 $grid-unit-30;
+	border-radius: 2px;
+
+	&-row {
+		display: grid;
+		grid-template-columns: 1.5fr 1fr 0.5fr;
+		height: $grid-unit-80;
+		align-items: center;
+		border-top: 1px solid $gray-100;
+
+		&:first-child {
+			border-top: none;
+
+			.wp-block-woocommerce-product-variation-items-field__empty-state-name {
+				width: 140px;
+			}
+		}
+
+		&:nth-child(2) {
+			opacity: 0.7;
+
+			.wp-block-woocommerce-product-variation-items-field__empty-state-name {
+				width: 75px;
+			}
+		}
+
+		&:nth-child(3) {
+			opacity: 0.5;
+
+			.wp-block-woocommerce-product-variation-items-field__empty-state-name {
+				width: 114px;
+			}
+		}
+
+		:last-child {
+			display: flex;
+			justify-content: flex-end;
+		}
+	}
+
+	&-name {
+		@include skeleton();
+	}
+
+	&-actions {
+		@include skeleton();
+		width: $grid-unit-60;
+	}
+}

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -53,7 +53,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	onRemove = () => {},
 	onRemoveCancel = () => {},
 	onNoticeDismiss = () => {},
-	renderCustomEmptyState = () => <AttributeEmptyStateSkeleton />,
+	renderCustomEmptyState,
 	uiStrings,
 	createNewAttributesAsGlobal = false,
 	useRemoveConfirmationModal = false,
@@ -203,19 +203,43 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
+	function renderEmptyState() {
+		if ( isMobileViewport || value.length ) return null;
+
+		if ( renderCustomEmptyState ) {
+			return renderCustomEmptyState( {
+				addAttribute( search ) {
+					setDefaultAttributeSearch( search );
+					openNewModal();
+				},
+			} );
+		}
+
+		return <AttributeEmptyStateSkeleton />;
+	}
+
+	function renderSectionActions() {
+		if ( renderCustomEmptyState && value.length === 0 ) return null;
+
+		return (
+			<SectionActions>
+				{ uiStrings?.newAttributeListItemLabel && (
+					<Button
+						variant="secondary"
+						className="woocommerce-add-attribute-list-item__add-button"
+						onClick={ openNewModal }
+					>
+						{ uiStrings.newAttributeListItemLabel }
+					</Button>
+				) }
+			</SectionActions>
+		);
+	}
+
 	return (
 		<div className="woocommerce-attribute-field">
-			<SectionActions>
-				<Button
-					variant="secondary"
-					className="woocommerce-add-attribute-list-item__add-button"
-					onClick={ () => {
-						openNewModal();
-					} }
-				>
-					{ uiStrings.newAttributeListItemLabel }
-				</Button>
-			</SectionActions>
+			{ renderSectionActions() }
+
 			{ uiStrings.notice && (
 				<Notice
 					isDismissible={ true }
@@ -345,14 +369,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					} }
 				/>
 			) }
-			{ ! isMobileViewport &&
-				value.length === 0 &&
-				renderCustomEmptyState( {
-					addAttribute( search ) {
-						setDefaultAttributeSearch( search );
-						openNewModal();
-					},
-				} ) }
+			{ renderEmptyState() }
 		</div>
 	);
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43808

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under the `Variations` tab, and where there are no `Variation options` added, the empty state for the `Variations` section should looks like 
<img width="688" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/59c8e38f-02e2-4773-920c-8e34f7176ec0">

5. Adding new `Variation options` should change that empty estate for a different one if no variations are generated or if all variations were removed. 
<img width="621" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/26de6f17-4e29-4292-9132-a589e168fafe">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
