### PR TITLE
Fix Deprecated dynamic property errors in php 8.2

### DIFF
--- a/plugins/woocommerce/changelog/pr-44896
+++ b/plugins/woocommerce/changelog/pr-44896
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make dynamic properties explicit in WC_Order_Item

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -16,7 +16,18 @@ defined( 'ABSPATH' ) || exit;
  * Order item class.
  */
 class WC_Order_Item extends WC_Data implements ArrayAccess {
+	/**
+	 * @deprecated 4.4.0 For legacy actions.
+	 * @var array
+	 */
+	public $legacy_values;
 
+	/**
+	 * @deprecated 4.4.0 For legacy actions.
+	 * @var string
+	 */
+	public $legacy_cart_item_key;
+	
 	/**
 	 * Order Data array. This is the core order data exposed in APIs since 3.0.0.
 	 *

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -17,17 +17,21 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Order_Item extends WC_Data implements ArrayAccess {
 	/**
+	 * Legacy cart item values.
+	 *
 	 * @deprecated 4.4.0 For legacy actions.
 	 * @var array
 	 */
 	public $legacy_values;
 
 	/**
+	 * Legacy cart item keys.
+	 *
 	 * @deprecated 4.4.0 For legacy actions.
 	 * @var string
 	 */
 	public $legacy_cart_item_key;
-	
+
 	/**
 	 * Order Data array. This is the core order data exposed in APIs since 3.0.0.
 	 *


### PR DESCRIPTION
The `\WC_Checkout::create_order_line_items` method assigns values to properties of the `WC_Order_Item_Product` class which did not exist.

PHP Deprecated:  Creation of dynamic property WC_Order_Item_Product::$legacy_values

PHP Deprecated:  Creation of dynamic property WC_Order_Item_Product::$legacy_cart_item_key

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Include the missing properties on the `WC_Order_Item_Product` class.

Fixes #38857

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new order which ends up calling `\WC_Checkout::create_order_line_items` (pretty much any order type).
2. Set the `error_reporting = E_ALL` in the PHP ini to show the errors in the log.
3. During unit testing you may use `convertErrorsToExceptions="true"` in the <phpunit> configuration to make the deprecated errors throw.
3. View the PHP error logs if throw on deprecated is not enabled.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix - Resolve assigning deprecated dynamic properties to `WC_Order_Item_Product` in PHP 8.2

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
