### PR TITLE
Don't throw exception if data exists for `needsRefreshForInteractivityAPI`

### DIFF
--- a/plugins/woocommerce/changelog/44808-dev-fix-fatal-interactivity
+++ b/plugins/woocommerce/changelog/44808-dev-fix-fatal-interactivity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a possible fatal exception setting a duplicate asset registry key `needsRefreshForInteractivityAPI`

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -49,7 +49,7 @@ class ClassicTemplate extends AbstractDynamicBlock {
 
 		// Indicate to interactivity powered components that this block is on the page,
 		// and needs refresh to update data.
-		$this->asset_data_registry->add( 'needsRefreshForInteractivityAPI', true );
+		$this->asset_data_registry->add( 'needsRefreshForInteractivityAPI', true, true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -180,6 +180,7 @@ class ProductQuery extends AbstractBlock {
 			// and needs refresh to update data.
 			$this->asset_data_registry->add(
 				'needsRefreshForInteractivityAPI',
+				true,
 				true
 			);
 			// Set this so that our product filters can detect if it's a PHP template.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes a possible fatal introduced by https://github.com/woocommerce/woocommerce/pull/44631 where if the registry entry is added twice an exception is thrown. If you pass true to check_key_exists, it will not override the key if it exists preventing an exception. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

To test this:

1. Add `Products (Beta)` block to a page or template
2. Add `WooCommerce Product Grid Block` to the same page or template
3. Save and view it on the front-end
4. There should be no exception thrown. Compare this to doing the same on `trunk` you'll see this exception `Fatal error: Uncaught InvalidArgumentException: Overriding existing data with an already registered key is not allowed in /var/www/html/wp-content/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php:431 ...`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a possible fatal exception setting a duplicate asset registry key `needsRefreshForInteractivityAPI`

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
