### PR TITLE
Introduce handleConfirm. Export handlePrompt & handleConfirm from product-editor

### DIFF
--- a/packages/js/product-editor/changelog/product-editor-prompt-exports
+++ b/packages/js/product-editor/changelog/product-editor-prompt-exports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Exports handlePrompt from @woocommerce/product-editor for use by extensions expanding the variation quick update menu. Also introduces handleConfirm and exposes it also

--- a/packages/js/product-editor/src/utils/handle-confirm.ts
+++ b/packages/js/product-editor/src/utils/handle-confirm.ts
@@ -15,12 +15,10 @@ export async function handleConfirm( {
 	onCancel,
 }: HandleConfirmProps ) {
 	// eslint-disable-next-line no-alert
-	const value = window.confirm( message );
-
-	if ( value === null ) {
-		onCancel?.();
+	if ( window.confirm(message) ) {
+		onOk?.();
 		return;
 	}
 
-	onOk();
+	onCancel?.();
 }

--- a/packages/js/product-editor/src/utils/handle-confirm.ts
+++ b/packages/js/product-editor/src/utils/handle-confirm.ts
@@ -18,9 +18,7 @@ export async function handleConfirm( {
 	const value = window.confirm( message );
 
 	if ( value === null ) {
-		if ( onCancel ) {
-			onCancel();
-		}
+		onCancel?.();
 		return;
 	}
 

--- a/packages/js/product-editor/src/utils/handle-confirm.ts
+++ b/packages/js/product-editor/src/utils/handle-confirm.ts
@@ -15,7 +15,7 @@ export async function handleConfirm( {
 	onCancel,
 }: HandleConfirmProps ) {
 	// eslint-disable-next-line no-alert
-	if ( window.confirm(message) ) {
+	if ( window.confirm( message ) ) {
 		onOk?.();
 		return;
 	}

--- a/packages/js/product-editor/src/utils/handle-confirm.ts
+++ b/packages/js/product-editor/src/utils/handle-confirm.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export type HandleConfirmProps = {
+	message?: string;
+	onOk(): void;
+	onCancel?(): void;
+};
+
+export async function handleConfirm( {
+	message = __( 'Are you sure?', 'woocommerce' ),
+	onOk,
+	onCancel,
+}: HandleConfirmProps ) {
+	// eslint-disable-next-line no-alert
+	const value = window.confirm( message );
+
+	if ( value === null ) {
+		if ( onCancel ) {
+			onCancel();
+		}
+		return;
+	}
+
+	onOk();
+}

--- a/packages/js/product-editor/src/utils/handle-prompt.ts
+++ b/packages/js/product-editor/src/utils/handle-prompt.ts
@@ -20,9 +20,7 @@ export async function handlePrompt( {
 	const value = window.prompt( message, defaultValue );
 
 	if ( value === null ) {
-		if ( onCancel ) {
-			onCancel();
-		}
+		onCancel?.();
 		return;
 	}
 

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -21,6 +21,8 @@ import {
 import { preventLeavingProductForm } from './prevent-leaving-product-form';
 import { hasAttributesUsedForVariations } from './has-attributes-used-for-variations';
 import { isValidEmail } from './validate-email';
+import { handlePrompt } from './handle-prompt';
+import { handleConfirm } from './handle-confirm';
 
 export * from './create-ordered-children';
 export * from './date';
@@ -45,6 +47,8 @@ export {
 	getProductTitle,
 	getProductVariationTitle,
 	getTruncatedProductVariationTitle,
+	handleConfirm,
+	handlePrompt,
 	hasAttributesUsedForVariations,
 	isValidEmail,
 	preventLeavingProductForm,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- exports handlePrompt from @woocommerce/product-editor for use by 3rd party extensions expanding the variation quick udpate menu
- introduces a similar handleConfirm feature, and similarly exposes it.

### How to test the changes in this Pull Request:

#### Updated test instructions using test plugin

Install and activate the test plugin: [test-44226-handle-confirm.zip](https://github.com/woocommerce/woocommerce/files/14672306/test-44226-handle-confirm.zip)

<img width="1263" alt="Screenshot 2024-03-20 at 16 26 04" src="https://github.com/woocommerce/woocommerce/assets/2098816/de8514fc-4aef-4607-bfbf-fca9599d4c4b">

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. On **Variations** tab, create variations
3. Select one or more variations and then select **Quick update** > **Test of handleConfirm**
4. Click **Cancel** and verify that **onCancel called** alert is shown
5. Select **Quick update** > **Test of handleConfirm**
6. Click **OK** and verify that **onOk called** alert is shown
7. Select **Quick update** > **Test of handlePrompt**
8. Click **Cancel** and verify that **onCancel called** alert is shown
9. Select **Quick update** > **Test of handlePrompt**
10. Enter a value, click **OK** and verify that **onOk called with value: [VALUE]** alert is shown (with the correct value)

#### Original test instructions (not needed if you use the updated instructions above)

Expand the variation quick access menu (see https://github.com/woocommerce/woocommerce/pull/43441). 
In your action, import the new methods and confirm they work as expected, e.g. 

```js
import {
	handlePrompt,
	handleConfirm,
	VariationQuickUpdateMenuItem,
} from '@woocommerce/product-editor';
```
....
```js
<VariationQuickUpdateMenuItem
    group="pricing"
    supportsMultipleSelection={ true }
    onClick={ ( { selection, onChange, onClose } ) => {
        handlePrompt( {
	    message: 'Do a thing',
	    onOk( value ) {
	        onChange(
                    console.log(value);
		);
	    },
	} );
	onClose();
    } }
>
    { 'handlePrompt test' }
</VariationQuickUpdateMenuItem>
```
```js
<VariationQuickUpdateMenuItem
    group="pricing"
    supportsMultipleSelection={ true }
    onClick={ ( { selection, onChange, onClose } ) => {
        handleConfirm( {
	    message: 'Are you sure?',
	    onOk() {
	        onChange(
                    console.log(confirmed);
		);
	    },
	} );
	onClose();
    } }
>
    { 'handleConfirm test' }
</VariationQuickUpdateMenuItem>
```

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
