### PR TITLE
APIv1 > Orders Controller > Avoid deprecated means of accessing coupon data

### DIFF
--- a/plugins/woocommerce/changelog/fix-39006-apiv1-orders-coupons-deprecations
+++ b/plugins/woocommerce/changelog/fix-39006-apiv1-orders-coupons-deprecations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Updates REST API V1 (though it generally should no longer be used) to prevent the emission of various deprecation notices.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -321,9 +321,9 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 		foreach ( $order->get_items( 'coupon' ) as $coupon_item_id => $coupon_item ) {
 			$coupon_line = array(
 				'id'           => $coupon_item_id,
-				'code'         => $coupon_item['name'],
-				'discount'     => wc_format_decimal( $coupon_item['discount_amount'], $dp ),
-				'discount_tax' => wc_format_decimal( $coupon_item['discount_amount_tax'], $dp ),
+				'code'         => $coupon_item->get_name(),
+				'discount'     => wc_format_decimal( $coupon_item->get_discount(), $dp ),
+				'discount_tax' => wc_format_decimal( $coupon_item->get_discount_tax(), $dp ),
 			);
 
 			$data['coupon_lines'][] = $coupon_line;

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller-tests.php
@@ -1,0 +1,44 @@
+<?php
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+
+/**
+ * Tests relating to WC_REST_Product_Reviews_V1_Controller.
+ */
+class WC_REST_Orders_V1_Controller_Tests extends WC_Unit_Test_Case {
+	/**
+	 * Test that an order can be fetched via REST API V1 without triggering a deprecation notice.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/39006
+	 *
+	 * @return void
+	 */
+	public function test_orders_with_coupons_can_be_fetched(): void {
+		// Create a legacy order (APIv1 does not work with HPOS).
+		if ( get_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ) !== 'no' ) {
+			$this->markTestSkipped( 'This test only runs when HPOS is not enabled.' );
+		}
+
+		// Create an order and apply a coupon.
+		CouponHelper::create_coupon( 'savebig' );
+		$coupon_line_item = new WC_Order_Item_Coupon();
+		$coupon_line_item->set_code( 'savebig' );
+
+		$order = OrderHelper::create_order();
+		$order->add_item( $coupon_line_item );
+		$order->save();
+
+		$api_request  = new WP_REST_Request( 'GET', '/wc/v1/orders/' . $order->get_id() );
+		$controller   = new WC_REST_Orders_V1_Controller();
+		$api_response = $controller->prepare_item_for_response( get_post( $order->get_id() ), $api_request );
+
+		$this->assertInstanceOf(
+			WP_REST_Response::class,
+			$api_response,
+			'API response was generated successfully, and without triggering a deprecation notice.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updates code inside our deprecated API v1 orders controller (some merchants rely on services that have not yet transitioned to currently supported versions of the REST API), to help prevent their logs from being peppered with unwanted noise.

Closes https://github.com/woocommerce/woocommerce/issues/39006.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Our expectations are that, functionally, nothing has changed as a result of this fix.
2. To confirm, start by creating an order. 
    - Ensure that "Compatibility Mode" is activated in WooCommerce > Settings > Advanced > Features under "Order data storage". REST API v1 is not compatible with HPOS, so the data needs to be available in the wp_posts table.
    - You can do this via the storefront, or manually in the admin environment, or else via the REST API.
    - It doesn't really matter how it is created, so long as your order uses a valid coupon code.
    - Make a note of the order ID.
3. Using REST API v1, fetch the order. Example below, using curl (but feel free to use whatever tool you prefer). Remember to update your authorization token, domain, and order ID.

```sh
curl -k -H "Authorization: Basic SUPPLY_YOUR_TOKEN_HERE" \
    "https://example/wp-json/wc/v1/orders/123456"
```

4. The response should be identical, regardless of whether you use this branch or `trunk`. When verifying this, pay particular attention to the `coupon_lines` section.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
