### PR TITLE
[Experimental] Refresh product collections that don't support the interactivity API 

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/frontend.ts
@@ -6,7 +6,10 @@ import { getSetting } from '@woocommerce/settings';
 
 const isBlockTheme = getSetting< boolean >( 'isBlockTheme' );
 const isProductArchive = getSetting< boolean >( 'isProductArchive' );
-const needsRefresh = getSetting< boolean >( 'needsRefresh' );
+const needsRefresh = getSetting< boolean >(
+	'needsRefreshForInteractivityAPI',
+	false
+);
 
 export function navigate( href: string, options = {} ) {
 	if ( needsRefresh || ( ! isBlockTheme && isProductArchive ) ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/frontend.ts
@@ -6,9 +6,10 @@ import { getSetting } from '@woocommerce/settings';
 
 const isBlockTheme = getSetting< boolean >( 'isBlockTheme' );
 const isProductArchive = getSetting< boolean >( 'isProductArchive' );
+const needsRefresh = getSetting< boolean >( 'needsRefresh' );
 
 export function navigate( href: string, options = {} ) {
-	if ( ! isBlockTheme && isProductArchive ) {
+	if ( needsRefresh || ( ! isBlockTheme && isProductArchive ) ) {
 		return ( window.location.href = href );
 	}
 	return navigateFn( href, options );

--- a/plugins/woocommerce/changelog/44631-dev-refresh-legacy-collection-blocks
+++ b/plugins/woocommerce/changelog/44631-dev-refresh-legacy-collection-blocks
@@ -1,4 +1,4 @@
-Significance: minor
-Type: add
+Significance: patch
+Type: update
 
-Add a flag that will force page refresh when combining interactivity filters with classic template or products (beta) blocks.
+[Experimental] Add a flag that will force page refresh when combining interactivity filters with classic template or products (beta) blocks.

--- a/plugins/woocommerce/changelog/44631-dev-refresh-legacy-collection-blocks
+++ b/plugins/woocommerce/changelog/44631-dev-refresh-legacy-collection-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a flag that will force page refresh when combining interactivity filters with classic template or products (beta) blocks.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -47,9 +47,9 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 
-		// Indicate to interactivity powered components that this block is on the page
+		// Indicate to interactivity powered components that this block is on the page,
 		// and needs refresh to update data.
-		$this->asset_data_registry->add( 'needsRefresh', true );
+		$this->asset_data_registry->add( 'needsRefreshForInteractivityAPI', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -38,6 +38,21 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	}
 
 	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+
+		// Indicate to interactivity powered components that this block is on the page
+		// and needs refresh to update data.
+		$this->asset_data_registry->add( 'needsRefresh', true );
+	}
+
+	/**
 	 * Enqueue assets used for rendering the block in editor context.
 	 *
 	 * This is needed if a block is not yet within the post content--`render` and `enqueue_assets` may not have ran.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -180,6 +180,12 @@ class ProductQuery extends AbstractBlock {
 		$this->parsed_block = $parsed_block;
 
 		if ( self::is_woocommerce_variation( $parsed_block ) ) {
+			// Indicate to interactivity powered components that this block is on the page
+			// and needs refresh to update data.
+			$this->asset_data_registry->add(
+				'needsRefreshForInteractivityAPI',
+				true
+			);
 			// Set this so that our product filters can detect if it's a PHP template.
 			$this->asset_data_registry->add( 'hasFilterableProducts', true, true );
 			$this->asset_data_registry->add( 'isRenderingPhpTemplate', true, true );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -130,10 +130,6 @@ class ProductQuery extends AbstractBlock {
 			$post_template_has_support_for_grid_view
 		);
 
-		// Indicate to interactivity powered components that this block is on the page
-		// and needs refresh to update data.
-		$this->asset_data_registry->add( 'needsRefresh', true );
-
 		// The `loop_shop_per_page` filter can be found in WC_Query::product_query().
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->asset_data_registry->add( 'loopShopPerPage', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ), true );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -130,6 +130,10 @@ class ProductQuery extends AbstractBlock {
 			$post_template_has_support_for_grid_view
 		);
 
+		// Indicate to interactivity powered components that this block is on the page
+		// and needs refresh to update data.
+		$this->asset_data_registry->add( 'needsRefresh', true );
+
 		// The `loop_shop_per_page` filter can be found in WC_Query::product_query().
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->asset_data_registry->add( 'loopShopPerPage', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ), true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The new interactivity API filter blocks don't refresh the page when updating a filter (in most cases) because the new product collection can handle that.

But we need to still support classic template and the soon to be deprecated "Products (Beta)" block. In this PR we add a flag to client side data for those cases, we use that flag to determine if a full page refresh is needed. Bottom line: if at least one of these is present on a page we will do full page refresh when updating the filters. This will be easy to change later as we do all the navigation for interactivity filters from a single function. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In site editor -> templates, edit the template block, add the new interactivity filters and the classic template block. To avoid confusion also remove "product collection" from shop page if it happens to be there already.
2. Load the shop page and change some of the filters, for each a refresh of the page should happen and the respective product collection should be properly filtered.
3. Create a page or template with the interactivity filters nested inside "Products (Beta)". There will be warning not to do this for each block, but thats ok.
4. Preview your new template or page and same as 2, change some filters and see a page refresh and see the filters applied.
5. You can also test the current case in a template or page add "Product Collection (Beta)" with new interactivity filters nested (and ensure no classic or product beta block is on the page). Preview the new content and apply the filters. the page should *not* refresh but filters should still be applied.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[Experimental] Add a flag that will force page refresh when combining interactivity filters with classic template or products (beta) blocks.


#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
