### PR TITLE
Fatal Error if FS_METHOD is ftpext under PHP 8.0 or later for Admin l…

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -64,7 +64,30 @@ class File {
 
 		global $wp_filesystem;
 
-		if ( ! $wp_filesystem instanceof WP_Filesystem_Direct ) {
+		$success = true;
+		if ( ! $wp_filesystem ) {
+			$constants = array(
+				'hostname'    => 'FTP_HOST',
+				'username'    => 'FTP_USER',
+				'password'    => 'FTP_PASS',
+				'public_key'  => 'FTP_PUBKEY',
+				'private_key' => 'FTP_PRIKEY',
+			);
+
+			$credentials = array();
+
+			// We provide credentials based on wp-config.php constants.
+			// Reference https://developer.wordpress.org/apis/wp-config-php/#wordpress-upgrade-constants.
+			foreach ( $constants as $key => $constant ) {
+				if ( defined( $constant ) ) {
+					$credentials[ $key ] = constant( $constant );
+				}
+			}
+
+			$success = WP_Filesystem( $credentials );
+		}
+
+		if ( ! $success || $wp_filesystem->errors->has_errors() ) {
 			WP_Filesystem();
 		}
 


### PR DESCRIPTION
Admin logging page fails with Fatal Error if FS_METHOD is ftpext under PHP 8.0 or later. This is because PHP 8.0 changed to send Fatal Error if null is given to ftp_nlist() which is called via WP_Filesystem under FS_METHOD is ftpext.

I wrote the corrected code based on the following correction pull request. https://github.com/tomusborne/generateblocks/pull/829

<img width="1427" alt="スクリーンショット 2024-02-22 4 09 41" src="https://github.com/woocommerce/woocommerce/assets/2194451/e3b762e5-b04f-4e11-98ba-d3bceae07d7c">


### Submission Review Guidelines:
-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. I check the admin status loggin page, after I changed the FS_METHOD to ftpext and ssh2, direct for the server.
2. I check the admin status loggin page, after I changed the FS_METHOD to ftpsockets for another server.
3. I check the server error log, there were no errors.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Minor

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixed the admin logging page fails with Fatal Error if FS_METHOD is ftpext under PHP 8.0 or later.

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
