### PR TITLE
Clean up block templates after running e2e tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
@@ -17,7 +17,7 @@ type TemplateCustomizationTest = {
 	} ) => Promise< void | Response | null >;
 	templateName: string;
 	templatePath: string;
-	templateType: string;
+	templateType: 'wp_template' | 'wp_template_part';
 	fallbackTemplate?: {
 		templateName: string;
 		templatePath: string;

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -4,6 +4,10 @@
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
 
 test.describe( 'Single Product template', async () => {
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+	} );
+
 	test( 'shows password form in products protected with password', async ( {
 		page,
 	} ) => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -15,6 +15,10 @@ const userText = 'Hello World in the Belt template';
 const themeTemplateText = 'Single Product Belt template loaded from theme';
 
 test.describe( 'Single Product Template', async () => {
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+	} );
+
 	test( 'loads the theme template for a specific product using the product slug and it can be customized', async ( {
 		admin,
 		editorUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-import { deleteAllTemplates } from '@wordpress/e2e-test-utils';
 import {
 	BLOCK_THEME_SLUG,
 	BLOCK_THEME_WITH_TEMPLATES_SLUG,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -22,8 +22,8 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 	const woocommerceTemplateUserText = `Hello World in the WooCommerce ${ testData.templateName } template`;
 
 	test.describe( `${ testData.templateName } template`, async () => {
-		test.afterAll( async () => {
-			await deleteAllTemplates( 'wp_template' );
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllTemplates( testData.templateType );
 		} );
 
 		test( `user-modified ${ testData.templateName } template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -15,6 +15,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 		testData.templateType === 'wp_template' ? 'template' : 'template part';
 
 	test.describe( `${ testData.templateName } template`, async () => {
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllTemplates( testData.templateType );
+		} );
+
 		test( 'can be modified and reverted', async ( {
 			admin,
 			frontendUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -19,6 +19,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 		testData.templateType === 'wp_template' ? 'template' : 'template part';
 
 	test.describe( `${ testData.templateName } template`, async () => {
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllTemplates( testData.templateType );
+		} );
+
 		test( "theme template has priority over WooCommerce's and can be modified", async ( {
 			admin,
 			editorUtils,

--- a/plugins/woocommerce/changelog/44600-fix-44445-clean-up-block-templates
+++ b/plugins/woocommerce/changelog/44600-fix-44445-clean-up-block-templates
@@ -1,0 +1,3 @@
+Significance: patch
+Type: update
+Comment: Clean up block templates after running e2e tests.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/44445.

As discussed in https://github.com/woocommerce/woocommerce/pull/44363#discussion_r1480440659, if one test failed in our e2e tests related to block customization, it might leave customized templates lingering around, polluting new tests. This PR cleans up block templates in an `afterAll()`.

### How to test the changes in this Pull Request:

Note: no need to test this for the release.

1. Verify e2e tests pass.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
