### PR TITLE
[CYS on Core] Ensure the size of fonts is not affected by the font family changes

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -16,6 +16,23 @@ import { isEqual, noop } from 'lodash';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
+// Removes the typography settings from the styles when the user is changing
+// to a new typography variation. Otherwise, some of the user's old
+// typography settings will persist making new typography settings
+// depend on old ones
+const resetTypographySettings = ( variation, userStyles ) => {
+	if ( variation.settings.typography ) {
+		delete userStyles.typography;
+		for ( const elementKey in userStyles.elements ) {
+			if ( userStyles.elements[ elementKey ].typography ) {
+				delete userStyles.elements[ elementKey ].typography;
+			}
+		}
+	}
+
+	return userStyles;
+};
+
 export const VariationContainer = ( { variation, children } ) => {
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
 	const context = useMemo( () => {
@@ -57,7 +74,10 @@ export const VariationContainer = ( { variation, children } ) => {
 					user.settings,
 					variation.settings
 				),
-				styles: variation.styles,
+				styles: mergeBaseAndUserConfigs(
+					resetTypographySettings( variation, user.styles ),
+					variation.styles
+				),
 			};
 		} );
 	};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -50,7 +50,7 @@ export const VariationContainer = ( { variation, children } ) => {
 				}
 			}
 		}
-		console.log( 'variation', user.settings, variation.settings );
+
 		setUserConfig( () => {
 			return {
 				settings: mergeBaseAndUserConfigs(

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -50,17 +50,14 @@ export const VariationContainer = ( { variation, children } ) => {
 				}
 			}
 		}
-
+		console.log( 'variation', user.settings, variation.settings );
 		setUserConfig( () => {
 			return {
 				settings: mergeBaseAndUserConfigs(
 					user.settings,
 					variation.settings
 				),
-				styles: mergeBaseAndUserConfigs(
-					user.styles,
-					variation.styles
-				),
+				styles: variation.styles,
 			};
 		} );
 	};

--- a/plugins/woocommerce/changelog/44424-44259-fix-font-size
+++ b/plugins/woocommerce/changelog/44424-44259-fix-font-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Ensure the size of fonts is not affected by a font family change.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR resets the typography settings from the user styles before applying the new ones to avoid influencing one another.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/44259

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the `WooCommerce Beta Tester` plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
5. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`
6. Follow the process.
7. Click on `Change fonts`.
8. Click on `Montserrat + Arvo`.
9. Click on `Albert Sans + Lora`, the size is the same.
10. Click on `Rubik + Inter` and you'll see the font is bigger.
11. Click back on `Albert Sans + Lora` and check the font is the same size compared to the initial `Albert Sans + Lora` pairing (clicking on `Montserrat + Arvo` should not influence the size of `Albert Sans + Lora`).
12. Go to `Change the color palette` and select a new one.
13. Go back to `Change fonts` and select a new one.
14. Make sure the color palette is kept after selecting the font.

| Before | After |
|--------|--------|
| https://github.com/woocommerce/woocommerce/assets/15730971/62553860-ca65-4476-b6e3-d615a4308ae7 |https://github.com/woocommerce/woocommerce/assets/186112/f62c33c1-66f9-41ef-ab93-6de41e35aee2| 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - Ensure the size of fonts is not affected by a font family change.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
