### PR TITLE
Fix promotions filtering by tab

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -6,7 +6,7 @@ import Notice from '../notice/notice';
 
 declare global {
 	interface Window {
-		wcMarketplace: {
+		wcMarketplace?: {
 			promotions?: Promotion[];
 		};
 	}
@@ -39,7 +39,7 @@ const Promotions: () => null | JSX.Element = () => {
 	if ( currentPage !== 'wc-admin' ) {
 		return null;
 	}
-	const promotions = window.wcMarketplace?.promotions ?? [];
+	const promotions = window?.wcMarketplace?.promotions ?? [];
 	const currentDateUTC = Date.now();
 	const currentPath = decodeURIComponent( urlParams.get( 'path' ) || '' );
 	const currentTab = urlParams.get( 'tab' );

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -65,11 +65,12 @@ const Promotions: () => null | JSX.Element = () => {
 						)
 							? currentPath
 							: `/${ currentPath }`;
-						return (
-							page.page === currentPage &&
+
+						return page.page === currentPage &&
 							normalizedPath === normalizedCurrentPath &&
-							( page.tab ? page.tab === currentTab : true )
-						);
+							page.tab
+							? page.tab === currentTab
+							: ! currentTab;
 					}
 				);
 

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -19,7 +19,7 @@ type Promotion = {
 	pages: Page[];
 	position: string;
 	content: { [ locale: string ]: string };
-	icon?: string | undefined;
+	icon?: string;
 	is_dismissible?: boolean;
 	menu_item_id?: string;
 	style?: string;
@@ -103,7 +103,7 @@ const Promotions: () => null | JSX.Element = () => {
 							variant={
 								promotion.style ? promotion.style : 'info'
 							}
-							icon={ promotion?.icon }
+							icon={ promotion?.icon || '' }
 							isDismissible={ promotion.is_dismissible || false }
 						/>
 					);

--- a/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/promotions/promotions.tsx
@@ -6,10 +6,8 @@ import Notice from '../notice/notice';
 
 declare global {
 	interface Window {
-		wc: {
-			marketplace?: {
-				promotions: Promotion[];
-			};
+		wcMarketplace: {
+			promotions?: Promotion[];
 		};
 	}
 }
@@ -41,7 +39,7 @@ const Promotions: () => null | JSX.Element = () => {
 	if ( currentPage !== 'wc-admin' ) {
 		return null;
 	}
-	const promotions = window.wc?.marketplace?.promotions ?? [];
+	const promotions = window.wcMarketplace?.promotions ?? [];
 	const currentDateUTC = Date.now();
 	const currentPath = decodeURIComponent( urlParams.get( 'path' ) || '' );
 	const currentTab = urlParams.get( 'tab' );

--- a/plugins/woocommerce/changelog/44884-update-promotions-show
+++ b/plugins/woocommerce/changelog/44884-update-promotions-show
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Fix condition in Promotions component so marketplace promotions are properly filtered by page.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -558,7 +558,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			// Marketplace promotions.
 			if ( in_array( $screen_id, array( 'woocommerce_page_wc-admin' ), true ) ) {
 
-				$promotions = get_transient( 'woocommerce_marketplace_promotions' );
+				$promotions = get_transient( WC_Admin_Marketplace_Promotions::TRANSIENT_NAME );
 
 				if ( false === $promotions ) {
 					return;
@@ -566,7 +566,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				wp_add_inline_script(
 					'wc-admin-app',
-					'window.wc = window.wc || {}; wc.marketplace = ' . wp_json_encode( array( 'promotions' => $promotions ) ),
+					'(window.wc = window.wc || {}).marketplace = ' . wp_json_encode( array( 'promotions' => $promotions ) ),
 					'before'
 				);
 			}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -566,7 +566,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				wp_add_inline_script(
 					'wc-admin-app',
-					'(window.wc = window.wc || {}).marketplace = ' . wp_json_encode( array( 'promotions' => $promotions ) ),
+					'window.wcMarketplace = ' . wp_json_encode( array( 'promotions' => $promotions ) ),
 					'before'
 				);
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Fix the condition in the `Promotions` component which checks for tab parameter to decide whether or not to show a notice on a given page. When the `pages` array of a promotion specifies a page with no `tab` property, the code is currently showing the promotion even on pages with tab parameters.
- Using reference to `WC_Admin_Marketplace_Promotions::TRANSIENT_NAME` when outputting JS data for promotions, instead of transient string.
- Better initialisation of wc global object in the inline script.
- Changes from adding a property to the `wc` global object to creating a new global object `wcMarketplace`, as `wc` was not being created on some external test sites.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 19573-gh-Automattic/woocommerce.com.
Related: https://github.com/woocommerce/woocommerce/pull/44840
Related: https://github.com/woocommerce/woocommerce/pull/44655

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Check out this branch.
2. Change the URL in `fetch_marketplace_promotions` on [this line](https://github.com/woocommerce/woocommerce/blob/a1a671d8728eb48f89a9b71d78e41d2aa0801baa/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php#L80) to the URL here: 339ad-pb/. This is a gist providing dummy data. If you can't access that URL and you have a GitHub account, create a [gist](https://gist.github.com/) of your own, paste in this content, and use the raw URL of that gist:

```
[
	{
		"date_from_gmt": "2024-02-14 00:00",
		"date_to_gmt": "2024-03-31 22:59",
		"format": "notice",
		"style": "info",
		"pages": [
			{ "page": "wc-admin", "path": "/extensions" },
			{ "page": "wc-admin", "path": "/extensions", "tab": "extensions" },
			{ "page": "wc-admin", "path": "/extensions", "tab": "themes" }
		],
		"content": {
			"en_US": "<b>Limited time sale</b> up to 40% off. Sale ends March 29 at 2pm UTC."
		},
		"icon": "percent",
		"is_dismissible": true
	},
	{
		"date_from_gmt": "2024-02-14 00:00",
		"date_to_gmt": "2024-03-31 22:59",
		"format": "notice",
		"style": "success",
		"pages": [{ "page": "wc-admin", "path": "/extensions", "tab": "extensions" }],
		"content": {
			"en_US": "<b>Limited time sale</b> up to 40% off. Sale ends March 29 at 2pm UTC.",
			"fr_FR": "<b>Vente \u00e0 dur\u00e9e limit\u00e9e</b> jusqu'\u00e0 40 % de r\u00e9duction. La vente se termine le 29 mars \u00e0 14h UTC."
		}
	},
	{
		"date_from_gmt": "2024-02-14 00:00",
		"date_to_gmt": "2024-02-20 22:59",
		"format": "notice",
		"style": "success",
		"pages": [{ "page": "wc-admin", "path": "/extensions", "tab": "extensions" }],
		"content": {
			"en_US": "Test item, should be filtered out"
		}
	},
	{
		"date_from_gmt": "2024-02-13 00:00",
		"date_to_gmt": "2024-03-31 22:59",
		"format": "menu_bubble",
		"content": { "en_US": "Sale" },
		"menu_item_id": "woocommerce-marketplace"
	},
	{
		"date_from_gmt": "2024-02-01 00:00",
		"date_to_gmt": "2024-02-01 22:59",
		"format": "menu_bubble",
		"content": { "en_US": "Test item, should be filtered out" },
		"menu_item_id": "woocommerce-marketplace"
	}
]
```

4. If you're doing repeated tests, and you're using wp-env, you can flush the transient the promotions class creates by doing `wp-env run cli wp transient delete --all`.
5. To bypass the transient, you can comment out these lines in [fetch_marketplace_promotions](https://github.com/woocommerce/woocommerce/blob/a1a671d8728eb48f89a9b71d78e41d2aa0801baa/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php#L83):

```php
if ( false !== $promotions ) {
	return;
}
```

6. The promotions class runs a scheduled action to fetch data. So it's convenient to install [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) in your environment. Then, to fetch the data again, find the scheduled action [woocommerce_marketplace_fetch_promotions](http://localhost:8888/wp-admin/tools.php?page=crontrol_admin_manage_page&s=woocommerce_marketplace_fetch_promotions) and click "Run now" to run it.
7. You should see a badge on the Extensions menu item, and these notices:

[Extensions Discover tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions)

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/0738e4ae-a295-458d-b389-f8e6ca649412">

<p>&nbsp;</p>

[Extensions Browse tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=extensions&path=%2Fextensions)

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/47eacfb1-dc38-402e-bffe-e003cde21a8b">

<p>&nbsp;</p>

[Extensions Themes tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=themes&path=%2Fextensions)

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/1f4b2f63-b304-4b6c-b028-8752106eb7b2">

<p>&nbsp;</p>

[Extensions My Subscriptions tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions) – no notice

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/27786640-959f-4773-a80d-03593a446a95">

<p>&nbsp;</p>

8. Other WooCommerce Admin pages should load and work as usual, with no new JS errors.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>