### PR TITLE
Product Gallery block > Pop-Up: Fix overlay sizing issue

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -31,7 +31,7 @@ $admin-bar-mobile-height: 46px;
 		z-index: 9999;
 		padding: $dialog-padding;
 		height: 100vh;
-		width: calc(100vw - 2*($dialog-padding));
+		width: calc(100vw - 2 * ($dialog-padding));
 
 		.admin-bar & {
 			margin-top: $admin-bar-desktop-height;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -13,28 +13,25 @@ $thumbnails-gap: 15px;
 $default-number-of-thumbnails: 3;
 $dialog-header-height: 29px;
 $dialog-header-padding-top: calc(30px / 2);
+$dialog-padding: 16px;
 $admin-bar-desktop-height: 32px;
 $admin-bar-mobile-height: 46px;
 
 // Product Gallery
 #{$gallery} {
-	.wc-block-product-gallery-dialog__overlay {
-		height: 100vh;
-		width: 100vw;
-		position: fixed;
-		top: 0;
-		left: 0;
-		background-color: #808080;
-		z-index: 9999;
-	}
-
 	dialog {
+		&.wc-block-product-gallery--dialog-open {
+			display: flex;
+		}
+
+		flex-direction: column;
 		position: fixed;
 		border: none;
 		top: 0;
 		z-index: 9999;
-		padding-top: 0;
+		padding: $dialog-padding;
 		height: 100vh;
+		width: calc(100vw - 2*($dialog-padding));
 
 		.admin-bar & {
 			margin-top: $admin-bar-desktop-height;
@@ -50,6 +47,10 @@ $admin-bar-mobile-height: 46px;
 
 		.wc-block-product-gallery-dialog__header {
 			padding-top: $dialog-header-padding-top;
+		}
+
+		.wc-block-product-gallery-dialog__body {
+			align-self: center;
 		}
 
 		.wc-block-product-galler-dialog__header-right {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.side_effects.spec.ts
@@ -381,12 +381,12 @@ test.describe( `${ blockData.name }`, () => {
 			} );
 			largeImageBlock.click();
 
-			const productGalleryPopUp = page.locator(
-				'.wc-block-product-gallery-dialog__overlay'
+			const productGalleryPopUpContent = page.locator(
+				'.wc-block-product-gallery-dialog__body'
 			);
 
 			const popUpSelectedImageId = await getVisibleLargeImageId(
-				productGalleryPopUp.locator(
+				productGalleryPopUpContent.locator(
 					`[data-block-name="woocommerce/product-gallery-large-image"]`
 				)
 			);
@@ -445,17 +445,17 @@ test.describe( `${ blockData.name }`, () => {
 
 			largeImageBlock.click();
 
-			const productGalleryPopUp = page.locator(
-				'.wc-block-product-gallery-dialog__overlay'
+			const productGalleryPopUpContent = page.locator(
+				'.wc-block-product-gallery-dialog__body'
 			);
 
 			const popUpInitialSelectedImageId = await getVisibleLargeImageId(
-				productGalleryPopUp.locator(
+				productGalleryPopUpContent.locator(
 					`[data-block-name="woocommerce/product-gallery-large-image"]`
 				)
 			);
 
-			const popUpNextButton = productGalleryPopUp
+			const popUpNextButton = productGalleryPopUpContent
 				.locator(
 					'.wc-block-product-gallery-large-image-next-previous--button'
 				)
@@ -463,23 +463,24 @@ test.describe( `${ blockData.name }`, () => {
 			await popUpNextButton.click();
 
 			const popUpNextImageId = await getVisibleLargeImageId(
-				productGalleryPopUp.locator(
+				productGalleryPopUpContent.locator(
 					`[data-block-name="woocommerce/product-gallery-large-image"]`
 				)
 			);
 
 			expect( popUpInitialSelectedImageId ).not.toBe( popUpNextImageId );
 
-			const closePopUpButton = productGalleryPopUp.locator(
+			const productGalleryPopUpHeader = page.locator(
+				'.wc-block-product-gallery-dialog__header'
+			);
+			const closePopUpButton = productGalleryPopUpHeader.locator(
 				'.wc-block-product-gallery-dialog__close'
 			);
 			closePopUpButton.click();
 
 			await page.waitForFunction( () => {
 				const isPopUpOpen = document
-					.querySelector(
-						'.wc-block-product-gallery-dialog__overlay'
-					)
+					.querySelector( '[aria-label="Product gallery"]' )
 					?.checkVisibility();
 
 				return isPopUpOpen === false;

--- a/plugins/woocommerce/changelog/fix-43826-overlay-sizing-issue
+++ b/plugins/woocommerce/changelog/fix-43826-overlay-sizing-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix overlay sizing issue with the Product Gallery Pop-Up.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -77,8 +77,7 @@ class ProductGallery extends AbstractBlock {
 
 		$gallery_dialog = strtr(
 			'
-		<div class="wc-block-product-gallery-dialog__overlay" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess">
-			<dialog data-wc-bind--open="context.isDialogOpen" role="dialog" aria-modal="true" aria-label="{{dialog_aria_label}}">
+			<dialog data-wc-bind--open="context.isDialogOpen" role="dialog" aria-modal="true" aria-label="{{dialog_aria_label}}" hidden data-wc-bind--hidden="!context.isDialogOpen" data-wc-watch="callbacks.keyboardAccess" data-wc-class--wc-block-product-gallery--dialog-open="context.isDialogOpen">
 				<div class="wc-block-product-gallery-dialog__header">
 				<div class="wc-block-product-galler-dialog__header-right">
 					<button class="wc-block-product-gallery-dialog__close" data-wc-on--click="actions.closeDialog" aria-label="{{close_dialog_aria_label}}">
@@ -92,8 +91,7 @@ class ProductGallery extends AbstractBlock {
 				<div class="wc-block-product-gallery-dialog__body">
 					{{html}}
 				</div>
-			</dialog>
-		</div>',
+			</dialog>',
 			array(
 				'{{html}}'                    => $html_processor->get_updated_html(),
 				'{{dialog_aria_label}}'       => __( 'Product gallery', 'woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR fixes an issue when you visit a product with a single image and open the Product Gallery Pop-Up. Depending on the size of the image, if it does not fill the entire screen, it can cause the background to be an incorrect color and the close button to appear in the middle of the screen.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43826 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Single Product template).
2. Click on "Edit" to open the Template editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block." Click on it.
4. In the block inserter, search for "Product Gallery" or browse through the available blocks until you find it.
5. Click on the "Product Gallery" block to add it to your content.
6. Visit a product with a single image.
7. Click on the large image to open the Product Gallery Pop-Up;
8. Make sure the close button appears correctly positioned to the top right of the screen, the background color of the pop-up is white, and you can navigate between the images without any issue;
9. Close the pop-up and visit a product with multiple images.
10. Make sure the close button appears correctly positioned to the top right of the screen, the background color of the pop-up is white, and you can navigate between the images without any issue;

| Before | After |
|--------|--------|
| ![CleanShot 2024-02-08 at 16 55 12@2x](https://github.com/woocommerce/woocommerce/assets/20469356/a279ae4e-e156-4d2d-8752-bcc16684e0f3) | ![CleanShot 2024-02-08 at 16 52 01@2x](https://github.com/woocommerce/woocommerce/assets/20469356/89d21337-4755-43d1-ba82-b7dc8d42c4b3) |

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix overlay sizing issue with the Product Gallery Pop-Up.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
