### PR TITLE
Add template title and description on 'get_block_template' hook

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -11,6 +11,8 @@ import { CUSTOMIZABLE_WC_TEMPLATES, WC_TEMPLATES_SLUG } from './constants';
 CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 	const userText = `Hello World in the ${ testData.templateName } template`;
 	const fallbackTemplateUserText = `Hello World in the fallback ${ testData.templateName } template`;
+	const templateTypeName =
+		testData.templateType === 'wp_template' ? 'template' : 'template part';
 
 	test.describe( `${ testData.templateName } template`, async () => {
 		test( 'can be modified and reverted', async ( {
@@ -31,6 +33,14 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 				attributes: { content: userText },
 			} );
 			await editorUtils.saveTemplate();
+			// Verify template name didn't change.
+			// See: https://github.com/woocommerce/woocommerce/issues/42221
+			await expect(
+				page.getByRole( 'heading', {
+					name: `Editing ${ templateTypeName }: ${ testData.templateName }`,
+				} )
+			).toBeVisible();
+
 			await testData.visitPage( { frontendUtils, page } );
 			await expect( page.getByText( userText ).first() ).toBeVisible();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -35,6 +35,13 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 				attributes: { content: userText },
 			} );
 			await editorUtils.saveTemplate();
+			// Verify template name didn't change.
+			// See: https://github.com/woocommerce/woocommerce/issues/42221
+			await expect(
+				page.getByRole( 'heading', {
+					name: `Editing template: ${ testData.templateName }`,
+				} )
+			).toBeVisible();
 
 			// Verify the template is the one modified by the user.
 			await testData.visitPage( { frontendUtils, page } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -15,6 +15,7 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 	}
 	const userText = `Hello World in the ${ testData.templateName } template`;
 	const fallbackTemplateUserText = `Hello World in the fallback ${ testData.templateName } template`;
+	const templateTypeName = testData.templateType === 'wp_template' ? 'template' : 'template part';
 
 	test.describe( `${ testData.templateName } template`, async () => {
 		test( "theme template has priority over WooCommerce's and can be modified", async ( {
@@ -39,7 +40,7 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			// See: https://github.com/woocommerce/woocommerce/issues/42221
 			await expect(
 				page.getByRole( 'heading', {
-					name: `Editing template: ${ testData.templateName }`,
+					name: `Editing ${templateTypeName}: ${ testData.templateName }`,
 				} )
 			).toBeVisible();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -15,7 +15,8 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 	}
 	const userText = `Hello World in the ${ testData.templateName } template`;
 	const fallbackTemplateUserText = `Hello World in the fallback ${ testData.templateName } template`;
-	const templateTypeName = testData.templateType === 'wp_template' ? 'template' : 'template part';
+	const templateTypeName =
+		testData.templateType === 'wp_template' ? 'template' : 'template part';
 
 	test.describe( `${ testData.templateName } template`, async () => {
 		test( "theme template has priority over WooCommerce's and can be modified", async ( {
@@ -40,7 +41,7 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			// See: https://github.com/woocommerce/woocommerce/issues/42221
 			await expect(
 				page.getByRole( 'heading', {
-					name: `Editing ${templateTypeName}: ${ testData.templateName }`,
+					name: `Editing ${ templateTypeName }: ${ testData.templateName }`,
 				} )
 			).toBeVisible();
 

--- a/plugins/woocommerce/changelog/44254-fix-42221-wrong-template-title
+++ b/plugins/woocommerce/changelog/44254-fix-42221-wrong-template-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Site Editor showing the template slug instead of the template title when saving a WooCommerce block template customized by the theme.

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -58,6 +58,7 @@ class BlockTemplatesController {
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 		add_filter( 'pre_get_block_template', array( $this, 'get_block_template_fallback' ), 10, 3 );
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
+		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 1 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'current_theme_supports-block-templates', array( $this, 'remove_block_template_support_for_shop_page' ) );
 		add_filter( 'taxonomy_template_hierarchy', array( $this, 'add_archive_product_to_eligible_for_fallback_templates' ), 10, 1 );
@@ -344,6 +345,25 @@ class BlockTemplatesController {
 
 		// Hand back over to Gutenberg if we can't find a template.
 		return $template;
+	}
+
+	/**
+	 * Add the template title and description to WooCommerce templates.
+	 *
+	 * @param WP_Block_Template|null $block_template The found block template, or null if there isn't one.
+	 * @return WP_Block_Template|null
+	 */
+	public function add_block_template_details( $block_template ) {
+		if ( ! $block_template ) {
+			return $block_template;
+		}
+		if ( ! $block_template->title || $block_template->title === $block_template->slug ) {
+			$block_template->title = BlockTemplateUtils::get_block_template_title( $block_template->slug );
+		}
+		if ( ! $block_template->description ) {
+			$block_template->description = BlockTemplateUtils::get_block_template_description( $block_template->slug );
+		}
+		return $block_template;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -389,9 +389,7 @@ class BlockTemplatesController {
 			if ( 'custom' !== $template_file->source ) {
 				$template = BlockTemplateUtils::build_template_result_from_file( $template_file, $template_type );
 			} else {
-				$template_file->title       = BlockTemplateUtils::get_block_template_title( $template_file->slug );
-				$template_file->description = BlockTemplateUtils::get_block_template_description( $template_file->slug );
-				$query_result[]             = $template_file;
+				$query_result[] = $template_file;
 				continue;
 			}
 
@@ -456,15 +454,13 @@ class BlockTemplatesController {
 					}
 				}
 
-				if ( 'theme' === $template->origin && BlockTemplateUtils::template_has_title( $template ) ) {
-					return $template;
-				}
-				if ( $template->title === $template->slug ) {
+				if ( ! $template->title || $template->title === $template->slug ) {
 					$template->title = BlockTemplateUtils::get_block_template_title( $template->slug );
 				}
 				if ( ! $template->description ) {
 					$template->description = BlockTemplateUtils::get_block_template_description( $template->slug );
 				}
+
 				return $template;
 			},
 			$query_result

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -357,7 +357,7 @@ class BlockTemplatesController {
 		if ( ! $block_template ) {
 			return $block_template;
 		}
-		if ( ! $block_template->title || $block_template->title === $block_template->slug ) {
+		if ( ! BlockTemplateUtils::template_has_title( $block_template ) ) {
 			$block_template->title = BlockTemplateUtils::get_block_template_title( $block_template->slug );
 		}
 		if ( ! $block_template->description ) {
@@ -474,7 +474,7 @@ class BlockTemplatesController {
 					}
 				}
 
-				if ( ! $template->title || $template->title === $template->slug ) {
+				if ( ! BlockTemplateUtils::template_has_title( $template ) ) {
 					$template->title = BlockTemplateUtils::get_block_template_title( $template->slug );
 				}
 				if ( ! $template->description ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #42221.

This PR adds the template title and description in the `get_block_template` hook, which fixes #42221. I also added some tests to verify there are no regressions in the future and took the opportunity to simplify how we attach the template title and description in `add_block_templates()`.

### How to test the changes in this Pull Request:

**Verify there are no regressions:**

Move around the Site Editor freely, keeping an eye on WooCommerce templates titles and descriptions, making sure they always appear correctly.

**Verify #42221 is fixed:**

1. Enable a theme with custom WooCommerce template, like Tsubaki.
2. Go to Appearance > Editor > Templates and edit a WooCommerce template (ie: Single Product). Note: make sure you didn't have any previous edits on that template. This fix doesn't work for templates that had been modified in the past.
3. Make some edits in the template, save, and verify the title of the template doesn't change. (Before the fix, it would change from _Single Product_ to _single-product_).

[Enregistrament de pantalla del 2024-02-01 11-10-29.webm](https://github.com/woocommerce/woocommerce/assets/3616980/e9c378fa-d6e3-4206-b611-a4104703ca51)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix the Site Editor showing the template slug instead of the template title when saving a WooCommerce block template customized by the theme.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
