### PR TITLE
Add e2e tests for password-protected Single Product block template

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/scripts/products.sh
@@ -34,6 +34,11 @@ wp post meta update $beanie_product_id _crosssell_ids "$cap_product_id"
 tshirt_with_logo_product_id=$(wp post list --post_type=product --field=ID --name="T-Shirt with Logo" --format=ids)
 wp wc product update $tshirt_with_logo_product_id --in_stock=false --user=1
 
+# Make a product visible only with password.
+sunglasses_product_id=$(wp post list --post_type=product --field=ID --name="Sunglasses" --format=ids)
+wp post update $sunglasses_product_id --post_password="password" --user=1
+
+
 # Enable attribute archives.
 attribute_ids=$(wp wc product_attribute list --fields=id --format=ids --user=1)
 if [ -n "$attribute_ids" ]; then

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -78,8 +78,12 @@ test.describe( 'Product Collection', () => {
 
 			await pageObject.publishAndGoToFrontend();
 
+			const frontendTitles =
+				await pageObject.productTitles.allInnerTexts();
 			expect(
-				await pageObject.productTitles.allInnerTexts()
+				frontendTitles.map( ( title ) =>
+					title.replace( 'Protected: ', '' )
+				)
 			).toStrictEqual( expectedTitles );
 		} );
 
@@ -181,8 +185,16 @@ test.describe( 'Product Collection', () => {
 			);
 
 			await pageObject.publishAndGoToFrontend();
+
+			const frontendAccessoriesProductNames = [
+				'Beanie',
+				'Beanie with Logo',
+				'Belt',
+				'Cap',
+				'Protected: Sunglasses',
+			];
 			await expect( pageObject.productTitles ).toHaveText(
-				accessoriesProductNames
+				frontendAccessoriesProductNames
 			);
 		} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+// Sunglasses are defined as requering password in /bin/scripts/products.sh.
+const productWithPasswordPermalink = '/product/sunglasses/';
+
+test.describe( 'Single Product template', async () => {
+	test( 'shows password form in products protected with password', async ( {
+		page,
+	} ) => {
+		await page.goto( productWithPasswordPermalink );
+		await expect(
+			page.getByText( 'This content is password protected.' ).first()
+		).toBeVisible();
+	} );
+} );

--- a/plugins/woocommerce/changelog/44304-fix-44297-single-product-password-test
+++ b/plugins/woocommerce/changelog/44304-fix-44297-single-product-password-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Add e2e tests for password-protected Single Product block template
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #44297.

This PR adds e2e tests to verify the Single Product block template displays the password form when a product is password-protected.

### How to test the changes in this Pull Request:

Note: no need to test this for the release.

1. Verify e2e tests pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Add e2e tests for password-protected Single Product block template

</details>
