### PR TITLE
Core - CYS: fix inter font not applied

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
@@ -70,6 +70,8 @@ export const PreloadFonts = () => {
 		};
 	} );
 
+	console.log( 'installedFontFamilies', installedFontFamilies );
+
 	const parsedInstalledFontFamilies = useMemo( () => {
 		return (
 			( installedFontFamilies || [] ).map( ( fontFamilyPost ) => {
@@ -94,11 +96,10 @@ export const PreloadFonts = () => {
 			return;
 		}
 
-		const { custom, theme } = enabledFontFamilies;
+		const { custom } = enabledFontFamilies;
 
 		const enabledFontSlugs = [
 			...( custom ? custom.map( ( font ) => font.slug ) : [] ),
-			...( theme ? theme.map( ( font ) => font.slug ) : [] ),
 		];
 
 		const fontFamiliesToEnable = parsedInstalledFontFamilies.reduce(
@@ -119,6 +120,10 @@ export const PreloadFonts = () => {
 			},
 			[] as Array< FontFamily >
 		);
+
+		console.log( 'fontFamiliesToEnable', fontFamiliesToEnable );
+
+		console.log( 'enabledFontFamilies', enabledFontFamilies );
 
 		setFontFamilies( {
 			...enabledFontFamilies,

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
@@ -70,8 +70,6 @@ export const PreloadFonts = () => {
 		};
 	} );
 
-	console.log( 'installedFontFamilies', installedFontFamilies );
-
 	const parsedInstalledFontFamilies = useMemo( () => {
 		return (
 			( installedFontFamilies || [] ).map( ( fontFamilyPost ) => {
@@ -120,10 +118,6 @@ export const PreloadFonts = () => {
 			},
 			[] as Array< FontFamily >
 		);
-
-		console.log( 'fontFamiliesToEnable', fontFamiliesToEnable );
-
-		console.log( 'enabledFontFamilies', enabledFontFamilies );
 
 		setFontFamilies( {
 			...enabledFontFamilies,

--- a/plugins/woocommerce/changelog/fix-inter-not-applied
+++ b/plugins/woocommerce/changelog/fix-inter-not-applied
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Core - CYS: fix Inter font not applied.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

These changes are necessary because the default font family of TT4 is called "Inter". Instead, the font family installed during the setup is called "Inter, sans serif": the issue is that both of them are the same slug. This caused the font "Inter, sans serif" didn't enable due to this logic: https://github.com/woocommerce/woocommerce/commit/447a6c1fa2b55ec3ed209079d85becfc40756ca4#diff-9d845082930383f4e8624300508b6237fcae0d9ca593d29111492cd0bca4c6a3R105-R122.


Overall, we should not rely on the fonts pre-installed with the theme because they can change with an update. For this reason, only the fonts installed during the setup must be enabled.



Closes https://github.com/woocommerce/woocommerce/issues/44543.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
5. Follow the process.
6. Due [to this bug](https://github.com/WordPress/gutenberg/issues/58765), it is necessary to refresh the page to ensure that the fonts are loaded.
13. Click on "Change Fonts".
14. Ensure that the `Inter` font is applied correctly.
15. Ensure that the rest of the fonts are applied correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Core - CYS: fix Inter font not applied.

</details>
