### PR TITLE
Update example plugin for Activity Notes to include namespacing 

### DIFF
--- a/plugins/woocommerce-admin/docs/examples/activity-panel-inbox.md
+++ b/plugins/woocommerce-admin/docs/examples/activity-panel-inbox.md
@@ -57,8 +57,10 @@ Here’s a short example plugin that adds a new activity panel inbox note on plu
  * Author: Automattic
  * Author URI: https://woo.com/
  * Text Domain: wapi-example-one
- * Version: 1.0.0
+ * Version: 1.0.1
  */
+
+use Automattic\WooCommerce\Admin\Notes\Note as Note;
 
 class WooCommerce_Activity_Panel_Inbox_Example_Plugin_One {
 	const NOTE_NAME = 'wapi-example-plugin-one';
@@ -67,7 +69,7 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_One {
 	 * Adds a note to the merchant' inbox.
 	 */
 	public static function add_activity_panel_inbox_welcome_note() {
-		if ( ! class_exists( 'Notes' ) ) {
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/changelog/update-activity-panel-inbox-md
+++ b/plugins/woocommerce/changelog/update-activity-panel-inbox-md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Updated example plugin code in activity-panel-inbox.md to include namespacing.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In `activity-panel-inbox.md`, we give example code for a plugin that demonstrates how to send an Activity Panel Inbox note to a WooCommerce store. This example doesn't work, as it lacks namespacing of `Automattic\WooCommerce\Admin\Notes\Note` and `Automattic\WooCommerce\Admin\Notes\Notes`. This PR adds the namespacing to the example.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. To reproduce the problem, create a PHP file in the `wp-content/plugins` folder of your WooCommerce test site and paste in the contents of the [current Markdown file](https://github.com/woocommerce/woocommerce/blob/1905534fb8bfd4b179ad2ab20e68d4d830ab5ea7/plugins/woocommerce-admin/docs/examples/activity-panel-inbox.md#adding-and-removing-inbox-items). This creates a plugin called "WooCommerce Activity Panel Inbox Example Plugin One".
2. Add a debug lines in the plugin code at the `return` lines in these places:

```php
		if ( ! class_exists( 'Notes' ) ) {
			return;
		}

		if ( ! class_exists( 'WC_Data_Store' ) ) {
			return;
		}
```

3. Activate the plugin in your plugins admin.

<img width="500" src="https://github.com/woocommerce/woocommerce/assets/1647564/6024dbc8-0dc9-4ce4-9136-73d8bb6eadee">

5. Note that the plugin does not create an Activity Panel Inbox item, because it returns from one of these places. There is no new record in the `wp_wc_admin_notes` table.
6. Deactivate the plugin and replace the plugin code with the code from this PR.
7. Activate the plugin again.
8. Note that a new record is added to `wp_wc_admin_notes`. 
9. Go to a page like `/wp-admin/admin.php?page=wc-settings`.
10. Click on the "Activity" button in the top right of your screen.
11. Note that the note appears in the Activity Panel Inbox.

<img width="500" src="https://github.com/woocommerce/woocommerce/assets/1647564/8e96cd14-d465-4bb0-99a3-e768f68d52fc">

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Updated example plugin code in `activity-panel-inbox.md` to include namespacing.

</details>
