### PR TITLE
exclude tests folders from template version linting

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -22,8 +22,9 @@ jobs:
         working-directory: 'tools/code-analyzer'
         run: |
           HEAD_REF=$(git rev-parse HEAD)
+          exclude="plugins/woocommerce/tests plugins/woocommerce-admin/tests plugins/woocommerce-blocks/tests"
           version=$(pnpm analyzer major-minor "$HEAD_REF" "plugins/woocommerce/woocommerce.php" | tail -n 1)
-          pnpm analyzer "$HEAD_REF" $version -o "github"
+          pnpm analyzer "$HEAD_REF" $version -o "github" -e $exclude
       - uses: 'actions/github-script@v6'
         name: 'Validate'
         with:

--- a/tools/code-analyzer/src/commands/analyzer/analyzer-lint.ts
+++ b/tools/code-analyzer/src/commands/analyzer/analyzer-lint.ts
@@ -35,6 +35,11 @@ const program = new Command()
 		'Git repo url or local path to a git repo.',
 		join( process.cwd(), '../../' )
 	)
+	.option(
+		'-e, --exclude <exclude...>',
+		'List of folders / files to exclude.',
+		[]
+	)
 	.addOption(
 		new Option( '-o, --outputStyle <outputStyle>' ).choices( [
 			'github',
@@ -42,14 +47,16 @@ const program = new Command()
 		] as const )
 	)
 	.action( async ( compare, sinceVersion, options ) => {
-		const { source, base, outputStyle = 'cli' } = options;
+		const { source, base, outputStyle = 'cli', exclude = [] } = options;
 
 		const changes = await scanForChanges(
 			compare,
 			sinceVersion,
 			source,
 			base,
-			outputStyle
+			outputStyle,
+			undefined,
+			exclude
 		);
 
 		if ( changes.templates.size ) {

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -36,10 +36,6 @@ const generateVersionDiff = async (
 		`Temporary clone of ${ source } created at ${ tmpRepoPath }`
 	);
 
-	Logger.notice(
-		`Temporary clone of ${ source } created at ${ tmpRepoPath }`
-	);
-
 	const diff = await generateDiff(
 		tmpRepoPath,
 		base,
@@ -119,7 +115,8 @@ export const scanForChanges = async (
 	source: string,
 	base: string,
 	outputStyle: 'cli' | 'github',
-	clonedPath?: string
+	clonedPath?: string,
+	exclude?: string[]
 ) => {
 	Logger.startTask( `Making temporary clone of ${ source }...` );
 
@@ -134,16 +131,12 @@ export const scanForChanges = async (
 		`Temporary clone of ${ source } created at ${ tmpRepoPath }`
 	);
 
-	Logger.notice(
-		`Temporary clone of ${ source } created at ${ tmpRepoPath }`
-	);
-
 	const diff = await generateDiff(
 		tmpRepoPath,
 		base,
 		compareVersion,
 		Logger.error,
-		[ 'tools' ]
+		[ 'tools', ...exclude ]
 	);
 
 	// Only checkout the compare version if we're in CLI mode.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds support for excluding folders from linting. The template linting workflow is update to exclude `plugins/(woocommerce|woocommerce-admin|woocommerce-blocks)/tests`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out #44612
2. Run `git log` and copy the first commit hash in the log: `HASH` in the remaining steps
3. Check out this branch
4. Change directory to `tools/code-analyzer`
5. Run `pnpm analyzer "HASH" 8.7.0 -o github
6. Note that there are the following warnings
```
::warning file=/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts,line=1,title=TEMPLATES::This template may require a version bump!
::warning file=/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts,line=1,title=TEMPLATES::This template may require a version bump!
::warning file=/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts,line=1,title=TEMPLATES::This template may require a version bump!
::warning file=/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts,line=1,title=TEMPLATES::This template may require a version bump!
::warning file=/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts,line=1,title=TEMPLATES::This template may require a version bump!
::warning file=/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts,line=1,title=TEMPLATES::This template may require a version bump!
```
7. Run `pnpm analyzer "HASH" 8.7.0 -o github -e plugins/woocommerce/tests plugins/woocommerce-admin/tests plugins/woocommerce-blocks/tests`
8. The warnings in step 6 should not be included in the output

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
