### PR TITLE
[POC] Add read-only support for billing and shipping addresses in Checkout

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
@@ -11,6 +11,7 @@ import {
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -33,6 +34,8 @@ interface CheckoutAddress {
 	useBillingAsShipping: boolean;
 	needsShipping: boolean;
 	showShippingMethods: boolean;
+	isBillingAddressReadOnly: boolean;
+	isShippingAddressReadOnly: boolean;
 }
 
 /**
@@ -64,6 +67,15 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		[ setBillingAddress ]
 	);
 
+	const isBillingAddressReadOnly = applyCheckoutFilter( {
+		filterName: 'isBillingAddressReadOnly',
+		defaultValue: false,
+	} );
+	const isShippingAddressReadOnly = applyCheckoutFilter( {
+		filterName: 'isShippingAddressReadOnly',
+		defaultValue: false,
+	} );
+
 	const forcedBillingAddress: boolean = getSetting(
 		'forcedBillingAddress',
 		false
@@ -85,5 +97,7 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 			! needsShipping || ! useShippingAsBilling || !! prefersCollection,
 		forcedBillingAddress,
 		useBillingAsShipping: forcedBillingAddress || !! prefersCollection,
+		isBillingAddressReadOnly,
+		isShippingAddressReadOnly,
 	};
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx
@@ -3,7 +3,11 @@
  */
 import { TotalsShipping } from '@woocommerce/base-components/cart-checkout';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
-import { useStoreCart, useEditorContext } from '@woocommerce/base-context/';
+import {
+	useStoreCart,
+	useEditorContext,
+	useCheckoutAddress,
+} from '@woocommerce/base-context/';
 import { TotalsWrapper } from '@woocommerce/blocks-components';
 import { getSetting } from '@woocommerce/settings';
 import { getShippingRatesPackageCount } from '@woocommerce/base-utils';
@@ -12,6 +16,7 @@ import { select } from '@wordpress/data';
 const Block = ( { className }: { className: string } ): JSX.Element | null => {
 	const { cartTotals, cartNeedsShipping } = useStoreCart();
 	const { isEditor } = useEditorContext();
+	const { isShippingAddressReadOnly } = useCheckoutAddress();
 
 	if ( ! cartNeedsShipping ) {
 		return null;
@@ -26,14 +31,16 @@ const Block = ( { className }: { className: string } ): JSX.Element | null => {
 	}
 
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
-
+	const isShippingCalculatorEnabled = getSetting< boolean >(
+		'isShippingCalculatorEnabled',
+		true
+	);
 	return (
 		<TotalsWrapper className={ className }>
 			<TotalsShipping
-				showCalculator={ getSetting< boolean >(
-					'isShippingCalculatorEnabled',
-					true
-				) }
+				showCalculator={
+					isShippingCalculatorEnabled && ! isShippingAddressReadOnly
+				}
 				showRateSelector={ true }
 				values={ cartTotals }
 				currency={ totalsCurrency }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -19,11 +19,13 @@ const AddressCard = ( {
 	onEdit,
 	target,
 	fieldConfig,
+	isAddressReadOnly,
 }: {
 	address: CartShippingAddress | CartBillingAddress;
 	onEdit: () => void;
 	target: string;
 	fieldConfig: FormFieldsConfig;
+	isAddressReadOnly: boolean;
 } ): JSX.Element | null => {
 	return (
 		<div className="wc-block-components-address-card">
@@ -58,7 +60,7 @@ const AddressCard = ( {
 					''
 				) }
 			</address>
-			{ onEdit && (
+			{ onEdit && ! isAddressReadOnly && (
 				<a
 					role="button"
 					href={ '#' + target }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-wrapper/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-wrapper/index.tsx
@@ -16,10 +16,12 @@ export const AddressWrapper = ( {
 	isEditing = false,
 	addressCard,
 	addressForm,
+	hideAddressForm = false,
 }: {
 	isEditing: boolean;
 	addressCard: () => JSX.Element;
 	addressForm: () => JSX.Element;
+	hideAddressForm: boolean;
 } ): JSX.Element | null => {
 	const wrapperClasses = classnames(
 		'wc-block-components-address-address-wrapper',
@@ -33,9 +35,11 @@ export const AddressWrapper = ( {
 			<div className="wc-block-components-address-card-wrapper">
 				{ addressCard() }
 			</div>
-			<div className="wc-block-components-address-form-wrapper">
-				{ addressForm() }
-			</div>
+			{ ! hideAddressForm && (
+				<div className="wc-block-components-address-form-wrapper">
+					{ addressForm() }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -30,6 +30,7 @@ const CustomerAddress = ( {
 		setShippingAddress,
 		setBillingAddress,
 		useBillingAsShipping,
+		isBillingAddressReadOnly,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
 	const [ editing, setEditing ] = useState( defaultEditing );
@@ -79,13 +80,14 @@ const CustomerAddress = ( {
 			<AddressCard
 				address={ billingAddress }
 				target="billing"
+				isAddressReadOnly={ isBillingAddressReadOnly }
 				onEdit={ () => {
 					setEditing( true );
 				} }
 				fieldConfig={ addressFieldsConfig }
 			/>
 		),
-		[ billingAddress, addressFieldsConfig ]
+		[ billingAddress, isBillingAddressReadOnly, addressFieldsConfig ]
 	);
 
 	const renderAddressFormComponent = useCallback(
@@ -109,6 +111,7 @@ const CustomerAddress = ( {
 			isEditing={ editing }
 			addressCard={ renderAddressCardComponent }
 			addressForm={ renderAddressFormComponent }
+			hideAddressForm={ isBillingAddressReadOnly }
 		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -41,6 +41,7 @@ const Block = ( {
 		shippingAddress,
 		useShippingAsBilling,
 		setUseShippingAsBilling,
+		isBillingAddressReadOnly,
 	} = useCheckoutAddress();
 	const { isEditor } = useEditorContext();
 
@@ -121,17 +122,22 @@ const Block = ( {
 					/>
 				) : null }
 			</WrapperComponent>
-			<CheckboxControl
-				className="wc-block-checkout__use-address-for-billing"
-				label={ __( 'Use same address for billing', 'woocommerce' ) }
-				checked={ useShippingAsBilling }
-				onChange={ ( checked: boolean ) => {
-					setUseShippingAsBilling( checked );
-					if ( checked ) {
-						syncBillingWithShipping();
-					}
-				} }
-			/>
+			{ ! isBillingAddressReadOnly && (
+				<CheckboxControl
+					className="wc-block-checkout__use-address-for-billing"
+					label={ __(
+						'Use same address for billing',
+						'woocommerce'
+					) }
+					checked={ useShippingAsBilling }
+					onChange={ ( checked: boolean ) => {
+						setUseShippingAsBilling( checked );
+						if ( checked ) {
+							syncBillingWithShipping();
+						}
+					} }
+				/>
+			) }
 		</>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -30,6 +30,7 @@ const CustomerAddress = ( {
 		setShippingAddress,
 		setBillingAddress,
 		useShippingAsBilling,
+		isShippingAddressReadOnly,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
 	const [ editing, setEditing ] = useState( defaultEditing );
@@ -81,10 +82,11 @@ const CustomerAddress = ( {
 				onEdit={ () => {
 					setEditing( true );
 				} }
+				isAddressReadOnly={ isShippingAddressReadOnly }
 				fieldConfig={ addressFieldsConfig }
 			/>
 		),
-		[ shippingAddress, addressFieldsConfig ]
+		[ shippingAddress, isShippingAddressReadOnly, addressFieldsConfig ]
 	);
 
 	const renderAddressFormComponent = useCallback(
@@ -106,6 +108,7 @@ const CustomerAddress = ( {
 			isEditing={ editing }
 			addressCard={ renderAddressCardComponent }
 			addressForm={ renderAddressFormComponent }
+			hideAddressForm={ isShippingAddressReadOnly }
 		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
@@ -12,6 +12,7 @@ import type {
 	CartShippingRate,
 } from '@woocommerce/types';
 import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
+import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import {
 	triggerAddedToCartEvent,
 	triggerAddingToCartEvent,
@@ -26,7 +27,6 @@ import { apiFetchWithHeaders } from '../shared-controls';
 import { ReturnOrGeneratorYieldUnion } from '../mapped-types';
 import { CartDispatchFromMap, CartSelectFromMap } from './index';
 import type { Thunks } from './thunks';
-import { applyCheckoutFilter } from '../../../../packages/checkout/filter-registry';
 
 // Thunks are functions that can be dispatched, similar to actions creators
 // @todo Many of the functions that return promises in this file need to be moved to thunks.ts.
@@ -38,24 +38,9 @@ export * from './thunks';
  * @param cart the parsed cart object. (Parsed into camelCase).
  */
 export const setCartData = ( cart: Cart ): { type: string; response: Cart } => {
-	const shippingAddress = applyCheckoutFilter( {
-		filterName: 'setFixedShippingAddress',
-		defaultValue: cart.shippingAddress,
-	} );
-	console.log( 'setCartData', shippingAddress );
-	const billingAddress = applyCheckoutFilter( {
-		filterName: 'setFixedBillingAddress',
-		defaultValue: cart.billingAddress,
-	} );
-	console.log( 'setCartData', billingAddress );
-	const cartWithUpdatedAddresses = {
-		...cart,
-		shippingAddress,
-		billingAddress,
-	};
 	return {
 		type: types.SET_CART_DATA,
-		response: cartWithUpdatedAddresses,
+		response: cart,
 	};
 };
 
@@ -458,7 +443,6 @@ export const setBillingAddress = (
 		filterName: 'setFixedBillingAddress',
 		defaultValue: billingAddress,
 	} );
-	console.log( 'setBillingAddress', address );
 	return { type: types.SET_BILLING_ADDRESS, address };
 };
 
@@ -472,7 +456,6 @@ export const setShippingAddress = (
 		filterName: 'setFixedShippingAddress',
 		defaultValue: shippingAddress,
 	} );
-	console.log( 'setShippingAddress', address );
 	return { type: types.SET_SHIPPING_ADDRESS, address };
 };
 

--- a/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
@@ -12,7 +12,6 @@ import type {
 	CartShippingRate,
 } from '@woocommerce/types';
 import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
-import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import {
 	triggerAddedToCartEvent,
 	triggerAddingToCartEvent,
@@ -27,6 +26,7 @@ import { apiFetchWithHeaders } from '../shared-controls';
 import { ReturnOrGeneratorYieldUnion } from '../mapped-types';
 import { CartDispatchFromMap, CartSelectFromMap } from './index';
 import type { Thunks } from './thunks';
+import { applyCheckoutFilter } from '../../../../packages/checkout/filter-registry';
 
 // Thunks are functions that can be dispatched, similar to actions creators
 // @todo Many of the functions that return promises in this file need to be moved to thunks.ts.
@@ -38,9 +38,24 @@ export * from './thunks';
  * @param cart the parsed cart object. (Parsed into camelCase).
  */
 export const setCartData = ( cart: Cart ): { type: string; response: Cart } => {
+	const shippingAddress = applyCheckoutFilter( {
+		filterName: 'setFixedShippingAddress',
+		defaultValue: cart.shippingAddress,
+	} );
+	console.log( 'setCartData', shippingAddress );
+	const billingAddress = applyCheckoutFilter( {
+		filterName: 'setFixedBillingAddress',
+		defaultValue: cart.billingAddress,
+	} );
+	console.log( 'setCartData', billingAddress );
+	const cartWithUpdatedAddresses = {
+		...cart,
+		shippingAddress,
+		billingAddress,
+	};
 	return {
 		type: types.SET_CART_DATA,
-		response: cart,
+		response: cartWithUpdatedAddresses,
 	};
 };
 
@@ -443,6 +458,7 @@ export const setBillingAddress = (
 		filterName: 'setFixedBillingAddress',
 		defaultValue: billingAddress,
 	} );
+	console.log( 'setBillingAddress', address );
 	return { type: types.SET_BILLING_ADDRESS, address };
 };
 
@@ -456,6 +472,7 @@ export const setShippingAddress = (
 		filterName: 'setFixedShippingAddress',
 		defaultValue: shippingAddress,
 	} );
+	console.log( 'setShippingAddress', address );
 	return { type: types.SET_SHIPPING_ADDRESS, address };
 };
 

--- a/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
@@ -12,6 +12,7 @@ import type {
 	CartShippingRate,
 } from '@woocommerce/types';
 import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
+import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import {
 	triggerAddedToCartEvent,
 	triggerAddingToCartEvent,
@@ -437,14 +438,26 @@ export const selectShippingRate =
  */
 export const setBillingAddress = (
 	billingAddress: Partial< BillingAddress >
-) => ( { type: types.SET_BILLING_ADDRESS, billingAddress } as const );
+) => {
+	const address = applyCheckoutFilter( {
+		filterName: 'setFixedBillingAddress',
+		defaultValue: billingAddress,
+	} );
+	return { type: types.SET_BILLING_ADDRESS, address };
+};
 
 /**
  * Sets shipping address locally, as opposed to updateCustomerData which sends it to the server.
  */
 export const setShippingAddress = (
 	shippingAddress: Partial< ShippingAddress >
-) => ( { type: types.SET_SHIPPING_ADDRESS, shippingAddress } as const );
+) => {
+	const address = applyCheckoutFilter( {
+		filterName: 'setFixedShippingAddress',
+		defaultValue: shippingAddress,
+	} );
+	return { type: types.SET_SHIPPING_ADDRESS, address };
+};
 
 /**
  * Updates the shipping and/or billing address for the customer and returns an updated cart.

--- a/plugins/woocommerce/changelog/44416-poc-add-billing-shipping-read-only-checkout-filters
+++ b/plugins/woocommerce/changelog/44416-poc-add-billing-shipping-read-only-checkout-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add read-only support for billing and shipping addresses in Checkout block.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the [woocommerce-readonly-addressfields](https://github.com/tarunvijwani/woocommerce-readonly-addressfields) plugin. 
2. Login to your site from my account page. 
3. Add a product to the cart and visit the Checkout block page
4. Confirm that the edit address card and address form are not displayed. 


| Before | After |
|---|---|
|<img width="521" alt="image" src="https://github.com/woocommerce/woocommerce/assets/11503784/cc105fab-cd41-404d-9a93-2e84157c28ab">|<img width="634" alt="image" src="https://github.com/woocommerce/woocommerce/assets/11503784/b0c0ec80-654b-4e82-a402-d58e5dc5f615">|
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add read-only support for billing and shipping addresses in Checkout block. 
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
