### PR TITLE
Hide unnecessary order attribution details

### DIFF
--- a/plugins/woocommerce/changelog/tweak-hide-unnecesary-order-attribution-details
+++ b/plugins/woocommerce/changelog/tweak-hide-unnecesary-order-attribution-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Hide more details toggle for simple source types – direct, web admin, mobile app.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -74,10 +74,18 @@ class OrderAttribution {
 
 		$this->format_meta_data( $meta );
 
+		// No more details if there is more than just the origin value - this is for unknown source types.
+		$has_more_details = array( 'origin' ) !== array_keys( $meta );
+
+		// For direct, web admin, or mobile app orders, don't show more details.
+		$simple_sources = array( 'direct', 'admin', 'mobile_app' );
+		if ( isset( $meta['source_type'] ) && in_array( $meta['source_type'], $simple_sources, true ) ) {
+			$has_more_details = false;
+		}
+
 		$template_data = array(
 			'meta'             => $meta,
-			// Only show more details toggle if there is more than just the origin.
-			'has_more_details' => array( 'origin' ) !== array_keys( $meta ),
+			'has_more_details' => $has_more_details,
 		);
 		wc_get_template( 'order/attribution-details.php', $template_data );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -74,11 +74,11 @@ class OrderAttribution {
 
 		$this->format_meta_data( $meta );
 
-		// No more details if there is more than just the origin value - this is for unknown source types.
+		// No more details if there is only the origin value - this is for unknown source types.
 		$has_more_details = array( 'origin' ) !== array_keys( $meta );
 
-		// For direct, web admin, or mobile app orders, don't show more details.
-		$simple_sources = array( 'direct', 'admin', 'mobile_app' );
+		// For direct, web admin, or mobile app orders, also don't show more details.
+		$simple_sources = array( 'typein', 'admin', 'mobile_app' );
 		if ( isset( $meta['source_type'] ) && in_array( $meta['source_type'], $simple_sources, true ) ) {
 			$has_more_details = false;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a small change to the Order Attribution metabox to hide the "More details" dropdown for a specific set of sources. Unknown sources already had the "more details" toggle hidden, but this PR hides it for direct, web admin, and mobile app orders too.

### Screenshots
🟡  **Before changes:**
Direct, Web admin and Mobile app "More details" are always the same, and not informative.

![image](https://github.com/woocommerce/woocommerce/assets/228780/4a64d37e-c60f-47fe-a7aa-1a0467993ac8)


🟢  **With changes:**
![image](https://github.com/woocommerce/woocommerce/assets/228780/61ed2c30-f0e2-4c85-91a3-cdbad7127e83)


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create orders with the various different order sources
    - Using an new incognito window for each order OR erasing the `sbjs_` cookies after each order
    - Via referral. Go to any website (<woo.com>, for example) and edit a link `href` in developer tools to point to the store. Add items to the cart and complete the checkout.
    - Organic. Same as above, but use <google.com>.
    - Using UTM parameters. Open the store with a URL like `https://woocommerce.store/shop/?utm_source=newsletter&utm_medium=email&utm_campaign=sale&utm_content=utmcontent&utm_term=utm_term`. Add items to the cart and complete the checkout.
    - Typein. Like above, but without any parameters.
    - Web admin. Create from the Add Order page.
    - Mobile app. Create an order like above, but change the meta value `_wc_order_attribution_source_type` to `mobile_app`. This can be done using the filter `add_filter( 'is_protected_meta', '__return_false' );` then editing the meta value on the Order edit page.
    - Unknown. Either disable order attribution and create another from the Add Order page, or create an order and delete all `_wc_order_attribution_*` meta values.
3. Confirm that the order attribution types that should have values, have them: referral, organic and source (utm) should have more details toggles.
4. Confirm that the simple order attribution types have no more details toggles: unknown, direct, web admin, mobile app.
5. Check for no errors and the correct values in the Orders table as well.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
