### PR TITLE
[POC] Update express payment method to include button style details

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
@@ -172,7 +172,7 @@ const ExpressPaymentMethods = () => {
 							buttonAttributes: {
 								height: '48px',
 								theme: 'light',
-								label: 'buy',
+								label: 'donate',
 							},
 						} ) }
 					</li>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
@@ -172,7 +172,7 @@ const ExpressPaymentMethods = () => {
 							buttonAttributes: {
 								height: '48px',
 								theme: 'light',
-								label: true,
+								label: 'buy',
 							},
 						} ) }
 					</li>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
@@ -21,7 +21,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import PaymentMethodErrorBoundary from './payment-method-error-boundary';
 import { STORE_KEY as PAYMENT_STORE_KEY } from '../../../data/payment/constants';
-import ExpressPaymentButtonWrapper from './express-payment/express-payment-button-wrapper';
 
 const ExpressPaymentMethods = () => {
 	const { isEditor } = useEditorContext();
@@ -170,6 +169,11 @@ const ExpressPaymentMethods = () => {
 							onError: onExpressPaymentError,
 							setExpressPaymentError:
 								deprecatedSetExpressPaymentError,
+							buttonAttributes: {
+								height: '48px',
+								theme: 'light',
+								label: true,
+							},
 						} ) }
 					</li>
 				) : null;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

P2 Post: pdFofs-1O1-p2

This is POC PR to demonstrate we can define the express payment button guidelines for the extensions. 

In this PR, we're enforcing the extension to use the light theme and use the `donate` button label with the height of `48px`.

The branch is based on https://github.com/woocommerce/woocommerce/pull/44346 PR branch. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a local with Stripe gateway payment method branch: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2891
2. Activate the Stripe plugin and enable express payment options. 
3. Add a product to the Cart and visit the Checkout block page with `https`.
4. Confirm the below express payment button is displayed for stripe:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/11503784/fcea0dcc-5346-4091-81e8-bcfd1a24045a)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
