### PR TITLE
Running async event to fetch promotions on `woocommerce_init` on an admin page

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -38,9 +38,11 @@ class WC_Admin_Marketplace_Promotions {
 		}
 
 		if ( self::is_admin_page() ) {
+			wp_schedule_single_event( time(), self::SCHEDULED_ACTION_HOOK );
+
 			// Schedule the action twice a day, starting now.
 			if ( false === wp_next_scheduled( self::SCHEDULED_ACTION_HOOK ) ) {
-				wp_schedule_event( time(), 'twicedaily', self::SCHEDULED_ACTION_HOOK );
+				wp_schedule_event( time() + ( 10 * MINUTE_IN_SECONDS ), 'twicedaily', self::SCHEDULED_ACTION_HOOK );
 			}
 
 			self::$locale = ( self::$locale ?? get_user_locale() ) ?? 'en_US';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

* Schedules single event to fetch promotions on `woocommerce_init` if we're on one of the pages in the WooCommerce menu.

In https://github.com/woocommerce/woocommerce/pull/44655, we're scheduling an action to run twice daily to fetch promotions and store them in a transient. In testing, however, it seems the action is not running soon enough or reliably enough. So we're now running it once on `woocommerce_init`, if the user is in one of the main WooCommerce admin pages.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `pnpm --filter="plugins/woocommerce" build` to make sure the notices will render correctly.
3. Change the URL in `fetch_marketplace_promotions` on [this line](https://github.com/woocommerce/woocommerce/blob/a1a671d8728eb48f89a9b71d78e41d2aa0801baa/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php#L80) to the URL here: 339ad-pb/. This is a gist providing dummy data. If you can't access that URL and you have a GitHub account, create a [gist](https://gist.github.com/) of your own, paste in this content, and use the raw URL of that gist:

```
[
	{
		"date_from_gmt": "2024-02-14 00:00",
		"date_to_gmt": "2024-03-31 22:59",
		"format": "notice",
		"style": "info",
		"pages": [
			{ "page": "wc-admin", "path": "/extensions" },
			{ "page": "wc-admin", "path": "/extensions", "tab": "extensions" },
			{ "page": "wc-admin", "path": "/extensions", "tab": "themes" }
		],
		"content": {
			"en_US": "<b>Limited time sale</b> up to 40% off. Sale ends March 29 at 2pm UTC."
		},
		"icon": "percent",
		"is_dismissible": true
	},
	{
		"date_from_gmt": "2024-02-14 00:00",
		"date_to_gmt": "2024-03-31 22:59",
		"format": "notice",
		"style": "success",
		"pages": [{ "page": "wc-admin", "path": "/extensions", "tab": "extensions" }],
		"content": {
			"en_US": "<b>Limited time sale</b> up to 40% off. Sale ends March 29 at 2pm UTC.",
			"fr_FR": "<b>Vente \u00e0 dur\u00e9e limit\u00e9e</b> jusqu'\u00e0 40 % de r\u00e9duction. La vente se termine le 29 mars \u00e0 14h UTC."
		}
	},
	{
		"date_from_gmt": "2024-02-14 00:00",
		"date_to_gmt": "2024-02-20 22:59",
		"format": "notice",
		"style": "success",
		"pages": [{ "page": "wc-admin", "path": "/extensions", "tab": "extensions" }],
		"content": {
			"en_US": "Test item, should be filtered out"
		}
	},
	{
		"date_from_gmt": "2024-02-13 00:00",
		"date_to_gmt": "2024-03-31 22:59",
		"format": "menu_bubble",
		"content": { "en_US": "Sale" },
		"menu_item_id": "woocommerce-marketplace"
	},
	{
		"date_from_gmt": "2024-02-01 00:00",
		"date_to_gmt": "2024-02-01 22:59",
		"format": "menu_bubble",
		"content": { "en_US": "Test item, should be filtered out" },
		"menu_item_id": "woocommerce-marketplace"
	}
]
```

4. If you're doing repeated tests, and you're using wp-env, you can flush the transient the promotions class creates by doing `wp-env run cli wp transient delete --all`.
5. To bypass the transient, you can comment out these lines in [fetch_marketplace_promotions](https://github.com/woocommerce/woocommerce/blob/a1a671d8728eb48f89a9b71d78e41d2aa0801baa/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php#L83):

```php
if ( false !== $promotions ) {
	return;
}
```

6. The promotions class runs a scheduled action to fetch data. So it's convenient to install [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) in your environment. Then, to fetch the data again, find the scheduled action [woocommerce_marketplace_fetch_promotions](http://localhost:8888/wp-admin/tools.php?page=crontrol_admin_manage_page&s=woocommerce_marketplace_fetch_promotions) and click "Run now" to run it.
7. You should see these notices:

[Extensions Discover tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions)

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/0738e4ae-a295-458d-b389-f8e6ca649412">

<p>&nbsp;</p>

[Extensions Browse tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=extensions&path=%2Fextensions)

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/47eacfb1-dc38-402e-bffe-e003cde21a8b">

<p>&nbsp;</p>

[Extensions Themes tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=themes&path=%2Fextensions)

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/1f4b2f63-b304-4b6c-b028-8752106eb7b2">

<p>&nbsp;</p>

[Extensions My Subscriptions tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions) – no notice

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/27786640-959f-4773-a80d-03593a446a95">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
