### PR TITLE
Graduate Additional fields API and make it experimental

### DIFF
--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -22,7 +22,7 @@
     - [The select input when focused](#the-select-input-when-focused)
 - [Validation and sanitization](#validation-and-sanitization)
     - [Sanitization](#sanitization)
-        - [Using the `_experimental_woocommerce_blocks_validate_additional_field` filter](#using-the-_experimental_woocommerce_blocks_validate_additional_field-filter)
+        - [Using the `_experimental_woocommerce_blocks_sanitize_additional_field` filter](#using-the-_experimental_woocommerce_blocks_sanitize_additional_field-filter)
             - [Example of sanitization](#example-of-sanitization)
     - [Validation](#validation)
         - [Single field validation](#single-field-validation)
@@ -312,9 +312,9 @@ These actions happen in two places:
 
 Sanitization is used to ensure the value of a field is in a specific format. An example is when taking a government ID, you may want to format it so that all letters are capitalized and there are no spaces. At this point, the value should **not** be checked for _validity_. That will come later. This step is only intended to set the field up for validation.
 
-#### Using the `_experimental_woocommerce_blocks_validate_additional_field` filter
+#### Using the `_experimental_woocommerce_blocks_sanitize_additional_field` filter
 
-To run a custom sanitization function for a field use the `_experimental_woocommerce_blocks_validate_additional_field` action.
+To run a custom sanitization function for a field use the `_experimental_woocommerce_blocks_sanitize_additional_field` action.
 
 | Argument     | Type              | Description                                                             |
 |--------------|-------------------|-------------------------------------------------------------------------|
@@ -327,7 +327,7 @@ This example shows how to remove whitespace and capitalize all letters in the ex
 
 ```php
 add_action(
-	'_experimental_woocommerce_blocks_validate_additional_field',
+	'_experimental_woocommerce_blocks_sanitize_additional_field',
 	function ( $field_value, $field_key ) {
 		if ( 'namespace/gov-id' === $field_key ) {
 			$field_value = str_replace( ' ', '', $field_key );
@@ -477,7 +477,7 @@ add_action(
 		);
 
 		add_action(
-			'_experimental_woocommerce_blocks_validate_additional_field',
+			'_experimental_woocommerce_blocks_sanitize_additional_field',
 			function ( $field_value, $field_key ) {
 				if ( 'namespace/gov-id' === $field_key || 'namespace/confirm-gov-id' === $field_key ) {
 					$field_value = str_replace( ' ', '', $field_key );

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -94,7 +94,7 @@ There are plans to expand this list, but for now these are the types available.
 
 ## Using the API
 
-To register additional checkout fields you must use the `woocommerce_blocks_register_checkout_field` function.
+To register additional checkout fields you must use the `__experimental_woocommerce_blocks_register_checkout_field` function.
 
 It is recommended to run this function after the `woocommerce_loaded` action.
 
@@ -188,7 +188,7 @@ This example demonstrates rendering a text field in the address section:
 add_action(
 	'woocommerce_loaded',
 	function() {
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'            => 'namespace/gov-id',
 				'label'         => 'Government ID',
@@ -231,7 +231,7 @@ This example demonstrates rendering a checkbox field in the contact information 
 add_action(
 	'woocommerce_loaded',
 	function() {
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'namespace/marketing-opt-in',
 				'label'    => 'Do you want to subscribe to our newsletter?',
@@ -257,7 +257,7 @@ This example demonstrates rendering a select field in the additional information
 add_action(
 	'woocommerce_loaded',
 	function() {
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'namespace/how-did-you-hear-about-us',
 				'label'    => 'How did you hear about us?',
@@ -449,7 +449,7 @@ This example is just a combined version of the examples shared above.
 add_action(
 	'woocommerce_loaded',
 	function() {
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'            => 'namespace/gov-id',
 				'label'         => 'Government ID',
@@ -462,7 +462,7 @@ add_action(
 				),
 			),
 		);
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'            => 'namespace/confirm-gov-id',
 				'label'         => 'Confirm government ID',

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -22,15 +22,15 @@
     - [The select input when focused](#the-select-input-when-focused)
 - [Validation and sanitization](#validation-and-sanitization)
     - [Sanitization](#sanitization)
-        - [Using the `woocommerce_blocks_sanitize_additional_field` filter](#using-the-woocommerce_blocks_sanitize_additional_field-filter)
+        - [Using the `__experimental___experimental_woocommerce_blocks_validate_additional_field` filter](#using-the-__experimental___experimental_woocommerce_blocks_validate_additional_field-filter)
             - [Example of sanitization](#example-of-sanitization)
     - [Validation](#validation)
         - [Single field validation](#single-field-validation)
-            - [Using the `woocommerce_blocks_validate_additional_field` action](#using-the-woocommerce_blocks_validate_additional_field-action)
+            - [Using the `__experimental_woocommerce_blocks_validate_additional_field` action](#using-the-__experimental_woocommerce_blocks_validate_additional_field-action)
                 - [The `WP_Error` object](#the-wp_error-object)
                 - [Example of single-field validation](#example-of-single-field-validation)
         - [Multiple field validation](#multiple-field-validation)
-            - [Using the `woocommerce_blocks_validate_location_{location}_fields` action](#using-the-woocommerce_blocks_validate_location_location_fields-action)
+            - [Using the `__experimental_woocommerce_blocks_validate_location_{location}_fields` action](#using-the-__experimental_woocommerce_blocks_validate_location_location_fields-action)
             - [Example of location validation](#example-of-location-validation)
 - [A full example](#a-full-example)
 
@@ -312,9 +312,9 @@ These actions happen in two places:
 
 Sanitization is used to ensure the value of a field is in a specific format. An example is when taking a government ID, you may want to format it so that all letters are capitalized and there are no spaces. At this point, the value should **not** be checked for _validity_. That will come later. This step is only intended to set the field up for validation.
 
-#### Using the `woocommerce_blocks_sanitize_additional_field` filter
+#### Using the `__experimental___experimental_woocommerce_blocks_validate_additional_field` filter
 
-To run a custom sanitization function for a field use the `woocommerce_blocks_sanitize_additional_field` action.
+To run a custom sanitization function for a field use the `__experimental___experimental_woocommerce_blocks_validate_additional_field` action.
 
 | Argument     | Type              | Description                                                             |
 |--------------|-------------------|-------------------------------------------------------------------------|
@@ -327,7 +327,7 @@ This example shows how to remove whitespace and capitalize all letters in the ex
 
 ```php
 add_action(
-	'woocommerce_blocks_sanitize_additional_field',
+	'__experimental___experimental_woocommerce_blocks_validate_additional_field',
 	function ( $field_value, $field_key ) {
 		if ( 'namespace/gov-id' === $field_key ) {
 			$field_value = str_replace( ' ', '', $field_key );
@@ -346,9 +346,9 @@ There are two phases of validation in the additional checkout fields system. The
 
 #### Single field validation
 
-##### Using the `woocommerce_blocks_validate_additional_field` action
+##### Using the `__experimental_woocommerce_blocks_validate_additional_field` action
 
-When the `woocommerce_blocks_validate_additional_field` action is fired  the callback receives the field's key, the field's value, and a `WP_Error` object.
+When the `__experimental_woocommerce_blocks_validate_additional_field` action is fired  the callback receives the field's key, the field's value, and a `WP_Error` object.
 
 To add validation errors to the response, use the [`WP_Error::add`](https://developer.wordpress.org/reference/classes/wp_error/add/) method.
 
@@ -368,7 +368,7 @@ The below example shows how to apply custom validation to the `namespace/gov-id`
 
 ```php
 add_action(
-'woocommerce_blocks_validate_additional_field',
+'__experimental_woocommerce_blocks_validate_additional_field',
 	function ( WP_Error $errors, $field_key, $field_value ) {
 		if ( 'namespace/gov-id' === $field_key ) {
 			$match = preg_match( '/[A-Z0-9]{5}/', $field_value );
@@ -389,11 +389,11 @@ If no validation errors are encountered the function can just return void.
 
 #### Multiple field validation
 
-There are cases where the validity of a field depends on the value of another field, for example validating the format of a government ID based on what country the shopper is in. In this case, validating only single fields (as above) is not sufficient as the country may be unknown during the `woocommerce_blocks_validate_additional_field` action.
+There are cases where the validity of a field depends on the value of another field, for example validating the format of a government ID based on what country the shopper is in. In this case, validating only single fields (as above) is not sufficient as the country may be unknown during the `__experimental_woocommerce_blocks_validate_additional_field` action.
 
 To solve this, it is possible to validate a field in the context of the location it renders in. The other fields in that location will be passed to this action.
 
-##### Using the `woocommerce_blocks_validate_location_{location}_fields` action
+##### Using the `__experimental_woocommerce_blocks_validate_location_{location}_fields` action
 
 This action will be fired for each location that additional fields can render in (`address`, `contact`, and `additional`). For `address` it fires twice, once for the billing address and once for the shipping address.
 
@@ -410,13 +410,13 @@ It is important to note that any fields rendered in other locations will not be 
 There are several places where these hooks are fired.
 
 - When checking out using the Checkout block or Store API.
-    - `woocommerce_blocks_validate_location_address_fields` (x2)
-    - `woocommerce_blocks_validate_location_contact_fields`
-    - `woocommerce_blocks_validate_location_additional_fields`
+    - `__experimental_woocommerce_blocks_validate_location_address_fields` (x2)
+    - `__experimental_woocommerce_blocks_validate_location_contact_fields`
+    - `__experimental_woocommerce_blocks_validate_location_additional_fields`
 - When updating addresses in the "My account" area
-    - `woocommerce_blocks_validate_location_address_fields` (**x1** - only the address being edited)
+    - `__experimental_woocommerce_blocks_validate_location_address_fields` (**x1** - only the address being edited)
 - When updating the "Account details" section in the "My account" area
-    - `woocommerce_blocks_validate_location_contact_fields`
+    - `__experimental_woocommerce_blocks_validate_location_contact_fields`
 
 ##### Example of location validation
 
@@ -426,7 +426,7 @@ The example below illustrates how to verify that the value of the confirmation f
 
 ```php
 add_action(
-	'woocommerce_blocks_validate_location_address_fields',
+	'__experimental_woocommerce_blocks_validate_location_address_fields',
 	function ( \WP_Error $errors, $fields, $group ) {
 		if ( $fields['namespace/gov-id'] !== $fields['namespace/confirm-gov-id'] ) {
 			$errors->add( 'gov_id_mismatch', 'Please ensure your government ID matches the confirmation.' );
@@ -437,7 +437,7 @@ add_action(
 );
 ```
 
-If these fields were rendered in the "contact" location instead, the code would be the same except the hook used would be: `woocommerce_blocks_validate_location_contact_fields`.
+If these fields were rendered in the "contact" location instead, the code would be the same except the hook used would be: `__experimental_woocommerce_blocks_validate_location_contact_fields`.
 
 ## A full example
 
@@ -477,7 +477,7 @@ add_action(
 		);
 
 		add_action(
-			'woocommerce_blocks_sanitize_additional_field',
+			'__experimental___experimental_woocommerce_blocks_validate_additional_field',
 			function ( $field_value, $field_key ) {
 				if ( 'namespace/gov-id' === $field_key || 'namespace/confirm-gov-id' === $field_key ) {
 					$field_value = str_replace( ' ', '', $field_key );
@@ -490,7 +490,7 @@ add_action(
 		);
 
 		add_action(
-		'woocommerce_blocks_validate_additional_field',
+		'__experimental_woocommerce_blocks_validate_additional_field',
 			function ( WP_Error $errors, $field_key, $field_value ) {
 				if ( 'namespace/gov-id' === $field_key ) {
 					$match = preg_match( '/[A-Z0-9]{5}/', $field_value );
@@ -509,7 +509,7 @@ add_action(
 );
 
 add_action(
-	'woocommerce_blocks_validate_location_address_fields',
+	'__experimental_woocommerce_blocks_validate_location_address_fields',
 	function ( \WP_Error $errors, $fields, $group ) {
 		if ( $fields['namespace/gov-id'] !== $fields['namespace/confirm-gov-id'] ) {
 			$errors->add( 'gov_id_mismatch', 'Please ensure your government ID matches the confirmation.' );

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -22,7 +22,7 @@
     - [The select input when focused](#the-select-input-when-focused)
 - [Validation and sanitization](#validation-and-sanitization)
     - [Sanitization](#sanitization)
-        - [Using the `__experimental___experimental_woocommerce_blocks_validate_additional_field` filter](#using-the-__experimental___experimental_woocommerce_blocks_validate_additional_field-filter)
+        - [Using the `_experimental_woocommerce_blocks_validate_additional_field` filter](#using-the-_experimental_woocommerce_blocks_validate_additional_field-filter)
             - [Example of sanitization](#example-of-sanitization)
     - [Validation](#validation)
         - [Single field validation](#single-field-validation)
@@ -312,9 +312,9 @@ These actions happen in two places:
 
 Sanitization is used to ensure the value of a field is in a specific format. An example is when taking a government ID, you may want to format it so that all letters are capitalized and there are no spaces. At this point, the value should **not** be checked for _validity_. That will come later. This step is only intended to set the field up for validation.
 
-#### Using the `__experimental___experimental_woocommerce_blocks_validate_additional_field` filter
+#### Using the `_experimental_woocommerce_blocks_validate_additional_field` filter
 
-To run a custom sanitization function for a field use the `__experimental___experimental_woocommerce_blocks_validate_additional_field` action.
+To run a custom sanitization function for a field use the `_experimental_woocommerce_blocks_validate_additional_field` action.
 
 | Argument     | Type              | Description                                                             |
 |--------------|-------------------|-------------------------------------------------------------------------|
@@ -327,7 +327,7 @@ This example shows how to remove whitespace and capitalize all letters in the ex
 
 ```php
 add_action(
-	'__experimental___experimental_woocommerce_blocks_validate_additional_field',
+	'_experimental_woocommerce_blocks_validate_additional_field',
 	function ( $field_value, $field_key ) {
 		if ( 'namespace/gov-id' === $field_key ) {
 			$field_value = str_replace( ' ', '', $field_key );
@@ -477,7 +477,7 @@ add_action(
 		);
 
 		add_action(
-			'__experimental___experimental_woocommerce_blocks_validate_additional_field',
+			'_experimental_woocommerce_blocks_validate_additional_field',
 			function ( $field_value, $field_key ) {
 				if ( 'namespace/gov-id' === $field_key || 'namespace/confirm-gov-id' === $field_key ) {
 					$field_value = str_replace( ' ', '', $field_key );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -607,7 +607,7 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			return apply_filters( 'woocommerce_blocks_sanitize_additional_field', $field_value, $field_key );
+			return apply_filters( '__experimental_woocommerce_blocks_sanitize_additional_field', $field_value, $field_key );
 
 		} catch ( \Throwable $e ) {
 			// One of the filters errored so skip it. This allows the checkout process to continue.
@@ -657,7 +657,7 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			do_action( 'woocommerce_blocks_validate_additional_field', $errors, $field_key, $field_value );
+			do_action( '__experimental_woocommerce_blocks_validate_additional_field', $errors, $field_key, $field_value );
 
 		} catch ( \Throwable $e ) {
 
@@ -760,7 +760,7 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			do_action( 'woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group );
+			do_action( '__experimental_woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group );
 
 		} catch ( \Throwable $e ) {
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -341,32 +341,32 @@ class CheckoutFields {
 	 */
 	private function validate_options( $options ) {
 		if ( empty( $options['id'] ) ) {
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0' );
 			return false;
 		}
 
 		// Having fewer than 2 after exploding around a / means there is no namespace.
 		if ( count( explode( '/', $options['id'] ) ) < 2 ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'A checkout field id must consist of namespace/name.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( empty( $options['label'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field label is required.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( empty( $options['location'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is required.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( ! in_array( $options['location'], array_keys( $this->fields_locations ), true ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is invalid.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
@@ -377,14 +377,14 @@ class CheckoutFields {
 		// Check to see if field is already in the array.
 		if ( ! empty( $this->additional_fields[ $id ] ) || in_array( $id, $this->fields_locations[ $location ], true ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The field is already registered.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		// Hidden fields are not supported right now. They will be registered with hidden => false.
 		if ( ! empty( $options['hidden'] ) && true === $options['hidden'] ) {
 			$message = sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			// Don't return here unlike the other fields because this is not an issue that will prevent registration.
 		}
 
@@ -396,20 +396,20 @@ class CheckoutFields {
 					$options['type'],
 					implode( ', ', $this->supported_field_types )
 				);
-				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+				_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 				return false;
 			}
 		}
 
 		if ( ! empty( $options['sanitize_callback'] ) && ! is_callable( $options['sanitize_callback'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The sanitize_callback must be a valid callback.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( ! empty( $options['validate_callback'] ) && ! is_callable( $options['validate_callback'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
@@ -429,7 +429,7 @@ class CheckoutFields {
 
 		if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options".' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
@@ -437,7 +437,7 @@ class CheckoutFields {
 		$field_data['required'] = true;
 		if ( isset( $options['required'] ) && false === $options['required'] ) {
 			$message = sprintf( 'Registering select fields as optional is not supported. "%s" will be registered as required.', $id );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 		}
 
 		$cleaned_options = array();
@@ -447,7 +447,7 @@ class CheckoutFields {
 		foreach ( $options['options'] as $option ) {
 			if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
 				$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.' );
-				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+				_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 				return false;
 			}
 
@@ -456,7 +456,7 @@ class CheckoutFields {
 
 			if ( in_array( $sanitized_value, $added_values, true ) ) {
 				$message = sprintf( 'Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', $id, $sanitized_value );
-				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+				_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 				continue;
 			}
 
@@ -488,7 +488,7 @@ class CheckoutFields {
 
 		if ( isset( $options['required'] ) && true === $options['required'] ) {
 			$message = sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 		}
 
 		return $field_data;
@@ -511,7 +511,7 @@ class CheckoutFields {
 
 		if ( ! is_array( $attributes ) || 0 === count( $attributes ) ) {
 			$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return [];
 		}
 
@@ -537,7 +537,7 @@ class CheckoutFields {
 		if ( count( $attributes ) !== count( $valid_attributes ) ) {
 			$invalid_attributes = array_keys( array_diff_key( $attributes, $valid_attributes ) );
 			$message            = sprintf( 'Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode( ', ', $invalid_attributes ) );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 		}
 
 		// Escape attributes to remove any malicious code and return them.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
  * @param array $options Field arguments. See CheckoutFields::register_checkout_field() for details.
  * @throws \Exception If field registration fails.
  */
-function __experimental_woocommerce_blocks_register_checkout_field( $options ) {
+function __experimental_woocommerce_blocks_register_checkout_field( $options ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
 
 	// Check if `woocommerce_blocks_loaded` ran. If not then the CheckoutFields class will not be available yet.
 	// In that case, re-hook `woocommerce_blocks_loaded` and try running this again.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
@@ -3,32 +3,29 @@
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 
-if ( ! function_exists( 'woocommerce_blocks_register_checkout_field' ) && Package::feature()->is_experimental_build() ) {
+/**
+ * Register a checkout field.
+ *
+ * @param array $options Field arguments. See CheckoutFields::register_checkout_field() for details.
+ * @throws \Exception If field registration fails.
+ */
+function __experimental_woocommerce_blocks_register_checkout_field( $options ) {
 
-	/**
-	 * Register a checkout field.
-	 *
-	 * @param array $options Field arguments. See CheckoutFields::register_checkout_field() for details.
-	 * @throws \Exception If field registration fails.
-	 */
-	function woocommerce_blocks_register_checkout_field( $options ) {
-
-		// Check if `woocommerce_blocks_loaded` ran. If not then the CheckoutFields class will not be available yet.
-		// In that case, re-hook `woocommerce_blocks_loaded` and try running this again.
-		$woocommerce_blocks_loaded_ran = did_action( 'woocommerce_blocks_loaded' );
-		if ( ! $woocommerce_blocks_loaded_ran ) {
-			add_action(
-				'woocommerce_blocks_loaded',
-				function() use ( $options ) {
-					woocommerce_blocks_register_checkout_field( $options );
-				}
-			);
-			return;
-		}
-		$checkout_fields = Package::container()->get( CheckoutFields::class );
-		$result          = $checkout_fields->register_checkout_field( $options );
-		if ( is_wp_error( $result ) ) {
-			throw new \Exception( $result->get_error_message() );
-		}
+	// Check if `woocommerce_blocks_loaded` ran. If not then the CheckoutFields class will not be available yet.
+	// In that case, re-hook `woocommerce_blocks_loaded` and try running this again.
+	$woocommerce_blocks_loaded_ran = did_action( 'woocommerce_blocks_loaded' );
+	if ( ! $woocommerce_blocks_loaded_ran ) {
+		add_action(
+			'woocommerce_blocks_loaded',
+			function() use ( $options ) {
+				__experimental_woocommerce_blocks_register_checkout_field( $options );
+			}
+		);
+		return;
+	}
+	$checkout_fields = Package::container()->get( CheckoutFields::class );
+	$result          = $checkout_fields->register_checkout_field( $options );
+	if ( is_wp_error( $result ) ) {
+		throw new \Exception( $result->get_error_message() );
 	}
 }


### PR DESCRIPTION
This PR graduates the additional fields API and adds a prefix to it. It also adds a prefix to all hooks and filters we introduced and updates the doc.

Closes https://github.com/woocommerce/woocommerce/issues/42135

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testing this would be part of testing the new additional fields API.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

- Graduate the Additional Fields API from a private API to an experimental API.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
