### PR TITLE
add to auto labeler and review assign for Vortex and Developer Advocacy

### DIFF
--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -15,3 +15,11 @@ when:
     assign:
       teams:
         - woo-fse
+  - author:
+      teamIs:
+        - vortex
+      ignore:
+        nameIs:
+    assign:
+      teams:
+        - vortex

--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,7 +1,16 @@
 # See https://github.com/shufo/auto-assign-reviewer-by-files/blob/main/README.md for configuration format
 
-".github/*":
+"*":
   - team: vortex
+
+".github/**/*":
+  - team: vortex
+
+"bin/*":
+  - team: vortex
+
+"docs/**/*":
+  - team: developer-advocacy
 
 "packages/js/api/**/*":
   - team: solaris
@@ -82,4 +91,13 @@
   - team: ghidorah
 
 "plugins/woocommerce-beta-tester/**/*":
+  - team: vortex
+
+"tools/**/*":
+  - team: vortex
+
+"**/composer.json":
+  - team: vortex
+
+"**/package.json":
   - team: vortex

--- a/.github/project-pr-labeler.yml
+++ b/.github/project-pr-labeler.yml
@@ -1,77 +1,87 @@
 'package: @woocommerce/api':
-- packages/js/api/**/*
+  - packages/js/api/**/*
 
 'package: @woocommerce/e2e-utils':
-- packages/js/e2e-utils/**/*
+  - packages/js/e2e-utils/**/*
 
 'package: @woocommerce/e2e-environment':
-- packages/js/e2e-environment/**/*
+  - packages/js/e2e-environment/**/*
 
 'package: @woocommerce/api-core-tests':
-- packages/js/api-core-tests/**/*
+  - packages/js/api-core-tests/**/*
 
 'package: @woocommerce/e2e-core-tests':
-- packages/js/e2e-core-tests/**/*
+  - packages/js/e2e-core-tests/**/*
 
 'package: @woocommerce/admin-e2e-tests':
-- packages/js/admin-e2e-tests/**/*
+  - packages/js/admin-e2e-tests/**/*
 
 'package: @woocommerce/components':
-- packages/js/components/**/*
+  - packages/js/components/**/*
 
 'package: @woocommerce/csv-export':
-- packages/js/csv-export/**/*
+  - packages/js/csv-export/**/*
 
 'package: @woocommerce/currency':
-- packages/js/currency/**/*
+  - packages/js/currency/**/*
 
 'package: @woocommerce/customer-effort-score':
-- packages/js/customer-effort-score/**/*
+  - packages/js/customer-effort-score/**/*
 
 'package: @woocommerce/data':
-- packages/js/data/**/*
+  - packages/js/data/**/*
 
 'package: @woocommerce/date':
-- packages/js/date/**/*
+  - packages/js/date/**/*
 
 'package: dependency-extraction-webpack-plugin':
-- packages/js/dependency-extraction-webpack-plugin/**/*
+  - packages/js/dependency-extraction-webpack-plugin/**/*
 
 'package: @woocommerce/eslint-plugin':
-- packages/js/eslint-plugin/**/*
+  - packages/js/eslint-plugin/**/*
 
 'package: @woocommerce/experimental':
-- packages/js/experimental/**/*
+  - packages/js/experimental/**/*
 
 'package: @woocommerce/explat':
-- packages/js/explat/**/*
+  - packages/js/explat/**/*
 
 'package: @woocommerce/navigation':
-- packages/js/navigation/**/*
+  - packages/js/navigation/**/*
 
 'package: @woocommerce/number':
-- packages/js/number/**/*
+  - packages/js/number/**/*
 
 'package: @woocommerce/onboarding':
-- packages/js/onboarding/**/*
+  - packages/js/onboarding/**/*
 
 'package: @woocommerce/tracks':
-- packages/js/tracks/**/*
+  - packages/js/tracks/**/*
 
 'plugin: woocommerce':
-- plugins/woocommerce/**/*
+  - plugins/woocommerce/**/*
 
 'plugin: woocommerce beta tester':
-- plugins/woocommerce-beta-tester/**/*
+  - plugins/woocommerce-beta-tester/**/*
 
 'plugin: woo-ai':
-- plugins/woo-ai/**/*
+  - plugins/woo-ai/**/*
 
 'focus: performance tests':
-- plugins/woocommerce/tests/performance/**/*
+  - plugins/woocommerce/tests/performance/**/*
 
 'focus: api tests':
-- plugins/woocommerce/tests/api-core-tests/**/*
+  - plugins/woocommerce/tests/api-core-tests/**/*
 
 'focus: e2e tests':
-- plugins/woocommerce/tests/e2e-pw/**/*
+  - plugins/woocommerce/tests/e2e-pw/**/*
+
+'focus: documentation':
+  - docs/**/*
+
+'tools: monorepo infrastructure':
+  - .github/**/*
+  - bin/**/*
+  - tools/**/*
+  - **/composer.json
+  - **/package.json


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds to the auto labelling & PR review assignment workflows:

- `docs` folder
  - Adds `focus: documentation` label
  - Requests `woocommerce/developer-advocacy` review

- For Vortex
  - Adds `tools: monorepo infrastructure` label
  - Requests `woocommerce/vortex` review 
  - On files and folders
    - files in the root
    - `tools/*`
    - `bin/*`
    - any `composer.json` or `package.json`
  - Requests `woocommerce/vortex` review on any PR authored by a member of the team


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. YAML review
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
