### PR TITLE
[HPOS CLI] Allow `--re-migrate` to be used even when `--verbose` is not set

### DIFF
--- a/plugins/woocommerce/changelog/fix-41248
+++ b/plugins/woocommerce/changelog/fix-41248
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow --re-migrate to work without --verbose in HPOS CLI verification tool.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -371,6 +371,8 @@ class CLIRunner {
 
 		$progress = WP_CLI\Utils\make_progress_bar( 'Order Data Verification', $order_count / $batch_size );
 
+		$error_processing = false;
+
 		if ( ! $order_count ) {
 			return WP_CLI::warning( __( 'There are no orders to verify, aborting.', 'woocommerce' ) );
 		}
@@ -404,53 +406,64 @@ class CLIRunner {
 			$failed_ids_in_current_batch = $this->post_to_cot_migrator->verify_migrated_orders( $order_ids );
 			$failed_ids_in_current_batch = $this->verify_meta_data( $order_ids, $failed_ids_in_current_batch );
 			$failed_ids                  = $verbose ? array() : $failed_ids + $failed_ids_in_current_batch;
+			$error_processing            = $error_processing || ! empty( $failed_ids_in_current_batch );
 			$processed                  += count( $order_ids );
 			$batch_total_time            = microtime( true ) - $batch_start_time;
 			$batch_count ++;
 			$total_time += $batch_total_time;
 
-			if ( $verbose && count( $failed_ids_in_current_batch ) > 0 ) {
-				$errors = wp_json_encode( $failed_ids_in_current_batch, JSON_PRETTY_PRINT );
-				WP_CLI::warning(
-					sprintf(
-					/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
-						_n(
-							'%1$d error found: %2$s. Please review the error above.',
-							'%1$d errors found: %2$s. Please review the errors above.',
-							count( $failed_ids_in_current_batch ),
-							'woocommerce'
-						),
-						count( $failed_ids_in_current_batch ),
-						$errors
-					)
-				);
-				if ( $remigrate ) {
+			if ( count( $failed_ids_in_current_batch ) > 0 ) {
+				if ( $verbose ) {
+					$errors = wp_json_encode( $failed_ids_in_current_batch, JSON_PRETTY_PRINT );
 					WP_CLI::warning(
 						sprintf(
-							__( 'Attempting to remigrate...', 'woocommerce' )
+						/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
+							_n(
+								'%1$d error found: %2$s. Please review the error above.',
+								'%1$d errors found: %2$s. Please review the errors above.',
+								count( $failed_ids_in_current_batch ),
+								'woocommerce'
+							),
+							count( $failed_ids_in_current_batch ),
+							$errors
 						)
 					);
-					$failed_ids = array_keys( $failed_ids_in_current_batch );
-					$this->synchronizer->process_batch( $failed_ids );
-					$errors_in_remigrate_batch = $this->post_to_cot_migrator->verify_migrated_orders( $failed_ids );
-					$errors_in_remigrate_batch = $this->verify_meta_data( $failed_ids, $errors_in_remigrate_batch );
+				}
+
+				if ( $remigrate ) {
+					$failed_ids       = $failed_ids ? array_diff_key( $failed_ids, $failed_ids_in_current_batch ) : array();
+					$error_processing = ( ! $verbose ) && $failed_ids;
+
+					$verbose && WP_CLI::warning( sprintf( __( 'Attempting to remigrate...', 'woocommerce' ) ) );
+
+					$failed_ids_in_current_batch_keys = array_keys( $failed_ids_in_current_batch );
+					$this->synchronizer->process_batch( $failed_ids_in_current_batch_keys );
+					$errors_in_remigrate_batch = $this->post_to_cot_migrator->verify_migrated_orders( $failed_ids_in_current_batch_keys );
+					$errors_in_remigrate_batch = $this->verify_meta_data( $failed_ids_in_current_batch_keys, $errors_in_remigrate_batch );
+
 					if ( count( $errors_in_remigrate_batch ) > 0 ) {
+						$error_processing = true;
 						$formatted_errors = wp_json_encode( $errors_in_remigrate_batch, JSON_PRETTY_PRINT );
-						WP_CLI::warning(
-							sprintf(
-							/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
-								_n(
-									'%1$d error found: %2$s when re-migrating order. Please review the error above.',
-									'%1$d errors found: %2$s when re-migrating orders. Please review the errors above.',
+
+						if ( $verbose ) {
+							WP_CLI::warning(
+								sprintf(
+								/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
+									_n(
+										'%1$d error found: %2$s when re-migrating order. Please review the error above.',
+										'%1$d errors found: %2$s when re-migrating orders. Please review the errors above.',
+										count( $errors_in_remigrate_batch ),
+										'woocommerce'
+									),
 									count( $errors_in_remigrate_batch ),
-									'woocommerce'
-								),
-								count( $errors_in_remigrate_batch ),
-								$formatted_errors
-							)
-						);
+									$formatted_errors
+								)
+							);
+						} else {
+							$failed_ids = $failed_ids + $errors_in_remigrate_batch;
+						}
 					} else {
-						WP_CLI::warning( 'Re-migration successful.', 'woocommerce' );
+						$verbose && WP_CLI::warning( 'Re-migration successful.', 'woocommerce' );
 					}
 				}
 			}
@@ -478,11 +491,7 @@ class CLIRunner {
 		$progress->finish();
 		WP_CLI::log( __( 'Verification completed.', 'woocommerce' ) );
 
-		if ( $verbose ) {
-			return;
-		}
-
-		if ( 0 === count( $failed_ids ) ) {
+		if ( ! $error_processing ) {
 			return WP_CLI::success(
 				sprintf(
 					/* Translators: %1$d is the number of migrated orders and %2$d is time taken. */
@@ -497,8 +506,6 @@ class CLIRunner {
 				)
 			);
 		} else {
-			$errors = wp_json_encode( $failed_ids, JSON_PRETTY_PRINT );
-
 			return WP_CLI::error(
 				sprintf(
 					'%1$s %2$s',
@@ -513,17 +520,19 @@ class CLIRunner {
 						$processed,
 						$total_time
 					),
-					sprintf(
-						/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
-						_n(
-							'%1$d error found: %2$s. Please review the error above.',
-							'%1$d errors found: %2$s. Please review the errors above.',
+					$failed_ids
+						? sprintf(
+							/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
+							_n(
+								'%1$d error found: %2$s. Please review the error above.',
+								'%1$d errors found: %2$s. Please review the errors above.',
+								count( $failed_ids ),
+								'woocommerce'
+							),
 							count( $failed_ids ),
-							'woocommerce'
-						),
-						count( $failed_ids ),
-						$errors
-					)
+							wp_json_encode( $failed_ids, JSON_PRETTY_PRINT )
+						)
+						: __( 'Please review the errors above.', 'woocommerce' )
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -308,7 +308,6 @@ class CLIRunner {
 	 *
 	 * [--re-migrate]
 	 * : Attempt to re-migrate orders that failed verification. You should only use this option when you have never run the site with HPOS as authoritative source of order data yet, or you have manually checked the reported errors, otherwise, you risk stale data overwriting the more recent data.
-	 * This option can only be enabled when --verbose flag is also set.
 	 * default: false
 	 *
 	 * ## EXAMPLES

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -459,6 +459,12 @@ class CLIRunner {
 								)
 							);
 						} else {
+							array_walk(
+								$errors_in_remigrate_batch,
+								function( &$errors_for_order ) {
+									$errors_for_order[] = array( 'remigrate_failed' => true );
+								}
+							);
 							$failed_ids = $failed_ids + $errors_in_remigrate_batch;
 						}
 					} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, while verifying order data via the CLI tool `wp cot verify_cot_data`, the `--re-migrate` flag (which attempts to sync the order again if verification fails) requires the use of `--verbose` too.

While this isn't necessarily problematic, it'd be best to support `--re-migrate` regardless of the `--verbose` flag to reduce confusion. This PR makes that possible and also allows the tool to display completion messages ("M orders were verified in N seconds") even when verbosity is enabled.

Closes #41248.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your site has a few test orders and note at least a few order IDs.
2. Make sure HPOS is set as datastore and compatibility mode is disabled in WC > Settings > Advanced > Features.
3. Run `wp wc cot sync` to sync orders.
4. Run `wp wc cot verify_cot_data` and make sure no verification errors are indicated. This way we make sure we're starting at a "no verification errors" state.
   If there are, in fact, errores reported for any order, you should be able to address those manually by running `wp hpos backfill <order_id> --from=posts --to=hpos`.
5. Run `wp wc cot verify_cot_data --verbose` and make sure the completion message appears ("Success: X orders were verified in Y seconds.")
6. Manually introduce some differences between the post and HPOS records of a few orders. For example, try a few variations of the following commands:
   - `wp post meta update <order id> some_random_meta_name 123`
   - `wp post meta update <anothe order id> _billing_first_name "Kip Stephen Thorne"`
7. Run `wp wc cot verify_cot_data` and confirm that the differences introduced above are reported as errors.
8. Run `wp wc cot verify_cot_data --re-migrate` and confirm that no errores are reported. Note that we didn't have to use `--verbose` for it to work.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
