### PR TITLE
[Experimental] Allow Additional Information block to be moved but not removed

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/attributes.tsx
@@ -20,7 +20,7 @@ export default {
 	lock: {
 		type: 'object',
 		default: {
-			move: true,
+			move: false,
 			remove: true,
 		},
 	},

--- a/plugins/woocommerce/changelog/44193-remove-lock-from-additional-information
+++ b/plugins/woocommerce/changelog/44193-remove-lock-from-additional-information
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: This is behind a feature flag.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Makes the `lock.move` attribute of the Checkout Additional Information block `false` to prevent it being removed, but allowing it to be _moved_.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


```
add_action(
	'woocommerce_blocks_loaded',
	function() {

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-on-porch',
				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'checkbox',
			),
		);

		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/location-on-porch',
				'label'    => __( 'Describe where we should hide the parcel', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'text',
			)
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-with-neighbor',
				'label'    => __( 'Which neighbor should we leave it with if unable to hide?', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'select',
				'options'  => array(
					array(
						'label' => 'Neighbor to the left',
						'value' => 'left',
					),
					array(
						'label' => 'Neighbor to the right',
						'value' => 'right',
					),
					array(
						'label' => 'Neighbor across the road',
						'value' => 'across',
					),
					array(
						'label' => 'Do not leave with a neighbor',
						'value' => 'none',
					),
				),
			)
		);
	}
);
````

1. Add the example snippet to your site
2. Load the Checkout block in the site editor.
3. Select the "Additional Information" block and ensure it can be moved using the arrows in the block controls toolbar.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

This is behind a feature flag.
</details>
