### PR TITLE
Refactor rating, stock filter block e2e tests to use new dynamic templates

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
@@ -1,14 +1,34 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { Post } from '@wordpress/e2e-test-utils-playwright/build-types/request-utils/posts';
+import path from 'path';
+
+const TEMPLATE_PATH = path.join( __dirname, './active-filters.handlebars' );
+
+const test = base.extend< {
+	defaultBlockPostPage: Post;
+} >( {
+	defaultBlockPostPage: async ( { requestUtils }, use ) => {
+		const testingPost = await requestUtils.createPostFromTemplate(
+			{ title: 'Active Filters Block' },
+			TEMPLATE_PATH,
+			{}
+		);
+
+		await use( testingPost );
+		await requestUtils.deletePost( testingPost.id );
+	},
+} );
 
 test.describe( 'Product Filter: Active Filters Block', async () => {
 	test.describe( 'frontend', () => {
 		test( 'Without any filters selected, only a wrapper block is rendered', async ( {
 			page,
+			defaultBlockPostPage,
 		} ) => {
-			await page.goto( '/product-filters-active-block/' );
+			await page.goto( defaultBlockPostPage.link );
 
 			const locator = page.locator(
 				'.wp-block-woocommerce-product-filter'
@@ -23,9 +43,10 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With rating filters applied it shows the correct active filters', async ( {
 			page,
+			defaultBlockPostPage,
 		} ) => {
 			await page.goto(
-				'/product-filters-active-block/?rating_filter=1,2,5'
+				`${ defaultBlockPostPage.link }?rating_filter=1,2,5`
 			);
 
 			const hasTitle =
@@ -46,9 +67,10 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With stock filters applied it shows the correct active filters', async ( {
 			page,
+			defaultBlockPostPage,
 		} ) => {
 			await page.goto(
-				'/product-filters-active-block/?filter_stock_status=instock,onbackorder'
+				`${ defaultBlockPostPage.link }?filter_stock_status=instock,onbackorder`
 			);
 
 			const hasTitle =
@@ -65,9 +87,10 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With attribute filters applied it shows the correct active filters', async ( {
 			page,
+			defaultBlockPostPage,
 		} ) => {
 			await page.goto(
-				'/product-filters-active-block/?filter_color=blue,gray&query_type_color=or'
+				`${ defaultBlockPostPage.link }?filter_color=blue,gray&query_type_color=or`
 			);
 
 			const hasTitle =
@@ -84,9 +107,10 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With price filters applied it shows the correct active filters', async ( {
 			page,
+			defaultBlockPostPage,
 		} ) => {
 			await page.goto(
-				'/product-filters-active-block/?min_price=17&max_price=71'
+				`${ defaultBlockPostPage.link }?min_price=17&max_price=71`
 			);
 
 			const hasTitle =

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
@@ -8,9 +8,9 @@ import path from 'path';
 const TEMPLATE_PATH = path.join( __dirname, './active-filters.handlebars' );
 
 const test = base.extend< {
-	defaultBlockPostPage: Post;
+	defaultBlockPost: Post;
 } >( {
-	defaultBlockPostPage: async ( { requestUtils }, use ) => {
+	defaultBlockPost: async ( { requestUtils }, use ) => {
 		const testingPost = await requestUtils.createPostFromTemplate(
 			{ title: 'Active Filters Block' },
 			TEMPLATE_PATH,
@@ -26,9 +26,9 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 	test.describe( 'frontend', () => {
 		test( 'Without any filters selected, only a wrapper block is rendered', async ( {
 			page,
-			defaultBlockPostPage,
+			defaultBlockPost,
 		} ) => {
-			await page.goto( defaultBlockPostPage.link );
+			await page.goto( defaultBlockPost.link );
 
 			const locator = page.locator(
 				'.wp-block-woocommerce-product-filter'
@@ -43,11 +43,9 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With rating filters applied it shows the correct active filters', async ( {
 			page,
-			defaultBlockPostPage,
+			defaultBlockPost,
 		} ) => {
-			await page.goto(
-				`${ defaultBlockPostPage.link }?rating_filter=1,2,5`
-			);
+			await page.goto( `${ defaultBlockPost.link }?rating_filter=1,2,5` );
 
 			const hasTitle =
 				( await page.locator( 'text=Rating:' ).count() ) === 1;
@@ -67,10 +65,10 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With stock filters applied it shows the correct active filters', async ( {
 			page,
-			defaultBlockPostPage,
+			defaultBlockPost,
 		} ) => {
 			await page.goto(
-				`${ defaultBlockPostPage.link }?filter_stock_status=instock,onbackorder`
+				`${ defaultBlockPost.link }?filter_stock_status=instock,onbackorder`
 			);
 
 			const hasTitle =
@@ -87,10 +85,10 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With attribute filters applied it shows the correct active filters', async ( {
 			page,
-			defaultBlockPostPage,
+			defaultBlockPost,
 		} ) => {
 			await page.goto(
-				`${ defaultBlockPostPage.link }?filter_color=blue,gray&query_type_color=or`
+				`${ defaultBlockPost.link }?filter_color=blue,gray&query_type_color=or`
 			);
 
 			const hasTitle =
@@ -107,10 +105,10 @@ test.describe( 'Product Filter: Active Filters Block', async () => {
 
 		test( 'With price filters applied it shows the correct active filters', async ( {
 			page,
-			defaultBlockPostPage,
+			defaultBlockPost,
 		} ) => {
 			await page.goto(
-				`${ defaultBlockPostPage.link }?min_price=17&max_price=71`
+				`${ defaultBlockPost.link }?min_price=17&max_price=71`
 			);
 
 			const hasTitle =

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.handlebars
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.handlebars
@@ -1,5 +1,5 @@
 <!-- wp:woocommerce/product-collection {"id":"bee7a337-f64e-4efd-be51-e68670b10000","queryId":0,"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true}} -->
-<div class="wp-block-woocommerce-product-collection">
+<div class='wp-block-woocommerce-product-collection'>
 	<!-- wp:woocommerce/product-template -->
 	<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
 
@@ -12,10 +12,10 @@
 
 	<!-- wp:woocommerce/product-filter {"filterType":"active-filters","heading":"Active filters"} -->
 	<!-- wp:heading {"level":3} -->
-	<h3 class="wp-block-heading">Active filters</h3>
+	<h3 class='wp-block-heading'>Active filters</h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:woocommerce/product-filter-active {"lock":{"remove":true}} /-->
-	<!-- /wp:woocommerce/product-filter -->
+	{{#> wp-block blockName='woocommerce/product-filter-active' attributes=attributes }}
+	{{/ wp-block }}
 </div>
 <!-- /wp:woocommerce/product-collection -->

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.block_theme.spec.ts
@@ -8,9 +8,9 @@ import path from 'path';
 const TEMPLATE_PATH = path.join( __dirname, './rating-filter.handlebars' );
 
 const test = base.extend< {
-	defaultBlockPostPage: Post;
+	defaultBlockPost: Post;
 } >( {
-	defaultBlockPostPage: async ( { requestUtils }, use ) => {
+	defaultBlockPost: async ( { requestUtils }, use ) => {
 		const testingPost = await requestUtils.createPostFromTemplate(
 			{ title: 'Active Filters Block' },
 			TEMPLATE_PATH,
@@ -26,9 +26,9 @@ test.describe( 'Product Filter: Rating Filter Block', async () => {
 	test.describe( 'frontend', () => {
 		test( 'Renders a checkbox list with the available ratings', async ( {
 			page,
-			defaultBlockPostPage,
+			defaultBlockPost,
 		} ) => {
-			await page.goto( defaultBlockPostPage.link );
+			await page.goto( defaultBlockPost.link );
 
 			const ratingStars = page.getByLabel( /^Rated \d out of 5/ );
 			const count = await ratingStars.count();
@@ -47,9 +47,9 @@ test.describe( 'Product Filter: Rating Filter Block', async () => {
 
 		test( 'Selecting a checkbox filters down the products', async ( {
 			page,
-			defaultBlockPostPage,
+			defaultBlockPost,
 		} ) => {
-			await page.goto( defaultBlockPostPage.link );
+			await page.goto( defaultBlockPost.link );
 
 			const ratingCheckboxes = page.getByLabel(
 				/Checkbox: Rated \d out of 5/
@@ -59,9 +59,7 @@ test.describe( 'Product Filter: Rating Filter Block', async () => {
 
 			// wait for navigation
 			await page.waitForURL(
-				( url ) =>
-					url.searchParams.has( 'rating_filter' ) &&
-					url.searchParams.get( 'rating_filter' ) === '1'
+				( url ) => url.searchParams.get( 'rating_filter' ) === '1'
 			);
 
 			const products = page.locator( '.wc-block-product' );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.block_theme.spec.ts
@@ -1,14 +1,34 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { Post } from '@wordpress/e2e-test-utils-playwright/build-types/request-utils/posts';
+import path from 'path';
+
+const TEMPLATE_PATH = path.join( __dirname, './rating-filter.handlebars' );
+
+const test = base.extend< {
+	defaultBlockPostPage: Post;
+} >( {
+	defaultBlockPostPage: async ( { requestUtils }, use ) => {
+		const testingPost = await requestUtils.createPostFromTemplate(
+			{ title: 'Active Filters Block' },
+			TEMPLATE_PATH,
+			{}
+		);
+
+		await use( testingPost );
+		await requestUtils.deletePost( testingPost.id );
+	},
+} );
 
 test.describe( 'Product Filter: Rating Filter Block', async () => {
 	test.describe( 'frontend', () => {
 		test( 'Renders a checkbox list with the available ratings', async ( {
 			page,
+			defaultBlockPostPage,
 		} ) => {
-			await page.goto( '/product-filters-rating-block/' );
+			await page.goto( defaultBlockPostPage.link );
 
 			const ratingStars = page.getByLabel( /^Rated \d out of 5/ );
 			const count = await ratingStars.count();
@@ -27,8 +47,9 @@ test.describe( 'Product Filter: Rating Filter Block', async () => {
 
 		test( 'Selecting a checkbox filters down the products', async ( {
 			page,
+			defaultBlockPostPage,
 		} ) => {
-			await page.goto( '/product-filters-rating-block/' );
+			await page.goto( defaultBlockPostPage.link );
 
 			const ratingCheckboxes = page.getByLabel(
 				/Checkbox: Rated \d out of 5/
@@ -38,7 +59,9 @@ test.describe( 'Product Filter: Rating Filter Block', async () => {
 
 			// wait for navigation
 			await page.waitForURL(
-				'/product-filters-rating-block/?rating_filter=1'
+				( url ) =>
+					url.searchParams.has( 'rating_filter' ) &&
+					url.searchParams.get( 'rating_filter' ) === '1'
 			);
 
 			const products = page.locator( '.wc-block-product' );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.handlebars
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.handlebars
@@ -15,7 +15,7 @@
 	<h3 class="wp-block-heading">Filter by Rating</h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:woocommerce/product-filter-rating {"lock":{"remove":true}} /-->
-	<!-- /wp:woocommerce/product-filter -->
+	{{#> wp-block blockName='woocommerce/product-filter-rating' attributes=attributes }}
+	{{/ wp-block }}
 </div>
 <!-- /wp:woocommerce/product-collection -->

--- a/plugins/woocommerce/changelog/44913-dev-refactor-product-filters-active-e2e
+++ b/plugins/woocommerce/changelog/44913-dev-refactor-product-filters-active-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Refactor rating, stock filter block e2e tests to use new dynamic templates
+


### PR DESCRIPTION

### Changes proposed in this Pull Request:

As part of continued efforts to refactor blocks e2e tests, I've refactored these recently created tests that use static templates generated at env startup, to instead generate them at runtime. The goal is to remove all these static templates, so that setup/teardown can all happen at runtime.


### How to test the changes in this Pull Request:
1. See the blocks e2e CI checks pass.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Refactor rating, stock filter block e2e tests to use new dynamic templates

</details>
