### PR TITLE
Restore nonce and store notices after hydrating data from controllers.

### DIFF
--- a/plugins/woocommerce/changelog/fix-44080
+++ b/plugins/woocommerce/changelog/fix-44080
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Follow up fixup to unreleased change, no changelog necessary.
+
+

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -65,21 +65,22 @@ class Hydration {
 				$schema_controller->get( $controller_class::SCHEMA_TYPE, $controller_class::SCHEMA_VERSION )
 			);
 
-			$response = $controller->get_response( $request );
-			return array(
+			$response       = $controller->get_response( $request );
+			$preloaded_data = array(
 				'body'    => $response->get_data(),
 				'headers' => $response->get_headers(),
 			);
+		} else {
+			// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
+			$preloaded_requests = rest_preload_api_request( [], $path );
+			$preloaded_data     = $preloaded_requests[ $path ] ?? [];
 		}
-
-		// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
-		$preloaded_requests = rest_preload_api_request( [], $path );
 
 		$this->restore_cached_store_notices();
 		$this->restore_nonce_check();
 
 		// Returns just the single preloaded request, or an empty array if it doesn't exist.
-		return $preloaded_requests[ $path ] ?? [];
+		return $preloaded_data;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -57,6 +57,8 @@ class Hydration {
 
 		$this->cache_store_notices();
 
+		$preloaded_data = array();
+
 		if ( null !== $controller_class ) {
 			$request           = new \WP_REST_Request( 'GET', $path );
 			$schema_controller = StoreApi::container()->get( SchemaController::class );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #44080, we inadvertently added a bug where we were returning early without restoring the notice and nonce checks that needed to be disabled before hydration requests. This PR is a fixup to place it back in.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

There is no clear option to test this from UX, so we will use custom snippets.

1. Add the following snippet to your test site which adds a dummy notice:
```php

add_filter( 'init', function () {
	if( ! function_exists( 'wc_has_notice' ) || WC()->session === null ) {
		return;
	}
	$notice = 'This is a test notice';
	if( ! wc_has_notice( $notice ) ) {
		wc_add_notice( $notice );
	}

	\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Domain\Services\Hydration::class )
		->get_rest_api_response_data( '/wc/store/v1/cart' );
});

```
3. Add any product in cart and go to the cart page.
4. You should see the test notice: `'This is a test notice'`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
