### PR TITLE
Logging: Add filter to modify the list of expired logs to be deleted

### DIFF
--- a/plugins/woocommerce/changelog/try-expired-logs-filter
+++ b/plugins/woocommerce/changelog/try-expired-logs-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a filter to allow preventing an expired log file from being deleted

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -246,6 +246,8 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 				 * @param bool $delete    True to delete the file.
 				 * @param File $file      The log file object.
 				 * @param int  $timestamp The expiration threshold.
+				 *
+				 * @since 8.7.0
 				 */
 				$delete = apply_filters( 'woocommerce_logger_delete_expired_file', true, $file, $timestamp );
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -233,7 +233,27 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 			)
 		);
 
-		if ( is_wp_error( $files ) || count( $files ) < 1 ) {
+		if ( is_wp_error( $files ) ) {
+			return 0;
+		}
+
+		$files = array_filter(
+			$files,
+			function( $file ) use ( $timestamp ) {
+				/**
+				 * Allows preventing an expired log file from being deleted.
+				 *
+				 * @param bool $delete    True to delete the file.
+				 * @param File $file      The log file object.
+				 * @param int  $timestamp The expiration threshold.
+				 */
+				$delete = apply_filters( 'woocommerce_logger_delete_expired_file', true, $file, $timestamp );
+
+				return boolval( $delete );
+			}
+		);
+
+		if ( count( $files ) < 1 ) {
 			return 0;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -272,31 +272,16 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 				time(),
 				'info',
 				sprintf(
-					'%s %s',
-					sprintf(
-						esc_html(
-							// translators: %s is a number of log files.
-							_n(
-								'%s expired log file was deleted.',
-								'%s expired log files were deleted.',
-								$deleted,
-								'woocommerce'
-							)
-						),
-						number_format_i18n( $deleted )
+					esc_html(
+						// translators: %s is a number of log files.
+						_n(
+							'%s expired log file was deleted.',
+							'%s expired log files were deleted.',
+							$deleted,
+							'woocommerce'
+						)
 					),
-					sprintf(
-						esc_html(
-							// translators: %s is a number of days.
-							_n(
-								'The retention period for log files is %s day.',
-								'The retention period for log files is %s days.',
-								$retention_days,
-								'woocommerce'
-							)
-						),
-						number_format_i18n( $retention_days )
-					)
+					number_format_i18n( $deleted )
 				),
 				array(
 					'source' => 'wc_logger',

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -154,15 +154,25 @@ class Settings {
 			'step' => 1,
 		);
 
+		$desc = array();
+
 		$hardcoded = has_filter( 'woocommerce_logger_days_to_retain_logs' );
-		$desc      = '';
 		if ( $hardcoded ) {
 			$custom_attributes['disabled'] = 'true';
 
-			$desc = sprintf(
+			$desc[] = sprintf(
 				// translators: %s is the name of a filter hook.
 				__( 'This setting cannot be changed here because it is being set by a filter on the %s hook.', 'woocommerce' ),
 				'<code>woocommerce_logger_days_to_retain_logs</code>'
+			);
+		}
+
+		$file_delete_has_filter = LogHandlerFileV2::class === $this->get_default_handler() && has_filter( 'woocommerce_logger_delete_expired_file' );
+		if ( $file_delete_has_filter ) {
+			$desc[] = sprintf(
+				// translators: %s is the name of a filter hook.
+				__( 'The %s hook has a filter set, so some log files may have different retention settings.', 'woocommerce' ),
+				'<code>woocommerce_logger_delete_expired_file</code>'
 			);
 		}
 
@@ -181,7 +191,7 @@ class Settings {
 				' %s',
 				__( 'days', 'woocommerce' ),
 			),
-			'desc'              => $desc,
+			'desc'              => implode( '<br><br>', $desc ),
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This provides a way for extensions to ensure that some log files are retained for a different time period than the normal retention period setting.

### How to test the changes in this Pull Request:

1. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) to generate test log files.
2. In WP Admin, navigate to WooCommerce > Status > Tools. Find the tool called `Debug Log Generator (Back-dated logs)` that's added by the above plugin. Click the `Generate` button to create some log files with various back-dated creation dates.
3. Click on the Logs tab (next to the Tools tab) and note that there should be 6 new log files with the `date-test` source with various creation dates, going back as far as 35 days.
4. Run this wp-cli command: `wp eval 'wc_get_logger()->clear_expired_logs();'` Assuming the retention period in the Logs Settings is set to the default 30 days, this command should result in 3 of those 6 log files being deleted. There should be a new log file with source `wc_logger` that contains an entry about how many files were deleted.
5. Now add this snippet to your test site:
    ```php
	add_filter(
		'woocommerce_logger_delete_expired_file',
		function( $delete, $file ) {
			$threshold = strtotime( '-33 days' );
			if ( $file->get_created_timestamp() < $threshold && 'date-test' === $file->get_source() ) {
				return true;
			}
	
			return false;
		},
		10,
		2
	);
    ```
6. Use the tool to generate some more back-dated logs, and then run the wp-cli command again. This time, only the file that is 35 days old should be deleted.
7. With the snippet added, check the Logs Settings screen. There should be a note next to the Retention Period setting explaining that some log files may have different retention settings because of a filter.