### PR TITLE
Fix deprecation notices for legacy order item keys.

### DIFF
--- a/plugins/woocommerce/changelog/fix-41567-deprecated-legacy-keys
+++ b/plugins/woocommerce/changelog/fix-41567-deprecated-legacy-keys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix deprecation notices for legacy order item keys.

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -15,6 +15,22 @@ defined( 'ABSPATH' ) || exit;
 class WC_Order_Item_Product extends WC_Order_Item {
 
 	/**
+	 * Legacy values.
+	 *
+	 * @deprecated 4.4.0 For legacy actions.
+	 * @var array
+	 */
+	public $legacy_values;
+
+	/**
+	 * Legacy cart item key.
+	 *
+	 * @deprecated 4.4.0 For legacy actions.
+	 * @var string
+	 */
+	public $legacy_cart_item_key;
+
+	/**
 	 * Order Data array. This is the core order data exposed in APIs since 3.0.0.
 	 *
 	 * @since 3.0.0

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -53,6 +53,14 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	protected $object_type = 'order_item';
 
 	/**
+	 * Legacy package key.
+	 *
+	 * @deprecated 4.4.0 For legacy actions.
+	 * @var string
+	 */
+	public $legacy_package_key;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int|object|array $item ID to load from the DB, or WC_Order_Item object.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I've split this off from https://github.com/woocommerce/woocommerce/pull/44181/files and this fixes the same issue as https://github.com/woocommerce/woocommerce/pull/41567

Under PHP 8.2 we see some notices on the frontend:

```
PHP Deprecated: Creation of dynamic property WC_Order_Item_Product::$legacy_values is deprecated
PHP Deprecated: Creation of dynamic property WC_Order_Item_Product::$legacy_cart_item_key is deprecated
PHP Deprecated: Creation of dynamic property WC_Order_Item_Shipping::$legacy_package_key is deprecated
```
By declaring the properties we fix the issue.

Closes #41567

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Before using this PR:

1. Install [query monitor](https://en-gb.wordpress.org/plugins/query-monitor/) plugin on a store running PHP 8.2+
2. browse to the checkout page with items in your cart logged in as admin
3. you'll see "Creation of dynamic property WC_Order_Item_Shipping::$legacy_package_key is deprecated" notices caught by query monitor

After applying this PR:

1. Repeat the above steps. No notices will be caught by query monitor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
