### PR TITLE
Open templates from list instead of loading the URL in block templates e2e tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
@@ -22,7 +22,7 @@ type TemplateCustomizationTest = {
 		templateName: string;
 		templatePath: string;
 	};
-	canBeOverridenByThemes: boolean;
+	canBeOverriddenByThemes: boolean;
 };
 
 export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
@@ -32,7 +32,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		templateName: 'Product Catalog',
 		templatePath: 'archive-product',
 		templateType: 'wp_template',
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { page } ) =>
@@ -40,7 +40,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		templateName: 'Product Search Results',
 		templatePath: 'product-search-results',
 		templateType: 'wp_template',
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { page } ) => await page.goto( '/color/blue' ),
@@ -51,7 +51,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 			templateName: 'Product Catalog',
 			templatePath: 'archive-product',
 		},
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { page } ) =>
@@ -63,7 +63,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 			templateName: 'Product Catalog',
 			templatePath: 'archive-product',
 		},
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { page } ) =>
@@ -75,14 +75,14 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 			templateName: 'Product Catalog',
 			templatePath: 'archive-product',
 		},
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { page } ) => await page.goto( '/product/hoodie' ),
 		templateName: 'Single Product',
 		templatePath: 'single-product',
 		templateType: 'wp_template',
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { frontendUtils } ) => {
@@ -97,7 +97,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		templateName: 'Mini-Cart',
 		templatePath: 'mini-cart',
 		templateType: 'wp_template_part',
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { frontendUtils } ) =>
@@ -105,7 +105,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		templateName: 'Page: Cart',
 		templatePath: 'page-cart',
 		templateType: 'wp_template',
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { frontendUtils } ) => {
@@ -117,7 +117,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		templateName: 'Page: Checkout',
 		templatePath: 'page-checkout',
 		templateType: 'wp_template',
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 	{
 		visitPage: async ( { frontendUtils } ) => {
@@ -133,7 +133,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		// automatically override the checkout header. That's because the
 		// Page: Checkout template still points to the default `checkout-header`
 		// from WooCommerce.
-		canBeOverridenByThemes: false,
+		canBeOverriddenByThemes: false,
 	},
 	{
 		visitPage: async ( { frontendUtils, page } ) => {
@@ -147,7 +147,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		templateName: 'Order Confirmation',
 		templatePath: 'order-confirmation',
 		templateType: 'wp_template',
-		canBeOverridenByThemes: true,
+		canBeOverriddenByThemes: true,
 	},
 ];
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
@@ -9,6 +9,7 @@ import type { FrontendUtils } from '@woocommerce/e2e-utils';
  */
 import { SIMPLE_VIRTUAL_PRODUCT_NAME } from '../checkout/constants';
 import { CheckoutPage } from '../checkout/checkout.page';
+import type { TemplateType } from '../../utils/types';
 
 type TemplateCustomizationTest = {
 	visitPage: ( props: {
@@ -17,7 +18,7 @@ type TemplateCustomizationTest = {
 	} ) => Promise< void | Response | null >;
 	templateName: string;
 	templatePath: string;
-	templateType: 'wp_template' | 'wp_template_part';
+	templateType: TemplateType;
 	fallbackTemplate?: {
 		templateName: string;
 		templatePath: string;

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -3,11 +3,16 @@
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
 
+/**
+ * Internal dependencies
+ */
+import type { TemplateType } from '../../utils/types';
+
 const testData = {
 	permalink: '/product/belt',
 	templateName: 'Single Product Belt',
 	templatePath: 'single-product-belt',
-	templateType: 'wp_template' as 'wp_template' | 'wp_template_part',
+	templateType: 'wp_template' as TemplateType,
 };
 
 const userText = 'Hello World in the Belt template';

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-import { BLOCK_THEME_WITH_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 const testData = {
 	permalink: '/product/belt',
 	templateName: 'Single Product Belt',
 	templatePath: 'single-product-belt',
-	templateType: 'wp_template',
+	templateType: 'wp_template' as 'wp_template' | 'wp_template_part',
 };
 
 const userText = 'Hello World in the Belt template';
@@ -25,12 +24,10 @@ test.describe( 'Single Product Template', async () => {
 		page,
 	} ) => {
 		// Edit the theme template.
-		await admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
-			postType: testData.templateType,
-		} );
-		await editorUtils.enterEditMode();
-		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.visitTemplateEditor(
+			testData.templateName,
+			testData.templateType
+		);
 		await editorUtils.editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: userText },

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Internal dependencies
  */
-import { CUSTOMIZABLE_WC_TEMPLATES, WC_TEMPLATES_SLUG } from './constants';
+import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
 
 CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 	if ( ! testData.canBeOverridenByThemes ) {
@@ -32,12 +32,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			page,
 		} ) => {
 			// Edit the WooCommerce default template
-			await admin.visitSiteEditor( {
-				postId: `${ WC_TEMPLATES_SLUG }//${ testData.templatePath }`,
-				postType: testData.templateType,
-			} );
-			await editorUtils.enterEditMode();
-			await editorUtils.closeWelcomeGuideModal();
+			await editorUtils.visitTemplateEditor(
+				testData.templateName,
+				testData.templateType
+			);
 			await editorUtils.editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: { content: woocommerceTemplateUserText },
@@ -49,12 +47,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			);
 
 			// Edit the theme template.
-			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
-				postType: testData.templateType,
-			} );
-			await editorUtils.enterEditMode();
-			await editorUtils.closeWelcomeGuideModal();
+			await editorUtils.visitTemplateEditor(
+				testData.templateName,
+				testData.templateType
+			);
 			await editorUtils.editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: { content: userText },

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -46,11 +46,15 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 				`npm run wp-env run tests-cli -- wp theme activate ${ BLOCK_THEME_WITH_TEMPLATES_SLUG }`
 			);
 
-			// Edit the theme template.
-			await editorUtils.visitTemplateEditor(
-				testData.templateName,
-				testData.templateType
-			);
+			// Edit the theme template. The theme template is not
+			// directly available from the UI, because the customized
+			// one takes priority, so we go directly to its URL.
+			await admin.visitSiteEditor( {
+				postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
+				postType: testData.templateType,
+			} );
+			await editorUtils.enterEditMode();
+			await editorUtils.closeWelcomeGuideModal();
 			await editorUtils.editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: { content: userText },

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -14,7 +14,7 @@ import {
 import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
 
 CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
-	if ( ! testData.canBeOverridenByThemes ) {
+	if ( ! testData.canBeOverriddenByThemes ) {
 		return;
 	}
 	const userText = `Hello World in the ${ testData.templateName } template`;

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -6,7 +6,7 @@ import { test, expect } from '@woocommerce/e2e-playwright-utils';
 /**
  * Internal dependencies
  */
-import { CUSTOMIZABLE_WC_TEMPLATES, WC_TEMPLATES_SLUG } from './constants';
+import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
 
 CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 	const userText = `Hello World in the ${ testData.templateName } template`;
@@ -26,12 +26,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			page,
 		} ) => {
 			// Verify the template can be edited.
-			await admin.visitSiteEditor( {
-				postId: `${ WC_TEMPLATES_SLUG }//${ testData.templatePath }`,
-				postType: testData.templateType,
-			} );
-			await editorUtils.enterEditMode();
-			await editorUtils.closeWelcomeGuideModal();
+			await editorUtils.visitTemplateEditor(
+				testData.templateName,
+				testData.templateType
+			);
 			await editorUtils.editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: { content: userText },
@@ -68,14 +66,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 				page,
 			} ) => {
 				// Edit fallback template and verify changes are visible.
-				await admin.visitSiteEditor( {
-					postId: `${ WC_TEMPLATES_SLUG }//${
-						testData.fallbackTemplate?.templatePath || ''
-					}`,
-					postType: testData.templateType,
-				} );
-				await editorUtils.enterEditMode();
-				await editorUtils.closeWelcomeGuideModal();
+				await editorUtils.visitTemplateEditor(
+					testData.templateName,
+					testData.templateType
+				);
 				await editorUtils.editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -67,7 +67,7 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			} ) => {
 				// Edit fallback template and verify changes are visible.
 				await editorUtils.visitTemplateEditor(
-					testData.templateName,
+					testData.fallbackTemplate?.templateName || '',
 					testData.templateType
 				);
 				await editorUtils.editor.insertBlock( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -79,7 +79,7 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			} ) => {
 				// Edit default template and verify changes are not visible, as the theme template has priority.
 				await editorUtils.visitTemplateEditor(
-					testData.templateName,
+					testData.fallbackTemplate?.templateName || '',
 					testData.templateType
 				);
 				await editorUtils.editor.insertBlock( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-import { BLOCK_THEME_WITH_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -30,12 +29,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 			page,
 		} ) => {
 			// Edit the theme template.
-			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
-				postType: testData.templateType,
-			} );
-			await editorUtils.enterEditMode();
-			await editorUtils.closeWelcomeGuideModal();
+			await editorUtils.visitTemplateEditor(
+				testData.templateName,
+				testData.templateType
+			);
 			await editorUtils.editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: { content: userText },
@@ -81,14 +78,10 @@ CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 				page,
 			} ) => {
 				// Edit default template and verify changes are not visible, as the theme template has priority.
-				await admin.visitSiteEditor( {
-					postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${
-						testData.fallbackTemplate?.templatePath || ''
-					}`,
-					postType: testData.templateType,
-				} );
-				await editorUtils.enterEditMode();
-				await editorUtils.closeWelcomeGuideModal();
+				await editorUtils.visitTemplateEditor(
+					testData.templateName,
+					testData.templateType
+				);
 				await editorUtils.editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -9,7 +9,7 @@ import { test, expect } from '@woocommerce/e2e-playwright-utils';
 import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
 
 CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
-	if ( ! testData.canBeOverridenByThemes ) {
+	if ( ! testData.canBeOverriddenByThemes ) {
 		return;
 	}
 	const userText = `Hello World in the ${ testData.templateName } template`;

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -2,17 +2,15 @@
  * External dependencies
  */
 import { Page } from '@playwright/test';
-import { Admin, Editor } from '@wordpress/e2e-test-utils-playwright';
+import { Editor } from '@wordpress/e2e-test-utils-playwright';
 import { BlockRepresentation } from '@wordpress/e2e-test-utils-playwright/build-types/editor/insert-block';
 
 export class EditorUtils {
 	editor: Editor;
 	page: Page;
-	admin: Admin;
-	constructor( editor: Editor, page: Page, admin: Admin ) {
+	constructor( editor: Editor, page: Page ) {
 		this.editor = editor;
 		this.page = page;
-		this.admin = admin;
 	}
 
 	/**

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -376,15 +376,38 @@ export class EditorUtils {
 		templateName: string,
 		templateType: 'wp_template' | 'wp_template_part'
 	) {
-		await this.page.goto(
-			`/wp-admin/site-editor.php?path=/${ templateType }/all`
-		);
-		const templateLink = this.page.getByRole( 'link', {
-			name: templateName,
-			exact: true,
-		} );
-		templateLink.click();
+		if ( templateType === 'wp_template_part' ) {
+			await this.page.goto(
+				`/wp-admin/site-editor.php?path=/${ templateType }/all`
+			);
+			const templateLink = this.page.getByRole( 'link', {
+				name: templateName,
+				exact: true,
+			} );
+			await templateLink.click();
+		} else {
+			await this.page.goto(
+				`/wp-admin/site-editor.php?path=/${ templateType }`
+			);
+			const templateButton = this.page.getByRole( 'button', {
+				name: templateName,
+				exact: true,
+			} );
+			await templateButton.click();
+		}
+
+		await this.enterEditMode();
 		await this.closeWelcomeGuideModal();
+		await this.waitForSiteEditorFinishLoading();
+
+		// Verify we are editing the correct template and it has the correct title.
+		const templateTypeName =
+			templateType === 'wp_template' ? 'template' : 'template part';
+		await this.page
+			.getByRole( 'heading', {
+				name: `Editing ${ templateTypeName }: ${ templateName }`,
+			} )
+			.waitFor();
 	}
 
 	async revertTemplateCreation( templateName: string ) {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -2,15 +2,17 @@
  * External dependencies
  */
 import { Page } from '@playwright/test';
-import { Editor } from '@wordpress/e2e-test-utils-playwright';
+import { Admin, Editor } from '@wordpress/e2e-test-utils-playwright';
 import { BlockRepresentation } from '@wordpress/e2e-test-utils-playwright/build-types/editor/insert-block';
 
 export class EditorUtils {
 	editor: Editor;
 	page: Page;
-	constructor( editor: Editor, page: Page ) {
+	admin: Admin;
+	constructor( editor: Editor, page: Page, admin: Admin ) {
 		this.editor = editor;
 		this.page = page;
+		this.admin = admin;
 	}
 
 	/**
@@ -370,6 +372,21 @@ export class EditorUtils {
 			.getByRole( 'button', { name: 'Dismiss this notice' } )
 			.getByText( 'Site updated.' )
 			.waitFor();
+	}
+
+	async visitTemplateEditor(
+		templateName: string,
+		templateType: 'wp_template' | 'wp_template_part'
+	) {
+		await this.page.goto(
+			`/wp-admin/site-editor.php?path=/${ templateType }/all`
+		);
+		const templateLink = this.page.getByRole( 'link', {
+			name: templateName,
+			exact: true,
+		} );
+		templateLink.click();
+		await this.closeWelcomeGuideModal();
 	}
 
 	async revertTemplateCreation( templateName: string ) {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -5,6 +5,11 @@ import { Page } from '@playwright/test';
 import { Editor } from '@wordpress/e2e-test-utils-playwright';
 import { BlockRepresentation } from '@wordpress/e2e-test-utils-playwright/build-types/editor/insert-block';
 
+/**
+ * Internal dependencies
+ */
+import type { TemplateType } from '../../utils/types';
+
 export class EditorUtils {
 	editor: Editor;
 	page: Page;
@@ -374,7 +379,7 @@ export class EditorUtils {
 
 	async visitTemplateEditor(
 		templateName: string,
-		templateType: 'wp_template' | 'wp_template_part'
+		templateType: TemplateType
 	) {
 		if ( templateType === 'wp_template_part' ) {
 			await this.page.goto(

--- a/plugins/woocommerce-blocks/tests/e2e/utils/types.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/types.ts
@@ -1,0 +1,1 @@
+export type TemplateType = 'wp_template' | 'wp_template_part';

--- a/plugins/woocommerce/changelog/44774-update-e2e-tests-open-template-from-list
+++ b/plugins/woocommerce/changelog/44774-update-e2e-tests-open-template-from-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Open templates from list instead of loading the URL in block templates e2e tests
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR creates a new util named `editorUtils.visitTemplateEditor()`. It has some benefits:

1. It encapsulates the logic of opening a template in the site editor, entering edit mode and closing the welcome modal.
2. It simulates the user going to the template list and clicking on the template with the provided name. With the old approach, we would go directly to the template screen URL. This new approach is more similar to what a real user would do and allows us to catch bugs where the template might be listed with the incorrect title or URL.

In addition to that, this PR fixes a typo: `canBeOverridenByThemes` → `canBeOverriddenByThemes`.

### How to test the changes in this Pull Request:

Note: no need to test this for the release.

1. Verify e2e tests pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Open templates from list instead of loading the URL in block templates e2e tests

</details>
