### PR TITLE
Fetch promotions from Woo.com and show bubble on Extensions menu item, if required

### DIFF
--- a/plugins/woocommerce/changelog/44655-add-marketplace-promotions
+++ b/plugins/woocommerce/changelog/44655-add-marketplace-promotions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Adds logic to get notices of promotions from Woo.com endpoint, and (if necessary) show a bubble next to the WooCommerce "Extensions" menu item.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -79,31 +79,19 @@ class WC_Admin_Addons {
 	 * @return array|WP_Error
 	 */
 	public static function fetch_featured() {
+		$transient_name = 'wc_addons_featured';
+		// Important: WCCOM Extensions API v2.0 is used.
+		$url      = 'https://woocommerce.com/wp-json/wccom-extensions/2.0/featured';
 		$locale   = get_user_locale();
-		$featured = self::get_locale_data_from_transient( 'wc_addons_featured', $locale );
+		$featured = self::get_locale_data_from_transient( $transient_name, $locale );
 
 		if ( false === $featured ) {
-			$headers = array();
-			$auth    = WC_Helper_Options::get( 'auth' );
-
-			if ( ! empty( $auth['access_token'] ) ) {
-				$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
-			}
-
-			$parameter_string = '?' . http_build_query( array( 'locale' => get_user_locale() ) );
-			$country          = WC()->countries->get_base_country();
-			if ( ! empty( $country ) ) {
-				$parameter_string = $parameter_string . '&' . http_build_query( array( 'country' => $country ) );
-			}
-
-			// Important: WCCOM Extensions API v2.0 is used.
-			$raw_featured = wp_safe_remote_get(
-				'https://woocommerce.com/wp-json/wccom-extensions/2.0/featured' . $parameter_string,
-				array(
-					'headers'    => $headers,
-					'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
-				)
+			$fetch_options = array(
+				'auth'    => true,
+				'locale'  => true,
+				'country' => true,
 			);
+			$raw_featured  = self::fetch( $url, $fetch_options );
 
 			if ( is_wp_error( $raw_featured ) ) {
 				do_action( 'woocommerce_page_wc-addons_connection_error', $raw_featured->get_error_message() );
@@ -143,7 +131,7 @@ class WC_Admin_Addons {
 			}
 
 			if ( $featured ) {
-				self::set_locale_data_in_transient( 'wc_addons_featured', $featured, $locale, DAY_IN_SECONDS );
+				self::set_locale_data_in_transient( $transient_name, $featured, $locale, DAY_IN_SECONDS );
 			}
 		}
 
@@ -1555,5 +1543,50 @@ class WC_Admin_Addons {
 		$transient_value            = is_array( $transient_value ) ? $transient_value : array();
 		$transient_value[ $locale ] = $value;
 		return set_transient( $transient, $transient_value, $expiration );
+	}
+
+	/**
+	 * Make wp_safe_remote_get request to Woo.com endpoint.
+	 * Optionally pass user auth token, locale or country.
+	 *
+	 * @param string $url     URL to request.
+	 * @param ?array $options Options for the request. For example, to pass auth token, locale and country,
+	 *                        pass array( 'auth' => true, 'locale' => true, 'country' => true, ).
+	 *
+	 * @return array|WP_Error
+	 */
+	public static function fetch( $url, $options = array() ) {
+		$headers = array();
+
+		if ( isset( $options['auth'] ) && $options['auth'] ) {
+			$auth = WC_Helper_Options::get( 'auth' );
+
+			if ( ! empty( $auth['access_token'] ) ) {
+				$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
+			}
+		}
+
+		$parameters = array();
+
+		if ( isset( $options['locale'] ) && $options['locale'] ) {
+			$parameters['locale'] = get_user_locale();
+		}
+
+		if ( isset( $options['country'] ) && $options['country'] ) {
+			$country = WC()->countries->get_base_country();
+			if ( ! empty( $country ) ) {
+				$parameters['country'] = $country;
+			}
+		}
+
+		$query_string = ! empty( $parameters ) ? '?' . http_build_query( $parameters ) : '';
+
+		return wp_safe_remote_get(
+			$url . $query_string,
+			array(
+				'headers'    => $headers,
+				'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -1561,7 +1561,7 @@ class WC_Admin_Addons {
 		if ( isset( $options['auth'] ) && $options['auth'] ) {
 			$auth = WC_Helper_Options::get( 'auth' );
 
-			if ( ! empty( $auth['access_token'] ) ) {
+			if ( isset( $auth['access_token'] ) && ! empty( $auth['access_token'] ) ) {
 				$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
 			}
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Addons Page
+ *
+ * @package  WooCommerce\Admin
+ * @version  2.5.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Admin_Marketplace_Promotions class.
+ */
+class WC_Admin_Marketplace_Promotions {
+
+	const TRANSIENT_NAME = 'wc_addons_marketplace_promotions';
+	/**
+	 * The user's locale, for example en_US.
+	 *
+	 * @var string
+	 */
+	public static string $locale;
+
+	/**
+	 * On selected WooCommerce admin pages, fetch promotions from transient or API.
+	 * On all pages, add menu badge to WooCommerce Extensions item if the
+	 * promotions API requests one.
+	 *
+	 * @return void
+	 */
+	public static function init_marketplace_promotions() {
+		if ( self::is_targeted_page_to_fetch_promotions() ) {
+			self::fetch_marketplace_promotions();
+		}
+
+		if ( self::is_targeted_page_to_show_bubble_promotions() ) {
+			self::$locale = ( self::$locale ?? get_user_locale() ) ?? 'en_US';
+			self::show_bubble_promotions();
+		}
+	}
+
+	/**
+	 * Check if the request is for one of the pages we will run fetch_marketplace_promotions
+	 * on: the WooCommerce Home and Extensions pages.
+	 *
+	 * @return bool
+	 */
+	private static function is_targeted_page_to_fetch_promotions(): bool {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			defined( 'DOING_AJAX' ) && DOING_AJAX
+			|| ! is_admin()
+			|| ! isset( $_GET['page'] )
+		) {
+			return false;
+		}
+
+		$targeted_page = 'wc-admin';
+		$targeted_path = '/extensions';
+
+		if ( $_GET['page'] === $targeted_page ) {
+			// WooCommerce home has page param but no path param.
+			return ! isset( $_GET['path'] ) || $_GET['path'] === $targeted_path;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return false;
+	}
+
+	/**
+	 * Check if the request is for one of the pages we will show menu item bubbles
+	 * on: the pages in the main WooCommerce menu, excluding Analytics and Marketing.
+	 *
+	 * We need to cover all the pages in the WooCommerce menu, because the Extensions item
+	 * is visible on any of these pages, and we want to show the bubble there.
+	 *
+	 * @return bool
+	 */
+	private static function is_targeted_page_to_show_bubble_promotions(): bool {
+		if (
+			( defined( 'DOING_AJAX' ) && DOING_AJAX )
+			|| ! is_admin()
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get promotions to show in the Woo in-app marketplace.
+	 * Only run on selected pages in the main WooCommerce menu in wp-admin.
+	 * Loads promotions in transient with one day life.
+	 *
+	 * @return void
+	 */
+	private static function fetch_marketplace_promotions() {
+		$url        = 'https://woo.com/wp-json/wccom-extensions/3.0/promotions';
+		$promotions = get_transient( self::TRANSIENT_NAME );
+
+		if ( false !== $promotions ) {
+			return;
+		}
+
+		$fetch_options  = array(
+			'auth'    => true,
+			'country' => true,
+		);
+		$raw_promotions = WC_Admin_Addons::fetch( $url, $fetch_options );
+
+		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
+		if ( is_wp_error( $raw_promotions ) ) {
+			/**
+			 * Allows connection error to be handled.
+			 *
+			 * @since 8.7
+			 */
+			do_action( 'woocommerce_page_wc-addons_connection_error', $raw_promotions->get_error_message() );
+		}
+
+		$response_code = (int) wp_remote_retrieve_response_code( $raw_promotions );
+		if ( 200 !== $response_code ) {
+			/**
+			 * Allows connection error to be handled.
+			 *
+			 * @since 8.7
+			 */
+			do_action( 'woocommerce_page_wc-addons_connection_error', $response_code );
+		}
+
+		$promotions = json_decode( wp_remote_retrieve_body( $raw_promotions ), true );
+		if ( empty( $promotions ) || ! is_array( $promotions ) ) {
+			/**
+			 * Allows connection error to be handled.
+			 *
+			 * @since 8.7
+			 */
+			do_action( 'woocommerce_page_wc-addons_connection_error', 'Empty or malformed response' );
+		}
+		// phpcs:enable WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+		if ( $promotions ) {
+			// Filter out any expired promotions.
+			$promotions = self::get_active_promotions( $promotions );
+			set_transient( self::TRANSIENT_NAME, $promotions, DAY_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * If there's an active promotion of the format `menu_bubble`,
+	 * add a filter to show a bubble on the Extensions item in the
+	 * WooCommerce menu.
+	 *
+	 * @return void
+	 * @throws Exception  If we are unable to create a DateTime from the date_to_gmt.
+	 */
+	private static function show_bubble_promotions() {
+
+		/**
+		 * Allows the menu bubble to be suppressed.
+		 *
+		 * @since 8.7
+		 */
+		if ( apply_filters( 'woocommerce_marketplace_suppress_menu_badges', false ) ) {
+			return;
+		}
+
+		$promotions = get_transient( self::TRANSIENT_NAME );
+		if ( ! $promotions ) {
+			return;
+		}
+
+		$bubble_promotions = self::get_promotions_of_format( $promotions, 'menu_bubble' );
+		if ( empty( $bubble_promotions ) ) {
+			return;
+		}
+
+		$now_date_time = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+
+		// Let's make absolutely sure the promotion is still active.
+		foreach ( $bubble_promotions as $promotion ) {
+			if ( ! isset( $promotion['date_to_gmt'] ) ) {
+				continue;
+			}
+
+			try {
+				$date_to_gmt = new DateTime( $promotion['date_to_gmt'], new DateTimeZone( 'UTC' ) );
+			} catch ( \Exception $ex ) {
+				continue;
+			}
+
+			if ( $now_date_time < $date_to_gmt ) {
+				add_filter(
+					'woocommerce_marketplace_menu_items',
+					function ( $marketplace_pages ) use ( $promotion ) {
+						return self::filter_marketplace_menu_items( $marketplace_pages, $promotion );
+					}
+				);
+
+				break;
+			}
+		}
+	}
+
+	/**
+	 * From the array of promotions, select those of a given format.
+	 *
+	 * @param ? array  $promotions  Array of data about promotions of all formats.
+	 * @param ? string $format      Format we want to filter for.
+	 *
+	 * @return array
+	 */
+	private static function get_promotions_of_format( $promotions = array(), $format = '' ): array {
+		if ( empty( $promotions ) || empty( $format ) ) {
+			return array();
+		}
+
+		return array_filter(
+			$promotions,
+			function( $promotion ) use ( $format ) {
+				return isset( $promotion['format'] ) && $format === $promotion['format'];
+			}
+		);
+	}
+
+	/**
+	 * Find promotions that are still active – they have a date range that
+	 * includes the current date.
+	 *
+	 * @param ?array $promotions  Data about current promotions.
+	 *
+	 * @return array
+	 */
+	private static function get_active_promotions( $promotions = array() ) {
+		$now_date_time     = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$active_promotions = array();
+
+		foreach ( $promotions as $promotion ) {
+			if ( ! isset( $promotion['date_from_gmt'] ) || ! isset( $promotion['date_to_gmt'] ) ) {
+				continue;
+			}
+
+			try {
+				$date_from_gmt = new DateTime( $promotion['date_from_gmt'], new DateTimeZone( 'UTC' ) );
+				$date_to_gmt   = new DateTime( $promotion['date_to_gmt'], new DateTimeZone( 'UTC' ) );
+			} catch ( \Exception $ex ) {
+				continue;
+			}
+
+			if ( $now_date_time >= $date_from_gmt && $now_date_time <= $date_to_gmt ) {
+				$active_promotions[] = $promotion;
+			}
+		}
+
+		// Sort promotions so the ones starting more recently are at the top.
+		usort(
+			$active_promotions,
+			function ( $a, $b ) {
+				return $b['date_from_gmt'] <=> $a['date_from_gmt'];
+			}
+		);
+
+		return $active_promotions;
+	}
+
+	/**
+	 * Callback for the `woocommerce_marketplace_menu_items` filter
+	 * in `Automattic\WooCommerce\Internal\Admin\Marketplace::get_marketplace_pages`.
+	 * At the moment, the Extensions page is the only page in `$menu_items`.
+	 * Adds a bubble to the menu item.
+	 *
+	 * @param array  $menu_items  Arrays representing items in nav menu.
+	 * @param ?array $promotion   Data about a promotion from the Woo.com API.
+	 *
+	 * @return array
+	 */
+	public static function filter_marketplace_menu_items( $menu_items, $promotion = array() ) {
+		if ( ! isset( $promotion['menu_item_id'] ) || ! isset( $promotion['content'] ) ) {
+			return $menu_items;
+		}
+		foreach ( $menu_items as $index => $menu_item ) {
+			if (
+				'woocommerce' === $menu_item['parent']
+				&& $promotion['menu_item_id'] === $menu_item['id']
+			) {
+				$bubble_text                   = $promotion['content'][ self::$locale ] ?? ( $promotion['content']['en_US'] ?? __( 'Sale', 'woocommerce' ) );
+				$menu_items[ $index ]['title'] = $menu_item['title'] . self::append_bubble( $bubble_text );
+
+				break;
+			}
+		}
+
+		return $menu_items;
+	}
+
+	/**
+	 * Return the markup for a menu item bubble with a given text.
+	 *
+	 * @param string $bubble_text Text of bubble.
+	 *
+	 * @return string
+	 */
+	private static function append_bubble( $bubble_text ) {
+		return ' <span class="awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge">' . esc_html( $bubble_text ) . '</span>';
+	}
+
+}

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -39,6 +39,9 @@ class WC_Admin {
 		if ( isset( $_GET['page'] ) && 'wc-addons' === $_GET['page'] ) {
 			add_filter( 'admin_body_class', array( 'WC_Admin_Addons', 'filter_admin_body_classes' ) );
 		}
+
+		// Fetch list of promotions from Woo.com for WooCommerce admin UI. We need to fire earlier than admin_init so we can filter menu items.
+		add_action( 'woocommerce_init', array( 'WC_Admin_Marketplace_Promotions', 'init_marketplace_promotions' ) );
 	}
 
 	/**
@@ -77,6 +80,9 @@ class WC_Admin {
 		// Marketplace suggestions & related REST API.
 		include_once __DIR__ . '/marketplace-suggestions/class-wc-marketplace-suggestions.php';
 		include_once __DIR__ . '/marketplace-suggestions/class-wc-marketplace-updater.php';
+
+		// Marketplace promotions.
+		include_once __DIR__ . '/class-wc-admin-marketplace-promotions.php';
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes 19553-gh-Automattic/woocommerce.com
Related: 19573-gh-Automattic/woocommerce.com

We would like to be able to highlight sales in the WooCommerce Marketplace.

- Adds `WC_Admin_Marketplace_Promotions` class. 
- On `woocommerce_init`, if we are on any of the admin pages in the WooCommerce menu (so not Analytics or Marketing), fetches promotions from a woo.com endpoint and caches them in a transient `wc_addons_marketplace_promotions`.
- If we're on any admin page, calls `show_bubble_promotions` to render menu item bubble on the Extensions menu item.
- Changed method `WC_Admin_Addons::fetch_with_locale` to `WC_Admin_Addons::fetch` and added `$options` parameter, so we can fetch without passing locale. We want to keep URLs for promotions requests as uniform as possible for better caching on the Woo.com side.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. We assume we're testing before 15 March 2024, when the WooCommerce endpoint is returning current promotions.
2. Check out this branch on your local WooCommerce environment.
3. Open the local error log so you can check for PHP errors. Open Docker Desktop and find the ID of your wp-env WordPress container. Then do `docker exec -it [ container ID ]_wordpress_1 tail -n 100 -f wp-content/debug.log`. Alternatively, open Docker Desktop, go to the `wordpress-1` container and check the files tab. Browse to `var/www/html/wp-content/debug.log`.
4. View any of the pages in the WooCommerce nav menu.
5. Observe the `Sale` bubble next to the "Extensions" menu item. Note: the bubble only appears after you visit the WooCommerce Home or Extensions pages. Therefore, it's not visible when you first view wp-admin and mouseover the WooCommerce menu. This is to avoid unnecessary requests to the API. (To test this repeatedly with a local wp-env environment, you can run `wp-env run cli wp transient delete --all` to delete the transient that stores this data.)
6. Add this debug line or clear transients with the above command, and view WooCommerce > Extensions. Check that the Discover page is populated with products. This means the request to the Woo.com `featured` endpoint has succeeded.

```diff
Index: plugins/woocommerce/includes/admin/class-wc-admin-addons.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php	(revision 531c38c32e4e651f7eb1387abb3fbaa5234058a4)
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php	(date 1708086930774)
@@ -83,7 +83,7 @@
 		// Important: WCCOM Extensions API v2.0 is used.
 		$url = 'https://woocommerce.com/wp-json/wccom-extensions/2.0/featured';
 		$locale   = get_user_locale();
-		$featured = self::get_locale_data_from_transient( $transient_name, $locale );
+		$featured = false; // self::get_locale_data_from_transient( $transient_name, $locale );
 
 		if ( false === $featured ) {
 			$fetch_options = array(
```

7. Go to WooCommerce > Extensions (http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions). Check that the content still loads as expected on the Discover page, and that you can still browse extensions on the Browse tab (http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=extensions&path=%2Fextensions), and search for products in the search input.
8. Check for any PHP errors in the debug log.
9. Please test around in this change. In particular, we're concerned that we don't make too many requests to the Woo.com endpoint.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds logic to get notices of promotions from Woo.com endpoint, and (if necessary) show a bubble next to the WooCommerce "Extensions" menu item.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

#### Screenshots

<img width="310" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/cf841ce8-bf15-4d46-91b3-ec6c25a40122">
