### PR TITLE
Blocks E2E: Stabilize a flaky Price Filter test

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
@@ -59,24 +59,27 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 		page,
 		frontendUtils,
 	} ) => {
+		// The price filter input is initially enabled, but it becomes disabled
+		// for the time it takes to fetch the data. To avoid setting the filter
+		// value before the input is properly initialized, we wait for the input
+		// to be disabled first. This is a safeguard to avoid flakiness which
+		// should be addressed in the code, but All Products block will be
+		// deprecated in the future, so we are not going to optimize it.
+		await page
+			.getByRole( 'textbox', {
+				name: 'Filter products by maximum price',
+				disabled: true,
+			} )
+			.waitFor( { timeout: 3000 } )
+			.catch(); // Do not throw in case Playwright doesn't make it in time.
+
 		const maxPriceInput = page.getByRole( 'textbox', {
 			name: 'Filter products by maximum price',
 		} );
 
-		// All Products block will be deprecated in the future, so we are not going to optimize it.
-
-		// eslint-disable-next-line playwright/no-networkidle
-		await page.waitForLoadState( 'networkidle' );
-
-		await frontendUtils.selectTextInput( maxPriceInput );
-		await maxPriceInput.fill( '$10', {
-			// eslint-disable-next-line playwright/no-force-option
-			force: true,
-		} );
+		await maxPriceInput.dblclick();
+		await maxPriceInput.fill( '$10' );
 		await maxPriceInput.press( 'Tab' );
-		await page.waitForResponse( ( response ) =>
-			response.url().includes( blockData.endpointAPI )
-		);
 
 		const allProductsBlock = await frontendUtils.getBlockByName(
 			'woocommerce/all-products'
@@ -89,9 +92,9 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 			blockData.placeholderUrl
 		);
 
-		const products = await allProductsBlock.getByRole( 'listitem' ).all();
+		const allProducts = allProductsBlock.getByRole( 'listitem' );
 
-		expect( products ).toHaveLength( 1 );
+		await expect( allProducts ).toHaveCount( 1 );
 		expect( page.url() ).toContain(
 			blockData.urlSearchParamWhenFilterIsApplied
 		);

--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
@@ -35,7 +35,7 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 		await editor.publishPost();
 		const url = new URL( page.url() );
 		const postId = url.searchParams.get( 'post' );
-		await page.goto( `/?p=${ postId }`, { waitUntil: 'commit' } );
+		await page.goto( `/?p=${ postId }` );
 	} );
 
 	test( 'should show all products', async ( { frontendUtils } ) => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
@@ -71,7 +71,9 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 				disabled: true,
 			} )
 			.waitFor( { timeout: 3000 } )
-			.catch(); // Do not throw in case Playwright doesn't make it in time.
+			// Do not throw in case Playwright doesn't make it in time for the
+			// initial (pre-request) render.
+			.catch();
 
 		const maxPriceInput = page.getByRole( 'textbox', {
 			name: 'Filter products by maximum price',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
@@ -71,9 +71,10 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 				disabled: true,
 			} )
 			.waitFor( { timeout: 3000 } )
-			// Do not throw in case Playwright doesn't make it in time for the
-			// initial (pre-request) render.
-			.catch();
+			.catch( () => {
+				// Do not throw in case Playwright doesn't make it in time for the
+				// initial (pre-request) render.
+			} );
 
 		const maxPriceInput = page.getByRole( 'textbox', {
 			name: 'Filter products by maximum price',

--- a/plugins/woocommerce/changelog/tweak-stabilize-flaky-price-filter-e2e
+++ b/plugins/woocommerce/changelog/tweak-stabilize-flaky-price-filter-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stabilize a flaky Price Filter test by addressing the unstable nature of the filter input.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Stabilize a flaky Price Filter test by addressing the unstable nature of the filter input (see inline comments).

### How to test the changes in this Pull Request:

The test should pass in CI. To test locally:

1. `cd plugins/woocommerce-blocks`
2. `pnpm env:start`
3. `pnpm test:e2e:side-effects -g "should show only products that match the filter"`