### PR TITLE
Fix refund props not updating properly with HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-44153
+++ b/plugins/woocommerce/changelog/fix-44153
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix refund props not updating properly with HPOS

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2550,6 +2550,9 @@ FROM $order_meta_table
 		}
 
 		$this->persist_order_to_db( $order );
+
+		$this->update_order_meta( $order );
+
 		$order->save_meta_data();
 
 		if ( $backfill ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
@@ -127,4 +127,140 @@ class OrdersTableRefundDataStoreTests extends WC_Unit_Test_Case {
 		$this->assertEquals( $user->ID, $refreshed_refund->get_data()['refunded_by'] );
 	}
 
+	/**
+	 * Helper function to create a complex order and its refund.
+	 *
+	 * @return array Order and refund.
+	 */
+	private function create_order_and_refund() {
+		$order  = OrderHelper::create_complex_data_store_order( $this->order_data_store );
+		$refund = wc_create_refund(
+			array(
+				'order_id'       => $order->get_id(),
+				'amount'         => 10,
+				'reason'         => 'Test',
+				'refund_payment' => false,
+				'refunded_by'    => 1,
+			)
+		);
+		$refund->save();
+		return array( $order, $refund );
+	}
+
+	/**
+	 * @testDox Refund props are set as expected with HPOS with sync.
+	 */
+	public function test_refund_update() {
+		$this->enable_cot_sync();
+		$this->toggle_cot_feature_and_usage( true );
+		list( $order, $refund ) = $this->create_order_and_refund();
+		$refund->add_meta_data( 'test', 'test' );
+		$refund->save();
+
+		$this->assertTrue( $refund->get_id() > 0 );
+		$this->assertEquals( 'Test', $refund->get_reason() );
+		$this->assertEquals( 10, $refund->get_amount() );
+		$this->assertFalse( $refund->get_refunded_payment() );
+
+		$refund->set_reason( 'Test 2' );
+		$refund->set_amount( 5 );
+		$refund->set_refunded_payment( true );
+		$refund->set_refunded_by( 2 );
+		$refund->update_meta_data( 'test', 'test 2' );
+		$refund->save();
+
+		$refreshed_refund = wc_get_order( $refund->get_id() );
+		$this->assertEquals( 'Test 2', $refreshed_refund->get_reason() );
+		$this->assertEquals( 5, $refreshed_refund->get_amount() );
+		$this->assertTrue( $refreshed_refund->get_refunded_payment() );
+		$this->assertEquals( 2, $refreshed_refund->get_refunded_by() );
+		$this->assertEquals( 'test 2', $refreshed_refund->get_meta( 'test' ) );
+
+		$this->assertEquals( 'Test 2', get_post_meta( $refund->get_id(), '_refund_reason', true ) );
+		$this->assertEquals( 5, get_post_meta( $refund->get_id(), '_refund_amount', true ) );
+		$this->assertEquals( 1, get_post_meta( $refund->get_id(), '_refunded_payment', true ) );
+		$this->assertEquals( 2, get_post_meta( $refund->get_id(), '_refunded_by', true ) );
+		$this->assertEquals( 'test 2', get_post_meta( $refund->get_id(), 'test', true ) );
+	}
+
+	/**
+	 * @testDox Refund props are set as expected with HPOS without sync.
+	 */
+	public function test_refund_update_without_sync() {
+		$this->disable_cot_sync();
+		$this->toggle_cot_feature_and_usage( true );
+		list( $order, $refund ) = $this->create_order_and_refund();
+		$refund->add_meta_data( 'test', 'test' );
+		$refund->save();
+
+		$this->assertTrue( $refund->get_id() > 0 );
+
+		$refund->set_reason( 'Test 2' );
+		$refund->set_amount( 5 );
+		$refund->set_refunded_payment( true );
+		$refund->set_refunded_by( 2 );
+		$refund->update_meta_data( 'test', 'test 2' );
+		$refund->save();
+
+		$refreshed_refund = wc_get_order( $refund->get_id() );
+		$this->assertEquals( 'Test 2', $refreshed_refund->get_reason() );
+		$this->assertEquals( 5, $refreshed_refund->get_amount() );
+		$this->assertTrue( $refreshed_refund->get_refunded_payment() );
+		$this->assertEquals( 2, $refreshed_refund->get_refunded_by() );
+		$this->assertEquals( 'test 2', $refreshed_refund->get_meta( 'test' ) );
+	}
+
+	/**
+	 * @testDox Refund meta data is updated as expted using the save metadata call.
+	 *
+	 * @param bool $sync_status Whether to enable sync.
+	 *
+	 * @testWith [true, false]
+	 */
+	public function test_refund_save_meta_data( $sync_status ) {
+		$sync_status && $this->enable_cot_sync();
+		$this->toggle_cot_authoritative( true );
+
+		list( $order, $refund ) = $this->create_order_and_refund();
+
+		$refund->add_meta_data( 'test_key1', 'test_value1' );
+		$refund->add_meta_data( 'test_key2', 'test_value2' );
+		$refund->add_meta_data( 'test_key3', 'test_value3_1' );
+		$refund->add_meta_data( 'test_key3', 'test_value3_2' );
+		$refund->save_meta_data();
+
+		$refreshed_refund = wc_get_order( $refund->get_id() );
+		$this->assertEquals( 'test_value1', $refreshed_refund->get_meta( 'test_key1' ) );
+		$this->assertEquals( 'test_value2', $refreshed_refund->get_meta( 'test_key2' ) );
+		$test_key3_data   = $refreshed_refund->get_meta( 'test_key3', false );
+		$test_key3_values = array();
+		foreach ( $test_key3_data as $test_key3_datum ) {
+			$test_key3_values[] = $test_key3_datum->value;
+		}
+		$this->assertEquals( array( 'test_value3_1', 'test_value3_2' ), $test_key3_values );
+
+		if ( $sync_status ) {
+			$this->assertEquals( 'test_value1', get_post_meta( $refund->get_id(), 'test_key1', true ) );
+			$this->assertEquals( 'test_value2', get_post_meta( $refund->get_id(), 'test_key2', true ) );
+			$this->assertEquals( array( 'test_value3_1', 'test_value3_2' ), get_post_meta( $refund->get_id(), 'test_key3' ) );
+		}
+
+		$refund->update_meta_data( 'test_key1', 'test_value1_updated' );
+		$refund->delete_meta_data( 'test_key2' );
+		$refund->delete_meta_data_value( 'test_key3', 'test_value3_1' );
+
+		$refund->save_meta_data();
+
+		$refreshed_refund = wc_get_order( $refund->get_id() );
+		$this->assertEquals( 'test_value1_updated', $refreshed_refund->get_meta( 'test_key1' ) );
+		$this->assertEquals( null, $refreshed_refund->get_meta( 'test_key2' ) );
+		$this->assertEquals( 'test_value3_2', $refreshed_refund->get_meta( 'test_key3' ) );
+
+		if ( $sync_status ) {
+			$this->assertEquals( 'test_value1_updated', get_post_meta( $refund->get_id(), 'test_key1', true ) );
+			$this->assertEquals( null, get_post_meta( $refund->get_id(), 'test_key2', true ) );
+			$this->assertEquals( 'test_value3_2', get_post_meta( $refund->get_id(), 'test_key3', true ) );
+		}
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

At some point, we introduced a regression that prevents refund props from updating when HPOS is authoritative. Refunds can still be created just fine, and since we don't allow refunds to be updated from interface anyway, we didn't have widespread complaints.

This PR fixes that, by explicitly calling update_meta_data, note that we add this change in OrderTableDataStore instead of the refunds data store to also fix this behavior in any derived data stores that we may have.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44153 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To test this PR, WP CLI access is required, since we don't allow modifying refunds from the interface.

1. Set HPOS as authoritative, and create any order. Note down the order ID, let's say it's XXX.
2. Open a `wp shell`, and try to update the refund props like so:
```php
// Let's create a refund first on the order.
$refund = wc_create_refund( array( 'order_id' => XXX, 'amount' => 1 ) );

// Check that the refund is created successfully.
assert( $refund->get_id() > 0 );

// Let's set a prop
$refund->set_reason('test');
$refund->save();

// Let's load the refund again from DB and check that prop was set.
$refreshed_refund = wc_get_order( $refund->get_id() );

assert( $refreshed_refund->get_id() > 0 );

// Check that our prop was set properly (should return true).
assert( $refreshed_refund->get_reason() === 'test' );
``` 

3. Optionally, open the order in admin view created in step 1. Verify that there is a refund, whose reason is set to `test`.
<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
