### PR TITLE
Make dashboard status widget compatible with HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-40382
+++ b/plugins/woocommerce/changelog/fix-40382
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes order counts in WooCommerce Status dashboard widget.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -89,24 +89,42 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			$orders_column_status = $hpos_enabled ? 'status' : 'post_status';
 			$orders_column_date   = $hpos_enabled ? 'date_created_gmt' : 'post_date_gmt';
 
-			$query            = array();
-			$query['fields']  = "SELECT SUM( order_item_meta.meta_value ) as qty, order_item_meta_2.meta_value as product_id FROM {$orders_table} AS orders";
-			$query['join']    = "INNER JOIN {$wpdb->prefix}woocommerce_order_items AS order_items ON orders.{$orders_column_id} = order_id ";
-			$query['join']   .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id ";
-			$query['join']   .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id ";
-			$query['where']   = "WHERE orders.{$orders_column_type} IN ( '" . implode( "','", wc_get_order_types( 'order-count' ) ) . "' ) ";
-			$query['where']  .= "AND orders.{$orders_column_status} IN ( 'wc-" . implode( "','wc-", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "' ) ";
+			$query           = array();
+			$query['fields'] = "SELECT SUM( order_item_meta.meta_value ) as qty, order_item_meta_2.meta_value as product_id FROM {$orders_table} AS orders";
+			$query['join']   = "INNER JOIN {$wpdb->prefix}woocommerce_order_items AS order_items ON orders.{$orders_column_id} = order_id ";
+			$query['join']  .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id ";
+			$query['join']  .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id ";
+			$query['where']  = "WHERE orders.{$orders_column_type} IN ( '" . implode( "','", wc_get_order_types( 'order-count' ) ) . "' ) ";
+
+			/**
+			 * Allows modifying the order statuses used in the top seller query inside the dashboard status widget.
+			 *
+			 * @since 2.2.0
+			 *
+			 * @param string[] $order_statuses Order statuses.
+			 */
+			$order_statuses  = apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) );
+			$query['where'] .= "AND orders.{$orders_column_status} IN ( 'wc-" . implode( "','wc-", $order_statuses ) . "' ) ";
+
 			$query['where']  .= "AND order_item_meta.meta_key = '_qty' ";
 			$query['where']  .= "AND order_item_meta_2.meta_key = '_product_id' ";
-			$query['where']  .= "AND orders.{$orders_column_date} >= '" . gmdate( 'Y-m-01', current_time( 'timestamp' ) ) . "' ";
-			$query['where']  .= "AND orders.{$orders_column_date} <= '" . gmdate( 'Y-m-d H:i:s', current_time( 'timestamp' ) ) . "' ";
+			$query['where']  .= "AND orders.{$orders_column_date} >= '" . gmdate( 'Y-m-01', current_time( 'timestamp' ) ) . "' "; // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+			$query['where']  .= "AND orders.{$orders_column_date} <= '" . gmdate( 'Y-m-d H:i:s', current_time( 'timestamp' ) ) . "' "; // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 			$query['groupby'] = 'GROUP BY product_id';
 			$query['orderby'] = 'ORDER BY qty DESC';
 			$query['limits']  = 'LIMIT 1';
 
-			$sql = implode( ' ', apply_filters( 'woocommerce_dashboard_status_widget_top_seller_query', $query ) ); //phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			/**
+			 * Allows modification of the query to determine the top seller product in the dashboard status widget.
+			 *
+			 * @since 2.2.0
+			 *
+			 * @param array $query SQL query parts.
+			 */
+			$query = apply_filters( 'woocommerce_dashboard_status_widget_top_seller_query', $query );
 
-			return $wpdb->get_row( $sql );
+			$sql = implode( ' ', $query );
+			return $wpdb->get_row( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -210,9 +211,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			$processing_count = 0;
 
 			foreach ( wc_get_order_types( 'order-count' ) as $type ) {
-				$counts            = (array) wp_count_posts( $type );
-				$on_hold_count    += isset( $counts['wc-on-hold'] ) ? $counts['wc-on-hold'] : 0;
-				$processing_count += isset( $counts['wc-processing'] ) ? $counts['wc-processing'] : 0;
+				$counts            = OrderUtil::get_count_for_type( $type );
+				$on_hold_count    += $counts['wc-on-hold'];
+				$processing_count += $counts['wc-processing'];
 			}
 			?>
 			<li class="processing-orders">

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -201,6 +201,7 @@ final class OrderUtil {
 
 		if ( false === $count_per_status ) {
 			if ( self::custom_orders_table_usage_is_enabled() ) {
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 				$results = $wpdb->get_results(
 					$wpdb->prepare(
 						'SELECT `status`, COUNT(*) AS `count` FROM ' . self::get_table_for_orders() . ' WHERE `type` = %s GROUP BY `status`',
@@ -208,10 +209,11 @@ final class OrderUtil {
 					),
 					ARRAY_A
 				);
+				// phpcs:enable
 
 				$count_per_status = array_map( 'absint', array_column( $results, 'count', 'status' ) );
 			} else {
-				$count_per_status = wp_count_posts( $order_type );
+				$count_per_status = (array) wp_count_posts( $order_type );
 			}
 
 			// Make sure all order statuses are included just in case.

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -8,7 +8,6 @@ namespace Automattic\WooCommerce\Utilities;
 use Automattic\WooCommerce\Caches\OrderCacheController;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Utilities\COTMigrationUtil;
 use WC_Order;
 use WP_Post;

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -184,4 +184,46 @@ final class OrderUtil {
 	public static function get_table_for_order_meta() {
 		return wc_get_container()->get( COTMigrationUtil::class )->get_table_for_order_meta();
 	}
+
+	/**
+	 * Counts number of orders of a given type.
+	 *
+	 * @since 8.7.0
+	 *
+	 * @param string $order_type Order type.
+	 * @return array<string,int> Array of order counts indexed by order type.
+	 */
+	public static function get_count_for_type( $order_type ) {
+		global $wpdb;
+
+		$cache_key        = 'order-count-' . $order_type;
+		$count_per_status = wp_cache_get( $cache_key, 'orders' );
+
+		if ( false === $count_per_status ) {
+			if ( self::custom_orders_table_usage_is_enabled() ) {
+				$results = $wpdb->get_results(
+					$wpdb->prepare(
+						'SELECT `status`, COUNT(*) AS `count` FROM ' . self::get_table_for_orders() . ' WHERE `type` = %s GROUP BY `status`',
+						$order_type
+					),
+					ARRAY_A
+				);
+
+				$count_per_status = array_map( 'absint', array_column( $results, 'count', 'status' ) );
+			} else {
+				$count_per_status = wp_count_posts( $order_type );
+			}
+
+			// Make sure all order statuses are included just in case.
+			$count_per_status = array_merge(
+				array_fill_keys( array_keys( wc_get_order_statuses() ), 0 ),
+				$count_per_status
+			);
+
+			wp_cache_set( $cache_key, $count_per_status, 'orders' );
+		}
+
+		return $count_per_status;
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3392,6 +3392,8 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 *
 	 * @testWith ["hpos"]
 	 *           ["posts"]
+	 *
+	 * @param string $datastore_to_use Which datastore to use. Either 'hpos' or 'posts'.
 	 */
 	public function test_order_util_get_count_for_type( $datastore_to_use ) {
 		$this->disable_cot_sync();
@@ -3403,7 +3405,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		}
 
 		// Create a few orders in various states.
-		$order_statuses  = array_keys( wc_get_order_statuses() );
+		$order_statuses = array_keys( wc_get_order_statuses() );
 
 		$expected_counts = array_combine( $order_statuses, array_fill( 0, count( $order_statuses ), 0 ) );
 		foreach ( $order_statuses as $i => $status ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3387,4 +3387,44 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta` in order with ID ' . $order->get_id() . ': "\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"', end( $fake_logger->warnings )['message'] );
 	}
 
+	/**
+	 * Tests that OrderUtil::get_count_for_type() counts orders correctly.
+	 *
+	 * @testWith ["hpos"]
+	 *           ["posts"]
+	 */
+	public function test_order_util_get_count_for_type( $datastore_to_use ) {
+		$this->disable_cot_sync();
+
+		if ( 'hpos' === $datastore_to_use ) {
+			$this->toggle_cot_authoritative( true );
+		} else {
+			$this->toggle_cot_authoritative( false );
+		}
+
+		// Create a few orders in various states.
+		$order_statuses  = array_keys( wc_get_order_statuses() );
+
+		$expected_counts = array_combine( $order_statuses, array_fill( 0, count( $order_statuses ), 0 ) );
+		foreach ( $order_statuses as $i => $status ) {
+			foreach ( range( 0, $i ) as $_ ) {
+				$expected_counts[ $status ] = $i + 1;
+
+				$order = WC_Helper_Order::create_order();
+				$order->set_status( $status );
+				$order->save();
+			}
+		}
+
+		$real_counts = OrderUtil::get_count_for_type( 'shop_order' );
+		foreach ( $expected_counts as $status => $count ) {
+			$this->assertArrayHasKey( $status, $real_counts );
+			$this->assertEquals( $count, $real_counts[ $status ] );
+		}
+
+		$other_counts = OrderUtil::get_count_for_type( 'shop_something' );
+		$this->assertEquals( 0, array_pop( $other_counts ) );
+
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds HPOS compatibility to the dashboard status widget, which hasn't been working so far unless you had compatibility mode enabled.

Closes #40382.

<img width="641" alt="Screenshot 2024-02-16 at 19 19 22" src="https://github.com/woocommerce/woocommerce/assets/184724/2790e527-2037-4a4a-a745-8bf13b84d58c">



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with a few orders in different states and different products.
2. Go to WC > Settings > Advanced > Features and make sure HPOS is enabled. If necessary, sync orders (`wp wc cot sync` via CLI) so that you can switch datastores.
3. Make sure compatibility mode is _disabled_.
4. Go to "Dashboard" on your site's admin.
5. If the "WooCommerce Status" widget isn't displayed, make sure it is enabled inside "Screen Options". You might also need to complete the onboarding steps _or_ skip them by running the following command:
   ```
   wp option update woocommerce_task_list_hidden yes
   ```
6. Make sure the widget displays correctly and totals are not `0.0`.
7. Go back to WC > Settings > Advanced > Features and switch to the posts datastore.
8. Confirm that the widget continues to display correct information.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
