### PR TITLE
Blocks E2E: Stabilize Product Collection "on sale" tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -56,20 +56,20 @@ test.describe( 'Product Collection', () => {
 			pageObject,
 		} ) => {
 			await pageObject.setNumberOfColumns( 2 );
-			await expect(
-				await pageObject.productTemplate.getAttribute( 'class' )
-			).toContain( 'columns-2' );
+			await expect( pageObject.productTemplate ).toHaveClass(
+				/columns-2/
+			);
 
 			await pageObject.setNumberOfColumns( 4 );
-			await expect(
-				await pageObject.productTemplate.getAttribute( 'class' )
-			).toContain( 'columns-4' );
+			await expect( pageObject.productTemplate ).toHaveClass(
+				/columns-4/
+			);
 
 			await pageObject.publishAndGoToFrontend();
 
-			await expect(
-				await pageObject.productTemplate.getAttribute( 'class' )
-			).toContain( 'columns-4' );
+			await expect( pageObject.productTemplate ).toHaveClass(
+				/columns-4/
+			);
 		} );
 
 		test( 'Order By - sort products by title in descending order correctly', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -100,7 +100,7 @@ test.describe( 'Product Collection', () => {
 			await expect( pageObject.products ).toHaveCount( 9 );
 			// All products should not be on sale.
 			await expect(
-				await pageObject.productImages.filter( {
+				pageObject.productImages.filter( {
 					hasText: 'Product on sale',
 				} )
 			).not.toHaveCount( 9 );
@@ -114,7 +114,7 @@ test.describe( 'Product Collection', () => {
 
 			// Expect all shown products to be on sale.
 			await expect(
-				await pageObject.productImages.filter( {
+				pageObject.productImages.filter( {
 					hasText: 'Product on sale',
 				} )
 			).toHaveCount( await pageObject.productImages.count() );
@@ -122,7 +122,7 @@ test.describe( 'Product Collection', () => {
 			await pageObject.publishAndGoToFrontend();
 			await expect( pageObject.products ).toHaveCount( 6 );
 			await expect(
-				await pageObject.productImages.filter( {
+				pageObject.productImages.filter( {
 					hasText: 'Product on sale',
 				} )
 			).toHaveCount( await pageObject.productImages.count() );
@@ -449,18 +449,18 @@ test.describe( 'Product Collection', () => {
 				maxPageToShow: 2,
 			} );
 
-			await expect( await pageObject.products ).toHaveCount( 3 );
+			await expect( pageObject.products ).toHaveCount( 3 );
 
 			await pageObject.setDisplaySettings( {
 				itemsPerPage: 2,
 				offset: 0,
 				maxPageToShow: 2,
 			} );
-			await expect( await pageObject.products ).toHaveCount( 2 );
+			await expect( pageObject.products ).toHaveCount( 2 );
 
 			await pageObject.publishAndGoToFrontend();
 
-			await expect( await pageObject.products ).toHaveCount( 2 );
+			await expect( pageObject.products ).toHaveCount( 2 );
 
 			const paginationNumbers =
 				pageObject.pagination.locator( '.page-numbers' );
@@ -959,13 +959,13 @@ test.describe( 'Product Collection', () => {
 				collection: 'productCatalog',
 			} );
 
-			await expect(
+			expect(
 				url.searchParams.has( 'productCollectionQueryContext[id]' )
 			).toBeTruthy();
 
 			// There shouldn't be collection in the query context
 			// Because Product Catalog isn't a collection
-			await expect(
+			expect(
 				url.searchParams.has(
 					'productCollectionQueryContext[collection]'
 				)
@@ -982,8 +982,8 @@ test.describe( 'Product Collection', () => {
 			const collectionName = url.searchParams.get(
 				'productCollectionQueryContext[collection]'
 			);
-			await expect( collectionName ).toBeTruthy();
-			await expect( collectionName ).toBe(
+			expect( collectionName ).toBeTruthy();
+			expect( collectionName ).toBe(
 				'woocommerce/product-collection/on-sale'
 			);
 		} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -93,39 +93,28 @@ test.describe( 'Product Collection', () => {
 		} );
 
 		// Products can be filtered based on 'on sale' status.
-		test( 'Products can be filtered based on "on sale" status.', async ( {
+		test( 'Products can be filtered based on "on sale" status', async ( {
 			pageObject,
 		} ) => {
-			// On each page we show 9 products.
-			await expect( pageObject.products ).toHaveCount( 9 );
-			// All products should not be on sale.
-			await expect(
-				pageObject.productImages.filter( {
-					hasText: 'Product on sale',
-				} )
-			).not.toHaveCount( 9 );
+			const allProducts = pageObject.products;
+			const salePoducts = pageObject.products.filter( {
+				hasText: 'Product on sale',
+			} );
+
+			await expect( allProducts ).toHaveCount( 9 );
+			await expect( salePoducts ).toHaveCount( 6 );
 
 			await pageObject.setShowOnlyProductsOnSale( {
 				onSale: true,
 			} );
 
-			// In test data we have only 6 products on sale
-			await expect( pageObject.products ).toHaveCount( 6 );
-
-			// Expect all shown products to be on sale.
-			await expect(
-				pageObject.productImages.filter( {
-					hasText: 'Product on sale',
-				} )
-			).toHaveCount( await pageObject.productImages.count() );
+			await expect( allProducts ).toHaveCount( 6 );
+			await expect( salePoducts ).toHaveCount( 6 );
 
 			await pageObject.publishAndGoToFrontend();
-			await expect( pageObject.products ).toHaveCount( 6 );
-			await expect(
-				pageObject.productImages.filter( {
-					hasText: 'Product on sale',
-				} )
-			).toHaveCount( await pageObject.productImages.count() );
+
+			await expect( allProducts ).toHaveCount( 6 );
+			await expect( salePoducts ).toHaveCount( 6 );
 		} );
 
 		test( 'Products can be filtered based on selection in handpicked products option', async ( {

--- a/plugins/woocommerce/changelog/tweak-stabilize-product-collection-e2e
+++ b/plugins/woocommerce/changelog/tweak-stabilize-product-collection-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stabilize the 'Products can be filtered based on "on sale" status' E2E test.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fix flaky `Products can be filtered based on "on sale" status` test.

  [This test was flaky](https://github.com/woocommerce/woocommerce/pull/44796/commits/6e13ec91fdecdfd30c6333a24915e69b0af09924) because we compared the current count of elements to an unknown count of elements calculated by `locator.count()`. That method is inherently unstable because it includes only the currently available elements, whereas the rest might still be loading.
  
- Clean up the suite & apply some good practices.

### How to test the changes in this Pull Request:

There no need to test manually. This suite should pass in CI. For safe measure, it should be restarted a couple of times to ensure the aforementioned test was indeed stabilized. 