### PR TITLE
Store API - Documentation: Fix broken link

### DIFF
--- a/plugins/woocommerce/changelog/44180-fix-link_documentation_store_api
+++ b/plugins/woocommerce/changelog/44180-fix-link_documentation_store_api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Store API - Documentation: Fix broken link.
+

--- a/plugins/woocommerce/src/StoreApi/README.md
+++ b/plugins/woocommerce/src/StoreApi/README.md
@@ -66,9 +66,9 @@ Available resources in the Store API are listed below, with links to more detail
 |                                                              | `GET`, `POST`, `PUT`, `DELETE` | [`/wc/store/v1/cart/items/:key`](docs/cart-items.md#single-cart-item)                         |
 | [`Cart Coupons`](docs/cart-coupons.md)                       | `GET`, `POST`, `DELETE`        | [`/wc/store/v1/cart/coupons`](docs/cart-coupons.md#list-cart-coupons)                         |
 |                                                              | `GET`, `DELETE`                | [`/wc/store/v1/cart/coupon/:code`](docs/cart-coupons.md#single-cart-coupon)                   |
-| [`Checkout`](docs/checkout.md)                               | `GET`, `POST`                  | [`/wc/store/v1/checkout`](docs/checkout.md)     
-| [`Checkout order`](docs/checkout-order.md)                   | `POST`                         | [`/wc/store/v1/checkout/:id`](docs/checkout-order.md)                                             |
-| [`Order`](docs/order.md)                                     | `GET`                          | [`/wc/store/v1/order/:id`](docs/order.md)  
+| [`Checkout`](docs/checkout.md)                               | `GET`, `POST`                  | [`/wc/store/v1/checkout`](docs/checkout.md)                                                   |
+| [`Checkout order`](docs/checkout-order.md)                   | `POST`                         | [`/wc/store/v1/checkout/:id`](docs/checkout-order.md)                                         |
+| [`Order`](docs/order.md)                                     | `GET`                          | [`/wc/store/v1/order/:id`](docs/order.md)                                                     |
 | [`Products`](docs/products.md)                               | `GET`                          | [`/wc/store/v1/products`](docs/products.md#list-products)                                     |
 |                                                              | `GET`                          | [`/wc/store/v1/products/:id`](docs/products.md#single-product)                                |
 | [`Product Collection Data`](docs/product-collection-data.md) | `GET`                          | [`/wc/store/v1/products/collection-data`](docs/product-collection-data.md)                    |

--- a/plugins/woocommerce/src/StoreApi/README.md
+++ b/plugins/woocommerce/src/StoreApi/README.md
@@ -146,7 +146,7 @@ Please review the [Store API Guiding principles](./docs/guiding-principles.md). 
 
 ## Extensibility
 
-The approach to extensibility within the Store API is to expose certain routes and schema to the ExtendSchema class. [Documentation for contributors on this can be found here](../../docs/internal-developers/rest-api/extend-rest-api-new-endpoint.md).
+The approach to extensibility within the Store API is to expose certain routes and schema to the ExtendSchema class. [Documentation for contributors on this can be found here](../../../woocommerce-blocks/docs/internal-developers/rest-api/extend-rest-api-new-endpoint.md).
 
 If a route includes the extensibility interface, 3rd party developers can use the shared `ExtendSchema::class` instance to register additional endpoint data and additional schema.
 


### PR DESCRIPTION
This PR updated a broken link into the documentation.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that the new link works correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Store API - Documentation: Fix broken link.


</details>
