### PR TITLE
Modify pre-publish texts after scheduling product

### DIFF
--- a/packages/js/product-editor/changelog/dev-44651_modify_prepublish_texts_after_scheduling_product
+++ b/packages/js/product-editor/changelog/dev-44651_modify_prepublish_texts_after_scheduling_product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+[Product editor block]: Modify pre-publish sidebar title after scheduling a product #44651

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -6,6 +6,7 @@ import { createElement } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -20,12 +21,18 @@ import { ScheduleSection } from './schedule-section';
 export function PrepublishPanel( {
 	productId,
 	productType = 'product',
-	title = __( 'Are you ready to add this product?', 'woocommerce' ),
+	title = __( 'Are you ready to publish this product?', 'woocommerce' ),
 	description = __(
 		'Double-check your settings before sharing this product with customers.',
 		'woocommerce'
 	),
 }: PrepublishPanelProps ) {
+	const [ editedDate, , date ] = useEntityProp< string >(
+		'postType',
+		productType,
+		'date_created'
+	);
+
 	const lastPersistedProduct = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( 'core' );
@@ -35,6 +42,14 @@ export function PrepublishPanel( {
 	);
 
 	const { closePrepublishPanel } = useDispatch( productEditorUiStore );
+
+	if ( editedDate !== date ) {
+		title = __( 'Are you ready to schedule this product?', 'woocommerce' );
+		description = __(
+			'Your product will be published at the specified date and time.',
+			'woocommerce'
+		);
+	}
 
 	return (
 		<div className="woocommerce-product-publish-panel">

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
@@ -122,7 +122,7 @@ export function ScheduleSection( { postType }: ScheduleSectionProps ) {
 			initialOpen={ false }
 			// @ts-expect-error title does currently support this value
 			title={ [
-				__( 'Add:', 'woocommerce' ),
+				__( 'Publish:', 'woocommerce' ),
 				<span className="editor-post-publish-panel__link" key="label">
 					{ getScheduleLabel(
 						editedDate === date ? undefined : editedDate


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR modifies the title and description shown in the pre-publish panel after scheduling a product.

**Before**

Title: `Are you ready to publish this product?`
Description: `Double-check your settings before sharing this product with customers.`

**After**

Title: `Are you ready to schedule this product?`
Description: `Your product will be published at the specified date and time.`

Closes #44651.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New.
3. Add a product name and press `Publish`.
4. The pre-publish panel should be shown.
5. Verify you see `Publish: Immediately` (this PR also updates this text, it used to say `Add`).
6. Expand the Schedule section and set a publish date in the future.
7. The pre-publish panel title and description should be updated.

![Screen Recording on 2024-02-15 at 01-54-18](https://github.com/woocommerce/woocommerce/assets/1314156/265049d7-fe9e-4115-81f6-eeacc5056592)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
