### PR TITLE
Add simple products to the Analytics orders query for the attributes filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-32237_orders_simple_products
+++ b/plugins/woocommerce/changelog/fix-32237_orders_simple_products
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Include simple product support in the attributes filter within the analytics orders view.

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1398,12 +1398,14 @@ class DataStore extends SqlQuery {
 
 				$in_comparator = '=' === $comparator ? 'in' : 'not in';
 
+
 				// Add subquery for products ordered using attributes not used in variations.
+				$term_attribute_subquery = "select product_id from {$wpdb->prefix}wc_product_attributes_lookup where is_variation_attribute=0 and term_id = %s";
 				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$sql_clauses['where'][] = $wpdb->prepare(
 					"
 					( ( {$join_alias}.meta_key = %s AND {$join_alias}.meta_value {$comparator} %s ) or (
-						{$wpdb->prefix}wc_order_product_lookup.variation_id = 0 and {$wpdb->prefix}wc_order_product_lookup.product_id {$in_comparator} ( select product_id from {$wpdb->prefix}wc_product_attributes_lookup where is_variation_attribute=0 and term_id = %s )
+						{$wpdb->prefix}wc_order_product_lookup.variation_id = 0 and {$wpdb->prefix}wc_order_product_lookup.product_id {$in_comparator} ({$term_attribute_subquery})
 					) )",
 					$meta_key,
 					$meta_value,

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1345,6 +1345,7 @@ class DataStore extends SqlQuery {
 					continue;
 				}
 
+				$term_id = '';
 				// If the tuple is numeric, assume these are IDs.
 				if ( is_numeric( $attribute_term[0] ) && is_numeric( $attribute_term[1] ) ) {
 					$attribute_id = intval( $attribute_term[0] );
@@ -1374,6 +1375,10 @@ class DataStore extends SqlQuery {
 					// Assume these are a custom attribute slug/value pair.
 					$meta_key   = esc_sql( $attribute_term[0] );
 					$meta_value = esc_sql( $attribute_term[1] );
+					$attr_term  = get_term_by( 'slug', $meta_value, $meta_key );
+					if ( false !== $attr_term ) {
+						$term_id = $attr_term->term_id;
+					}
 				}
 
 				$join_alias       = 'orderitemmeta1';
@@ -1391,19 +1396,20 @@ class DataStore extends SqlQuery {
 					$sql_clauses['join'][] = "JOIN {$wpdb->prefix}woocommerce_order_itemmeta as {$join_alias} ON {$join_alias}.order_item_id = {$table_to_join_on}.order_item_id";
 				}
 
-				$in_comparator = $comparator === '=' ? 'in' : 'not in';
+				$in_comparator = '=' === $comparator ? 'in' : 'not in';
 
 				// Add subquery for products ordered using attributes not used in variations.
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$sql_clauses['where'][] = $wpdb->prepare(
 					"
 					( ( {$join_alias}.meta_key = %s AND {$join_alias}.meta_value {$comparator} %s ) or (
-						wp_wc_order_product_lookup.variation_id = 0 and wp_wc_order_product_lookup.product_id {$in_comparator} ( select product_id from wp_wc_product_attributes_lookup where is_variation_attribute=0 and term_id = %s )
+						{$wpdb->prefix}wc_order_product_lookup.variation_id = 0 and {$wpdb->prefix}wc_order_product_lookup.product_id {$in_comparator} ( select product_id from {$wpdb->prefix}wc_product_attributes_lookup where is_variation_attribute=0 and term_id = %s )
 					) )",
 					$meta_key,
 					$meta_value,
 					$term_id,
 				);
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			}
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1398,10 +1398,10 @@ class DataStore extends SqlQuery {
 
 				$in_comparator = '=' === $comparator ? 'in' : 'not in';
 
-
 				// Add subquery for products ordered using attributes not used in variations.
 				$term_attribute_subquery = "select product_id from {$wpdb->prefix}wc_product_attributes_lookup where is_variation_attribute=0 and term_id = %s";
 				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 				$sql_clauses['where'][] = $wpdb->prepare(
 					"
 					( ( {$join_alias}.meta_key = %s AND {$join_alias}.meta_value {$comparator} %s ) or (
@@ -1412,6 +1412,7 @@ class DataStore extends SqlQuery {
 					$term_id,
 				);
 				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 			}
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1412,7 +1412,7 @@ class DataStore extends SqlQuery {
 		$num_attribute_filters = count( $sql_clauses['join'] );
 
 		for ( $i = 2; $i < $num_attribute_filters; $i++ ) {
-			$join_alias            = 'orderitemmeta' . $i - 1;
+			$join_alias            = 'orderitemmeta' . $i;
 			$sql_clauses['join'][] = "AND orderitemmeta1.order_item_id = {$join_alias}.order_item_id";
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders-stats.php
@@ -147,6 +147,26 @@ class WC_Admin_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 		$order_variation_1  = wc_get_product( $product_variations[1] ); // Variation: size = large.
 		$order_variation_2  = wc_get_product( $product_variations[3] ); // Variation: size = huge, colour = red, number = 2.
 
+		// Create a simple product.
+		$size_attr_id = wc_attribute_taxonomy_id_by_name( 'pa_size' );
+		$large_term   = get_term_by( 'slug', 'large', 'pa_size' );
+
+		$global_attribute = new WC_Product_Attribute();
+		$global_attribute->set_id( $size_attr_id );
+		$global_attribute->set_name( 'pa_size' );
+		$global_attribute->set_options( array( $large_term->term_id ) ); // Set to small.
+		$global_attribute->set_position( 1 );
+		$global_attribute->set_visible( true );
+		$global_attribute->set_variation( false );
+		$attributes['global-size'] = $global_attribute;
+
+		$simple_product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'attributes' => $attributes,
+			)
+		);
+
 		// Create orders for variations.
 		$variation_order_1 = WC_Helper_Order::create_order( $this->user, $order_variation_1 );
 		$variation_order_1->set_status( 'completed' );
@@ -155,6 +175,10 @@ class WC_Admin_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 		$variation_order_2 = WC_Helper_Order::create_order( $this->user, $order_variation_2 );
 		$variation_order_2->set_status( 'completed' );
 		$variation_order_2->save();
+
+		$simple_product_order_1 = WC_Helper_Order::create_order( $this->user, $simple_product );
+		$simple_product_order_1->set_status( 'completed' );
+		$simple_product_order_1->save();
 
 		// Create more orders for simple products.
 		for ( $i = 0; $i < 10; $i++ ) {
@@ -172,16 +196,14 @@ class WC_Admin_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 
 		// Sanity check before filtering by attribute.
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 12, $response_orders['totals']['orders_count'] );
+		$this->assertEquals( 13, $response_orders['totals']['orders_count'] );
 
 		// Filter by the "size" attribute, with value "large".
-		$size_attr_id = wc_attribute_taxonomy_id_by_name( 'pa_size' );
-		$small_term   = get_term_by( 'slug', 'large', 'pa_size' );
-		$request      = new WP_REST_Request( 'GET', $this->endpoint );
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
 				'attribute_is' => array(
-					array( $size_attr_id, $small_term->term_id ),
+					array( $size_attr_id, $large_term->term_id ),
 				),
 			)
 		);
@@ -189,8 +211,8 @@ class WC_Admin_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 		$response_orders = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 1, $response_orders['totals']['orders_count'] );
-		$this->assertEquals( $variation_order_1->get_total(), $response_orders['totals']['total_sales'] );
+		$this->assertEquals( 2, $response_orders['totals']['orders_count'] );
+		$this->assertEquals( $variation_order_1->get_total() + $simple_product_order_1->get_total(), $response_orders['totals']['total_sales'] );
 
 		// Filter by excluding the "size" attribute, with value "large".
 		$size_attr_id = wc_attribute_taxonomy_id_by_name( 'pa_size' );
@@ -207,8 +229,8 @@ class WC_Admin_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 		$response_orders = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 1, $response_orders['totals']['orders_count'] );
+		$this->assertEquals( 11, $response_orders['totals']['orders_count'] );
 		// This should be the second variation order.
-		$this->assertEquals( $variation_order_2->get_total(), $response_orders['totals']['total_sales'] );
+		$this->assertEquals( 11 * $variation_order_2->get_total(), $response_orders['totals']['total_sales'] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Modifies the attributes filter to include simple products that use global attributes.

Closes #32237

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create two global attributes, like: size with terms: small, medium, large and colour with terms: red, yellow, blue.
2. Create two products one simple product and one variable
- The simple can contain one attribute of each ( small and red? ), can name it a "small red t-shirt"
- The variable can include all options of both attributes, can name it "Variable t-shirts"
3. Buy the simple product in an order by it-self
4. Buy the variable product with the small attribute selected and any colour.
5. Mark the order as completed
6. Go to **WooCommerce > Status > Scheduled actions** and make sure none are pending.
7. Go to Reports > Orders
8. Change the date to from beginning of the year to today
9. Filter by advanced search
10. Choose attribute from the list 
12. Set to "is", and choose Size and pick attribute small
13. Click 'filter'
14. There should be two orders present, one with the simple product and one with the variable
15. If you selected a different colour for the variable order then the simple product then add another attribute filter and choose Color
16. It should show the correct data.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
