### PR TITLE
Product Gallery block: Enable keyboard navigation for thumbnails

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -82,6 +82,12 @@ const productGallery = {
 			const context = getContext();
 			selectImage( context, 'previous' );
 		},
+		onThumbnailKeyDown: ( event: KeyboardEvent ) => {
+			const context = getContext();
+			if ( event.code === 'Enter' ) {
+				context.selectedImage = context.imageId;
+			}
+		},
 	},
 	callbacks: {
 		watchForChangesOnAddToCartForm: () => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -18,7 +18,7 @@ const getContext = ( ns?: string ) =>
 	getContextFn< ProductGalleryContext >( ns );
 
 type Store = typeof productGallery & StorePart< ProductGallery >;
-const { state } = store< Store >( 'woocommerce/product-gallery' );
+const { state, actions } = store< Store >( 'woocommerce/product-gallery' );
 
 const selectImage = (
 	context: ProductGalleryContext,
@@ -55,6 +55,9 @@ const productGallery = {
 		get pagerButtonPressed(): boolean {
 			return state.isSelected ? true : false;
 		},
+		get thumbnailTabIndex(): string {
+			return state.isSelected ? '0' : '-1';
+		},
 	},
 	actions: {
 		closeDialog: () => {
@@ -86,6 +89,16 @@ const productGallery = {
 			const context = getContext();
 			if ( event.code === 'Enter' ) {
 				context.selectedImage = context.imageId;
+			}
+		},
+		onSelectedLargeImageKeyDown: ( event: KeyboardEvent ) => {
+			if ( state.isSelected && event.code === 'Enter' ) {
+				actions.openDialog();
+			}
+		},
+		onViewAllImagesKeyDown: ( event: KeyboardEvent ) => {
+			if ( event.code === 'Enter' ) {
+				actions.openDialog();
 			}
 		},
 	},

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -87,17 +87,38 @@ const productGallery = {
 		},
 		onThumbnailKeyDown: ( event: KeyboardEvent ) => {
 			const context = getContext();
-			if ( event.code === 'Enter' ) {
+			if (
+				event.code === 'Enter' ||
+				event.code === 'Space' ||
+				event.code === 'NumpadEnter'
+			) {
+				if ( event.code === 'Space' ) {
+					event.preventDefault();
+				}
 				context.selectedImage = context.imageId;
 			}
 		},
 		onSelectedLargeImageKeyDown: ( event: KeyboardEvent ) => {
-			if ( state.isSelected && event.code === 'Enter' ) {
+			if (
+				( state.isSelected && event.code === 'Enter' ) ||
+				event.code === 'Space' ||
+				event.code === 'NumpadEnter'
+			) {
+				if ( event.code === 'Space' ) {
+					event.preventDefault();
+				}
 				actions.openDialog();
 			}
 		},
 		onViewAllImagesKeyDown: ( event: KeyboardEvent ) => {
-			if ( event.code === 'Enter' ) {
+			if (
+				event.code === 'Enter' ||
+				event.code === 'Space' ||
+				event.code === 'NumpadEnter'
+			) {
+				if ( event.code === 'Space' ) {
+					event.preventDefault();
+				}
 				actions.openDialog();
 			}
 		},

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -145,6 +145,7 @@ $admin-bar-mobile-height: 46px;
 		margin-right: auto;
 		margin-left: auto;
 		max-width: $outside-image-max-width;
+		padding: 5px;
 	}
 
 	.wc-block-product-gallery-large-image__container {
@@ -175,6 +176,7 @@ $admin-bar-mobile-height: 46px;
 		overflow: hidden;
 		margin-right: auto;
 		margin-left: auto;
+		padding: 5px;
 	}
 
 
@@ -201,9 +203,11 @@ $admin-bar-mobile-height: 46px;
 		display: flex;
 		flex-direction: column;
 		position: absolute;
-		width: 100%;
-		height: 100%;
-		top: 0;
+		width: calc(100% - 10px);
+		height: calc(100% - 10px);
+		top: 5px;
+		left: 5px;
+
 
 		// Reset the margin of the inner blocks when the Next/Previous buttons are outside the image.
 		#{$gallery-next-previous-outside-image} & > * {

--- a/plugins/woocommerce/changelog/44236-fix-43759-enable-keyboard-navigation-for-thumbnails
+++ b/plugins/woocommerce/changelog/44236-fix-43759-enable-keyboard-navigation-for-thumbnails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add functionality to navigate between Product Gallery image thumbnails with the keyboard.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
@@ -117,9 +117,11 @@ class ProductGalleryLargeImage extends AbstractBlock {
 	 */
 	private function get_main_images_html( $context, $product_id ) {
 		$attributes = array(
-			'class'                => 'wc-block-woocommerce-product-gallery-large-image__image',
-			'data-wc-bind--hidden' => '!state.isSelected',
-			'data-wc-watch'        => 'callbacks.scrollInto',
+			'class'                  => 'wc-block-woocommerce-product-gallery-large-image__image',
+			'data-wc-bind--hidden'   => '!state.isSelected',
+			'data-wc-watch'          => 'callbacks.scrollInto',
+			'data-wc-bind--tabindex' => 'state.thumbnailTabIndex',
+			'data-wc-on--keydown'    => 'actions.onSelectedLargeImageKeyDown',
 			'data-wc-class--wc-block-woocommerce-product-gallery-large-image__image--active-image-slide' => 'state.isSelected',
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
@@ -87,7 +87,7 @@ class ProductGalleryLargeImage extends AbstractBlock {
 
 		return strtr(
 			'<div class="wc-block-product-gallery-large-image wp-block-woocommerce-product-gallery-large-image" {directives}>
-				<ul class="wc-block-product-gallery-large-image__container">
+				<ul class="wc-block-product-gallery-large-image__container" tabindex="-1">
 					{main_images}
 				</ul>
 					{content}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -48,7 +48,7 @@ class ProductGalleryThumbnails extends AbstractBlock {
 	 * @return string
 	 */
 	protected function generate_view_all_html( $remaining_thumbnails_count ) {
-		$view_all_html = '<div class="wc-block-product-gallery-thumbnails__thumbnail__overlay wc-block-product-gallery-dialog-on-click" data-wc-on--click="actions.openDialog">
+		$view_all_html = '<div class="wc-block-product-gallery-thumbnails__thumbnail__overlay wc-block-product-gallery-dialog-on-click" data-wc-on--click="actions.openDialog" tabindex="0">
 			<span class="wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count wc-block-product-gallery-dialog-on-click">+%1$s</span>
 			<span class="wc-block-product-gallery-thumbnails__thumbnail__view-all wc-block-product-gallery-dialog-on-click">%2$s</span>
 			</div>';
@@ -156,6 +156,9 @@ class ProductGalleryThumbnails extends AbstractBlock {
 							$processor = new \WP_HTML_Tag_Processor( $product_gallery_image_html );
 
 							if ( $processor->next_tag( 'img' ) ) {
+
+								$processor->set_attribute( 'data-wc-on--keydown', 'actions.onThumbnailKeyDown' );
+								$processor->set_attribute( 'tabindex', '0' );
 								$processor->set_attribute(
 									'data-wc-on--click',
 									'actions.selectImage'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -48,7 +48,7 @@ class ProductGalleryThumbnails extends AbstractBlock {
 	 * @return string
 	 */
 	protected function generate_view_all_html( $remaining_thumbnails_count ) {
-		$view_all_html = '<div class="wc-block-product-gallery-thumbnails__thumbnail__overlay wc-block-product-gallery-dialog-on-click" data-wc-on--click="actions.openDialog" tabindex="0">
+		$view_all_html = '<div class="wc-block-product-gallery-thumbnails__thumbnail__overlay wc-block-product-gallery-dialog-on-click" data-wc-on--click="actions.openDialog" data-wc-on--keydown="actions.onViewAllImagesKeyDown" tabindex="0">
 			<span class="wc-block-product-gallery-thumbnails__thumbnail__remaining-thumbnails-count wc-block-product-gallery-dialog-on-click">+%1$s</span>
 			<span class="wc-block-product-gallery-thumbnails__thumbnail__view-all wc-block-product-gallery-dialog-on-click">%2$s</span>
 			</div>';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43759 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. Click on "Edit" to open the Template editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block." Click on it.
4. In the block inserter, search for "Product Gallery" or browse through the available blocks until you find it.
5. Click on the "Product Gallery" block to add it to your content.
6. Using the keyboard, press 'Tab' multiple times and make sure you can easily select each thumbnail image and the large image.
7. With a thumbnail image selected, press 'Enter' to replace the Large Image with the selected thumbnail image.
8. When you have the "View All" thumbnail selected, press 'Enter' to open the Product Gallery Pop-Up.
9. Close the Product Gallery Pop-Up.
10. Select the Large Image and press 'Enter' to open the Product Gallery Pop-Up.

**Before**

https://github.com/woocommerce/woocommerce/assets/20469356/423c1e6e-eaa4-4798-8cec-f7590c2b0123

**After**

https://github.com/woocommerce/woocommerce/assets/20469356/da993559-c835-4f87-abd2-7f2693066ae6

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add functionality to navigate between Product Gallery image thumbnails with the keyboard.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>