### PR TITLE
Change Visibility section label when a password is set

### DIFF
--- a/packages/js/product-editor/changelog/dev-44623_change_visibility_section_label_if_password
+++ b/packages/js/product-editor/changelog/dev-44623_change_visibility_section_label_if_password
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+[Product editor block]: Change visibility label if a password is set #44623

--- a/packages/js/product-editor/changelog/dev-44623_change_visibility_section_label_if_password
+++ b/packages/js/product-editor/changelog/dev-44623_change_visibility_section_label_if_password
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-[Product editor block]: Change visibility label if a password is set #44623
+[Product editor block]: Change visibility label when a password is set #44623

--- a/packages/js/product-editor/src/components/prepublish-panel/visibility-section/visibility-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/visibility-section/visibility-section.tsx
@@ -31,17 +31,25 @@ export function VisibilitySection( { productType }: VisibilitySectionProps ) {
 		'post_password'
 	);
 
+	function getVisibilityLabel() {
+		if ( postPassword !== '' ) {
+			return __( 'Password protected', 'woocommerce' );
+		}
+		if ( catalogVisibility === 'visible' ) {
+			return __( 'Public', 'woocommerce' );
+		}
+		return __( 'Hidden', 'woocommerce' );
+	}
+
 	return (
 		<PanelBody
 			initialOpen={ false }
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore We need to send an Element.
 			title={ [
-				__( 'Visibility:', 'woocommerce' ),
+				__( 'Visibility: ', 'woocommerce' ),
 				<span className="editor-post-publish-panel__link" key="label">
-					{ catalogVisibility === 'visible'
-						? __( 'Public', 'woocommerce' )
-						: __( 'Hidden', 'woocommerce' ) }
+					{ getVisibilityLabel() }
 				</span>,
 			] }
 		>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to modify the Visibility section when a password is set.

Before

![Screenshot 2024-02-14 at 17 30 57](https://github.com/woocommerce/woocommerce/assets/1314156/74711673-df70-4f66-bb7c-52d1bf97e1b6)


After

![Screenshot 2024-02-14 at 17 47 27](https://github.com/woocommerce/woocommerce/assets/1314156/86d1565c-a396-4812-8648-d9916201b7a5)

Closes #44623.

// cc @j111q 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New.
3. Add a product name and press `Publish`.
4. The prepublish panel should be visible.
5. Expand the Visibility section and press `Require a password`.
6. Add a password.
7. Verify that the Visibility label changes from `Public` to `Password protected`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
