### PR TITLE
[CYS] Reduce the width of the "Design your own" text box on the Intro screen

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
@@ -166,7 +166,7 @@
 		width: 450px;
 
 		@media only screen and (min-width: 1400px) {
-			width: 650px;
+			width: 710px;
 		}
 
 		button.is-link {

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
@@ -166,7 +166,7 @@
 		width: 450px;
 
 		@media only screen and (min-width: 1400px) {
-			width: 700px;
+			width: 650px;
 		}
 
 		button.is-link {

--- a/plugins/woocommerce/changelog/44545-reduce-box-width
+++ b/plugins/woocommerce/changelog/44545-reduce-box-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+CYS - Reduce the width of the "Design your own" text box on the Intro screen


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR decreases the `woocommerce-customize-store-banner-content` width to avoid a single word in the second line of the sentence.

Closes https://github.com/woocommerce/woocommerce/issues/44545

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the `WooCommerce Beta Tester` plugin is installed and activated (available on this monorepo).
2. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
3. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
4. Make sure the copy looks like the `After` screenshot below.

| Before | After |
|--------|--------|
| <img width="1390" alt="Screenshot 2024-02-12 at 15 25 11" src="https://github.com/woocommerce/woocommerce/assets/186112/85693e0f-38a2-4a1a-824c-a3c8c1155323"> | <img width="1575" alt="Screenshot 2024-02-14 at 10 05 53" src="https://github.com/woocommerce/woocommerce/assets/186112/29badf4e-adcb-4046-9b17-800c59095d50">| 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Reduce the width of the "Design your own" text box on the Intro screen.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
