### PR TITLE
Try: Example block hooks

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+/**
+ * HookedBlockExamples.
+ */
+class HookedBlockExamples {
+
+    public function init() {
+        add_filter( 'hooked_block_types', array( $this, 'add_sku_field' ), 10, 4 );
+        add_filter( 'hooked_block_types', array( $this, 'add_custom_product_tab_1' ), 10, 4 );
+        add_filter( 'hooked_block_woocommerce/product-tab', array( $this, 'add_custom_product_tab_1_data' ), 10, 5 );
+        add_filter( 'hooked_block_types', array( $this, 'add_custom_product_tab_2' ), 10, 4 );
+        add_filter( 'hooked_block_woocommerce/product-tab', array( $this, 'add_custom_product_tab_2_data' ), 10, 5 );
+        add_filter( 'hooked_block_types', array( $this, 'add_price_block_1' ), 10, 4 );
+        add_filter( 'hooked_block_types', array( $this, 'add_price_block_2' ), 10, 4 );
+        add_filter( 'hooked_block_woocommerce/product-regular-price-field', array( $this, 'add_price_block_2_data' ), 10, 5 );
+        add_filter( 'hooked_block_types', array( $this, 'add_block_to_hooked_block' ), 10, 4 );
+    }
+
+    /**
+     * Add SKU field.
+     *
+     * This hook works because it is a unique block that doesn't require attributes and
+     * is attached to another unique field that is not repeated.
+     */
+    public function add_sku_field( $hooked_blocks, $position, $anchor_block, $context ) {
+        if ( 
+            'woocommerce/product-name-field' === $anchor_block &&
+            'after' === $position &&
+            'product-form' === $context->area
+        ) {
+            $hooked_blocks[] = 'woocommerce/product-sku-field';
+        }
+    
+        return $hooked_blocks;
+    }
+    
+    /**
+     * Add the product tab intended to be "Custom tab 1"
+     *
+     * This gets added, but later needs to be hooked to include attributes.
+     */
+    public function add_custom_product_tab_1( $hooked_blocks, $position, $anchor_block, $context ) {
+        if ( 
+            'woocommerce/product-tab' === $anchor_block &&
+            'after' === $position &&
+            'product-form' === $context->area
+        ) {
+            $hooked_blocks[] = 'woocommerce/product-tab';
+        }
+    
+        return $hooked_blocks;
+    }
+    
+    /**
+     * Add the data for the previously hooked "Custom tab 1"
+     *
+     * Despite requiring a number of checks, this one works a intended.
+     */
+    public function add_custom_product_tab_1_data( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
+        // Check if the block already has attrs to avoid altering other hooked blocks.
+        if ( ! empty( $parsed_hooked_block['attrs'] ) ) {
+            return $parsed_hooked_block;
+        }
+    
+        // Prevent this block from hooking after all product tabs.
+        if (
+            ! isset( $parsed_anchor_block['blockName'] ) ||
+            'woocommerce/product-tab' !== $parsed_anchor_block['blockName'] ||
+            ! isset( $parsed_anchor_block['attrs']['id'] ) ||
+            'pricing' !== $parsed_anchor_block['attrs']['id']
+        ) {
+            return null;
+        }
+    
+        $parsed_hooked_block['attrs']['id'] = 'custom_tab_1';
+        $parsed_hooked_block['attrs']['title'] = 'Custom Tab 1';
+        return $parsed_hooked_block;
+    }
+    
+    /**
+     * Add the product tab intended to be "Custom tab 1"
+     *
+     * This gets added, but later needs to be hooked to include attributes.
+     */
+    public function add_custom_product_tab_2( $hooked_blocks, $position, $anchor_block, $context ) {
+        if ( 
+            'woocommerce/product-tab' === $anchor_block &&
+            'after' === $position &&
+            'product-form' === $context->area
+        ) {
+            $hooked_blocks[] = 'woocommerce/product-tab';
+        }
+    
+        return $hooked_blocks;
+    }
+    
+    /**
+     * Add the data for the previously hooked "Custom tab 2"
+     *
+     * This callback will return early since attributes will always
+     * be set by the `add_custom_product_tab_1_data` callback first.
+     */
+    public function add_custom_product_tab_2_data( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
+        // Check if the block already has attrs to avoid altering other hooked blocks.
+        if ( ! empty( $parsed_hooked_block['attrs'] ) ) {
+            return $parsed_hooked_block;
+        }
+    
+        // Prevent this block from hooking after all product tabs.
+        if (
+            ! isset( $parsed_anchor_block['blockName'] ) ||
+            'woocommerce/product-tab' !== $parsed_anchor_block['blockName'] ||
+            ! isset( $parsed_anchor_block['attrs']['id'] ) ||
+            'pricing' !== $parsed_anchor_block['attrs']['id']
+        ) {
+            return null;
+        }
+    
+        $parsed_hooked_block['attrs']['id'] = 'custom_tab_2';
+        $parsed_hooked_block['attrs']['title'] = 'Custom Tab 2';
+        return $parsed_hooked_block;
+    }
+
+    /**
+     * Add price block 1.
+     *
+     * This price block does not have attributes and will later be overwritten by a 2nd price block's attributes.
+     */
+    public function add_price_block_1( $hooked_blocks, $position, $anchor_block, $context ) {
+        if ( 
+            'woocommerce/product-name-field' === $anchor_block &&
+            'after' === $position &&
+            'product-form' === $context->area
+        ) {
+            $hooked_blocks[] = 'woocommerce/product-regular-price-field';
+        }
+    
+        return $hooked_blocks;
+    }
+
+    /**
+     * Add price block 2.
+     *
+     * This price block does not have attributes and will later be overwritten by a 2nd price block's attributes.
+     */
+    public function add_price_block_2( $hooked_blocks, $position, $anchor_block, $context ) {
+        if ( 
+            'woocommerce/product-name-field' === $anchor_block &&
+            'after' === $position &&
+            'product-form' === $context->area
+        ) {
+            $hooked_blocks[] = 'woocommerce/product-regular-price-field';
+        }
+    
+        return $hooked_blocks;
+    }
+
+    /**
+     * Add the data for the previously hooked "price block 2"
+     *
+     * This correctly sets data for price block 2 but also errantly sets
+     * attributes for price block 1 since it does not contain the optional attributes.
+     */
+    public function add_price_block_2_data( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
+        // Check if the block already has attrs to avoid altering other hooked blocks.
+        if ( ! empty( $parsed_hooked_block['attrs'] ) ) {
+            return $parsed_hooked_block;
+        }
+    
+        // Prevent this block from hooking after all product tabs.
+        if (
+            isset( $parsed_anchor_block['blockName'] ) &&
+            'woocommerce/product-name-field' !== $parsed_anchor_block['blockName']
+        ) {
+            return null;
+        }
+    
+        $parsed_hooked_block['attrs']['label'] = 'Price block 2';
+        return $parsed_hooked_block;
+    }
+
+    /**
+     * Add a block to a previously hooked block.
+     * 
+     * This will fail since block hooks don't run on blocks that were also hooked in.
+     */
+    public function add_block_to_hooked_block(  $hooked_blocks, $position, $anchor_block, $context  ) {
+        if ( 
+            'woocommerce/product-regular-price-field' === $anchor_block &&
+            'after' === $position &&
+            'product-form' === $context->area
+        ) {
+            $hooked_blocks[] = 'woocommerce/product-sale-price-field';
+        }
+    
+        return $hooked_blocks;
+    }
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -79,6 +79,9 @@ class Init {
 
 			add_action( 'rest_api_init', array( $this, 'register_layout_templates' ) );
 
+			$hooked_block_examples = new HookedBlockExamples();
+			$hooked_block_examples->init();
+
 			// Make sure the block registry is initialized so that core blocks are registered.
 			BlockRegistry::get_instance();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR demonstrates usage of the block hooks `hooked_block_types` and `hooked_block_{block_type}` to insert blocks into the product editor.

While this is close to working for the product editor, we see a few issues that prevents this from being a viable solution as it currently is:

* Generic blocks being inserted with the same block type (a common case) will overwrite all of the same block types who don't yet have attributes set.  The first hook to use `hooked_block_{block_type}` will dominate the others. (See "Custom tab 1" and "Custom tab 2")
* Blocks that have optional attributes will suffer the same overwrite issue mentioned in the last point. (See Price Block 2 which overwrites the price block without attributes)
* Blocks that were added via hooks can't be used as anchor points. (See the lack of the sale price field)

<img width="803" alt="Screenshot 2024-02-21 at 12 45 28 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/ee16ed5c-cb8b-476b-b43f-1daa3a8bbb95">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install the WordPress 6.5 beta 2 release.
2. Enable the product editor under WooCommerce->Settings->Advanced->Features.
3. Navigate to Products->Add new
4. See the hooked blocks.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
