### PR TITLE
Add `Always show pre-publish checks` checkbox

### DIFF
--- a/packages/js/product-editor/changelog/add-43707_show_prepublish_checks_section
+++ b/packages/js/product-editor/changelog/add-43707_show_prepublish_checks_section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Always show pre-publish checks checkbox #44595

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -65,9 +65,7 @@ export function Header( {
 		'name'
 	);
 
-	const { isResolving, showPrepublishChecks } = useShowPrepublishChecks();
-
-	const isPrepublishButtonVisible = ! isResolving && showPrepublishChecks;
+	const { showPrepublishChecks } = useShowPrepublishChecks();
 
 	const sidebarWidth = useAdminSidebarWidth();
 
@@ -165,7 +163,7 @@ export function Header( {
 
 					<PublishButton
 						productType={ productType }
-						prePublish={ isPrepublishButtonVisible }
+						prePublish={ showPrepublishChecks }
 					/>
 
 					<WooHeaderItem.Slot name="product" />

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -27,6 +27,7 @@ import { PublishButton } from './publish-button';
 import { LoadingState } from './loading-state';
 import { Tabs } from '../tabs';
 import { HEADER_PINNED_ITEMS_SCOPE, TRACKS_SOURCE } from '../../constants';
+import { useShowPrepublishChecks } from '../../hooks/use-show-prepublish-checks';
 
 export type HeaderProps = {
 	onTabSelect: ( tabId: string | null ) => void;
@@ -63,6 +64,10 @@ export function Header( {
 		productType,
 		'name'
 	);
+
+	const { isResolving, showPrepublishChecks } = useShowPrepublishChecks();
+
+	const isPrepublishButtonVisible = ! isResolving && showPrepublishChecks;
 
 	const sidebarWidth = useAdminSidebarWidth();
 
@@ -158,7 +163,10 @@ export function Header( {
 						productStatus={ lastPersistedProduct?.status }
 					/>
 
-					<PublishButton productType={ productType } prePublish />
+					<PublishButton
+						productType={ productType }
+						prePublish={ isPrepublishButtonVisible }
+					/>
 
 					<WooHeaderItem.Slot name="product" />
 					<PinnedItems.Slot scope={ HEADER_PINNED_ITEMS_SCOPE } />

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -64,11 +64,10 @@ export function PrepublishPanel( {
 				<h4>{ title }</h4>
 				<span>{ description }</span>
 			</div>
-
-			<VisibilitySection productType={ productType } />
-
-			<ScheduleSection postType={ productType } />
-
+			<div className="woocommerce-product-publish-panel__content">
+				<VisibilitySection productType={ productType } />
+				<ScheduleSection postType={ productType } />
+			</div>
 			<div className="woocommerce-product-publish-panel__footer">
 				<ShowPrepublishChecksSection />
 			</div>

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -17,6 +17,7 @@ import { store as productEditorUiStore } from '../../store/product-editor-ui';
 import { TRACKS_SOURCE } from '../../constants';
 import { VisibilitySection } from './visibility-section';
 import { ScheduleSection } from './schedule-section';
+import { ShowPrepublishChecksSection } from './show-prepublish-checks-section';
 
 export function PrepublishPanel( {
 	productType = 'product',
@@ -63,9 +64,14 @@ export function PrepublishPanel( {
 				<h4>{ title }</h4>
 				<span>{ description }</span>
 			</div>
+
 			<VisibilitySection productType={ productType } />
 
 			<ScheduleSection postType={ productType } />
+
+			<div className="woocommerce-product-publish-panel__footer">
+				<ShowPrepublishChecksSection />
+			</div>
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/index.ts
+++ b/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/index.ts
@@ -1,0 +1,1 @@
+export * from './show-prepublish-checks-section';

--- a/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/show-prepublish-checks-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/show-prepublish-checks-section.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
+import { CheckboxControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { TRACKS_SOURCE } from '../../../constants';
+
+export function ShowPrepublishChecksSection() {
+	const { disablePublishSidebar, enablePublishSidebar } =
+		useDispatch( 'core/editor' );
+
+	const { isPrepublishSidebarEnabled } = useSelect( ( select ) => {
+		const { isPublishSidebarEnabled } = select( 'core/editor' );
+		return {
+			isPrepublishSidebarEnabled: isPublishSidebarEnabled() ?? true,
+		};
+	}, [] );
+
+	return (
+		<div className="woocommerce-publish-panel-show-checks">
+			<CheckboxControl
+				label={ __( 'Always show pre-publish checks.', 'woocommerce' ) }
+				checked={ isPrepublishSidebarEnabled }
+				onChange={ ( selected: boolean ) => {
+					if ( selected ) {
+						enablePublishSidebar();
+					} else {
+						disablePublishSidebar();
+					}
+					recordEvent( 'product_prepublish_panel', {
+						source: TRACKS_SOURCE,
+						action: 'enable_prepublish_checks',
+						value: selected,
+					} );
+				} }
+			/>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/show-prepublish-checks-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/show-prepublish-checks-section.tsx
@@ -5,35 +5,28 @@ import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import { CheckboxControl } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { TRACKS_SOURCE } from '../../../constants';
+import { useShowPrepublishChecks } from '../../../hooks/use-show-prepublish-checks';
 
 export function ShowPrepublishChecksSection() {
-	const { disablePublishSidebar, enablePublishSidebar } =
-		useDispatch( 'core/editor' );
+	const { isResolving, showPrepublishChecks, togglePrepublishChecks } =
+		useShowPrepublishChecks();
 
-	const { isPrepublishSidebarEnabled } = useSelect( ( select ) => {
-		const { isPublishSidebarEnabled } = select( 'core/editor' );
-		return {
-			isPrepublishSidebarEnabled: isPublishSidebarEnabled() ?? true,
-		};
-	}, [] );
+	if ( isResolving ) {
+		return null;
+	}
 
 	return (
 		<div className="woocommerce-publish-panel-show-checks">
 			<CheckboxControl
 				label={ __( 'Always show pre-publish checks.', 'woocommerce' ) }
-				checked={ isPrepublishSidebarEnabled }
+				checked={ showPrepublishChecks }
 				onChange={ ( selected: boolean ) => {
-					if ( selected ) {
-						enablePublishSidebar();
-					} else {
-						disablePublishSidebar();
-					}
+					togglePrepublishChecks();
 					recordEvent( 'product_prepublish_panel', {
 						source: TRACKS_SOURCE,
 						action: 'enable_prepublish_checks',

--- a/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/show-prepublish-checks-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/show-prepublish-checks-section/show-prepublish-checks-section.tsx
@@ -29,7 +29,7 @@ export function ShowPrepublishChecksSection() {
 					togglePrepublishChecks();
 					recordEvent( 'product_prepublish_panel', {
 						source: TRACKS_SOURCE,
-						action: 'enable_prepublish_checks',
+						action: 'toggle_prepublish_checks',
 						value: selected,
 					} );
 				} }

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -43,6 +43,14 @@
 			margin: 8px 0;
 		}
 	}
+
+	&__footer {
+		padding: 0 $grid-unit-20;
+		position: absolute;
+		bottom: $gap-largest;
+		left: 0;
+		width: 100%;
+	}
 }
 
 @keyframes product-publish-panel__slide-in-animation {

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -1,11 +1,19 @@
 @import './visibility-section/style.scss';
 
 .woocommerce-product-publish-panel {
+	bottom: 0;
+    right: 0;
+    top: $admin-bar-height-big;
+	overflow: auto;
+    position: fixed;
 	background: $white;
 	transform: translateX(+100%);
 	animation: product-publish-panel__slide-in-animation 0.1s forwards;
+    width: 100%;
 
 	@include break-medium() {
+		top: $admin-bar-height;
+		width: $sidebar-width - $border-width;
 		@include reduce-motion("animation");
 
 		body.is-fullscreen-mode & {
@@ -44,9 +52,13 @@
 		}
 	}
 
+	&__content {
+		// Ensure the pre-publish panel accounts for the header and footer height.
+		min-height: calc(100% - #{$header-height + 172px});
+	}
+
 	&__footer {
-		padding: 0 $grid-unit-20;
-		position: absolute;
+		padding: $grid-unit-20;
 		bottom: $gap-largest + $gap-large;
 		left: 0;
 		width: 100%;

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -54,14 +54,20 @@
 
 	&__content {
 		// Ensure the pre-publish panel accounts for the header and footer height.
-		min-height: calc(100% - #{$header-height + 172px});
+		min-height: calc( 100% - #{ $header-height + 200px } );
 	}
 
 	&__footer {
-		padding: $grid-unit-20;
-		bottom: $gap-largest + $gap-large;
+		padding: 0 $grid-unit-20;
 		left: 0;
 		width: 100%;
+		min-height: $gap-largest + $gap-large;
+		display: flex;
+		align-items: center;
+
+		.components-base-control__field {
+			margin: 0;
+		}
 	}
 }
 

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -47,7 +47,7 @@
 	&__footer {
 		padding: 0 $grid-unit-20;
 		position: absolute;
-		bottom: $gap-largest;
+		bottom: $gap-largest + $gap-large;
 		left: 0;
 		width: 100%;
 	}

--- a/packages/js/product-editor/src/constants.ts
+++ b/packages/js/product-editor/src/constants.ts
@@ -5,6 +5,8 @@ export const NEW_PRODUCT_MANAGEMENT_ENABLED_OPTION_NAME =
 	'woocommerce_new_product_management_enabled';
 export const SINGLE_VARIATION_NOTICE_DISMISSED_OPTION =
 	'woocommerce_single_variation_notice_dismissed';
+export const SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME =
+	'woocommerce_show_prepublish_checks_enabled';
 
 export const NUMBERS_AND_ALLOWED_CHARS = '[^-0-9%s1%s2]';
 export const NUMBERS_AND_DECIMAL_SEPARATOR = '[^-\\d\\%s]+';

--- a/packages/js/product-editor/src/hooks/use-show-prepublish-checks.ts
+++ b/packages/js/product-editor/src/hooks/use-show-prepublish-checks.ts
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME } from '../constants';
+
+export function useShowPrepublishChecks() {
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+
+	const { isResolving, showPrepublishChecks } = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
+
+		const showPrepublishChecksOption =
+			getOption( SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME ) || 'yes';
+
+		const resolving = ! hasFinishedResolution( 'getOption', [
+			SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME,
+		] );
+
+		return {
+			isResolving: resolving,
+			showPrepublishChecks: showPrepublishChecksOption === 'yes',
+		};
+	}, [] );
+
+	const togglePrepublishChecks = () => {
+		updateOptions( {
+			[ SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME ]: showPrepublishChecks
+				? 'no'
+				: 'yes',
+		} );
+	};
+
+	return {
+		isResolving,
+		showPrepublishChecks,
+		togglePrepublishChecks,
+	};
+}

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -238,6 +238,7 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 								total_palettes={ theme.total_palettes }
 								link_url={ theme?.link_url }
 								is_active={ theme.is_active }
+								price={ theme.price }
 								onClick={ () => {
 									if ( theme.is_active ) {
 										sendEvent( {

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
@@ -278,27 +278,36 @@
 			}
 		}
 
-		.theme-card__active {
-			border-radius: 100px;
-			background: rgba(56, 88, 233, 0.2);
-			padding: 5px 10px;
-			justify-content: flex-end;
-			align-items: center;
-			gap: 10px;
-			color: #1d35b4;
-			font-size: 12px;
-			font-style: normal;
-			font-weight: 500;
-			line-height: 20px; /* 166.667% */
-			margin-right: 10px;
-		}
-
 		.theme-card__free {
 			color: #1e1e1e;
 			font-size: 14px;
 			font-style: normal;
 			font-weight: 400;
 			line-height: 16px; /* 114.286% */
+		}
+
+		.theme-card__active {
+			background: rgba(56, 88, 233, 0.2);
+			color: #1d35b4;
+		}
+
+		.theme-card__paid {
+			background: #dcdcde;
+			color: #2c3338;
+		}
+
+		.theme-card__active,
+		.theme-card__paid {
+			border-radius: 100px;
+			padding: 5px 10px;
+			justify-content: flex-end;
+			align-items: center;
+			gap: 10px;
+			font-size: 12px;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px; /* 166.667% */
+			margin-right: 10px;
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/customize-store/intro/theme-card.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/theme-card.tsx
@@ -19,6 +19,7 @@ export const ThemeCard = ( {
 	total_palettes = 0,
 	link_url = '',
 	is_active = false,
+	price = 'Free',
 	onClick,
 }: TypeThemeCard & {
 	onClick: () => void;
@@ -49,7 +50,12 @@ export const ThemeCard = ( {
 						{ __( 'Active theme', 'woocommerce' ) }
 					</span>
 				) }
-				<span className="theme-card__free">Free</span>
+				{ price !== 'Free' && (
+					<span className="theme-card__paid">
+						{ __( 'Paid', 'woocommerce' ) }
+					</span>
+				) }
+				<span className="theme-card__free">{ price }</span>
 			</div>
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/customize-store/intro/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/types.ts
@@ -13,6 +13,7 @@ export type ThemeCard = {
 	thumbnail_url: string;
 	is_active: boolean;
 	link_url?: string;
+	price: string;
 	color_palettes: ColorPalette[];
 	total_palettes: number;
 };

--- a/plugins/woocommerce/changelog/44811-update-blocks-build-message
+++ b/plugins/woocommerce/changelog/44811-update-blocks-build-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Update Blocks build message when asset files are not built.
+

--- a/plugins/woocommerce/changelog/44822-44609-cys-on-core-update-the-themes-list-on-the-intro-screen
+++ b/plugins/woocommerce/changelog/44822-44609-cys-on-core-update-the-themes-list-on-the-intro-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the themes list on the Customize Your Store intro screen.

--- a/plugins/woocommerce/changelog/45096-fix-remove-wp-nightly-test
+++ b/plugins/woocommerce/changelog/45096-fix-remove-wp-nightly-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This PR affects tooling and a change entry is not required.
+

--- a/plugins/woocommerce/changelog/add-43707_show_prepublish_checks_section
+++ b/plugins/woocommerce/changelog/add-43707_show_prepublish_checks_section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Always show pre-publish checks checkbox #44595

--- a/plugins/woocommerce/changelog/e2e-add-merchant-transform-cart-test
+++ b/plugins/woocommerce/changelog/e2e-add-merchant-transform-cart-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: add test for transforming classic cart to cart block

--- a/plugins/woocommerce/changelog/fix-43289-woocommerce-css-watch
+++ b/plugins/woocommerce/changelog/fix-43289-woocommerce-css-watch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+WooCommerce build watching will now also detect CSS file changes.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -256,6 +256,7 @@
 			"node_modules/@woocommerce/classic-assets/build",
 			"node_modules/@woocommerce/admin-library/build"
 		],
+		"ext": "js,css,php,json",
 		"ignoreRoot": []
 	},
 	"wireit": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -125,25 +125,6 @@
 					}
 				},
 				{
-					"name": "PHP WP: nightly",
-					"command": "test:php:env",
-					"changes": [
-						"composer.lock",
-						"includes/**/*.php",
-						"patterns/**/*.php",
-						"src/**/*.php",
-						"templates/**/*.php",
-						"tests/php/**/*.php",
-						"tests/unit-tests/**/*.php"
-					],
-					"testEnv": {
-						"start": "env:test",
-						"config": {
-							"wpVersion": "nightly"
-						}
-					}
-				},
-				{
 					"name": "PHP WP: latest - 1",
 					"command": "test:php:env",
 					"changes": [

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -249,9 +249,69 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 			);
 		}
 
+		$core_themes = array(
+			array(
+				'name'           => 'Twenty Twenty-Four',
+				'price'          => 'Free',
+				'color_palettes' => array(
+					array(
+						'title'     => 'Black and white',
+						'primary'   => '#FEFBF3',
+						'secondary' => '#7F7E7A',
+					),
+					array(
+						'title'     => 'Brown Sugar',
+						'primary'   => '#EFEBE0',
+						'secondary' => '#AC6239',
+					),
+					array(
+						'title'     => 'Midnight',
+						'primary'   => '#161514',
+						'secondary' => '#AFADA7',
+					),
+					array(
+						'title'     => 'Olive',
+						'primary'   => '#FEFBF3',
+						'secondary' => '#7F7E7A',
+					),
+				),
+				'total_palettes' => 0,
+				'slug'           => 'twentytwentyfour',
+				'thumbnail_url'  => 'https://i0.wp.com/themes.svn.wordpress.org/twentytwentyfour/1.0/screenshot.png',
+				'link_url'       => 'https://wordpress.org/themes/twentytwentyfour/',
+			),
+			array(
+				'name'           => 'Highline',
+				'price'          => '$79/year',
+				'color_palettes' => array(),
+				'total_palettes' => 0,
+				'slug'           => 'highline',
+				'thumbnail_url'  => 'https://woo.com/wp-content/uploads/2023/12/Featured-image-538x403-1.png',
+				'link_url'       => 'https://woo.com/products/highline/',
+			),
+			array(
+				'name'           => 'Luminate',
+				'price'          => '$79/year',
+				'color_palettes' => array(),
+				'total_palettes' => 0,
+				'slug'           => 'luminate',
+				'thumbnail_url'  => 'https://woo.com/wp-content/uploads/2022/07/Featured-image-538x403-2.png',
+				'link_url'       => 'https://woo.com/products/luminate/',
+			),
+			array(
+				'name'           => 'Nokul',
+				'price'          => '$79/year',
+				'color_palettes' => array(),
+				'total_palettes' => 0,
+				'slug'           => 'nokul',
+				'thumbnail_url'  => 'https://woo.com/wp-content/uploads/2022/11/Product-logo.jpg',
+				'link_url'       => 'https://woo.com/products/nokul/',
+			),
+		);
+
 		// To be implemented: 1. Fetch themes from the marketplace API. 2. Convert prices to the requested currency.
 		// These are Dotcom themes.
-		$themes = array(
+		$default_themes = array(
 			array(
 				'name'           => 'Tsubaki',
 				'price'          => 'Free',
@@ -269,7 +329,6 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 				'slug'           => 'tazza',
 				'thumbnail_url'  => 'https://i0.wp.com/s2.wp.com/wp-content/themes/premium/tazza/screenshot.png',
 				'link_url'       => 'https://wordpress.com/theme/tazza/',
-				'total_palettes' => 0,
 			),
 			array(
 				'name'           => 'Amulet',
@@ -332,6 +391,9 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 				'link_url'       => 'https://wordpress.com/theme/zaino/',
 			),
 		);
+
+		$ai_connection_enabled = get_option( 'woocommerce_blocks_allow_ai_connection' );
+		$themes                = $ai_connection_enabled ? $default_themes : $core_themes;
 
 		// To be implemented: Filter themes based on industry.
 		if ( $industry ) {

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -205,6 +205,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_product_tour_modal_hidden',
 			'woocommerce_block_product_tour_shown',
 			'woocommerce_revenue_report_date_tour_shown',
+			'woocommerce_show_prepublish_checks_enabled',
 			'woocommerce_date_type',
 			'date_format',
 			'time_format',

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -190,11 +190,12 @@ class Bootstrap {
 			function() {
 				echo '<div class="error"><p>';
 				printf(
-					/* translators: %1$s is the install command, %2$s is the build command, %3$s is the watch command. */
-					esc_html__( 'WooCommerce Blocks development mode requires files to be built. From the plugin directory, run %1$s to install dependencies, %2$s to build the files or %3$s to build the files and watch for changes.', 'woocommerce' ),
-					'<code>npm install</code>',
-					'<code>npm run build</code>',
-					'<code>npm start</code>'
+					/* translators: %1$s is the node install command, %2$s is the install command, %3$s is the build command, %4$s is the watch command. */
+					esc_html__( 'WooCommerce Blocks development mode requires files to be built. From the root directory, run %1$s to ensure your node version is aligned, run %2$s to install dependencies, %3$s to build the files or %4$s to build the files and watch for changes.', 'woocommerce' ),
+					'<code>nvm use</code>',
+					'<code>pnpm install</code>',
+					'<code>pnpm --filter="@woocommerce/plugin-woocommerce" build</code>',
+					'<code>pnpm --filter="@woocommerce/plugin-woocommerce" watch:build</code>'
 				);
 				echo '</p></div>';
 			}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
@@ -1,0 +1,72 @@
+const { test, expect } = require( '@playwright/test' );
+const { closeWelcomeModal } = require( '../../utils/editor' );
+
+const transformedCartBlockTitle = `Transformed Cart ${ Date.now() }`;
+const transformedCartBlockSlug = transformedCartBlockTitle
+	.replace( / /gi, '-' )
+	.toLowerCase();
+
+test.describe( 'Transform Classic Cart To Cart Block', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+
+	test( 'can transform classic cart to cart block', async ( { page } ) => {
+		// go to create a new page
+		await page.goto( 'wp-admin/post-new.php?post_type=page' );
+
+		await closeWelcomeModal( { page } );
+
+		// fill page title
+		await page
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( transformedCartBlockTitle );
+
+		// add classic cart block
+		await page.getByRole( 'textbox', { name: 'Add title' } ).click();
+		await page.getByLabel( 'Add block' ).click();
+		await page
+			.getByPlaceholder( 'Search', { exact: true } )
+			.fill( 'classic cart' );
+		await page
+			.getByRole( 'option' )
+			.filter( { hasText: 'Classic Cart' } )
+			.click();
+
+		// transform into blocks
+		await expect(
+			page.locator(
+				'.wp-block-woocommerce-classic-shortcode__placeholder-copy'
+			)
+		).toBeVisible();
+		await page
+			.getByRole( 'button' )
+			.filter( { hasText: 'Transform into blocks' } )
+			.click();
+		await expect( page.getByLabel( 'Dismiss this notice' ) ).toContainText(
+			'Classic shortcode transformed to blocks.'
+		);
+
+		// save and publish the page
+		await page
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+		await expect(
+			page.getByText( `${ transformedCartBlockTitle } is now live.` )
+		).toBeVisible();
+
+		// go to frontend to verify transformed cart block
+		await page.goto( transformedCartBlockSlug );
+		await expect(
+			page.getByRole( 'heading', { name: transformedCartBlockTitle } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Your cart is currently empty!' )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: 'Browse store' } )
+		).toBeVisible();
+	} );
+} );

--- a/tools/monorepo-utils/.gitignore
+++ b/tools/monorepo-utils/.gitignore
@@ -1,4 +1,5 @@
 # We are going to include the bundled version of the tool so that we don't need
 # to build the tool in order to use it. This saves a lot of time in CI since
 # we don't need to install any dependencies.
-!dist
+!dist/index.js
+!dist/index.js.LICENSE.txt


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The sidebar/modal can be optional when the form doesn't contain any validation error.
This PR adds the `Always show pre-publish checks` checkbox.

![Screenshot 2024-02-14 at 10 14 43](https://github.com/woocommerce/woocommerce/assets/1314156/f263ea67-fdb7-4bc6-8954-d4d562563334)

Closes #43707.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New.
3. Add a product name and press `Publish`.
4. The prepublish panel should be visible.
5. Verify that the `Always show pre-publish checks` checkbox is visible.

![Screenshot 2024-02-14 at 16 07 23](https://github.com/woocommerce/woocommerce/assets/1314156/a8775f9c-6f30-473e-9ac7-1acce5be164d)

6. It should be checked by default.
7. Uncheck the checkbox and close the panel.
8. Press Publish again. Now, the panel shouldn't be visible anymore.
9. If you want to re-enable the panel, you should remove the option `woocommerce_show_prepublish_checks_enabled` from the database. You can do it at Tools > WCA Test Helper > Options.
10. Also verify the checkbox looks good on different screen sizes.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
