### PR TITLE
Product Gallery block: Add logic to trap keyboard focus within the Product Gallery Pop-Up

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -249,6 +249,61 @@ const productGallery = {
 			return () =>
 				document.removeEventListener( 'keydown', handleKeyEvents );
 		},
+		dialogFocusTrap: () => {
+			const dialogOverlay = document.querySelector(
+				'.wc-block-product-gallery-dialog__overlay'
+			) as HTMLElement | null;
+
+			if ( ! dialogOverlay ) {
+				return;
+			}
+
+			const handleKeyEvents = ( event: KeyboardEvent ) => {
+				if ( event.code === 'Tab' ) {
+					if ( ! dialogOverlay ) {
+						return;
+					}
+
+					const focusableElementsSelectors =
+						'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+					const focusableElements = dialogOverlay.querySelectorAll(
+						focusableElementsSelectors
+					);
+
+					if ( ! focusableElements.length ) {
+						return;
+					}
+
+					const firstFocusableElement =
+						focusableElements[ 0 ] as HTMLElement;
+					const lastFocusableElement = focusableElements[
+						focusableElements.length - 1
+					] as HTMLElement;
+
+					if (
+						! event.shiftKey &&
+						event.target === lastFocusableElement
+					) {
+						event.preventDefault();
+						firstFocusableElement.focus();
+					}
+
+					if (
+						event.shiftKey &&
+						event.target === firstFocusableElement
+					) {
+						event.preventDefault();
+						lastFocusableElement.focus();
+					}
+				}
+			};
+
+			dialogOverlay.addEventListener( 'keydown', handleKeyEvents );
+
+			return () =>
+				dialogOverlay.removeEventListener( 'keydown', handleKeyEvents );
+		},
 	},
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -80,15 +80,15 @@ const productGallery = {
 			document.body.classList.add(
 				'wc-block-product-gallery-modal-open'
 			);
-			const dialogOverlay = document.querySelector(
-				'.wc-block-product-gallery-dialog__overlay'
+			const dialogPopUp = document.querySelector(
+				'dialog[aria-label="Product gallery"]'
 			);
-			if ( ! dialogOverlay ) {
+			if ( ! dialogPopUp ) {
 				return;
 			}
-			( dialogOverlay as HTMLElement ).focus();
+			( dialogPopUp as HTMLElement ).focus();
 
-			const dialogPreviousButton = dialogOverlay.querySelectorAll(
+			const dialogPreviousButton = dialogPopUp.querySelectorAll(
 				'.wc-block-product-gallery-large-image-next-previous--button'
 			)[ 0 ];
 
@@ -250,11 +250,11 @@ const productGallery = {
 				document.removeEventListener( 'keydown', handleKeyEvents );
 		},
 		dialogFocusTrap: () => {
-			const dialogOverlay = document.querySelector(
-				'.wc-block-product-gallery-dialog__overlay'
+			const dialogPopUp = document.querySelector(
+				'dialog[aria-label="Product gallery"]'
 			) as HTMLElement | null;
 
-			if ( ! dialogOverlay ) {
+			if ( ! dialogPopUp ) {
 				return;
 			}
 
@@ -263,7 +263,7 @@ const productGallery = {
 					const focusableElementsSelectors =
 						'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-					const focusableElements = dialogOverlay.querySelectorAll(
+					const focusableElements = dialogPopUp.querySelectorAll(
 						focusableElementsSelectors
 					);
 
@@ -295,10 +295,10 @@ const productGallery = {
 				}
 			};
 
-			dialogOverlay.addEventListener( 'keydown', handleKeyEvents );
+			dialogPopUp.addEventListener( 'keydown', handleKeyEvents );
 
 			return () =>
-				dialogOverlay.removeEventListener( 'keydown', handleKeyEvents );
+				dialogPopUp.removeEventListener( 'keydown', handleKeyEvents );
 		},
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -260,10 +260,6 @@ const productGallery = {
 
 			const handleKeyEvents = ( event: KeyboardEvent ) => {
 				if ( event.code === 'Tab' ) {
-					if ( ! dialogOverlay ) {
-						return;
-					}
-
 					const focusableElementsSelectors =
 						'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 

--- a/plugins/woocommerce/changelog/44439-fix-43762-trap-keyboard-focus-inside-product-gallery-pop-up
+++ b/plugins/woocommerce/changelog/44439-fix-43762-trap-keyboard-focus-inside-product-gallery-pop-up
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add focus trapping within the Product Gallery Pop-Up to enhance keyboard navigation and accessibility.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -77,7 +77,7 @@ class ProductGallery extends AbstractBlock {
 
 		$gallery_dialog = strtr(
 			'
-			<dialog data-wc-bind--open="context.isDialogOpen" role="dialog" aria-modal="true" aria-label="{{dialog_aria_label}}" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" data-wc-class--wc-block-product-gallery--dialog-open="context.isDialogOpen">
+			<dialog data-wc-bind--open="context.isDialogOpen" role="dialog" aria-modal="true" aria-label="{{dialog_aria_label}}" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" data-wc-watch--dialog-focus-trap="callbacks.dialogFocusTrap" data-wc-class--wc-block-product-gallery--dialog-open="context.isDialogOpen">
 				<div class="wc-block-product-gallery-dialog__header">
 				<div class="wc-block-product-galler-dialog__header-right">
 					<button class="wc-block-product-gallery-dialog__close" data-wc-on--click="actions.closeDialog" aria-label="{{close_dialog_aria_label}}">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -77,7 +77,7 @@ class ProductGallery extends AbstractBlock {
 
 		$gallery_dialog = strtr(
 			'
-		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess">
+		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" data-wc-watch--dialog-focus-trap="callbacks.dialogFocusTrap">
 			<dialog data-wc-bind--open="context.isDialogOpen" role="dialog" aria-modal="true" aria-label="{{dialog_aria_label}}">
 				<div class="wc-block-product-gallery-dialog__header">
 				<div class="wc-block-product-galler-dialog__header-right">


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When opening the Product Gallery pop-up, keyboard focus is not trapped within the pop-up itself. This allows users to accidentally navigate away from the pop-up using keyboard commands, potentially leading to confusion and accessibility challenges.

This PR adds the logic to trap the keyboard focus within the Product Gallery pop-up.

Closes #43762 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. Click on "Edit" to open the Template editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block." Click on it.
4. In the block inserter, search for "Product Gallery" or browse through the available blocks until you find it.
5. Click on the "Product Gallery" block to add it to your content.
6. Visit a product with multiple images.
7. Click on the large image to open the Product Gallery Pop-Up;
8. Make sure the focus is on the Previous Image button;
9. Press 'Tab' multiple times and ensure the focus is always within the Product Gallery Pop-Up.
10. Press 'Shift + Tab' multiple times to navigate backward and ensure the focus is always within the Product Gallery Pop-Up.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add focus trapping within the Product Gallery Pop-Up to enhance keyboard navigation and accessibility.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
