### PR TITLE
Add `wc hpos backfill` tool to backfill from/to either datastore

### DIFF
--- a/plugins/woocommerce/changelog/hpos-41909
+++ b/plugins/woocommerce/changelog/hpos-41909
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds `wp wc hpos backfill` tool to backfill from/to either order datastore.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1097,9 +1097,9 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	public function backfill( array $args = array(), array $assoc_args = array() ) {
 		$legacy_handler = wc_get_container()->get( LegacyDataHandler::class );
 
-		$from         = $assoc_args['from'] ?? '';
-		$to           = $assoc_args['to'] ?? '';
-		$order_id     = absint( $args[0] );
+		$from     = $assoc_args['from'] ?? '';
+		$to       = $assoc_args['to'] ?? '';
+		$order_id = absint( $args[0] );
 
 		if ( ! $order_id ) {
 			WP_CLI::error( __( 'Please provide a valid order ID.', 'woocommerce' ) );

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1098,6 +1098,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 
 		foreach ( array( 'from', 'to' ) as $datastore ) {
 			if ( ! in_array( ${"$datastore"}, array( 'posts', 'hpos' ), true ) ) {
+				// translators: %s is a shell argument representing a datastore name.
 				WP_CLI::error( sprintf( __( '\'%s\' is not a valid datastore.', 'woocommerce' ), ${"$datastore"} ) );
 			}
 		}
@@ -1111,6 +1112,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 		} catch ( \Exception $e ) {
 			WP_CLI::error(
 				sprintf(
+					// translators: %1$d is an order ID, %2$s and %3$s are datastore names, %4$s is an error message.
 					__( 'An error occurred while backfilling order %1$d from %2$s to %3$s: %4$s', 'woocommerce' ),
 					$order_id,
 					$from,
@@ -1122,7 +1124,8 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 
 		WP_CLI::success(
 			sprintf(
-				__( 'Order %d backfilled from %s to %s.', 'woocommerce' ),
+				// translators: %1$d is an order ID, %2$s and %3$s are datastore names ("hpos" or "posts" for example).
+				__( 'Order %1$d backfilled from %2$s to %3$s.', 'woocommerce' ),
 				$order_id,
 				$from,
 				$to

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -262,7 +262,7 @@ class CLIRunner {
 	 * ## EXAMPLES
 	 *
 	 *     # Copy all order data into the post meta table, 500 posts at a time.
-	 *     wp wc cot backfill --batch-size=500
+	 *     wp wc cot migrate --batch-size=500
 	 *
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -994,7 +994,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>
+	 * <order_id>
 	 * :The ID of the order.
 	 *
 	 * [--format=<format>]
@@ -1070,8 +1070,8 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>
-	 * :The ID of the order.
+	 * <order_id>
+	 * : The ID of the order.
 	 *
 	 * [--from=<hpos|posts>]
 	 * : Source datastore. Defaults to the currently active datastore.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1073,11 +1073,21 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * <order_id>
 	 * : The ID of the order.
 	 *
-	 * [--from=<hpos|posts>]
-	 * : Source datastore. Defaults to the currently active datastore.
+	 * --from=<datastore>
+	 * : Source datastore. Either 'hpos' or 'posts'.
+	 * ---
+	 * options:
+	 *   - hpos
+	 *   - posts
+	 * ---
 	 *
-	 * [--to=<hpos|posts>]
-	 * : Destination datastore. Defaults to the current backup datastore.
+	 * --to=<datastore>
+	 * : Destination datastore. Either 'hpos' or 'posts'.
+	 * ---
+	 * options:
+	 *   - hpos
+	 *   - posts
+	 * ---
 	 *
 	 * @since 8.6.0
 	 *
@@ -1087,9 +1097,8 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	public function backfill( array $args = array(), array $assoc_args = array() ) {
 		$legacy_handler = wc_get_container()->get( LegacyDataHandler::class );
 
-		$hpos_enabled = $this->synchronizer->custom_orders_table_is_authoritative();
-		$from         = strtolower( trim( $assoc_args['from'] ?? ( $hpos_enabled ? 'hpos' : 'posts' ) ) );
-		$to           = strtolower( trim( $assoc_args['to'] ?? ( $hpos_enabled ? 'posts' : 'hpos' ) ) );
+		$from         = $assoc_args['from'] ?? '';
+		$to           = $assoc_args['to'] ?? '';
 		$order_id     = absint( $args[0] );
 
 		if ( ! $order_id ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -39,8 +39,9 @@ class LegacyDataHandler {
 	/**
 	 * Class initialization, invoked by the DI container.
 	 *
-	 * @param OrdersTableDataStore $data_store HPOS datastore instance to use.
-	 * @param DataSynchronizer     $data_synchronizer DataSynchronizer instance to use.
+	 * @param OrdersTableDataStore             $data_store            HPOS datastore instance to use.
+	 * @param DataSynchronizer                 $data_synchronizer     DataSynchronizer instance to use.
+	 * @param PostsToOrdersMigrationController $posts_to_cot_migrator Posts to HPOS migration controller instance to use.
 	 *
 	 * @internal
 	 */

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -29,6 +30,13 @@ class LegacyDataHandler {
 	private DataSynchronizer $data_synchronizer;
 
 	/**
+	 * Instance of the PostsToOrdersMigrationController.
+	 *
+	 * @var PostsToOrdersMigrationController
+	 */
+	private PostsToOrdersMigrationController $posts_to_cot_migrator;
+
+	/**
 	 * Class initialization, invoked by the DI container.
 	 *
 	 * @param OrdersTableDataStore $data_store HPOS datastore instance to use.
@@ -36,9 +44,10 @@ class LegacyDataHandler {
 	 *
 	 * @internal
 	 */
-	final public function init( OrdersTableDataStore $data_store, DataSynchronizer $data_synchronizer ) {
-		$this->data_store        = $data_store;
-		$this->data_synchronizer = $data_synchronizer;
+	final public function init( OrdersTableDataStore $data_store, DataSynchronizer $data_synchronizer, PostsToOrdersMigrationController $posts_to_cot_migrator ) {
+		$this->data_store            = $data_store;
+		$this->data_synchronizer     = $data_synchronizer;
+		$this->posts_to_cot_migrator = $posts_to_cot_migrator;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -278,8 +278,15 @@ class LegacyDataHandler {
 			$data_store->prime_caches_for_orders( array( $order_id ), array() );
 		}
 
-		$classname = wc_get_order_type( $data_store->get_order_type( $order_id ) )['class_name'];
-		$order     = new $classname();
+		$order_type = wc_get_order_type( $data_store->get_order_type( $order_id ) );
+
+		if ( ! $order_type ) {
+			// translators: %d is an order ID.
+			throw new \Exception( sprintf( __( '%d is not an order or has an invalid order type.', 'woocommerce' ), $order_id ) );
+		}
+
+		$classname  = $order_type['class_name'];
+		$order      = new $classname();
 		$order->set_id( $order_id );
 
 		// Switch datastore if necessary.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -267,6 +267,7 @@ class LegacyDataHandler {
 	 * @param int    $order_id      Order ID.
 	 * @param string $data_store_id Datastore to use. Should be either 'hpos' or 'posts'. Defaults to 'hpos'.
 	 * @return \WC_Order Order instance.
+	 * @throws \Exception When an error occurs.
 	 */
 	public function get_order_from_datastore( int $order_id, string $data_store_id = 'hpos' ) {
 		$data_store = ( 'hpos' === $data_store_id ) ? $this->data_store : $this->data_store->get_cpt_data_store_instance();
@@ -285,8 +286,8 @@ class LegacyDataHandler {
 			throw new \Exception( sprintf( __( '%d is not an order or has an invalid order type.', 'woocommerce' ), $order_id ) );
 		}
 
-		$classname  = $order_type['class_name'];
-		$order      = new $classname();
+		$classname = $order_type['class_name'];
+		$order     = new $classname();
 		$order->set_id( $order_id );
 
 		// Switch datastore if necessary.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -211,7 +211,7 @@ class LegacyDataHandler {
 		$diff = array();
 
 		$hpos_order = $this->get_order_from_datastore( $order_id, 'hpos' );
-		$cpt_order  = $this->get_order_from_datastore( $order_id, 'cpt' );
+		$cpt_order  = $this->get_order_from_datastore( $order_id, 'posts' );
 
 		if ( $hpos_order->get_type() !== $cpt_order->get_type() ) {
 			$diff['type'] = array( $hpos_order->get_type(), $cpt_order->get_type() );
@@ -255,7 +255,7 @@ class LegacyDataHandler {
 	 * @since 8.6.0
 	 *
 	 * @param int    $order_id      Order ID.
-	 * @param string $data_store_id Datastore to use. Should be either 'hpos' or 'cpt'. Defaults to 'hpos'.
+	 * @param string $data_store_id Datastore to use. Should be either 'hpos' or 'posts'. Defaults to 'hpos'.
 	 * @return \WC_Order Order instance.
 	 */
 	public function get_order_from_datastore( int $order_id, string $data_store_id = 'hpos' ) {

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -95,6 +95,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 			array(
 				OrdersTableDataStore::class,
 				DataSynchronizer::class,
+				PostsToOrdersMigrationController::class,
 			)
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
@@ -175,11 +175,10 @@ class LegacyDataHandlerTests extends WC_Unit_Test_Case {
 		$order_hpos->update_meta_data( 'meta_key', 'hpos' );
 		$order_hpos->save();
 
-
 		// Fetch the posts version and make sure it's different.
 		$order_cpt = $this->sut->get_order_from_datastore( $order->get_id(), $destination_data_store );
 		$this->assertNotEquals( $order_hpos->get_billing_first_name(), $order_cpt->get_billing_first_name() );
-		$this->assertNotEquals( $order_hpos->get_meta( 'meta_key' ), $order_cpt->get_meta( 'meta_key') );
+		$this->assertNotEquals( $order_hpos->get_meta( 'meta_key' ), $order_cpt->get_meta( 'meta_key' ) );
 
 		// Backfill to posts.
 		$this->sut->backfill_order_to_datastore( $order->get_id(), $source_data_store, $destination_data_store );
@@ -187,7 +186,7 @@ class LegacyDataHandlerTests extends WC_Unit_Test_Case {
 		// Confirm data is now the same.
 		$order_cpt = $this->sut->get_order_from_datastore( $order->get_id(), $destination_data_store );
 		$this->assertEquals( $order_hpos->get_billing_first_name(), $order_cpt->get_billing_first_name() );
-		$this->assertEquals( $order_hpos->get_meta( 'meta_key' ), $order_cpt->get_meta( 'meta_key') );
+		$this->assertEquals( $order_hpos->get_meta( 'meta_key' ), $order_cpt->get_meta( 'meta_key' ) );
 	}
 
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a new CLI tool `wp hpos backfill` that can be used to backfill orders from either the HPOS or CPT datastore, regardless of what the current datastore is.
This can be used to resolve situations where a given order has correct data in either table but the merchant can't change datastores or the sync process would overwrite other orders.

Closes #41909.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Settings > Advanced > Features and make sure HPOS is set as datastore and compat mode is disabled.
1. If your site doesn't have any orders, create at least one in WC > Orders > Add order.
1. Open any order (in the admin) and take note of its ID.
1. Go to Custom Fields and add a custom field by specifying a name (say, `<meta_key>`) and value and clicking "Add Custom Field" or saving the order.
1. Confirm that the backup post doesn't have this metadata (since compat mode is disabled) by running `wp post meta list <order_id>` and confirming the list doesn't include this new meta / is empty.
1. Run `wp wc hpos backfill <order_id> --from=hpos --to=posts`.
1. Run `wp post meta list <order_id>` and confirm that now all the order metadata appears, including the metadata you manually added.
1. Directly modify the post metadata by running `wp post meta update <order_id> <meta_key> <any_other_meta_value>`.
1. Confirm that this metadata is not yet in the HPOS tables by re-opening this order in the admin and verifying that the Custom Fields metabox still lists the original value.
1. Run `wp wc hpos backfill <order_id> --from=posts --to=hpos` to backfill from posts to HPOS.
1. Refresh the order edit screen / re-open the order for editing in the admin, and confirm that the Custom Fields metabox now lists the metadata we manually added to the post (in step 8).


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
