### PR TITLE
fix: shipping tour should not show usps/dhl to non-us merchants

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -68,7 +68,6 @@ const useShowShippingTour = () => {
 		};
 	} );
 
-	console.log( 'isLoading', isLoading, businessCountry );
 	return {
 		isLoading,
 		show:

--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -13,6 +13,10 @@ import {
 } from '@wordpress/element';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+/**
+ * Internal dependencies
+ */
+import { getCountryCode } from '~/dashboard/utils';
 
 const REVIEWED_DEFAULTS_OPTION =
 	'woocommerce_admin_reviewed_default_shipping_zones';
@@ -37,6 +41,7 @@ const useShowShippingTour = () => {
 	const {
 		hasCreatedDefaultShippingZones,
 		hasReviewedDefaultShippingOptions,
+		businessCountry,
 		isLoading,
 	} = useSelect( ( select ) => {
 		const { hasFinishedResolution, getOption } =
@@ -49,14 +54,21 @@ const useShowShippingTour = () => {
 				] ) &&
 				! hasFinishedResolution( 'getOption', [
 					REVIEWED_DEFAULTS_OPTION,
+				] ) &&
+				! hasFinishedResolution( 'getOption', [
+					'woocommerce_default_country',
 				] ),
 			hasCreatedDefaultShippingZones:
 				getOption( CREATED_DEFAULTS_OPTION ) === 'yes',
 			hasReviewedDefaultShippingOptions:
 				getOption( REVIEWED_DEFAULTS_OPTION ) === 'yes',
+			businessCountry: getCountryCode(
+				getOption( 'woocommerce_default_country' ) as string
+			),
 		};
 	} );
 
+	console.log( 'isLoading', isLoading, businessCountry );
 	return {
 		isLoading,
 		show:
@@ -64,6 +76,7 @@ const useShowShippingTour = () => {
 			! isLoading &&
 			hasCreatedDefaultShippingZones &&
 			! hasReviewedDefaultShippingOptions,
+		isUspsDhlEligible: businessCountry === 'US',
 	};
 };
 
@@ -203,7 +216,7 @@ export const ShippingTour: React.FC< {
 	showShippingRecommendationsStep: boolean;
 } > = ( { showShippingRecommendationsStep } ) => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
-	const { show: showTour } = useShowShippingTour();
+	const { show: showTour, isUspsDhlEligible } = useShowShippingTour();
 	const [ step, setStepNumber ] = useState( 0 );
 	const { createNotice } = useDispatch( 'core/notices' );
 
@@ -326,7 +339,7 @@ export const ShippingTour: React.FC< {
 
 	const isWcsSectionPresent = document.querySelector( WCS_LINK_SELECTOR );
 
-	if ( isWcsSectionPresent ) {
+	if ( isWcsSectionPresent && isUspsDhlEligible ) {
 		tourConfig.steps.push( {
 			referenceElements: {
 				desktop: WCS_LINK_SELECTOR,

--- a/plugins/woocommerce/changelog/fix-shipping-tour-usps-dhl
+++ b/plugins/woocommerce/changelog/fix-shipping-tour-usps-dhl
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixed shipping tour so that it doesn't show USPS/DHL for non-US customers
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #https://github.com/woocommerce/woocommerce/issues/38111

- added conditional check for US business location before showing the USPS/DHL tip in shipping tour

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up woocommerce and make sure that business location is set to somewhere in US, and Woo Shipping & Taxes plugin is installed in the Core Profiler store setup process. Also ensure that Marketplace suggestions are enabled in WooCommerce settings > Woo.com as it is a precondition for the shipping tour to show up.
2. Go to shipping settings and observe that the USPS/DHL step is shown (as per screenshot)
3. Change country to non-US locale and observe that the USPS/DHL step is no longer shown


<img width="1565" alt="image" src="https://github.com/woocommerce/woocommerce/assets/27843274/44db93ce-e194-4fea-95d3-aa07ae4ca62d">

<img width="1574" alt="image" src="https://github.com/woocommerce/woocommerce/assets/27843274/78b2a78f-2b1f-4843-abf8-5f9026560b0f">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
