### PR TITLE
[Experimental] Add option to `show_in_order_confirmation` for additional checkout fields

### DIFF
--- a/plugins/woocommerce/changelog/add-register-checkout-field-show-in-options-43524
+++ b/plugins/woocommerce/changelog/add-register-checkout-field-show-in-options-43524
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+This is behind a feature flag.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFields.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFields.php
@@ -33,9 +33,11 @@ class AdditionalFields extends AbstractOrderConfirmationBlock {
 
 		$controller = Package::container()->get( CheckoutFields::class );
 		$content   .= $this->render_additional_fields(
-			array_merge(
-				$controller->get_order_additional_fields_with_values( $order, 'contact', '', 'view' ),
-				$controller->get_order_additional_fields_with_values( $order, 'additional', '', 'view' ),
+			$controller->filter_fields_for_order_confirmation(
+				array_merge(
+					$controller->get_order_additional_fields_with_values( $order, 'contact', '', 'view' ),
+					$controller->get_order_additional_fields_with_values( $order, 'additional', '', 'view' ),
+				)
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -251,27 +251,28 @@ class CheckoutFields {
 		$field_data = wp_parse_args(
 			$options,
 			array(
-				'id'            => '',
-				'label'         => '',
-				'optionalLabel' => sprintf(
+				'id'                         => '',
+				'label'                      => '',
+				'optionalLabel'              => sprintf(
 					/* translators: %s Field label. */
 					__( '%s (optional)', 'woocommerce' ),
 					$options['label']
 				),
-				'location'      => '',
-				'type'          => 'text',
-				'hidden'        => false,
-				'required'      => false,
-				'attributes'    => array(),
+				'location'                   => '',
+				'type'                       => 'text',
+				'hidden'                     => false,
+				'required'                   => false,
+				'attributes'                 => array(),
+				'show_in_order_confirmation' => true,
 			)
 		);
 
 		$field_data['attributes'] = $this->register_field_attributes( $field_data['id'], $field_data['attributes'] );
 
 		if ( 'checkbox' === $field_data['type'] ) {
-			$field_data = $this->process_checkbox_field( $options, $field_data );
+			$field_data = $this->process_checkbox_field( $field_data, $options );
 		} elseif ( 'select' === $field_data['type'] ) {
-			$field_data = $this->process_select_field( $options, $field_data );
+			$field_data = $this->process_select_field( $field_data, $options );
 		}
 
 		// $field_data will be false if an error that will prevent the field being registered is encountered.
@@ -985,7 +986,6 @@ class CheckoutFields {
 	 * For now, this only supports fields in address location.
 	 *
 	 * @param array $fields The fields to filter.
-	 *
 	 * @return array The filtered fields.
 	 */
 	public function filter_fields_for_customer( $fields ) {
@@ -999,6 +999,21 @@ class CheckoutFields {
 				return in_array( $key, $customer_fields_keys, true );
 			},
 			ARRAY_FILTER_USE_KEY
+		);
+	}
+
+	/**
+	 * Filter fields for order confirmation.
+	 *
+	 * @param array $fields The fields to filter.
+	 * @return array The filtered fields.
+	 */
+	public function filter_fields_for_order_confirmation( $fields ) {
+		return array_filter(
+			$fields,
+			function( $field ) {
+				return ! empty( $field['show_in_order_confirmation'] );
+			}
 		);
 	}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -242,55 +242,46 @@ class CheckoutFields {
 	 * @return \WP_Error|void True if the field was registered, a WP_Error otherwise.
 	 */
 	public function register_checkout_field( $options ) {
-
 		// Check the options and show warnings if they're not supplied. Return early if an error that would prevent registration is encountered.
-		$result = $this->validate_options( $options );
-		if ( false === $result ) {
+		if ( false === $this->validate_options( $options ) ) {
 			return;
 		}
 
 		// The above validate_options function ensures these options are valid. Type might not be supplied but then it defaults to text.
-		$id       = $options['id'];
-		$location = $options['location'];
-		$type     = $options['type'] ?? 'text';
-
-		$field_data = array(
-			'label'         => $options['label'],
-			'hidden'        => false,
-			'type'          => $type,
-			'optionalLabel' => empty( $options['optionalLabel'] ) ? sprintf(
-			/* translators: %s Field label. */
-				__( '%s (optional)', 'woocommerce' ),
-				$options['label']
-			) : $options['optionalLabel'],
-			'required'      => empty( $options['required'] ) ? false : $options['required'],
+		$field_data = wp_parse_args(
+			$options,
+			array(
+				'id'            => '',
+				'label'         => '',
+				'optionalLabel' => sprintf(
+					/* translators: %s Field label. */
+					__( '%s (optional)', 'woocommerce' ),
+					$options['label']
+				),
+				'location'      => '',
+				'type'          => 'text',
+				'hidden'        => false,
+				'required'      => false,
+				'attributes'    => array(),
+			)
 		);
 
-		$field_data['attributes'] = $this->register_field_attributes( $id, $options['attributes'] ?? [] );
+		$field_data['attributes'] = $this->register_field_attributes( $field_data['id'], $field_data['attributes'] );
 
-		if ( 'checkbox' === $type ) {
-			$result = $this->process_checkbox_field( $options, $field_data );
-
-			// $result will be false if an error that will prevent the field being registered is encountered.
-			if ( false === $result ) {
-				return;
-			}
-			$field_data = $result;
+		if ( 'checkbox' === $field_data['type'] ) {
+			$field_data = $this->process_checkbox_field( $options, $field_data );
+		} elseif ( 'select' === $field_data['type'] ) {
+			$field_data = $this->process_select_field( $options, $field_data );
 		}
 
-		if ( 'select' === $type ) {
-			$result = $this->process_select_field( $options, $field_data );
-
-			// $result will be false if an error that will prevent the field being registered is encountered.
-			if ( false === $result ) {
-				return;
-			}
-			$field_data = $result;
+		// $field_data will be false if an error that will prevent the field being registered is encountered.
+		if ( false === $field_data ) {
+			return;
 		}
 
 		// Insert new field into the correct location array.
-		$this->additional_fields[ $id ]        = $field_data;
-		$this->fields_locations[ $location ][] = $id;
+		$this->additional_fields[ $field_data['id'] ]        = $field_data;
+		$this->fields_locations[ $field_data['location'] ][] = $field_data['id'];
 	}
 
 	/**
@@ -367,12 +358,12 @@ class CheckoutFields {
 	/**
 	 * Processes the options for a select field and returns the new field_options array.
 	 *
-	 * @param array $options     The options supplied during field registration.
 	 * @param array $field_data  The field data array to be updated.
+	 * @param array $options     The options supplied during field registration.
 	 *
 	 * @return array|false The updated $field_data array or false if an error was encountered.
 	 */
-	private function process_select_field( $options, $field_data ) {
+	private function process_select_field( $field_data, $options ) {
 		$id = $options['id'];
 
 		if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
@@ -423,12 +414,12 @@ class CheckoutFields {
 	/**
 	 * Processes the options for a checkbox field and returns the new field_options array.
 	 *
-	 * @param array $options     The options supplied during field registration.
 	 * @param array $field_data  The field data array to be updated.
+	 * @param array $options     The options supplied during field registration.
 	 *
 	 * @return array|false The updated $field_data array or false if an error was encountered.
 	 */
-	private function process_checkbox_field( $options, $field_data ) {
+	private function process_checkbox_field( $field_data, $options ) {
 		$id = $options['id'];
 
 		// Checkbox fields are always optional. Log a warning if it's set explicitly as true.
@@ -451,11 +442,8 @@ class CheckoutFields {
 	 * @return array The processed attributes.
 	 */
 	private function register_field_attributes( $id, $attributes ) {
-
 		// We check if attributes are valid. This is done to prevent too much nesting and also to allow field registration
 		// even if the attributes property is invalid. We can just skip it and register the field without attributes.
-		$has_attributes = false;
-
 		if ( empty( $attributes ) ) {
 			return [];
 		}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
@@ -1,14 +1,15 @@
 <?php
 
 use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 
 if ( ! function_exists( 'woocommerce_blocks_register_checkout_field' ) && Package::feature()->is_experimental_build() ) {
 
 	/**
 	 * Register a checkout field.
 	 *
-	 * @param array $options Field arguments.
-	 * @throws Exception If field registration fails.
+	 * @param array $options Field arguments. See CheckoutFields::register_checkout_field() for details.
+	 * @throws \Exception If field registration fails.
 	 */
 	function woocommerce_blocks_register_checkout_field( $options ) {
 
@@ -24,10 +25,10 @@ if ( ! function_exists( 'woocommerce_blocks_register_checkout_field' ) && Packag
 			);
 			return;
 		}
-		$checkout_fields = Package::container()->get( \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::class );
+		$checkout_fields = Package::container()->get( CheckoutFields::class );
 		$result          = $checkout_fields->register_checkout_field( $options );
 		if ( is_wp_error( $result ) ) {
-			throw new Exception( $result->get_error_message() );
+			throw new \Exception( $result->get_error_message() );
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces a new option to `woocommerce_blocks_register_checkout_field ` called `show_in_order_confirmation` which controls if fields appear in the order confirmation/order emails.

I've cleaned up some the registration functions for readability, and introduced usage of `wp_parse_args` so supported properties are more visible.

Closes #43524

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

```php
add_action(
	'woocommerce_blocks_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/custom-field-1',
				'label'    => __( 'This is a text custom field', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'text',
			)
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/custom-field-2',
				'label'    => __( 'This is another text custom field', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'text',
				'show_in_order_confirmation' => false
			)
		);
	}
);
```

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Register a checkout field using the above code. You can implement this using a code snippets plugin.
2. Add something to your cart and go to block checkout.
3. Complete the custom fields you just registered as well as the rest of the checkout and place order.
4. On the confirmation page, confirm `This is a text custom field` is visible and `This is another text custom field` is hidden.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
