### PR TITLE
Blocks E2E: Stabilize flaky cart test

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -33,17 +33,11 @@ test.describe( `${ blockData.name } Block`, () => {
 	test( 'can be added in the Post Editor only as inner block of the Single Product Block', async ( {
 		admin,
 		editor,
-		page,
 		editorUtils,
 	} ) => {
 		// Add to Cart with Options in the Post Editor is only available as inner block of the Single Product Block.
 		await admin.createNewPost( { legacyCanvas: true } );
 		await editor.insertBlock( { name: 'woocommerce/single-product' } );
-		await page.waitForResponse(
-			( response ) =>
-				response.url().includes( 'wc/store/v1/products' ) &&
-				response.status() === 200
-		);
 
 		await configureSingleProductBlock( editorUtils );
 

--- a/plugins/woocommerce/changelog/44639-tweak-stabilize-block-theme-e2e
+++ b/plugins/woocommerce/changelog/44639-tweak-stabilize-block-theme-e2e
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Stabilize a flaky E2E cart test
+Stabilize a flaky E2E Add to Cart Form test

--- a/plugins/woocommerce/changelog/44639-tweak-stabilize-block-theme-e2e
+++ b/plugins/woocommerce/changelog/44639-tweak-stabilize-block-theme-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stabilize a flaky E2E cart test


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Stabilizes a flaky test by removing an obsolete call to `waitForRequest`.

Failure example:

<img width="1477" alt="Screenshot 2024-02-15 at 11 52 13" src="https://github.com/woocommerce/woocommerce/assets/1451471/20102c6f-683d-45bc-bfb9-a2d5dfbe9fc9">

### How to test the changes in this Pull Request:

The test should pass in CI. To test locally:

1. `cd plugins/woocommerce-blocks`
2. `pnpm env:start`
3. `pnpm test:e2e -g "can be added in the Post Editor only as inner block of the Single Product Block"`

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Stabilize a flaky E2E cart test

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
