### PR TITLE
[CYS] Disable the Change fonts items and add the "Coming soon" badge

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -29,7 +29,6 @@ import { Look } from '~/customize-store/design-with-ai/types';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
 import { FlowType } from '~/customize-store/types';
 import { FontFamily } from './font-families-loader-dot-com';
-import { isAIFlow } from '~/customize-store/guards';
 
 export const FontPairing = () => {
 	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
@@ -46,10 +45,6 @@ export const FontPairing = () => {
 	} );
 
 	const { useGlobalSetting } = unlock( blockEditorPrivateApis );
-
-	const [ custom ] = useGlobalSetting( 'typography.fontFamilies.custom' ) as [
-		Array< FontFamily >
-	];
 
 	const { context } = useContext( CustomizeStoreContext );
 	const aiOnline = context.flowType === FlowType.AIOnline;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -8,12 +8,6 @@ import { __experimentalGrid as Grid, Spinner } from '@wordpress/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useContext, useMemo } from '@wordpress/element';
-import {
-	privateApis as blockEditorPrivateApis,
-	// @ts-ignore no types exist yet.
-} from '@wordpress/block-editor';
-// @ts-expect-error no types exist yet.
-import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 
 /**
  * Internal dependencies
@@ -28,7 +22,6 @@ import { FontPairingVariationPreview } from './preview';
 import { Look } from '~/customize-store/design-with-ai/types';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
 import { FlowType } from '~/customize-store/types';
-import { FontFamily } from './font-families-loader-dot-com';
 
 export const FontPairing = () => {
 	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
@@ -43,8 +36,6 @@ export const FontPairing = () => {
 			] ),
 		};
 	} );
-
-	const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
 	const { context } = useContext( CustomizeStoreContext );
 	const aiOnline = context.flowType === FlowType.AIOnline;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-main.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-main.tsx
@@ -32,6 +32,28 @@ import { recordEvent } from '@woocommerce/tracks';
 import { SidebarNavigationScreen } from './sidebar-navigation-screen';
 import { ADMIN_URL } from '~/utils/admin-settings';
 
+const ComingSoonSideBarNavigationItem = ( {
+	children,
+	...rest
+}: {
+	children: React.ReactNode;
+} ) => {
+	const comingSoonBadge = (
+		<span className="woocommerce-badge">
+			{ __( 'Coming soon', 'woocommerce' ) }
+		</span>
+	);
+	return (
+		<SidebarNavigationItem
+			withChevron={ false }
+			suffix={ comingSoonBadge }
+			{ ...rest }
+		>
+			{ children }
+		</SidebarNavigationItem>
+	);
+};
+
 export const SidebarNavigationScreenMain = () => {
 	return (
 		<SidebarNavigationScreen
@@ -104,9 +126,9 @@ export const SidebarNavigationScreenMain = () => {
 							{ __( 'Change the color palette', 'woocommerce' ) }
 						</NavigatorButton>
 						<NavigatorButton
-							as={ SidebarNavigationItem }
+							as={ ComingSoonSideBarNavigationItem }
+							disabled={ true }
 							path="/customize-store/assembler-hub/typography"
-							withChevron
 							icon={ typography }
 							onClick={ () => {
 								recordEvent(

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -487,7 +487,7 @@
 
 	.woocommerce-customize-store_sidebar-typography-upgrade-notice {
 		margin-top: 48px;
-		color: #1E1E1E;
+		color: #1e1e1e;
 		font-size: 11px;
 		padding: 0;
 		h4 {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -231,6 +231,15 @@
 				line-height: 16px; /* 123.077% */
 				letter-spacing: -0.078px;
 			}
+
+			.woocommerce-badge {
+				font-size: 0.6875rem;
+				font-weight: 400;
+				border-radius: 4px;
+				padding: 3px 8px 3px 8px;
+				line-height: 16px;
+				height: auto;
+			}
 		}
 
 		.edit-site-sidebar-navigation-item.components-item .edit-site-sidebar-navigation-item__drilldown-indicator {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR disables and adds the "Coming soon" badge to the "Change fonts" section on the assembler.
The section is going to be disabled until the WordPress 6.5 release.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the `WooCommerce Beta Tester` plugin is installed and activated (available on this monorepo).
2. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
3. Go to `WooCommerce > Home`, click on `Start customizing`, and finish the flow.
4. Check the `Change fonts` sections looks like this 👇 and it's disabled
<img width="384" alt="Screenshot 2024-02-20 at 16 36 20" src="https://github.com/woocommerce/woocommerce/assets/186112/00f9a2ab-0912-48ce-8711-bec9664315f2">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
