### PR TITLE
[Experiment] Fix additional address field validation notices

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
@@ -104,6 +104,12 @@
 					}
 				}
 
+				// Force empty rows to have a height.
+				&::after {
+					content: " ";
+					display: inline-block;
+				}
+
 				&:hover,
 				&:focus,
 				&.is-highlighted,

--- a/plugins/woocommerce/changelog/add-register-checkout-field-show-in-options-43524
+++ b/plugins/woocommerce/changelog/add-register-checkout-field-show-in-options-43524
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-This is behind a feature flag.
+Comment: This is behind a feature flag

--- a/plugins/woocommerce/changelog/fix-additional-address-field-validation-notices
+++ b/plugins/woocommerce/changelog/fix-additional-address-field-validation-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+This is behind a feature flag.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -257,7 +257,7 @@ class CheckoutFields {
 	 * @return mixed
 	 */
 	public function default_sanitize_callback( $value, $field ) {
-		return wc_clean( $value );
+		return $value;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -464,7 +464,7 @@ class CheckoutFields {
 		$field_data['options'] = $cleaned_options;
 
 		// If the field is not required, inject an empty option at the start.
-		if ( isset( $options['required'] ) && false === $options['required'] && ! in_array( '', $added_values, true ) ) {
+		if ( isset( $field_data['required'] ) && false === $field_data['required'] && ! in_array( '', $added_values, true ) ) {
 			$field_data['options'] = array_merge(
 				array(
 					array(

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -433,13 +433,6 @@ class CheckoutFields {
 			return false;
 		}
 
-		// Select fields are always required. Log a warning if it's set explicitly as false.
-		$field_data['required'] = true;
-		if ( isset( $options['required'] ) && false === $options['required'] ) {
-			$message = sprintf( 'Registering select fields as optional is not supported. "%s" will be registered as required.', $id );
-			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
-		}
-
 		$cleaned_options = array();
 		$added_values    = array();
 
@@ -469,6 +462,20 @@ class CheckoutFields {
 		}
 
 		$field_data['options'] = $cleaned_options;
+
+		// If the field is not required, inject an empty option at the start.
+		if ( isset( $options['required'] ) && false === $options['required'] && ! in_array( '', $added_values, true ) ) {
+			$field_data['options'] = array_merge(
+				array(
+					array(
+						'value' => '',
+						'label' => '',
+					),
+				),
+				$field_data['options']
+			);
+		}
+
 		return $field_data;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes 2 issues with additional fields blocking checkout with notices:

1. When using a checkbox address field, update events would show a notice because the value was posted as a string
2. When using select boxes, on first checkout the user would be forced to make a selection even if not applicable. Fields can now be optional.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Test snippet:

<details>

```php
add_action(
	'woocommerce_blocks_loaded',
	function() {
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/address-field',
				'label'    => __( 'Test checkbox', 'woocommerce' ),
				'location' => 'address',
				'type'     => 'checkbox',
			),
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-on-porch2',
				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'checkbox',
			),
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/location-on-porch2',
				'label'    => __( 'Describe where we should hide the parcel', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'text',
			)
		);
		woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/leave-with-neighbor2',
				'label'    => __( 'Which neighbor should we leave it with if unable to hide?', 'woocommerce' ),
				'location' => 'additional',
				'type'     => 'select',
				'required' => false,
				'options'  => array(
					array(
						'label' => 'Neighbor to the left',
						'value' => 'left',
					),
					array(
						'label' => 'Neighbor to the right',
						'value' => 'right',
					),
					array(
						'label' => 'Neighbor across the road',
						'value' => 'across',
					),
					array(
						'label' => 'Do not leave with a neighbor',
						'value' => 'none',
					),
				),
			)
		);
	}
);
```

</details>

1. Checkout and edit address. Do not check the custom checkbox and do not select an option for "Which neighbor should we leave it with if unable to hide?". Checkout should proceed without error.
3. Checkout again and edit the zip code. After update, there should be no validation errors surfaced.
4. Choose a value for "Which neighbor should we leave it with if unable to hide?" and ensure it persists after checkout.

This requires doc updates @opr 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
