### PR TITLE
Remote Spec Splits - Create new value 1 - 120

### DIFF
--- a/plugins/woocommerce/changelog/44786-add-woocommerce_remote_variant
+++ b/plugins/woocommerce/changelog/44786-add-woocommerce_remote_variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a new remote variant for random distribution of cohort assignment.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -285,7 +285,7 @@ final class WooCommerce {
 	 * Add woocommerce_inbox_variant for the Remote Inbox Notification.
 	 *
 	 * P2 post can be found at https://wp.me/paJDYF-1uJ.
-	 * 
+	 *
 	 * This will no longer be used. The more flexible add_woocommerce_remote_variant
 	 * below will be used instead.
 	 */
@@ -295,9 +295,9 @@ final class WooCommerce {
 			update_option( $config_name, wp_rand( 1, 12 ) );
 		}
 	}
-		
+
 	/**
-	 * Add woocommerce_remote_variant_assignment used to determine cohort 
+	 * Add woocommerce_remote_variant_assignment used to determine cohort
 	 * or group assignment for Remote Spec Engines.
 	 */
 	public function add_woocommerce_remote_variant() {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -250,6 +250,8 @@ final class WooCommerce {
 		add_action( 'deactivated_plugin', array( $this, 'deactivated_plugin' ) );
 		add_action( 'woocommerce_installed', array( $this, 'add_woocommerce_inbox_variant' ) );
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_inbox_variant' ) );
+		add_action( 'woocommerce_installed', array( $this, 'add_woocommerce_remote_variant' ) );
+		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 
 		// These classes set up hooks on instantiation.
 		$container = wc_get_container();
@@ -283,6 +285,9 @@ final class WooCommerce {
 	 * Add woocommerce_inbox_variant for the Remote Inbox Notification.
 	 *
 	 * P2 post can be found at https://wp.me/paJDYF-1uJ.
+	 * 
+	 * This will no longer be used. The more flexible add_woocommerce_remote_variant
+	 * below will be used instead.
 	 */
 	public function add_woocommerce_inbox_variant() {
 		$config_name = 'woocommerce_inbox_variant_assignment';
@@ -290,6 +295,18 @@ final class WooCommerce {
 			update_option( $config_name, wp_rand( 1, 12 ) );
 		}
 	}
+		
+	/**
+	 * Add woocommerce_remote_variant_assignment used to determine cohort 
+	 * or group assignment for Remote Spec Engines.
+	 */
+	public function add_woocommerce_remote_variant() {
+		$config_name = 'woocommerce_remote_variant_assignment';
+		if ( false === get_option( $config_name, false ) ) {
+			update_option( $config_name, wp_rand( 1, 120 ) );
+		}
+	}
+
 	/**
 	 * Ensures fatal errors are logged so they can be picked up in the status report.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `woocommerce_inbox_variant_assignment` option has been used to randomly assign an installation toward a cohort or group for purposes of testing Remote Inbox Notifications (RIN). The RIN engine has since been expanded to include various other promotions or suggestions to merchants and WooCommerce has outgrown the splitting capability of `woocommerce_inbox_variant_assignment`'s 1-2 assignment.

This PR proposes creating new option for the same purpose, but 1-120 called `woocommerce_remote_variant_assignment` which is more agnostic to current and future use cases.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Locally you can reinstall WC `pnpm env:restart` or otherwise use a fresh JN site
2. From the CLI, make sure the new otpion exists, `wp option get woocommerce_remote_variant_assignment`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a new remote variant for random distribution of cohort assignment.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
