### PR TITLE
Prevent script caching by using the WC core version to hash WC blocks assets instead of old WC Blocks version

### DIFF
--- a/plugins/woocommerce/changelog/fix-woocommerce-blocks-transient-hash
+++ b/plugins/woocommerce/changelog/fix-woocommerce-blocks-transient-hash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure WooCommerce Blocks scripts are uncached following a plugin update

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -15,6 +15,8 @@ class Api {
 
 	/**
 	 * Stores the prefixed WC version. Used because the WC Blocks version has not been updated since the monorepo merge.
+	 *
+	 * @var string
 	 */
 	private $wc_version;
 

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -18,7 +18,7 @@ class Api {
 	 *
 	 * @var string
 	 */
-	private $wc_version;
+	public $wc_version;
 
 	/**
 	 * Stores inline scripts already enqueued.

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -68,7 +68,8 @@ class Api {
 	 * @param Package $package An instance of Package.
 	 */
 	public function __construct( Package $package ) {
-		$this->wc_version    = Constants::get_constant( 'WC_VERSION' );
+		// Use wc- prefix here to prevent collisions when WC Core version catches up to a version previously used by the WC Blocks feature plugin.
+		$this->wc_version    = 'wc-' . Constants::get_constant( 'WC_VERSION' );
 		$this->package       = $package;
 		$this->disable_cache = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) || ! $this->package->feature()->is_production_environment();
 

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Exception;
+use Automattic\Jetpack\Constants;
 /**
  * The Api class provides an interface to various asset registration helpers.
  *
@@ -123,7 +124,8 @@ class Api {
 	 * @return string The generated hash.
 	 */
 	private function get_script_data_hash() {
-		return md5( get_option( 'siteurl', '' ) . $this->package->get_version() . $this->package->get_path() );
+		// wc- added here in 8.6.0 to avoid collisions when WC core version becomes the same as a version previously used by WC Blocks.
+		return md5( 'wc-' . get_option( 'siteurl', '' ) . Constants::get_constant( 'WC_VERSION' ); . $this->package->get_path() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -279,7 +279,7 @@ final class AssetsController {
 		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && file_exists( \Automattic\WooCommerce\Blocks\Package::get_path() . $file ) ) {
 			return filemtime( \Automattic\WooCommerce\Blocks\Package::get_path() . $file );
 		}
-		return \Automattic\WooCommerce\Blocks\Package::get_version();
+		return $this->api->wc_version;
 	}
 
 	/**


### PR DESCRIPTION
This is because the previous hash was generated using WC blocks version, which hasn't been updated since joining the monorepo.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In this PR, we update the way the hash for WC blocks assets is generated. The asset data is stored in a transient to improve website performance, and we check whether the transient needs to be regenerated by comparing a hash in the transient to a hash we generate. Previously this was based on the WC blocks version in `src/Blocks/Package.php` but this hasn't been updated since WC Blocks was merged into the monorepo. Therefore, when updating to new versions of WC Core, the transient was not cleaned out. The hash did not change due to the version remaining the same.

This PR will now use the WC core version which will be updated on each release. Because of the changed version, the transient will update and fresh data will be cached.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### User facing steps

1. Install WC  8.5.2 on a website
2. Add items to your cart and go to the Checkout block. Complete the flow.
3. Install the version of WC from this branch (zip file here: [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/14304035/woocommerce.zip) )
4. Repeat step 2 and confirm you don't see any errors.

#### Dev/advanced testing

1. Install WC  8.5.2 on a website
2. Add items to your cart.
3. Open dev tools and open the network tab.
4. Go to the Checkout block
5. Search for the file `checkout-frontend.js`. Notice the version number on the end of the URL.
6. Install the version of WC from this branch (zip file here: [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/14304035/woocommerce.zip) )
7. Refresh the page, check the version number of `checkout-frontend.js` - ensure it is different to the one from 8.5.2

##### Optional further testing with Transients Manager - only applicable to sites NOT using persistent object caches.

1. Install Transients Manager https://en-gb.wordpress.org/plugins/transients-manager/ **note, this doesn't seem to work on JN or sites using an object cache, so skip this step if using one of those. You'll see `You are using a persistent object cache. This screen may show incomplete information.` in the Tools -> Transients screen if this is the case.**
2. Install WC 8.5.2 on your site. Load the Checkout block.
3. Look at the transient: `_transient_woocommerce_blocks_asset_api_script_data` (might also be called `_transient_woocommerce_blocks_asset_api_script_data_ssl`) - save the data somewhere.
4. Install the version of WC from this branch (zip file here: [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/14304035/woocommerce.zip) )
5. Look at the transient: `_transient_woocommerce_blocks_asset_api_script_data` again - save the data somewhere.
6. Compare the data, it should be different. Specifically the versions of files should be `8.6.0` instead of `11.8.0-dev`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
