### PR TITLE
Clean up logic related to block templates in class-wc-template-loader.php

### DIFF
--- a/plugins/woocommerce-blocks/docs/internal-developers/templates/block-template-controller.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/templates/block-template-controller.md
@@ -70,8 +70,6 @@ This method will return `WP_Block_Template` or `null`.
 
 This method is applied to the filter `template_redirect` and executed before WordPress determines which template to load.
 
-This allows us to hook into WooCommerce core through the filter `woocommerce_has_block_template` where we can determine if a specific block template exists and should be loaded.
-
 **Typically executed when:**
 
 -   A user loads a page on the front-end.
@@ -79,7 +77,6 @@ This allows us to hook into WooCommerce core through the filter `woocommerce_has
 **This method is responsible for:**
 
 -   Determining if the current page has an appropriate WooCommerce block template available to render.
--   Checking if the currently loaded page is from WooCommerce. It then checks if the theme has an appropriate template to use: if it does not, then it finally checks if WooCommerce has a default block template available. If so, we override the value through `woocommerce_has_block_template` to resolve `true`.
 
 ### Return value
 

--- a/plugins/woocommerce-blocks/docs/internal-developers/templates/block-template-controller.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/templates/block-template-controller.md
@@ -2,13 +2,13 @@
 
 ## Table of Contents <!-- omit in toc -->
 
--   [Overview](#overview)
--   [add_block_templates( $query_result, $query, \$template_type )](#add_block_templates-query_result-query-template_type-)
-    -   [Return value](#return-value)
--   [get_block_file_template( $template, $id, \$template_type )](#get_block_file_template-template-id-template_type-)
-    -   [Return value](#return-value-1)
--   [render_block_template()](#render_block_template)
-    -   [Return value](#return-value-2)
+- [Overview](#overview)
+- [add_block_templates](#add_block_templates)
+    - [add_block_templates return value](#add_block_templates-return-value)
+- [get_block_file_template](#get_block_file_template)
+    - [get_block_file_template return value](#get_block_file_template-return-value)
+- [render_block_template](#render_block_template)
+    - [render_block_template return value](#render_block_template-return-value)
 
 The `BlockTemplateController` class contains all the business logic which loads the templates into the Site Editor or on the front-end through various hooks available in WordPress & WooCommerce core. Without documenting every method individually, I will look to provide some insight into key functionality.
 
@@ -22,7 +22,9 @@ Within each method section, I will explain in what scenarios they are executed.
 -   filter: `pre_get_block_file_template` with `get_block_file_template`.
 -   action: `template_redirect` with `render_block_template`.
 
-## add_block_templates( $query_result, $query, \$template_type )
+## add_block_templates
+
+Usage: `add_block_templates( $query_result, $query, $template_type )`.
 
 This method is applied to the filter `get_block_templates`, which is executed before returning a unified list of template objects based on a query.
 
@@ -39,11 +41,13 @@ This method is applied to the filter `get_block_templates`, which is executed be
 -   In the event the theme has a `archive-product.html` template file, but not category/tag/attribute template files, it is eligible to use the `archive-product.html` file in their place. So we trick Gutenberg in thinking some templates (e.g. category/tag/attribute) have a theme file available if it is using the `archive-product.html` template, even though _technically_ the theme does not have a specific file for them.
 -   Ensuring we do not add irrelevant WooCommerce templates in the returned list. For example, if `$query['post_type']` has a value (e.g. `product`) this means the query is requesting templates related to that specific post type, so we filter out any irrelevant ones. This _could_ be used to show/hide templates from the template dropdown on the "Edit Product" screen in WP Admin.
 
-### Return value
+### add_block_templates return value
 
 This method will return an array of `WP_Block_Template` values
 
-## get_block_file_template( $template, $id, \$template_type )
+## get_block_file_template
+
+Usage: `get_block_file_template( $template, $id, $template_type )`
 
 This method is applied to the filter `pre_get_block_file_template` inside the WordPress core function `get_block_file_template` (not to be confused with this method from the `BlockTemplateController` class, which has the same name).
 
@@ -62,11 +66,13 @@ During step 2 it's important we hook into the `pre_get_block_file_template`. If 
 
 -   Loading the template files from the filesystem, and building a `WP_Block_Template` version of it.
 
-### Return value
+### get_block_file_template return value
 
 This method will return `WP_Block_Template` or `null`.
 
-## render_block_template()
+## render_block_template
+
+Usage: `render_block_template()`
 
 This method is applied to the filter `template_redirect` and executed before WordPress determines which template to load.
 
@@ -78,6 +84,6 @@ This method is applied to the filter `template_redirect` and executed before Wor
 
 -   Determining if the current page has an appropriate WooCommerce block template available to render.
 
-### Return value
+### render_block_template return value
 
 Void. This method does not return a value but rather sets up hooks to render block templates on the front-end.

--- a/plugins/woocommerce/changelog/44646-fix-44540-simplify-template-loader-logic
+++ b/plugins/woocommerce/changelog/44646-fix-44540-simplify-template-loader-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Cleanup logic related to block templates in class-wc-template-loader.php
+

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -101,10 +101,7 @@ class WC_Template_Loader {
 	}
 
 	/**
-	 * Checks whether a block template for a given taxonomy exists.
-	 *
-	 * **Note:** This checks both the `templates` and `block-templates` directories
-	 * as both conventions should be supported.
+	 * Checks whether a WooCommerce block template for a given taxonomy exists.
 	 *
 	 * @param object $taxonomy Object taxonomy to check.
 	 * @return boolean
@@ -120,10 +117,7 @@ class WC_Template_Loader {
 	}
 
 	/**
-	 * Checks whether a block template with that name exists.
-	 *
-	 * **Note: ** This checks both the `templates` and `block-templates` directories
-	 * as both conventions should be supported.
+	 * Checks whether the template matches a WooCommerce block template.
 	 *
 	 * @since  5.5.0
 	 * @param string $template_name Template to check.
@@ -134,30 +128,16 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		$has_template            = false;
-		$template_filename       = $template_name . '.html';
-		// Since Gutenberg 12.1.0, the conventions for block templates directories have changed,
-		// we should check both these possible directories for backwards-compatibility.
-		$possible_templates_dirs = array( 'templates', 'block-templates' );
-
-		// Combine the possible root directory names with either the template directory
-		// or the stylesheet directory for child themes, getting all possible block templates
-		// locations combinations.
-		$filepath        = DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $template_filename;
-		$legacy_filepath = DIRECTORY_SEPARATOR . 'block-templates' . DIRECTORY_SEPARATOR . $template_filename;
-		$possible_paths  = array(
-			get_stylesheet_directory() . $filepath,
-			get_stylesheet_directory() . $legacy_filepath,
-			get_template_directory() . $filepath,
-			get_template_directory() . $legacy_filepath,
+		$woocommerce_templates = array(
+			'archive-product',
+			'product-search-results',
+			'single-product',
+			'taxonomy-product_attribute',
+			'taxonomy-product_cat',
+			'taxonomy-product_tag',
 		);
-
-		// Check the first matching one.
-		foreach ( $possible_paths as $path ) {
-			if ( is_readable( $path ) ) {
-				$has_template = true;
-				break;
-			}
+		if ( wc_current_theme_is_fse_theme() && in_array( $template_name, $woocommerce_templates ) ) {
+			return (bool) apply_filters( 'woocommerce_has_block_template', true, $template_name );
 		}
 
 		/**
@@ -168,7 +148,7 @@ class WC_Template_Loader {
 		 * @param boolean $has_template value to be filtered.
 		 * @param string $template_name The name of the template.
 		 */
-		return (bool) apply_filters( 'woocommerce_has_block_template', $has_template, $template_name );
+		return (bool) apply_filters( 'woocommerce_has_block_template', false, $template_name );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -56,7 +56,7 @@ class WC_Template_Loader {
 	}
 
 	/**
-	 * Load a template.
+	 * Load a template in classic themes.
 	 *
 	 * Handles template usage so that we can use our own templates instead of the theme's.
 	 *
@@ -71,7 +71,7 @@ class WC_Template_Loader {
 	 * @return string
 	 */
 	public static function template_loader( $template ) {
-		if ( is_embed() ) {
+		if ( is_embed() || wc_current_theme_is_fse_theme() ) {
 			return $template;
 		}
 
@@ -111,9 +111,6 @@ class WC_Template_Loader {
 	 * @return string
 	 */
 	private static function get_template_loader_default_file() {
-		if ( wc_current_theme_is_fse_theme() ) {
-			return '';
-		}
 		if (
 			is_singular( 'product' )
 		) {

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -653,10 +653,6 @@ class BlockTemplatesController {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			if ( ! BlockTemplateUtils::theme_has_template( 'single-product' ) ) {
-				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-			}
 		} elseif (
 			( is_product_taxonomy() && is_tax( 'product_cat' ) ) && $this->block_template_is_available( 'taxonomy-product_cat' )
 		) {
@@ -664,10 +660,6 @@ class BlockTemplatesController {
 
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
-
-			if ( ! BlockTemplateUtils::theme_has_template( 'taxonomy-product_cat' ) ) {
-				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 			}
 		} elseif (
 			( is_product_taxonomy() && is_tax( 'product_tag' ) ) && $this->block_template_is_available( 'taxonomy-product_tag' )
@@ -677,19 +669,11 @@ class BlockTemplatesController {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			if ( ! BlockTemplateUtils::theme_has_template( 'taxonomy-product_tag' ) ) {
-				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-			}
 		} elseif ( is_post_type_archive( 'product' ) && is_search() ) {
 			$templates = get_block_templates( array( 'slug__in' => array( ProductSearchResultsTemplate::SLUG ) ) );
 
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-			}
-
-			if ( ! BlockTemplateUtils::theme_has_template( ProductSearchResultsTemplate::SLUG ) ) {
-				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 			}
 		} elseif (
 			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) && $this->block_template_is_available( 'archive-product' )
@@ -699,20 +683,6 @@ class BlockTemplatesController {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			if ( ! BlockTemplateUtils::theme_has_template( 'archive-product' ) ) {
-				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-			}
-		} elseif (
-			is_cart() &&
-			! BlockTemplateUtils::theme_has_template( CartTemplate::get_slug() ) && $this->block_template_is_available( CartTemplate::get_slug() )
-		) {
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-		} elseif (
-			is_checkout() &&
-			! BlockTemplateUtils::theme_has_template( CheckoutTemplate::get_slug() ) && $this->block_template_is_available( CheckoutTemplate::get_slug() )
-		) {
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		} else {
 			$queried_object = get_queried_object();
 			if ( is_null( $queried_object ) ) {
@@ -725,10 +695,6 @@ class BlockTemplatesController {
 
 				if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 					add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
-				}
-
-				if ( ! BlockTemplateUtils::theme_has_template( ProductAttributeTemplate::SLUG ) ) {
-					add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 				}
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -19,6 +19,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		global $wp_taxonomies;
 
 		$this->initialize_template_loader();
+		switch_theme( 'storefront' );
 
 		// Check Single Product
 		$this->load_product_in_query();
@@ -51,6 +52,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		global $wp_taxonomies;
 
 		$this->initialize_template_loader();
+		switch_theme( 'twentytwentythree' );
 
 		// Check Single Product
 		$this->load_product_in_query();
@@ -81,15 +83,14 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	private function initialize_template_loader() {
 		// be sure shop is always returning same id doesn't matter the test setup environment
-		add_filter( 'woocommerce_get_shop_page_id', function ( $page ) {
-			return 5;
-		}, 10, 1 );
-
-		if ( ! function_exists( 'wp_is_block_theme' ) ) {
-			function wp_is_block_theme() {
-				return true;
-			}
-		}
+		add_filter(
+			'woocommerce_get_shop_page_id',
+			function ( $page ) {
+				return 5;
+			},
+			10,
+			1
+		);
 
 		WC_Template_Loader::init();
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -20,9 +20,6 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 		$this->initialize_template_loader();
 
-		// forcing has_block_template to be false
-		add_filter( 'woocommerce_has_block_template', '__return_false', 10, 2 );
-
 		// Check Single Product
 		$this->load_product_in_query();
 		$this->assertDefaultTemplateFileName( 'single-product' );
@@ -54,9 +51,6 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		global $wp_taxonomies;
 
 		$this->initialize_template_loader();
-
-		// forcing has_block_template to be false
-		add_filter( 'woocommerce_has_block_template', '__return_true', 10, 2 );
 
 		// Check Single Product
 		$this->load_product_in_query();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Supersedes https://github.com/woocommerce/woocommerce/pull/44455.

Closes https://github.com/woocommerce/woocommerce/issues/44453.
Closes https://github.com/woocommerce/woocommerce/issues/44540.

I think the logic we had to determine whether to load a block template or a PHP template was unnecessarily complex. We can simply check if `wc_current_theme_is_fse_theme()`, if `true`, then we don't run any of the PHP templating logic.

This also allows us to remove the `woocommerce_has_block_template` filter.

Why was it this way? I'm not 100% sure, but I think it's mostly for historical reasons. Before WooCommerce included block templates bundled in the plugin, we were supporting block templates from themes. Ie, a theme could have a `single-product.html` and we would render that template, even considering that WooCommerce didn't have a default `single-product.html` template.

But since WooCommerce comes with a default HTML file for all templates, we no longer need to check if the theme has the file in order to determine whether it's available or not, we know it will also be available.

Simplifying the logic magically fixes https://github.com/woocommerce/woocommerce/issues/44453,

Sidenote: If you are curious, you can compare the dates of the PRs where we started to support block themes: https://github.com/woocommerce/woocommerce/pull/30013 and where we added the default block templates: https://github.com/woocommerce/woocommerce-blocks/pull/5054.

### How to test the changes in this Pull Request:

**Make sure there are no regressions related to block and classic templates**

1. With a classic theme (ie: Storefront), visit several pages in the frontend and verify the correct template is rendered. Ie: Shop, Single Product, Cart, Checkout, etc.
2. Repeat the same with a block theme (ie: Twenty Twenty Four).
3. And repeat the same with a block theme with custom WooCommerce templates (ie: Tsubaki).

**Verify #44453 is fixed**

1. Go to WooCommerce > Settings > Products > Advanced and disable _Use the product attributes lookup table for catalog filtering_.
2. With a block theme with custom WooCommerce templates (ie: Tsubaki) go to `/shop/?product_cat=Clothing&filter_size=large`. Note: the values of `product_cat` and `filter_xyz` might vary depending on the categories and attributes of your store. In case of doubt, you can import the [products from `sample-data`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/sample-data).
3. Verify the page is rendered correctly.

Before | After
--- | ---
![image](https://github.com/woocommerce/woocommerce/assets/3616980/12413fda-2c24-49d7-8b21-3cbb4537776f) | ![image](https://github.com/woocommerce/woocommerce/assets/3616980/2ab71af9-754c-46db-be31-9e25598f0167)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Cleanup logic related to block templates in class-wc-template-loader.php

</details>
