### PR TITLE
[CYS] Add title to the "Product Gallery" pattern

### DIFF
--- a/plugins/woocommerce/changelog/44555-product-gallery-pattern-add-title
+++ b/plugins/woocommerce/changelog/44555-product-gallery-pattern-add-title
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+CYS - Add title to the "Product Gallery" pattern.

--- a/plugins/woocommerce/patterns/product-query-product-gallery.php
+++ b/plugins/woocommerce/patterns/product-query-product-gallery.php
@@ -5,10 +5,16 @@
  * Categories: WooCommerce
  * Block Types: core/query/woocommerce/product-query
  */
+
+$products_title = $content['titles'][0]['default'] ?? '';
 ?>
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"margin":{"top":"0px","bottom":"80px"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide" style="margin-top:0px;margin-bottom:80px;padding-top:0;padding-right:var(--wp--preset--spacing--30);padding-bottom:0;padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:heading {"level":3,"align":"wide"} -->
+	<h3 class="wp-block-heading alignwide"><?php echo esc_html( $products_title ); ?></h3>
+	<!-- /wp:heading -->
+
 	<!-- wp:woocommerce/product-collection {"query":{"perPage":6,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"align":"wide","layout":{"type":"default"}} -->
 		<div class="wp-block-woocommerce-product-collection alignwide">
 			<!-- wp:woocommerce/product-template -->

--- a/plugins/woocommerce/src/Blocks/AIContent/dictionary.json
+++ b/plugins/woocommerce/src/Blocks/AIContent/dictionary.json
@@ -354,6 +354,18 @@
 		}
 	},
 	{
+		"name": "Product Gallery",
+		"slug": "woocommerce-blocks/product-query-product-gallery",
+		"content": {
+			"titles": [
+				{
+					"default": "Last chance",
+					"ai_prompt": "An impact phrase that advertises the featured products with at least 10 characters"
+				}
+			]
+		}
+	},
+	{
 		"name": "Featured Products 2 Columns",
 		"slug": "woocommerce-blocks/featured-products-2-cols",
 		"content": {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a title to the `Product Gallery` pattern.

Closes https://github.com/woocommerce/woocommerce/issues/44555.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Basic flow**
1. Create a new page or post and insert the `Product Gallery` pattern.
2. Make sure it has the `Last chance` title.

**AI flow on WooExpress**
1. Ensure the `WooCommerce Beta Tester` plugin is installed and activated (available on this monorepo).
2. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
3. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store` and finish the CYS flow.
4. Click on `Change your homepage` and select the last homepage option.
5. Scroll down on the assembler until the last block, which should be the `Product Gallery` pattern.
6. Make sure it has a title.

<img width="1822" alt="Screenshot 2024-02-13 at 11 07 11" src="https://github.com/woocommerce/woocommerce/assets/186112/1217a7a4-81b8-4c1e-ae18-1388226e0abe">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Add title to the "Product Gallery" pattern.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
