### PR TITLE
Logging: Add check for file key when parsing backtrace

### DIFF
--- a/plugins/woocommerce/changelog/fix-44475-logging-backtrace-fix
+++ b/plugins/woocommerce/changelog/fix-44475-logging-backtrace-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure that no undefined index warnings are thrown while parsing the backtrace to determine a log's source

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -123,6 +123,10 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 		$backtrace = static::get_backtrace();
 
 		foreach ( $backtrace as $frame ) {
+			if ( ! isset( $frame['file'] ) ) {
+				continue;
+			}
+
 			foreach ( $source_roots as $type => $path ) {
 				if ( 0 === strpos( $frame['file'], $path ) ) {
 					$relative_path = trim( substr( $frame['file'], strlen( $path ) ), DIRECTORY_SEPARATOR );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Ensures that no undefined index warnings are thrown while parsing the backtrace to determine a log's source.

Fixes #44475

### How to test the changes in this Pull Request:

I couldn't actually figure out how to create a situation where a backtrace frame _didn't_ have a `file` key. It may be specific to the environment that PHP is running in. The original report is here: p1707414971393689-slack-C0E1AV8T0

Instead, I guess you can just ensure that this change doesn't break anything in the normal flow. First install the Query Monitor plugin so you can see PHP warnings as they come in. Then add this snippet to mu-plugins:

```php
add_action(
	'admin_init',
	function() {
		wc_get_logger()->error(
			'Test log'
		);
	}
);
```

With the snippet in place, go to WP Admin and then navigate to WooCommerce > Status > Logs. You should see a log file with source `mu-plugins-index` (assuming the file you added the snippet to is named "index.php"), and the log file should have a few entries in it. Refresh the screen, and make sure Query Monitor hasn't picked up any PHP warnings about missing array keys.