### PR TITLE
Filtering product variations by attributes that are not associated to any generated variations leads to blank variations results

### DIFF
--- a/packages/js/product-editor/changelog/fix-44465
+++ b/packages/js/product-editor/changelog/fix-44465
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add empty state when filtering variations by attribute terms and the response is empty

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -14,15 +14,14 @@
 		&-header {
 			.woocommerce-product-variations__table-row {
 				min-height: auto;
-
-				&:last-child {
-					text-transform: uppercase;
-					color: $gray-700;
-					font-weight: 500;
-					font-size: 11px;
-					line-height: $grid-unit-20;
-					border-bottom: 1px solid $gray-200;
-				}
+			}
+			.woocommerce-product-variations__table-rowheader {
+				text-transform: uppercase;
+				color: $gray-700;
+				font-weight: 500;
+				font-size: 11px;
+				line-height: $grid-unit-20;
+				border-bottom: 1px solid $gray-200;
 			}
 		}
 		&-body {

--- a/packages/js/product-editor/src/components/variations-table/table-empty-or-error-state/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/table-empty-or-error-state/styles.scss
@@ -9,7 +9,7 @@
 	position: absolute;
 	z-index: 1;
 	width: 100%;
-	height: 100%;
+	height: auto;
 
 	&__message {
 		color: $gray-900;

--- a/packages/js/product-editor/src/components/variations-table/table-empty-or-error-state/table-empty-or-error-state.tsx
+++ b/packages/js/product-editor/src/components/variations-table/table-empty-or-error-state/table-empty-or-error-state.tsx
@@ -13,8 +13,10 @@ import { ErrorVariationsImage } from '../../../images/error-variations-image';
 import { EmptyVariationsImage } from '../../../images/empty-variations-image';
 
 export function EmptyOrErrorTableState( {
-	onActionClick,
+	message,
+	actionText,
 	isError,
+	onActionClick,
 }: TableEmptyOrErrorStateProps ) {
 	return (
 		<div className="woocommerce-variations-table-error-or-empty-state">
@@ -22,14 +24,15 @@ export function EmptyOrErrorTableState( {
 			<p className="woocommerce-variations-table-error-or-empty-state__message">
 				{ isError
 					? __( 'We couldn’t load the variations', 'woocommerce' )
-					: __( 'No variations yet', 'woocommerce' ) }
+					: message ?? __( 'No variations yet', 'woocommerce' ) }
 			</p>
 
 			<div className="woocommerce-variations-table-error-or-empty-state__actions">
 				<Button variant="link" onClick={ onActionClick }>
 					{ isError
 						? __( 'Try again', 'woocommerce' )
-						: __( 'Generate from options', 'woocommerce' ) }
+						: actionText ??
+						  __( 'Generate from options', 'woocommerce' ) }
 				</Button>
 			</div>
 		</div>

--- a/packages/js/product-editor/src/components/variations-table/table-empty-or-error-state/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/table-empty-or-error-state/types.ts
@@ -4,6 +4,8 @@
 import { MouseEvent } from 'react';
 
 export type TableEmptyOrErrorStateProps = {
-	onActionClick( event: MouseEvent< HTMLButtonElement > ): void;
+	message?: string;
+	actionText?: string;
 	isError: boolean;
+	onActionClick( event: MouseEvent< HTMLButtonElement > ): void;
 };

--- a/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
@@ -78,6 +78,8 @@ export function useVariations( { productId }: UseVariationsProps ) {
 				requestParams
 			);
 
+			console.log( 'getCurrentVariationsPage', { data, total } );
+
 			setVariations( data );
 			setTotalCount( total );
 			setIsLoading( false );
@@ -255,8 +257,12 @@ export function useVariations( { productId }: UseVariationsProps ) {
 		return Boolean( filters.length );
 	}
 
-	function clearFilters() {
+	async function clearFilters() {
 		setFilters( [] );
+
+		return getCurrentVariationsPage( {
+			product_id: productId,
+		} );
 	}
 
 	// Updating
@@ -473,7 +479,7 @@ export function useVariations( { productId }: UseVariationsProps ) {
 
 	useEffect( () => {
 		if ( isGenerating ) {
-			clearFilters();
+			setFilters( [] );
 			onClearSelection();
 		}
 

--- a/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
@@ -78,8 +78,6 @@ export function useVariations( { productId }: UseVariationsProps ) {
 				requestParams
 			);
 
-			console.log( 'getCurrentVariationsPage', { data, total } );
-
 			setVariations( data );
 			setTotalCount( total );
 			setIsLoading( false );

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -283,6 +283,43 @@ export const VariationsTable = forwardRef<
 		} );
 	}
 
+	function renderTableBody() {
+		return totalCount > 0 ? (
+			<Sortable
+				className="woocommerce-product-variations__table-body"
+				role="rowgroup"
+			>
+				{ variations.map( ( variation ) => (
+					<ListItem
+						key={ `${ variation.id }` }
+						className="woocommerce-product-variations__table-row"
+						role="row"
+					>
+						<VariationsTableRow
+							variation={ variation }
+							variableAttributes={ variableAttributes }
+							isUpdating={ isUpdating[ variation.id ] }
+							isSelected={ isSelected( variation ) }
+							isSelectionDisabled={ isSelectingAll }
+							hideActionButtons={ ! areSomeSelected }
+							onChange={ handleVariationChange }
+							onDelete={ handleDeleteVariationClick }
+							onEdit={ editVariationClickHandler( variation ) }
+							onSelect={ onSelect( variation ) }
+						/>
+					</ListItem>
+				) ) }
+			</Sortable>
+		) : (
+			<EmptyOrErrorTableState
+				isError={ false }
+				message={ __( 'No variations were found', 'woocommerce' ) }
+				actionText={ __( 'Clear filters', 'woocommerce' ) }
+				onActionClick={ clearFilters }
+			/>
+		);
+	}
+
 	return (
 		<div className="woocommerce-product-variations" ref={ ref }>
 			{ noticeText && (
@@ -452,44 +489,8 @@ export const VariationsTable = forwardRef<
 							)
 						) }
 					</div>
-				) : totalCount > 0 ? (
-					<Sortable
-						className="woocommerce-product-variations__table-body"
-						role="rowgroup"
-					>
-						{ variations.map( ( variation ) => (
-							<ListItem
-								key={ `${ variation.id }` }
-								className="woocommerce-product-variations__table-row"
-								role="row"
-							>
-								<VariationsTableRow
-									variation={ variation }
-									variableAttributes={ variableAttributes }
-									isUpdating={ isUpdating[ variation.id ] }
-									isSelected={ isSelected( variation ) }
-									isSelectionDisabled={ isSelectingAll }
-									hideActionButtons={ ! areSomeSelected }
-									onChange={ handleVariationChange }
-									onDelete={ handleDeleteVariationClick }
-									onEdit={ editVariationClickHandler(
-										variation
-									) }
-									onSelect={ onSelect( variation ) }
-								/>
-							</ListItem>
-						) ) }
-					</Sortable>
 				) : (
-					<EmptyOrErrorTableState
-						isError={ false }
-						message={ __(
-							'No variations were found',
-							'woocommerce'
-						) }
-						actionText={ __( 'Clear filters', 'woocommerce' ) }
-						onActionClick={ clearFilters }
-					/>
+					renderTableBody()
 				) }
 
 				{ totalCount > 5 && (

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -135,6 +135,8 @@ export const VariationsTable = forwardRef<
 		onPerPageChange,
 		onFilter,
 		getFilters,
+		hasFilters,
+		clearFilters,
 
 		selected,
 		isSelectingAll,
@@ -300,7 +302,7 @@ export const VariationsTable = forwardRef<
 			) }
 
 			<div className="woocommerce-product-variations__table" role="table">
-				{ totalCount > 0 && (
+				{ ( hasFilters() || totalCount > 0 ) && (
 					<div
 						className="woocommerce-product-variations__table-header"
 						role="rowgroup"
@@ -388,47 +390,49 @@ export const VariationsTable = forwardRef<
 							</div>
 						</div>
 
-						<div
-							className="woocommerce-product-variations__table-row"
-							role="rowheader"
-						>
+						{ totalCount > 0 && (
 							<div
-								className="woocommerce-product-variations__table-column woocommerce-product-variations__selection"
-								role="columnheader"
+								className="woocommerce-product-variations__table-row woocommerce-product-variations__table-rowheader"
+								role="rowheader"
 							>
-								<CheckboxControl
-									value="all"
-									checked={ areAllSelected }
-									// @ts-expect-error Property 'indeterminate' does not exist
-									indeterminate={
-										! areAllSelected && areSomeSelected
-									}
-									onChange={ onSelectPage }
-									aria-label={ __(
-										'Select all',
-										'woocommerce'
-									) }
-								/>
+								<div
+									className="woocommerce-product-variations__table-column woocommerce-product-variations__selection"
+									role="columnheader"
+								>
+									<CheckboxControl
+										value="all"
+										checked={ areAllSelected }
+										// @ts-expect-error Property 'indeterminate' does not exist
+										indeterminate={
+											! areAllSelected && areSomeSelected
+										}
+										onChange={ onSelectPage }
+										aria-label={ __(
+											'Select all',
+											'woocommerce'
+										) }
+									/>
+								</div>
+								<div
+									className="woocommerce-product-variations__table-column"
+									role="columnheader"
+								>
+									{ __( 'Variation', 'woocommerce' ) }
+								</div>
+								<div
+									className="woocommerce-product-variations__table-column woocommerce-product-variations__price"
+									role="columnheader"
+								>
+									{ __( 'Price', 'woocommerce' ) }
+								</div>
+								<div
+									className="woocommerce-product-variations__table-column"
+									role="columnheader"
+								>
+									{ __( 'Stock', 'woocommerce' ) }
+								</div>
 							</div>
-							<div
-								className="woocommerce-product-variations__table-column"
-								role="columnheader"
-							>
-								{ __( 'Variation', 'woocommerce' ) }
-							</div>
-							<div
-								className="woocommerce-product-variations__table-column woocommerce-product-variations__price"
-								role="columnheader"
-							>
-								{ __( 'Price', 'woocommerce' ) }
-							</div>
-							<div
-								className="woocommerce-product-variations__table-column"
-								role="columnheader"
-							>
-								{ __( 'Stock', 'woocommerce' ) }
-							</div>
-						</div>
+						) }
 					</div>
 				) }
 
@@ -448,7 +452,7 @@ export const VariationsTable = forwardRef<
 							)
 						) }
 					</div>
-				) : (
+				) : totalCount > 0 ? (
 					<Sortable
 						className="woocommerce-product-variations__table-body"
 						role="rowgroup"
@@ -476,6 +480,16 @@ export const VariationsTable = forwardRef<
 							</ListItem>
 						) ) }
 					</Sortable>
+				) : (
+					<EmptyOrErrorTableState
+						isError={ false }
+						message={ __(
+							'No variations were found',
+							'woocommerce'
+						) }
+						actionText={ __( 'Clear filters', 'woocommerce' ) }
+						onActionClick={ clearFilters }
+					/>
 				) }
 
 				{ totalCount > 5 && (


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44465

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under the `Variations` tab, add some `Variation options` with the following steps.
4.1. Click `Add options` button from the empty box 
<img width="687" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/0d27efc0-6750-461a-b9f8-8a457b9f3441">
 
4.2. Make sure the variation option contains at least 2 terms.
4.3. Pick only one term from the variation option 
<img width="829" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/ebbb7fc4-b1b1-4daa-9966-fa5c62aeb3b9">

4.4. Then click the `Add` button from the modal to generate variations.
4.5. You should see only one variation generated from the option term you picked in 4.3 like 
<img width="706" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/cd24900b-103d-4971-836c-23725e6bedb8">

5. Then click `Add ...` from the filter dropdown menu below the `Variations` section header and select a different option term than the one picked in point 4.3 like 
<img width="691" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/27a756b8-3d5a-4b88-ba18-3d814c418d25">

6. From the filter dropdown menu click `Filter` button.
7. After that the resulting table should be empty while keeping the filter dropdown on the header and showing and empty state like this 
<img width="718" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/b2d4b432-cbbe-41f2-97d7-60bd5943bbca">

8. Clicking `Clear filters` from the empty state the table should come back to the same state as in point 4.5 
<img width="698" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c73ac8e7-b272-457f-aec2-27e284981498">
