### PR TITLE
Order attribution - avoid attributing AJAX-checkouts to Web Admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-incorrect-web-admin-order-attribution
+++ b/plugins/woocommerce/changelog/fix-incorrect-web-admin-order-attribution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix orders being attributed to Web Admin incorrectly in certain cases.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -181,13 +181,14 @@ class OrderAttributionController implements RegisterHooksInterface {
 
 	/**
 	 * If the order is created in the admin, set the source type and origin to admin/Web admin.
+	 * Ensure it's not an AJAX request because these can come from the frontend in some cases.
 	 *
 	 * @param WC_Order $order The recently created order object.
 	 *
 	 * @since 8.5.0
 	 */
 	private function maybe_set_admin_source( WC_Order $order ) {
-		if ( function_exists( 'is_admin' ) && is_admin() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			$order->add_meta_data( $this->get_meta_prefixed_field_name( 'source_type' ), 'admin' );
 			$order->save();
 		}

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -189,7 +189,11 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 */
 	private function maybe_set_admin_source( WC_Order $order ) {
 		// If ajax request but not from admin, bail.
-		if ( wp_doing_ajax() && strpos( $_SERVER['HTTP_REFERER'], get_admin_url() ) !== 0 )  {
+		if (
+			wp_doing_ajax() &&
+			isset( $_SERVER['HTTP_REFERER'] ) &&
+			strpos( esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), get_admin_url() ) !== 0
+		) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -188,12 +188,11 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 * @since 8.5.0
 	 */
 	private function maybe_set_admin_source( WC_Order $order ) {
-		// If ajax request but not from admin, bail.
-		if (
-			wp_doing_ajax() &&
-			isset( $_SERVER['HTTP_REFERER'] ) &&
-			strpos( esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), get_admin_url() ) !== 0
-		) {
+
+		// For ajax requests, bail if the referer is not an admin page.
+		$http_referer     = esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ?? '' ) );
+		$referer_is_admin = 0 === strpos( $http_referer, get_admin_url() );
+		if ( ! $referer_is_admin && wp_doing_ajax() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -181,17 +181,25 @@ class OrderAttributionController implements RegisterHooksInterface {
 
 	/**
 	 * If the order is created in the admin, set the source type and origin to admin/Web admin.
-	 * Ensure it's not an AJAX request because these can come from the frontend in some cases.
+	 * Only execute this if the order is created in the admin interface (or via ajax in the admin interface).
 	 *
 	 * @param WC_Order $order The recently created order object.
 	 *
 	 * @since 8.5.0
 	 */
 	private function maybe_set_admin_source( WC_Order $order ) {
-		if ( is_admin() && ! wp_doing_ajax() ) {
-			$order->add_meta_data( $this->get_meta_prefixed_field_name( 'source_type' ), 'admin' );
-			$order->save();
+		// If ajax request but not from admin, bail.
+		if ( wp_doing_ajax() && strpos( $_SERVER['HTTP_REFERER'], get_admin_url() ) !== 0 )  {
+			return;
 		}
+
+		// If not admin interface page, bail.
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$order->add_meta_data( $this->get_meta_prefixed_field_name( 'source_type' ), 'admin' );
+		$order->save();
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This prevents orders created through AJAX checkout requests from getting an extra `source_type` meta value as "Web admin" incorrectly. Ref p1706574180153889-slack-C7U3Y3VMY
![image](https://github.com/woocommerce/woocommerce/assets/228780/d5554ae8-30c0-41b3-a0e1-fe6cb2116315)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Ensure that orders created in the Web Admin are still classified as Web Admin:**
1. Create an order using the **Add Order** button (`/wp-admin/post-new.php?post_type=shop_order`).
2. Confirm that its origin in the Orders Table is "Web admin":
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/6b21db04-7108-4e5d-96f6-270d53acb035)

**Ensure that orders created via AJAX requests aren't classified as Web Admin**
1. Configure the shop:
    - Classic checkout
    - Cash on delivery enabled
    - Flat rate shipping to Europe
3. Add some products to the cart.
4. Go to the checkout page, confirm there's a `woocommerce-process-checkout-nonce`:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/b31127c1-7494-4564-904b-6869ab0ef2aa)
5. Execute the following snippet in the browser dev console (it will attempt to build the URL automatically assuming `shop.dom/checkout/` is the URL; otherwise, set the URL manually):

    <details>
    <summary>JavaScript block</summary>
    ```javascript
    var nonce_val = jQuery('#woocommerce-process-checkout-nonce').val();
    var ajax_url =window.location.href
        .replace(
            '/checkout/', 
            '/wp-admin/admin-ajax.php?action=woocommerce_checkout&woocommerce-process-checkout-nonce=' + nonce_val
        );
    
    jQuery.post(
        ajax_url, 
        {
            billing_first_name: "PR44219",
            billing_last_name: "Test",
            billing_company: "",
            billing_country: "UA",
            billing_address_1: "Test",
            billing_address_2: "Test",
            billing_city: "Test",
            billing_state: "UA07",
            billing_postcode: "44219",
            billing_phone: "44219",
            billing_email: "admin@example.com",
            shipping_first_name: "PR44219",
            shipping_last_name: "Test",
            shipping_company: "",
            shipping_country: "UA",
            shipping_address_1: "Test",
            shipping_address_2: "Test",
            shipping_city: "Test",
            shipping_state: "UA07",
            shipping_postcode: "44219",
            order_comments: "",
            shipping_method: ["flat_rate:3"],
            payment_method: "cod",
            wc_order_attribution_source_type: 'utm',
            wc_order_attribution_referrer: '(none)',
            wc_order_attribution_utm_campaign: 'sale',
            wc_order_attribution_utm_source: 'NEWSOURCE',
            wc_order_attribution_utm_medium: 'social',
            wc_order_attribution_utm_content: '(none)',
            wc_order_attribution_utm_id: '20231121',
            wc_order_attribution_utm_term: 'testing',
            wc_order_attribution_session_entry: 'https://fakestore.com/shop',
            wc_order_attribution_session_start_time: '2024-01-31 11:30:13',
            wc_order_attribution_session_pages: '8',
            wc_order_attribution_session_count: '2',
        wc_order_attribution_user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/    120.0.0.0 Safari/537.36',
        })    
        .done(function(data, textStatus, jqXHR) {
            console.log('Status Code:', jqXHR.status);
            console.log('Status Text:', jqXHR.statusText);
            console.log('WooCommerce Response:', data.result);
            if(data.order_id) { 
                console.log('WooCommerce Order ID:', data.order_id);
            }
        })
        .fail(function(jqXHR, textStatus, errorThrown) {
            console.error('Status Code:', jqXHR.status);
            console.error('Status Text:', jqXHR.statusText);
        });
    ```
    </details>

4. Confirm in the dev console that the console show `Status Code: 200` and `Status Text: success`.
4. Note that without these changes, the "Origin" in the Orders Table will be Web Admin, and with it, it will show the Source:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/8fffbb6a-e80b-42f0-a001-43738bfb21aa)
    (In the page edit form the correct Source value will always be displayed):
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/4d1066a9-3cbf-4ab4-b230-6296173f11ea)

**Ensure that regular orders are still attributed correctly**
1. In a new incognito tab, visit the shop _with_ UTM params: `web.com/shop/?utm_source=GOODTEST&utm_medium=test&utm_campaign=pr-test`
2. add items to the cart and go through the checkout.
4. Confirm the Orders table and Order Edit metaboxes show the expected values:
![image](https://github.com/woocommerce/woocommerce/assets/228780/bde4f654-0bc7-4032-88ee-1b76d5603e37)


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>