### PR TITLE
Improve tasklist performance, add prop to track

### DIFF
--- a/plugins/woocommerce/changelog/tweak-improve-tasklist-performance
+++ b/plugins/woocommerce/changelog/tweak-improve-tasklist-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve tasklist performance and add tasklist id track props

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -740,6 +740,11 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$lists = is_array( $task_list_ids ) && count( $task_list_ids ) > 0 ? TaskLists::get_lists_by_ids( $task_list_ids ) : TaskLists::get_lists();
 
+		// We have no use for hidden lists, it's expensive to compute individual tasks completion.
+		$lists = array_filter( $lists, function( $list ) {
+			return ! $list->is_hidden();
+		} );
+
 		$json = array_map(
 			function( $list ) {
 				return $list->sort_tasks()->get_json();

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -741,9 +741,12 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$lists = is_array( $task_list_ids ) && count( $task_list_ids ) > 0 ? TaskLists::get_lists_by_ids( $task_list_ids ) : TaskLists::get_lists();
 
 		// We have no use for hidden lists, it's expensive to compute individual tasks completion.
-		$lists = array_filter( $lists, function( $list ) {
-			return ! $list->is_hidden();
-		} );
+		$lists = array_filter(
+			$lists,
+			function( $list ) {
+				return ! $list->is_hidden();
+			}
+		);
 
 		$json = array_map(
 			function( $list ) {

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -343,9 +343,10 @@ class TaskList {
 		$completed_lists[] = $this->get_list_id();
 		update_option( self::COMPLETED_OPTION, $completed_lists );
 		$this->maybe_set_default_layout( $completed_lists );
-		$this->record_tracks_event( 'tasks_completed',
+		$this->record_tracks_event(
+			'tasks_completed',
 			array(
-				'tasklist_id' => $this->id
+				'tasklist_id' => $this->id,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -168,7 +168,7 @@ class TaskList {
 	 * @return bool
 	 */
 	public function is_visible() {
-		if ( ! $this->visible || ! count( $this->get_viewable_tasks() ) > 0 ) {
+		if ( ! $this->visible || $this->is_hidden() || ! count( $this->get_viewable_tasks() ) > 0 ) {
 			return false;
 		}
 		return ! $this->is_hidden();
@@ -199,6 +199,7 @@ class TaskList {
 				'action'                => 'remove_card',
 				'completed_task_count'  => $completed_count,
 				'incomplete_task_count' => count( $viewable_tasks ) - $completed_count,
+				'tasklist_id'           => $this->id,
 			)
 		);
 
@@ -324,11 +325,17 @@ class TaskList {
 	 * Track list completion of viewable tasks.
 	 */
 	public function possibly_track_completion() {
-		if ( ! $this->is_complete() ) {
+		if ( $this->has_previously_completed() ) {
 			return;
 		}
 
-		if ( $this->has_previously_completed() ) {
+		// If it's hidden, completion is tracked via hide method.
+		if ( $this->is_hidden() ) {
+			return;
+		}
+
+		// Expensive check, do it last.
+		if ( ! $this->is_complete() ) {
 			return;
 		}
 
@@ -336,7 +343,11 @@ class TaskList {
 		$completed_lists[] = $this->get_list_id();
 		update_option( self::COMPLETED_OPTION, $completed_lists );
 		$this->maybe_set_default_layout( $completed_lists );
-		$this->record_tracks_event( 'tasks_completed' );
+		$this->record_tracks_event( 'tasks_completed',
+			array(
+				'tasklist_id' => $this->id
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -407,7 +407,7 @@ class TaskLists {
 	public static function setup_tasks_remaining() {
 		$setup_list = self::get_list( 'setup' );
 
-		if ( ! $setup_list || $setup_list->is_hidden() || $setup_list->is_complete() ) {
+		if ( ! $setup_list || $setup_list->is_hidden() || $setup_list->has_previously_completed() || $setup_list->is_complete() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

These are performance causing issues:
- When viewing homescreen, the tasklist is queried despite hidden or completed
- When accessing wp-admin, tasklist completion is checked everytime
- While assessing tasklist completion, 3 different remote specs are called 

This PR improves tasklist performance by:
- Having cheaper check first
- Removing tasklist from API when it's hidden

This PR also adds tasklist id to track for better track context.

### How to test the changes in this Pull Request:

#### Prerequisite
1. Install and activate `woocommerce-beta-tester` plugin

#### Testing tasklist behavior

1. Go to Homescreen
2. Observe tasklist is shown
3. Click on `Add products`
4. Observe the products task is shown
5. Add a physical product and publish
6. Go back to Homescreen
7. Observe the product task is completed

#### Testing tasklist track
1. Go to [TaskLists.php](https://github.com/woocommerce/woocommerce/blob/c6e11562ac7dc6658ef03a466752e1bfdcbd8e28/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php#L112-L120) and comment out all except for `Products`
2. Refresh homescreen and observe `You've completed store setup` is shown
1. Go to WooCommerce > Status > Logs and look for a log with the name `tracks-*`
2. Look for `wcadmin_tasklist_tasks_completed` and observe there's prop `tasklist_id: setup`

#### Testing hidden tasklist

1. Edit the file [DataSourcePoller.php](https://github.com/woocommerce/woocommerce/blob/c6e11562ac7dc6658ef03a466752e1bfdcbd8e28/plugins/woocommerce/src/Admin/DataSourcePoller.php#L106) and add `self::get_logger()->info( 'Data source: ' .  $this->id );`
1. Go to WooCommerce > Home
1. Go to WooCommerce > Status > Logs and look for a log with the name `plugin-woocommerce*`
4. Observe there's multiple data source query from `payment_method_promotion`, `payment_gateway_suggestions`
5. Go to WooCommerce > Home
6. Hide the **main and "Things to do next" tasklist**
7. Delete the logfile
8. Refresh homescreen
9. Look for a new logfile `plugin-woocommerce*`
10. Observe there's only data source queries for `payment_method_promotion`



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
