### PR TITLE
Proposal: Avoid continuing with WC_Data::save() when no local changes exist

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -227,6 +227,10 @@ abstract class WC_Data {
 			return $this->get_id();
 		}
 
+		if ( ! $this->has_unsaved_changes() ) {
+			return $this->get_id();
+		}
+
 		/**
 		 * Trigger action before saving to the DB. Allows you to adjust object props before save.
 		 *
@@ -851,6 +855,30 @@ abstract class WC_Data {
 	public function apply_changes() {
 		$this->data    = array_replace_recursive( $this->data, $this->changes ); // @codingStandardsIgnoreLine
 		$this->changes = array();
+	}
+
+	/**
+	 * Whether the data or meta data has changes applied.
+	 *
+	 * @return bool
+	 */
+	protected function has_unsaved_changes(): bool {
+		if ( count( $this->get_changes() ) > 0 ) {
+			return true;
+		}
+
+		if ( ! is_null( $this->meta_data ) ) {
+			foreach ( $this->meta_data as $meta ) {
+				if ( count( $meta->get_changes() ) > 0 ||
+				     ( is_null( $meta->value ) && ! empty( $meta->id ) ) ||
+				     empty( $meta->id )
+				) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -227,10 +227,6 @@ abstract class WC_Data {
 			return $this->get_id();
 		}
 
-		if ( ! $this->has_unsaved_changes() ) {
-			return $this->get_id();
-		}
-
 		/**
 		 * Trigger action before saving to the DB. Allows you to adjust object props before save.
 		 *
@@ -240,6 +236,9 @@ abstract class WC_Data {
 		do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 		if ( $this->get_id() ) {
+			if ( ! $this->has_unsaved_changes() ) {
+				return $this->get_id();
+			}
 			$this->data_store->update( $this );
 		} else {
 			$this->data_store->create( $this );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Introduce a protected method to the WC_Data class that will determine whether there are any local changes to a data object that will be checked prior to continuing with the `::save()` method execution.

This is purely an example proposal and is not meant to be merged as is.
