### PR TITLE
Product Gallery block: Focus should return to trigger element when closing pop-up

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { store, getContext as getContextFn } from '@woocommerce/interactivity';
+import {
+	store,
+	getContext as getContextFn,
+	getElement,
+} from '@woocommerce/interactivity';
 import { StorePart } from '@woocommerce/utils';
 
 export interface ProductGalleryContext {
@@ -12,6 +16,7 @@ export interface ProductGalleryContext {
 	dialogVisibleImagesIds: string[];
 	isDialogOpen: boolean;
 	productId: string;
+	elementThatTriggeredDialogOpening: HTMLElement | null;
 }
 
 const getContext = ( ns?: string ) =>
@@ -41,6 +46,11 @@ const closeDialog = ( context: ProductGalleryContext ) => {
 	// Reset the main image.
 	context.selectedImage = context.firstMainImageId;
 	document.body.classList.remove( 'wc-block-product-gallery-modal-open' );
+
+	if ( context.elementThatTriggeredDialogOpening ) {
+		context.elementThatTriggeredDialogOpening?.focus();
+		context.elementThatTriggeredDialogOpening = null;
+	}
 };
 
 const productGallery = {
@@ -127,6 +137,9 @@ const productGallery = {
 					event.preventDefault();
 				}
 				actions.openDialog();
+				const largeImageElement = getElement()?.ref as HTMLElement;
+				const context = getContext();
+				context.elementThatTriggeredDialogOpening = largeImageElement;
 			}
 		},
 		onViewAllImagesKeyDown: ( event: KeyboardEvent ) => {
@@ -139,6 +152,10 @@ const productGallery = {
 					event.preventDefault();
 				}
 				actions.openDialog();
+				const viewAllImagesElement = getElement()?.ref as HTMLElement;
+				const context = getContext();
+				context.elementThatTriggeredDialogOpening =
+					viewAllImagesElement;
 			}
 		},
 	},

--- a/plugins/woocommerce/changelog/44414-fix-42335-focus-should-return-to-trigger-element-when-closing-pop-up
+++ b/plugins/woocommerce/changelog/44414-fix-42335-focus-should-return-to-trigger-element-when-closing-pop-up
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Focus return to the trigger element when closing the Product Gallery Pop-Up

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -141,13 +141,14 @@ class ProductGallery extends AbstractBlock {
 				'data-wc-context',
 				wp_json_encode(
 					array(
-						'selectedImage'                   => $product_gallery_first_image_id,
-						'firstMainImageId'                => $product_gallery_first_image_id,
-						'isDialogOpen'                    => false,
-						'visibleImagesIds'                => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
-						'dialogVisibleImagesIds'          => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
-						'mouseIsOverPreviousOrNextButton' => false,
-						'productId'                       => $product_id,
+						'selectedImage'                     => $product_gallery_first_image_id,
+						'firstMainImageId'                  => $product_gallery_first_image_id,
+						'isDialogOpen'                      => false,
+						'visibleImagesIds'                  => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
+						'dialogVisibleImagesIds'            => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
+						'mouseIsOverPreviousOrNextButton'   => false,
+						'productId'                         => $product_id,
+						'elementThatTriggeredDialogOpening' => null,
 					)
 				)
 			);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -141,13 +141,13 @@ class ProductGallery extends AbstractBlock {
 				'data-wc-context',
 				wp_json_encode(
 					array(
-						'selectedImage'                     => $product_gallery_first_image_id,
-						'firstMainImageId'                  => $product_gallery_first_image_id,
-						'isDialogOpen'                      => false,
-						'visibleImagesIds'                  => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
-						'dialogVisibleImagesIds'            => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
-						'mouseIsOverPreviousOrNextButton'   => false,
-						'productId'                         => $product_id,
+						'selectedImage'                   => $product_gallery_first_image_id,
+						'firstMainImageId'                => $product_gallery_first_image_id,
+						'isDialogOpen'                    => false,
+						'visibleImagesIds'                => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
+						'dialogVisibleImagesIds'          => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
+						'mouseIsOverPreviousOrNextButton' => false,
+						'productId'                       => $product_id,
 						'elementThatTriggeredDialogOpening' => null,
 					)
 				)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43761 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. Click on "Edit" to open the Template editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block." Click on it.
4. In the block inserter, search for "Product Gallery" or browse through the available blocks until you find it.
5. Click on the "Product Gallery" block to add it to your content.
6. Visit a product with multiple images.
7. Using the keyboard, press 'Tab' multiple times until you select the "View All" button;
8. Press 'Enter' or 'Space' to open the Product Gallery Pop-Up;
9. Press 'Esc' to close the pop-up once it is open.
10. Make sure the focus returns to the trigger element (the View All button);
11. Keep pressing 'Tab' until you select the Large Image;
12. Press 'Enter' to open the Product Gallery Pop-Up again.
13. Press 'Esc' to close the pop-up once it is open.
14. Make sure the focus returns to the trigger element (the Large Image);

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Focus return to the trigger element when closing the Product Gallery Pop-Up

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
