### PR TITLE
[HPOS CLI] Flush in-memory cache after each batch in migration

### DIFF
--- a/plugins/woocommerce/changelog/fix-33348
+++ b/plugins/woocommerce/changelog/fix-33348
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve memory usage in HPOS sync CLI tool.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -219,6 +219,9 @@ class CLIRunner {
 
 			$orders_remaining = count( $this->synchronizer->get_next_batch_to_process( 1 ) ) > 0;
 			$order_count      = $remaining_count - $batch_size;
+
+			function_exists( 'wp_cache_flush_runtime' ) && wp_cache_flush_runtime();
+			$GLOBALS['wpdb']->flush();
 		}
 
 		$progress->finish();

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -220,7 +220,10 @@ class CLIRunner {
 			$orders_remaining = count( $this->synchronizer->get_next_batch_to_process( 1 ) ) > 0;
 			$order_count      = $remaining_count - $batch_size;
 
-			function_exists( 'wp_cache_flush_runtime' ) && wp_cache_flush_runtime();
+			if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_runtime' ) ) {
+				wp_cache_flush_runtime();
+			}
+
 			$GLOBALS['wpdb']->flush();
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
With this PR, the WP runtime cache is cleared after a batch is processed in the `wp cot sync` WP-CLI tool. The `wpdb` cache is also flushed.
This should help a little with memory usage, esp. for long running processes.


Closes #33348.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Though this is not an exact science since memory usage depends on a bunch of things, we will use a PHP snippet to attempt to measure usage while running the CLI tool.

1. Drop the following PHP snippet as a .php file in `wp-content/mu-plugins/`:
   ```php
   <?php
   add_action(
	   'shutdown',
	   function() {
		   printf( 'Peak memory usage: %s', size_format( memory_get_peak_usage(), 2 ) );
	   }
   );
   ```
2. Make sure HPOS is set as datastore in WC > Settings > Advanced > Features and that compatibility mode is disabled.
3. I recommend using Smooth Generator to generate a few orders (e.g. `wp wc generate orders 2000`).
5. Run `wp wc hpos cleanup all` to clean up order data from the posts table.
6. Run `wp wc cot sync` and record the memory usage reported.
7. Check out `trunk` and repeat 3-4 comparing the results.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
