### PR TITLE
Add default values for admin address filters

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-default-value-for-additional-fields-filter
+++ b/plugins/woocommerce/changelog/fix-add-default-value-for-additional-fields-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add default values for 'woocommerce_admin_billing_fields' and 'woocommerce_admin_shipping_fields' filters

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsAdmin.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsAdmin.php
@@ -84,7 +84,7 @@ class CheckoutFieldsAdmin {
 	 * @param string            $context The context to show the fields for.
 	 * @return array
 	 */
-	public function admin_address_fields( $fields, $order = 0, $context = 'edit' ) {
+	public function admin_address_fields( $fields, $order = null, $context = 'edit' ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return $fields;
 		}
@@ -118,7 +118,7 @@ class CheckoutFieldsAdmin {
 	 * @param string            $context The context to show the fields for.
 	 * @return array
 	 */
-	public function admin_contact_fields( $fields, $order = 0, $context = 'edit' ) {
+	public function admin_contact_fields( $fields, $order = null, $context = 'edit' ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return $fields;
 		}
@@ -143,7 +143,7 @@ class CheckoutFieldsAdmin {
 	 * @param string            $context The context to show the fields for.
 	 * @return array
 	 */
-	public function admin_additional_fields( $fields, $order = 0, $context = 'edit' ) {
+	public function admin_additional_fields( $fields, $order = null, $context = 'edit' ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return $fields;
 		}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsAdmin.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsAdmin.php
@@ -84,7 +84,7 @@ class CheckoutFieldsAdmin {
 	 * @param string            $context The context to show the fields for.
 	 * @return array
 	 */
-	public function admin_address_fields( $fields, $order, $context = 'edit' ) {
+	public function admin_address_fields( $fields, $order = 0, $context = 'edit' ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return $fields;
 		}
@@ -118,7 +118,7 @@ class CheckoutFieldsAdmin {
 	 * @param string            $context The context to show the fields for.
 	 * @return array
 	 */
-	public function admin_contact_fields( $fields, $order, $context = 'edit' ) {
+	public function admin_contact_fields( $fields, $order = 0, $context = 'edit' ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return $fields;
 		}
@@ -143,7 +143,7 @@ class CheckoutFieldsAdmin {
 	 * @param string            $context The context to show the fields for.
 	 * @return array
 	 */
-	public function admin_additional_fields( $fields, $order, $context = 'edit' ) {
+	public function admin_additional_fields( $fields, $order = 0, $context = 'edit' ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return $fields;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Recently in the work we did for additional fields, we expanded some WooCommerce Order filters like `woocommerce_admin_shipping_fields` and `woocommerce_admin_billing_fields` filters and added 2 new arguments, we also consume them in our work.

This created an issue for other plugins who recall those hooks with the old number of parameters.

To fix this, I added default values to where we consume them.

Issue reported here https://wordpress.org/support/topic/fatal-error-after-woocommerce-update-9

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Install this plugin [AliExpress Dropshipping with AliNext Lite](https://wordpress.org/plugins/ali2woo-lite/)
2. Visit an order page.
3. You shouldn't see a fatal.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add default values for 'woocommerce_admin_billing_fields' and 'woocommerce_admin_shipping_fields' filters

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
