### PR TITLE
Product Gallery block: Announce Pop-Up Opening with Voiceovers

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -67,15 +67,25 @@ const productGallery = {
 			document.body.classList.add(
 				'wc-block-product-gallery-modal-open'
 			);
-
-			const dialogCloseButton = document.querySelector(
-				'.wc-block-product-gallery-dialog__close'
+			const dialogOverlay = document.querySelector(
+				'.wc-block-product-gallery-dialog__overlay'
 			);
-
-			if ( ! dialogCloseButton ) {
+			if ( ! dialogOverlay ) {
 				return;
 			}
-			( dialogCloseButton as HTMLButtonElement ).focus();
+			( dialogOverlay as HTMLElement ).focus();
+
+			const dialogPreviousButton = dialogOverlay.querySelectorAll(
+				'.wc-block-product-gallery-large-image-next-previous--button'
+			)[ 0 ];
+
+			if ( ! dialogPreviousButton ) {
+				return;
+			}
+
+			setTimeout( () => {
+				( dialogPreviousButton as HTMLButtonElement ).focus();
+			}, 100 );
 		},
 		selectImage: () => {
 			const context = getContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { store, getContext as getContextFn } from '@woocommerce/interactivity';
 import { StorePart } from '@woocommerce/utils';
 
 export interface ProductGalleryContext {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { store, getContext as getContextFn } from '@woocommerce/interactivity';
 import { StorePart } from '@woocommerce/utils';
 
 export interface ProductGalleryContext {
@@ -67,6 +66,15 @@ const productGallery = {
 			document.body.classList.add(
 				'wc-block-product-gallery-modal-open'
 			);
+
+			const dialogCloseButton = document.querySelector(
+				'.wc-block-product-gallery-dialog__close'
+			);
+
+			if ( ! dialogCloseButton ) {
+				return;
+			}
+			( dialogCloseButton as HTMLButtonElement ).focus();
 		},
 		selectImage: () => {
 			const context = getContext();

--- a/plugins/woocommerce/changelog/44332-fix-43760-announce-pop-up-opening-with-voiceovers
+++ b/plugins/woocommerce/changelog/44332-fix-43760-announce-pop-up-opening-with-voiceovers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Announce Pop-Up Opening with Voiceovers

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -95,8 +95,8 @@ class ProductGallery extends AbstractBlock {
 			</dialog>
 		</div>',
 			array(
-				'{{html}}' => $html_processor->get_updated_html(),
-				'{{dialog_aria_label}}' => __( 'Product gallery', 'woocommerce' ),
+				'{{html}}'                    => $html_processor->get_updated_html(),
+				'{{dialog_aria_label}}'       => __( 'Product gallery', 'woocommerce' ),
 				'{{close_dialog_aria_label}}' => __( 'Close Product Gallery dialog', 'woocommerce' ),
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -77,25 +77,27 @@ class ProductGallery extends AbstractBlock {
 
 		$gallery_dialog = strtr(
 			'
-		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" role="dialog" aria-modal="true">
-			<dialog data-wc-bind--open="context.isDialogOpen">
-			<div class="wc-block-product-gallery-dialog__header">
-			<div class="wc-block-product-galler-dialog__header-right">
-				<button class="wc-block-product-gallery-dialog__close" data-wc-on--click="actions.closeDialog" aria-label="Close">
-					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-						<rect width="24" height="24" rx="2"/>
-						<path d="M13 11.8L19.1 5.5L18.1 4.5L12 10.7L5.9 4.5L4.9 5.5L11 11.8L4.5 18.5L5.5 19.5L12 12.9L18.5 19.5L19.5 18.5L13 11.8Z" fill="black"/>
-					</svg>
-				</button>
-			</div>
-			</div>
-			<div class="wc-block-product-gallery-dialog__body">
-				{{html}}
-			</div>
+		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" data-wc-watch--check-dialog-visibility="callbacks.checkDialogVisibility">
+			<dialog data-wc-bind--open="context.isDialogOpen" role="dialog" aria-modal="true" aria-label="{{dialog_aria_label}}">
+				<div class="wc-block-product-gallery-dialog__header">
+				<div class="wc-block-product-galler-dialog__header-right">
+					<button class="wc-block-product-gallery-dialog__close" data-wc-on--click="actions.closeDialog" aria-label="{{close_dialog_aria_label}}">
+						<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<rect width="24" height="24" rx="2"/>
+							<path d="M13 11.8L19.1 5.5L18.1 4.5L12 10.7L5.9 4.5L4.9 5.5L11 11.8L4.5 18.5L5.5 19.5L12 12.9L18.5 19.5L19.5 18.5L13 11.8Z" fill="black"/>
+						</svg>
+					</button>
+				</div>
+				</div>
+				<div class="wc-block-product-gallery-dialog__body">
+					{{html}}
+				</div>
 			</dialog>
 		</div>',
 			array(
 				'{{html}}' => $html_processor->get_updated_html(),
+				'{{dialog_aria_label}}' => __( 'Product gallery', 'woocommerce' ),
+				'{{close_dialog_aria_label}}' => __( 'Close Product Gallery dialog', 'woocommerce' ),
 			)
 		);
 		return $gallery_dialog;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -77,7 +77,7 @@ class ProductGallery extends AbstractBlock {
 
 		$gallery_dialog = strtr(
 			'
-		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" data-wc-watch--check-dialog-visibility="callbacks.checkDialogVisibility">
+		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess">
 			<dialog data-wc-bind--open="context.isDialogOpen" role="dialog" aria-modal="true" aria-label="{{dialog_aria_label}}">
 				<div class="wc-block-product-gallery-dialog__header">
 				<div class="wc-block-product-galler-dialog__header-right">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -77,11 +77,11 @@ class ProductGallery extends AbstractBlock {
 
 		$gallery_dialog = strtr(
 			'
-		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess">
+		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" role="dialog" aria-modal="true">
 			<dialog data-wc-bind--open="context.isDialogOpen">
 			<div class="wc-block-product-gallery-dialog__header">
 			<div class="wc-block-product-galler-dialog__header-right">
-				<button class="wc-block-product-gallery-dialog__close" data-wc-on--click="actions.closeDialog">
+				<button class="wc-block-product-gallery-dialog__close" data-wc-on--click="actions.closeDialog" aria-label="Close">
 					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<rect width="24" height="24" rx="2"/>
 						<path d="M13 11.8L19.1 5.5L18.1 4.5L12 10.7L5.9 4.5L4.9 5.5L11 11.8L4.5 18.5L5.5 19.5L12 12.9L18.5 19.5L19.5 18.5L13 11.8Z" fill="black"/>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
@@ -89,6 +89,10 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 				'data-wc-on--click',
 				'actions.selectPreviousImage'
 			);
+			$p->set_attribute(
+				'aria-label',
+				__( 'Previous image', 'woocommerce' )
+			);
 			$prev_button = $p->get_updated_html();
 		}
 
@@ -99,6 +103,10 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 			$p->set_attribute(
 				'data-wc-on--click',
 				'actions.selectNextImage'
+			);
+			$p->set_attribute(
+				'aria-label',
+				__( 'Next image', 'woocommerce' )
 			);
 			$next_button = $p->get_updated_html();
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43760.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. Click on "Edit" to open the Template editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block." Click on it.
4. In the block inserter, search for "Product Gallery" or browse through the available blocks until you find it.
5. Click on the "Product Gallery" block to add it to your content.
6. Save the changes and visit a product with multiple images.
7. Enable VoiceOver (here are [instructions for the MacOS](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac#:~:text=Choose%20Apple%20menu%20%3E%20System%20Settings,turn%20VoiceOver%20on%20or%20off.));
8. Click on the Large Image;
9. Make sure that the VoiceOver announces that the user is inside a dialog;

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Announce Pop-Up Opening with Voiceovers

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
