### PR TITLE
Product Editor: Export recent SlotFills as __experimental

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-header-slot-fills-rename
+++ b/packages/js/product-editor/changelog/update-product-editor-header-slot-fills-rename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Export __experimentalVariationQUickUpdateMenuItem, __experimentalPluginHeaderItemModal, __experimentalPluginHeaderItemPopover

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -10,7 +10,10 @@ export { DetailsFeatureField as __experimentalDetailsFeatureField } from './deta
 export { DetailsSummaryField as __experimentalDetailsSummaryField } from './details-summary-field';
 export { DetailsDescriptionField as __experimentalDetailsDescriptionField } from './details-description-field';
 export { WooProductMoreMenuItem as __experimentalWooProductMoreMenuItem } from './header';
-export { PluginHeaderItemModal, PluginHeaderItemPopover } from './header';
+export {
+	PluginHeaderItemModal as __experimentalPluginHeaderItemModal,
+	PluginHeaderItemPopover as __experimentalPluginHeaderItemPopover,
+} from './header';
 export {
 	Editor as __experimentalEditor,
 	initBlocks as __experimentalInitBlocks,

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -36,7 +36,7 @@ export { AttributeControl as __experimentalAttributeControl } from './attribute-
 export { Attributes as __experimentalAttributes } from './attributes';
 export * from './add-new-shipping-class-modal';
 export { VariationSwitcherFooter as __experimentalVariationSwitcherFooter } from './variation-switcher-footer';
-export { VariationQuickUpdateMenuItem } from './variations-table/variation-actions-menus';
+export { VariationQuickUpdateMenuItem as __experimentalVariationQuickUpdateMenuItem } from './variations-table/variation-actions-menus';
 
 export * from './remove-confirmation-modal';
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR renames the exports of the recently added slot fills so that they are prefixed by `__experimental`, marking them as experimental so that extension developers are aware that the API for these may change in the future.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Make sure unit tests pass...

```bash
pnpm --filter=@woocommerce/product-editor test:js
```

#### Manual testing

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Install the following test plugin, which adds two header items, and two variation quick action menu items under the "Pricing" group (see below for details).

[test-44285-slot-fills-rename.zip](https://github.com/woocommerce/woocommerce/files/14210027/test-44285-slot-fills-rename.zip)

2. Go to **Products** > **Add New**
3. Verify that the header items work as expected:

The first header item shows a popover:

<img width="524" alt="Screenshot 2024-02-05 at 15 39 05" src="https://github.com/woocommerce/woocommerce/assets/2098816/1ecc295f-8e10-4ce8-80f3-b7cab52f2645">

The second header item shows a modal that has a button to set the product name to a random string:

<img width="877" alt="Screenshot 2024-02-05 at 15 39 30" src="https://github.com/woocommerce/woocommerce/assets/2098816/53885b61-76b2-4e60-b17c-1453cf8603fd">

4. Add some variations on the **Variations** tab
5. Verify the two menu items under the "Pricing" group added by the test plugin function:

- **Add 100 to regular price (single selection only)**
- **50% off sale (multiple selection allowed)**

<img width="1038" alt="Screenshot 2024-02-05 at 15 38 05" src="https://github.com/woocommerce/woocommerce/assets/2098816/e919dccd-6696-4279-907e-8689bf03bb97">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
