### PR TITLE
CYS - Core: fix fonts not loaded after the setup

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/iframe.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/iframe.jsx
@@ -117,6 +117,7 @@ function Iframe( {
 				// content.
 				src={ src }
 				title={ __( 'Editor canvas', 'woocommerce' ) }
+				name="editor-canvas"
 			>
 				{ iframeDocument &&
 					createPortal(

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
@@ -72,6 +72,12 @@ export const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
 				const loadedFace = await newFont.load();
 
 				document.fonts.add( loadedFace );
+				const iframeDocument = document.querySelector(
+					'iframe[name="editor-canvas"]'
+				) as HTMLObjectElement | null;
+				if ( iframeDocument ) {
+					iframeDocument.contentDocument?.fonts.add( loadedFace );
+				}
 				if ( onLoad ) {
 					onLoad();
 				}

--- a/plugins/woocommerce/changelog/44548-cys-core-after-the-setup-fonts-arent-loaded
+++ b/plugins/woocommerce/changelog/44548-cys-core-after-the-setup-fonts-arent-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS - Core: fix fonts not loaded after the setup


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR ensures that the fonts are loaded on the main document and the iframe.

Closes #44548.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Install this build of Gutenberg that contains the new Font Library API: [gutenberg.zip](https://github.com/woocommerce/woocommerce/files/14236920/gutenberg.zip).
5. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
6. Follow the process.
7. Wait until the Assembler is loaded.
8. Click on "Change Fonts".
9. Ensure that the right fonts are applied.
10. Refresh the page.
11. Ensure that the right fonts are applied
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
