### PR TITLE
Add message after publishing a product to pre-publish panel

### DIFF
--- a/packages/js/product-editor/changelog/add-44474_post_publishing_message
+++ b/packages/js/product-editor/changelog/add-44474_post_publishing_message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add message after publishing a product to pre-publish panel #44864

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -14,6 +14,7 @@ import { MouseEvent } from 'react';
  */
 import { useValidations } from '../../../../contexts/validation-context';
 import { WPError } from '../../../../utils/get-product-error-message';
+import { useProductURL } from '../../../../hooks/use-product-url';
 import { PreviewButtonProps } from '../../preview-button';
 
 export function usePreview( {
@@ -36,11 +37,7 @@ export function usePreview( {
 		'id'
 	);
 
-	const [ permalink ] = useEntityProp< string >(
-		'postType',
-		productType,
-		'permalink'
-	);
+	const { getProductURL } = useProductURL( productType );
 
 	const { hasEdits, isDisabled } = useSelect(
 		( select ) => {
@@ -71,12 +68,6 @@ export function usePreview( {
 
 	// @ts-expect-error There are no types for this.
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
-
-	let previewLink: URL | undefined;
-	if ( typeof permalink === 'string' ) {
-		previewLink = new URL( permalink );
-		previewLink.searchParams.append( 'preview', 'true' );
-	}
 
 	/**
 	 * Overrides the default anchor behaviour when the product has unsaved changes.
@@ -157,7 +148,7 @@ export function usePreview( {
 		'aria-disabled': ariaDisabled,
 		// Note that the href is always passed for a11y support. So
 		// the final rendered element is always an anchor.
-		href: previewLink?.toString(),
+		href: getProductURL( true ),
 		variant: 'tertiary',
 		onClick: handleClick,
 	};

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/index.ts
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/index.ts
@@ -1,0 +1,2 @@
+export * from './post-publish-section';
+export * from './post-publish-title';

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-section.tsx
@@ -67,13 +67,14 @@ export function PostPublishSection( { postType }: PostPublishSectionProps ) {
 				<strong>{ __( 'What’s next?', 'woocommerce' ) }</strong>
 			</p>
 			<div className="post-publish-section__postpublish-post-address-container">
+				{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+				{ /* @ts-ignore TextControl requires an 'onChange' but it's not necessary here. */ }
 				<TextControl
 					className="post-publish-section__postpublish-post-address"
 					readOnly
 					label={ __( 'product address', 'woocommerce' ) }
 					value={ productURL }
 					onFocus={ onSelectInput }
-					onChange={ () => {} }
 				/>
 
 				<div className="post-publish-section__copy-button-wrap">

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-section.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { createElement, useState, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, PanelBody, TextControl } from '@wordpress/components';
+import { recordEvent } from '@woocommerce/tracks';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { Ref } from 'react';
+import { getNewPath } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { useProductScheduled } from '../../../hooks/use-product-scheduled';
+import { PostPublishSectionProps } from './types';
+import { TRACKS_SOURCE } from '../../../constants';
+import { useProductURL } from '../../../hooks/use-product-url';
+
+export function PostPublishSection( { postType }: PostPublishSectionProps ) {
+	const { getProductURL } = useProductURL( postType );
+	const { isScheduled } = useProductScheduled( postType );
+
+	const [ showCopyConfirmation, setShowCopyConfirmation ] =
+		useState< boolean >( false );
+
+	const productURL = getProductURL( isScheduled );
+
+	const CopyButton = ( {
+		text,
+		onCopy,
+		children,
+	}: {
+		text: string;
+		onCopy: () => void;
+		children: JSX.Element;
+	} ) => {
+		const ref = useCopyToClipboard(
+			text,
+			onCopy
+		) as Ref< HTMLButtonElement >;
+		return (
+			<Button variant="secondary" ref={ ref }>
+				{ children }
+			</Button>
+		);
+	};
+
+	const onCopyURL = () => {
+		recordEvent( 'product_prepublish_panel', {
+			source: TRACKS_SOURCE,
+			action: 'copy_product_url',
+		} );
+		setShowCopyConfirmation( true );
+		setTimeout( () => {
+			setShowCopyConfirmation( false );
+		}, 4000 );
+	};
+
+	const onSelectInput = ( event: React.FocusEvent< HTMLInputElement > ) => {
+		event.target.select();
+	};
+
+	return (
+		<PanelBody>
+			<p className="post-publish-section__postpublish-subheader">
+				<strong>{ __( 'What’s next?', 'woocommerce' ) }</strong>
+			</p>
+			<div className="post-publish-section__postpublish-post-address-container">
+				<TextControl
+					className="post-publish-section__postpublish-post-address"
+					readOnly
+					label={ __( 'product address', 'woocommerce' ) }
+					value={ productURL }
+					onFocus={ onSelectInput }
+					onChange={ () => {} }
+				/>
+
+				<div className="post-publish-section__copy-button-wrap">
+					<CopyButton text={ productURL } onCopy={ onCopyURL }>
+						<>
+							{ showCopyConfirmation
+								? __( 'Copied!', 'woocommerce' )
+								: __( 'Copy', 'woocommerce' ) }
+						</>
+					</CopyButton>
+				</div>
+			</div>
+
+			<div className="post-publish-section__postpublish-buttons">
+				{ ! isScheduled && (
+					<Button variant="primary" href={ productURL }>
+						{ __( 'View Product', 'woocommerce' ) }
+					</Button>
+				) }
+				<Button
+					variant={ isScheduled ? 'primary' : 'secondary' }
+					href={ getNewPath( {}, '/add-product', {} ) }
+				>
+					{ __( 'Add New Product', 'woocommerce' ) }
+				</Button>
+			</div>
+		</PanelBody>
+	);
+}

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-section.tsx
@@ -13,7 +13,7 @@ import { getNewPath } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { useProductScheduled } from '../../../hooks/use-product-scheduled';
-import { PostPublishSectionProps } from './types';
+import { CopyButtonProps, PostPublishSectionProps } from './types';
 import { TRACKS_SOURCE } from '../../../constants';
 import { useProductURL } from '../../../hooks/use-product-url';
 
@@ -26,15 +26,7 @@ export function PostPublishSection( { postType }: PostPublishSectionProps ) {
 
 	const productURL = getProductURL( isScheduled );
 
-	const CopyButton = ( {
-		text,
-		onCopy,
-		children,
-	}: {
-		text: string;
-		onCopy: () => void;
-		children: JSX.Element;
-	} ) => {
+	const CopyButton = ( { text, onCopy, children }: CopyButtonProps ) => {
 		const ref = useCopyToClipboard(
 			text,
 			onCopy

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-title.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-title.tsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { PostPublishTitleProps } from './types';
+import { useProductURL } from '../../../hooks/use-product-url';
+import { useProductScheduled } from '../../../hooks/use-product-scheduled';
+
+export function PostPublishTitle( {
+	productType = 'product',
+}: PostPublishTitleProps ) {
+	const { getProductURL } = useProductURL( productType );
+	const { isScheduled, formattedDate } = useProductScheduled( productType );
+	const [ editedProductName ] = useEntityProp< string >(
+		'postType',
+		productType,
+		'name'
+	);
+
+	const productURLString = getProductURL( false );
+	const getPostPublishedTitle = () => {
+		if ( isScheduled ) {
+			return createInterpolateElement(
+				sprintf(
+					/* translators: %s is the date when the product will be published */
+					__(
+						'<productURL /> now scheduled. It will go live on %s',
+						'woocommerce'
+					),
+					formattedDate
+				),
+				{
+					productURL: (
+						<a
+							className="woocommerce-product-list__product-name"
+							href={ productURLString }
+							target="_blank"
+							rel="noreferrer"
+						>
+							{ editedProductName }
+						</a>
+					),
+				}
+			);
+		}
+		return createInterpolateElement(
+			__( '<productURL /> is now live.', 'woocommerce' ),
+			{
+				productURL: (
+					<a
+						className="woocommerce-product-list__product-name"
+						href={ productURLString }
+						target="_blank"
+						rel="noreferrer"
+					>
+						{ editedProductName }
+					</a>
+				),
+			}
+		);
+	};
+
+	return (
+		<div className="woocommerce-product-publish-panel__published">
+			{ getPostPublishedTitle() }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-title.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/post-publish-title.tsx
@@ -30,7 +30,7 @@ export function PostPublishTitle( {
 				sprintf(
 					/* translators: %s is the date when the product will be published */
 					__(
-						'<productURL /> now scheduled. It will go live on %s',
+						'<productURL /> is now scheduled. It will go live on %s',
 						'woocommerce'
 					),
 					formattedDate

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/types.ts
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/types.ts
@@ -1,0 +1,7 @@
+export type PostPublishSectionProps = {
+	postType: string;
+};
+
+export type PostPublishTitleProps = {
+	productType: string;
+};

--- a/packages/js/product-editor/src/components/prepublish-panel/post-publish/types.ts
+++ b/packages/js/product-editor/src/components/prepublish-panel/post-publish/types.ts
@@ -5,3 +5,9 @@ export type PostPublishSectionProps = {
 export type PostPublishTitleProps = {
 	productType: string;
 };
+
+export type CopyButtonProps = {
+	text: string;
+	onCopy: () => void;
+	children: JSX.Element;
+};

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -43,7 +43,7 @@ export function PrepublishPanel( {
 
 	const { closePrepublishPanel } = useDispatch( productEditorUiStore );
 
-	const isPublished =
+	const isPublishedOrScheduled =
 		productType === 'product' && prevStatus !== 'future'
 			? productStatus === 'publish'
 			: true;
@@ -57,7 +57,7 @@ export function PrepublishPanel( {
 	}
 
 	function getHeaderActions() {
-		if ( isPublished ) {
+		if ( isPublishedOrScheduled ) {
 			return (
 				<Button
 					className="woocommerce-publish-panel-close"
@@ -93,7 +93,7 @@ export function PrepublishPanel( {
 	}
 
 	function getPanelTitle() {
-		if ( isPublished ) {
+		if ( isPublishedOrScheduled ) {
 			return <PostPublishTitle productType={ productType } />;
 		}
 		return (
@@ -105,7 +105,7 @@ export function PrepublishPanel( {
 	}
 
 	function getPanelSections() {
-		if ( isPublished ) {
+		if ( isPublishedOrScheduled ) {
 			return <PostPublishSection postType={ productType } />;
 		}
 		return (
@@ -119,7 +119,7 @@ export function PrepublishPanel( {
 	return (
 		<div
 			className={ classnames( 'woocommerce-product-publish-panel', {
-				'is-published': isPublished,
+				'is-published': isPublishedOrScheduled,
 			} ) }
 		>
 			<div className="woocommerce-product-publish-panel__header">

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -9,7 +9,6 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useEntityProp } from '@wordpress/core-data';
 import { closeSmall } from '@wordpress/icons';
 import classnames from 'classnames';
-import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -45,10 +44,10 @@ export function PrepublishPanel( {
 		productType,
 		'status'
 	);
-	const [ productId ] = useEntityProp< number >(
+	const [ permalink ] = useEntityProp< string >(
 		'postType',
 		productType,
-		'id'
+		'permalink'
 	);
 	const { closePrepublishPanel } = useDispatch( productEditorUiStore );
 
@@ -99,13 +98,19 @@ export function PrepublishPanel( {
 		);
 	}
 
+	let productURL: URL | undefined;
+	if ( typeof permalink === 'string' ) {
+		productURL = new URL( permalink );
+		productURL.searchParams.append( 'preview', 'true' );
+	}
+
 	function getPanelTitle() {
 		if ( isPublished ) {
 			return (
 				<div className="woocommerce-product-publish-panel__published">
 					<a
 						className="woocommerce-product-list__product-name"
-						href={ getNewPath( {}, `/product/${ productId }`, {} ) }
+						href={ productURL?.toString() }
 						target="_blank"
 						rel="noreferrer"
 					>

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -9,6 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useEntityProp } from '@wordpress/core-data';
 import { closeSmall } from '@wordpress/icons';
 import classnames from 'classnames';
+import type { Product } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import { TRACKS_SOURCE } from '../../constants';
 import { VisibilitySection } from './visibility-section';
 import { ScheduleSection } from './schedule-section';
 import { ShowPrepublishChecksSection } from './show-prepublish-checks-section';
+import { PostPublishSection, PostPublishTitle } from './post-publish';
 
 export function PrepublishPanel( {
 	productType = 'product',
@@ -34,25 +36,23 @@ export function PrepublishPanel( {
 		productType,
 		'date_created'
 	);
-	const [ editedProductName ] = useEntityProp< string >(
-		'postType',
-		productType,
-		'name'
-	);
 	const [ productStatus ] = useEntityProp< string >(
 		'postType',
 		productType,
 		'status'
 	);
-	const [ permalink ] = useEntityProp< string >(
+	const [ , , prevStatus ] = useEntityProp< Product[ 'status' ] >(
 		'postType',
 		productType,
-		'permalink'
+		'status'
 	);
+
 	const { closePrepublishPanel } = useDispatch( productEditorUiStore );
 
 	const isPublished =
-		productType === 'product' ? productStatus === 'publish' : true;
+		productType === 'product' && prevStatus !== 'future'
+			? productStatus === 'publish'
+			: true;
 
 	if ( editedDate !== date ) {
 		title = __( 'Are you ready to schedule this product?', 'woocommerce' );
@@ -98,27 +98,9 @@ export function PrepublishPanel( {
 		);
 	}
 
-	let productURL: URL | undefined;
-	if ( typeof permalink === 'string' ) {
-		productURL = new URL( permalink );
-	}
-
 	function getPanelTitle() {
 		if ( isPublished ) {
-			return (
-				<div className="woocommerce-product-publish-panel__published">
-					<a
-						className="woocommerce-product-list__product-name"
-						href={ productURL?.toString() }
-						target="_blank"
-						rel="noreferrer"
-					>
-						{ editedProductName }
-					</a>
-					&nbsp;
-					{ __( 'is now live.', 'woocommerce' ) }
-				</div>
-			);
+			return <PostPublishTitle productType={ productType } />;
 		}
 		return (
 			<>
@@ -130,7 +112,7 @@ export function PrepublishPanel( {
 
 	function getPanelSections() {
 		if ( isPublished ) {
-			return null;
+			return <PostPublishSection postType={ productType } />;
 		}
 		return (
 			<>

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -36,16 +36,10 @@ export function PrepublishPanel( {
 		productType,
 		'date_created'
 	);
-	const [ productStatus ] = useEntityProp< string >(
-		'postType',
-		productType,
-		'status'
-	);
-	const [ , , prevStatus ] = useEntityProp< Product[ 'status' ] >(
-		'postType',
-		productType,
-		'status'
-	);
+
+	const [ productStatus, , prevStatus ] = useEntityProp<
+		Product[ 'status' ]
+	>( 'postType', productType, 'status' );
 
 	const { closePrepublishPanel } = useDispatch( productEditorUiStore );
 

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -55,9 +55,6 @@ export function PrepublishPanel( {
 	const isPublished =
 		productType === 'product' ? productStatus === 'publish' : true;
 
-	console.log( 'isPublished', isPublished );
-	console.log( 'productStatus', productStatus );
-
 	if ( editedDate !== date ) {
 		title = __( 'Are you ready to schedule this product?', 'woocommerce' );
 		description = __(

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -101,7 +101,6 @@ export function PrepublishPanel( {
 	let productURL: URL | undefined;
 	if ( typeof permalink === 'string' ) {
 		productURL = new URL( permalink );
-		productURL.searchParams.append( 'preview', 'true' );
 	}
 
 	function getPanelTitle() {

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -32,6 +32,7 @@
 		align-items: center;
 		gap: 8px;
 		padding: 0 $grid-unit-20;
+		justify-content: right;
 
 		> button {
 			flex: 1;
@@ -40,6 +41,11 @@
 		.components-button {
 			width: 100%;
 			justify-content: center;
+		}
+
+		.woocommerce-publish-panel-close {
+			flex: unset;
+			width: unset;
 		}
 	}
 
@@ -67,6 +73,15 @@
 
 		.components-base-control__field {
 			margin: 0;
+		}
+	}
+}
+
+.is-published {
+	.woocommerce-product-publish-panel {
+		&__header, &__title {
+			border-bottom: $border-width solid $gray-200;
+			font-weight: 500;
 		}
 	}
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -52,17 +52,17 @@
 	}
 
 	&__content {
-		// Ensure the pre-publish panel accounts for the header and footer height.
-		min-height: calc( 100% - #{ $header-height + 200px } );
+		min-height: calc( 100% - #{ $header-height + 220px } );
 	}
 
 	&__footer {
-		padding: 0 $grid-unit-20;
+		padding: $gap $grid-unit-20 $gap-largest $grid-unit-20;
 		left: 0;
 		width: 100%;
 		min-height: $gap-largest + $gap-large;
 		display: flex;
 		align-items: center;
+		padding-bottom: $gap-largest;
 
 		.components-base-control__field {
 			margin: 0;
@@ -75,6 +75,9 @@
 		&__header, &__title {
 			border-bottom: $border-width solid $gray-200;
 			font-weight: 500;
+		}
+		&__content {
+			min-height: calc( 100% - #{ $header-height + 147px } );
 		}
 	}
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -70,10 +70,13 @@
 	}
 
 	.post-publish-section {
+		&__postpublish-subheader {
+			margin: 0 0 $gap-small;
+		}
 		&__postpublish-post-address-container {
 			align-items: flex-end;
 			display: flex;
-			margin-bottom: $gap-large;
+			margin-bottom: $gap-small;
 			gap: $gap;
 		}
 		&__postpublish-post-address {
@@ -103,7 +106,7 @@
 			font-weight: 500;
 		}
 		&__content {
-			min-height: calc( 100% - #{ $header-height + 147px } );
+			min-height: calc( 100% - #{ $header-height + 177px } );
 		}
 	}
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -111,6 +111,12 @@
 .interface-interface-skeleton__actions {
 	transform: translateX(+100%);
 	animation: product-publish-panel__slide-in-animation 0.1s forwards;
+	@include break-medium() {
+		// Keep it open on focus to avoid conflict with navigate-regions animation.
+		[role="region"]:focus & {
+			transform: translateX(0%);
+		}
+	}
 }
 
 @keyframes product-publish-panel__slide-in-animation {

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -62,7 +62,7 @@
 		min-height: $gap-largest + $gap-large;
 		display: flex;
 		align-items: center;
-		padding-bottom: $gap-largest;
+		margin-bottom: 20px;
 
 		.components-base-control__field {
 			margin: 0;
@@ -100,13 +100,16 @@
 }
 
 .is-published {
+	display: flex;
+	flex-direction: column;
 	.woocommerce-product-publish-panel {
 		&__header, &__title {
 			border-bottom: $border-width solid $gray-200;
 			font-weight: 500;
 		}
 		&__content {
-			min-height: calc( 100% - #{ $header-height + 177px } );
+			min-height: 180px;
+			flex-grow: 1;
 		}
 	}
 }

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -68,6 +68,32 @@
 			margin: 0;
 		}
 	}
+
+	.post-publish-section {
+		&__postpublish-post-address-container {
+			align-items: flex-end;
+			display: flex;
+			margin-bottom: $gap-large;
+			gap: $gap;
+		}
+		&__postpublish-post-address {
+			flex: 1;
+		}
+		&__copy-button-wrap {
+			flex-shrink: 0;
+			margin-bottom: $gap-smaller;
+		}
+		&__postpublish-buttons {
+			display: flex;
+			justify-content: space-between;
+			gap: $gap-small;
+			.components-button {
+				padding: $gap-smaller;
+				flex: 1;
+    			justify-content: center;
+			}
+		}
+	}
 }
 
 .is-published {
@@ -80,6 +106,11 @@
 			min-height: calc( 100% - #{ $header-height + 147px } );
 		}
 	}
+}
+
+.interface-interface-skeleton__actions {
+	transform: translateX(+100%);
+	animation: product-publish-panel__slide-in-animation 0.1s forwards;
 }
 
 @keyframes product-publish-panel__slide-in-animation {

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -7,22 +7,15 @@
 	overflow: auto;
     position: fixed;
 	background: $white;
-	transform: translateX(+100%);
-	animation: product-publish-panel__slide-in-animation 0.1s forwards;
     width: 100%;
 
 	@include break-medium() {
-		top: $admin-bar-height;
+		top: 0;
 		width: $sidebar-width - $border-width;
 		@include reduce-motion("animation");
 
 		body.is-fullscreen-mode & {
 			top: 0;
-		}
-
-		// Keep it open on focus to avoid conflict with navigate-regions animation.
-		[role="region"]:focus & {
-			transform: translateX(0%);
 		}
 	}
 

--- a/packages/js/product-editor/src/hooks/use-product-url.ts
+++ b/packages/js/product-editor/src/hooks/use-product-url.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+import { useCallback } from 'react';
+
+export function useProductURL( productType: string ) {
+	const [ permalink ] = useEntityProp< string >(
+		'postType',
+		productType,
+		'permalink'
+	);
+	const getProductURL = useCallback(
+		( isPreview: boolean ) => {
+			const productURL = new URL( permalink ) as URL | undefined;
+			if ( isPreview ) {
+				productURL?.searchParams.append( 'preview', 'true' );
+			}
+			return productURL?.toString() || '';
+		},
+		[ permalink ]
+	);
+	return { getProductURL };
+}

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -35,11 +35,6 @@
 		@include break-medium() {
 			top: $admin-bar-height;
 			width: $sidebar-width;
-
-			// Keep it open on focus to avoid conflict with navigate-regions animation.
-			[role="region"]:focus & {
-				transform: translateX(0%);
-			}
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -32,8 +32,6 @@
 		z-index: 9999;
 		width: 100%;
 		overflow: auto;
-		transform: translateX(+100%);
-		animation: product-publish-panel__slide-in-animation 0.1s forwards;
 		@include break-medium() {
 			top: $admin-bar-height;
 			width: $sidebar-width;

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -32,9 +32,16 @@
 		z-index: 9999;
 		width: 100%;
 		overflow: auto;
+		transform: translateX(+100%);
+		animation: product-publish-panel__slide-in-animation 0.1s forwards;
 		@include break-medium() {
 			top: $admin-bar-height;
 			width: $sidebar-width;
+
+			// Keep it open on focus to avoid conflict with navigate-regions animation.
+			[role="region"]:focus & {
+				transform: translateX(0%);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a message after publishing (or scheduling) a product.

It will be similar to what we see after publishing a post:
![Screenshot 2024-02-21 at 08 05 46](https://github.com/woocommerce/woocommerce/assets/1314156/c0efa1c6-057f-41c0-858c-e2635a1524c0)

Closes #44474.

ACs
- [x] `[product name] is now live.` when a product has been published.
- [x] Not show the Publish/Cancel buttons but instead just an x ( same as the post/site editor ).
- [x] show a `What's next?` section with the product address and a copy button.
- [x] Add buttons to `View product` and `Add New Product` 
- [x] For scheduled products it will say: [product name] is now scheduled. It will go live on [date]
- [x] The button `View product` won't be visible for scheduled products.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New > General.
3. Add a product name, a price and press `Publish`.
4. The prepublish panel will be visible. Press `Publish`.
5. Verify you see the following in the prepublish panel.

![Screenshot 2024-03-06 at 11 47 20](https://github.com/woocommerce/woocommerce/assets/1314156/d52fdd59-839f-4b7e-90c5-ef9a0e43afff)

- `[product name] is now live.` when a product has been published.
- Under `Product address` it will be an input with the product URL and a button to copy it.
- Not show the Publish/Cancel buttons but instead just an x ( same as the post/site editor ).
- Buttons to `View product` and `Add New Product`.

6. Repeat steps 2 and 3.
7. Now schedule the new product for a date in the future.
8. Press `Schedule`.
9. Verify you see the following in the prepublish panel.

![Screenshot 2024-03-06 at 11 51 24](https://github.com/woocommerce/woocommerce/assets/1314156/5d2b1d07-c75e-4f00-b878-5041ebdfc7bd)

- The text: `[product name] is now scheduled. It will go live on [date]` is visible.
- Under `Product address` it will be an input with the product URL and a button to copy it.
- The button `View product` won't be visible for scheduled products.
- The Publish/Cancel buttons won't be visible. Instead, just an x will be visible.

10. Verify the panel works well on different screens.
11. Since the UsePreview hook has been modified here, test that button as well.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
