### PR TITLE
exclude dependabot from commmunity contributor label

### DIFF
--- a/.github/workflows/scripts/is-community-contributor.js
+++ b/.github/workflows/scripts/is-community-contributor.js
@@ -16,6 +16,10 @@ const getIssueAuthor = ( payload ) => {
 
 const isCommunityContributor = async ( owner, repo, username ) => {
 	if ( username ) {
+		if ( username === 'app/dependabot' ) {
+			return false;
+		}
+
 		const {
 			data: { permission },
 		} = await octokit.rest.repos.getCollaboratorPermissionLevel( {

--- a/.github/workflows/scripts/is-community-contributor.js
+++ b/.github/workflows/scripts/is-community-contributor.js
@@ -6,6 +6,10 @@ const core = require( '@actions/core' );
 // this won't work.
 const octokit = new Octokit();
 
+const ignoredUsernames = [ 'dependabot[bot]' ];
+const checkIfIgnoredUsername = ( username ) =>
+	ignoredUsernames.includes( username );
+
 const getIssueAuthor = ( payload ) => {
 	return (
 		payload?.issue?.user?.login ||
@@ -15,11 +19,7 @@ const getIssueAuthor = ( payload ) => {
 };
 
 const isCommunityContributor = async ( owner, repo, username ) => {
-	if ( username ) {
-		if ( username === 'app/dependabot' ) {
-			return false;
-		}
-
+	if ( username && ! checkIfIgnoredUsername( username ) ) {
 		const {
 			data: { permission },
 		} = await octokit.rest.repos.getCollaboratorPermissionLevel( {
@@ -31,6 +31,7 @@ const isCommunityContributor = async ( owner, repo, username ) => {
 		return permission === 'read' || permission === 'none';
 	}
 
+	console.log( 'Not a community contributor!' );
 	return false;
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Dependabot PRs are being labeled as community contributions. This PR excludes the dependabot user from community contributor logic.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Compare this branch with the prior art `plugins/woocommerce-blocks/.gituhb/workflows/scripts/is-community-contributor.js`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
