### PR TITLE
Move condition to check post status before rendering product

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-shortcode-post-status
+++ b/plugins/woocommerce/changelog/fix-product-shortcode-post-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the product_page shortcode not working if "status" is passed in as "any".

--- a/plugins/woocommerce/includes/class-wc-shortcodes.php
+++ b/plugins/woocommerce/includes/class-wc-shortcodes.php
@@ -572,7 +572,12 @@ class WC_Shortcodes {
 
 		$single_product = new WP_Query( $args );
 
-		if ( ! isset( $force_rendering ) && 'publish' !== $single_product->post->post_status && ! current_user_can( 'read_product', $product_id ) ) {
+		if (
+			! isset( $force_rendering ) &&
+			$single_product->have_posts() &&
+			'publish' !== $single_product->post->post_status &&
+			! current_user_can( 'read_product', $single_product->post->ID )
+		) {
 			return '';
 		}
 

--- a/plugins/woocommerce/includes/class-wc-shortcodes.php
+++ b/plugins/woocommerce/includes/class-wc-shortcodes.php
@@ -514,6 +514,7 @@ class WC_Shortcodes {
 			$product_id = wc_get_product_id_by_sku( $atts['sku'] );
 		}
 
+		unset( $atts['status'] );
 		$product_status = empty( $atts['status'] ) ? 'publish' : $atts['status'];
 		/**
 		 * Filters the list of invalid statuses for the `product_page` shortcode.
@@ -537,9 +538,6 @@ class WC_Shortcodes {
 		 */
 		$force_rendering = apply_filters( 'woocommerce_shortcode_product_page_force_rendering', null, $product_id );
 		if ( isset( $force_rendering ) && ! $force_rendering ) {
-			return '';
-		}
-		if ( ! isset( $force_rendering ) && 'publish' !== $product_status && ! current_user_can( 'read_product', $product_id ) ) {
 			return '';
 		}
 
@@ -574,6 +572,10 @@ class WC_Shortcodes {
 		add_filter( 'woocommerce_add_to_cart_form_action', '__return_empty_string' );
 
 		$single_product = new WP_Query( $args );
+
+		if ( ! isset( $force_rendering ) && 'publish' !== $single_product->post->post_status && ! current_user_can( 'read_product', $product_id ) ) {
+			return '';
+		}
 
 		$preselected_id = '0';
 

--- a/plugins/woocommerce/includes/class-wc-shortcodes.php
+++ b/plugins/woocommerce/includes/class-wc-shortcodes.php
@@ -514,7 +514,6 @@ class WC_Shortcodes {
 			$product_id = wc_get_product_id_by_sku( $atts['sku'] );
 		}
 
-		unset( $atts['status'] );
 		$product_status = empty( $atts['status'] ) ? 'publish' : $atts['status'];
 		/**
 		 * Filters the list of invalid statuses for the `product_page` shortcode.

--- a/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
@@ -85,6 +85,30 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Ensure the `product_page` shortcode renders a published product correctly even with status set to `any`.
+	 */
+	public function test_product_page_shortcode_published_product_status_any() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Test Product' );
+		$product->save();
+		$product_id = $product->get_id();
+		wp_set_current_user( 0 );
+		$this->disable_deprecation_notice();
+
+		$product_page = WC_Shortcodes::product_page(
+			array(
+				'id'     => $product_id,
+				'status' => 'any',
+			)
+		);
+
+		$this->enable_deprecation_notice();
+
+		$this->assertNotEmpty( $product->get_name() );
+		$this->assertStringContainsString( $product->get_name(), $product_page );
+	}
+
+	/**
 	 * Ensure the `product_page` shortcode renders a published product correctly when given an SKU.
 	 */
 	public function test_product_page_shortcode_published_product_by_sku() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

We were previously checking the status set on the shortcode rather than on the product introduced in https://github.com/Automattic/woocommerce/pull/298. We need to check the post_status once we have fetched the product before rendering.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/44679

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Reproduce the issue:**
1. Install https://wordpress.org/themes/accesspress-lite/
2. Install WC 8.6 or trunk
3. View product pages as logged out user and check they are rendering blank pages

**Test this PR fixes the issue**
1. Install https://wordpress.org/themes/accesspress-lite/
2. Install WC from this PR's branch
3. View product pages as logged out user and check they are rendering product correctly
4. Change status of products and test they are rendering as expected for both logged out and logged in users.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix product pages rendering blank product details

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
