### PR TITLE
Fix for the dependency injection container resolution by tag

### DIFF
--- a/plugins/woocommerce/changelog/pr-44496
+++ b/plugins/woocommerce/changelog/pr-44496
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix for the dependency injection container resolution by tag

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -49,6 +49,13 @@ class ExtendedContainer extends BaseContainer {
 	);
 
 	/**
+	 * A list of tags that have already been fully resolved, see 'get' for details.
+	 *
+	 * @var array
+	 */
+	private array $known_tags = array();
+
+	/**
 	 * Register a class in the container.
 	 *
 	 * @param string    $class_name Class name.
@@ -153,6 +160,17 @@ class ExtendedContainer extends BaseContainer {
 	public function get( $id, bool $new = false ) {
 		if ( false === strpos( $id, '\\' ) ) {
 			throw new ContainerException( "Attempt to get an instance of the non-namespaced class '$id' from the container, did you forget to add a namespace import?" );
+		}
+
+		// This is a workaround for an issue that arises when using service providers inheriting from AbstractInterfaceServiceProvider:
+		// if one of these providers registers classes both by name and by tag, and one of its registered classes is requested
+		// with 'get' by name before a list of classes is requested by tag, then that service provider gets locked as
+		// the only one providing that tag, and the others get ignored. This is due to the fact that container definitions
+		// are created "on the fly" as needed and the base 'get' method won't try to register additional providers
+		// if the requested tag is already provided by at least one of the already existing definitions.
+		if ( $this->definitions->hasTag( $id ) && ! in_array( $id, $this->known_tags, true ) && $this->providers->provides( $id ) ) {
+			$this->providers->register( $id );
+			$this->known_tags[] = $id;
 		}
 
 		return parent::get( $id, $new );

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassA.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassA.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+/**
+ * Example class that is going to be retrieved by name from the dependency injection container.
+ */
+class ClassA {
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassAWithInterface1.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassAWithInterface1.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+/**
+ * Example class that is going to be retrieved by interface name from the dependency injection container.
+ */
+class ClassAWithInterface1 implements TheInterface {
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassAWithInterface2.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassAWithInterface2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+/**
+ * Example class that is going to be retrieved by interface name from the dependency injection container.
+ */
+class ClassAWithInterface2 implements TheInterface {
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassB.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassB.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+/**
+ * Example class that is going to be retrieved by name from the dependency injection container.
+ */
+class ClassB {
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassBWithInterface1.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassBWithInterface1.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+/**
+ * Example class that is going to be retrieved by interface name from the dependency injection container.
+ */
+class ClassBWithInterface1 implements TheInterface {
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassBWithInterface2.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ClassBWithInterface2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+/**
+ * Example class that is going to be retrieved by interface name from the dependency injection container.
+ */
+class ClassBWithInterface2 implements TheInterface {
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ProviderA.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ProviderA.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\AbstractInterfaceServiceProvider;
+
+/**
+ * Example service provider for the dependency injection container, it registers classes both by name and by interface.
+ */
+class ProviderA extends AbstractInterfaceServiceProvider {
+	// phpcs:disable Squiz.Commenting
+
+	protected $provides = array(
+		ClassA::class,
+		ClassAWithInterface1::class,
+		ClassAWithInterface2::class,
+	);
+
+	public function register() {
+		$this->share( ClassA::class );
+		$this->share_with_implements_tags( ClassAWithInterface1::class );
+		$this->share_with_implements_tags( ClassAWithInterface2::class );
+	}
+
+	// phpcs:enable Squiz.Commenting
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ProviderB.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/ProviderB.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\AbstractInterfaceServiceProvider;
+
+/**
+ * Example service provider for the dependency injection container, it registers classes both by name and by interface.
+ */
+class ProviderB extends AbstractInterfaceServiceProvider {
+	// phpcs:disable Squiz.Commenting
+
+	protected $provides = array(
+		ClassB::class,
+		ClassBWithInterface1::class,
+		ClassBWithInterface2::class,
+	);
+
+	public function register() {
+		$this->share( ClassA::class );
+		$this->share_with_implements_tags( ClassBWithInterface1::class );
+		$this->share_with_implements_tags( ClassBWithInterface2::class );
+	}
+
+	// phpcs:enable Squiz.Commenting
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/TheInterface.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExampleProviders/TheInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders;
+
+/**
+ * Example interface for classes that are going to be retrieved by interface name from the dependency injection container.
+ */
+interface TheInterface {
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExtendedContainerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/ExtendedContainerTest.php
@@ -13,6 +13,14 @@ use Automattic\WooCommerce\Testing\Tools\DependencyManagement\MockableLegacyProx
 use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses\ClassWithDependencies;
 use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses\DependencyClass;
 use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses\DerivedDependencyClass;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\ClassA;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\ClassAWithInterface1;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\ClassAWithInterface2;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\ClassBWithInterface1;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\ClassBWithInterface2;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\ProviderA;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\ProviderB;
+use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleProviders\TheInterface;
 
 /**
  * Tests for ExtendedContainer.
@@ -255,5 +263,27 @@ class ExtendedContainerTest extends \WC_Unit_Test_Case {
 		$sut->reset_all_replacements();
 
 		$this->assertInstanceOf( MockableLegacyProxy::class, $sut->get( LegacyProxy::class ) );
+	}
+
+	/**
+	 * @testdox Classes implementing a given interface can be registered in different providers and they are all returned even if a 'get' by class name is executed first.
+	 *
+	 * Note: see the comment inside ExtendedContainer::get for a detailed explanation about the fix that is being tested here.
+	 */
+	public function test_all_classes_implementing_an_interface_are_registered_correctly() {
+		$this->sut->addServiceProvider( ProviderA::class );
+		$this->sut->addServiceProvider( ProviderB::class );
+
+		$this->sut->get( ClassA::class );
+
+		$actual   = array_map( 'get_class', $this->sut->get( TheInterface::class ) );
+		$expected = array(
+			ClassAWithInterface1::class,
+			ClassAWithInterface2::class,
+			ClassBWithInterface1::class,
+			ClassBWithInterface2::class,
+		);
+
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes an issue that arises when using service providers inheriting from `AbstractInterfaceServiceProvider`. See the comment on top of the added code (in `ExtendedContainer::get`) for details.

### How to test the changes in this Pull Request:

Run the following from the command line:

```
wp eval '$classes = wc_get_container()->get(Automattic\WooCommerce\Internal\RegisterHooksInterface::class); foreach($classes as $c) echo get_class($c) . "\n";'
```

Without this fix only one class name is displayed, `OrderCouponDataMigrator`. With the fix the names of three more classes are displayed too.

**Confirm the Order Attribution classes are loaded**

Create an order (either in the shop or in the WooCommerce dashboard), and confirm that the "Origin" column is visible at far right of the Orders table:

![fUL6f6.gif](https://github.com/woocommerce/woocommerce/assets/228780/ef7a42df-6cdb-47c6-b8b6-47ffa73b2021)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>