### PR TITLE
Update usages of WooCommerce Blocks version checks

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-version-cleanup
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-version-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update usages of WooCommerce Blocks version checks to use WooCommerce core version when possible

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -298,7 +298,7 @@ class BlockPatterns {
 	public function schedule_on_plugin_update( $upgrader_object, $options ) {
 		if ( 'update' === $options['action'] && 'plugin' === $options['type'] && isset( $options['plugins'] ) ) {
 			foreach ( $options['plugins'] as $plugin ) {
-				if ( str_contains( $plugin, 'woocommerce-gutenberg-products-block.php' ) || str_contains( $plugin, 'woocommerce.php' ) ) {
+				if ( str_contains( $plugin, 'woocommerce.php' ) ) {
 					$business_description = get_option( 'woo_ai_describe_store_description' );
 
 					if ( $business_description ) {

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Domain;
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\AssetsController;
@@ -106,9 +107,9 @@ class Bootstrap {
 		$this->load_interactivity_api();
 
 		// This is just a temporary solution to make sure the migrations are run. We have to refactor this. More details: https://github.com/woocommerce/woocommerce-blocks/issues/10196.
-		if ( $this->package->get_version() !== $this->package->get_version_stored_on_db() ) {
+		if ( $this->package->get_woocommerce_blocks_version() !== $this->package->get_woocommerce_blocks_version_stored_on_db() ) {
 			$this->migration->run_migrations();
-			$this->package->set_version_stored_on_db();
+			$this->package->set_woocommerce_blocks_version_stored_on_db();
 		}
 
 		add_action(
@@ -387,28 +388,28 @@ class Bootstrap {
 		$this->container->register(
 			'Automattic\WooCommerce\Blocks\StoreApi\Formatters',
 			function( Container $container ) {
-				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\StoreApi\Formatters', '7.2.0', 'Automattic\WooCommerce\StoreApi\Formatters', '7.4.0' );
+				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\StoreApi\Formatters', '6.4.0', 'Automattic\WooCommerce\StoreApi\Formatters', '6.5.0' );
 				return $container->get( StoreApi::class )->container()->get( \Automattic\WooCommerce\StoreApi\Formatters::class );
 			}
 		);
 		$this->container->register(
 			'Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi',
 			function( Container $container ) {
-				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi', '7.2.0', 'Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema', '7.4.0' );
+				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi', '6.4.0', 'Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema', '6.5.0' );
 				return $container->get( StoreApi::class )->container()->get( \Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema::class );
 			}
 		);
 		$this->container->register(
 			'Automattic\WooCommerce\Blocks\StoreApi\SchemaController',
 			function( Container $container ) {
-				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\StoreApi\SchemaController', '7.2.0', 'Automattic\WooCommerce\StoreApi\SchemaController', '7.4.0' );
+				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\StoreApi\SchemaController', '6.4.0', 'Automattic\WooCommerce\StoreApi\SchemaController', '6.5.0' );
 				return $container->get( StoreApi::class )->container()->get( SchemaController::class );
 			}
 		);
 		$this->container->register(
 			'Automattic\WooCommerce\Blocks\StoreApi\RoutesController',
 			function( Container $container ) {
-				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\StoreApi\RoutesController', '7.2.0', 'Automattic\WooCommerce\StoreApi\RoutesController', '7.4.0' );
+				$this->deprecated_dependency( 'Automattic\WooCommerce\Blocks\StoreApi\RoutesController', '6.4.0', 'Automattic\WooCommerce\StoreApi\RoutesController', '6.5.0' );
 				return $container->get( StoreApi::class )->container()->get( RoutesController::class );
 			}
 		);
@@ -479,7 +480,7 @@ class Bootstrap {
 		}
 
 		// If the $trigger_error_version was not yet reached, only log the error.
-		if ( version_compare( $this->package->get_version(), $trigger_error_version, '<' ) ) {
+		if ( version_compare( Constants::get_constant( 'WC_VERSION' ), $trigger_error_version, '<' ) ) {
 			$log_error = true;
 		}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -107,9 +107,9 @@ class Bootstrap {
 		$this->load_interactivity_api();
 
 		// This is just a temporary solution to make sure the migrations are run. We have to refactor this. More details: https://github.com/woocommerce/woocommerce-blocks/issues/10196.
-		if ( $this->package->get_woocommerce_blocks_version() !== $this->package->get_woocommerce_blocks_version_stored_on_db() ) {
+		if ( $this->package->get_version() !== $this->package->get_version_stored_on_db() ) {
 			$this->migration->run_migrations();
-			$this->package->set_woocommerce_blocks_version_stored_on_db();
+			$this->package->set_version_stored_on_db();
 		}
 
 		add_action(

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -56,74 +56,34 @@ class Package {
 	}
 
 	/**
-	 * Returns the version of WooCommerce Blocks. Since Blocks was merged into
-	 * WooCommerce Core, this method has been deprecated.
+	 * Returns the version of WooCommerce Blocks.
 	 *
-	 * @deprecated 8.7.0
-	 * @return string
-	 */
-	public function get_version() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '8.7.0', 'WC_VERSION' );
-		return $this->get_woocommerce_blocks_version();
-	}
-
-	/**
-	 * Returns the version of WooCommerce Blocks for internal usage. Needed for
-	 * tasks like migrations.
-	 * Note that the version of WooCommerce Blocks doesn't update anymore. Use
+	 * Note: since Blocks was merged into WooCommerce Core, the version of
+	 * WC Blocks doesn't update anymore. Use
 	 * `Constants::get_constant( 'WC_VERSION' )` when possible to get the
 	 * WooCommerce Core version.
 	 *
-	 * @internal
 	 * @return string
 	 */
-	public function get_woocommerce_blocks_version() {
+	public function get_version() {
 		return $this->version;
 	}
 
 	/**
-	 * Returns the version of WooCommerce stored in the database. Since Blocks
-	 * was merged into WooCommerce Core, this method has been deprecated.
+	 * Returns the version of WooCommerce Blocks stored in the database.
 	 *
-	 * @deprecated 8.7.0
 	 * @return string
 	 */
 	public function get_version_stored_on_db() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '8.7.0' );
-		return $this->get_woocommerce_blocks_version_stored_on_db();
-	}
-
-	/**
-	 * Returns the version of WooCommerce Blocks store in the database for
-	 * internal usage. Needed for tasks like migrations.
-	 *
-	 * @internal
-	 * @return string
-	 */
-	public function get_woocommerce_blocks_version_stored_on_db() {
 		return get_option( Options::WC_BLOCK_VERSION, '' );
 	}
 
 	/**
-	 * Sets the version of WooCommerce Blocks in the database. Needed for
-	 * tasks like migrations.
+	 * Sets the version of WooCommerce Blocks in the database.
 	 * This is useful during the first installation or after the upgrade process.
-	 *
-	 * @deprecated 8.7.0
 	 */
 	public function set_version_stored_on_db() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '8.7.0' );
-		$this->set_woocommerce_blocks_version_stored_on_db();
-	}
-
-	/**
-	 * Sets the version of WooCommerce Blocks in the database. Intended to be
-	 * used only internally.
-	 *
-	 * @internal
-	 */
-	public function set_woocommerce_blocks_version_stored_on_db() {
-		update_option( Options::WC_BLOCK_VERSION, $this->get_woocommerce_blocks_version() );
+		update_option( Options::WC_BLOCK_VERSION, $this->get_version() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -56,30 +56,74 @@ class Package {
 	}
 
 	/**
-	 * Returns the version of the plugin.
+	 * Returns the version of WooCommerce Blocks. Since Blocks was merged into
+	 * WooCommerce Core, this method has been deprecated.
 	 *
+	 * @deprecated 8.7.0
 	 * @return string
 	 */
 	public function get_version() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '8.7.0', 'WC_VERSION' );
+		return $this->get_woocommerce_blocks_version();
+	}
+
+	/**
+	 * Returns the version of WooCommerce Blocks for internal usage. Needed for
+	 * tasks like migrations.
+	 * Note that the version of WooCommerce Blocks doesn't update anymore. Use
+	 * `Constants::get_constant( 'WC_VERSION' )` when possible to get the
+	 * WooCommerce Core version.
+	 *
+	 * @internal
+	 * @return string
+	 */
+	public function get_woocommerce_blocks_version() {
 		return $this->version;
 	}
 
 	/**
-	 * Returns the version of the plugin stored in the database.
+	 * Returns the version of WooCommerce stored in the database. Since Blocks
+	 * was merged into WooCommerce Core, this method has been deprecated.
 	 *
+	 * @deprecated 8.7.0
 	 * @return string
 	 */
 	public function get_version_stored_on_db() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '8.7.0' );
+		return $this->get_woocommerce_blocks_version_stored_on_db();
+	}
+
+	/**
+	 * Returns the version of WooCommerce Blocks store in the database for
+	 * internal usage. Needed for tasks like migrations.
+	 *
+	 * @internal
+	 * @return string
+	 */
+	public function get_woocommerce_blocks_version_stored_on_db() {
 		return get_option( Options::WC_BLOCK_VERSION, '' );
 	}
 
 	/**
-	 * Set the version of the plugin stored in the database.
+	 * Sets the version of WooCommerce Blocks in the database. Needed for
+	 * tasks like migrations.
 	 * This is useful during the first installation or after the upgrade process.
+	 *
+	 * @deprecated 8.7.0
 	 */
 	public function set_version_stored_on_db() {
-		update_option( Options::WC_BLOCK_VERSION, $this->get_version() );
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '8.7.0' );
+		$this->set_woocommerce_blocks_version_stored_on_db();
+	}
 
+	/**
+	 * Sets the version of WooCommerce Blocks in the database. Intended to be
+	 * used only internally.
+	 *
+	 * @internal
+	 */
+	public function set_woocommerce_blocks_version_stored_on_db() {
+		update_option( Options::WC_BLOCK_VERSION, $this->get_woocommerce_blocks_version() );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/44688.

This PR includes these changes:

* `BlockPatterns.php` still had an instance checking for the `woocommerce-gutenberg-products-block.php` file, I removed it as it shouldn't be needed anymore.
* `Bootstrap::deprecated_dependency()` has been updated to use WC core versions instead of WC Blocks'.

<details>
<summary>Previous changes</summary>

* ~`Package->get_version()`, `Package->get_version_stored_on_db()` and `Package->set_version_stored_on_db()` have been deprecated. Instead, we recommend using `WC_VERSION` to check WooCommerce's version.~ This change has been undone. See: 34cc95924a8cce8426b721341763cccf93dc95f5.
  * ~Note: as @senadir noted in the issue, there are several plugins out there using `Package->get_version()`. That's mostly used to check if they should enable some features related to WC Blocks. In all case, it can be replaced with a check on `WC_VERSION`, but we should probably add a dev note in the release post explaining this a bit. Another option would be not to deprecate these methods yet.~
  * ~We have some migrations that rely on the deprecated methods. For now, I created auxiliary internal methods, so migrations keep working. I don't think we can easily port those migrations to use `WC_VERSION`, as they rely on old WC Blocks versions being stored in the database. Also, I don't think it makes much sense updating that code to use WC core versions if, in fact, they are checking a WC Blocks version. So I left it as it is. Heads-up, though, that there is an ongoing discussion on what to do with one of those migrations here: https://github.com/woocommerce/woocommerce/issues/42300.~
* ~Updates the version used to register the `'wc-interactivity'` script, so it uses the WC core version instead of WC Blocks'.~ This has been extracted to a [separate PR](https://github.com/woocommerce/woocommerce/pull/44806) to ease its review.

</details>

### How to test the changes in this Pull Request:

Testing steps for devs:

1. Add a code snippet calling one of the deprecated classes somewhere in the code base. For example, I added this code to `AllReviews.php`:
```diff
<?php
namespace Automattic\WooCommerce\Blocks\BlockTypes;

+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\StoreApi\Formatters;

class AllReviews extends AbstractBlock {
	protected $block_name = 'all-reviews';

	protected function get_block_type_script( $key = null ) {
+		$schema = Package::container()->get( Formatters::class );
		...
```
2. If, like me, you added the code snippet to a block class, create a post, add that block and view the block in the frontend.
3. Now, check the error logs of your store and verify there is an entry like: `Automattic\WooCommerce\Blocks\StoreApi\Formatters is <strong>deprecated</strong> since version 6.4.0! Use Automattic\WooCommerce\StoreApi\Formatters instead.`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
