### PR TITLE
[create-product-editor-block] Fix product editor block registration

### DIFF
--- a/packages/js/create-product-editor-block/block-templates/index.ts.mustache
+++ b/packages/js/create-product-editor-block/block-templates/index.ts.mustache
@@ -1,27 +1,23 @@
 /**
  * External dependencies
  */
-import { BlockConfiguration, registerBlockType } from '@wordpress/blocks';
+import { registerProductEditorBlockType } from '@woocommerce/product-editor';
 
 /**
  * Internal dependencies
  */
 import './editor.scss'; // see https://www.npmjs.com/package/@wordpress/scripts#using-css
-
-/**
- * Internal dependencies
- */
+import blockConfiguration from './block.json';
 import { Edit } from './edit';
-import metadata from './block.json';
 
-/**
- * Every block starts by registering a new block type definition.
- *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
- */
-registerBlockType( metadata as BlockConfiguration, {
-	/**
-	 * @see ./edit.js
-	 */
+const { name, ...metadata } = blockConfiguration;
+
+const settings = {
 	edit: Edit,
+};
+
+registerProductEditorBlockType( {
+	name,
+	metadata: metadata as never,
+	settings: settings as never,
 } );

--- a/packages/js/create-product-editor-block/changelog/fix-create-product-editor-block-registration
+++ b/packages/js/create-product-editor-block/changelog/fix-create-product-editor-block-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Example uses registerProductEditorBlockType

--- a/packages/js/create-product-editor-block/changelog/fix-create-product-editor-block-registration
+++ b/packages/js/create-product-editor-block/changelog/fix-create-product-editor-block-registration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Example uses registerProductEditorBlockType
+Example uses registerProductEditorBlockType to register block so that functionality such as hideConditions and disableConditions work with block.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the `woocommerce/create-product-editor-block` package to use the `registerProductEditorBlockType()` registration function in the generated skeleton code, which adds support for conditional visibility (`hideConditions`, `disableConditions`).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Follow the instructions in the package's README.md (note, since you are testing a version of the package that hasn't been published yet, you will need to use the `npx @wordpress/create-block --template ./path/to/woocommerce/packages/js/create-product-editor-block my-extension-name` form of the command, with a local path to the template)
2. Verify that the generated skeleton project can be used, with the built-in `wp-env` support, to render the example block in the block-based product form, with no modifications of any files or any commands other than those mentioned in the README.md.
    - (Go to **Products** > **Add New** and verify the block is shown.)
4. Update the generated PHP code to add `hideConditions`, such as the following, which will hide the block if the product type is not `simple`:

```php
$basic_details->add_block(
  [
	  'id' 	     => 'extension-example-product-editor-block',
	  'order'	     => 40,
	  'blockName'  => 'extension/example-product-editor-block',
	  'attributes' => [
		  'message' => 'Example Product Editor Block',
	  ],
	  'hideConditions' => [
		  [ 'expression' => 'editedProduct.type !== "simple"' ]
	  ]
  ]
);
```
5. Verify the block shows for a normal product, and is hidden for a variable product.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
