### PR TITLE
Ensure Shop Page Uses Block Renderer When Applicable (#44453)

### DIFF
--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -193,7 +193,9 @@ class WC_Template_Loader {
 			if ( self::taxonomy_has_block_template( $object ) ) {
 				$default_file = '';
 			} else {
-				if ( taxonomy_is_product_attribute( $object->taxonomy ) ) {
+				if ( is_shop() && self::has_block_template( 'archive-product' ) ) {
+					$default_file = '';
+				} elseif ( taxonomy_is_product_attribute( $object->taxonomy ) ) {
 					$default_file = 'taxonomy-product-attribute.php';
 				} elseif ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
 					$default_file = 'taxonomy-' . $object->taxonomy . '.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implemented an update to prioritize block rendering for the Shop page with filter queries, adjusting the template selection to favor 'archive-product' block templates. Note: The impact on other taxonomies has not been fully explored; caution is advised.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44453  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

- Navigate to a WordPress environment with WooCommerce installed and activated.
- Ensure that a block template for 'archive-product' is available and activated.
- Visit the Shop page without applying the patch, noting the rendering inconsistency when the product lookup table is not used.
- Apply the patch and refresh the Shop page. The Block UI should now render correctly, demonstrating that the Shop page is utilizing the block renderer.
- Disable the block template for 'archive-product' and verify that the fallback behavior remains intact, with the appropriate template being loaded for product attributes, categories, and tags.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Shop page rendering to use block renderer when a block template for 'archive-product' is available, improving consistency and user experience.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
