### PR TITLE
Product Collection: Improve flaky E2E test

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -553,11 +553,6 @@ class ProductCollectionPage {
 	 */
 	private async insertSingleProductBlock() {
 		await this.editor.insertBlock( { name: 'woocommerce/single-product' } );
-		await this.page.waitForResponse(
-			( response ) =>
-				response.url().includes( 'wc/store/v1/products' ) &&
-				response.status() === 200
-		);
 		const singleProductBlock = await this.editorUtils.getBlockByName(
 			'woocommerce/single-product'
 		);

--- a/plugins/woocommerce/changelog/test-improve-flaky-e2e-test
+++ b/plugins/woocommerce/changelog/test-improve-flaky-e2e-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Product Collection: fix flaky E2E test


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Following the improvement from https://github.com/woocommerce/woocommerce/pull/44639 this PR stabilises another E2E tests in Product Collection that required inserting Single Product block and used the same code.

Example of such test:

<img width="1273" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/a4b97fa9-bab3-4caa-8720-7332300324b1">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note: to be checked only by dev team:

1. CI should pass and
- `Product Collection - With other blocks - In Single Product block`
- `Product Collection - Location is recognised - as product in Single Product block in post`
are not flaky

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
