### PR TITLE
[Experimental] Fix a bug in new attribute filter where we didn't set the attribute from content panel

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/components/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/components/inspector-controls.tsx
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { BlockEditProps } from '@wordpress/blocks';
 import {
 	PanelBody,
 	ToggleControl,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/components/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/components/inspector-controls.tsx
@@ -23,8 +23,11 @@ import { BlockAttributes } from '../types';
 
 export const Inspector = ( {
 	attributes,
-	setAttributes,
-}: BlockEditProps< BlockAttributes > ) => {
+	setAttributeId,
+}: {
+	attributes: BlockAttributes;
+	setAttributeId: ( id: unknown ) => void;
+} ) => {
 	const { attributeId, showCounts, queryType, displayStyle, selectType } =
 		attributes;
 	return (
@@ -120,7 +123,7 @@ export const Inspector = ( {
 				<AttributeSelectControls
 					isCompact={ true }
 					attributeId={ attributeId }
-					setAttributes={ setAttributes }
+					setAttributeId={ setAttributeId }
 				/>
 			</PanelBody>
 		</InspectorControls>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/edit.tsx
@@ -115,6 +115,7 @@ const Edit = ( props: EditProps ) => {
 	const [ isEditing, setIsEditing ] = useState(
 		! attributeId && ! isPreview
 	);
+
 	const [ attributeOptions, setAttributeOptions ] = useState<
 		AttributeTerm[]
 	>( [] );
@@ -240,13 +241,18 @@ const Edit = ( props: EditProps ) => {
 			</Wrapper>
 		);
 
+	const inspectorProps = {
+		...props,
+		setAttributeId,
+	};
+
 	return (
 		<Wrapper
 			onClickToolbarEdit={ toggleEditing }
 			isEditing={ isEditing }
 			blockProps={ blockProps }
 		>
-			<Inspector { ...props } />
+			<Inspector { ...inspectorProps } />
 			<Disabled>
 				{ displayStyle === 'dropdown' ? (
 					<AttributeDropdown

--- a/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/style.scss
@@ -117,10 +117,14 @@
 		padding: $gap-small 0;
 		text-align: center;
 		border: none;
+		display: flex;
+		justify-content: center;
 
 		.woocommerce-search-list__not-found-icon,
 		.woocommerce-search-list__not-found-text {
-			display: inline-block;
+			display: flex;
+			align-content: center;
+			flex-wrap: wrap;
 		}
 
 		.woocommerce-search-list__not-found-icon {
@@ -236,7 +240,7 @@
 
 		@for $i from 1 to 5 {
 			&.depth-#{$i} {
-				padding-left: $gap * ( $i + 1 );
+				padding-left: $gap * ($i + 1);
 			}
 
 			&.depth-#{$i} .woocommerce-search-list__item-label::before {

--- a/plugins/woocommerce/changelog/44757-dev-fe-filters-fix-content-panel-bug
+++ b/plugins/woocommerce/changelog/44757-dev-fe-filters-fix-content-panel-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+[Experimental] Fix a bug in new attribute filter where we didn't set the attribute from content panel


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Solves https://github.com/woocommerce/woocommerce/issues/44756

When implementing the attribute filter block, we missed that it was not setting the attribute when editing it from the inspector "content" panel. This fixes that bug.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add the new product filter: attribute (beta) filter block to a page or template
2. Choose an attribute to filter by and click done.
3. Select the block, now open inspector panel, go to "content", try changing the attribute to see it update, also confirm search filtering of the attributes works as before.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[Experimental] Fix a bug in new attribute filter where we didn't set the attribute from content panel

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
