### PR TITLE
[Experimental] Add e2e tests for the new active filter block

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/README.md
+++ b/plugins/woocommerce-blocks/tests/e2e/README.md
@@ -103,7 +103,7 @@ pnpm run test:e2e:classic-theme
 pnpm run test:e2e:block-theme-with-templates
 ```
 
-\_Note: All command parameters of `test:e2e` can be used for these commands too.
+_Note: All command parameters of `test:e2e` can be used for these commands too.
 
 ### Other ways of running tests
 

--- a/plugins/woocommerce-blocks/tests/e2e/README.md
+++ b/plugins/woocommerce-blocks/tests/e2e/README.md
@@ -60,6 +60,18 @@ pnpm run env:restart
 pnpm run test:e2e
 ```
 
+### Adding posts for testing block content
+
+During test setup posts are automatically created from all the html files contained in `./bin/posts`.
+All posts are given a title like `File Name Block` which generates a url like `file-name-block`.
+
+e.g. `my-test.html` will generate a post with the title `My Test Block` and permalink `my-test-block`.
+You'll be able to navigate to that page in your test like:
+
+```ts
+await page.goto( '/my-test-block/' );
+```
+
 ### Tests with side effects
 
 We call tests that affect other tests (ones that modify the site settings, using
@@ -88,7 +100,7 @@ pnpm run test:e2e:classic-theme
 pnpm run test:e2e:block-theme-with-templates
 ```
 
-_Note: All command parameters of `test:e2e` can be used for these commands too.
+\_Note: All command parameters of `test:e2e` can be used for these commands too.
 
 ### Other ways of running tests
 

--- a/plugins/woocommerce-blocks/tests/e2e/README.md
+++ b/plugins/woocommerce-blocks/tests/e2e/README.md
@@ -72,6 +72,9 @@ You'll be able to navigate to that page in your test like:
 await page.goto( '/my-test-block/' );
 ```
 
+Please also note that the posts are generated during initial environment setup, so if you
+add or edit a post file you'll need to restart the environment to see the changes.
+
 ### Tests with side effects
 
 We call tests that affect other tests (ones that modify the site settings, using

--- a/plugins/woocommerce-blocks/tests/e2e/bin/posts/product-filters-active.html
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/posts/product-filters-active.html
@@ -10,14 +10,6 @@
 	<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
 	<!-- /wp:woocommerce/product-template -->
 
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-	<!-- wp:query-pagination-previous /-->
-
-	<!-- wp:query-pagination-numbers /-->
-
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination -->
-
 	<!-- wp:woocommerce/product-filter {"filterType":"active-filters","heading":"Active filters"} -->
 	<!-- wp:heading {"level":3} -->
 	<h3 class="wp-block-heading">Active filters</h3>
@@ -25,45 +17,5 @@
 
 	<!-- wp:woocommerce/product-filter-active {"lock":{"remove":true}} /-->
 	<!-- /wp:woocommerce/product-filter -->
-
-	<!-- wp:woocommerce/product-filter {"filterType":"attribute-filter","heading":"Filter by Attribute"} -->
-	<!-- wp:heading {"level":3} -->
-	<h3 class="wp-block-heading">Filter by Attribute</h3>
-	<!-- /wp:heading -->
-
-	<!-- wp:woocommerce/product-filter-attribute {"attributeId":1,"lock":{"remove":true}} /-->
-	<!-- /wp:woocommerce/product-filter -->
-
-	<!-- wp:paragraph -->
-	<p>my cool paragrapg</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:woocommerce/product-filter {"filterType":"price-filter","heading":"Filter by Price"} -->
-	<!-- wp:heading {"level":3} -->
-	<h3 class="wp-block-heading">Filter by Price</h3>
-	<!-- /wp:heading -->
-
-	<!-- wp:woocommerce/product-filter-price {"lock":{"remove":true}} /-->
-	<!-- /wp:woocommerce/product-filter -->
-
-	<!-- wp:woocommerce/product-filter {"filterType":"stock-filter","heading":"Filter by Stock Status"} -->
-	<!-- wp:heading {"level":3} -->
-	<h3 class="wp-block-heading">Filter by Stock Status</h3>
-	<!-- /wp:heading -->
-
-	<!-- wp:woocommerce/product-filter-stock-status {"displayStyle":"dropdown","lock":{"remove":true}} /-->
-	<!-- /wp:woocommerce/product-filter -->
-
-	<!-- wp:woocommerce/product-filter {"filterType":"rating-filter","heading":"Filter by Rating"} -->
-	<!-- wp:heading {"level":3} -->
-	<h3 class="wp-block-heading">Filter by Rating</h3>
-	<!-- /wp:heading -->
-
-	<!-- wp:woocommerce/product-filter-rating {"showCounts":true,"displayStyle":"dropdown","lock":{"remove":true}} /-->
-	<!-- /wp:woocommerce/product-filter -->
 </div>
 <!-- /wp:woocommerce/product-collection -->
-
-<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->

--- a/plugins/woocommerce-blocks/tests/e2e/bin/posts/product-filters-active.html
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/posts/product-filters-active.html
@@ -1,0 +1,69 @@
+<!-- wp:woocommerce/product-collection {"id":"bee7a337-f64e-4efd-be51-e68670b10000","queryId":0,"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true}} -->
+<div class="wp-block-woocommerce-product-collection">
+	<!-- wp:woocommerce/product-template -->
+	<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
+
+	<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+	<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+	<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+	<!-- /wp:woocommerce/product-template -->
+
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<!-- wp:query-pagination-previous /-->
+
+	<!-- wp:query-pagination-numbers /-->
+
+	<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+
+	<!-- wp:woocommerce/product-filter {"filterType":"active-filters","heading":"Active filters"} -->
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading">Active filters</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/product-filter-active {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/product-filter -->
+
+	<!-- wp:woocommerce/product-filter {"filterType":"attribute-filter","heading":"Filter by Attribute"} -->
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading">Filter by Attribute</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/product-filter-attribute {"attributeId":1,"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/product-filter -->
+
+	<!-- wp:paragraph -->
+	<p>my cool paragrapg</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:woocommerce/product-filter {"filterType":"price-filter","heading":"Filter by Price"} -->
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading">Filter by Price</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/product-filter-price {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/product-filter -->
+
+	<!-- wp:woocommerce/product-filter {"filterType":"stock-filter","heading":"Filter by Stock Status"} -->
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading">Filter by Stock Status</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/product-filter-stock-status {"displayStyle":"dropdown","lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/product-filter -->
+
+	<!-- wp:woocommerce/product-filter {"filterType":"rating-filter","heading":"Filter by Rating"} -->
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading">Filter by Rating</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/product-filter-rating {"showCounts":true,"displayStyle":"dropdown","lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/product-filter -->
+</div>
+<!-- /wp:woocommerce/product-collection -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+test.describe( 'Product Filter: Active Filters Block', async () => {
+	describe( 'frontend', () => {
+		test( 'Without any filters selected, only a wrapper block is rendered', async ( {
+			page,
+		} ) => {
+			await page.goto( '/product-filters-active-block/' );
+
+			const locator = page.locator(
+				'.wp-block-woocommerce-product-filter'
+			);
+
+			const count = await locator.count();
+			expect( count ).toBe( 1 );
+
+			const html = await locator.innerHTML();
+			expect( html.trim() ).toBe( '' );
+		} );
+
+		test( 'With rating filters applied it shows the correct active filters', async ( {
+			page,
+		} ) => {
+			await page.goto(
+				'/product-filters-active-block/?rating_filter=1,2,5'
+			);
+
+			const listLocator = page.locator( '.filter-list' );
+			const hasTitle =
+				( await listLocator.locator( 'text=Rating:' ).count() ) === 1;
+
+			expect( hasTitle ).toBe( true );
+
+			for ( const text of [
+				'Rated 1 out of 5',
+				'Rated 2 out of 5',
+				'Rated 5 out of 5',
+			] ) {
+				const hasFilter =
+					( await listLocator
+						.locator( `text=${ text }` )
+						.count() ) === 1;
+				expect( hasFilter ).toBe( true );
+			}
+		} );
+
+		test( 'With stock filters applied it shows the correct active filters', async ( {
+			page,
+		} ) => {
+			await page.goto(
+				'/product-filters-active-block/?filter_stock_status=instock,outofstock'
+			);
+
+			const listLocator = page.locator( '.filter-list' );
+			const hasTitle =
+				( await listLocator.locator( 'text=Rating:' ).count() ) === 1;
+
+			expect( hasTitle ).toBe( true );
+
+			for ( const text of [ 'In stock', 'Out of stock' ] ) {
+				const hasFilter =
+					( await listLocator
+						.locator( `text=${ text }` )
+						.count() ) === 1;
+				expect( hasFilter ).toBe( true );
+			}
+		} );
+
+		test( 'With attribute filters applied it shows the correct active filters', async ( {
+			page,
+		} ) => {
+			await page.goto(
+				'/product-filters-active-block/?filter_color=blue,gray&query_type_color=or'
+			);
+
+			const listLocator = page.locator( '.filter-list' );
+			const hasTitle =
+				( await listLocator.locator( 'text=Color:' ).count() ) === 1;
+
+			expect( hasTitle ).toBe( true );
+
+			for ( const text of [ 'Blue', 'Gray' ] ) {
+				const hasFilter =
+					( await listLocator
+						.locator( `text=${ text }` )
+						.count() ) === 1;
+				expect( hasFilter ).toBe( true );
+			}
+		} );
+
+		test( 'With price filters applied it shows the correct active filters', async ( {
+			page,
+		} ) => {
+			await page.goto(
+				'/product-filters-active-block/?min_price=17&max_price=71'
+			);
+
+			const listLocator = page.locator( '.filter-list' );
+			const hasTitle =
+				( await listLocator.locator( 'text=Price:' ).count() ) === 1;
+
+			expect( hasTitle ).toBe( true );
+
+			const hasFilter =
+				( await listLocator
+					.locator( `text=Between $17 and $71` )
+					.count() ) === 1;
+			expect( hasFilter ).toBe( true );
+		} );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
 
 test.describe( 'Product Filter: Active Filters Block', async () => {
-	describe( 'frontend', () => {
+	test.describe( 'frontend', () => {
 		test( 'Without any filters selected, only a wrapper block is rendered', async ( {
 			page,
 		} ) => {
@@ -51,16 +51,18 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 			page,
 		} ) => {
 			await page.goto(
-				'/product-filters-active-block/?filter_stock_status=instock,outofstock'
+				'/product-filters-active-block/?filter_stock_status=instock,onbackorder'
 			);
 
 			const listLocator = page.locator( '.filter-list' );
 			const hasTitle =
-				( await listLocator.locator( 'text=Rating:' ).count() ) === 1;
+				( await listLocator
+					.locator( 'text=Stock Status:' )
+					.count() ) === 1;
 
 			expect( hasTitle ).toBe( true );
 
-			for ( const text of [ 'In stock', 'Out of stock' ] ) {
+			for ( const text of [ 'In stock', 'On backorder' ] ) {
 				const hasFilter =
 					( await listLocator
 						.locator( `text=${ text }` )

--- a/plugins/woocommerce/changelog/44190-dev-add-e2e-tests-active-filters-block
+++ b/plugins/woocommerce/changelog/44190-dev-add-e2e-tests-active-filters-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: [Experimental] Add e2e tests for the new active filters block.
+


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/42170 by adding some basic tests of the active filters block.

I also added some details to the tests README just to help others get going faster in future.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. You can see the tests pass in CI
2. You can check out this branch locally. Follow the instructions in the test README
3. Run these new tests specifically (from blocks dir): `pnpm test:e2e ./tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
[Experimental] Add e2e tests for the new active filters block.

</details>
