### PR TITLE
Remove property type hints in TransientFilesEngine and ReceiptRenderingEngine

### DIFF
--- a/plugins/woocommerce/changelog/pr-44829
+++ b/plugins/woocommerce/changelog/pr-44829
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove property type hint in TransientFilesEngine
+Remove property type hints in TransientFilesEngine and ReceiptRenderingEngine

--- a/plugins/woocommerce/changelog/pr-44829
+++ b/plugins/woocommerce/changelog/pr-44829
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove property type hint in TransientFilesEngine

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
@@ -51,14 +51,14 @@ class ReceiptRenderingEngine {
 	 *
 	 * @var TransientFilesEngine
 	 */
-	private TransientFilesEngine $transient_files_engine;
+	private $transient_files_engine;
 
 	/**
 	 * The instance of LegacyProxy to use.
 	 *
 	 * @var LegacyProxy
 	 */
-	private LegacyProxy $legacy_proxy;
+	private $legacy_proxy;
 
 	/**
 	 * Initializes the class.

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -45,7 +45,7 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	 *
 	 * @var LegacyProxy
 	 */
-	private LegacyProxy $legacy_proxy;
+	private $legacy_proxy;
 
 	/**
 	 * Register hooks.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A user [is reporting](https://wordpress.org/support/topic/php-parse-error-syntax-error-after-update-to-wc-8-6/) the following error after upgrading to WooCommerce 8.6:

```
PHP Parse error:  syntax error, unexpected 'LegacyProxy' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in /home/................../public_html/wp-content/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php on line 48
```

While this looks like an error due to WooCommerce running in PHP 7.3 or older, the fact is that this is actually happening in PHP 7.4.

At this point it's not clear why this is happening, but for now the type hint is being removed, so that the transient files engine (which is a dependency of the receipts printing engine) doesn't break. Similar type hints in `ReceiptRenderingEngine` are removed too.

### How to test the changes in this Pull Request:

Running the unit tests should be enough. Optionally, you can also repeat the tests of https://github.com/woocommerce/woocommerce/pull/43502.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>