### PR TITLE
Revert 44084 and 44790 to be punted to next release

### DIFF
--- a/plugins/woocommerce/changelog/fix-43879
+++ b/plugins/woocommerce/changelog/fix-43879
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Don't load REST API when generating possible routes.

--- a/plugins/woocommerce/changelog/fix-44080
+++ b/plugins/woocommerce/changelog/fix-44080
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Follow up fixup to unreleased change, no changelog necessary.
-
-

--- a/plugins/woocommerce/changelog/revert-44084
+++ b/plugins/woocommerce/changelog/revert-44084
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Reverts PR 44084 and 44790, no changelog is needed.
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -463,25 +463,6 @@ abstract class AbstractBlock {
 	 * @return array
 	 */
 	protected function get_routes_from_namespace( $namespace ) {
-		/**
-		 * Gives opportunity to return routes without invoking the compute intensive REST API.
-		 *
-		 * @since 8.7.0
-		 * @param array  $routes    Array of routes.
-		 * @param string $namespace Namespace for routes.
-		 * @param string $context   Context, can be edit or view.
-		 */
-		$routes = apply_filters(
-			'woocommerce_blocks_pre_get_routes_from_namespace',
-			[],
-			$namespace,
-			'view'
-		);
-
-		if ( ! empty( $routes ) ) {
-			return $routes;
-		}
-
 		$rest_server     = rest_get_server();
 		$namespace_index = $rest_server->get_namespace_index(
 			[

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -57,8 +57,6 @@ class Hydration {
 
 		$this->cache_store_notices();
 
-		$preloaded_data = array();
-
 		if ( null !== $controller_class ) {
 			$request           = new \WP_REST_Request( 'GET', $path );
 			$schema_controller = StoreApi::container()->get( SchemaController::class );
@@ -67,22 +65,21 @@ class Hydration {
 				$schema_controller->get( $controller_class::SCHEMA_TYPE, $controller_class::SCHEMA_VERSION )
 			);
 
-			$response       = $controller->get_response( $request );
-			$preloaded_data = array(
+			$response = $controller->get_response( $request );
+			return array(
 				'body'    => $response->get_data(),
 				'headers' => $response->get_headers(),
 			);
-		} else {
-			// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
-			$preloaded_requests = rest_preload_api_request( [], $path );
-			$preloaded_data     = $preloaded_requests[ $path ] ?? [];
 		}
+
+		// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
+		$preloaded_requests = rest_preload_api_request( [], $path );
 
 		$this->restore_cached_store_notices();
 		$this->restore_nonce_check();
 
 		// Returns just the single preloaded request, or an empty array if it doesn't exist.
-		return $preloaded_data;
+		return $preloaded_requests[ $path ] ?? [];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -2,9 +2,6 @@
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
-use Automattic\WooCommerce\StoreApi\RoutesController;
-use Automattic\WooCommerce\StoreApi\SchemaController;
-use Automattic\WooCommerce\StoreApi\StoreApi;
 
 /**
  * Service class that handles hydration of API data for blocks.
@@ -41,36 +38,8 @@ class Hydration {
 	 * @return array Response data.
 	 */
 	public function get_rest_api_response_data( $path = '' ) {
-		if ( ! str_starts_with( $path, '/wc/store' ) ) {
-			return [];
-		}
-
-		$available_routes = StoreApi::container()->get( RoutesController::class )->get_all_routes( 'v1', true );
-		$controller_class = $this->match_route_to_handler( $path, $available_routes );
-
-		/**
-		 * We disable nonce check to support endpoints such as checkout. The caveat here is that we need to be careful to only support GET requests. No other request type should be processed without nonce check. Additionally, no GET request can modify data as part of hydration request, for example adding items to cart.
-		 *
-		 * Long term, we should consider validating nonce here, instead of disabling it temporarily.
-		 */
-		$this->disable_nonce_check();
-
 		$this->cache_store_notices();
-
-		if ( null !== $controller_class ) {
-			$request           = new \WP_REST_Request( 'GET', $path );
-			$schema_controller = StoreApi::container()->get( SchemaController::class );
-			$controller        = new $controller_class(
-				$schema_controller,
-				$schema_controller->get( $controller_class::SCHEMA_TYPE, $controller_class::SCHEMA_VERSION )
-			);
-
-			$response = $controller->get_response( $request );
-			return array(
-				'body'    => $response->get_data(),
-				'headers' => $response->get_headers(),
-			);
-		}
+		$this->disable_nonce_check();
 
 		// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
 		$preloaded_requests = rest_preload_api_request( [], $path );
@@ -80,27 +49,6 @@ class Hydration {
 
 		// Returns just the single preloaded request, or an empty array if it doesn't exist.
 		return $preloaded_requests[ $path ] ?? [];
-	}
-
-	/**
-	 * Inspired from WP core's `match_request_to_handler`, this matches a given path from available route regexes.
-	 * However, unlike WP core, this does not check against query params, request method etc.
-	 *
-	 * @param string $path The path to match.
-	 * @param array  $available_routes Available routes in { $regex1 => $contoller_class1, ... } format.
-	 *
-	 * @return string|null
-	 */
-	private function match_route_to_handler( $path, $available_routes ) {
-		$matched_route = null;
-		foreach ( $available_routes as $route_path => $controller ) {
-			$match = preg_match( '@^' . $route_path . '$@i', $path );
-			if ( $match ) {
-				$matched_route = $controller;
-				break;
-			}
-		}
-		return $matched_route;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
@@ -30,15 +30,6 @@ class BusinessDescription extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/ai/business-description';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
@@ -30,15 +30,6 @@ class Images extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/ai/images';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
@@ -34,15 +34,6 @@ class Patterns extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/ai/patterns';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
@@ -31,15 +31,6 @@ class Product extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/ai/product';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
@@ -32,15 +32,6 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/ai/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
@@ -32,15 +32,6 @@ class StoreInfo extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/ai/store-info';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
@@ -45,15 +45,6 @@ class StoreTitle extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/ai/store-title';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -30,15 +30,6 @@ class Batch extends AbstractRoute implements RouteInterface {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/batch';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
@@ -18,15 +18,6 @@ class Cart extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -20,15 +20,6 @@ class CartAddItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/add-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
@@ -20,15 +20,6 @@ class CartApplyCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/apply-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
@@ -27,15 +27,6 @@ class CartCoupons extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/coupons';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
@@ -27,15 +27,6 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/coupons/(?P<code>[\w-]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
@@ -27,15 +27,6 @@ class CartExtensions extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/extensions';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
@@ -27,15 +27,6 @@ class CartItems extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/items';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
@@ -27,15 +27,6 @@ class CartItemsByKey extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/items/(?P<key>[\w-]{32})';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
@@ -20,15 +20,6 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/remove-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -23,15 +23,6 @@ class CartRemoveItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/remove-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -20,15 +20,6 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/select-shipping-rate';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -25,15 +25,6 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/update-customer';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -18,15 +18,6 @@ class CartUpdateItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/cart/update-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -44,15 +44,6 @@ class Checkout extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/checkout';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -41,15 +41,6 @@ class CheckoutOrder extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/checkout/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
@@ -51,15 +51,6 @@ class Order extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/order/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -20,15 +20,6 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/attributes/(?P<attribute_id>[\d]+)/terms';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
@@ -25,15 +25,6 @@ class ProductAttributes extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/attributes';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
@@ -27,15 +27,6 @@ class ProductAttributesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/attributes/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
@@ -25,15 +25,6 @@ class ProductCategories extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/categories';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
@@ -27,15 +27,6 @@ class ProductCategoriesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/categories/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -30,15 +30,6 @@ class ProductCollectionData extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/collection-data';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -28,15 +28,6 @@ class ProductReviews extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/reviews';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
@@ -18,15 +18,6 @@ class ProductTags extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/tags';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
@@ -28,15 +28,6 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -27,15 +27,6 @@ class ProductsById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -27,15 +27,6 @@ class ProductsBySlug extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return self::get_path_regex();
-	}
-
-	/**
-	 * Get the path of this rest route.
-	 *
-	 * @return string
-	 */
-	public static function get_path_regex() {
 		return '/products/(?P<slug>[\S]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -22,13 +22,6 @@ class RoutesController {
 	protected $routes = [];
 
 	/**
-	 * Namespace for the API.
-	 *
-	 * @var string
-	 */
-	private static $api_namespace = 'wc/store';
-
-	/**
 	 * Constructor.
 	 *
 	 * @param SchemaController $schema_controller Schema controller class passed to each route.
@@ -83,8 +76,8 @@ class RoutesController {
 	 * Register all Store API routes. This includes routes under specific version namespaces.
 	 */
 	public function register_all_routes() {
-		$this->register_routes( 'v1', self::$api_namespace );
-		$this->register_routes( 'v1', self::$api_namespace . '/v1' );
+		$this->register_routes( 'v1', 'wc/store' );
+		$this->register_routes( 'v1', 'wc/store/v1' );
 		$this->register_routes( 'private', 'wc/private' );
 	}
 
@@ -109,35 +102,6 @@ class RoutesController {
 			$this->schema_controller,
 			$this->schema_controller->get( $route::SCHEMA_TYPE, $route::SCHEMA_VERSION )
 		);
-	}
-
-	/**
-	 * Get a route path without instantiating the corresponding RoutesController object.
-	 *
-	 * @throws \Exception If the schema does not exist.
-	 *
-	 * @param string $version API Version being requested.
-	 * @param string $controller Whether to return controller name. If false, returns empty array. Note:
-	 * When $controller param is true, the output should not be used directly in front-end code, to prevent class names from leaking. It's not a security issue necessarily, but it's not a good practice.
-	 * When $controller param is false, it currently returns and empty array. But it can be modified in future to return include more details about the route info that can be used in frontend.
-	 *
-	 * @return string[] List of route paths.
-	 */
-	public function get_all_routes( $version = 'v1', $controller = false ) {
-		$routes = [];
-
-		foreach ( $this->routes[ $version ] as $key => $route_class ) {
-
-			if ( ! method_exists( $route_class, 'get_path_regex' ) ) {
-				throw new \Exception( "{$route_class} route does not have a get_path_regex method" );
-			}
-
-			$route_path = '/' . trailingslashit( self::$api_namespace ) . $version . $route_class::get_path_regex();
-
-			$routes[ $route_path ] = $controller ? $route_class : array();
-		}
-
-		return $routes;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -35,24 +35,6 @@ final class StoreApi {
 			},
 			11
 		);
-
-		add_action(
-			'woocommerce_blocks_pre_get_routes_from_namespace',
-			function( $routes, $namespace, $context ) {
-				if ( 'wc/store/v1' !== $namespace ) {
-					return array();
-				}
-
-				$routes = array_merge(
-					$routes,
-					self::container()->get( RoutesController::class )->get_all_routes( 'v1' )
-				);
-
-				return $routes;
-			},
-			10,
-			3
-		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR reverts #44080 and #44790 to allow more time for testing and compatibility. During release testing, we discovered that there would be 3pd plugins that actually hooking into REST API hooks and while we do have a way to this backward compatible (see #44831) we'd like to have more time to properly test the fix.

So this reverts punts these PR to a later release and allow us more time for testing.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Since the original PRs were not functional in the first place, E2E tests for blocks passing are enough. Exploratory testing for blocks may also be considered (such as checking out orders using cart and checkout blocks).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
