### PR TITLE
[PoC] Product Editor select block with options binding

### DIFF
--- a/packages/js/product-editor/src/blocks/generic/select/block.json
+++ b/packages/js/product-editor/src/blocks/generic/select/block.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-select-field",
+	"title": "Product select field",
+	"category": "woocommerce",
+	"description": "A select field for use in the product editor.",
+	"keywords": [ "products", "select" ],
+	"textdomain": "default",
+	"attributes": {
+		"label": {
+			"type": "string"
+		},
+		"property": {
+			"type": "string"
+		},
+		"options": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"label": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"disabled": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"editorStyle": "file:./editor.css",
+	"usesContext": [ "postType" ]
+}

--- a/packages/js/product-editor/src/blocks/generic/select/block.json
+++ b/packages/js/product-editor/src/blocks/generic/select/block.json
@@ -27,10 +27,6 @@
 					}
 				}
 			}
-		},
-		"disabled": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/select/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/select/edit.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useProductEntityProp from '../../../hooks/use-product-entity-prop';
+import { ProductEditorBlockEditProps } from '../../../types';
+import { SelectBlockAttributes } from './types';
+
+export function Edit( {
+	attributes,
+	context: { postType },
+}: ProductEditorBlockEditProps< SelectBlockAttributes > ) {
+	const blockProps = useWooBlockProps( attributes );
+
+	const { label, property, options, disabled } = attributes;
+
+	const [ value, setValue ] = useProductEntityProp< [] >( property, {
+		postType,
+		fallbackValue: [],
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<SelectControl
+				label={ label }
+				// @ts-ignore wrong types; false ok
+				multiple={ false }
+				value={ value }
+				options={ options }
+				disabled={ disabled }
+				onChange={ setValue }
+			/>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/generic/select/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/select/edit.tsx
@@ -18,7 +18,7 @@ export function Edit( {
 }: ProductEditorBlockEditProps< SelectBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 
-	const { label, property, options, disabled } = attributes;
+	const { label, property, options } = attributes;
 
 	const [ value, setValue ] = useProductEntityProp< [] >( property, {
 		postType,
@@ -32,8 +32,8 @@ export function Edit( {
 				// @ts-ignore wrong types; false ok
 				multiple={ false }
 				value={ value }
-				options={ options }
-				disabled={ disabled }
+				options={ options || [ { label: 'Loading...', value: '' } ] }
+				disabled={ ! options }
 				onChange={ setValue }
 			/>
 		</div>

--- a/packages/js/product-editor/src/blocks/generic/select/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/select/index.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { registerProductEditorBlockType } from '../../../utils';
+
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { Edit } from './edit';
+import { SelectBlockAttributes } from './types';
+
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< SelectBlockAttributes >;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: Edit,
+};
+
+export const init = () =>
+	registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );

--- a/packages/js/product-editor/src/blocks/generic/select/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/select/types.ts
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import type { BlockAttributes } from '@wordpress/blocks';
+
+export interface SelectBlockAttributes extends BlockAttributes {
+	property: string;
+	options: { label: string; value: string }[];
+}

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -35,3 +35,4 @@ export { init as initText } from './generic/text';
 export { init as initNumber } from './generic/number';
 export { init as initLinkedProductList } from './generic/linked-product-list';
 export { init as initTextArea } from './generic/text-area';
+export { init as initSelect } from './generic/select';

--- a/packages/js/product-editor/src/wp-hooks/add-binding-to-select-options.tsx
+++ b/packages/js/product-editor/src/wp-hooks/add-binding-to-select-options.tsx
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createElement, useEffect, useState } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import useProductEntityProp from '../hooks/use-product-entity-prop';
+
+const createOption = ( customArg: string, num: number ) => ( {
+	label: `Option ${ customArg.toUpperCase() }-${ num }`,
+	value: `option-${ customArg }-${ num }`,
+} );
+
+const bindingSources = {
+	'custom-options': {
+		name: 'custom-options',
+		label: 'Custom Options',
+		// @ts-ignore todo: fix types
+		useSource( props, sourceAttributes ) {
+			const options = [
+				createOption( sourceAttributes.customArg, 1 ),
+				createOption( sourceAttributes.customArg, 2 ),
+				createOption( sourceAttributes.customArg, 3 ),
+			];
+
+			return {
+				placeholder: [ { label: 'Loading...', value: '' } ],
+				useValue: [ options ],
+			};
+		},
+	},
+	'custom-options-async': {
+		name: 'custom-options-async',
+		label: 'Custom Options Async',
+		// @ts-ignore todo: fix types
+		useSource( props, sourceAttributes ) {
+			const [ options, setOptions ] = useState( null );
+
+			useEffect( () => {
+				setTimeout( () => {
+					// @ts-ignore todo: fix types
+					setOptions( [
+						createOption( sourceAttributes.customArg, 1 ),
+						createOption( sourceAttributes.customArg, 2 ),
+						createOption( sourceAttributes.customArg, 3 ),
+					] );
+				}, 5000 );
+			}, [ sourceAttributes ] );
+
+			return {
+				placeholder: [ { label: 'Loading (5s)...', value: '' } ],
+				useValue: [ options ],
+			};
+		},
+	},
+	'custom-options-product-props': {
+		name: 'custom-options-product-props',
+		label: 'Custom Options Product Props',
+		// @ts-ignore todo: fix types
+		useSource() {
+			const [ regularPrice ] = useProductEntityProp( 'regular_price' );
+
+			let options;
+
+			if ( ( parseFloat( regularPrice as string ) || 0 ) > 10 ) {
+				options = [
+					{ label: 'Expensive Option', value: 'expensive-option' },
+					{
+						label: 'Super Expensive Option',
+						value: 'super-expensive-option',
+					},
+				];
+			} else {
+				options = [
+					{ label: 'Cheap Option', value: 'cheap-option' },
+					{
+						label: 'Super Cheap Option',
+						value: 'super-cheap-option',
+					},
+				];
+			}
+
+			return {
+				placeholder: [ { label: 'Loading...', value: '' } ],
+				useValue: [ options ],
+			};
+		},
+	},
+};
+
+const maybeAddBindingToSelectOptions = createHigherOrderComponent<
+	Record< string, unknown >
+>( ( BlockEdit ) => {
+	return ( props ) => {
+		if (
+			props.name === 'woocommerce/product-select-field' &&
+			// @ts-ignore todo: fix types
+			props.attributes.metadata?.bindings?.options?.source
+		) {
+			const optionsBindingSource =
+				// @ts-ignore todo: fix types
+				props.attributes.metadata.bindings.options.source;
+
+			// @ts-ignore todo: fix types
+			const source = bindingSources[ optionsBindingSource ];
+
+			if ( ! source ) {
+				throw new Error( `Unknown source ${ optionsBindingSource }` );
+			}
+
+			const { placeholder, useValue: [ options ] = [] } =
+				source.useSource(
+					props,
+					// @ts-ignore todo: fix types
+					props.attributes.metadata.bindings.options.args
+				);
+
+			if ( placeholder && ! options ) {
+				// @ts-ignore todo: fix types
+				props.attributes.options = placeholder;
+				// @ts-ignore todo: fix types
+				props.attributes.disabled = true;
+			}
+
+			if ( options ) {
+				// @ts-ignore todo: fix types
+				props.attributes.options = options;
+				// @ts-ignore todo: fix types
+				props.attributes.disabled = false;
+			}
+
+			return <BlockEdit { ...props } />;
+		}
+
+		return <BlockEdit { ...props } />;
+	};
+}, 'maybeAddBindingToSelectOptions' );
+
+export default function () {
+	addFilter(
+		'editor.BlockEdit',
+		'woocommerce/add-binding-to-select-options',
+		maybeAddBindingToSelectOptions
+	);
+}

--- a/packages/js/product-editor/src/wp-hooks/add-binding-to-select-options.tsx
+++ b/packages/js/product-editor/src/wp-hooks/add-binding-to-select-options.tsx
@@ -28,7 +28,7 @@ const bindingSources = {
 			];
 
 			return {
-				placeholder: [ { label: 'Loading...', value: '' } ],
+				placeholder: null,
 				useValue: [ options ],
 			};
 		},
@@ -52,7 +52,7 @@ const bindingSources = {
 			}, [ sourceAttributes ] );
 
 			return {
-				placeholder: [ { label: 'Loading (5s)...', value: '' } ],
+				placeholder: null,
 				useValue: [ options ],
 			};
 		},
@@ -85,7 +85,7 @@ const bindingSources = {
 			}
 
 			return {
-				placeholder: [ { label: 'Loading...', value: '' } ],
+				placeholder: null,
 				useValue: [ options ],
 			};
 		},

--- a/packages/js/product-editor/src/wp-hooks/add-metadata-to-attributes.ts
+++ b/packages/js/product-editor/src/wp-hooks/add-metadata-to-attributes.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+export default function () {
+	addFilter(
+		'blocks.registerBlockType',
+		'woocommerce/add-metadata-to-attributes',
+		( settings ) => {
+			if ( ! settings.attributes ) {
+				settings.attributes = {};
+			}
+
+			if ( ! settings.attributes.metadata ) {
+				settings.attributes.metadata = {
+					type: 'object',
+					default: {},
+				};
+			}
+
+			return settings;
+		}
+	);
+}

--- a/packages/js/product-editor/src/wp-hooks/index.ts
+++ b/packages/js/product-editor/src/wp-hooks/index.ts
@@ -2,7 +2,11 @@
  * Internal dependencies
  */
 import registerHideInventoryAdvancedCollapsible from './hide-inventory-advanced-collapsible';
+import registerAddMetadataToAttributes from './add-metadata-to-attributes';
+import registerAddBindingToSelectOptions from './add-binding-to-select-options';
 
 export default function registerProductEditorHooks() {
 	registerHideInventoryAdvancedCollapsible();
+	registerAddMetadataToAttributes();
+	registerAddBindingToSelectOptions();
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR shows how the Block Binding API could be used to provide options to a new `woocommerce/product-select-field` block for use in the Product Editor.

Since the Block Binding API isn't available yet, a hardcoded similar implementation is included in this PR just to show the concept. A more complete fallback implementation is being investigated separately.

#### Restrictions in this PR

- Sources are hardcoded
- Binding support implementation is hardcoded for only the `options` attribute of the `woocommerce/product-select-field` block, and doesn't use the actual Block Binding API implementation, even it is were available
- Saving of selected option is hardcoded to store `value` in property (binding could be used to make this more flexible as well)

#### General concept

- Options for the select field are specified using the `options` block attribute
- These options can be hardcoded in the layout template when the field is added
- If the options are dynamic and/or not known until runtime, binding can be used to hook up a source for the options
- This approach completely separates the data from the field implementation, which will allow for reuse and flexibility without the need to create custom blocks or modify our generic block implementation
- We could provide built-in default sources, to account for common scenarios. For example:
    - Get options from a REST API endpoint (args provided to the source could include URL, props for `label` and `value`,e tc.) 
- Developers could register custom sources if they needed to handle other scenarios:
    - Complex processing of REST API responses
    - Determining options based on edited product properties
- This approach can be used for any block attributes

#### Examples shown in test plugin

[test-44429-try-select.zip](https://github.com/woocommerce/woocommerce/files/14194520/test-44429-try-select.zip)

<img width="680" alt="Screenshot 2024-02-07 at 10 05 46" src="https://github.com/woocommerce/woocommerce/assets/2098816/83d32630-4488-4bbb-b770-1e5f6b8fd520">

##### Hardcoded options in layout template (simplest scenario)

First select field in test plugin.

This example shows how it is easy for a developer to hardcoded options for a select field, which will often be the case, especially when just getting started working on an extension.

Template API:

```php
$section->add_block(
	array(
		'id'         => 'test-44429-try-select-block',
		'blockName'  => 'woocommerce/product-select-field',
		'attributes' => array(
			'label'    => __( 'woocommerce/product-select-field', 'YOUR_TEXT_DOMAIN' ),
			'property' => 'meta_data.test_44429_try_select',
			'options'  => array(
				array(
					'label' => __( 'Option 1', 'YOUR_TEXT_DOMAIN' ),
					'value' => 'option-1',
				),
				array(
					'label' => __( 'Option 2', 'YOUR_TEXT_DOMAIN' ),
					'value' => 'option-2',
				),
				array(
					'label' => __( 'Option 3', 'YOUR_TEXT_DOMAIN' ),
					'value' => 'option-3',
				),
			),
		),
	)
);
```

Binding API:

None

##### Dynamic options at runtime using source

Second and third select fields in test plugin.

These examples show how a binding source can be used, passing an argument to the binding source.

Template API:

```php
$section->add_block(
	array(
		'id'         => 'test-44429-try-select-block-a',
		'blockName'  => 'woocommerce/product-select-field',
		'attributes' => array(
			'label'    => __( 'woocommerce/product-select-field A', 'YOUR_TEXT_DOMAIN' ),
			'property' => 'meta_data.test_44429_try_select_a',
			'metadata' => array(
				'bindings' => array(
					'options' => array(
						'source' => 'custom-options',
						'args'   => array(
							'customArg' => 'a',
						),
					)
				),
			),
		),
	)
);

$section->add_block(
	array(
		'id'         => 'test-44429-try-select-block-b',
		'blockName'  => 'woocommerce/product-select-field',
		'attributes' => array(
			'label'    => __( 'woocommerce/product-select-field B', 'YOUR_TEXT_DOMAIN' ),
			'property' => 'meta_data.test_44429_try_select_b',
			'metadata' => array(
				'bindings' => array(
					'options' => array(
						'source' => 'custom-options',
						'args'   => array(
							'customArg' => 'b',
						),
					)
				),
			),
		),
	)
);
```

Binding API source:

```js
{
  name: 'custom-options',
  label: 'Custom Options',
  useSource( props, sourceAttributes ) {
	  const options = [
		  createOption( sourceAttributes.customArg, 1 ),
		  createOption( sourceAttributes.customArg, 2 ),
		  createOption( sourceAttributes.customArg, 3 ),
	  ];
  
	  return {
		  placeholder: [ { label: 'Loading...', value: '' } ],
		  useValue: [ options ],
	  };
  },
},
```

##### Dynamic options at runtime using async source

Fourth select field in test plugin.

This example is identical to the example above, from the template API standpoint. 

It shows how a binding source can provide the options asynchronously (such as would happen with a fetch from a REST API endpoint).

Template API:

```php
$section->add_block(
	array(
		'id'         => 'test-44429-try-select-block-c',
		'blockName'  => 'woocommerce/product-select-field',
		'attributes' => array(
			'label'    => __( 'woocommerce/product-select-field C', 'YOUR_TEXT_DOMAIN' ),
			'property' => 'meta_data.test_44429_try_select_c',
			'metadata' => array(
				'bindings' => array(
					'options' => array(
						'source' => 'custom-options-async',
						'args'   => array(
							'customArg' => 'c',
						),
					)
				),
			),
		),
	)
);
```

Binding API source:

```js
{
  name: 'custom-options-async',
  label: 'Custom Options Async',
  useSource( props, sourceAttributes ) {
	  const [ options, setOptions ] = useState( null );
  
	  useEffect( () => {
		  setTimeout( () => {
			  setOptions( [
				  createOption( sourceAttributes.customArg, 1 ),
				  createOption( sourceAttributes.customArg, 2 ),
				  createOption( sourceAttributes.customArg, 3 ),
			  ] );
		  }, 5000 );
	  }, [ sourceAttributes ] );
  
	  return {
		  placeholder: [ { label: 'Loading (5s)...', value: '' } ],
		  useValue: [ options ],
	  };
  },
}
```

##### Dynamic options at runtime based on edited product properties

Fifth select field in test plugin.

This example is identical to the examples above, from the template API standpoint. 

It shows how a binding source can use the edited product to dynamically adjust what options are available.

Template API:

```php
$section->add_block(
	array(
		'id'         => 'test-44429-try-select-block-d',
		'blockName'  => 'woocommerce/product-select-field',
		'attributes' => array(
			'label'    => __( 'woocommerce/product-select-field D', 'YOUR_TEXT_DOMAIN' ),
			'property' => 'meta_data.test_44429_try_select_d',
			'metadata' => array(
				'bindings' => array(
					'options' => array(
						'source' => 'custom-options-product-props',
					)
				),
			),
		),
	)
);
```

Binding API source:

```js
{
  name: 'custom-options-product-props',
  label: 'Custom Options Product Props',
  useSource() {
	  const [ regularPrice ] = useProductEntityProp( 'regular_price' );
  
	  let options;
  
	  if ( ( parseFloat( regularPrice as string ) || 0 ) > 10 ) {
		  options = [
			  { label: 'Expensive Option', value: 'expensive-option' },
			  {
				  label: 'Super Expensive Option',
				  value: 'super-expensive-option',
			  },
		  ];
	  } else {
		  options = [
			  { label: 'Cheap Option', value: 'cheap-option' },
			  {
				  label: 'Super Cheap Option',
				  value: 'super-cheap-option',
			  },
		  ];
	  }
  
	  return {
		  placeholder: [ { label: 'Loading...', value: '' } ],
		  useValue: [ options ],
	  };
  },
}
```

#### Thoughts/issues

- The Block Binding syntax is verbose, but easy to understand
- The Block Binding API provides a `placeholder` concept for returning data from a source. This may not be sufficient for a block to determine if data still needs to the resolved.
    - It works for the custom select field block in this PR, but in other cases it may not be possible to distinguish between the placeholder value and a resolved value.
    - If we wanted to provide a custom loading message in our select field block, we could expose an attribute to set this

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

[test-44429-try-select.zip](https://github.com/woocommerce/woocommerce/files/14194520/test-44429-try-select.zip)




1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
