### PR TITLE
[WIP] [Experimental] Remove fe filter variations in favor of separately registered wrapper blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/constants.ts
@@ -1,7 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 export const BLOCK_NAME_MAP = {
 	'active-filters': 'woocommerce/product-filter-active',
 	'price-filter': 'woocommerce/product-filter-price',
 	'stock-filter': 'woocommerce/product-filter-stock-status',
 	'rating-filter': 'woocommerce/product-filter-rating',
 	'attribute-filter': 'woocommerce/product-filter-attribute',
+};
+
+export const BLOCK_TITLE_MAP = {
+	'active-filters': __(
+		'Product Filter: Active Filters (Beta)',
+		'woocommerce'
+	),
+	'price-filter': __( 'Product Filter: Price (Beta)', 'woocommerce' ),
+	'stock-filter': __( 'Product Filter: Stock Status (Beta)', 'woocommerce' ),
+	'rating-filter': __( 'Product Filter: Rating (Beta)', 'woocommerce' ),
+	'attribute-filter': __( 'Product Filter: Attribute (Beta)', 'woocommerce' ),
+};
+
+export const BLOCK_ICON_MAP = {
+	'active-filters': 'filter',
+	'price-filter': 'currency',
+	'stock-filter': 'box',
+	'rating-filter': 'star-filled',
+	'attribute-filter': 'tag',
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/index.tsx
@@ -6,17 +6,8 @@ import {
 	createBlock,
 	registerBlockType,
 } from '@wordpress/blocks';
-import {
-	Icon,
-	box,
-	category,
-	currencyDollar,
-	more,
-	starEmpty,
-} from '@wordpress/icons';
+import { Icon, more } from '@wordpress/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
-import { __ } from '@wordpress/i18n';
-import { toggle } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -24,167 +15,81 @@ import { toggle } from '@woocommerce/icons';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
-import { BLOCK_NAME_MAP } from './constants';
+import { BLOCK_NAME_MAP, BLOCK_TITLE_MAP } from './constants';
 import { BlockAttributes } from './types';
 
 if ( isExperimentalBuild() ) {
-	registerBlockType( metadata, {
-		icon: {
-			src: (
-				<Icon
-					icon={ more }
-					className="wc-block-editor-components-block-icon"
-				/>
-			),
-		},
-		edit,
-		save,
-		variations: [
-			{
-				name: 'product-filter-active',
-				title: __(
-					'Product Filter: Active Filters (Beta)',
-					'woocommerce'
-				),
-				description: __(
-					'Display the currently active filters.',
-					'woocommerce'
-				),
-				attributes: {
-					heading: __( 'Active filters', 'woocommerce' ),
-					filterType: 'active-filters',
+	for ( const filterType of Object.keys( BLOCK_NAME_MAP ) as Array<
+		keyof typeof BLOCK_NAME_MAP
+	> ) {
+		const blockMeta = {
+			...metadata,
+			name: `${ BLOCK_NAME_MAP[ filterType ] }-wrapper`,
+			title: BLOCK_TITLE_MAP[ filterType ],
+			attributes: {
+				...metadata.attributes,
+				filterType: {
+					type: 'string',
+					default: filterType,
 				},
-				icon: {
-					src: (
-						<Icon
-							icon={ toggle }
-							className="wc-block-editor-components-block-icon"
-						/>
-					),
-				},
-				isDefault: true,
-			},
-			{
-				name: 'product-filter-price',
-				title: __( 'Product Filter: Price (Beta)', 'woocommerce' ),
-				description: __(
-					'Enable customers to filter the product collection by choosing a price range.',
-					'woocommerce'
-				),
-				attributes: {
-					filterType: 'price-filter',
-					heading: __( 'Filter by Price', 'woocommerce' ),
-				},
-				icon: {
-					src: (
-						<Icon
-							icon={ currencyDollar }
-							className="wc-block-editor-components-block-icon"
-						/>
-					),
+				heading: {
+					type: 'string',
+					default: BLOCK_TITLE_MAP[ filterType ],
 				},
 			},
-			{
-				name: 'product-filter-stock-status',
-				title: __(
-					'Product Filter: Stock Status (Beta)',
-					'woocommerce'
-				),
-				description: __(
-					'Enable customers to filter the product collection by stock status.',
-					'woocommerce'
-				),
-				attributes: {
-					filterType: 'stock-filter',
-					heading: __( 'Filter by Stock Status', 'woocommerce' ),
-				},
-				icon: {
-					src: (
-						<Icon
-							icon={ box }
-							className="wc-block-editor-components-block-icon"
-						/>
-					),
-				},
-			},
-			{
-				name: 'product-filter-attribute',
-				title: __( 'Product Filter: Attribute (Beta)', 'woocommerce' ),
-				description: __(
-					'Enable customers to filter the product collection by selecting one or more attributes, such as color.',
-					'woocommerce'
-				),
-				attributes: {
-					filterType: 'attribute-filter',
-					heading: __( 'Filter by Attribute', 'woocommerce' ),
-				},
-				icon: {
-					src: (
-						<Icon
-							icon={ category }
-							className="wc-block-editor-components-block-icon"
-						/>
-					),
-				},
-			},
-			{
-				name: 'product-filter-rating',
-				title: __( 'Product Filter: Rating (Beta)', 'woocommerce' ),
-				description: __(
-					'Enable customers to filter the product collection by rating.',
-					'woocommerce'
-				),
-				attributes: {
-					filterType: 'rating-filter',
-					heading: __( 'Filter by Rating', 'woocommerce' ),
-				},
-				icon: {
-					src: (
-						<Icon
-							icon={ starEmpty }
-							className="wc-block-editor-components-block-icon"
-						/>
-					),
-				},
-			},
-		],
-		transforms: {
-			from: [
-				{
-					type: 'block',
-					blocks: [ 'woocommerce/filter-wrapper' ],
-					transform: (
-						attributes: BlockAttributes,
-						innerBlocks: BlockInstance[]
-					) => {
-						const newInnerBlocks: BlockInstance[] = [];
-						// Loop through inner blocks to preserve the block order.
-						innerBlocks.forEach( ( block ) => {
-							if (
-								block.name ===
-								`woocommerce/${ attributes.filterType }`
-							) {
-								newInnerBlocks.push(
-									createBlock(
-										BLOCK_NAME_MAP[ attributes.filterType ],
-										block.attributes
-									)
-								);
-							}
+		};
 
-							if ( block.name === 'core/heading' ) {
-								newInnerBlocks.push( block );
-							}
-						} );
+		registerBlockType( blockMeta, {
+			icon: {
+				src: (
+					<Icon
+						icon={ more }
+						className="wc-block-editor-components-block-icon"
+					/>
+				),
+			},
+			edit,
+			save,
+			transforms: {
+				from: [
+					{
+						type: 'block',
+						blocks: [ 'woocommerce/filter-wrapper' ],
+						transform: (
+							attributes: BlockAttributes,
+							innerBlocks: BlockInstance[]
+						) => {
+							const newInnerBlocks: BlockInstance[] = [];
+							// Loop through inner blocks to preserve the block order.
+							innerBlocks.forEach( ( block ) => {
+								if (
+									block.name ===
+									`woocommerce/${ attributes.filterType }`
+								) {
+									newInnerBlocks.push(
+										createBlock(
+											BLOCK_NAME_MAP[
+												attributes.filterType
+											],
+											block.attributes
+										)
+									);
+								}
 
-						return createBlock(
-							'woocommerce/product-filter',
-							attributes,
-							newInnerBlocks
-						);
+								if ( block.name === 'core/heading' ) {
+									newInnerBlocks.push( block );
+								}
+							} );
+
+							return createBlock(
+								`${ BLOCK_NAME_MAP[ filterType ] }-wrapper`,
+								attributes,
+								newInnerBlocks
+							);
+						},
 					},
-				},
-			],
-		},
-	} );
+				],
+			},
+		} );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The wrapper blocks for the front-end filters are always named "Product Filter" which makes for confusing block hierarchy. A user should be able to see what filter its for without expanding the block tree. This fixes that by registering separate blocks for each wrapper block instead of using variations. 

Resolves https://github.com/woocommerce/woocommerce/issues/44752
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

TBD
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
