### PR TITLE
Fix attribute terms orderby term_id

### DIFF
--- a/plugins/woocommerce/changelog/44780-patch-1
+++ b/plugins/woocommerce/changelog/44780-patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix ordering of attribute terms

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -38,6 +38,7 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 		case 'menu_order':
 		case 'name_num':
 		case 'parent':
+		case 'id':
 			$defaults['orderby'] = $orderby;
 			break;
 	}


### PR DESCRIPTION
Fixes #45521 sorting attribute terms by their ID. 
Currently this setting will cause the attribute terms ordered by name instead.

<img width="1534" alt="Screenshot 2024-02-20 at 10 47 51" src="https://github.com/woocommerce/woocommerce/assets/4417047/0a84e66a-abfa-4854-b17e-1fcac2786b01">

<img width="1136" alt="Screenshot 2024-02-20 at 10 50 42" src="https://github.com/woocommerce/woocommerce/assets/4417047/c4bf9e3d-c312-45f3-a0e9-b61561d30d80">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to `Products > Attributes`
2. Create an attribute and set `Default sort order` to `Term ID`
3. Add new attribute terms
4. Terms are order by name instead.
5. Apply this patch, now the attribute terms are ordered by their ID 

<img width="1532" alt="Screenshot 2024-02-20 at 10 51 53" src="https://github.com/woocommerce/woocommerce/assets/4417047/f33e648c-9ca1-4c46-9937-30989be1b81f">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix ordering of attribute terms

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
