### PR TITLE
[CYS] Ensure the font family for buttons match the one assigned for the content, not the title

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
@@ -257,8 +257,7 @@ export const FONT_PAIRINGS_WHEN_AI_IS_OFFLINE = [
 			elements: {
 				button: {
 					typography: {
-						fontFamily:
-							'var(--wp--preset--font-family--montserrat)',
+						fontFamily: 'var(--wp--preset--font-family--arvo)',
 						fontStyle: 'normal',
 						fontWeight: '500',
 					},
@@ -490,7 +489,7 @@ export const FONT_PAIRINGS = [
 				button: {
 					typography: {
 						fontFamily:
-							'var(--wp--preset--font-family--commissioner)',
+							'var(--wp--preset--font-family--crimson-pro)',
 						fontWeight: '400',
 						lineHeight: '1',
 					},

--- a/plugins/woocommerce/changelog/44010-fix-font-pairings
+++ b/plugins/woocommerce/changelog/44010-fix-font-pairings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Fix button typhography for the "Montserrat + Arvo" and "Commissioner + Crimson Pro" font pairings.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the button typhography for the "Montserrat + Arvo" and "Commissioner + Crimson Pro" font pairings.

Closes https://github.com/woocommerce/woocommerce/issues/44010

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Local or JN**
1. Ensure the `WooCommerce Beta Tester` plugin is installed and activated (available on this monorepo).
2. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
3. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
4. Follow the process.
5. Click on `Change fonts`.
6. For each one of the font pairings available make sure they are correctly applied to buttons and titles. Pay special attention to the `Montserrat + Arvo` and `Commissioner + Crimson Pro` fonts.

**WooExpress**
Repeat the previous steps in a WooExpress store. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - Fix button typhography for the "Montserrat + Arvo" and "Commissioner + Crimson Pro" font pairings.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
