### PR TITLE
Remove bottom spacing below last payment method in Checkout block.

### DIFF
--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -31,10 +31,6 @@
 .wc-block-components-checkout-step__content > * {
 	margin-bottom: $gap;
 }
-.wc-block-components-checkout-step--with-step-number .wc-block-components-checkout-step__content > :last-child {
-	margin-bottom: 0;
-	padding-bottom: $gap;
-}
 
 .wc-block-components-checkout-step__heading {
 	margin: em($gap-small) 0 em($gap);

--- a/plugins/woocommerce/changelog/fix-44632-payment-method-bottom-spacing
+++ b/plugins/woocommerce/changelog/fix-44632-payment-method-bottom-spacing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove bottom spacing below last payment method in Checkout block.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44632.

Until now, the bottom spacing was controlled by the following CSS definition:

```css
.wc-block-components-checkout-step--with-step-number .wc-block-components-checkout-step__content > :last-child {
	margin-bottom: 0;
	padding-bottom: $gap;
}
```

This definition is not needed, due to the following existing CSS definition:

```css
.wc-block-components-checkout-step__content > * {
	margin-bottom: $gap;
}
```

This PR removes the spaces below the last payment method in the Checkout block, regardless of whether there is only one payment method or multiple payment methods.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout` and activate multiple payment methods.
2. Go to the frontend and add a product to the cart.
3. Go to the checkout (using the Checkout block).
4. Verify that all payment methods have the same bottom spacing.
5. Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout` and ensure that only one payment method is active.
6. Go back to the checkout.
7. Verify that the same bottom spacing is visible as in step 4.
8. Verify that the bottom spaces of all other sections are not affected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
