### PR TITLE
Dont render attribution metabox for non-supported order types.

### DIFF
--- a/plugins/woocommerce/changelog/fix-44677
+++ b/plugins/woocommerce/changelog/fix-44677
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Don't render attribution metabox for other order types.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -257,7 +257,7 @@ class Edit {
 			return;
 		}
 
-		if( ! OrderUtil::is_order_edit_screen() ) {
+		if ( ! OrderUtil::is_order_edit_screen() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -152,7 +152,6 @@ class Edit {
 		$this->add_save_meta_boxes();
 		$this->handle_order_update();
 		$this->add_order_meta_boxes( $this->screen_id, __( 'Order', 'woocommerce' ) );
-		$this->maybe_register_order_attribution( $this->screen_id, __( 'Order', 'woocommerce' ) );
 		$this->add_order_specific_meta_box();
 		$this->add_order_taxonomies_meta_box();
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
+use Automattic\WooCommerce\Admin\Overrides\Order;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
@@ -81,7 +82,6 @@ class Edit {
 		add_meta_box( 'woocommerce-order-downloads', __( 'Downloadable product permissions', 'woocommerce' ) . wc_help_tip( __( 'Note: Permissions for order items will automatically be granted when the order status changes to processing/completed.', 'woocommerce' ) ), 'WC_Meta_Box_Order_Downloads::output', $screen_id, 'normal', 'default' );
 		/* Translators: %s order type name. */
 		add_meta_box( 'woocommerce-order-actions', sprintf( __( '%s actions', 'woocommerce' ), $title ), 'WC_Meta_Box_Order_Actions::output', $screen_id, 'side', 'high' );
-		self::maybe_register_order_attribution( $screen_id, $title );
 	}
 
 	/**
@@ -151,6 +151,7 @@ class Edit {
 		$this->add_save_meta_boxes();
 		$this->handle_order_update();
 		$this->add_order_meta_boxes( $this->screen_id, __( 'Order', 'woocommerce' ) );
+		$this->maybe_register_order_attribution( $this->screen_id, __( 'Order', 'woocommerce' ) );
 		$this->add_order_specific_meta_box();
 		$this->add_order_taxonomies_meta_box();
 
@@ -217,7 +218,7 @@ class Edit {
 	 *
 	 * @return void
 	 */
-	private static function maybe_register_order_attribution( string $screen_id, string $title ) {
+	private function maybe_register_order_attribution( string $screen_id, string $title ) {
 		/**
 		 * Features controller.
 		 *
@@ -225,6 +226,11 @@ class Edit {
 		 */
 		$feature_controller = wc_get_container()->get( FeaturesController::class );
 		if ( ! $feature_controller->feature_is_enabled( 'order_attribution' ) ) {
+			return;
+		}
+
+		// Automattic\WooCommerce\Admin\Overrides\Order provides necessary methods to render this metabox.
+		if ( ! $this->order instanceof Order ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -25,7 +25,11 @@ class CustomerHistory {
 			return;
 		}
 
-		$customer_history = $this->get_customer_history( $order->get_report_customer_id() );
+		$customer_history = null;
+
+		if ( method_exists( $order, 'get_report_customer_id' ) ) {
+			$customer_history = $this->get_customer_history( $order->get_report_customer_id() );
+		}
 
 		if ( ! $customer_history ) {
 			$customer_history = array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Bail early if the order type is anything other than the `Automattic\WooCommerce\Admin\Overrides\Order` which provides the necessary method for rendering this metabox.

Closes #44677 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This fix can be tested on any order type other than the core order type that renders their own admin page. For example, we can test with subscriptions. 

Edit: Please also repeat these testing instructions for both HPOS and post data stores. Note that if WooCommcerce analytics is disabled then the customer history stats will not be displayed.

1. Create a new subscription order, by first creating a subscription product and adding a new subscription to it.
2. Open the edit page for that subscription. It should load properly. Check that the customer history meta box is not displayed for the subs order.

Additionally, we need to test that the order attribution meta box is indeed displayed for normal orders.
1. Open any order edit screen in the admin view. 
2. Check that the order attribution screen is displayed as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
