### PR TITLE
Make combobox suggestions have same border as main input

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
@@ -72,6 +72,7 @@
 			background-color: $select-dropdown-light;
 			border: 1px solid $input-border-gray;
 			border-top: 0;
+			border-bottom: 0;
 			margin: 3em 0 0 0;
 			padding: 0;
 			max-height: 300px;
@@ -80,7 +81,7 @@
 			color: $input-text-active;
 			border-bottom-left-radius: $universal-border-radius;
 			border-bottom-right-radius: $universal-border-radius;
-			box-shadow: 0 0 0 1px $input-border-gray;
+			box-shadow: 0 1px 0 1px $input-border-gray;
 			box-sizing: border-box;
 
 			.has-dark-controls & {

--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
@@ -72,7 +72,7 @@
 			background-color: $select-dropdown-light;
 			border: 1px solid $input-border-gray;
 			border-top: 0;
-			margin: 3em 0 0 -1px;
+			margin: 3em 0 0 0;
 			padding: 0;
 			max-height: 300px;
 			min-width: 100%;
@@ -80,6 +80,8 @@
 			color: $input-text-active;
 			border-bottom-left-radius: $universal-border-radius;
 			border-bottom-right-radius: $universal-border-radius;
+			box-shadow: 0 0 0 1px $input-border-gray;
+			box-sizing: border-box;
 
 			.has-dark-controls & {
 				background-color: $select-dropdown-dark;

--- a/plugins/woocommerce/changelog/44183-fix-combobox-border
+++ b/plugins/woocommerce/changelog/44183-fix-combobox-border
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure a consistent border style is applied to combobox suggestions and the main input.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a box-shadow to the combobox, also adds `box-sizing: border-box` and removes a negative margin.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an item to your cart and go to the Checkout block.
2. Change your country to United States.
3. Open the "State" input and ensure the border is applied evenly around the main input box and the options. (See the before/after shots below)
4. Try in multiple themes, block themes and classic themes (Storefront, Twenty Twenty-One, Twenty Twenty-Four etc.)

| Before | After |
| ------ | ----- |
| <img width="291" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/71f1ec4c-f89d-4328-b2e9-525e78009826"> | <img width="292" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/14ee7b33-4c3e-4598-909d-f2abb3b6178c"> |

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure a consistent border style is applied to combobox suggestions and the main input.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
