### PR TITLE
[CYS - Core] improve logic to find active fonts

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -95,10 +95,10 @@ export const VariationContainer = ( { variation, children } ) => {
 		// With the Font Library, the fontFamilies object contains an array of font families installed with the Font Library under the key 'custom'.
 		// We need to compare only the active theme font families, so we compare the theme font families with the current variation.
 		const { theme } = user.settings.typography.fontFamilies;
-
-		return isEqual( variation.settings.typography, {
-			fontFamilies: { theme },
-		} );
+		return variation.settings.typography?.fontFamilies.theme.every(
+			( { slug } ) =>
+				theme.some( ( { slug: themeSlug } ) => themeSlug === slug )
+		);
 	}, [ user, variation ] );
 
 	let label = variation?.title;

--- a/plugins/woocommerce/changelog/44724-fix-font-is-not-selected
+++ b/plugins/woocommerce/changelog/44724-fix-font-is-not-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: [CYS - Core] improve logic to find active fonts
+

--- a/plugins/woocommerce/changelog/44724-fix-font-is-not-selected
+++ b/plugins/woocommerce/changelog/44724-fix-font-is-not-selected
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
-Comment: [CYS - Core] improve logic to find active fonts
+[CYS - Core] improve logic to find active fonts
 

--- a/plugins/woocommerce/changelog/44724-fix-font-is-not-selected
+++ b/plugins/woocommerce/changelog/44724-fix-font-is-not-selected
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
-[CYS - Core] improve logic to find active fonts
+Comment: [CYS - Core] improve logic to find active fonts
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a regression caused by https://github.com/woocommerce/woocommerce/pull/44586. 
I updated the logic to ensure that the font pair is active.

Fixes https://github.com/woocommerce/woocommerce/issues/44726



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Install this build of Gutenberg: [gutenberg.zip](https://github.com/woocommerce/woocommerce/files/14236920/gutenberg.zip)
5. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
6. Follow the process.
7. Click on `Change your fonts`.
8. Ensure that the first font pair is selected.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

[CYS - Core] improve logic to find active fonts

</details>
