### PR TITLE
Core - CYS: fix fonts not loaded on the font picker iframes

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
@@ -145,6 +145,12 @@ export const PreloadFonts = () => {
 		( fontPair ) => fontPair?.settings?.typography?.fontFamilies?.theme
 	);
 
+	const iframeInstance = useMemo( () => {
+		return document.querySelector(
+			'.block-editor-block-preview__content iframe'
+		) as HTMLObjectElement | null;
+	}, [] );
+
 	const fontFamilies = allFontChoices.map( ( fontPair ) => {
 		return [
 			...fontPair.map( ( font ) => {
@@ -171,6 +177,7 @@ export const PreloadFonts = () => {
 			{ isNoAIFlow( context.flowType ) && (
 				<FontFamiliesLoader
 					fontFamilies={ enabledFontFamilies.custom }
+					iframeInstance={ iframeInstance }
 				/>
 			) }
 		</>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
@@ -14,6 +14,7 @@ import { FontFamily } from '~/customize-store/types/font';
 
 type Props = {
 	fontFamilies: Array< FontFamily >;
+	iframeInstance: HTMLObjectElement | null;
 	onLoad?: () => void;
 	preload?: boolean;
 };
@@ -40,7 +41,11 @@ const getDisplaySrcFromFontFace = ( input: string, urlPrefix: string ) => {
 
 	return ! isUrlEncoded( input ) ? encodeURI( input ) : input;
 };
-export const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
+export const FontFamiliesLoader = ( {
+	fontFamilies,
+	iframeInstance,
+	onLoad,
+}: Props ) => {
 	const { site, currentTheme } = useSelect( ( select ) => {
 		return {
 			// @ts-expect-error No types for this exist yet.
@@ -72,18 +77,15 @@ export const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
 				const loadedFace = await newFont.load();
 
 				document.fonts.add( loadedFace );
-				const iframeDocument = document.querySelector(
-					'iframe[name="editor-canvas"]'
-				) as HTMLObjectElement | null;
-				if ( iframeDocument ) {
-					iframeDocument.contentDocument?.fonts.add( loadedFace );
+				if ( iframeInstance ) {
+					iframeInstance.contentDocument?.fonts.add( loadedFace );
 				}
 				if ( onLoad ) {
 					onLoad();
 				}
 			} );
 		} );
-	}, [ fontFamilies, onLoad, themeUrl ] );
+	}, [ fontFamilies, iframeInstance, onLoad, themeUrl ] );
 
 	return <></>;
 };

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -8,6 +8,12 @@ import { __experimentalGrid as Grid, Spinner } from '@wordpress/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 import { useContext, useMemo } from '@wordpress/element';
+import {
+	privateApis as blockEditorPrivateApis,
+	// @ts-ignore no types exist yet.
+} from '@wordpress/block-editor';
+// @ts-expect-error no types exist yet.
+import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 
 /**
  * Internal dependencies
@@ -18,6 +24,8 @@ import { FontPairingVariationPreview } from './preview';
 import { Look } from '~/customize-store/design-with-ai/types';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
 import { FlowType } from '~/customize-store/types';
+import { FontFamily } from './font-families-loader-dot-com';
+import { isAIFlow } from '~/customize-store/guards';
 
 export const FontPairing = () => {
 	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
@@ -33,18 +41,44 @@ export const FontPairing = () => {
 		};
 	} );
 
+	const { useGlobalSetting } = unlock( blockEditorPrivateApis );
+
+	const [ custom ] = useGlobalSetting( 'typography.fontFamilies.custom' ) as [
+		Array< FontFamily >
+	];
+
 	const { context } = useContext( CustomizeStoreContext );
 	const aiOnline = context.flowType === FlowType.AIOnline;
 
-	const fontPairings = useMemo(
-		() =>
-			aiOnline && aiSuggestions?.lookAndFeel
+	const fontPairings = useMemo( () => {
+		if ( isAIFlow( context.flowType ) ) {
+			return aiOnline && aiSuggestions?.lookAndFeel
 				? FONT_PAIRINGS.filter( ( font ) =>
 						font.lookAndFeel.includes( aiSuggestions?.lookAndFeel )
 				  )
-				: FONT_PAIRINGS_WHEN_AI_IS_OFFLINE,
-		[ aiOnline, aiSuggestions?.lookAndFeel ]
-	);
+				: FONT_PAIRINGS_WHEN_AI_IS_OFFLINE;
+		}
+
+		return FONT_PAIRINGS_WHEN_AI_IS_OFFLINE.map( ( pair ) => {
+			const fontFamilies = pair.settings.typography.fontFamilies;
+			const fonts = custom.filter( ( customFont ) =>
+				fontFamilies.theme.some(
+					( themeFont ) => themeFont.slug === customFont.slug
+				)
+			);
+
+			return {
+				...pair,
+				settings: {
+					typography: {
+						fontFamilies: {
+							theme: fonts,
+						},
+					},
+				},
+			};
+		}, [] );
+	}, [ aiOnline, aiSuggestions?.lookAndFeel, context.flowType, custom ] );
 
 	if ( isLoading ) {
 		return (

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
@@ -11,13 +11,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
-import {
-	useCallback,
-	useContext,
-	useMemo,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useContext, useMemo, useRef, useState } from '@wordpress/element';
 import {
 	privateApis as blockEditorPrivateApis,
 	// @ts-ignore no types exist yet.

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
@@ -11,7 +11,13 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
-import { useContext, useMemo, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useContext,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import {
 	privateApis as blockEditorPrivateApis,
 	// @ts-ignore no types exist yet.
@@ -29,6 +35,7 @@ import { FontFamily } from '~/customize-store/types/font';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
 import { isAIFlow, isNoAIFlow } from '~/customize-store/guards';
 import { FontFamiliesLoaderDotCom } from './font-families-loader-dot-com';
+import { FontFamiliesLoader } from './font-families-loader';
 
 const { useGlobalStyle, useGlobalSetting } = unlock( blockEditorPrivateApis );
 
@@ -36,6 +43,21 @@ const DEFAULT_LARGE_FONT_STYLES: React.CSSProperties = {
 	fontSize: '13vw', // 18px for min-width wide breakpoint and 15px for max-width wide
 	lineHeight: '20px',
 	color: '#000000',
+};
+
+// For some reason, Chrome doesn't render the fonts correctly if the font-family with spaces is not wrapped in single quotes.
+// Example: "Bodoni Moda", serif => '"Bodoni Moda"', serif
+const formatFontFamily = ( input: string ) => {
+	return input
+		.split( ',' )
+		.map( ( font ) => {
+			font = font.trim();
+			if ( font.startsWith( '"' ) ) {
+				return `'${ font }'`;
+			}
+			return font;
+		} )
+		.join( ', ' );
 };
 
 export const FontPairingVariationPreview = () => {
@@ -107,11 +129,14 @@ export const FontPairingVariationPreview = () => {
 
 	const handleOnLoad = () => setIsLoaded( true );
 
+	const iframeInstance = useRef< HTMLObjectElement | null >( null );
+
 	return (
 		<GlobalStylesVariationIframe
 			width={ width }
 			height={ normalizedHeight }
 			containerResizeListener={ containerResizeListener }
+			iframeInstance={ iframeInstance }
 		>
 			<>
 				<div
@@ -152,7 +177,10 @@ export const FontPairingVariationPreview = () => {
 										...DEFAULT_LARGE_FONT_STYLES,
 										letterSpacing: headingLetterSpacing,
 										fontWeight: headingFontWeight,
-										fontFamily: headingFontFamily,
+										fontFamily:
+											formatFontFamily(
+												headingFontFamily
+											),
 										fontStyle: headingFontStyle,
 									} }
 								>
@@ -165,7 +193,8 @@ export const FontPairingVariationPreview = () => {
 										fontSize: '13px',
 										letterSpacing: textLetterSpacing,
 										fontWeight: textFontWeight,
-										fontFamily: textFontFamily,
+										fontFamily:
+											formatFontFamily( textFontFamily ),
 										fontStyle: textFontStyle,
 									} }
 								>
@@ -179,6 +208,13 @@ export const FontPairingVariationPreview = () => {
 					<FontFamiliesLoaderDotCom
 						fontFamilies={ fontFamilies }
 						onLoad={ handleOnLoad }
+					/>
+				) }
+				{ isNoAIFlow( context.flowType ) && (
+					<FontFamiliesLoader
+						fontFamilies={ fontFamilies }
+						onLoad={ handleOnLoad }
+						iframeInstance={ iframeInstance.current }
 					/>
 				) }
 			</>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/index.tsx
@@ -10,7 +10,7 @@ import {
 	// @ts-ignore no types exist yet.
 } from '@wordpress/block-editor';
 import { useRefEffect } from '@wordpress/compose';
-import { useMemo } from 'react';
+import { MutableRefObject, useMemo } from 'react';
 // @ts-ignore No types for this exist yet.
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 
@@ -28,6 +28,7 @@ interface Props {
 	inlineCss?: string;
 	containerResizeListener: JSX.Element;
 	children: JSX.Element;
+	iframeInstance?: MutableRefObject< HTMLObjectElement | null >;
 	onFocusOut?: () => void;
 }
 
@@ -38,6 +39,7 @@ export const GlobalStylesVariationIframe = ( {
 	containerResizeListener,
 	children,
 	onFocusOut,
+	iframeInstance,
 	...props
 }: Props ) => {
 	const [ styles ] = useGlobalStylesOutput();
@@ -65,6 +67,7 @@ export const GlobalStylesVariationIframe = ( {
 
 	return (
 		<Iframe
+			ref={ iframeInstance }
 			className="global-styles-variation-container__iframe"
 			style={ {
 				height,

--- a/plugins/woocommerce/changelog/44427-cys-on-core-fix-fonts-are-not-loaded-on-the-font-picker
+++ b/plugins/woocommerce/changelog/44427-cys-on-core-fix-fonts-are-not-loaded-on-the-font-picker
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Core - CYS: fix fonts not loaded on the font picker iframes


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44427.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Local Installation

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Install this build of Gutenberg that contains the new Font Library API: [gutenberg.zip](https://github.com/woocommerce/woocommerce/files/14236920/gutenberg.zip)
5. Go on `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and enable the tracking.
6. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
7. Follow the process.
8. Click on `Change your font`.
9. For each preview, ensure that the right fonts are rendered.

![image](https://github.com/woocommerce/woocommerce/assets/4463174/69977636-3998-46ae-aae0-afc87d689e20)


### Woo Express installation

1. Create a new WooCommerce installation with this version.
2. Ensure Jetpack is installed and your site is connected with JP.
3. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
4. Ensure the Woo AI plugin is installed and activated (available on this monorepo).
5. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
6. Head over to WooCommerce -> Home and click on "Start Customizing".
7. Ensure that all the flow works correctly.
8. Follow the process.
9. Click on `Change your font`.
10. For each preview, ensure that the right fonts are rendered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
