### PR TITLE
Product Gallery block: Prevent block error when a user inputs a decimal number for the Number of Thumbnails setting

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/block-settings/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/block-settings/index.tsx
@@ -103,7 +103,7 @@ export const ProductGalleryThumbnailsBlockSettings = ( {
 					value={ context.thumbnailsNumberOfThumbnails }
 					onChange={ ( value: number ) =>
 						updateBlockAttributes( productGalleryClientId, {
-							thumbnailsNumberOfThumbnails: value,
+							thumbnailsNumberOfThumbnails: Math.round( value ),
 						} )
 					}
 					help={ __(
@@ -112,6 +112,7 @@ export const ProductGalleryThumbnailsBlockSettings = ( {
 					) }
 					max={ maxNumberOfThumbnails }
 					min={ minNumberOfThumbnails }
+					step={ 1 }
 				/>
 			) }
 		</>

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { Locator, Page } from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -24,6 +25,15 @@ const blockData = {
 	},
 	slug: 'single-product',
 	productPage: '/product/v-neck-t-shirt/',
+};
+
+const changeNumberOfThumbnailsInputValue = async (
+	page: Page,
+	numberOfThumbnailInput: Locator,
+	value: string
+) => {
+	await numberOfThumbnailInput.fill( value );
+	await page.keyboard.press( 'Enter' );
 };
 
 const test = base.extend< { pageObject: ProductGalleryPage } >( {
@@ -444,6 +454,49 @@ test.describe( `${ blockData.name }`, () => {
 				);
 
 			expect( isThumbnailsFrontendBlockEarlier ).toBe( false );
+		} );
+
+		test( 'Ensure entered Number of Thumbnails rounds to integer', async ( {
+			page,
+			editor,
+			pageObject,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'woocommerce/product-gallery',
+			} );
+
+			const thumbnailsBlock = await pageObject.getThumbnailsBlock( {
+				page: 'editor',
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+			const numberOfThumbnailInput = page.getByRole( 'spinbutton', {
+				name: 'Number of Thumbnails',
+			} );
+
+			await changeNumberOfThumbnailsInputValue(
+				page,
+				numberOfThumbnailInput,
+				'4.2'
+			);
+
+			let numberOfThumbnailsOnScreen = await thumbnailsBlock
+				.locator( '.wc-block-product-gallery-thumbnails__thumbnail' )
+				.all();
+
+			expect( numberOfThumbnailsOnScreen ).toHaveLength( 4 );
+
+			await changeNumberOfThumbnailsInputValue(
+				page,
+				numberOfThumbnailInput,
+				'4.7'
+			);
+
+			numberOfThumbnailsOnScreen = await thumbnailsBlock
+				.locator( '.wc-block-product-gallery-thumbnails__thumbnail' )
+				.all();
+
+			expect( numberOfThumbnailsOnScreen ).toHaveLength( 5 );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/44282-fix-43796-restrict-number-of-thumbnails-setting-to-integer-values-2
+++ b/plugins/woocommerce/changelog/44282-fix-43796-restrict-number-of-thumbnails-setting-to-integer-values-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restrict the Number of Thumbnails setting from the Product Gallery block to integer values


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR prevents an error when a user inputs a decimal number in the Number of Thumbnails settings of the Product Gallery block. Now, every time the input changes, we round it to the nearest integer (for instance, 4.2 would be converted to 4, while 4.8 would be converted to 5).

E2E tests were also included to cover this functionality and prevent future errors.

Closes #43796.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. Click on "Edit" to open the WordPress editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block." Click on it.
4. In the block inserter, search for "Product Gallery" or browse the available blocks until you find them.
5. Click on the "Product Gallery" block to add it to your content.
6. Select the "Product Gallery (Beta)" block.
7. On the right-side menu, change the "Number of Thumbnails" input field to some decimal value, for example 4.2.
8. Make sure you see four thumbnails being rendered.
9. On the right-side menu, change the "Number of Thumbnails" input field to some different decimal value, such as 5.6.
10. Make sure you see six thumbnails being rendered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Restrict the Number of Thumbnails setting from the Product Gallery block to integer values

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>