### PR TITLE
Session handler: restore use of _table property, for consistency with other methods.

### DIFF
--- a/plugins/woocommerce/changelog/fix-28913-session-table-property
+++ b/plugins/woocommerce/changelog/fix-28913-session-table-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix regression (and inconsistency) in the way the session handler references its database table.

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -358,7 +358,7 @@ class WC_Session_Handler extends WC_Session {
 
 			$wpdb->query(
 				$wpdb->prepare(
-					"INSERT INTO {$wpdb->prefix}woocommerce_sessions (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d)
+					"INSERT INTO $this->_table (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d)
  					ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)",
 					$this->_customer_id,
 					maybe_serialize( $this->_data ),

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -358,6 +358,7 @@ class WC_Session_Handler extends WC_Session {
 
 			$wpdb->query(
 				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"INSERT INTO $this->_table (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d)
  					ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)",
 					$this->_customer_id,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

[`WC_Session_Handler`](https://github.com/woocommerce/woocommerce/blob/8.5.2/plugins/woocommerce/includes/class-wc-session-handler.php) uses its [`_table`](https://github.com/woocommerce/woocommerce/blob/8.5.2/plugins/woocommerce/includes/class-wc-session-handler.php#L55) property to store a reference to the `woocommerce_sessions` database table. 

At one point, all methods within the class used this property to refer to the table, and that meant subclasses could change the target database table quite easily. This was apparently broken by mistake in https://github.com/woocommerce/woocommerce/pull/21455, which hard-coded the table name within one method.

This change restores the use of `_table` across the class. Functionally, nothing actually changes: it just makes it easier for third parties to implement certain types of customization (and also makes things more consistent than previously).

I did not add a unit test, because the class depends on the cookies superglobal and it felt cleaner to infer it is operating successfully via our existing battery of storefront, cart and checkout E2E tests.

Closes #28193.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

You should experience the same behavior with or without this change (we are verifying nothing has changed or broken, rather than looking for a difference):

1. Login as a known shopper.
2. Add an item to the cart.
3. Open a new browsing session (this could mean using a different browser, an incognito or private browsing session, or a fresh container if you use Firefox).
4. Login as the same shopper.
5. You should find the cart is populated with the same item you added in the first browsing session: this indicates that session data is continuing to work correctly with this change in place.

<div align="center"><img width="760" alt="Two separate browser sessions, showing the same cart contents for the same authenticated shopper." src="https://github.com/woocommerce/woocommerce/assets/3594411/f1508f5f-44df-4af4-896d-bdafc1b44ff0"></div>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
