### PR TITLE
Change specificity of date picker rules

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-panel-date-picker
+++ b/plugins/woocommerce/changelog/fix-order-panel-date-picker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix alignment of date fields in the order panel

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1935,15 +1935,6 @@ ul.wc_coupon_list_block {
 				width: 100% !important;
 			}
 
-			.date-picker {
-				width: 50%;
-			}
-
-			.hour,
-			.minute {
-				width: 3.5em;
-			}
-
 			small {
 				display: block;
 				margin: 5px 0 0;
@@ -1979,6 +1970,13 @@ ul.wc_coupon_list_block {
 			.wc-category-search,
 			.wc-customer-search {
 				width: 100%;
+			}
+			input.date-picker {
+				width: 50%;
+			}
+			input.hour,
+			input.minute {
+				width: 3.5em;
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a display regression from https://github.com/woocommerce/woocommerce/pull/43748 where the date picker fields became full width.

![Screenshot 2024-01-30 at 10 11 51](https://github.com/woocommerce/woocommerce/assets/90977/16ac0ac1-6ed1-4c53-96d5-5df32719960c)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. View the order in the admin area.
2. Confirm order date fields are rendered correctly (inline, not full width) in the order details panel.

**Developers only**

1. Add this code to register a checkbox field:

```
add_action(
	'woocommerce_blocks_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/test-checkbox',
				'label'    => 'Check the box',
				'location' => 'address',
				'type'     => 'checkbox',
			)
		);
	}
);
```

2. Place an order being sure to check this new box in the address area
3. View the order in the admin area
4. Confirm date fields are rendered correctly (inline, not full width)
5. Edit the address in the address panel. Confirm the checkbox is not 100% width of the container

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
