### PR TITLE
add missing community reviewer folders

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -72,6 +72,9 @@
 "packages/js/onboarding/**/*":
   - team: ghidorah
 
+"packages/js/product-editor/**/*":
+  - team: mothra
+
 "packages/js/tracks/**/*":
   - team: mothra
 
@@ -85,10 +88,14 @@
 "plugins/woocommerce/src/Internal/Admin/**/*":
   - team: mothra
   - team: ghidorah
-  
+
 "plugins/woocommerce-admin/**/*":
   - team: mothra
   - team: ghidorah
+
+"plugins/woocommerce-blocks/**/*":
+  - team: rubik
+  - team: woo-fse
 
 "plugins/woocommerce-beta-tester/**/*":
   - team: vortex


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the `product-editor` and `woocommerce-blocks` folders to the community PR reviewers configuration. Here are two recent community PRs that were not assigned a reviewer:

- [woocommerce-blocks](https://github.com/woocommerce/woocommerce/pull/44799)
- [product-editor](https://github.com/woocommerce/woocommerce/pull/44226)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. YAML review
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
