### PR TITLE
add/explat experiment name validation

### DIFF
--- a/packages/js/explat/changelog/dev-bump-explat-client-version
+++ b/packages/js/explat/changelog/dev-bump-explat-client-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bumped explat-client and explat-client-react-helper versions

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -54,8 +54,8 @@
 		]
 	},
 	"dependencies": {
-		"@automattic/explat-client": "^0.0.3",
-		"@automattic/explat-client-react-helpers": "^0.0.4",
+		"@automattic/explat-client": "^0.0.5",
+		"@automattic/explat-client-react-helpers": "^0.0.6",
 		"@wordpress/api-fetch": "wp-6.0",
 		"@wordpress/hooks": "wp-6.0",
 		"cookie": "^0.4.2",

--- a/plugins/woocommerce-admin/changelog/dev-bump-explat-client-version
+++ b/plugins/woocommerce-admin/changelog/dev-bump-explat-client-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bumped explat-client and explat-client-react-helper versions

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -41,8 +41,8 @@
 	},
 	"dependencies": {
 		"@automattic/components": "^2.0.1",
-		"@automattic/explat-client": "^0.0.3",
-		"@automattic/explat-client-react-helpers": "^0.0.4",
+		"@automattic/explat-client": "^0.0.5",
+		"@automattic/explat-client-react-helpers": "^0.0.6",
 		"@automattic/interpolate-components": "^1.2.1",
 		"@react-spring/web": "^9.7.3",
 		"@types/wordpress__blocks": "11.0.7",

--- a/plugins/woocommerce/changelog/fix-php-explat-client-experiment-name-validation
+++ b/plugins/woocommerce/changelog/fix-php-explat-client-experiment-name-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Adjusted explat experiment name validation to match server side. Also made it fail more prominently in non-production environments.
+
+

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -194,7 +194,7 @@ final class Experimental_Abtest {
 		}
 
 		// Make sure test name is a valid one.
-		if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $test_name ) ) {
+		if ( ! preg_match( '/^[a-z0-9_,]+$/', $test_name ) ) {
 			return new \WP_Error( 'invalid_test_name', 'Invalid A/B test name.' );
 		}
 

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -128,30 +128,16 @@ final class Experimental_Abtest {
 			return 'control';
 		}
 
-		$variation = $this->fetch_variation( $test_name, $this->is_development_or_testing_env() );
+		$variation = $this->fetch_variation( $test_name );
 
 		// If there was an error retrieving a variation, conceal the error for the consumer.
-		if ( is_wp_error( $variation ) && !$this->is_development_or_testing_env() ) {
+		if ( is_wp_error( $variation ) && 'production' === wp_get_environment_type() ) {
 			return 'control';
 		}
 
 		return $variation;
 	}
 
-	/**
-	 * Determine if the current environment is development or testing.
-	 *
-	 * @return bool True if the environment is development or testing, false otherwise.
-	 */
-	private function is_development_or_testing_env() {
-		if ( defined( 'WP_ENV' ) && in_array( WP_ENV, array( 'development', 'staging', 'test' ), true ) ) {
-			return true;
-		}
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			return true;
-		}
-		return false;
-	}
 
 	/**
 	 * Perform the request for a experiment assignment of a provided A/B test from WP.com.

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -198,7 +198,7 @@ final class Experimental_Abtest {
 		}
 
 		// Make sure test name is a valid one.
-		if ( ! preg_match( '/^[a-z0-9_,]+$/', $test_name ) ) {
+		if ( ! preg_match( '/^[a-z0-9_]+$/', $test_name ) ) {
 			return new \WP_Error( 'invalid_test_name', 'Invalid A/B test name.' );
 		}
 

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -128,16 +128,30 @@ final class Experimental_Abtest {
 			return 'control';
 		}
 
-		$variation = $this->fetch_variation( $test_name );
+		$variation = $this->fetch_variation( $test_name, $this->is_development_or_testing_env() );
 
 		// If there was an error retrieving a variation, conceal the error for the consumer.
-		if ( is_wp_error( $variation ) ) {
+		if ( is_wp_error( $variation ) && !$this->is_development_or_testing_env() ) {
 			return 'control';
 		}
 
 		return $variation;
 	}
 
+	/**
+	 * Determine if the current environment is development or testing.
+	 *
+	 * @return bool True if the environment is development or testing, false otherwise.
+	 */
+	private function is_development_or_testing_env() {
+		if ( defined( 'WP_ENV' ) && in_array( WP_ENV, array( 'development', 'staging', 'test' ), true ) ) {
+			return true;
+		}
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			return true;
+		}
+		return false;
+	}
 
 	/**
 	 * Perform the request for a experiment assignment of a provided A/B test from WP.com.

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -131,7 +131,11 @@ final class Experimental_Abtest {
 		$variation = $this->fetch_variation( $test_name );
 
 		// If there was an error retrieving a variation, conceal the error for the consumer.
-		if ( is_wp_error( $variation ) && 'production' === wp_get_environment_type() ) {
+		// If there was an error retrieving a variation, throw an exception in non-production environments.
+		if ( is_wp_error( $variation ) ) {
+			if ( 'production' !== wp_get_environment_type() ) {
+				throw new \Exception( $variation->get_error_message() );
+			}
 			return 'control';
 		}
 

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -121,6 +121,7 @@ final class Experimental_Abtest {
 	 *
 	 * @param string $test_name Name of the A/B test.
 	 * @return mixed|null A/B test variation, or null on failure.
+	 * @throws \Exception If there is an error retrieving the variation and the environment is not production.
 	 */
 	public function get_variation( $test_name ) {
 		// Default to the control variation when users haven't consented to tracking.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -108,8 +108,8 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 	 * Test get_variation with valid experiment name.
 	 */
 	public function test_fetch_variation_with_valid_name() {
-		$exp = new Experimental_Abtest( 'anon', 'platform', false );
-		$variation = $exp->get_variation( 'valid_experiment_name_1,2' );
+		$exp = new Experimental_Abtest( 'anon', 'platform', true );
+		$variation = $exp->get_variation( 'valid_experiment_name_2' );
 		$this->assertNotInstanceOf( 'WP_Error', $variation );
 	}
 
@@ -117,7 +117,7 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 	 * Test get_variation with invalid experiment name.
 	 */
 	public function test_fetch_variation_with_invalid_name() {
-		$exp = new Experimental_Abtest( 'anon', 'platform', false );
+		$exp = new Experimental_Abtest( 'anon', 'platform', true );
 		$variation = $exp->get_variation( 'Invalid-Experiment-Name!' );
 		$this->assertInstanceOf( 'WP_Error', $variation );
 		$this->assertEquals( 'invalid_test_name', $variation->get_error_code() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -103,7 +103,7 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 			true
 		);
 	}
-}
+
 	/**
 	 * Test fetch_variation with valid experiment name.
 	 */
@@ -122,3 +122,4 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( 'WP_Error', $variation );
 		$this->assertEquals( 'invalid_test_name', $variation->get_error_code() );
 	}
+}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -118,8 +118,8 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_fetch_variation_with_invalid_name() {
 		$exp = new Experimental_Abtest( 'anon', 'platform', true );
-		$variation = $exp->get_variation( 'Invalid-Experiment-Name!' );
-		$this->assertInstanceOf( 'WP_Error', $variation );
-		$this->assertEquals( 'invalid_test_name', $variation->get_error_code() );
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage( 'Invalid A/B test name.' );
+		$exp->get_variation( 'Invalid-Experiment-Name!' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -108,7 +108,7 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 	 * Test get_variation with valid experiment name.
 	 */
 	public function test_fetch_variation_with_valid_name() {
-		$exp = new Experimental_Abtest( 'anon', 'platform', true );
+		$exp       = new Experimental_Abtest( 'anon', 'platform', true );
 		$variation = $exp->get_variation( 'valid_experiment_name_2' );
 		$this->assertNotInstanceOf( 'WP_Error', $variation );
 	}
@@ -122,5 +122,4 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		$this->expectExceptionMessage( 'Invalid A/B test name.' );
 		$exp->get_variation( 'Invalid-Experiment-Name!' );
 	}
-}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -123,3 +123,4 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		$exp->get_variation( 'Invalid-Experiment-Name!' );
 	}
 }
+}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -104,3 +104,21 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		);
 	}
 }
+	/**
+	 * Test fetch_variation with valid experiment name.
+	 */
+	public function test_fetch_variation_with_valid_name() {
+		$exp = new Experimental_Abtest( 'anon', 'platform', true );
+		$variation = $exp->fetch_variation( 'valid_experiment_name_1,2' );
+		$this->assertNotInstanceOf( 'WP_Error', $variation );
+	}
+
+	/**
+	 * Test fetch_variation with invalid experiment name.
+	 */
+	public function test_fetch_variation_with_invalid_name() {
+		$exp = new Experimental_Abtest( 'anon', 'platform', true );
+		$variation = $exp->fetch_variation( 'Invalid-Experiment-Name!' );
+		$this->assertInstanceOf( 'WP_Error', $variation );
+		$this->assertEquals( 'invalid_test_name', $variation->get_error_code() );
+	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -105,20 +105,20 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test fetch_variation with valid experiment name.
+	 * Test get_variation with valid experiment name.
 	 */
 	public function test_fetch_variation_with_valid_name() {
-		$exp = new Experimental_Abtest( 'anon', 'platform', true );
-		$variation = $exp->fetch_variation( 'valid_experiment_name_1,2' );
+		$exp = new Experimental_Abtest( 'anon', 'platform', false );
+		$variation = $exp->get_variation( 'valid_experiment_name_1,2' );
 		$this->assertNotInstanceOf( 'WP_Error', $variation );
 	}
 
 	/**
-	 * Test fetch_variation with invalid experiment name.
+	 * Test get_variation with invalid experiment name.
 	 */
 	public function test_fetch_variation_with_invalid_name() {
-		$exp = new Experimental_Abtest( 'anon', 'platform', true );
-		$variation = $exp->fetch_variation( 'Invalid-Experiment-Name!' );
+		$exp = new Experimental_Abtest( 'anon', 'platform', false );
+		$variation = $exp->get_variation( 'Invalid-Experiment-Name!' );
 		$this->assertInstanceOf( 'WP_Error', $variation );
 		$this->assertEquals( 'invalid_test_name', $variation->get_error_code() );
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1854,11 +1854,11 @@ importers:
   packages/js/explat:
     dependencies:
       '@automattic/explat-client':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5
       '@automattic/explat-client-react-helpers':
-        specifier: ^0.0.4
-        version: 0.0.4
+        specifier: ^0.0.6
+        version: 0.0.6
       '@wordpress/api-fetch':
         specifier: wp-6.0
         version: 6.3.1
@@ -3147,11 +3147,11 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(@types/react@17.0.71)(@wordpress/data@6.6.1)(react-dom@17.0.2)(react@17.0.2)
       '@automattic/explat-client':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5
       '@automattic/explat-client-react-helpers':
-        specifier: ^0.0.4
-        version: 0.0.4
+        specifier: ^0.0.6
+        version: 0.0.6
       '@automattic/interpolate-components':
         specifier: ^1.2.1
         version: 1.2.1(@types/react@17.0.71)(react@17.0.2)
@@ -5173,16 +5173,16 @@ packages:
     resolution: {integrity: sha512-g+6cYJCi0m9OHU+E4146og8piMY/gtB7iTzQu1NsOkcLzeLjdAdIk0w+jNf+DE6XYnbgUOSnnoTw/iDbYNKwZw==}
     dev: false
 
-  /@automattic/explat-client-react-helpers@0.0.4:
-    resolution: {integrity: sha512-rS9cVNvWa54oZijIONk0pO/6/xdBBzDtETnRDDAyBQwbVNKlgQ1Ueu7bfGWPq9MXcR0pJ/dfSSlMcNIgR06Hnw==}
+  /@automattic/explat-client-react-helpers@0.0.6:
+    resolution: {integrity: sha512-rYVVi1C2SG/SYnQaESIwdBkou2tkS4aqk4rWx3H6JiTzXa3pyRPEcNG0u+Y/J56AQ8AUUKIGcBon6Rv5lhh3lw==}
     dependencies:
-      '@automattic/explat-client': 0.0.3
+      '@automattic/explat-client': 0.0.5
       react: 17.0.2
       tslib: 2.6.2
     dev: false
 
-  /@automattic/explat-client@0.0.3:
-    resolution: {integrity: sha512-N2/H9l3JZLZLSIyZJMnHKUWZWFjeakU40vm3k3EHdCHdKh8pu2Mz/BrMbtWImYBzaEJnbUZrHM/fAuhFy4sORg==}
+  /@automattic/explat-client@0.0.5:
+    resolution: {integrity: sha512-ql/d7qQ9q2J7K5g9LGd6mDOw8BOhdb05cajWU71Y6KJpvRD8h/zTNGNb+mN9JulNufT+7LxxxF2Kpzui4CFJqw==}
     dependencies:
       tslib: 2.6.2
     dev: false
@@ -33617,6 +33617,7 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
+    dev: true
 
   /fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
@@ -45204,7 +45205,6 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       scheduler: 0.19.1
-    bundledDependencies: false
 
   /react-dom@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -45737,7 +45737,6 @@ packages:
       react-is: 16.13.1
       scheduler: 0.19.1
     dev: true
-    bundledDependencies: false
 
   /react-test-renderer@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==}


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce/issues/41854#issue-2023487202

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Adjusts the experiment name validation on the PHP end, to match actual server side validation
- Made it not conceal the error in experiment fetching in non-prod environments

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up wc core
2. Add the below code somewhere where its executed
3. Observe that it fatals on a non-prod environment

```
$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
			isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '',
			'woocommerce',
			true
		);
		$var = $abtest->get_variation( 'Invalid_Experiment' );
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
