### PR TITLE
[Product Block Editor]: redefine the app dashboard size

### DIFF
--- a/packages/js/product-editor/changelog/update-update-product-editor-dashboard-sizes
+++ b/packages/js/product-editor/changelog/update-update-product-editor-dashboard-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: redefine the app dashboard size

--- a/packages/js/product-editor/src/blocks/generic/tab/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/tab/editor.scss
@@ -4,6 +4,19 @@
 	}
 }
 
+.wp-block-woocommerce-product-tab {
+	padding-left: calc( 2 * $gap );
+	padding-right: calc( 2 * $gap );
+
+	@include breakpoint(">782px") {
+		padding-left: 0;
+		padding-right: 0;
+		max-width: 650px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
 .woocommerce-product-tabs {
 	.wp-block-woocommerce-product-tab__button:focus:not( :disabled ) {
 		box-shadow: none;

--- a/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { BaseControl } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { useInstanceId } from '@wordpress/compose';
 import classNames from 'classnames';
@@ -15,7 +14,6 @@ import {
 	AlignmentControl,
 	BlockControls,
 	RichText,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 
 /**
@@ -35,6 +33,7 @@ export function SummaryBlockEdit( {
 	const blockProps = useWooBlockProps( attributes, {
 		style: { direction },
 	} );
+
 	const contentId = useInstanceId(
 		SummaryBlockEdit,
 		'wp-block-woocommerce-product-summary-field__content'
@@ -44,9 +43,6 @@ export function SummaryBlockEdit( {
 		context.postType || 'product',
 		attributes.property
 	);
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore No types for this exist yet.
-	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	function handleAlignmentChange( value: SummaryAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );
@@ -54,15 +50,6 @@ export function SummaryBlockEdit( {
 
 	function handleDirectionChange( value: SummaryAttributes[ 'direction' ] ) {
 		setAttributes( { direction: value } );
-	}
-
-	function handleBlur( event: React.FocusEvent< 'p', Element > ) {
-		const isToolbar = event.relatedTarget?.closest(
-			'.block-editor-block-contextual-toolbar'
-		);
-		if ( ! isToolbar ) {
-			clearSelectedBlock();
-		}
 	}
 
 	return (
@@ -127,7 +114,6 @@ export function SummaryBlockEdit( {
 						} ) }
 						dir={ direction }
 						allowedFormats={ allowedFormats }
-						onBlur={ handleBlur }
 					/>
 				</div>
 			</BaseControl>

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -1,5 +1,5 @@
 .woocommerce-product-block-editor {
-	padding-top: 43px; //
+	padding-top: 43px; // required space to locate the dashboard just below the admin bar. @todo: find a better way to do this.
 
 	h1,
 	h2,

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -1,5 +1,5 @@
 .woocommerce-product-block-editor {
-	padding-top: 106px;
+	padding-top: 43px; //
 
 	h1,
 	h2,
@@ -147,17 +147,7 @@
 
 	.block-editor-block-list__layout {
 		&.is-root-container {
-			padding-left: calc(2 * $gap);
-			padding-right: calc(2 * $gap);
 			padding-bottom: 128px;
-
-			@include breakpoint(">782px") {
-				padding-left: 0;
-				padding-right: 0;
-				max-width: 650px;
-				margin-left: auto;
-				margin-right: auto;
-			}
 		}
 
 		.block-editor-block-list__block:not([contenteditable]):focus:after {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR redefines the size of the App dashboard ( Canvas is the name that the Block Editor uses) to increase the surface where the clickout event is detected by the app. Ultimately, the block toolbars will be hidden when the user clicks on the dashboard.
Also, it removes the `onBlur` stuff from the summary block.

Closes https://github.com/woocommerce/woocommerce/issues/44165

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enatble the Product Editor
2. Go to the General tab
3. Use the `description` and `summary` block
4. Focus on the textarea field
5. Confirm you see the block toolbar 
6. Confirm the toolbar hides when you click on any place of the app dashboard
7. Confirm the toolbar hides when leaving the input by pressing the `tab` key
8. Go to a Variant product page
9. General tab
10. Same test for the Variation details

# 🍿 

https://github.com/woocommerce/woocommerce/assets/77539/d8a18407-01f8-4813-8925-49ac8ecbf119

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
