### PR TITLE
Add the collapsible Schedule section

### DIFF
--- a/packages/js/product-editor/changelog/add-43706
+++ b/packages/js/product-editor/changelog/add-43706
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the collapsible Schedule section

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -5,6 +5,7 @@ import type { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { isInTheFuture } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { MouseEvent } from 'react';
 
@@ -34,6 +35,11 @@ export function usePublish( {
 		productType,
 		'id'
 	);
+	const [ editedDateCreated, _, dateCreated ] = useEntityProp< string >(
+		'postType',
+		productType,
+		'date_created'
+	);
 
 	const { isSaving, isDirty } = useSelect(
 		( select ) => {
@@ -42,8 +48,6 @@ export function usePublish( {
 				isSavingEntityRecord,
 				// @ts-expect-error There are no types for this.
 				hasEditsForEntityRecord,
-				// @ts-expect-error There are no types for this.
-				getRawEntityRecord,
 			} = select( 'core' );
 
 			return {
@@ -53,11 +57,6 @@ export function usePublish( {
 					productId
 				),
 				isDirty: hasEditsForEntityRecord(
-					'postType',
-					productType,
-					productId
-				),
-				currentPost: getRawEntityRecord< boolean >(
 					'postType',
 					productType,
 					productId
@@ -146,10 +145,21 @@ export function usePublish( {
 		}
 	}
 
-	return {
-		children: isPublished
+	function getButtonText() {
+		const isScheduled =
+			dateCreated !== editedDateCreated &&
+			isInTheFuture( editedDateCreated );
+		if ( isScheduled ) {
+			return __( 'Schedule', 'woocommerce' );
+		}
+
+		return isPublished
 			? __( 'Update', 'woocommerce' )
-			: __( 'Publish', 'woocommerce' ),
+			: __( 'Publish', 'woocommerce' );
+	}
+
+	return {
+		children: getButtonText(),
 		...props,
 		isBusy,
 		'aria-disabled': isDisabled,

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -35,7 +35,7 @@ export function usePublish( {
 		productType,
 		'id'
 	);
-	const [ editedDateCreated, _, dateCreated ] = useEntityProp< string >(
+	const [ editedDateCreated, , dateCreated ] = useEntityProp< string >(
 		'postType',
 		productType,
 		'date_created'

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -5,7 +5,6 @@ import type { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { isInTheFuture } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { MouseEvent } from 'react';
 
@@ -15,6 +14,7 @@ import { MouseEvent } from 'react';
 import { useValidations } from '../../../../contexts/validation-context';
 import type { WPError } from '../../../../utils/get-product-error-message';
 import type { PublishButtonProps } from '../../publish-button';
+import { useProductScheduled } from '../../../../hooks/use-product-scheduled';
 
 export function usePublish( {
 	productType = 'product',
@@ -35,11 +35,8 @@ export function usePublish( {
 		productType,
 		'id'
 	);
-	const [ editedDateCreated, , dateCreated ] = useEntityProp< string >(
-		'postType',
-		productType,
-		'date_created'
-	);
+
+	const isScheduled = useProductScheduled( productType );
 
 	const { isSaving, isDirty } = useSelect(
 		( select ) => {
@@ -146,9 +143,6 @@ export function usePublish( {
 	}
 
 	function getButtonText() {
-		const isScheduled =
-			dateCreated !== editedDateCreated &&
-			isInTheFuture( editedDateCreated );
 		if ( isScheduled ) {
 			return __( 'Schedule', 'woocommerce' );
 		}

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-button.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-button.tsx
@@ -15,6 +15,7 @@ import { store as productEditorUiStore } from '../../store/product-editor-ui';
 import { PrepublishButtonProps } from './types';
 import { useValidations } from '../../contexts/validation-context';
 import { TRACKS_SOURCE } from '../../constants';
+import { useProductScheduled } from '../../hooks/use-product-scheduled';
 
 export function PrepublishButton( {
 	productId,
@@ -49,6 +50,7 @@ export function PrepublishButton( {
 
 	const isBusy = isSaving || isValidating;
 	const isDisabled = isBusy || ! isDirty;
+	const isScheduled = useProductScheduled( productType );
 
 	return (
 		<Button
@@ -61,7 +63,11 @@ export function PrepublishButton( {
 			} }
 			isBusy={ isBusy }
 			aria-disabled={ isDisabled }
-			children={ __( 'Publish', 'woocommerce' ) }
+			children={
+				isScheduled
+					? __( 'Schedule', 'woocommerce' )
+					: __( 'Publish', 'woocommerce' )
+			}
 			variant={ 'primary' }
 		/>
 	);

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -62,7 +62,7 @@ export function PrepublishPanel( {
 			</div>
 			<VisibilitySection productType={ productType } />
 
-			<ScheduleSection />
+			<ScheduleSection postType={ productType } />
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -15,6 +15,7 @@ import { PrepublishPanelProps } from './types';
 import { store as productEditorUiStore } from '../../store/product-editor-ui';
 import { TRACKS_SOURCE } from '../../constants';
 import { VisibilitySection } from './visibility-section';
+import { ScheduleSection } from './schedule-section';
 
 export function PrepublishPanel( {
 	productId,
@@ -60,6 +61,8 @@ export function PrepublishPanel( {
 				<span>{ description }</span>
 			</div>
 			<VisibilitySection productType={ productType } />
+
+			<ScheduleSection />
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/index.ts
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/index.ts
@@ -1,0 +1,2 @@
+export * from './schedule-section';
+export * from './types';

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
@@ -6,42 +6,128 @@ import {
 	__experimentalPublishDateTimePicker as PublishDateTimePicker,
 } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
-import { __experimentalGetSettings as getSettings } from '@wordpress/date';
+import {
+	DateSettings,
+	dateI18n,
+	getDate,
+	__experimentalGetSettings as getSettings,
+} from '@wordpress/date';
 import { createElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x, isRTL, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { ScheduleSectionProps } from './types';
+import {
+	getSiteSettingsTimezoneAbbreviation,
+	isSameDay,
+	isSiteSettingsTime12HourFormatted,
+	isSiteSettingsTimezoneSameAsDateTimezone,
+} from '../../../utils';
 
-function is12HourTime() {
-	const settings = getSettings() as { formats: { time: string } };
+export function getFormattedDateTime( value: string ) {
+	const { formats } = getSettings() as DateSettings;
 
-	return /a(?!\\)/i.test(
-		settings.formats.time
-			.toLowerCase()
-			.replace( /\\\\/g, '' )
-			.split( '' )
-			.reverse()
-			.join( '' )
+	return dateI18n(
+		sprintf(
+			// translators: %s: Time of day the product is scheduled for.
+			_x(
+				'F j, Y %s',
+				'product schedule full date format',
+				'woocommerce'
+			),
+			formats.time
+		),
+		value,
+		undefined
 	);
 }
 
+export function getFullScheduleLabel( dateAttribute: string ) {
+	const timezoneAbbreviation = getSiteSettingsTimezoneAbbreviation();
+	const formattedDate = getFormattedDateTime( dateAttribute );
+
+	return isRTL()
+		? `${ timezoneAbbreviation } ${ formattedDate }`
+		: `${ formattedDate } ${ timezoneAbbreviation }`;
+}
+
+export function getScheduleLabel( dateAttribute?: string, now = new Date() ) {
+	if ( ! dateAttribute ) {
+		return __( 'Immediately', 'woocommerce' );
+	}
+
+	// If the user timezone does not equal the site timezone then using words
+	// like 'tomorrow' is confusing, so show the full date.
+	if ( ! isSiteSettingsTimezoneSameAsDateTimezone( now ) ) {
+		return getFullScheduleLabel( dateAttribute );
+	}
+
+	const { formats } = getSettings() as DateSettings;
+	const date = getDate( dateAttribute );
+
+	if ( isSameDay( date, now ) ) {
+		return sprintf(
+			// translators: %s: Time of day the product is scheduled for.
+			__( 'Today at %s', 'woocommerce' ),
+			dateI18n( formats.time, dateAttribute, undefined )
+		);
+	}
+
+	const tomorrow = new Date( now );
+	tomorrow.setDate( tomorrow.getDate() + 1 );
+
+	if ( isSameDay( date, tomorrow ) ) {
+		return sprintf(
+			// translators: %s: Time of day the product is scheduled for.
+			__( 'Tomorrow at %s', 'woocommerce' ),
+			dateI18n( formats.time, dateAttribute, undefined )
+		);
+	}
+
+	if ( date.getFullYear() === now.getFullYear() ) {
+		return dateI18n(
+			sprintf(
+				// translators: %s: Time of day the product is scheduled for.
+				_x(
+					'F j %s',
+					'product schedule date format without year',
+					'woocommerce'
+				),
+				formats.time
+			),
+			date,
+			undefined
+		);
+	}
+
+	return getFormattedDateTime( dateAttribute );
+}
+
 export function ScheduleSection( {}: ScheduleSectionProps ) {
-	const [ date, setDate ] = useProductEntityProp( 'date_created' );
+	const [ date, setDate ] = useProductEntityProp< string >( 'date_created' );
 
 	function handlePublishDateTimePickerChange( value: string ) {
 		setDate( value );
 	}
 
 	return (
-		<PanelBody initialOpen={ false } title={ __( 'Add', 'woocommerce' ) }>
+		<PanelBody
+			initialOpen={ false }
+			// @ts-expect-error title does currently support this value
+			title={ [
+				__( 'Add:', 'woocommerce' ),
+				<span className="editor-post-publish-panel__link" key="label">
+					{ getScheduleLabel( date ) }
+				</span>,
+			] }
+		>
 			<PublishDateTimePicker
 				currentDate={ date }
 				onChange={ handlePublishDateTimePickerChange }
-				is12Hour={ is12HourTime() }
+				is12Hour={ isSiteSettingsTime12HourFormatted() }
 			/>
 		</PanelBody>
 	);

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { PanelBody } from '@wordpress/components';
+import { createElement, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ScheduleSectionProps } from './types';
+
+export function ScheduleSection( {}: ScheduleSectionProps ) {
+	return (
+		<PanelBody initialOpen={ false } title={ __( 'Add', 'woocommerce' ) }>
+			<></>
+		</PanelBody>
+	);
+}

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
@@ -1,10 +1,6 @@
 /**
  * External dependencies
  */
-import {
-	// @ts-expect-error no exported member
-	__experimentalPublishDateTimePicker as PublishDateTimePicker,
-} from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
 import {
 	DateSettings,
@@ -14,6 +10,10 @@ import {
 } from '@wordpress/date';
 import { createElement } from '@wordpress/element';
 import { __, _x, isRTL, sprintf } from '@wordpress/i18n';
+import {
+	// @ts-expect-error no exported member
+	__experimentalPublishDateTimePicker as PublishDateTimePicker,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -106,8 +106,10 @@ export function getScheduleLabel( dateAttribute?: string, now = new Date() ) {
 	return getFormattedDateTime( dateAttribute );
 }
 
-export function ScheduleSection( {}: ScheduleSectionProps ) {
-	const [ date, setDate ] = useProductEntityProp< string >( 'date_created' );
+export function ScheduleSection( { postType }: ScheduleSectionProps ) {
+	const [ date, setDate ] = useProductEntityProp< string >( 'date_created', {
+		postType,
+	} );
 
 	function handlePublishDateTimePickerChange( value: string ) {
 		setDate( value );

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { PanelBody } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 import {
 	DateSettings,
 	dateI18n,
@@ -18,7 +19,6 @@ import {
 /**
  * Internal dependencies
  */
-import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { ScheduleSectionProps } from './types';
 import {
 	getSiteSettingsTimezoneAbbreviation,
@@ -107,9 +107,11 @@ export function getScheduleLabel( dateAttribute?: string, now = new Date() ) {
 }
 
 export function ScheduleSection( { postType }: ScheduleSectionProps ) {
-	const [ date, setDate ] = useProductEntityProp< string >( 'date_created', {
+	const [ editedDate, setDate, date ] = useEntityProp< string >(
+		'postType',
 		postType,
-	} );
+		'date_created'
+	);
 
 	function handlePublishDateTimePickerChange( value: string ) {
 		setDate( value );
@@ -122,12 +124,14 @@ export function ScheduleSection( { postType }: ScheduleSectionProps ) {
 			title={ [
 				__( 'Add:', 'woocommerce' ),
 				<span className="editor-post-publish-panel__link" key="label">
-					{ getScheduleLabel( date ) }
+					{ getScheduleLabel(
+						editedDate === date ? undefined : editedDate
+					) }
 				</span>,
 			] }
 		>
 			<PublishDateTimePicker
-				currentDate={ date }
+				currentDate={ editedDate }
 				onChange={ handlePublishDateTimePickerChange }
 				is12Hour={ isSiteSettingsTime12HourFormatted() }
 			/>

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
@@ -1,19 +1,48 @@
 /**
  * External dependencies
  */
+import {
+	// @ts-expect-error no exported member
+	__experimentalPublishDateTimePicker as PublishDateTimePicker,
+} from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
-import { createElement, Fragment } from '@wordpress/element';
+import { __experimentalGetSettings as getSettings } from '@wordpress/date';
+import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { ScheduleSectionProps } from './types';
 
+function is12HourTime() {
+	const settings = getSettings() as { formats: { time: string } };
+
+	return /a(?!\\)/i.test(
+		settings.formats.time
+			.toLowerCase()
+			.replace( /\\\\/g, '' )
+			.split( '' )
+			.reverse()
+			.join( '' )
+	);
+}
+
 export function ScheduleSection( {}: ScheduleSectionProps ) {
+	const [ date, setDate ] = useProductEntityProp( 'date_created' );
+
+	function handlePublishDateTimePickerChange( value: string ) {
+		setDate( value );
+	}
+
 	return (
 		<PanelBody initialOpen={ false } title={ __( 'Add', 'woocommerce' ) }>
-			<></>
+			<PublishDateTimePicker
+				currentDate={ date }
+				onChange={ handlePublishDateTimePickerChange }
+				is12Hour={ is12HourTime() }
+			/>
 		</PanelBody>
 	);
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/types.ts
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/types.ts
@@ -1,0 +1,1 @@
+export type ScheduleSectionProps = {};

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/types.ts
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/types.ts
@@ -1,1 +1,3 @@
-export type ScheduleSectionProps = {};
+export type ScheduleSectionProps = {
+	postType: string;
+};

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useVariationSwitcher as __experimentalUseVariationSwitcher } from './us
 export { default as __experimentalUseProductEntityProp } from './use-product-entity-prop';
 export { default as __experimentalUseProductMetadata } from './use-product-metadata';
 export { useProductTemplate as __experimentalUseProductTemplate } from './use-product-template';
+export { useProductScheduled as __experimentalUseProductScheduled } from './use-product-scheduled';

--- a/packages/js/product-editor/src/hooks/use-product-scheduled/index.ts
+++ b/packages/js/product-editor/src/hooks/use-product-scheduled/index.ts
@@ -1,0 +1,1 @@
+export * from './use-product-scheduled';

--- a/packages/js/product-editor/src/hooks/use-product-scheduled/use-product-scheduled.ts
+++ b/packages/js/product-editor/src/hooks/use-product-scheduled/use-product-scheduled.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+import { isInTheFuture } from '@wordpress/date';
+
+export function useProductScheduled( postType: string ) {
+	const [ date ] = useEntityProp< string >(
+		'postType',
+		postType,
+		'date_created'
+	);
+
+	return isInTheFuture( date );
+}

--- a/packages/js/product-editor/src/utils/date/get-site-settings-timezone-abbreviation.ts
+++ b/packages/js/product-editor/src/utils/date/get-site-settings-timezone-abbreviation.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import {
+	TimezoneConfig,
+	__experimentalGetSettings as getSettings,
+} from '@wordpress/date';
+
+export function getSiteSettingsTimezoneAbbreviation() {
+	const { timezone } = getSettings() as {
+		timezone: TimezoneConfig & { offsetFormatted: string };
+	};
+
+	if ( timezone.abbr && isNaN( Number( timezone.abbr ) ) ) {
+		return timezone.abbr;
+	}
+
+	const symbol = Number( timezone.offset ) < 0 ? '' : '+';
+	return `UTC${ symbol }${ timezone.offsetFormatted }`;
+}

--- a/packages/js/product-editor/src/utils/date/get-site-settings-timezone-abbreviation.ts
+++ b/packages/js/product-editor/src/utils/date/get-site-settings-timezone-abbreviation.ts
@@ -16,5 +16,5 @@ export function getSiteSettingsTimezoneAbbreviation() {
 	}
 
 	const symbol = Number( timezone.offset ) < 0 ? '' : '+';
-	return `UTC${ symbol }${ timezone.offsetFormatted }`;
+	return `UTC${ symbol }${ timezone.offsetFormatted ?? timezone.offset }`;
 }

--- a/packages/js/product-editor/src/utils/date/index.ts
+++ b/packages/js/product-editor/src/utils/date/index.ts
@@ -1,0 +1,4 @@
+export * from './get-site-settings-timezone-abbreviation';
+export * from './is-same-day';
+export * from './is-site-settings-time-12-hour-formatted';
+export * from './is-site-settings-timezone-same-as-date-timezone';

--- a/packages/js/product-editor/src/utils/date/is-same-day.ts
+++ b/packages/js/product-editor/src/utils/date/is-same-day.ts
@@ -1,0 +1,7 @@
+export function isSameDay( left: Date, right: Date ) {
+	return (
+		left.getDate() === right.getDate() &&
+		left.getMonth() === right.getMonth() &&
+		left.getFullYear() === right.getFullYear()
+	);
+}

--- a/packages/js/product-editor/src/utils/date/is-site-settings-time-12-hour-formatted.ts
+++ b/packages/js/product-editor/src/utils/date/is-site-settings-time-12-hour-formatted.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import {
+	DateSettings,
+	__experimentalGetSettings as getSettings,
+} from '@wordpress/date';
+
+export function isSiteSettingsTime12HourFormatted() {
+	const settings = getSettings() as DateSettings;
+
+	return /a(?!\\)/i.test(
+		settings.formats.time
+			.toLowerCase()
+			.replace( /\\\\/g, '' )
+			.split( '' )
+			.reverse()
+			.join( '' )
+	);
+}

--- a/packages/js/product-editor/src/utils/date/is-site-settings-timezone-same-as-date-timezone.ts
+++ b/packages/js/product-editor/src/utils/date/is-site-settings-timezone-same-as-date-timezone.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import {
+	DateSettings,
+	__experimentalGetSettings as getSettings,
+} from '@wordpress/date';
+
+export function isSiteSettingsTimezoneSameAsDateTimezone( date: Date ) {
+	const { timezone } = getSettings() as DateSettings;
+
+	const siteOffset = Number( timezone.offset );
+	const dateOffset = -1 * ( date.getTimezoneOffset() / 60 );
+	return siteOffset === dateOffset;
+}

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -23,6 +23,7 @@ import { hasAttributesUsedForVariations } from './has-attributes-used-for-variat
 import { isValidEmail } from './validate-email';
 
 export * from './create-ordered-children';
+export * from './date';
 export * from './sort-fills-by-order';
 export * from './register-product-editor-block-type';
 export * from './init-block';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43706

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New
3. Add a product `Name` and press `Add`.
4. The pre-publish panel should be visible.
5. A new schedule section should be shown within the panel 
<img width="295" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/4c6ff9e9-e641-4c92-89c7-a36ac202920e">

6. The `Add: xxx` section title should work exactly as in the post/site editor
7. When expanded, the user can select the time and date
8. If no custom time and date is selected, the section says `Add: Immediately`. If the user adds a custom time and date, it says: `Add: [date] [time]`.
9. When the user selects a future time and date, the top button's label changes to `Schedule`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
