### PR TITLE
Fix e2e tests due to duplicate rows when clearing customizations

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -6,7 +6,7 @@ import { BLOCK_THEME_WITH_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 const testData = {
 	permalink: '/product/belt',
-	templateName: 'Product: Belt',
+	templateName: 'Single Product Belt',
 	templatePath: 'single-product-belt',
 	templateType: 'wp_template',
 };

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -373,8 +373,11 @@ export class EditorUtils {
 	}
 
 	async revertTemplateCreation( templateName: string ) {
-		const templateRow = this.page.getByRole( 'row', {
-			name: templateName,
+		const templateRow = this.page.getByRole( 'row' ).filter( {
+			has: this.page.getByRole( 'heading', {
+				name: templateName,
+				exact: true,
+			} ),
 		} );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
 		await this.page
@@ -394,8 +397,11 @@ export class EditorUtils {
 	}
 
 	async revertTemplateCustomizations( templateName: string ) {
-		const templateRow = this.page.getByRole( 'row', {
-			name: templateName,
+		const templateRow = this.page.getByRole( 'row' ).filter( {
+			has: this.page.getByRole( 'heading', {
+				name: templateName,
+				exact: true,
+			} ),
 		} );
 		templateRow.getByRole( 'button', { name: 'Actions' } ).click();
 		await this.page

--- a/plugins/woocommerce/changelog/44454-fix-e2e-templates-tests-duplicate-rows
+++ b/plugins/woocommerce/changelog/44454-fix-e2e-templates-tests-duplicate-rows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix e2e tests due to duplicate rows when clearing customizations.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There are some tests failing in `trunk` because when we try to revert template customizations from the automated tests, there are two rows which match the `Single Product` text (`Single Product` and `Single Product Belt`). That causes the tests to fail because there are two matches for the locator.

This PR makes the locator more specific, so there is only one match even if two templates contain the same words.

### How to test the changes in this Pull Request:

Note: no need to test this for the release.

1. Verify e2e tests pass.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Fix block template e2e tests due to duplicate rows when clearing customizations

</details>
