### PR TITLE
[CYS] Fix - Add back parent machine to the `designWithNoAiStateMachineDefinition` child machine option

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/index.tsx
@@ -23,6 +23,7 @@ export type DesignWithoutAiComponentMeta = {
 };
 
 export const DesignWithNoAiController = ( {
+	parentMachine,
 	parentContext,
 }: {
 	parentMachine?: AnyInterpreter;
@@ -31,6 +32,7 @@ export const DesignWithNoAiController = ( {
 } ) => {
 	const [ , , service ] = useMachine( designWithNoAiStateMachineDefinition, {
 		devTools: process.env.NODE_ENV === 'development',
+		parent: parentMachine,
 		context: {
 			...designWithNoAiStateMachineDefinition.context,
 			isFontLibraryAvailable:

--- a/plugins/woocommerce/changelog/44397-add-back-parent-machine
+++ b/plugins/woocommerce/changelog/44397-add-back-parent-machine
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix - Add back the parent machine to the `designWithNoAiStateMachineDefinition` child machine option.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PRs brings back the `parent` option which was removed https://github.com/woocommerce/woocommerce/pull/44358/files#diff-131db08faf692fcb6f26787e0a49d747ddd753d9ba4a7d110bfacc29cf774bc9L34
This was causing the CYS flow to get stuck and an error when some of the steps in the `designWithNoAiStateMachineDefinition` needed to go to the `onError` handler:
<img width="1508" alt="Screenshot 2024-02-06 at 13 20 58" src="https://github.com/woocommerce/woocommerce/assets/186112/c5168d63-6120-448e-9fee-5a3360b3779f">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. After the `try {`, add this line of code: `throw new Error( 'Product creation failed' );` ([source code](https://github.com/woocommerce/woocommerce/blob/30cf0a47d28725394becee34e51cd595e817d04e/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts))
![image](https://github.com/woocommerce/woocommerce/assets/4463174/78c6e952-a31c-43e2-b368-3ebc2a113d03)
5. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`
6. Follow the process.
7. Ensure that you are redirected to the intro page with an error message on top.
8. Click on `Please try again` and ensure that the process starts again and you keep getting the error.
9. Click on the `Start designing` button and ensure that the process starts again and you keep getting the error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix - Add back the parent machine to the `designWithNoAiStateMachineDefinition` child machine option.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>