### PR TITLE
[Experiment] Additional field extensible sanitisation and validation handling

### DIFF
--- a/plugins/woocommerce/changelog/update-account-additional-fields-validaiton-44019
+++ b/plugins/woocommerce/changelog/update-account-additional-fields-validaiton-44019
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+This is behind a feature flag.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -353,8 +353,15 @@ class WC_Form_Handler {
 				$customer->save();
 			}
 
+			/**
+			 * Hook: woocommerce_save_account_details.
+			 *
+			 * @since 3.6.0
+			 * @param int $user_id User ID being saved.
+			 */
 			do_action( 'woocommerce_save_account_details', $user->ID );
 
+			// Notices are checked here so that if something created a notice during the save hooks above, the redirect will not happen.
 			if ( 0 === wc_notice_count( 'error' ) ) {
 				wc_add_notice( __( 'Account details changed successfully.', 'woocommerce' ) );
 				wp_safe_redirect( wc_get_endpoint_url( 'edit-account', '', wc_get_page_permalink( 'myaccount' ) ) );

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -353,12 +353,13 @@ class WC_Form_Handler {
 				$customer->save();
 			}
 
-			wc_add_notice( __( 'Account details changed successfully.', 'woocommerce' ) );
-
 			do_action( 'woocommerce_save_account_details', $user->ID );
 
-			wp_safe_redirect( wc_get_endpoint_url( 'edit-account', '', wc_get_page_permalink( 'myaccount' ) ) );
-			exit;
+			if ( 0 === wc_notice_count( 'error' ) ) {
+				wc_add_notice( __( 'Account details changed successfully.', 'woocommerce' ) );
+				wp_safe_redirect( wc_get_endpoint_url( 'edit-account', '', wc_get_page_permalink( 'myaccount' ) ) );
+				exit;
+			}
 		}
 	}
 
@@ -901,7 +902,7 @@ class WC_Form_Handler {
 		$quantity     = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) );  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$variations   = array();
 
-		$product      = wc_get_product( $product_id );
+		$product = wc_get_product( $product_id );
 
 		foreach ( $_REQUEST as $key => $value ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( 'attribute_' !== substr( $key, 0, 10 ) ) {

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -661,24 +661,6 @@ class CheckoutFields {
 	}
 
 	/**
-	 * Returns an array of fields definitions only meant for order.
-	 *
-	 * @return array An array of fields definitions.
-	 */
-	public function get_order_only_fields() {
-		// For now, all contact fields are order only fields, along with additional fields.
-		$order_fields_keys = array_merge( $this->get_contact_fields_keys(), $this->get_additional_fields_keys() );
-
-		return array_filter(
-			$this->get_additional_fields(),
-			function( $key ) use ( $order_fields_keys ) {
-				return in_array( $key, $order_fields_keys, true );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
-	}
-
-	/**
 	 * Returns an array of fields for a given group.
 	 *
 	 * @param string $location The location to get fields for (address|contact|additional).
@@ -1038,6 +1020,28 @@ class CheckoutFields {
 					$key = str_replace( '/shipping/', '', $key );
 				}
 				return in_array( $key, $customer_fields_keys, true );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+	}
+
+	/**
+	 * From a set of fields, returns only the ones for a given location.
+	 *
+	 * @param array  $fields The fields to filter.
+	 * @param string $location The location to validate the field for (address|contact|additional).
+	 * @return array The filtered fields.
+	 */
+	public function filter_fields_for_location( $fields, $location ) {
+		return array_filter(
+			$fields,
+			function( $key ) use ( $location ) {
+				if ( 0 === strpos( $key, '/billing/' ) ) {
+					$key = str_replace( '/billing/', '', $key );
+				} elseif ( 0 === strpos( $key, '/shipping/' ) ) {
+					$key = str_replace( '/shipping/', '', $key );
+				}
+				return $this->is_field( $key ) && $this->get_field_location( $key ) === $location;
 			},
 			ARRAY_FILTER_USE_KEY
 		);

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -555,7 +555,7 @@ class CheckoutFields {
 				'address_type' => null,
 				// The customer object interacting with checkout or forms.
 				'customer'     => wc()->customer,
-				// A list of sibling fields being updated during the same request.
+				// A list of fields (key value pairs) being updated during the same request.
 				'fields'       => array(),
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -591,12 +591,12 @@ class CheckoutFields {
 			 * Pass an error object to allow validation of an additional field.
 			 *
 			 * @param WP_Error $errors      A WP_Error object that extensions may add errors to.
-			 * @param mixed    $field_value The value of the field being validated.
 			 * @param string   $field_key   Key of the field being sanitized.
+			 * @param mixed    $field_value The value of the field being validated.
 			 *
 			 * @since 8.7.0
 			 */
-			do_action( 'woocommerce_blocks_validate_additional_field', $errors, $field_value, $field_key );
+			do_action( 'woocommerce_blocks_validate_additional_field', $errors, $field_key, $field_value );
 
 		} catch ( \Throwable $e ) {
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -592,13 +592,13 @@ class CheckoutFields {
 	 * @return mixed
 	 */
 	public function sanitize_field( $field_key, $field_value ) {
-		$field = $this->additional_fields[ $field_key ];
-
-		if ( $field ) {
-			$field_value = call_user_func( $field['sanitize_callback'], $field_value, $field );
-		}
-
 		try {
+			$field = $this->additional_fields[ $field_key ] ?? null;
+
+			if ( $field ) {
+				$field_value = call_user_func( $field['sanitize_callback'], $field_value, $field );
+			}
+
 			/**
 			 * Allow custom sanitization of an additional field.
 			 *
@@ -614,8 +614,7 @@ class CheckoutFields {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
-					'The filter %s encountered an error. The field %s will not have any custom sanitization applied to it. %s',
-					'woocommerce_blocks_sanitize_additional_field',
+					'Field sanitization for %s encountered an error. %s',
 					esc_html( $field_key ),
 					esc_html( $e->getMessage() )
 				),
@@ -637,17 +636,18 @@ class CheckoutFields {
 	 */
 	public function validate_field( $field_key, $field_value ) {
 		$errors = new WP_Error();
-		$field  = $this->additional_fields[ $field_key ];
-
-		if ( $field ) {
-			$validation = call_user_func( $field['validate_callback'], $field_value, $field );
-
-			if ( is_wp_error( $validation ) ) {
-				$errors->merge_from( $validation );
-			}
-		}
 
 		try {
+			$field = $this->additional_fields[ $field_key ] ?? null;
+
+			if ( $field ) {
+				$validation = call_user_func( $field['validate_callback'], $field_value, $field );
+
+				if ( is_wp_error( $validation ) ) {
+					$errors->merge_from( $validation );
+				}
+			}
+
 			/**
 			 * Pass an error object to allow validation of an additional field.
 			 *
@@ -665,8 +665,7 @@ class CheckoutFields {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
-					'The action %s encountered an error. The field %s may not have any custom validation applied to it. %s',
-					'woocommerce_blocks_validate_additional_field',
+					'Field validation for %s encountered an error. %s',
 					esc_html( $field_key ),
 					esc_html( $e->getMessage() )
 				),

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -604,15 +604,13 @@ class CheckoutFields {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
-					'The action %s encountered an error. The field %s will not have any custom validation applied to it. %s',
+					'The action %s encountered an error. The field %s may not have any custom validation applied to it. %s',
 					'woocommerce_blocks_validate_additional_field',
 					esc_html( $field_key ),
 					esc_html( $e->getMessage() )
 				),
 				E_USER_WARNING
 			);
-
-			return new WP_Error();
 		}
 
 		return $errors;
@@ -696,9 +694,9 @@ class CheckoutFields {
 			/**
 			 * Pass an error object to allow validation of an additional field.
 			 *
-			 * @param WP_Error $errors      A WP_Error object that extensions may add errors to.
-			 * @param mixed    $field_value The value of the field being validated.
-			 * @param string   $field_key   Key of the field being sanitized.
+			 * @param WP_Error $errors  A WP_Error object that extensions may add errors to.
+			 * @param mixed    $fields  List of fields (key value pairs) in this location.
+			 * @param string   $group   The group of this location (shipping|billing|'').
 			 *
 			 * @since 8.7.0
 			 */
@@ -710,15 +708,13 @@ class CheckoutFields {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
-					'The action %s encountered an error. The field location %s will not have any custom validation applied to it. %s',
+					'The action %s encountered an error. The field location %s may not have any custom validation applied to it. %s',
 					esc_html( 'woocommerce_blocks_validate_' . $location . '_fields' ),
 					esc_html( $location ),
 					esc_html( $e->getMessage() )
 				),
 				E_USER_WARNING
 			);
-
-			return new WP_Error();
 		}
 
 		return $errors;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -700,7 +700,7 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			do_action( 'woocommerce_blocks_validate_' . $location . '_fields', $errors, $fields, $group );
+			do_action( 'woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group );
 
 		} catch ( \Throwable $e ) {
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
@@ -232,17 +232,17 @@ class CheckoutFieldsFrontend {
 		$fields   = $this->checkout_fields_controller->get_fields_for_location( 'address' );
 
 		foreach ( $fields as $key => $field ) {
-			$post_key                      = "/{$address_type}/{$key}";
-			$address[ $post_key ]          = $field;
-			$address[ $post_key ]['value'] = $this->checkout_fields_controller->get_field_from_customer( $key, $customer, $address_type );
+			$field_key                      = "/{$address_type}/{$key}";
+			$address[ $field_key ]          = $field;
+			$address[ $field_key ]['value'] = $this->checkout_fields_controller->get_field_from_customer( $key, $customer, $address_type );
 
 			if ( 'select' === $field['type'] ) {
-				$address[ $post_key ]['options'] = array_column( $field['options'], 'label', 'value' );
+				$address[ $field_key ]['options'] = array_column( $field['options'], 'label', 'value' );
 			}
 
 			if ( 'checkbox' === $field['type'] ) {
-				$address[ $post_key ]['checked_value']   = '1';
-				$address[ $post_key ]['unchecked_value'] = '0';
+				$address[ $field_key ]['checked_value']   = '1';
+				$address[ $field_key ]['unchecked_value'] = '0';
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
@@ -193,27 +193,28 @@ class CheckoutFieldsFrontend {
 			if ( ! isset( $_POST[ $key ] ) ) {
 				continue;
 			}
-			$sanitized_value      = $this->checkout_fields_controller->sanitize_field( $key, wc_clean( wp_unslash( $_POST[ $key ] ) ) );
-			$field_values[ $key ] = $sanitized_value;
-		}
 
-		// Validate and persist individual additional fields.
-		foreach ( $field_values as $key => $value ) {
-			$validation_result = $this->checkout_fields_controller->validate_field( $key, $value );
+			$field_value = $this->checkout_fields_controller->sanitize_field( $key, wc_clean( wp_unslash( $_POST[ $key ] ) ) );
+			$validation  = $this->checkout_fields_controller->validate_field( $key, $field_value );
 
-			if ( is_wp_error( $validation_result ) && $validation_result->has_errors() ) {
-				wc_add_notice( $validation_result->get_error_message(), 'error' );
+			if ( is_wp_error( $validation ) && $validation->has_errors() ) {
+				wc_add_notice( $validation->get_error_message(), 'error' );
 				continue;
 			}
 
+			$field_values[ $key ] = $field_value;
+		}
+
+		// Persist individual additional fields to customer.
+		foreach ( $field_values as $key => $value ) {
 			$this->checkout_fields_controller->persist_field_for_customer( $key, $value, $customer );
 		}
 
 		// Validate all fields for this location.
-		$validation_result = $this->checkout_fields_controller->validate_fields_for_location( $field_values, 'contact' );
+		$location_validation = $this->checkout_fields_controller->validate_fields_for_location( $field_values, 'contact' );
 
-		if ( is_wp_error( $validation_result ) && $validation_result->has_errors() ) {
-			wc_add_notice( $validation_result->get_error_message(), 'error' );
+		if ( is_wp_error( $location_validation ) && $location_validation->has_errors() ) {
+			wc_add_notice( $location_validation->get_error_message(), 'error' );
 		}
 
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
@@ -272,27 +273,27 @@ class CheckoutFieldsFrontend {
 				continue;
 			}
 
-			$sanitized_value      = $this->checkout_fields_controller->sanitize_field( $key, wc_clean( wp_unslash( $_POST[ $post_key ] ) ) );
-			$field_values[ $key ] = $sanitized_value;
-		}
+			$field_value = $this->checkout_fields_controller->sanitize_field( $key, wc_clean( wp_unslash( $_POST[ $post_key ] ) ) );
+			$validation  = $this->checkout_fields_controller->validate_field( $key, $field_value );
 
-		// Validate and persist individual additional fields.
-		foreach ( $field_values as $key => $value ) {
-			$validation_result = $this->checkout_fields_controller->validate_field( $key, $value );
-
-			if ( is_wp_error( $validation_result ) && $validation_result->has_errors() ) {
-				wc_add_notice( $validation_result->get_error_message(), 'error' );
+			if ( is_wp_error( $validation ) && $validation->has_errors() ) {
+				wc_add_notice( $validation->get_error_message(), 'error' );
 				continue;
 			}
 
+			$field_values[ $key ] = $field_value;
+		}
+
+		// Persist individual additional fields to customer.
+		foreach ( $field_values as $key => $value ) {
 			$this->checkout_fields_controller->persist_field_for_customer( "/{$address_type}/{$key}", $value, $customer );
 		}
 
 		// Validate all fields for this location.
-		$validation_result = $this->checkout_fields_controller->validate_fields_for_location( array_merge( $address, $field_values ), 'address', $address_type );
+		$location_validation = $this->checkout_fields_controller->validate_fields_for_location( array_merge( $address, $field_values ), 'address', $address_type );
 
-		if ( is_wp_error( $validation_result ) && $validation_result->has_errors() ) {
-			wc_add_notice( $validation_result->get_error_message(), 'error' );
+		if ( is_wp_error( $location_validation ) && $location_validation->has_errors() ) {
+			wc_add_notice( $location_validation->get_error_message(), 'error' );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -415,8 +415,9 @@ class Checkout extends AbstractCartRoute {
 
 		// Billing address is a required field.
 		foreach ( $request['billing_address'] as $key => $value ) {
-			if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
-				$customer->{"set_billing_$key"}( $value );
+			$callback = "set_billing_$key";
+			if ( is_callable( [ $customer, $callback ] ) ) {
+				$customer->$callback( $value );
 			} elseif ( $this->additional_fields_controller->is_field( $key ) ) {
 				$this->additional_fields_controller->persist_field_for_customer( "/billing/$key", $value, $customer );
 			}
@@ -426,10 +427,9 @@ class Checkout extends AbstractCartRoute {
 		$shipping_address_values = $request['shipping_address'] ?? $request['billing_address'];
 
 		foreach ( $shipping_address_values as $key => $value ) {
-			if ( is_callable( [ $customer, "set_shipping_$key" ] ) ) {
-				$customer->{"set_shipping_$key"}( $value );
-			} elseif ( 'phone' === $key ) {
-				$customer->update_meta_data( 'shipping_phone', $value );
+			$callback = "set_shipping_$key";
+			if ( is_callable( [ $customer, $callback ] ) ) {
+				$customer->$callback( $value );
 			} elseif ( $this->additional_fields_controller->is_field( $key ) ) {
 				$this->additional_fields_controller->persist_field_for_customer( "/shipping/$key", $value, $customer );
 			}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -404,6 +404,52 @@ class Checkout extends AbstractCartRoute {
 	}
 
 	/**
+	 * Process customer address fields.
+	 *
+	 * @param \WC_Customer     $customer Customer object.
+	 * @param \WP_REST_Request $request Full details about the request.
+	 */
+	private function update_customer_address_data_from_request( $customer, $request ) {
+		$posted_billing  = $request['billing_address'];
+		$posted_shipping = $request['shipping_address'] ?? $request['billing_address'];
+
+		foreach ( $posted_billing as $key => $value ) {
+			$callback = "set_billing_$key";
+			if ( is_callable( [ $customer, $callback ] ) ) {
+				$customer->$callback( $value );
+			} elseif ( $this->additional_fields_controller->is_field( $key ) ) {
+				$this->additional_fields_controller->persist_field_for_customer( "/billing/$key", $value, $customer );
+			}
+		}
+
+		foreach ( $posted_shipping as $key => $value ) {
+			$callback = "set_shipping_$key";
+			if ( is_callable( [ $customer, $callback ] ) ) {
+				$customer->$callback( $value );
+			} elseif ( $this->additional_fields_controller->is_field( $key ) ) {
+				$this->additional_fields_controller->persist_field_for_customer( "/shipping/$key", $value, $customer );
+			}
+		}
+	}
+
+	/**
+	 * Process customer additional fields.
+	 *
+	 * @param \WC_Customer     $customer Customer object.
+	 * @param \WP_REST_Request $request Full details about the request.
+	 */
+	private function update_customer_additional_fields_from_request( $customer, $request ) {
+		// Persist contact fields.
+		$contact_field_keys = array_filter( (array) $this->additional_fields_controller->get_contact_fields_keys() );
+
+		foreach ( $contact_field_keys as $key ) {
+			if ( isset( $request['additional_fields'], $request['additional_fields'][ $key ] ) ) {
+				$this->additional_fields_controller->persist_field_for_customer( $key, $request['additional_fields'][ $key ], $customer );
+			}
+		}
+	}
+
+	/**
 	 * Updates the current customer session using data from the request (e.g. address data).
 	 *
 	 * Address session data is synced to the order itself later on by OrderController::update_order_from_cart()
@@ -413,38 +459,8 @@ class Checkout extends AbstractCartRoute {
 	private function update_customer_from_request( \WP_REST_Request $request ) {
 		$customer = wc()->customer;
 
-		// Billing address is a required field.
-		foreach ( $request['billing_address'] as $key => $value ) {
-			if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
-				$customer->{"set_billing_$key"}( $value );
-			} elseif ( $this->additional_fields_controller->is_field( $key ) ) {
-				$this->additional_fields_controller->persist_field_for_customer( "/billing/$key", $value, $customer );
-			}
-		}
-
-		// If shipping address (optional field) was not provided, set it to the given billing address (required field).
-		$shipping_address_values = $request['shipping_address'] ?? $request['billing_address'];
-
-		foreach ( $shipping_address_values as $key => $value ) {
-			if ( is_callable( [ $customer, "set_shipping_$key" ] ) ) {
-				$customer->{"set_shipping_$key"}( $value );
-			} elseif ( 'phone' === $key ) {
-				$customer->update_meta_data( 'shipping_phone', $value );
-			} elseif ( $this->additional_fields_controller->is_field( $key ) ) {
-				$this->additional_fields_controller->persist_field_for_customer( "/shipping/$key", $value, $customer );
-			}
-		}
-
-		// Persist contact fields to session.
-		$contact_fields = $this->additional_fields_controller->get_contact_fields_keys();
-
-		if ( ! empty( $contact_fields ) ) {
-			foreach ( $contact_fields as $key ) {
-				if ( isset( $request['additional_fields'], $request['additional_fields'][ $key ] ) ) {
-					$this->additional_fields_controller->persist_field_for_customer( $key, $request['additional_fields'][ $key ], $customer );
-				}
-			}
-		}
+		$this->update_customer_address_data_from_request( $customer, $request );
+		$this->update_customer_additional_fields_from_request( $customer, $request );
 
 		/**
 		 * Fires when the Checkout Block/Store API updates a customer from the API request data.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -247,8 +247,14 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
 			// Skip additional validation if the schema validation failed.
 			if ( true === $result && in_array( $key, $additional_keys, true ) ) {
-				$address_type = 'shipping_address' === $this->title ? 'shipping' : 'billing';
-				$result       = $this->additional_fields_controller->validate_field( $key, $address[ $key ], $request, $address_type );
+				$result = $this->additional_fields_controller->validate_field(
+					$key,
+					$address[ $key ],
+					array(
+						'address_type' => 'shipping_address' === $this->title ? 'shipping' : 'billing',
+						'fields'       => $address,
+					)
+				);
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\Blocks\Package;
+
 /**
  * AddressSchema class.
  *
@@ -247,19 +248,18 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
 			// Skip additional validation if the schema validation failed.
 			if ( true === $result && in_array( $key, $additional_keys, true ) ) {
-				$result = $this->additional_fields_controller->validate_field(
-					$key,
-					$address[ $key ],
-					array(
-						'address_type' => 'shipping_address' === $this->title ? 'shipping' : 'billing',
-						'fields'       => $address,
-					)
-				);
+				$result = $this->additional_fields_controller->validate_field( $key, $address[ $key ] );
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {
 				$errors->merge_from( $result );
 			}
+		}
+
+		$result = $this->additional_fields_controller->validate_fields_for_location( $address, 'address', $this->title === 'billing_address' ? 'billing' : 'shipping' );
+
+		if ( is_wp_error( $result ) && $result->has_errors() ) {
+			$errors->merge_from( $result );
 		}
 
 		return $errors->has_errors( $errors ) ? $errors : true;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -136,7 +136,9 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema[ $key ], $key );
 						break;
 				}
-				$carry[ $key ] = $this->additional_fields_controller->sanitize_field( $key, $carry[ $key ] );
+				if ( $this->additional_fields_controller->is_field( $key ) ) {
+					$carry[ $key ] = $this->additional_fields_controller->sanitize_field( $key, $carry[ $key ] );
+				}
 				return $carry;
 			},
 			[]

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -133,10 +133,10 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
 						break;
 					default:
-						$rest_sanitized = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema[ $key ], $key );
-						$carry[ $key ]  = $rest_sanitized;
+						$carry[ $key ] = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema[ $key ], $key );
 						break;
 				}
+				$carry[ $key ] = $this->additional_fields_controller->sanitize_field( $key, $carry[ $key ] );
 				return $carry;
 			},
 			[]
@@ -256,7 +256,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			}
 		}
 
-		$result = $this->additional_fields_controller->validate_fields_for_location( $address, 'address', $this->title === 'billing_address' ? 'billing' : 'shipping' );
+		$result = $this->additional_fields_controller->validate_fields_for_location( $address, 'address', 'billing_address' === $this->title ? 'billing' : 'shipping' );
 
 		if ( is_wp_error( $result ) && $result->has_errors() ) {
 			$errors->merge_from( $result );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -379,7 +379,13 @@ class CheckoutSchema extends AbstractSchema {
 
 			// Only allow custom validation on fields that pass the schema validation.
 			if ( true === $result ) {
-				$result = $this->additional_fields_controller->validate_field( $key, $field_value, $request );
+				$result = $this->additional_fields_controller->validate_field(
+					$key,
+					$field_value,
+					array(
+						'fields' => $fields,
+					)
+				);
 			}
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -74,10 +74,7 @@ class CheckoutSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_properties() {
-		$additional_field_schema = $this->get_additional_fields_schema(
-			$this->additional_fields_controller->get_fields_for_location( 'contact' ),
-			$this->additional_fields_controller->get_fields_for_location( 'additional' )
-		);
+		$additional_field_schema = $this->get_additional_fields_schema();
 		return [
 			'order_id'          => [
 				'description' => __( 'The order ID to process during checkout.', 'woocommerce' ),
@@ -283,10 +280,22 @@ class CheckoutSchema extends AbstractSchema {
 	/**
 	 * Get the schema for additional fields.
 	 *
+	 * @return array
+	 */
+	protected function get_additional_fields_schema() {
+		return $this->generate_additional_fields_schema(
+			$this->additional_fields_controller->get_fields_for_location( 'contact' ),
+			$this->additional_fields_controller->get_fields_for_location( 'additional' )
+		);
+	}
+
+	/**
+	 * Generate the schema for additional fields.
+	 *
 	 * @param array[] ...$args One or more arrays of additional fields.
 	 * @return array
 	 */
-	protected function get_additional_fields_schema( ...$args ) {
+	protected function generate_additional_fields_schema( ...$args ) {
 		$additional_fields = array_merge( ...$args );
 		$schema            = [];
 		foreach ( $additional_fields as $key => $field ) {
@@ -338,10 +347,7 @@ class CheckoutSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function sanitize_additional_fields( $fields ) {
-		$properties         = $this->get_additional_fields_schema(
-			$this->additional_fields_controller->get_fields_for_location( 'contact' ),
-			$this->additional_fields_controller->get_fields_for_location( 'additional' )
-		);
+		$properties         = $this->get_additional_fields_schema();
 		$sanitization_utils = new SanitizationUtils();
 		$fields             = $sanitization_utils->wp_kses_array(
 			array_reduce(
@@ -373,22 +379,16 @@ class CheckoutSchema extends AbstractSchema {
 	 * @return true|\WP_Error
 	 */
 	public function validate_additional_fields( $fields, $request ) {
-		$errors = new \WP_Error();
-		$fields = $this->sanitize_additional_fields( $fields );
+		$errors                  = new \WP_Error();
+		$fields                  = $this->sanitize_additional_fields( $fields );
+		$additional_field_schema = $this->get_additional_fields_schema();
 
-		// Get these separately so we can validate each location.
-		$contact_properties    = $this->get_additional_fields_schema( $this->additional_fields_controller->get_fields_for_location( 'contact' ) );
-		$additional_properties = $this->get_additional_fields_schema( $this->additional_fields_controller->get_fields_for_location( 'additional' ) );
-		$all_properties        = array_merge( $contact_properties, $additional_properties );
-
-		// Validate all individual properties first.
-		foreach ( array_keys( $all_properties ) as $key ) {
-			if ( ! isset( $fields[ $key ] ) && false === $all_properties[ $key ]['required'] ) {
+		// Validate individual properties first.
+		foreach ( $fields as $key => $field_value ) {
+			if ( ! isset( $additional_field_schema[ $key ] ) ) {
 				continue;
 			}
-
-			$field_value = isset( $fields[ $key ] ) ? $fields[ $key ] : null;
-			$result      = rest_validate_value_from_schema( $field_value, $all_properties[ $key ], $key );
+			$result = rest_validate_value_from_schema( $field_value, $additional_field_schema[ $key ], $key );
 
 			// Only allow custom validation on fields that pass the schema validation.
 			if ( true === $result ) {
@@ -399,10 +399,10 @@ class CheckoutSchema extends AbstractSchema {
 				$location = $this->additional_fields_controller->get_field_location( $key );
 				foreach ( $result->get_error_codes() as $code ) {
 					$result->add_data(
-						[
+						array(
 							'location' => $location,
 							'key'      => $key,
-						],
+						),
 						$code
 					);
 				}
@@ -410,19 +410,17 @@ class CheckoutSchema extends AbstractSchema {
 			}
 		}
 
-		// Now validate by location so the groups of fields can be validated together.
-		$errors->merge_from(
-			$this->additional_fields_controller->validate_fields_for_location(
-				$this->additional_fields_controller->filter_fields_for_location( $fields, 'contact' ),
-				'contact'
-			)
-		);
-		$errors->merge_from(
-			$this->additional_fields_controller->validate_fields_for_location(
-				$this->additional_fields_controller->filter_fields_for_location( $fields, 'additional' ),
-				'additional'
-			)
-		);
+		// Validate groups of properties per registered location.
+		$locations = array( 'contact', 'additional' );
+
+		foreach ( $locations as $location ) {
+			$location_fields = $this->additional_fields_controller->filter_fields_for_location( $fields, $location );
+			$result          = $this->additional_fields_controller->validate_fields_for_location( $location_fields, $location );
+
+			if ( is_wp_error( $result ) && $result->has_errors() ) {
+				$errors->merge_from( $result );
+			}
+		}
 
 		return $errors->has_errors( $errors ) ? $errors : true;
 	}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -365,7 +365,7 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	public function validate_additional_fields( $fields, $request ) {
 		$errors     = new \WP_Error();
-		$fields     = $this->sanitize_additional_fields( $fields, $request );
+		$fields     = $this->sanitize_additional_fields( $fields );
 		$properties = $this->get_additional_fields_schema();
 
 		foreach ( array_keys( $properties ) as $key ) {

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -339,6 +339,7 @@ class OrderController {
 
 		$errors_by_code = array();
 		$error_codes    = $errors->get_error_codes();
+
 		foreach ( $error_codes as $code ) {
 			$errors_by_code[ $code ] = $errors->get_error_messages( $code );
 		}
@@ -415,6 +416,16 @@ class OrderController {
 			if ( empty( $address[ $address_field_key ] ) && $address_field['required'] ) {
 				/* translators: %s Field label. */
 				$errors->add( $address_type, sprintf( __( '%s is required', 'woocommerce' ), $address_field['label'] ), $address_field_key );
+			}
+		}
+
+		// Validate additional fields.
+		$result = $this->additional_fields_controller->validate_fields_for_location( $address, 'address', $address_type );
+
+		if ( $result->has_errors() ) {
+			// Add errors to main error object but ensure they maintain the billing/shipping error code.
+			foreach ( $result->get_error_codes() as $code ) {
+				$errors->add( $address_type, $result->get_error_message( $code ), $code );
 			}
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces new hooks for extensions to sanitise and validate registered checkout fields.

- Validation now uses an action hook with the error object passed by reference. This negates the need to compare the error object before and after hooks to ensure the object did not change
- Add sanitisation hook for custom sanitisation rules on additional fields
- Validation hook for custom validation rules on additional fields - key and value only
- Location validation hook for custom validation rules on additional fields where there are dependencies on the values of other fields in that location
- Validation applied to my account area

Closes #44019 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Developers should use this snippet this add some custom fields. Gov ID and email have validation methods.

<details>

```
add_action(
	'woocommerce_blocks_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id'                => 'plugin-namespace/alt-email',
				'label'             => 'Alternative Email Field',
				'location'          => 'contact',
				'type'              => 'text',
				'required'          => true,
				'sanitize_callback' => function( $field_value ) {
					return sanitize_email( $field_value );
				},
				'validate_callback' => function( $field_value ) {
					if ( ! is_email( $field_value ) ) {
						return new \WP_Error( 'invalid_alt_email', 'Please ensure your alternative email matches the correct format.' );
					}
				},
			),
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'                => 'plugin-namespace/gov-id',
				'label'             => 'Government ID',
				'location'          => 'address',
				'type'              => 'text',
				'required'          => true,
				'sanitize_callback' => function( $field_value ) {
					return str_replace( ' ', '', $field_value );
				},
			),
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/confirm-gov-id',
				'label'    => 'Confirm Government ID',
				'location' => 'address',
				'type'     => 'text',
				'required' => true,
			),
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-on-porch',
				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'checkbox',
				'required' => true,
			),
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/location-on-porch',
				'label'    => __( 'Describe where we should hide the parcel', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'text',
			)
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-with-neighbor',
				'label'    => __( 'Which neighbor should we leave it with if unable to hide?', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'select',
				'options'  => array(
					array(
						'label' => 'Neighbor to the left',
						'value' => 'left',
					),
					array(
						'label' => 'Neighbor to the right',
						'value' => 'right',
					),
					array(
						'label' => 'Neighbor across the road',
						'value' => 'across',
					),
					array(
						'label' => 'Do not leave with a neighbor',
						'value' => 'none',
					),
				),
			)
		);

		add_action(
			'woocommerce_blocks_sanitize_additional_field',
			function( $value, $key ) {
				if ( 'plugin-namespace/confirm-gov-id' === $key ) {
					return str_replace( ' ', '', $value );
				}
				return $value;
			},
			10,
			2
		);
		add_action(
			'woocommerce_blocks_validate_additional_field',
			function ( \WP_Error $errors, $field_key, $field_value ) {
				if ( 'plugin-namespace/gov-id' === $field_key ) {
					$match = preg_match( '/[A-Z0-9]{5}/', $field_value );
					if ( 0 === $match || false === $match ) {
						$errors->add( 'invalid_gov_id', 'Please ensure your government ID matches the correct format.' );
					}
				}
			},
			10,
			3
		);
		add_action(
			'woocommerce_blocks_validate_location_address_fields',
			function ( \WP_Error $errors, $fields, $group ) {
				if ( $fields['plugin-namespace/gov-id'] !== $fields['plugin-namespace/confirm-gov-id'] ) {
					$errors->add( 'gov_id_mismatch', 'Please ensure your government ID matches the confirmation.' );
				}
			},
			10,
			3
		);
	}
);
```

</details>

1. Add items to cart and go to checkout.
2. Enter something in the custom "additional email" field that is not an email, and enter some letters in the Gov ID fields. Ensure both Gov ID address fields are different.
3. After typing in Gov ID the checkout will refresh. You'll see an error notice with 2 bullets (formatting is wrong, and fields do not match). Correct this and ensure the errors go away.
4. Place order and it will throw another error this time about email. Correct this and place the order again. It should go through.
5. Check the confirmation page values match what you submitted.
6. Go to the My Account page.
7. Under addresses, edit an address. Try changing the Gov ID fields and submit with errors. You'll see an error notice if it fails validation.
8. If you refresh the page before fixing the validation errors, correct values are restored.
9. If you fix the validation errors, the new values should save to the account.
10. Under "account details" change "Alternative Email" to something else. Save. See error message.
11. Correct the email field and save. Change should persist.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
