### PR TITLE
BlockTemplateUtils cleanup

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -63,7 +63,7 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 				editorUtils,
 				page,
 			} ) => {
-				// Edit default template and verify changes are visible.
+				// Edit fallback template and verify changes are visible.
 				await admin.visitSiteEditor( {
 					postId: `${ WC_TEMPLATES_SLUG }//${
 						testData.fallbackTemplate?.templatePath || ''

--- a/plugins/woocommerce/changelog/44256-update-clean-up-blocktemplatescontroller
+++ b/plugins/woocommerce/changelog/44256-update-clean-up-blocktemplatescontroller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Clean up some methods of `BlockTemplateUtils` and make `BlockTemplatesController` only load in themes that support templates/template parts.
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -283,7 +283,7 @@ class WC_Admin_Meta_Boxes {
 	 * @return string[] Templates array excluding block-based templates.
 	 */
 	public function remove_block_templates( $templates ) {
-		if ( count( $templates ) === 0 || ! wc_current_theme_is_fse_theme() || ( ! function_exists( 'gutenberg_get_block_template' ) && ! function_exists( 'get_block_template' ) ) ) {
+		if ( count( $templates ) === 0 || ! wc_current_theme_is_fse_theme() ) {
 			return $templates;
 		}
 
@@ -296,9 +296,7 @@ class WC_Admin_Meta_Boxes {
 				continue;
 			}
 
-			$block_template = function_exists( 'gutenberg_get_block_template' ) ?
-				gutenberg_get_block_template( $theme . '//' . $template_key ) :
-				get_block_template( $theme . '//' . $template_key );
+			$block_template = get_block_template( $theme . '//' . $template_key );
 
 			// If the block template has the product post type specified, include it.
 			if ( $block_template && is_array( $block_template->post_types ) && in_array( 'product', $block_template->post_types ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -160,7 +160,7 @@ class BlockTemplatesController {
 	 */
 	public function render_woocommerce_template_part( $attributes ) {
 		if ( isset( $attributes['theme'] ) && 'woocommerce/woocommerce' === $attributes['theme'] ) {
-			$template_part = BlockTemplateUtils::get_block_template( $attributes['theme'] . '//' . $attributes['slug'], 'wp_template_part' );
+			$template_part = get_block_template( $attributes['theme'] . '//' . $attributes['slug'], 'wp_template_part' );
 
 			if ( $template_part && ! empty( $template_part->content ) ) {
 				return do_blocks( $template_part->content );
@@ -315,7 +315,7 @@ class BlockTemplatesController {
 		if ( BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG === strtolower( $template_id ) ) {
 			// Because we are using get_block_templates we have to unhook this method to prevent a recursive loop where this filter is applied.
 			remove_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
-			$template_with_deprecated_id = BlockTemplateUtils::get_block_template( $id, $template_type );
+			$template_with_deprecated_id = get_block_template( $id, $template_type );
 			// Let's hook this method back now that we have used the function.
 			add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -596,9 +596,8 @@ class BlockTemplatesController {
 	public function get_block_templates( $slugs = array(), $template_type = 'wp_template' ) {
 		$templates_from_db  = BlockTemplateUtils::get_block_templates_from_db( $slugs, $template_type );
 		$templates_from_woo = $this->get_block_templates_from_woocommerce( $slugs, $templates_from_db, $template_type );
-		$templates          = array_merge( $templates_from_db, $templates_from_woo );
 
-		return BlockTemplateUtils::filter_block_templates_by_feature_flag( $templates );
+		return array_merge( $templates_from_db, $templates_from_woo );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -476,7 +476,7 @@ class MiniCart extends AbstractBlock {
 			$theme_has_mini_cart   = BlockTemplateUtils::theme_has_template_part( 'mini-cart' );
 			$template_slug_to_load = $theme_has_mini_cart ? get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
 		}
-		$template_part = BlockTemplateUtils::get_block_template( $template_slug_to_load . '//mini-cart', 'wp_template_part' );
+		$template_part = get_block_template( $template_slug_to_load . '//mini-cart', 'wp_template_part' );
 
 		if ( $template_part && ! empty( $template_part->content ) ) {
 			$template_part_contents = do_blocks( $template_part->content );

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -151,23 +151,17 @@ class Bootstrap {
 			// regular rest requests to maintain compatibility with the store editor.
 			$this->container->get( BlockPatterns::class );
 			$this->container->get( BlockTypesController::class );
+			$this->container->get( BlockTemplatesController::class );
+			$this->container->get( ProductSearchResultsTemplate::class );
+			$this->container->get( ProductAttributeTemplate::class );
+			$this->container->get( CartTemplate::class );
+			$this->container->get( CheckoutTemplate::class );
+			$this->container->get( CheckoutHeaderTemplate::class );
+			$this->container->get( OrderConfirmationTemplate::class );
+			$this->container->get( ClassicTemplatesCompatibility::class );
+			$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
+			$this->container->get( SingleProductTemplateCompatibility::class )->init();
 			$this->container->get( Notices::class )->init();
-
-			if ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) {
-				$this->container->get( BlockTemplatesController::class );
-				$this->container->get( CheckoutHeaderTemplate::class );
-
-				if ( wc_current_theme_is_fse_theme() ) {
-					$this->container->get( ProductSearchResultsTemplate::class );
-					$this->container->get( ProductAttributeTemplate::class );
-					$this->container->get( CartTemplate::class );
-					$this->container->get( CheckoutTemplate::class );
-					$this->container->get( OrderConfirmationTemplate::class );
-					$this->container->get( ClassicTemplatesCompatibility::class );
-					$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
-					$this->container->get( SingleProductTemplateCompatibility::class )->init();
-				}
-			}
 		}
 
 		$this->container->get( QueryFilters::class )->init();

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -151,17 +151,23 @@ class Bootstrap {
 			// regular rest requests to maintain compatibility with the store editor.
 			$this->container->get( BlockPatterns::class );
 			$this->container->get( BlockTypesController::class );
-			$this->container->get( BlockTemplatesController::class );
-			$this->container->get( ProductSearchResultsTemplate::class );
-			$this->container->get( ProductAttributeTemplate::class );
-			$this->container->get( CartTemplate::class );
-			$this->container->get( CheckoutTemplate::class );
-			$this->container->get( CheckoutHeaderTemplate::class );
-			$this->container->get( OrderConfirmationTemplate::class );
-			$this->container->get( ClassicTemplatesCompatibility::class );
-			$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
-			$this->container->get( SingleProductTemplateCompatibility::class )->init();
 			$this->container->get( Notices::class )->init();
+
+			if ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) {
+				$this->container->get( BlockTemplatesController::class );
+				$this->container->get( CheckoutHeaderTemplate::class );
+
+				if ( wc_current_theme_is_fse_theme() ) {
+					$this->container->get( ProductSearchResultsTemplate::class );
+					$this->container->get( ProductAttributeTemplate::class );
+					$this->container->get( CartTemplate::class );
+					$this->container->get( CheckoutTemplate::class );
+					$this->container->get( OrderConfirmationTemplate::class );
+					$this->container->get( ClassicTemplatesCompatibility::class );
+					$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
+					$this->container->get( SingleProductTemplateCompatibility::class )->init();
+				}
+			}
 		}
 
 		$this->container->get( QueryFilters::class )->init();

--- a/plugins/woocommerce/src/Blocks/Migration.php
+++ b/plugins/woocommerce/src/Blocks/Migration.php
@@ -70,7 +70,7 @@ class Migration {
 	 * Rename `checkout` template to `page-checkout`.
 	 */
 	public static function wc_blocks_update_1120_rename_checkout_template() {
-		$template = BlockTemplateUtils::get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//checkout', 'wp_template' );
+		$template = get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//checkout', 'wp_template' );
 
 		if ( $template && ! empty( $template->wp_id ) ) {
 			if ( ! defined( 'WP_POST_REVISIONS' ) ) {
@@ -90,7 +90,7 @@ class Migration {
 	 * Rename `cart` template to `page-cart`.
 	 */
 	public static function wc_blocks_update_1120_rename_cart_template() {
-		$template = BlockTemplateUtils::get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//cart', 'wp_template' );
+		$template = get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//cart', 'wp_template' );
 
 		if ( $template && ! empty( $template->wp_id ) ) {
 			if ( ! defined( 'WP_POST_REVISIONS' ) ) {

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -493,28 +493,6 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Retrieves a single unified template object using its id.
-	 *
-	 * @param string $id            Template unique identifier (example: theme_slug//template_slug).
-	 * @param string $template_type Optional. Template type: `wp_template` or 'wp_template_part`.
-	 *                              Default `wp_template`.
-	 *
-	 * @return WP_Block_Template|null Template.
-	 */
-	public static function get_block_template( $id, $template_type ) {
-		if ( function_exists( 'get_block_template' ) ) {
-			return get_block_template( $id, $template_type );
-		}
-
-		if ( function_exists( 'gutenberg_get_block_template' ) ) {
-			return gutenberg_get_block_template( $id, $template_type );
-		}
-
-		return null;
-
-	}
-
-	/**
 	 * Checks if we can fall back to the `archive-product` template for a given slug.
 	 *
 	 * `taxonomy-product_cat`, `taxonomy-product_tag`, `taxonomy-product_attribute` templates can
@@ -820,7 +798,7 @@ class BlockTemplateUtils {
 			$theme_has_template    = self::theme_has_template_part( $slug );
 			$template_slug_to_load = $theme_has_template ? get_stylesheet() : self::PLUGIN_SLUG;
 		}
-		$template_part = self::get_block_template( $template_slug_to_load . '//' . $slug, 'wp_template_part' );
+		$template_part = get_block_template( $template_slug_to_load . '//' . $slug, 'wp_template_part' );
 
 		if ( $template_part && ! empty( $template_part->content ) ) {
 			return $template_part->content;

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -493,6 +493,20 @@ class BlockTemplateUtils {
 	}
 
 	/**
+	 * Retrieves a single unified template object using its id.
+	 *
+	 * @param string $id            Template unique identifier (example: theme_slug//template_slug).
+	 * @param string $template_type Optional. Template type: `wp_template` or 'wp_template_part`.
+	 *                              Default `wp_template`.
+	 *
+	 * @return WP_Block_Template|null Template.
+	 */
+	public static function get_block_template( $id, $template_type ) {
+		wc_deprecated_function( 'BlockTemplateUtils::get_block_template()', '8.7', 'get_block_template()' );
+		return get_block_template( $id, $template_type );
+	}
+
+	/**
 	 * Checks if we can fall back to the `archive-product` template for a given slug.
 	 *
 	 * `taxonomy-product_cat`, `taxonomy-product_tag`, `taxonomy-product_attribute` templates can

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -621,25 +621,8 @@ class BlockTemplateUtils {
 	 * @return WP_Block_Template[] An array of block template objects.
 	 */
 	public static function filter_block_templates_by_feature_flag( $block_templates ) {
-		$feature_gating = new FeatureGating();
-		$flag           = $feature_gating->get_flag();
-
-		/**
-		 * An array of block templates with slug as key and flag as value.
-		 *
-		 * @var array
-		*/
-		$block_templates_with_feature_gate = array();
-
-		return array_filter(
-			$block_templates,
-			function( $block_template ) use ( $flag, $block_templates_with_feature_gate ) {
-				if ( isset( $block_templates_with_feature_gate[ $block_template->slug ] ) ) {
-					return $block_templates_with_feature_gate[ $block_template->slug ] <= $flag;
-				}
-				return true;
-			}
-		);
+		wc_deprecated_function( 'BlockTemplateUtils::filter_block_templates_by_feature_flag()', '8.7' );
+		return $block_templates;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -493,20 +493,6 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Retrieves a single unified template object using its id.
-	 *
-	 * @param string $id            Template unique identifier (example: theme_slug//template_slug).
-	 * @param string $template_type Optional. Template type: `wp_template` or 'wp_template_part`.
-	 *                              Default `wp_template`.
-	 *
-	 * @return WP_Block_Template|null Template.
-	 */
-	public static function get_block_template( $id, $template_type ) {
-		wc_deprecated_function( 'BlockTemplateUtils::get_block_template()', '8.7', 'get_block_template()' );
-		return get_block_template( $id, $template_type );
-	}
-
-	/**
 	 * Checks if we can fall back to the `archive-product` template for a given slug.
 	 *
 	 * `taxonomy-product_cat`, `taxonomy-product_tag`, `taxonomy-product_attribute` templates can
@@ -611,18 +597,6 @@ class BlockTemplateUtils {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Filter block templates by feature flag.
-	 *
-	 * @param WP_Block_Template[] $block_templates An array of block template objects.
-	 *
-	 * @return WP_Block_Template[] An array of block template objects.
-	 */
-	public static function filter_block_templates_by_feature_flag( $block_templates ) {
-		wc_deprecated_function( 'BlockTemplateUtils::filter_block_templates_by_feature_flag()', '8.7' );
-		return $block_templates;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -702,18 +702,11 @@ class BlockTemplateUtils {
 
 	/**
 	 * Returns whether the blockified templates should be used or not.
-	 * First, we need to make sure WordPress version is higher than 6.1 (lowest that supports Products block).
-	 * Then, if the option is not stored on the db, we need to check if the current theme is a block one or not.
+	 * If the option is not stored on the db, we need to check if the current theme is a block one or not.
 	 *
 	 * @return boolean
 	 */
 	public static function should_use_blockified_product_grid_templates() {
-		$minimum_wp_version = '6.1';
-
-		if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
-			return false;
-		}
-
 		$use_blockified_templates = get_option( Options::WC_BLOCK_USE_BLOCKIFIED_PRODUCT_GRID_BLOCK_AS_TEMPLATE );
 
 		if ( false === $use_blockified_templates ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:

* Removes `BlockTemplateUtils::get_block_template()`. Instead, we can safely use `get_block_template()` from WordPress, which [was introduced in version WP 5.8.0](https://github.com/WordPress/wordpress-develop/blob/3600105163a45e62f07da3cb5607846f3e4bb4fd/src/wp-includes/block-template-utils.php#L1043) (WC only supports WP 6.3 or higher).
* Removes `BlockTemplateUtils::filter_block_templates_by_feature_flag()`. That function was last used two years ago and it doesn't make sense in the monorepo. In both cases, I'm removing the method instead of deprecating it as `BlockTemplateUtils` is marked as an internal class, so it should be safe.
* Removes an unnecessary WP version comparison inside `should_use_blockified_product_grid_templates()`.

### How to test the changes in this Pull Request:

This PR is not introducing any new features, so testing it means making sure there are no regressions. Luckily, any regressions would probably be easily visible, as there would be a PHP error.

With a block theme (ie: Twenty-Twenty Four):

1. Visit several pages in the frontend: single product, page, product category, cart, checkout... Verify all of them render correctly.
2. Edit some templates in the Site Editor, verify edits are saved and applied in the frontend.
3. Edit the Mini-Cart template part in the Site Editor and verify the changes are applied when using the Mini-Cart in the frontend.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Clean up some methods of `BlockTemplateUtils` and make `BlockTemplatesController` only load in themes that support templates/template parts.

</details>
