### PR TITLE
Improve password-protected Single Product block template to verify correct template is displayed after correct password is introduced

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/scripts/products.sh
@@ -38,7 +38,6 @@ wp wc product update $tshirt_with_logo_product_id --in_stock=false --user=1
 sunglasses_product_id=$(wp post list --post_type=product --field=ID --name="Sunglasses" --format=ids)
 wp post update $sunglasses_product_id --post_password="password" --user=1
 
-
 # Enable attribute archives.
 attribute_ids=$(wp wc product_attribute list --fields=id --format=ids --user=1)
 if [ -n "$attribute_ids" ]; then

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -12,6 +12,13 @@ test.describe( 'Single Product template', async () => {
 		await expect(
 			page.getByText( 'This content is password protected.' ).first()
 		).toBeVisible();
+
+		// Verify after introducing the password, the page is visible.
+		await page.getByLabel( 'Password:' ).fill( 'password' );
+		await page.getByRole( 'button', { name: 'Enter' } ).click();
+		await expect(
+			page.getByRole( 'link', { name: 'Description' } )
+		).toBeVisible();
 	} );
 
 	test( 'loads the Single Product template for a specific product', async ( {

--- a/plugins/woocommerce/changelog/44452-update-single-product-password-test-correct
+++ b/plugins/woocommerce/changelog/44452-update-single-product-password-test-correct
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Improve password-protected Single Product block template to verify correct template is displayed after correct password is introduced.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/44304.

In #44304 we added a test to verify that if a product is password-protected, we display the template with the password field. This PR expands that test to verify that if the user introduces the correct password, then the default template is displayed.

### How to test the changes in this Pull Request:

Note: no need to test this for the release.

1. Verify e2e tests pass.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Improve password-protected Single Product block template to verify correct template is displayed after correct password is introduced

</details>
