### PR TITLE
Add custom order fields drop-down to custom fields metabox under HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-44029
+++ b/plugins/woocommerce/changelog/fix-44029
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add used meta keys dropdown in HPOS custom fields metabox.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2786,6 +2786,17 @@ ul.wc_coupon_list_block {
 	}
 }
 
+#order_custom #postcustomstuff {
+	.add-custom-field {
+		padding: 12px 8px 8px;
+	}
+
+	.submit {
+		border: 0 none;
+		float: none;
+	}
+}
+
 #side-sortables #woocommerce-order-downloads {
 	.buttons,
 	.select2-container {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -176,10 +176,10 @@ class CustomMetaBox {
 							}
 							?>
 						</select>
-						<input class="hide-if-js" type="text" id="metakeyinput" name="metakeyinput" value="" />
-						<a href="#postcustomstuff" class="hide-if-no-js" onclick="jQuery('#metakeyinput, #metakeyselect, #enternew, #cancelnew').toggle();return false;">
-							<span id="enternew"><?php esc_html_e( 'Enter new', 'woocommerce' ); ?></span>
-							<span id="cancelnew" class="hidden"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></span></a>
+						<input class="hidden" type="text" id="metakeyinput" name="metakeyinput" value="" aria-label="<?php esc_attr_e( 'New custom field name', 'woocommerce' ); ?>" />
+						<button type="button" id="newmeta-button" class="button button-small hide-if-no-js" onclick="jQuery('#metakeyinput, #metakeyselect, #enternew, #cancelnew').toggleClass('hidden');jQuery('#metakeyinput, #metakeyselect').filter(':visible').trigger('focus');">
+						<span id="enternew"><?php esc_html_e( 'Enter new', 'woocommerce' ); ?></span>
+						<span id="cancelnew" class="hidden"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></span>
 					<?php } else { ?>
 						<input type="text" id="metakeyinput" name="metakeyinput" value="" />
 					<?php } ?>

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -169,7 +169,7 @@ class CustomMetaBox {
 							<option value="#NONE#"><?php esc_html_e( '&mdash; Select &mdash;', 'woocommerce' ); ?></option>
 							<?php
 							foreach ( $keys as $key ) {
-								if ( is_protected_meta( $key, 'post' ) || ! current_user_can( 'edit_others_shop_order', $order->get_id() ) ) {
+								if ( is_protected_meta( $key, 'post' ) || ! current_user_can( 'edit_others_shop_orders' ) ) {
 									continue;
 								}
 								echo "\n<option value='" . esc_attr( $key ) . "'>" . esc_html( $key ) . '</option>';

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -113,12 +113,7 @@ class CustomMetaBox {
 		 * @param \WC_Order  $order The current post object.
 		 */
 		$keys = apply_filters( 'postmeta_form_keys', null, $order );
-
-		$limit = 0;
-
-		if ( null === $keys ) {
-			$meta_data_store = wc_get_container()->get( OrdersTableDataStoreMeta::class );
-
+		if ( null === $keys || ! is_array( $keys ) ) {
 			/**
 			 * Compatibility filter for 'postmeta_form_limit', which filters the number of custom fields to retrieve
 			 * for the drop-down in the Custom Fields meta box.
@@ -127,15 +122,12 @@ class CustomMetaBox {
 			 *
 			 * @param int $limit Number of custom fields to retrieve. Default 30.
 			 */
-			$keys = $meta_data_store->get_meta_keys( apply_filters( 'postmeta_form_limit', 30 ) );
+			$limit = apply_filters( 'postmeta_form_limit', 30 );
+			$keys  = wc_get_container()->get( OrdersTableDataStoreMeta::class )->get_meta_keys( $limit );
 		}
 
 		if ( $keys ) {
 			natcasesort( $keys );
-		}
-
-		if ( $limit ) {
-			$keys = array_slice( $keys, 0, absint( $limit ) );
 		}
 
 		return $keys;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -242,8 +242,8 @@ class CustomMetaBox {
 		$order_id = (int) $_POST['order_id'] ?? 0;
 		$order    = $this->verify_order_edit_permission_for_ajax( $order_id );
 
-		$select_meta_key = sanitize_text_field( wp_unslash( trim( $_POST['metakeyselect'] ?? '' ) ) );
-		$input_meta_key  = sanitize_text_field( wp_unslash( trim( $_POST['metakeyinput'] ?? '' ) ) );
+		$select_meta_key = trim( sanitize_text_field( wp_unslash( $_POST['metakeyselect'] ?? '' ) ) );
+		$input_meta_key  = trim( sanitize_text_field( wp_unslash( $_POST['metakeyinput'] ?? '' ) ) );
 
 		if ( empty( $_POST['meta'] ) && in_array( $select_meta_key, array( '', '#NONE#' ), true ) && ! $input_meta_key ) {
 			wp_die( 1 );
@@ -254,7 +254,8 @@ class CustomMetaBox {
 			$this->handle_update_meta( $order, $meta );
 		} else { // add meta.
 			$meta_value = sanitize_text_field( wp_unslash( $_POST['metavalue'] ?? '' ) );
-			$this->handle_add_meta(  $order, $input_meta_key ?: $select_meta_key, $meta_value );
+			$meta_key   = $input_meta_key ? $input_meta_key : $select_meta_key;
+			$this->handle_add_meta( $order, $meta_key, $meta_value );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -249,12 +249,12 @@ class CustomMetaBox {
 			wp_die( 1 );
 		}
 
-		if ( $input_meta_key || $select_meta_key ) { // add meta.
-			$meta_value = sanitize_text_field( wp_unslash( $_POST['metavalue'] ?? '' ) );
-			$this->handle_add_meta(  $order, $input_meta_key ?: $select_meta_key, $meta_value );
-		} elseif ( ! empty( $_POST['meta'] ) ) {
+		if ( ! empty( $_POST['meta'] ) ) { // update.
 			$meta = wp_unslash( $_POST['meta'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitization done below in array_walk.
 			$this->handle_update_meta( $order, $meta );
+		} else { // add meta.
+			$meta_value = sanitize_text_field( wp_unslash( $_POST['metavalue'] ?? '' ) );
+			$this->handle_add_meta(  $order, $input_meta_key ?: $select_meta_key, $meta_value );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -242,16 +242,18 @@ class CustomMetaBox {
 		$order_id = (int) $_POST['order_id'] ?? 0;
 		$order    = $this->verify_order_edit_permission_for_ajax( $order_id );
 
-		if ( isset( $_POST['metakeyselect'] ) && '#NONE#' === $_POST['metakeyselect'] && empty( $_POST['metakeyinput'] ) ) {
+		$select_meta_key = sanitize_text_field( wp_unslash( trim( $_POST['metakeyselect'] ?? '' ) ) );
+		$input_meta_key  = sanitize_text_field( wp_unslash( trim( $_POST['metakeyinput'] ?? '' ) ) );
+
+		if ( empty( $_POST['meta'] ) && in_array( $select_meta_key, array( '', '#NONE#' ), true ) && ! $input_meta_key ) {
 			wp_die( 1 );
 		}
 
-		if ( isset( $_POST['metakeyinput'] ) ) { // add meta.
-			$meta_key   = sanitize_text_field( wp_unslash( $_POST['metakeyinput'] ) );
+		if ( $input_meta_key || $select_meta_key ) { // add meta.
 			$meta_value = sanitize_text_field( wp_unslash( $_POST['metavalue'] ?? '' ) );
-			$this->handle_add_meta( $order, $meta_key, $meta_value );
-		} else { // update.
-			$meta = wp_unslash( $_POST['meta'] ?? array() ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitization done below in array_walk.
+			$this->handle_add_meta(  $order, $input_meta_key ?: $select_meta_key, $meta_value );
+		} elseif ( ! empty( $_POST['meta'] ) ) {
+			$meta = wp_unslash( $_POST['meta'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitization done below in array_walk.
 			$this->handle_update_meta( $order, $meta );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -177,28 +177,27 @@ class CustomMetaBox {
 						<input type="text" id="metakeyinput" name="metakeyinput" value="" />
 					<?php } ?>
 				</td>
-				<td><textarea id="metavalue" name="metavalue" rows="2" cols="25"></textarea></td>
+				<td><textarea id="metavalue" name="metavalue" rows="2" cols="25"></textarea>
+				<?php wp_nonce_field( 'add-meta', '_ajax_nonce-add-meta', false ); ?>
+				</td>
 			</tr>
-
-			<tr><td colspan="2">
-					<div class="submit">
-						<?php
-						submit_button(
-							__( 'Add Custom Field', 'woocommerce' ),
-							'',
-							'addmeta',
-							false,
-							array(
-								'id'            => 'newmeta-submit',
-								'data-wp-lists' => 'add:the-list:newmeta',
-							)
-						);
-						?>
-					</div>
-					<?php wp_nonce_field( 'add-meta', '_ajax_nonce-add-meta', false ); ?>
-				</td></tr>
 			</tbody>
 		</table>
+
+		<div class="submit add-custom-field">
+			<?php
+			submit_button(
+				__( 'Add Custom Field', 'woocommerce' ),
+				'',
+				'addmeta',
+				false,
+				array(
+					'id'            => 'newmeta-submit',
+					'data-wp-lists' => 'add:the-list:newmeta',
+				)
+			);
+			?>
+		</div>
 		<?php
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -92,7 +92,6 @@ class CustomMetaBox {
 	 * Compute keys to display in autofill when adding new meta key entry in custom meta box.
 	 * Currently, returns empty keys, will be implemented after caching is merged.
 	 *
-	 * @param array|null         $keys Keys to display in autofill.
 	 * @param \WP_Post|\WC_Order $order Order object.
 	 *
 	 * @return array|mixed Array of keys to display in autofill.
@@ -118,7 +117,16 @@ class CustomMetaBox {
 
 		if ( null === $keys ) {
 			$meta_data_store = wc_get_container()->get( OrdersTableDataStoreMeta::class );
-			$keys            = $meta_data_store->get_meta_keys( apply_filters( 'postmeta_form_limit', 30 ) );
+
+			/**
+			 * Compatibility filter for 'postmeta_form_limit', which filters the number of custom fields to retrieve
+			 * for the drop-down in the Custom Fields meta box.
+			 *
+			 * @since 8.7.0
+			 *
+			 * @param int $limit Number of custom fields to retrieve. Default 30.
+			 */
+			$keys = $meta_data_store->get_meta_keys( apply_filters( 'postmeta_form_limit', 30 ) );
 		}
 
 		if ( $keys ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -92,11 +92,12 @@ class CustomMetaBox {
 	 * Compute keys to display in autofill when adding new meta key entry in custom meta box.
 	 * Currently, returns empty keys, will be implemented after caching is merged.
 	 *
+	 * @param mixed $deprecated Unused argument. For backwards compatibility.
 	 * @param \WP_Post|\WC_Order $order Order object.
 	 *
-	 * @return array|mixed Array of keys to display in autofill.
+	 * @return array Array of keys to display in autofill.
 	 */
-	public function order_meta_keys_autofill( $order ) {
+	public function order_meta_keys_autofill( $deprecated, $order ) {
 		if ( ! is_a( $order, \WC_Order::class ) ) {
 			return array();
 		}
@@ -150,7 +151,7 @@ class CustomMetaBox {
 	public function render_meta_form( \WC_Order $order ) : void {
 		$meta_key_input_id = 'metakeyselect';
 
-		$keys = $this->order_meta_keys_autofill( $order );
+		$keys = $this->order_meta_keys_autofill( null, $order );
 		?>
 		<p><strong><?php esc_html_e( 'Add New Custom Field:', 'woocommerce' ); ?></strong></p>
 		<table id="newmeta">

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -122,7 +122,7 @@ class CustomMetaBox {
 			 * Compatibility filter for 'postmeta_form_limit', which filters the number of custom fields to retrieve
 			 * for the drop-down in the Custom Fields meta box.
 			 *
-			 * @since 8.7.0
+			 * @since 8.8.0
 			 *
 			 * @param int $limit Number of custom fields to retrieve. Default 30.
 			 */

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -92,8 +92,8 @@ class CustomMetaBox {
 	 * Compute keys to display in autofill when adding new meta key entry in custom meta box.
 	 * Currently, returns empty keys, will be implemented after caching is merged.
 	 *
-	 * @param mixed $deprecated Unused argument. For backwards compatibility.
-	 * @param \WP_Post|\WC_Order $order Order object.
+	 * @param mixed              $deprecated Unused argument. For backwards compatibility.
+	 * @param \WP_Post|\WC_Order $order      Order object.
 	 *
 	 * @return array Array of keys to display in autofill.
 	 */

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -260,7 +260,7 @@ abstract class CustomMetaDataStore {
 			$query .= $wpdb->prepare( 'LIMIT %d ', $limit );
 		}
 
-		return $wpdb->get_col( $query );
+		return $wpdb->get_col( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $query is prepared.
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -235,7 +235,7 @@ abstract class CustomMetaDataStore {
 	/**
 	 * Returns distinct meta keys in use.
 	 *
-	 * @since 8.7.0
+	 * @since 8.8.0
 	 *
 	 * @param int    $limit           Maximum number of meta keys to return. Defaults to 100.
 	 * @param string $order           Order to use for the results. Either 'ASC' or 'DESC'. Defaults to 'ASC'.

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -232,4 +232,35 @@ abstract class CustomMetaDataStore {
 		return $meta;
 	}
 
+	/**
+	 * Returns distinct meta keys in use.
+	 *
+	 * @since 8.7.0
+	 *
+	 * @param int    $limit           Maximum number of meta keys to return. Defaults to 100.
+	 * @param string $order           Order to use for the results. Either 'ASC' or 'DESC'. Defaults to 'ASC'.
+	 * @param bool   $include_private Whether to include private meta keys in the results. Defaults to FALSE.
+	 * @return string[]
+	 */
+	public function get_meta_keys( $limit = 100, $order = 'ASC', $include_private = false ) {
+		global $wpdb;
+
+		$db_info = $this->get_db_info();
+
+		$query = "SELECT DISTINCT meta_key FROM {$db_info['table']} ";
+
+		if ( ! $include_private ) {
+			$query .= $wpdb->prepare( 'WHERE meta_key NOT LIKE %s ', $wpdb->esc_like( '_' ) . '%' );
+		}
+
+		$order  = in_array( $order, array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';
+		$query .= 'ORDER BY meta_key ' . $order . ' ';
+
+		if ( $limit ) {
+			$query .= $wpdb->prepare( 'LIMIT %d ', $limit );
+		}
+
+		return $wpdb->get_col( $query );
+	}
+
 }

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -253,7 +253,7 @@ abstract class CustomMetaDataStore {
 			$query .= $wpdb->prepare( 'WHERE meta_key NOT LIKE %s ', $wpdb->esc_like( '_' ) . '%' );
 		}
 
-		$order  = in_array( $order, array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';
+		$order  = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';
 		$query .= 'ORDER BY meta_key ' . $order . ' ';
 
 		if ( $limit ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR brings to HPOS the dropdown of custom fields that is available for regular posts in the WP admin edit screen.
This dropdown lists a selection of non-private meta keys from _all_ other orders allowing easy re-use.

<img width="977" alt="Screenshot 2024-02-23 at 11 04 39" src="https://github.com/woocommerce/woocommerce/assets/184724/e31576e9-4104-4fe6-bd82-c8dca82b8fb2">
<img width="969" alt="Screenshot 2024-02-23 at 11 04 45" src="https://github.com/woocommerce/woocommerce/assets/184724/9a6766b4-0da1-44f9-9e13-7e9f9ee71d84">

Closes #44029.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is the selected order datastore in WC > Settings > Advanced > Features.
1. Ideally, start with a 0 orders setup.
1. Go to WC > Orders > Add order and confirm that no dropdown appears in the "Custom Fields" metabox and instead you see a regular input:
   <img width="1004" alt="Screenshot 2024-03-01 at 10 53 32" src="https://github.com/woocommerce/woocommerce/assets/184724/d73f2f7f-8367-414c-91cc-7a84bb76af12">
1. Fill out the order fields and make sure to also add a few meta keys / values inside the "Custom Fields" metabox. Make sure to add at least a few that don't start with `_` as those are considered private.
1. Click "Create" to save the order.
1. Confirm that the "Add New Custom Field" form inside the "Custom Fields" metabox has a drop-down listing meta keys from other orders.
1. Test that you can add metadata to the order by choosing a meta key from the dropdown and specifying the value.
1. Test that you can add metadata to the order by clicking "Enter new" and entering any meta key / value combination.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
