### PR TITLE
[Experimental] Add e2e tests for the new stock status filter block

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/bin/posts/product-filters-stock-status.html
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/posts/product-filters-stock-status.html
@@ -1,0 +1,21 @@
+<!-- wp:woocommerce/product-collection {"id":"bee7a337-f64e-4efd-be51-e68670b10000","queryId":0,"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true}} -->
+<div class="wp-block-woocommerce-product-collection">
+	<!-- wp:woocommerce/product-template -->
+	<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
+
+	<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+	<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+	<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+	<!-- /wp:woocommerce/product-template -->
+
+	<!-- wp:woocommerce/product-filter {"filterType":"stock-filter","heading":"Filter by Stock Status"} -->
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading">Filter by Stock Status</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/product-filter-stock-status {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/product-filter -->
+</div>
+<!-- /wp:woocommerce/product-collection -->

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+test.describe( 'Product Filter: Stock Status Block', async () => {
+	test.describe( 'frontend', () => {
+		test( 'Renders a checkbox list with the available stock statuses', async ( {
+			page,
+		} ) => {
+			await page.goto( '/product-filters-stock-status-block/' );
+			await page.evaluate( () =>
+				window.scrollTo( 0, document.body.scrollHeight * 0.35 )
+			);
+
+			const ratingStars = page.locator(
+				'.wc-block-components-product-rating__stars'
+			);
+			const count = await ratingStars.count();
+			expect( count ).toBe( 2 );
+
+			//  See bin/scripts/parallel/reviews.sh for reviews data.
+			await expect( ratingStars.nth( 0 ) ).toHaveAttribute(
+				'aria-label',
+				'Rated 1 out of 5'
+			);
+			await expect( ratingStars.nth( 1 ) ).toHaveAttribute(
+				'aria-label',
+				'Rated 5 out of 5'
+			);
+		} );
+
+		test( 'Selecting a stock status filters the list of products', async ( {
+			page,
+		} ) => {} );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
@@ -9,29 +9,38 @@ test.describe( 'Product Filter: Stock Status Block', async () => {
 			page,
 		} ) => {
 			await page.goto( '/product-filters-stock-status-block/' );
-			await page.evaluate( () =>
-				window.scrollTo( 0, document.body.scrollHeight * 0.35 )
+
+			const stockStatuses = page.locator(
+				'.wc-block-components-checkbox__label'
 			);
 
-			const ratingStars = page.locator(
-				'.wc-block-components-product-rating__stars'
-			);
-			const count = await ratingStars.count();
-			expect( count ).toBe( 2 );
+			await expect( stockStatuses ).toHaveCount( 2 );
 
-			//  See bin/scripts/parallel/reviews.sh for reviews data.
-			await expect( ratingStars.nth( 0 ) ).toHaveAttribute(
-				'aria-label',
-				'Rated 1 out of 5'
-			);
-			await expect( ratingStars.nth( 1 ) ).toHaveAttribute(
-				'aria-label',
-				'Rated 5 out of 5'
-			);
+			await expect( stockStatuses.nth( 0 ) ).toHaveText( 'In stock' );
+			await expect( stockStatuses.nth( 1 ) ).toHaveText( 'Out of stock' );
 		} );
 
 		test( 'Selecting a stock status filters the list of products', async ( {
 			page,
-		} ) => {} );
+		} ) => {
+			await page.goto( '/product-filters-stock-status-block/' );
+
+			const stockStatusCheckboxes = page.locator(
+				'.wc-block-components-checkbox__input'
+			);
+
+			// Out of stock
+			stockStatusCheckboxes.nth( 1 ).check();
+
+			// wait for navigation
+			await page.waitForURL(
+				'/product-filters-stock-status-block/?filter_stock_status=outofstock'
+			);
+
+			const products = page.locator( '.wc-block-product' );
+			const productCount = await products.count();
+
+			expect( productCount ).toBe( 1 );
+		} );
 	} );
 } );


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/42252 by adding basic e2e tests for the stock status filter.

In future when we add a dynamic templating solution we can more easily test a bunch of different options being passed to the block.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. See the CI pass

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
