### PR TITLE
Add/44643 variation empty state experiment

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -16,7 +16,7 @@ import { createNoticesFromResponse } from '../../../lib/notices';
 import { getAdminSetting } from '~/utils/admin-settings';
 
 const EXPERIMENT_NAME =
-	'woocommerce_product_creation_experience_linked_products_202402_v1';
+	'woocommerce_product_creation_experience_empty_state_updates_202403_v1';
 
 export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );

--- a/plugins/woocommerce/changelog/add-44643_variation_empty_state_experiment
+++ b/plugins/woocommerce/changelog/add-44643_variation_empty_state_experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update experiment name for enabling new product editor.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the experiment name for the latest WC Release.

Partially addresses #44643   .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Open your console and go to **Application > Local Storage** and make sure the item with key: `explat-experiment--woocommerce_product_creation_experience_empty_state_updates_202403_v1` is removed or does not exist.
2. Go to the ExPlat experiment woocommerce_product_creation_experience_empty_state_updates_202403_v1 and choose the variation you want to test. ( **Note:** When testing each version make sure you have the product editor feature flag disabled. For example when it is enabled the task list will ignore the experiment and always redirect to the new editor, meaning that testing the `control` version doesn't seem to work ).
3. When hovering over any Bookmarklet link of control or treatment variation, a popover should appear with instructions to try one of the variations ( redo step 1 when switch treatment versions ).
4. Be sure to save the suggested link to your browser bookmarks.
5. Go to WooCommerce > Home and go through the OBW ( Onboarding workflow ) or skip it.
6. Go to /wp-admin/admin.php?page=wc-admin and click on the second item to add a new product.
7. Click on the bookmark saved in step 3.
8. After clicking the saved bookmark, a modal with this title should be shown ExPlat: Successful Assignment
    Close the modal. 
9. Click on any of the product types ( test a couple ). 
    If you chose the "control" variation, you should see the old/legacy product form.
    If you selected the "treatment" variation, you should see the blocks product editor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
