### PR TITLE
Improve remote specifications transient handling and error management

### DIFF
--- a/plugins/woocommerce/changelog/update-store-default-specs-when-fails
+++ b/plugins/woocommerce/changelog/update-store-default-specs-when-fails
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Store default specs into transient when spec rules fails
+Improved Transient Handling and Error Management for PaymentGateways, Free Extensions, and WCPayPromotion

--- a/plugins/woocommerce/changelog/update-store-default-specs-when-fails
+++ b/plugins/woocommerce/changelog/update-store-default-specs-when-fails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Store default specs into transient when spec rules fails

--- a/plugins/woocommerce/changelog/update-store-default-specs-when-fails
+++ b/plugins/woocommerce/changelog/update-store-default-specs-when-fails
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Improved Transient Handling and Error Management for PaymentGateways, Free Extensions, and WCPayPromotion
+Improve remote specifications transient handling and error management

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -155,7 +155,21 @@ abstract class DataSourcePoller {
 	}
 
 	/**
-	 * Read a single data source and return the read specs
+	 * Set the specs transient.
+	 *
+	 * @param array $specs The specs to set in the transient.
+	 * @param int   $expiration The expiration time for the transient.
+	 */
+	public function set_specs_transient( $specs, $expiration = 0 ) {
+		set_transient(
+			$this->args['transient_name'],
+			$specs,
+			$expiration,
+		);
+	}
+
+	/**
+	 *  Read a single data source and return the read specs
 	 *
 	 * @param string $url The URL to read the specs from.
 	 *
@@ -183,7 +197,7 @@ abstract class DataSourcePoller {
 			// phpcs:ignore
 			$logger->error( print_r( $response, true ), $logger_context );
 
-			return [];
+			return array();
 		}
 
 		$body  = $response['body'];
@@ -195,7 +209,7 @@ abstract class DataSourcePoller {
 				$logger_context
 			);
 
-			return [];
+			return array();
 		}
 
 		if ( ! is_array( $specs ) ) {
@@ -204,7 +218,7 @@ abstract class DataSourcePoller {
 				$logger_context
 			);
 
-			return [];
+			return array();
 		}
 
 		return $specs;

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -138,8 +138,7 @@ abstract class DataSourcePoller {
 		$locale                 = get_user_locale();
 		$specs_group[ $locale ] = $specs;
 		// Persist the specs as a transient.
-		set_transient(
-			$this->args['transient_name'],
+		$this->set_specs_transient(
 			$specs_group,
 			$this->args['transient_expiry']
 		);

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -170,7 +170,7 @@ abstract class DataSourcePoller {
 	}
 
 	/**
-	 *  Read a single data source and return the read specs
+	 * Read a single data source and return the read specs
 	 *
 	 * @param string $url The URL to read the specs from.
 	 *

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -133,7 +133,8 @@ abstract class DataSourcePoller {
 			$this->merge_specs( $specs_from_data_source, $specs, $url );
 		}
 
-		$specs_group            = get_transient( $this->args['transient_name'] ) ?? array();
+		$specs_group            = get_transient( $this->args['transient_name'] );
+		$specs_group            = is_array( $specs_group ) ? $specs_group : array();
 		$locale                 = get_user_locale();
 		$specs_group[ $locale ] = $specs;
 		// Persist the specs as a transient.

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
@@ -31,7 +31,6 @@ class EvaluateSuggestion {
 		return $suggestion;
 	}
 
-
 	/**
 	 * Evaluates the specs and returns the visible suggestions.
 	 *

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
@@ -30,4 +30,32 @@ class EvaluateSuggestion {
 
 		return $suggestion;
 	}
+
+
+	/**
+	 * Evaluates the specs and returns the visible suggestions.
+	 *
+	 * @param array $specs payment suggestion spec array.
+	 * @return array The visible suggestions and errors.
+	 */
+	public static function evaluate_specs( $specs ) {
+		$suggestions = array();
+		$errors      = array();
+
+		foreach ( $specs as $spec ) {
+			try {
+				$suggestion = self::evaluate( $spec );
+				if ( ! property_exists( $suggestion, 'is_visible' ) || $suggestion->is_visible ) {
+					$suggestions[] = $suggestion;
+				}
+			} catch ( \Throwable $e ) {
+				$errors[] = $e;
+			}
+		}
+
+		return array(
+			'suggestions' => $suggestions,
+			'errors'      => $errors,
+		);
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -35,19 +35,27 @@ class Init {
 	 * @return array
 	 */
 	public static function get_suggestions( array $specs = null ) {
-		$suggestions = array();
 		if ( null === $specs ) {
 			$specs = self::get_specs();
 		}
 
+		$suggestions = array();
+		$has_error   = false;
 		foreach ( $specs as $spec ) {
 			try {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
 				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			} catch ( \Throwable $e ) {
-				// Ignore errors.
+				$has_error = true;
 			}
+		}
+
+		if ( $has_error ) {
+			PaymentGatewaySuggestionsDataSourcePoller::get_instance()->set_specs_transient(
+				DefaultPaymentGateways::get_all(),
+				3 * HOUR_IN_SECONDS
+			);
 		}
 
 		return array_values(

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -57,7 +57,7 @@ class EvaluateExtension {
 	 * @param array $allowed_bundles Optional array of allowed bundles to be returned.
 	 * @return array The bundles and errors.
 	 */
-	public static function evaluate_bundles( $specs, $allowed_bundles ) {
+	public static function evaluate_bundles( $specs, $allowed_bundles = array() ) {
 		$bundles = array();
 
 		foreach ( $specs as $spec ) {

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -49,4 +49,44 @@ class EvaluateExtension {
 
 		return $extension;
 	}
+
+	/**
+	 * Evaluates the specs and returns the bundles with visible extensions.
+	 *
+	 * @param array $specs extensions spec array.
+	 * @param array $allowed_bundles Optional array of allowed bundles to be returned.
+	 * @return array The bundles and errors.
+	 */
+	public static function evaluate_bundles( $specs, $allowed_bundles ) {
+		$bundles = array();
+
+		foreach ( $specs as $spec ) {
+			$spec              = (object) $spec;
+			$bundle            = (array) $spec;
+			$bundle['plugins'] = array();
+
+			if ( ! empty( $allowed_bundles ) && ! in_array( $spec->key, $allowed_bundles, true ) ) {
+				continue;
+			}
+
+			$errors = array();
+			foreach ( $spec->plugins as $plugin ) {
+				try {
+					$extension = self::evaluate( (object) $plugin );
+					if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
+						$bundle['plugins'][] = $extension;
+					}
+				} catch ( \Throwable $e ) {
+					$errors[] = $e;
+				}
+			}
+
+			$bundles[] = $bundle;
+		}
+
+		return array(
+			'bundles' => $bundles,
+			'errors'  => $errors,
+		);
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
@@ -41,16 +41,23 @@ class Init {
 				continue;
 			}
 
+			$has_error = false;
 			foreach ( $spec->plugins as $plugin ) {
 				try {
 					$extension = EvaluateExtension::evaluate( (object) $plugin );
 					if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
 						$bundle['plugins'][] = $extension;
 					}
-					// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 				} catch ( \Throwable $e ) {
-					// Ignore errors.
+					$has_error = true;
 				}
+			}
+
+			if ( $has_error ) {
+				RemoteFreeExtensionsDataSourcePoller::get_instance()->set_specs_transient(
+					DefaultFreeExtensions::get_all(),
+					3 * HOUR_IN_SECONDS
+				);
 			}
 
 			$bundles[] = $bundle;

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
@@ -41,14 +41,16 @@ class Init {
 			}
 		);
 
-		if ( count( $results['errors'] ) > 0 ) {
-			$specs = empty( $plugins ) ? DefaultFreeExtensions::get_all() : $specs;
-			// Set the specs transient with expired time to 3 hours.
-			RemoteFreeExtensionsDataSourcePoller::get_instance()->set_specs_transient( array( $locale => $specs ), 3 * HOUR_IN_SECONDS );
+		// When no plugins are visible, replace it with defaults and save for 3 hours.
+		if ( empty( $plugins ) ) {
+			RemoteFreeExtensionsDataSourcePoller::get_instance()->set_specs_transient( array( $locale => DefaultFreeExtensions::get_all() ), 3 * HOUR_IN_SECONDS );
 
-			if ( empty( $plugins ) ) {
-				return EvaluateExtension::evaluate_bundles( DefaultFreeExtensions::get_all() )['bundles'];
-			}
+			return EvaluateExtension::evaluate_bundles( DefaultFreeExtensions::get_all(), $allowed_bundles )['bundles'];
+		}
+
+		// When plugins is not empty but has errors, save it for 3 hours.
+		if ( count( $results['errors'] ) > 0 ) {
+			RemoteFreeExtensionsDataSourcePoller::get_instance()->set_specs_transient( array( $locale => $specs ), 3 * HOUR_IN_SECONDS );
 		}
 
 		return $results['bundles'];

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -30,8 +30,8 @@ class Init {
 		}
 
 		add_filter( 'woocommerce_payment_gateways', array( __CLASS__, 'possibly_register_pre_install_wc_pay_promotion_gateway' ) );
-		add_filter( 'option_woocommerce_gateway_order', [ __CLASS__, 'set_gateway_top_of_list' ] );
-		add_filter( 'default_option_woocommerce_gateway_order', [ __CLASS__, 'set_gateway_top_of_list' ] );
+		add_filter( 'option_woocommerce_gateway_order', array( __CLASS__, 'set_gateway_top_of_list' ) );
+		add_filter( 'default_option_woocommerce_gateway_order', array( __CLASS__, 'set_gateway_top_of_list' ) );
 
 		$rtl = is_rtl() ? '.rtl' : '';
 
@@ -122,17 +122,22 @@ class Init {
 	 * Go through the specs and run them.
 	 */
 	public static function get_promotions() {
-		$suggestions = array();
-		$specs       = self::get_specs();
+		$specs = self::get_specs();
 
+		$suggestions = array();
+		$has_error   = false;
 		foreach ( $specs as $spec ) {
 			try {
 				$suggestion    = EvaluateSuggestion::evaluate( $spec );
 				$suggestions[] = $suggestion;
 				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			} catch ( \Throwable $e ) {
-				// Ignore errors.
+				$has_error = true;
 			}
+		}
+
+		if ( $has_error ) {
+			WCPayPromotionDataSourcePoller::get_instance()->set_specs_transient( array(), 3 * HOUR_IN_SECONDS );
 		}
 
 		return array_values(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Admin\DataSourcePoller;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as PaymentGatewaySuggestions;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\DefaultPaymentGateways;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\PaymentGatewaySuggestionsDataSourcePoller;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\PassRuleProcessor;
 
 /**
  * class WC_Admin_Tests_PaymentGatewaySuggestions_Init
@@ -59,10 +60,18 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 		return array(
 			'en_US' => array(
 				array(
-					'id'         => 'mock-gateway',
+					'id'         => 'mock-gateway-1',
 					'is_visible' => (object) array(
 						'type'      => 'base_location_country',
 						'value'     => 'ZA',
+						'operation' => '=',
+					),
+				),
+				array(
+					'id'         => 'mock-gateway-2',
+					'is_visible' => (object) array(
+						'type'      => 'base_location_country',
+						'value'     => 'US',
 						'operation' => '=',
 					),
 				),
@@ -111,27 +120,15 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 	/**
 	 * Test that non-matched suggestions are not shown.
 	 */
-	public function test_non_matching_suggestions() {
+	public function test_matching_suggestions() {
 		update_option( 'woocommerce_default_country', 'US' );
 		set_transient(
 			'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
 			$this->get_mock_specs()
 		);
 		$suggestions = PaymentGatewaySuggestions::get_suggestions();
-		$this->assertCount( 0, $suggestions );
-	}
-
-	/**
-	 * Test that matched suggestions are shown.
-	 */
-	public function test_matching_suggestions() {
-		update_option( 'woocommerce_default_country', 'ZA' );
-		set_transient(
-			'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
-			$this->get_mock_specs()
-		);
-		$suggestions = PaymentGatewaySuggestions::get_suggestions();
-		$this->assertEquals( 'mock-gateway', $suggestions[0]->id );
+		$this->assertCount( 1, $suggestions );
+		$this->assertEquals( 'mock-gateway-2', $suggestions[0]->id );
 	}
 
 	/**
@@ -163,6 +160,27 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 
 		$suggestions = PaymentGatewaySuggestions::get_suggestions();
 		$this->assertEquals( 'default-gateway', $suggestions[0]->id );
+	}
+
+	/**
+	 * Test that empty suggestions are replaced with defaults.
+	 */
+	public function test_empty_suggestions() {
+		set_transient(
+			'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
+			array(
+				'en_US' => array(),
+			)
+		);
+
+		$suggestions       = PaymentGatewaySuggestions::get_suggestions();
+		$stored_transients = get_transient( 'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs' );
+
+		$this->assertEquals( 'bacs', $suggestions[0]->id );
+		$this->assertEquals( count( $stored_transients['en_US'] ), count( DefaultPaymentGateways::get_all() ) );
+
+		$expires = (int) get_transient( '_transient_timeout_woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs' );
+		$this->assertTrue( ( $expires - time() ) < 3 * HOUR_IN_SECONDS );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -180,7 +180,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 		$this->assertEquals( count( $stored_transients['en_US'] ), count( DefaultPaymentGateways::get_all() ) );
 
 		$expires = (int) get_transient( '_transient_timeout_woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs' );
-		$this->assertTrue( ( $expires - time() ) < 3 * HOUR_IN_SECONDS );
+		$this->assertTrue( ( $expires - time() ) <= 3 * HOUR_IN_SECONDS );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/InitTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\RemoteFreeExtensions;
+
+use Automattic\WooCommerce\Admin\DataSourcePoller;
+
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init as RemoteFreeExtensions;
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\DefaultFreeExtensions;
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\RemoteFreeExtensionsDataSourcePoller;
+use WC_Unit_Test_Case;
+
+/**
+ * class WC_Admin_Tests_RemoteFreeExtensions_Init
+ *
+ * @covers \Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init
+ */
+class InitTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		delete_option( 'woocommerce_show_marketplace_suggestions' );
+		add_filter(
+			'transient_woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs',
+			function( $value ) {
+				if ( $value ) {
+					return $value;
+				}
+
+				$locale = get_user_locale();
+
+				return array(
+					$locale => array(
+						array(
+							'key'     => 'obw/basics',
+							'title'   => __( 'Get the basics', 'woocommerce' ),
+							'plugins' => array(
+								array(
+									'name'       => 'mock-extension-1',
+									'key'        => 'mock-extension-1',
+									'is_visible' => (object) array(
+										'type'      => 'base_location_country',
+										'value'     => 'ZA',
+										'operation' => '=',
+									),
+								),
+								array(
+									'name'       => 'mock-extension-2',
+									'key'        => 'mock-extension-2',
+									'is_visible' => (object) array(
+										'type'      => 'base_location_country',
+										'value'     => 'US',
+										'operation' => '=',
+									),
+								),
+							),
+						),
+					),
+				);
+			},
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		RemoteFreeExtensions::delete_specs_transient();
+		remove_all_filters( 'transient_woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
+		update_option( 'woocommerce_default_country', 'US' );
+	}
+
+	/**
+	 * Test that default extensions are provided when remote sources don't exist.
+	 */
+	public function test_get_default_specs() {
+		remove_all_filters( 'transient_woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
+		add_filter(
+			DataSourcePoller::FILTER_NAME,
+			function() {
+				return array();
+			}
+		);
+		$specs    = RemoteFreeExtensions::get_specs();
+		$defaults = DefaultFreeExtensions::get_all();
+		remove_all_filters( DataSourcePoller::FILTER_NAME );
+		$this->assertEquals( $defaults, $specs );
+	}
+
+	/**
+	 * Test that specs are read from cache when they exist.
+	 */
+	public function test_specs_transient() {
+		set_transient(
+			'woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs',
+			array(
+				'en_US' => array(
+					array(
+						'name' => 'mock1',
+					),
+					array(
+						'name' => 'mock2',
+					),
+				),
+			)
+		);
+		$specs = RemoteFreeExtensions::get_specs();
+		$this->assertCount( 2, $specs );
+	}
+
+
+	/**
+	 * Test that matched extensions are shown.
+	 */
+	public function test_matching_extensions() {
+		update_option( 'woocommerce_default_country', 'ZA' );
+		$bundles = RemoteFreeExtensions::get_extensions();
+		$this->assertEquals( 'mock-extension-1', $bundles[0]['plugins'][0]->name );
+		$this->assertCount( 1, $bundles[0]['plugins'] );
+	}
+
+	/**
+	 * Test that empty bundles are replaced with defaults.
+	 */
+	public function test_empty_extensions() {
+		set_transient(
+			'woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs',
+			array(
+				'en_US' => array(),
+			)
+		);
+
+		$bundles           = RemoteFreeExtensions::get_extensions();
+		$stored_transients = get_transient( 'woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
+		$this->assertTrue( count( $bundles ) > 1 );
+		$this->assertEquals( count( $stored_transients['en_US'] ), count( DefaultFreeExtensions::get_all() ) );
+
+		$expires = (int) get_transient( '_transient_timeout_woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
+		$this->assertTrue( ( $expires - time() ) < 3 * HOUR_IN_SECONDS );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/WCPayPromotion/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/WCPayPromotion/InitTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\WCPayPromotion;
+
+use Automattic\WooCommerce\Admin\DataSourcePoller;
+
+use Automattic\WooCommerce\Internal\Admin\WCPayPromotion\Init as WCPayPromotion;
+use Automattic\WooCommerce\Internal\Admin\WCPayPromotion\WCPayPromotionDataSourcePoller;
+use WC_Unit_Test_Case;
+
+/**
+ * class WC_Admin_Tests_WCPayPromotion_Init
+ *
+ * @covers \Automattic\WooCommerce\Internal\Admin\WCPayPromotion\Init
+ */
+class InitTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		delete_option( 'woocommerce_show_marketplace_suggestions' );
+		add_filter(
+			'transient_woocommerce_admin_' . WCPayPromotionDataSourcePoller::ID . '_specs',
+			function( $value ) {
+				if ( $value ) {
+					return $value;
+				}
+
+				$locale = get_user_locale();
+
+				return array(
+					$locale => array(
+						array(
+							'id'         => 'mock-gateway',
+							'is_visible' => (object) array(
+								'type'      => 'base_location_country',
+								'value'     => 'ZA',
+								'operation' => '=',
+							),
+						),
+					),
+				);
+			}
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WCPayPromotion::delete_specs_transient();
+		remove_all_filters( 'transient_woocommerce_admin_' . WCPayPromotionDataSourcePoller::ID . '_specs' );
+		update_option( 'woocommerce_default_country', 'US' );
+	}
+
+	/**
+	 * Test that default specs are provided when remote sources don't exist.
+	 */
+	public function test_get_default_specs() {
+		remove_all_filters( 'transient_woocommerce_admin_' . WCPayPromotionDataSourcePoller::ID . '_specs' );
+		add_filter(
+			DataSourcePoller::FILTER_NAME,
+			function() {
+				return array();
+			}
+		);
+		$specs = WCPayPromotion::get_specs();
+		remove_all_filters( DataSourcePoller::FILTER_NAME );
+		$this->assertEquals( array(), $specs );
+	}
+
+	/**
+	 * Test that specs are read from cache when they exist.
+	 */
+	public function test_specs_transient() {
+		set_transient(
+			'woocommerce_admin_' . WCPayPromotionDataSourcePoller::ID . '_specs',
+			array(
+				'en_US' => array(
+					array(
+						'id' => 'mock1',
+					),
+					array(
+						'id' => 'mock2',
+					),
+				),
+			)
+		);
+		$specs = WCPayPromotion::get_specs();
+		$this->assertCount( 2, $specs );
+	}
+
+	/**
+	 * Test that non-matching suggestions are not shown.
+	 */
+	public function test_non_matching_extensions() {
+		update_option( 'woocommerce_default_country', 'US' );
+		$promotions = WCPayPromotion::get_promotions();
+		$this->assertCount( 0, $promotions );
+	}
+
+	/**
+	 * Test that matched suggestions are shown.
+	 */
+	public function test_matching_suggestions() {
+		update_option( 'woocommerce_default_country', 'ZA' );
+		$promotions = WCPayPromotion::get_promotions();
+		$this->assertEquals( 'mock-gateway', $promotions[0]->id );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/44261.

1. Improve remote specifications transient handling and error management

For PaymentGatewaySuggestions and RemoteFreeExtensions,
- When "suggestions" is empty, replace transient with defaults and save for 3 hours
- When "suggestions" is not empty but has errors, save transient for 3 hours

For WCPayPromotion:
- When it has errors, save the transient for 3 hours
- We don't need to replace the transient with defaults because the default is an empty array. DataSourcePoller will always re-fetch the data when it's an empty array.

2. Adds unit tests


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Testing

**Test remote specs still work as expected**

1. If using an existing site, clear transients by running `wp transient delete --all`
2. Ensure WooCommerce > Settings > Advanced > Woo.com > `Display suggestions within WooCommerce` is checked
3. Go to Setup Wizard, `/wp-admin/admin.php?page=wc-admin&path=/setup-wizard`
5. Click continue
6. In `the Which one of these best describes you?` step, select `I'm already selling` and `I'm selling both online and offline`

7. Select `Australia — Australian Capital Territory` and continue
8. Skip plugin installation
9. Observe no fatal when loading homescreen
10. Go to `Tools > WCA Test Helper > Tools`, Run `wc_admin_daily` job
11. Ensure the job is run successfully
12. Go to `/wp-admin/admin.php?page=wc-admin&task=payments`
13. Confirm it displays the gateways like below

<img src="https://github.com/woocommerce/woocommerce/assets/4344253/4a8cd771-4079-4859-9ad3-87dbf4d801ec" width="500px" />

14. Run `wp transient get timeout_woocommerce_admin_payment_gateway_suggestions_specs`
15. Confirm it returns a timestamp that is about 7 days from now 
16. Run `wp transient get timeout_woocommerce_admin_remote_free_extensions_specs`
17.  Confirm it returns a timestamp that is about 7 days from now 
18. Run` wp transient get timeout_woocommerce_admin_payment_method_promotion_specs`
19.  Confirm it returns a timestamp that is about 7 days from now 

**Has errors**

Setup:

1. Cherry-pick the commit a2bf028baa5a03279fa9813016f28a08410da1fb from [this branch](https://github.com/woocommerce/woocommerce/commit/a2bf028baa5a03279fa9813016f28a08410da1fb)
2. Or manually set the following APIs
    - PaymentGatewaySuggestionsDataSourcePoller ([file](https://github.com/woocommerce/woocommerce/blob/0aebb139c2b1004879dca63825dc6654c4f46bea/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaySuggestionsDataSourcePoller.php#L21)): https://api.npoint.io/83d63d29d478ececdbc5
    - RemoteFreeExtensionsDataSourcePoller ([file](https://github.com/woocommerce/woocommerce/blob/0aebb139c2b1004879dca63825dc6654c4f46bea/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php#L13)): https://api.npoint.io/34e72d8b75957e47ff1e
    - WCPayPromotionDataSourcePoller ([file](https://github.com/woocommerce/woocommerce/blob/0aebb139c2b1004879dca63825dc6654c4f46bea/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPayPromotionDataSourcePoller.php#L17)): https://api.npoint.io/6eed3f7093fa2ca8fd1f
   - make the [!contains' and 'in'](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php#L43-L58) to throw an exception 

```php
throw new Exception( 'Fail' );
```

1. Run`wp transient delete --all`
2. Ensure WooCommerce > Settings > Advanced > Woo.com > `Display suggestions within WooCommerce` is checked
3. Go to `Tools > WCA Test Helper > Tools`, Run `wc_admin_daily` job
4. Ensure the job is run successfully
5. Go to `/wp-admin/admin.php?page=wc-admin&task=payments`
6. Observe that it shows `Airwallex Payments` gateway

<img src="https://github.com/woocommerce/woocommerce/assets/4344253/0c4b0be1-353c-45e7-8515-6b3c517693b2" width="500px" />


7. Go to `/wp-admin/admin.php?page=wc-admin&task=marketing`
8. Observe that it shows `Google Listings & Ads`, `Pinterest for WooCommerce`, and `TikTok for WooCommerce` in GROW YOUR STOR section.
9. Run `wp transient get woocommerce_admin_payment_gateway_suggestions_specs --format=json`
10. Observe that it returns default specs instead of specs from https://api.npoint.io/83d63d29d478ececdbc5

```json
{"en_US":[{"id":"affirm","title":"Affirm","content":"Affirm\u2019s tailored Buy Now Pay Later programs remove price as a barrier, turning browsers into buyers, increasing average order value, and expanding your customer base."......
```

11. Run `wp transient get timeout_woocommerce_admin_payment_gateway_suggestions_specs`
12. Confirm it returns a timestamp that is less than 3 hours from now
13. Run `wp transient get woocommerce_admin_remote_free_extensions_specs --format=json`
14. Observe that it returns default specs instead of specs from https://api.npoint.io/34e72d8b75957e47ff1e
```json
{"en_US":[{"key":"obw\/basics","title":"Get the basics","plugins":[{"name":"WooPayments","image_url":"http:\/\/localhost:8885\/mywordpress\/wp-content\/plugins\/woocommerce\/assets\/images\/onboarding\/wcpay.svg","description":"Accept credit cards and other popular payment methods with <a href=\"https:\/\/woo.com\/products\/woocommerce-payments\" target=\"_blank\">WooPayments<\/a>","is_visible":[{"type":"or","operands":[{"type":"base_location_country","value":"US","operation":"="},{"type":"base_location_country","value":"PR","operation":"="},{"type":"base_location_country","value":"AU","operation":"="},{"type":"base_location_country","value":"CA","operation":"="},....
```

15. Run `wp transient get timeout_woocommerce_admin_remote_free_extensions_specs`
16. Confirm it returns a timestamp that is less than 3 hours from now.
17. Run `wp transient get woocommerce_admin_payment_method_promotion_specs --format=json`
18. Observe that it returns same data as https://api.npoint.io/6eed3f7093fa2ca8fd1f
19. Run `wp transient get timeout_woocommerce_admin_payment_method_promotion_specs`
20. Confirm it returns a timestamp that is less than 3 hours from now.

## Test 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
