### PR TITLE
Remove class scoping and just use text to find elements

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
@@ -28,9 +28,8 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 				'/product-filters-active-block/?rating_filter=1,2,5'
 			);
 
-			const listLocator = page.locator( '.filter-list' );
 			const hasTitle =
-				( await listLocator.locator( 'text=Rating:' ).count() ) === 1;
+				( await page.locator( 'text=Rating:' ).count() ) === 1;
 
 			expect( hasTitle ).toBe( true );
 
@@ -40,9 +39,7 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 				'Rated 5 out of 5',
 			] ) {
 				const hasFilter =
-					( await listLocator
-						.locator( `text=${ text }` )
-						.count() ) === 1;
+					( await page.locator( `text=${ text }` ).count() ) === 1;
 				expect( hasFilter ).toBe( true );
 			}
 		} );
@@ -54,19 +51,14 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 				'/product-filters-active-block/?filter_stock_status=instock,onbackorder'
 			);
 
-			const listLocator = page.locator( '.filter-list' );
 			const hasTitle =
-				( await listLocator
-					.locator( 'text=Stock Status:' )
-					.count() ) === 1;
+				( await page.locator( 'text=Stock Status:' ).count() ) === 1;
 
 			expect( hasTitle ).toBe( true );
 
 			for ( const text of [ 'In stock', 'On backorder' ] ) {
 				const hasFilter =
-					( await listLocator
-						.locator( `text=${ text }` )
-						.count() ) === 1;
+					( await page.locator( `text=${ text }` ).count() ) === 1;
 				expect( hasFilter ).toBe( true );
 			}
 		} );
@@ -78,17 +70,14 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 				'/product-filters-active-block/?filter_color=blue,gray&query_type_color=or'
 			);
 
-			const listLocator = page.locator( '.filter-list' );
 			const hasTitle =
-				( await listLocator.locator( 'text=Color:' ).count() ) === 1;
+				( await page.locator( 'text=Color:' ).count() ) === 1;
 
 			expect( hasTitle ).toBe( true );
 
 			for ( const text of [ 'Blue', 'Gray' ] ) {
 				const hasFilter =
-					( await listLocator
-						.locator( `text=${ text }` )
-						.count() ) === 1;
+					( await page.locator( `text=${ text }` ).count() ) === 1;
 				expect( hasFilter ).toBe( true );
 			}
 		} );
@@ -100,16 +89,14 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 				'/product-filters-active-block/?min_price=17&max_price=71'
 			);
 
-			const listLocator = page.locator( '.filter-list' );
 			const hasTitle =
-				( await listLocator.locator( 'text=Price:' ).count() ) === 1;
+				( await page.locator( 'text=Price:' ).count() ) === 1;
 
 			expect( hasTitle ).toBe( true );
 
 			const hasFilter =
-				( await listLocator
-					.locator( `text=Between $17 and $71` )
-					.count() ) === 1;
+				( await page.locator( `text=Between $17 and $71` ).count() ) ===
+				1;
 			expect( hasFilter ).toBe( true );
 		} );
 	} );

--- a/plugins/woocommerce/changelog/44289-dev-dont-use-classes-e2e-active-filter
+++ b/plugins/woocommerce/changelog/44289-dev-dont-use-classes-e2e-active-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Refactor e2e tests for new interactivity active filter block
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/44190 it was pointed out by @dinhtungdu correctly that I should not use class selectors for e2e tests as they're more fragile and things like classes and html structure are prone to frequent change.

Originally I thought a refactor would involve adding roles or labels, but actually just removing scoping by class from the selectors solves most of the problem, as I'm using text selectors in these tests anyway.

Note: there is just one remaining class selector for the empty block. I will think about how we could refactor that in future but at least I think its not prone to change since its a WP generated block class.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. See tests pass in CI

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Refactor e2e tests for new interactivity active filter block
</details>
