### PR TITLE
Adding accessible markup to pagination template #44376

### DIFF
--- a/plugins/woocommerce/changelog/44376
+++ b/plugins/woocommerce/changelog/44376
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add aria labels to pagination elements for accessibility.

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woo.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.3.1
+ * @version 8.8.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -28,7 +28,7 @@ if ( $total <= 1 ) {
 	return;
 }
 ?>
-<nav class="woocommerce-pagination">
+<nav class="woocommerce-pagination" aria-label="Pagination">
 	<?php
 	echo paginate_links(
 		apply_filters(
@@ -39,11 +39,12 @@ if ( $total <= 1 ) {
 				'add_args'  => false,
 				'current'   => max( 1, $current ),
 				'total'     => $total,
-				'prev_text' => is_rtl() ? '&rarr;' : '&larr;',
-				'next_text' => is_rtl() ? '&larr;' : '&rarr;',
+				'prev_text' => "<span class='screen-reader-text'>" . esc_html__( 'Go to previous page', 'woocommerce' ) . "</span>" . ( is_rtl() ? '&rarr;' : '&larr;' ),
+				'next_text' => "<span class='screen-reader-text'>" . esc_html__( 'Go to next page', 'woocommerce' ) . "</span>" . ( is_rtl() ? '&larr;' : '&rarr;' ),
 				'type'      => 'list',
 				'end_size'  => 3,
 				'mid_size'  => 3,
+				'before_page_number' => "<span class='screen-reader-text'>" . esc_html__( 'Go to page', 'woocommerce' ) . "</span>",
 			)
 		)
 	);


### PR DESCRIPTION
Screen reader software needs accessible markup to dictate links with context.

This PR adds markup so screen readers will describe where each link goes.

Ex. "Go to page 3"

While I was in that template I also added `aria-label="pagination"` to further help screen readers.

Video (🔉 on):

https://github.com/woocommerce/woocommerce/assets/1065372/21778296-415d-4965-9b01-9c9dc2df8714



See full issue: https://github.com/woocommerce/woocommerce/issues/44376


