### PR TITLE
CYS - Core: install fonts only when the tracking is enabled

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -63,6 +63,11 @@ const installAndActivateTheme = async () => {
 };
 
 const installFontFamilies = async () => {
+	const isTrackingEnabled = window.wcTracks?.isEnabled || false;
+	if ( ! isTrackingEnabled ) {
+		return;
+	}
+
 	try {
 		const installedFontFamily = ( await resolveSelect(
 			'core'

--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -115,7 +115,7 @@ export const fetchIntroData = async () => {
 const fetchIsFontLibraryAvailable = async () => {
 	try {
 		await apiFetch( {
-			path: '/wp/v2/font-collections',
+			path: '/wp/v2/font-collections?_fields=slug',
 			method: 'GET',
 		} );
 

--- a/plugins/woocommerce/changelog/44552-cys-core-ensure-that-fonts-arent-installed-on-the-cys-loading-screen-when-the-user-did-not-opt-in
+++ b/plugins/woocommerce/changelog/44552-cys-core-ensure-that-fonts-arent-installed-on-the-cys-loading-screen-when-the-user-did-not-opt-in
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Core: install fonts only when the tracking is enabled


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As @nefeline mentioned on https://github.com/woocommerce/woocommerce/pull/44473, we must ensure that fonts aren't installed on the CYS loading screen when the user did not opt-in.

A similar check is done on the PHP side: https://github.com/woocommerce/woocommerce/pull/44473/files#diff-9ff9cbf9fc5ce9eb0df48369788b45884e619f1841b94e4e3fce7bcb75c14e9fR105-R114

Closes #44552.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Install this build of Gutenberg that contains the new Font Library API: [gutenberg.zip](https://github.com/woocommerce/woocommerce/files/14236920/gutenberg.zip)
5. Go on `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and enable the tracking.
6. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
10. Open the network tools.
11. Follow the process.
12. Ensure that requests are done on the `/font-faces/` and `/font-family` endpoints.
13. Go on `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`.
14. Disable the tracking.
15. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
16. Open the network tools.
17. Ensure that no requests are done on the `/font-faces/` and `/font-family` endpoints.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - Core: install fonts only when the tracking is enabled

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
