### PR TITLE
CYS - AI flow: fix regression - no fonts visible

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
@@ -19,7 +19,6 @@ import {
 // @ts-ignore No types for this exist yet.
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 import { GlobalStylesVariationIframe } from '../global-styles-variation-iframe';
-import { FontFamiliesLoader } from './font-families-loader';
 import {
 	FONT_PREVIEW_LARGE_WIDTH,
 	FONT_PREVIEW_LARGE_HEIGHT,

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
@@ -29,6 +29,7 @@ import {
 import { FontFamily } from '~/customize-store/types/font';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
 import { isAIFlow, isNoAIFlow } from '~/customize-store/guards';
+import { FontFamiliesLoaderDotCom } from './font-families-loader-dot-com';
 
 const { useGlobalStyle, useGlobalSetting } = unlock( blockEditorPrivateApis );
 
@@ -176,7 +177,7 @@ export const FontPairingVariationPreview = () => {
 					</div>
 				</div>
 				{ isAIFlow( context.flowType ) && (
-					<FontFamiliesLoader
+					<FontFamiliesLoaderDotCom
 						fontFamilies={ fontFamilies }
 						onLoad={ handleOnLoad }
 					/>

--- a/plugins/woocommerce/changelog/44280-fix-font-ai-flow-no-visible
+++ b/plugins/woocommerce/changelog/44280-fix-font-ai-flow-no-visible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: CYS - AI flow: fix regression - no fonts visible
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes a regression caused by #44004. The wrong component is rendered when the flow is `AIOnline`. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### JN Installation


1. Create a new WooCommerce installation with this version.
2. Ensure Jetpack is installed and your site is connected with JP.
3. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
4. Ensure the Woo AI plugin is installed and activated (available on this monorepo).
5. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
6. Head over to WooCommerce -> Home and click on "Start Customizing".
7. Ensure that all the flow works correctly.
8. On the sidebar, select `change your font` and ensure that the fonts are visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

CYS - AI flow: fix regression - no fonts visible 

</details>
