### PR TITLE
[Product Block Editor]: add plain and rich text mode to the Textarea field block

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-text-area-plain-mode
+++ b/packages/js/product-editor/changelog/update-product-editor-text-area-plain-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: add plain and rich text mode to the Textarea field block

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -31,6 +31,10 @@
 			"type": "string",
 			"enum": [ "left", "center", "right", "justify" ]
 		},
+		"mode": {
+			"type": "string",
+			"enum": [ "plain-text", "rich-text" ]
+		},
 		"allowedFormats": {
 			"type": "array",
 			"default": [

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -33,7 +33,8 @@
 		},
 		"mode": {
 			"type": "string",
-			"enum": [ "plain-text", "rich-text" ]
+			"enum": [ "plain-text", "rich-text" ],
+			"default": "rich-text"
 		},
 		"allowedFormats": {
 			"type": "array",

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -37,6 +37,7 @@ export function TextAreaBlockEdit( {
 		direction,
 	} = attributes;
 	const blockProps = useWooBlockProps( attributes, {
+		className: 'wp-block-woocommerce-product-text-area-field',
 		style: { direction },
 	} );
 
@@ -69,7 +70,7 @@ export function TextAreaBlockEdit( {
 	const blockControlsProps = { group: 'block' };
 
 	return (
-		<div className={ 'wp-block-woocommerce-product-text-area-field' }>
+		<div { ...blockProps }>
 			<BlockControls { ...blockControlsProps }>
 				<AligmentToolbarButton
 					align={ align }
@@ -87,24 +88,22 @@ export function TextAreaBlockEdit( {
 				label={ label }
 				help={ help }
 			>
-				<div { ...blockProps }>
-					<RichText
-						id={ contentId.toString() }
-						identifier="content"
-						tagName="p"
-						value={ content || '' }
-						onChange={ setContent }
-						data-empty={ Boolean( content ) }
-						className={ classNames( 'components-summary-control', {
-							[ `has-text-align-${ align }` ]: align,
-						} ) }
-						dir={ direction }
-						allowedFormats={ allowedFormats }
-						placeholder={ placeholder }
-						required={ required }
-						disabled={ disabled }
-					/>
-				</div>
+				<RichText
+					id={ contentId.toString() }
+					identifier="content"
+					tagName="p"
+					value={ content || '' }
+					onChange={ setContent }
+					data-empty={ Boolean( content ) }
+					className={ classNames( 'components-summary-control', {
+						[ `has-text-align-${ align }` ]: align,
+					} ) }
+					dir={ direction }
+					allowedFormats={ allowedFormats }
+					placeholder={ placeholder }
+					required={ required }
+					disabled={ disabled }
+				/>
 			</BaseControl>
 		</div>
 	);

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -75,17 +75,19 @@ export function TextAreaBlockEdit( {
 
 	return (
 		<div { ...blockProps }>
-			<BlockControls { ...blockControlsBlockProps }>
-				<AligmentToolbarButton
-					align={ align }
-					setAlignment={ setAlignment }
-				/>
+			{ isRichTextMode && (
+				<BlockControls { ...blockControlsBlockProps }>
+					<AligmentToolbarButton
+						align={ align }
+						setAlignment={ setAlignment }
+					/>
 
-				<RTLToolbarButton
-					direction={ direction }
-					onChange={ changeDirection }
-				/>
-			</BlockControls>
+					<RTLToolbarButton
+						direction={ direction }
+						onChange={ changeDirection }
+					/>
+				</BlockControls>
+			) }
 
 			<BaseControl
 				id={ contentId.toString() }

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -68,14 +68,14 @@ export function TextAreaBlockEdit( {
 		setAttributes( { direction: value } );
 	}
 
-	const blockControlsProps = { group: 'block' };
+	const blockControlsBlockProps = { group: 'block' };
 
 	const isRichTextMode = mode === 'rich-text';
 	const isPlainTextMode = mode === 'plain-text';
 
 	return (
 		<div { ...blockProps }>
-			<BlockControls { ...blockControlsProps }>
+			<BlockControls { ...blockControlsBlockProps }>
 				<AligmentToolbarButton
 					align={ align }
 					setAlignment={ setAlignment }

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { createElement } from '@wordpress/element';
-import { BaseControl } from '@wordpress/components';
+import { BaseControl, TextareaControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { BlockControls, RichText } from '@wordpress/block-editor';
 import classNames from 'classnames';
@@ -35,6 +35,7 @@ export function TextAreaBlockEdit( {
 		align,
 		allowedFormats,
 		direction,
+		mode = 'rich-text',
 	} = attributes;
 	const blockProps = useWooBlockProps( attributes, {
 		className: 'wp-block-woocommerce-product-text-area-field',
@@ -69,6 +70,9 @@ export function TextAreaBlockEdit( {
 
 	const blockControlsProps = { group: 'block' };
 
+	const isRichTextMode = mode === 'rich-text';
+	const isPlainTextMode = mode === 'plain-text';
+
 	return (
 		<div { ...blockProps }>
 			<BlockControls { ...blockControlsProps }>
@@ -88,22 +92,34 @@ export function TextAreaBlockEdit( {
 				label={ label }
 				help={ help }
 			>
-				<RichText
-					id={ contentId.toString() }
-					identifier="content"
-					tagName="p"
-					value={ content || '' }
-					onChange={ setContent }
-					data-empty={ Boolean( content ) }
-					className={ classNames( 'components-summary-control', {
-						[ `has-text-align-${ align }` ]: align,
-					} ) }
-					dir={ direction }
-					allowedFormats={ allowedFormats }
-					placeholder={ placeholder }
-					required={ required }
-					disabled={ disabled }
-				/>
+				{ isRichTextMode && (
+					<RichText
+						id={ contentId.toString() }
+						identifier="content"
+						tagName="p"
+						value={ content || '' }
+						onChange={ setContent }
+						data-empty={ Boolean( content ) }
+						className={ classNames( 'components-summary-control', {
+							[ `has-text-align-${ align }` ]: align,
+						} ) }
+						dir={ direction }
+						allowedFormats={ allowedFormats }
+						placeholder={ placeholder }
+						required={ required }
+						disabled={ disabled }
+					/>
+				) }
+
+				{ isPlainTextMode && (
+					<TextareaControl
+						value={ content || '' }
+						onChange={ setContent }
+						placeholder={ placeholder }
+						required={ required }
+						disabled={ disabled }
+					/>
+				) }
 			</BaseControl>
 		</div>
 	);

--- a/packages/js/product-editor/src/blocks/generic/text-area/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text-area/types.ts
@@ -28,6 +28,7 @@ export type TextAreaBlockEditAttributes = ProductEditorBlockAttributes & {
 	align?: 'left' | 'center' | 'right' | 'justify';
 	allowedFormats?: AllowedFormat[];
 	direction?: 'ltr' | 'rtl';
+	mode: 'plain-text' | 'rich-text';
 };
 
 export type TextAreaBlockEditProps =


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the `mode` attribute which can take two values: `rich-text` (default) and `plain-text`.
The textarea will change its visualization depending on these values: plain or rich

Closes https://github.com/woocommerce/woocommerce/issues/44182

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To test these changes, let's use the React Developers Tools.

1. Install the React Developer Tools: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) - [Chrome](https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
2. Enable the Product Editor
3. Create/edit a product
4. Identify the `Summary` field of the `General` tab / `Basics details` section
5. Confirm the field works as expected: set text format to the content 
6. Open the dev tools of your browser
7. Select the React tab
8. Filter the components by the `TextArea` name
9. Identify the block attributes 
10. Change the mode to `plain-text`
11. Confirm the app shows the textarea in `plain` mode

https://github.com/woocommerce/woocommerce/assets/77539/4854716d-a6ce-416a-9525-a543c79f43a5


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
