### PR TITLE
Adding accessible markup to sale price.

### DIFF
--- a/plugins/woocommerce/changelog/31099
+++ b/plugins/woocommerce/changelog/31099
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Improve accessibility of sale price markup.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1291,14 +1291,25 @@ function wc_format_stock_quantity_for_display( $stock_quantity, $product ) {
  */
 function wc_format_sale_price( $regular_price, $sale_price ) {
 	
-	$price = '<del>
-			<span class="screen-reader-text">' . esc_html__('Original price was:', 'woocommerce') . '</span> ' 
-			. ( is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price ) . 
-		'</del> 
-		<ins>
-			<span class="screen-reader-text">' . esc_html__('Current price is:', 'woocommerce') . '</span> ' 
-			. ( is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price ) . 
-		'</ins>';
+	// format the prices 
+	$formatted_regular_price = is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price;
+	$formatted_sale_price = is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price;
+
+	// strike through pricing
+	$price = '<del aria-hidden="true">' . $formatted_regular_price . '</del> ';
+
+	// for accessibility (a11y) we'll also display that information to screen readers
+	$price .= '<span class="screen-reader-text">';
+	$price .= sprintf( esc_html__( 'Original price was: %s.', 'woocommerce' ), $formatted_regular_price );
+	$price .= '</span>';
+
+	// add the sale price
+	$price .= '<ins aria-hidden="true">' . $formatted_sale_price . '</ins>';
+
+	// for accessibility (a11y) we'll also display that information to screen readers
+	$price .= '<span class="screen-reader-text">';
+	$price .= sprintf( esc_html__( 'Current price is: %s.', 'woocommerce' ), $formatted_sale_price );
+	$price .= '</span>';
 
 	return apply_filters( 'woocommerce_format_sale_price', $price, $regular_price, $sale_price );
 }

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1300,7 +1300,7 @@ function wc_format_sale_price( $regular_price, $sale_price ) {
 
 	// for accessibility (a11y) we'll also display that information to screen readers
 	$price .= '<span class="screen-reader-text">';
-	$price .= sprintf( esc_html__( 'Original price was: %s.', 'woocommerce' ), $formatted_regular_price );
+	$price .= esc_html( sprintf( __( 'Original price was: %s.', 'woocommerce' ), wp_strip_all_tags( $formatted_regular_price ) ) );
 	$price .= '</span>';
 
 	// add the sale price
@@ -1308,7 +1308,7 @@ function wc_format_sale_price( $regular_price, $sale_price ) {
 
 	// for accessibility (a11y) we'll also display that information to screen readers
 	$price .= '<span class="screen-reader-text">';
-	$price .= sprintf( esc_html__( 'Current price is: %s.', 'woocommerce' ), $formatted_sale_price );
+	$price .= esc_html( sprintf( __( 'Current price is: %s.', 'woocommerce' ), wp_strip_all_tags( $formatted_sale_price ) ) );
 	$price .= '</span>';
 
 	return apply_filters( 'woocommerce_format_sale_price', $price, $regular_price, $sale_price );

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1290,26 +1290,25 @@ function wc_format_stock_quantity_for_display( $stock_quantity, $product ) {
  * @return string
  */
 function wc_format_sale_price( $regular_price, $sale_price ) {
-
-	// format the prices
+	// Format the prices.
 	$formatted_regular_price = is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price;
-	$formatted_sale_price = is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price;
+	$formatted_sale_price    = is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price;
 
-	// strike through pricing
+	// Strikethrough pricing.
 	$price = '<del aria-hidden="true">' . $formatted_regular_price . '</del> ';
 
-	// for accessibility (a11y) we'll also display that information to screen readers
+	// For accessibility (a11y) we'll also display that information to screen readers.
 	$price .= '<span class="screen-reader-text">';
-	// translators: Original price was %s. E.g. Original price was $20.00.
+	// translators: %s is a product's regular price.
 	$price .= esc_html( sprintf( __( 'Original price was: %s.', 'woocommerce' ), wp_strip_all_tags( $formatted_regular_price ) ) );
 	$price .= '</span>';
 
-	// add the sale price
+	// Add the sale price.
 	$price .= '<ins aria-hidden="true">' . $formatted_sale_price . '</ins>';
 
-	// for accessibility (a11y) we'll also display that information to screen readers
+	// For accessibility (a11y) we'll also display that information to screen readers.
 	$price .= '<span class="screen-reader-text">';
-	// translators: Current price is %s. E.g. Current price is $15.00.
+	// translators: %s is a product's current (sale) price.
 	$price .= esc_html( sprintf( __( 'Current price is: %s.', 'woocommerce' ), wp_strip_all_tags( $formatted_sale_price ) ) );
 	$price .= '</span>';
 

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1290,8 +1290,8 @@ function wc_format_stock_quantity_for_display( $stock_quantity, $product ) {
  * @return string
  */
 function wc_format_sale_price( $regular_price, $sale_price ) {
-	
-	// format the prices 
+
+	// format the prices
 	$formatted_regular_price = is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price;
 	$formatted_sale_price = is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price;
 

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1290,7 +1290,16 @@ function wc_format_stock_quantity_for_display( $stock_quantity, $product ) {
  * @return string
  */
 function wc_format_sale_price( $regular_price, $sale_price ) {
-	$price = '<del aria-hidden="true">' . ( is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price ) . '</del> <ins>' . ( is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price ) . '</ins>';
+	
+	$price = '<del>
+			<span class="screen-reader-text">' . esc_html__('Original price was:', 'woocommerce') . '</span> ' 
+			. ( is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price ) . 
+		'</del> 
+		<ins>
+			<span class="screen-reader-text">' . esc_html__('Current price is:', 'woocommerce') . '</span> ' 
+			. ( is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price ) . 
+		'</ins>';
+
 	return apply_filters( 'woocommerce_format_sale_price', $price, $regular_price, $sale_price );
 }
 

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1300,6 +1300,7 @@ function wc_format_sale_price( $regular_price, $sale_price ) {
 
 	// for accessibility (a11y) we'll also display that information to screen readers
 	$price .= '<span class="screen-reader-text">';
+	// translators: Original price was %s. E.g. Original price was $20.00.
 	$price .= esc_html( sprintf( __( 'Original price was: %s.', 'woocommerce' ), wp_strip_all_tags( $formatted_regular_price ) ) );
 	$price .= '</span>';
 
@@ -1308,6 +1309,7 @@ function wc_format_sale_price( $regular_price, $sale_price ) {
 
 	// for accessibility (a11y) we'll also display that information to screen readers
 	$price .= '<span class="screen-reader-text">';
+	// translators: Current price is %s. E.g. Current price is $15.00.
 	$price .= esc_html( sprintf( __( 'Current price is: %s.', 'woocommerce' ), wp_strip_all_tags( $formatted_sale_price ) ) );
 	$price .= '</span>';
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-edit.spec.js
@@ -163,7 +163,7 @@ baseTest.describe( 'Products > Edit Product', () => {
 					.soft( page.locator( 'p' ).locator( 'del' ) )
 					.toHaveText( `$${ expectedRegularPrice }` );
 				await expect
-					.soft( page.locator( 'p' ).getByRole( 'insertion' ) )
+					.soft( page.locator( 'p' ).locator( 'ins' ) )
 					.toHaveText( `$${ expectedSalePrice }` );
 				await expect
 					.soft( page.getByText( `${ expectedStockQty } in stock` ) )

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -932,7 +932,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_format_sale_price() {
-		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <ins><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span></ins>', wc_format_sale_price( '10', '5' ) );
+		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;10.00.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;5.00.</span>', wc_format_sale_price( '10', '5' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
@@ -262,11 +262,11 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 
 		$product = wc_get_product( $product1_id );
 		$this->assertEquals( $product1_id, $product->get_id() );
-		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <ins><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>7.00</bdi></span></ins>', $product->get_price_html() );
+		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;10.00.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>7.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;7.00.</span>', $product->get_price_html() );
 
 		$product = wc_get_product( $product2_id );
 		$this->assertEquals( $product2_id, $product->get_id() );
-		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>20.00</bdi></span></del> <ins><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>16.00</bdi></span></ins>', $product->get_price_html() );
+		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>20.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;20.00.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>16.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;16.00.</span>', $product->get_price_html() );
 
 		$product = wc_get_product( $product3_id );
 		$this->assertEquals( $product3_id, $product->get_id() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds accessible markup to the sale price.

A user who only uses screen reader software can now hear and understand the original price as well as the current (sale) price.

This is important for accessibility.

Here's a demo (🔉 on):

https://github.com/woocommerce/woocommerce/assets/1065372/e35fb5af-aac0-4af0-85c6-64d74d3e2f87

Full issue: https://github.com/woocommerce/woocommerce/issues/31099

### How to test the changes in this Pull Request:
1. Create a simple product in WC > Products with a sale price set.
2. Click its permalink on the admin or search for the product on the frontend and go to the product's page.
3. Using the devtools inspector choose the area around the product price (or look for the `<p class="price">` tag).
4. Confirm that both the `<del>` and `<ins>` tags are present and have `aria-hidden` set. These tags should include the original and sale price, respectively (see screenshot below).
5. Confirm that there are a couple of `<span>` tags with class `screen-reader-text` which clarify with text what the original and current prices are (see screenshot below).

<img width="465" alt="Screenshot 2024-03-14 at 09 28 29" src="https://github.com/woocommerce/woocommerce/assets/184724/8204638b-0d58-403c-84ae-a784d9f58e75">
