### PR TITLE
Add supports for aspectRatio in the Product Image block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -11,6 +11,9 @@ import { __experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles 
 
 export const supports = {
 	html: false,
+	dimensions: {
+		aspectRatio: true
+	},
 	...( isFeaturePluginBuild() && {
 		__experimentalBorder: {
 			radius: true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While `aspectRatio` was added to the Product Image block at the code level (https://github.com/woocommerce/woocommerce-blocks/pull/11145), this did not expose a UI for setting this in the design tools for the block because the UI was not available at the time. Beginning with WP 6.5 (and in the latest GB version) the UI is available by defining block supports for `aspectRatio` which this PR does.

This is a progressive enhancement, meaning that the definition won't affect anything in environments where the site is on < WP 6.5.

**PR still in progress, doesn't look like the configured `aspectRatio` is respected when the block is rendered.**
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
