### PR TITLE
Marketplace: Fix the bug hiding connection warning

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/install-flow/install-new-product-modal.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/install-flow/install-new-product-modal.tsx
@@ -110,8 +110,13 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 
 		setShowModal( true );
 		setProduct( productToInstall );
-	}, [ query, props.products, installedProducts ] );
+	}, [ query, props.products, installedProducts, isStoreConnected ] );
 
+	/**
+	 * WordPress gives us a activateURL as a response to us installig the product.
+	 * Even though it's not an API endpoint, we can hit that URL with fetch
+	 * and activate the plugin.
+	 */
 	function activateClick() {
 		if ( ! activateUrl ) {
 			return;
@@ -170,6 +175,7 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 				).then( ( downloadResponse ) => {
 					dispatch( installingStore ).stopInstalling( product.id );
 
+					// No activateUrl means we can't activate the plugin.
 					if ( downloadResponse.data.activateUrl ) {
 						setActivateUrl( downloadResponse.data.activateUrl );
 
@@ -185,7 +191,7 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 			} )
 			.catch( ( error ) => {
 				/**
-				 * apiFetch doesn't return the error code in the error condition.
+				 * apiFetch doesn't return the HTTP error code in the error condition.
 				 * We'll rely on the data returned by the server.
 				 */
 				if ( error.data.redirect_location ) {
@@ -197,6 +203,7 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 						),
 					} );
 
+					// Wait to allow users to read the notice.
 					setTimeout( () => {
 						window.location.href = error.data.redirect_location;
 					}, 5000 );
@@ -207,7 +214,7 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 						message:
 							error.data.message ??
 							__(
-								'An error ocurred. Please try again later.',
+								'An error occurred. Please try again later.',
 								'woocommerce'
 							),
 					} );

--- a/plugins/woocommerce-admin/client/marketplace/components/install-flow/install-new-product-modal.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/install-flow/install-new-product-modal.tsx
@@ -40,6 +40,7 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 	);
 	const [ product, setProduct ] = useState< Product >();
 	const [ installedProducts, setInstalledProducts ] = useState< string[] >();
+	const [ isStoreConnected, setIsStoreConnected ] = useState< boolean >();
 	const [ activateUrl, setActivateUrl ] = useState< string >();
 	const [ documentationUrl, setDocumentationUrl ] = useState< string >();
 	const [ showModal, setShowModal ] = useState< boolean >( false );
@@ -54,22 +55,9 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 	// Check if the store is connected to Woo.com. This is run once, when the component is mounted.
 	useEffect( () => {
 		const wccomSettings = getAdminSetting( 'wccomHelper', {} );
-		const isStoreConnected = wccomSettings?.isConnected;
 
 		setInstalledProducts( wccomSettings?.installedProducts );
-
-		if ( isStoreConnected === false ) {
-			setInstallStatus( InstallFlowStatus.notConnected );
-			setNotice( {
-				status: 'warning',
-				message: __(
-					'In order to install a product, you need to first connect your account.',
-					'woocommerce'
-				),
-			} );
-		} else {
-			setInstallStatus( InstallFlowStatus.notInstalled );
-		}
+		setIsStoreConnected( wccomSettings?.isConnected );
 	}, [] );
 
 	/**
@@ -105,6 +93,19 @@ function InstallNewProductModal( props: { products: Product[] } ) {
 			if ( isInstalled ) {
 				return;
 			}
+		}
+
+		if ( ! isStoreConnected ) {
+			setInstallStatus( InstallFlowStatus.notConnected );
+			setNotice( {
+				status: 'warning',
+				message: __(
+					'In order to install a product, you need to first connect your account.',
+					'woocommerce'
+				),
+			} );
+		} else {
+			setInstallStatus( InstallFlowStatus.notInstalled );
 		}
 
 		setShowModal( true );

--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card-footer.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card-footer.tsx
@@ -41,6 +41,7 @@ function ProductCardFooter( props: { product: Product } ) {
 			return false;
 		}
 
+		// This value is sent from the Woo.com API.
 		if ( ! productToCheck.isInstallable ) {
 			return false;
 		}

--- a/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
@@ -27,6 +27,10 @@ export function MarketplaceContextProvider( props: {
 		[]
 	);
 
+	/**
+	 * Knowing installed products will help us to determine which products
+	 * should have the "Add to Site" button enabled.
+	 */
 	useEffect( () => {
 		const wccomSettings = getAdminSetting( 'wccomHelper', {} );
 		const installedProductSlugs: string[] =

--- a/plugins/woocommerce/changelog/44207-fix-44131-connection-warning-bug
+++ b/plugins/woocommerce/changelog/44207-fix-44131-connection-warning-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix the Marketplace page bug where the connection warning is not shown
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We check the connection only when the page loads and show it when a first time user opens a model. If a user opens a second modal without taking action on the first one, we never check for connection again and cause the bug. 

With this code, we still check the connection for once when the page loads, however we keep it in the component state to be able to use it later to check agan.

Closes #44131 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and do `pnpm install & pnpm build`
2. Open the store and disconnect from Woo.com by **Avatar > Disconnect Account** from the top right.
3. Go to the **Browse** tab. Click **Add to Store** for one product. Confirm you see the warning for connection. Do nothing and just close the modal.
4. Click on another **Add to Store** button and see you get to see the connection warning again. 
5. Follow the primary action (Install & Activate) and complete the flow.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment Fix the Marketplace page bug where the connection warning is not shown
</details>
