### PR TITLE
[E2E] Robustify order confirmation assertions (checkout spec)

### DIFF
--- a/plugins/woocommerce/changelog/add-improve-robustness-of-checkout-confirmation-test
+++ b/plugins/woocommerce/changelog/add-improve-robustness-of-checkout-confirmation-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: There are no functional changes being introduced, we're just making an E2E test (covering the checkout flow) a little more robust.
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -351,7 +351,7 @@ test.describe( 'Checkout page', () => {
 			// The order having just been placed, a verify-email field should not be present.
 			await expect(
 				page.locator( 'form.woocommerce-verify-email p:nth-child(3)' )
-			).toBeFalsy();
+			).not.toBeVisible();
 
 			// get order ID from the page
 			const orderReceivedText = await page

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -348,6 +348,11 @@ test.describe( 'Checkout page', () => {
 				page.getByRole( 'heading', { name: 'Order received' } )
 			).toBeVisible();
 
+			// The order having just been placed, a verify-email field should not be present.
+			await expect(
+				page.locator( 'form.woocommerce-verify-email p:nth-child(3)' )
+			).toBeFalsy();
+
 			// get order ID from the page
 			const orderReceivedText = await page
 				.locator( '.woocommerce-order-overview__order.order' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the order confirmation page appears after checking out, [we expect an 'order received' heading to be present](https://github.com/woocommerce/woocommerce/blob/ded33b70493678d9b75b4f26d00e226e87c64932/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js#L348), but we do not expect the shopper to be immediately asked to confirm their email address (this is reserved for cases where a guest shopper cannot be identified, and after a grace period has elapsed).

- See [this PR](https://github.com/woocommerce/woocommerce/pull/44266) (which targets a different branch) to see the new assertion failing/to see a case where this would successfully prevent a regression.
- This all relates to the change [proposed here](https://github.com/woocommerce/woocommerce/pull/43834).

This change adds an addition assertion to confirm that the email verification field is **not** present (at least not initially). 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Review and revise the new assertion/expectation: this PR does not introduce any functional changes outside of the test suite.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
