### PR TITLE
Removed Unnecessary `@woocommerce/plugin-woocommerce` Asset Copy Caching

### DIFF
--- a/plugins/woocommerce/changelog/44234-fix-woocommerce-build-cache-bloat
+++ b/plugins/woocommerce/changelog/44234-fix-woocommerce-build-cache-bloat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Tooling only change.
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -257,15 +257,6 @@
 	"wireit": {
 		"build:project:copy-assets": {
 			"command": "rm -rf assets/client/blocks assets/client/admin assets/js assets/css && cp -r ../woocommerce-admin/build assets/client/admin && cp -r client/legacy/build/js assets/js && cp -r client/legacy/build/css assets/css && cp -r ../woocommerce-blocks/build assets/client/blocks && cp -r ../woocommerce-blocks/blocks.ini blocks.ini",
-			"clean": "if-file-deleted",
-			"files": [],
-			"output": [
-				"assets/client/admin",
-				"assets/client/blocks",
-				"blocks.ini",
-				"assets/js",
-				"assets/css"
-			],
 			"dependencies": [
 				"dependencyOutputs"
 			]


### PR DESCRIPTION
Since this task is copying the build outputs of other directories there's no reason to duplicate them in the cache.
This leads to bloat that we can avoid.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There's _technically_ no reason to cache the output of this job. It's a copy operation that brings the assets from one directory, and as such, we can just re-run it each time. It does a clean on its own and nothing should go wrong with doing it this way.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter='@woocommerce/plugin-woocommerce build` to hydrate the cache.
2. Re-run the command and make sure only the WooCommerce plugin re-runs the build.
3. Run `rm -rf plugins/woocommerce/assets/client/blocks` to delete the assets
4. Re-run the build and make sure that it copies the assets again as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Tooling only change.

</details>
