### PR TITLE
Fetch & display marketplace promotions

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -22,6 +22,7 @@ import {
 	recordLegacyTabView,
 } from '../../utils/tracking';
 import InstallNewProductModal from '../install-flow/install-new-product-modal';
+import Promotions from '../promotions/promotions';
 
 export default function Content(): JSX.Element {
 	const marketplaceContextValue = useContext( MarketplaceContext );
@@ -134,6 +135,7 @@ export default function Content(): JSX.Element {
 
 	return (
 		<div className="woocommerce-marketplace__content">
+			<Promotions />
 			<InstallNewProductModal products={ products } />
 			{ renderContent() }
 		</div>

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -1,0 +1,145 @@
+/* global userLocale, WC_marketplace_promotions */
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { LOCALE } from '../../../utils/admin-settings';
+import Notice from '../notice/notice';
+
+declare const WC_marketplace_promotions: {
+	data: Promotion[];
+};
+
+type Promotion = {
+	date_from_gmt: string;
+	date_to_gmt: string;
+	format: string;
+	pages: Page[];
+	position: string;
+	content: { [ locale: string ]: string };
+	icon?: string;
+	is_dismissible?: boolean;
+	menu_item_id?: string;
+	style?: string;
+};
+
+type Page = {
+	page: string;
+	path: string;
+	tab?: string;
+};
+
+const Promotions: React.FC = () => {
+	const promotionsEndpoint =
+		'https://woo.com/wp-json/wccom-extensions/3.0/promotions';
+	const initialPromotions =
+		typeof WC_marketplace_promotions !== 'undefined' &&
+		WC_marketplace_promotions.data.length > 0
+			? WC_marketplace_promotions.data
+			: null;
+
+	const [ fetchedPromotions, setFetchedPromotions ] = useState<
+		Promotion[] | null
+	>( initialPromotions );
+
+	// Fallback to fetching promotions if initialPromotions is null, which should not happen.
+	useEffect( () => {
+		// Only fetch promotions if initialPromotions is null (indicating WC_marketplace_promotions was not set or empty)
+		if ( initialPromotions === null ) {
+			const fetchPromotions = async () => {
+				try {
+					const response = await fetch( promotionsEndpoint );
+					if ( ! response.ok ) {
+						throw new Error( 'Network response was not ok' );
+					}
+					const data = await response.json();
+					setFetchedPromotions( data ); // Assuming the data is an array of promotions
+				} catch ( error ) {
+					console.error( 'Failed to fetch promotions:', error );
+				}
+			};
+
+			fetchPromotions();
+		}
+	}, [ initialPromotions ] );
+
+	// Determine the source of promotions to use, preferring locally available data
+	const promotionsToUse = fetchedPromotions || initialPromotions;
+
+	if ( ! promotionsToUse || promotionsToUse.length === 0 ) {
+		return null;
+	}
+
+	const currentDate = new Date().toISOString();
+	const urlParams = new URLSearchParams( window.location.search );
+	const currentPage = urlParams.get( 'page' );
+	const currentPath = decodeURIComponent( urlParams.get( 'path' ) || '' );
+	const currentTab = urlParams.get( 'tab' );
+
+	return (
+		<>
+			{ promotionsToUse.map( ( promotion, index ) => {
+				// Skip this promotion if pages are not defined
+				if ( ! promotion.pages ) {
+					return null;
+				}
+
+				// Check if the current page, path & tab match the promotion's pages
+				const matchesPagePath = promotion.pages.some( ( page ) => {
+					const normalizedPagePath = page.path.startsWith( '/' )
+						? page.path
+						: `/${ page.path }`;
+					const normalizedCurrentPath = currentPath.startsWith( '/' )
+						? currentPath
+						: `/${ currentPath }`;
+					return (
+						page.page === currentPage &&
+						normalizedPagePath === normalizedCurrentPath &&
+						( page.tab ? page.tab === currentTab : true )
+					);
+				} );
+
+				if ( ! matchesPagePath ) {
+					return null;
+				}
+
+				const startDate = new Date( promotion.date_from_gmt );
+				const endDate = new Date( promotion.date_to_gmt );
+				const now = new Date( currentDate );
+
+				// Promotion is not active
+				if ( now < startDate || now > endDate ) {
+					return null;
+				}
+
+				// Promotion is a notice
+				if ( promotion.format === 'notice' ) {
+					return (
+						<Notice
+							key={ index }
+							id={
+								promotion.menu_item_id ?? `promotion-${ index }`
+							}
+							description={
+								promotion.content[ LOCALE.userLocale ] ||
+								promotion.content.en_US
+							}
+							variant={
+								promotion.style ? promotion.style : 'info'
+							}
+							icon={ promotion.icon }
+							isDismissible={ promotion.is_dismissible || false }
+						/>
+					);
+				}
+				return null;
+			} ) }
+		</>
+	);
+};
+
+export default Promotions;

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -6,9 +6,28 @@ import Notice from '../notice/notice';
 
 declare global {
 	interface Window {
-		wc: Record< string, string | number | boolean | null >;
+		wc: Record< string, string | number | boolean | object | null >;
 	}
 }
+
+type Promotion = {
+	date_from_gmt: string;
+	date_to_gmt: string;
+	format: string;
+	pages: Page[];
+	position: string;
+	content: { [ locale: string ]: string };
+	icon?: string | undefined;
+	is_dismissible?: boolean;
+	menu_item_id?: string;
+	style?: string;
+};
+
+type Page = {
+	page: string;
+	path: string;
+	tab?: string;
+};
 
 const Promotions: () => null | JSX.Element = () => {
 	const urlParams = new URLSearchParams( window.location.search );
@@ -25,26 +44,30 @@ const Promotions: () => null | JSX.Element = () => {
 
 	return (
 		<>
-			{ promotions.map( ( promotion, index ) => {
+			{ promotions.map( ( promotion: Promotion, index: number ) => {
 				// Skip this promotion if pages are not defined
 				if ( ! promotion.pages ) {
 					return null;
 				}
 
 				// Check if the current page, path & tab match the promotion's pages
-				const matchesPagePath = promotion.pages.some( ( page ) => {
-					const normalizedPath = page.path.startsWith( '/' )
-						? page.path
-						: `/${ page.path }`;
-					const normalizedCurrentPath = currentPath.startsWith( '/' )
-						? currentPath
-						: `/${ currentPath }`;
-					return (
-						page.page === currentPage &&
-						normalizedPath === normalizedCurrentPath &&
-						( page.tab ? page.tab === currentTab : true )
-					);
-				} );
+				const matchesPagePath = promotion.pages.some(
+					( page: Page ) => {
+						const normalizedPath = page.path.startsWith( '/' )
+							? page.path
+							: `/${ page.path }`;
+						const normalizedCurrentPath = currentPath.startsWith(
+							'/'
+						)
+							? currentPath
+							: `/${ currentPath }`;
+						return (
+							page.page === currentPage &&
+							normalizedPath === normalizedCurrentPath &&
+							( page.tab ? page.tab === currentTab : true )
+						);
+					}
+				);
 
 				if ( ! matchesPagePath ) {
 					return null;

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -47,7 +47,7 @@ const Promotions: React.FC = () => {
 		return null;
 	}
 	const promotions = window.wc?.marketplace?.promotions ?? [];
-	const currentDate = new Date().toISOString();
+	const currentDateUTC = Date.now();
 	const currentPath = decodeURIComponent( urlParams.get( 'path' ) || '' );
 	const currentTab = urlParams.get( 'tab' );
 
@@ -78,12 +78,11 @@ const Promotions: React.FC = () => {
 					return null;
 				}
 
-				const startDate = new Date( promotion.date_from_gmt );
-				const endDate = new Date( promotion.date_to_gmt );
-				const now = new Date( currentDate );
+				const startDate = new Date( promotion.date_from_gmt ).getTime();
+				const endDate = new Date( promotion.date_to_gmt ).getTime();
 
 				// Promotion is not active
-				if ( now < startDate || now > endDate ) {
+				if ( currentDateUTC < startDate || currentDateUTC > endDate ) {
 					return null;
 				}
 

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import { LOCALE } from '../../../utils/admin-settings';
@@ -10,34 +6,11 @@ import Notice from '../notice/notice';
 
 declare global {
 	interface Window {
-		wc: {
-			marketplace: {
-				promotions: Promotion[];
-			};
-		};
+		wc: Record< string, string | number | boolean | null >;
 	}
 }
 
-type Promotion = {
-	date_from_gmt: string;
-	date_to_gmt: string;
-	format: string;
-	pages: Page[];
-	position: string;
-	content: { [ locale: string ]: string };
-	icon?: string;
-	is_dismissible?: boolean;
-	menu_item_id?: string;
-	style?: string;
-};
-
-type Page = {
-	page: string;
-	path: string;
-	tab?: string;
-};
-
-const Promotions: React.FC = () => {
+const Promotions: () => null | JSX.Element = () => {
 	const urlParams = new URLSearchParams( window.location.search );
 	const currentPage = urlParams.get( 'page' );
 
@@ -60,7 +33,7 @@ const Promotions: React.FC = () => {
 
 				// Check if the current page, path & tab match the promotion's pages
 				const matchesPagePath = promotion.pages.some( ( page ) => {
-					const normalizedPagePath = page.path.startsWith( '/' )
+					const normalizedPath = page.path.startsWith( '/' )
 						? page.path
 						: `/${ page.path }`;
 					const normalizedCurrentPath = currentPath.startsWith( '/' )
@@ -68,7 +41,7 @@ const Promotions: React.FC = () => {
 						: `/${ currentPath }`;
 					return (
 						page.page === currentPage &&
-						normalizedPagePath === normalizedCurrentPath &&
+						normalizedPath === normalizedCurrentPath &&
 						( page.tab ? page.tab === currentTab : true )
 					);
 				} );
@@ -87,6 +60,10 @@ const Promotions: React.FC = () => {
 
 				// Promotion is a notice
 				if ( promotion.format === 'notice' ) {
+					if ( ! promotion?.content ) {
+						return null;
+					}
+
 					return (
 						<Notice
 							key={ index }
@@ -100,7 +77,7 @@ const Promotions: React.FC = () => {
 							variant={
 								promotion.style ? promotion.style : 'info'
 							}
-							icon={ promotion.icon }
+							icon={ promotion?.icon }
 							isDismissible={ promotion.is_dismissible || false }
 						/>
 					);

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -6,7 +6,11 @@ import Notice from '../notice/notice';
 
 declare global {
 	interface Window {
-		wc: Record< string, string | number | boolean | object | null >;
+		wc: {
+			marketplace?: {
+				promotions: Promotion[];
+			};
+		};
 	}
 }
 

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -39,11 +39,15 @@ type Page = {
 };
 
 const Promotions: React.FC = () => {
-	const promotions = window.wc?.marketplace?.promotions ?? [];
-
-	const currentDate = new Date().toISOString();
 	const urlParams = new URLSearchParams( window.location.search );
 	const currentPage = urlParams.get( 'page' );
+
+	// Check if the current page is not 'wc-admin'
+	if ( currentPage !== 'wc-admin' ) {
+		return null;
+	}
+	const promotions = window.wc?.marketplace?.promotions ?? [];
+	const currentDate = new Date().toISOString();
 	const currentPath = decodeURIComponent( urlParams.get( 'path' ) || '' );
 	const currentTab = urlParams.get( 'tab' );
 

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -1,4 +1,3 @@
-/* global userLocale */
 /**
  * External dependencies
  */

--- a/plugins/woocommerce/changelog/add-marketplace-promotions-display
+++ b/plugins/woocommerce/changelog/add-marketplace-promotions-display
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds logic to display notices of promotions from Woo.com on in-app marketplace pages

--- a/plugins/woocommerce/client/legacy/js/admin/wc-marketplace-promotions.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-marketplace-promotions.js
@@ -1,1 +1,0 @@
-/* Will be used for promotions positionning */

--- a/plugins/woocommerce/client/legacy/js/admin/wc-marketplace-promotions.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-marketplace-promotions.js
@@ -1,0 +1,1 @@
+/* Will be used for promotions positionning */

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -149,6 +149,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			wp_register_script( 'wc-shipping-zone-methods', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zone-methods' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), $version );
 			wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'wc-backbone-modal' ), $version, array( 'in_footer' => false ) );
 			wp_register_script( 'wc-clipboard', WC()->plugin_url() . '/assets/js/admin/wc-clipboard' . $suffix . '.js', array( 'jquery' ), $version );
+			wp_register_script( 'wc-marketplace-promotions', WC()->plugin_url() . '/assets/js/admin/wc-marketplace-promotions' . $suffix . '.js', array(), $version );
 			wp_register_script( 'select2', WC()->plugin_url() . '/assets/js/select2/select2.full' . $suffix . '.js', array( 'jquery' ), '4.0.3' );
 			wp_register_script( 'selectWoo', WC()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.6' );
 			wp_register_script( 'wc-enhanced-select', WC()->plugin_url() . '/assets/js/admin/wc-enhanced-select' . $suffix . '.js', array( 'jquery', 'selectWoo' ), $version );
@@ -553,6 +554,25 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					)
 				);
 				wp_enqueue_script( 'marketplace-suggestions' );
+			}
+
+			// Marketplace promotions.
+			if ( in_array( $screen_id, array( 'woocommerce_page_wc-admin' ), true ) ) {
+
+				$promotions = get_transient( 'wc_addons_marketplace_promotions' );
+
+				if ( false === $promotions ) {
+					return;
+				}
+
+				wp_enqueue_script( 'wc-marketplace-promotions' );
+				wp_localize_script(
+					'wc-marketplace-promotions',
+					'WC_marketplace_promotions',
+					array(
+						'data' => $promotions
+					)
+				);
 			}
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -149,7 +149,6 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			wp_register_script( 'wc-shipping-zone-methods', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zone-methods' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), $version );
 			wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'wc-backbone-modal' ), $version, array( 'in_footer' => false ) );
 			wp_register_script( 'wc-clipboard', WC()->plugin_url() . '/assets/js/admin/wc-clipboard' . $suffix . '.js', array( 'jquery' ), $version );
-			wp_register_script( 'wc-marketplace-promotions', WC()->plugin_url() . '/assets/js/admin/wc-marketplace-promotions' . $suffix . '.js', array(), $version );
 			wp_register_script( 'select2', WC()->plugin_url() . '/assets/js/select2/select2.full' . $suffix . '.js', array( 'jquery' ), '4.0.3' );
 			wp_register_script( 'selectWoo', WC()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.6' );
 			wp_register_script( 'wc-enhanced-select', WC()->plugin_url() . '/assets/js/admin/wc-enhanced-select' . $suffix . '.js', array( 'jquery', 'selectWoo' ), $version );
@@ -560,18 +559,15 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			if ( in_array( $screen_id, array( 'woocommerce_page_wc-admin' ), true ) ) {
 
 				$promotions = get_transient( 'wc_addons_marketplace_promotions' );
-
+			
 				if ( false === $promotions ) {
 					return;
 				}
-
-				wp_enqueue_script( 'wc-marketplace-promotions' );
-				wp_localize_script(
-					'wc-marketplace-promotions',
-					'WC_marketplace_promotions',
-					array(
-						'data' => $promotions
-					)
+			
+				wp_add_inline_script(
+					'wc-admin-app',
+					'window.wc = window.wc || {}; wc.marketplace = ' . wp_json_encode( array( 'promotions' => $promotions ) ),
+					'before'
 				);
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related: https://github.com/Automattic/woocommerce.com/issues/19573
Related: https://github.com/woocommerce/woocommerce/pull/44655

We want to display the promos fetched from https://github.com/woocommerce/woocommerce/pull/44655 within the WC Admin UI. That's what this PR addresses.
- introduces the `<Promotions>` component which aims to get the promos from the local cache (`wc_addons_marketplace_promotions`) but provides a fallback to call the endpoint
- localizes promos within the `WC_marketplace_promotions` variable to make it accessible by the component
- updates the `<Content>` component to load the promos

Promos are
- pages, patch and tab restricted
- localized
- can have various formats (Notice being the one we use here) 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally
2. run `nvm use`
3. run `cd plugins/woocommerce`
4. run `pnpm -- wp-env start`
5. run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
6. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions
7. confirm you see one single notice, in English (the endpoint doesn't provide localized content yet)

<img width="1248" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1649788/4deec26c-5f5b-49bf-8ec8-cef358421962">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>