### PR TITLE
Add menu item to publish button with 'Move to trash'

### DIFF
--- a/packages/js/product-editor/changelog/add-43047
+++ b/packages/js/product-editor/changelog/add-43047
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add menu item to publish button with 'Move to trash'

--- a/packages/js/product-editor/src/components/button-with-dropdown-menu/index.tsx
+++ b/packages/js/product-editor/src/components/button-with-dropdown-menu/index.tsx
@@ -13,11 +13,9 @@ import type { ButtonWithDropdownMenuProps } from './types';
 
 export * from './types';
 
-export const ButtonWithDropdownMenu: React.FC<
-	ButtonWithDropdownMenuProps
-> = ( {
+export function ButtonWithDropdownMenu( {
 	dropdownButtonLabel = __( 'More options', 'woocommerce' ),
-	controls = [],
+	controls,
 	defaultOpen = false,
 	popoverProps: {
 		placement = 'bottom-end',
@@ -29,8 +27,9 @@ export const ButtonWithDropdownMenu: React.FC<
 		offset: 0,
 	},
 	className,
+	renderMenu,
 	...props
-} ) => {
+}: ButtonWithDropdownMenuProps ) {
 	return (
 		<Flex
 			className={ `woocommerce-button-with-dropdown-menu${
@@ -65,8 +64,10 @@ export const ButtonWithDropdownMenu: React.FC<
 						offset,
 					} }
 					defaultOpen={ defaultOpen }
-				/>
+				>
+					{ renderMenu }
+				</DropdownMenu>
 			</FlexItem>
 		</Flex>
 	);
-};
+}

--- a/packages/js/product-editor/src/components/button-with-dropdown-menu/types.ts
+++ b/packages/js/product-editor/src/components/button-with-dropdown-menu/types.ts
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import type {
+	Dropdown,
 	// @ts-expect-error no exported member.
 	DropdownOption,
 } from '@wordpress/components';
@@ -44,4 +45,5 @@ export type ButtonWithDropdownMenuProps = Omit<
 	defaultOpen?: boolean;
 	controls?: DropdownOption[];
 	popoverProps?: PopoverProps;
+	renderMenu?( props: Dropdown.RenderProps ): React.ReactElement;
 };

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -4,18 +4,17 @@
 import { MouseEvent } from 'react';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import type { Product, ProductVariation } from '@woocommerce/data';
+import type { Product } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
-import { useValidations } from '../../../../contexts/validation-context';
+import { useProductManager } from '../../../../hooks/use-product-manager';
 import type { WPError } from '../../../../utils/get-product-error-message';
 import type { PublishButtonProps } from '../../publish-button';
 
-export function usePublish( {
+export function usePublish< T = Product >( {
 	productType = 'product',
 	disabled,
 	onClick,
@@ -23,21 +22,11 @@ export function usePublish( {
 	onPublishError,
 	...props
 }: PublishButtonProps & {
-	onPublishSuccess?( product: Product ): void;
+	onPublishSuccess?( product: T ): void;
 	onPublishError?( error: WPError ): void;
-} ): Button.ButtonProps & {
-	publish(
-		productOrVariation?: Partial< Product | ProductVariation >
-	): Promise< Product | ProductVariation | undefined >;
-	deleteProduct( force?: boolean ): Promise< Product | ProductVariation >;
-} {
-	const { isValidating, validate } = useValidations< Product >();
-
-	const [ productId ] = useEntityProp< number >(
-		'postType',
-		productType,
-		'id'
-	);
+} ): Button.ButtonProps {
+	const { isValidating, isDirty, isPublishing, publish } =
+		useProductManager( productType );
 
 	const [ status, , prevStatus ] = useEntityProp< Product[ 'status' ] >(
 		'postType',
@@ -45,131 +34,10 @@ export function usePublish( {
 		'status'
 	);
 
-	const { isSaving, isDirty } = useSelect(
-		( select ) => {
-			const {
-				// @ts-expect-error There are no types for this.
-				isSavingEntityRecord,
-				// @ts-expect-error There are no types for this.
-				hasEditsForEntityRecord,
-			} = select( 'core' );
-
-			return {
-				isSaving: isSavingEntityRecord< boolean >(
-					'postType',
-					productType,
-					productId
-				),
-				isDirty: hasEditsForEntityRecord(
-					'postType',
-					productType,
-					productId
-				),
-			};
-		},
-		[ productId ]
-	);
-
-	const isBusy = isSaving || isValidating;
+	const isBusy = isPublishing || isValidating;
 	const isDisabled = disabled || isBusy || ! isDirty;
 
-	// @ts-expect-error There are no types for this.
-	const { editEntityRecord, saveEditedEntityRecord, deleteEntityRecord } =
-		useDispatch( 'core' );
-
-	function catchWPError( error: Error ) {
-		const wpError: WPError = {
-			code:
-				status === 'publish' || status === 'future'
-					? 'product_publish_error'
-					: 'product_create_error',
-			message: error.message,
-			data: {},
-		};
-
-		if ( 'variations' in error ) {
-			wpError.code = 'variable_product_no_variation_prices';
-			wpError.message = error.variations as string;
-		} else {
-			const errorMessage = Object.values( error ).find(
-				( value ) => value !== undefined
-			) as string | undefined;
-
-			if ( errorMessage !== undefined ) {
-				wpError.code = 'product_form_field_error';
-				wpError.message = errorMessage;
-			}
-		}
-
-		return wpError;
-	}
-
-	async function publish(
-		productOrVariation: Partial< Product | ProductVariation > = {}
-	) {
-		const isPublished = status === 'publish' || status === 'future';
-
-		try {
-			// The publish button click not only change the status of the product
-			// but also save all the pending changes. So even if the status is
-			// publish it's possible to save the product too.
-			const data = ! isPublished
-				? { status: 'publish', ...productOrVariation }
-				: productOrVariation;
-
-			await validate( data as Partial< Product > );
-
-			await editEntityRecord( 'postType', productType, productId, data );
-
-			const publishedProduct = await saveEditedEntityRecord<
-				Product | ProductVariation
-			>( 'postType', productType, productId, {
-				throwOnError: true,
-			} );
-
-			if ( publishedProduct && onPublishSuccess ) {
-				onPublishSuccess( publishedProduct );
-			}
-
-			return publishedProduct as Product | ProductVariation;
-		} catch ( error ) {
-			if ( onPublishError ) {
-				let wpError = error as WPError;
-				if ( ! wpError.code ) {
-					wpError = catchWPError( error as Error );
-				}
-				onPublishError( wpError );
-			}
-		}
-	}
-
-	async function deleteProduct( force = false ) {
-		try {
-			await validate();
-
-			await saveEditedEntityRecord< Product | ProductVariation >(
-				'postType',
-				productType,
-				productId,
-				{
-					throwOnError: true,
-				}
-			);
-
-			return deleteEntityRecord( 'postType', productType, productId, {
-				force,
-				throwOnError: true,
-			} );
-		} catch ( error ) {
-			let wpError = error as WPError;
-			if ( ! wpError.code ) {
-				wpError = catchWPError( error as Error );
-			}
-			throw wpError;
-		}
-	}
-
-	async function handleClick( event: MouseEvent< HTMLButtonElement > ) {
+	function handleClick( event: MouseEvent< HTMLButtonElement > ) {
 		if ( isDisabled ) {
 			event.preventDefault?.();
 			return;
@@ -179,7 +47,7 @@ export function usePublish( {
 			onClick( event );
 		}
 
-		await publish();
+		publish().then( onPublishSuccess ).catch( onPublishError );
 	}
 
 	function getButtonText() {
@@ -204,7 +72,5 @@ export function usePublish( {
 		'aria-disabled': isDisabled,
 		variant: 'primary',
 		onClick: handleClick,
-		publish,
-		deleteProduct,
 	};
 }

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/index.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/index.ts
@@ -1,0 +1,2 @@
+export * from './publish-button-menu';
+export * from './types';

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createElement, Fragment, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { getAdminLink } from '@woocommerce/settings';
+import { navigateTo } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { useProductManager } from '../../../../hooks/use-product-manager';
+import { useProductScheduled } from '../../../../hooks/use-product-scheduled';
+import { recordProductEvent } from '../../../../utils/record-product-event';
+import { getProductErrorMessage } from '../../../../utils/get-product-error-message';
+import { ButtonWithDropdownMenu } from '../../../button-with-dropdown-menu';
+import { SchedulePublishModal } from '../../../schedule-publish-modal';
+import { showSuccessNotice } from '../utils';
+import type { PublishButtonMenuProps } from './types';
+
+export function PublishButtonMenu( {
+	postType,
+	...props
+}: PublishButtonMenuProps ) {
+	const { isScheduled, schedule, date, formattedDate } =
+		useProductScheduled( postType );
+	const [ showScheduleModal, setShowScheduleModal ] = useState<
+		'schedule' | 'edit' | undefined
+	>();
+	const { trash } = useProductManager( postType );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( 'core/notices' );
+
+	function scheduleProduct( dateString?: string ) {
+		schedule( dateString )
+			.then( ( scheduledProduct ) => {
+				recordProductEvent( 'product_schedule', scheduledProduct );
+
+				showSuccessNotice( scheduledProduct );
+			} )
+			.catch( ( error ) => {
+				const message = getProductErrorMessage( error );
+				createErrorNotice( message );
+			} )
+			.finally( () => {
+				setShowScheduleModal( undefined );
+			} );
+	}
+
+	function renderSchedulePublishModal() {
+		return (
+			showScheduleModal && (
+				<SchedulePublishModal
+					postType={ postType }
+					value={ showScheduleModal === 'edit' ? date : undefined }
+					onCancel={ () => setShowScheduleModal( undefined ) }
+					onSchedule={ scheduleProduct }
+				/>
+			)
+		);
+	}
+
+	function renderMenu( { onClose }: Dropdown.RenderProps ) {
+		return (
+			<>
+				<MenuGroup>
+					{ isScheduled ? (
+						<>
+							<MenuItem
+								onClick={ () => {
+									scheduleProduct();
+									onClose();
+								} }
+							>
+								{ __( 'Publish now', 'woocommerce' ) }
+							</MenuItem>
+							<MenuItem
+								info={ formattedDate }
+								onClick={ () => {
+									setShowScheduleModal( 'edit' );
+									onClose();
+								} }
+							>
+								{ __( 'Edit schedule', 'woocommerce' ) }
+							</MenuItem>
+						</>
+					) : (
+						<MenuItem
+							onClick={ () => {
+								setShowScheduleModal( 'schedule' );
+								onClose();
+							} }
+						>
+							{ __( 'Schedule publish', 'woocommerce' ) }
+						</MenuItem>
+					) }
+				</MenuGroup>
+				<MenuGroup>
+					<MenuItem
+						isDestructive
+						onClick={ () => {
+							trash()
+								.then( ( deletedProduct ) => {
+									recordProductEvent(
+										'product_delete',
+										deletedProduct
+									);
+									createSuccessNotice(
+										__(
+											'Product successfully deleted',
+											'woocommerce'
+										)
+									);
+									const productListUrl = getAdminLink(
+										'edit.php?post_type=product'
+									);
+									navigateTo( {
+										url: productListUrl,
+									} );
+								} )
+								.catch( ( error ) => {
+									const message =
+										getProductErrorMessage( error );
+									createErrorNotice( message );
+								} );
+							onClose();
+						} }
+					>
+						{ __( 'Move to trash', 'woocommerce' ) }
+					</MenuItem>
+				</MenuGroup>
+			</>
+		);
+	}
+
+	return (
+		<>
+			<ButtonWithDropdownMenu { ...props } renderMenu={ renderMenu } />
+
+			{ renderSchedulePublishModal() }
+		</>
+	);
+}

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { ButtonWithDropdownMenuProps } from '../../../button-with-dropdown-menu';
+
+export type PublishButtonMenuProps = ButtonWithDropdownMenuProps & {
+	postType: string;
+};

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -6,7 +6,6 @@ import { Button, Dropdown } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { type Product } from '@woocommerce/data';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';

--- a/packages/js/product-editor/src/components/header/publish-button/utils/index.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './show-success-notice';

--- a/packages/js/product-editor/src/components/header/publish-button/utils/show-success-notice.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/utils/show-success-notice.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import type { Product, ProductStatus } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { formatScheduleDatetime } from '../../../../utils';
+
+function getNoticeContent( product: Product, prevStatus?: ProductStatus ) {
+	if (
+		window.wcAdminFeatures[ 'product-pre-publish-modal' ] &&
+		product.status === 'future'
+	) {
+		return sprintf(
+			// translators: %s: The datetime the product is scheduled for.
+			__( 'Product scheduled for %s.', 'woocommerce' ),
+			formatScheduleDatetime( `${ product.date_created_gmt }+00:00` )
+		);
+	}
+
+	if ( prevStatus === 'publish' || prevStatus === 'future' ) {
+		return __( 'Product updated.', 'woocommerce' );
+	}
+
+	return __( 'Product published.', 'woocommerce' );
+}
+
+export function showSuccessNotice(
+	product: Product,
+	prevStatus?: ProductStatus
+) {
+	const { createSuccessNotice } = dispatch( 'core/notices' );
+
+	const noticeContent = getNoticeContent( product, prevStatus );
+	const noticeOptions = {
+		icon: '🎉',
+		actions: [
+			{
+				label: __( 'View in store', 'woocommerce' ),
+				// Leave the url to support a11y.
+				url: product.permalink,
+				onClick( event: React.MouseEvent< HTMLAnchorElement > ) {
+					event.preventDefault();
+					// Notice actions do not support target anchor prop,
+					// so this forces the page to be opened in a new tab.
+					window.open( product.permalink, '_blank' );
+				},
+			},
+		],
+	};
+
+	createSuccessNotice( noticeContent, noticeOptions );
+}

--- a/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/schedule-section/schedule-section.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { PanelBody } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -13,22 +12,15 @@ import {
 /**
  * Internal dependencies
  */
-import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { useProductScheduled } from '../../../hooks/use-product-scheduled';
 import { isSiteSettingsTime12HourFormatted } from '../../../utils';
 import { ScheduleSectionProps } from './types';
 
 export function ScheduleSection( { postType }: ScheduleSectionProps ) {
-	const [ productId ] = useProductEntityProp< number >( 'id' );
-	const { schedule, date, formattedDate } = useProductScheduled( postType );
-
-	// @ts-expect-error There are no types for this.
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { setDate, date, formattedDate } = useProductScheduled( postType );
 
 	async function handlePublishDateTimePickerChange( value: string | null ) {
-		await schedule( ( product ) => {
-			return editEntityRecord( 'postType', postType, productId, product );
-		}, value ?? undefined );
+		await setDate( value ?? undefined );
 	}
 
 	return (

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { default as __experimentalUseProductEntityProp } from './use-product-ent
 export { default as __experimentalUseProductMetadata } from './use-product-metadata';
 export { useProductTemplate as __experimentalUseProductTemplate } from './use-product-template';
 export { useProductScheduled as __experimentalUseProductScheduled } from './use-product-scheduled';
+export { useProductManager as __experimentalUseProductManager } from './use-product-manager';

--- a/packages/js/product-editor/src/hooks/use-product-manager/index.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/index.ts
@@ -1,0 +1,1 @@
+export * from './use-product-manager';

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+import { dispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import type { Product, ProductStatus } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { useValidations } from '../../contexts/validation-context';
+import type { WPError } from '../../utils/get-product-error-message';
+
+function errorHandler( error: WPError, productStatus: ProductStatus ) {
+	if ( error.code ) {
+		return error;
+	}
+
+	const wpError: WPError = {
+		code:
+			productStatus === 'publish' || productStatus === 'future'
+				? 'product_publish_error'
+				: 'product_create_error',
+		message: error.message,
+		data: {},
+	};
+
+	if ( 'variations' in error ) {
+		wpError.code = 'variable_product_no_variation_prices';
+		wpError.message = error.variations as string;
+	} else {
+		const errorMessage = Object.values( error ).find(
+			( value ) => value !== undefined
+		) as string | undefined;
+
+		if ( errorMessage !== undefined ) {
+			wpError.code = 'product_form_field_error';
+			wpError.message = errorMessage;
+		}
+	}
+
+	return wpError;
+}
+
+export function useProductManager< T = Product >( postType: string ) {
+	const [ id ] = useEntityProp< number >( 'postType', postType, 'id' );
+	const [ status ] = useEntityProp< ProductStatus >(
+		'postType',
+		postType,
+		'status'
+	);
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ isTrashing, setTrashing ] = useState( false );
+	const { isValidating, validate } = useValidations< T >();
+	const { isDirty } = useSelect(
+		( select ) => ( {
+			// @ts-expect-error There are no types for this.
+			isDirty: select( 'core' ).hasEditsForEntityRecord(
+				'postType',
+				postType,
+				id
+			),
+		} ),
+		[ postType, id ]
+	);
+
+	async function save( extraProps: Partial< T > = {} ) {
+		try {
+			setIsSaving( true );
+
+			await validate( extraProps );
+
+			// @ts-expect-error There are no types for this.
+			const { editEntityRecord, saveEditedEntityRecord } =
+				dispatch( 'core' );
+
+			await editEntityRecord< T >( 'postType', postType, id, extraProps );
+
+			const savedProduct = await saveEditedEntityRecord< T >(
+				'postType',
+				postType,
+				id,
+				{
+					throwOnError: true,
+				}
+			);
+
+			return savedProduct as T;
+		} catch ( error ) {
+			throw errorHandler( error as WPError, status );
+		} finally {
+			setIsSaving( false );
+		}
+	}
+
+	async function publish( extraProps: Partial< T > = {} ) {
+		const isPublished = status === 'publish' || status === 'future';
+
+		// The publish button click not only change the status of the product
+		// but also save all the pending changes. So even if the status is
+		// publish it's possible to save the product too.
+		const data: Partial< T > = isPublished
+			? extraProps
+			: { status: 'publish', ...extraProps };
+
+		return save( data );
+	}
+
+	async function trash( force = false ) {
+		try {
+			setTrashing( true );
+
+			await validate();
+
+			// @ts-expect-error There are no types for this.
+			const { deleteEntityRecord, saveEditedEntityRecord } =
+				dispatch( 'core' );
+
+			await saveEditedEntityRecord< T >( 'postType', postType, id, {
+				throwOnError: true,
+			} );
+
+			const deletedProduct = await deleteEntityRecord< T >(
+				'postType',
+				postType,
+				id,
+				{
+					force,
+					throwOnError: true,
+				}
+			);
+
+			return deletedProduct as T;
+		} catch ( error ) {
+			throw errorHandler( error as WPError, status );
+		} finally {
+			setTrashing( false );
+		}
+	}
+
+	return {
+		isValidating,
+		isDirty,
+		isSaving,
+		isPublishing: isSaving,
+		isTrashing,
+		save,
+		publish,
+		trash,
+	};
+}

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -17,30 +17,30 @@ function errorHandler( error: WPError, productStatus: ProductStatus ) {
 		return error;
 	}
 
-	const wpError: WPError = {
+	if ( 'variations' in error && error.variations ) {
+		return {
+			code: 'variable_product_no_variation_prices',
+			message: error.variations,
+		};
+	}
+
+	const errorMessage = Object.values( error ).find(
+		( value ) => value !== undefined
+	) as string | undefined;
+
+	if ( errorMessage !== undefined ) {
+		return {
+			code: 'product_form_field_error',
+			message: errorMessage,
+		};
+	}
+
+	return {
 		code:
 			productStatus === 'publish' || productStatus === 'future'
 				? 'product_publish_error'
 				: 'product_create_error',
-		message: error.message,
-		data: {},
 	};
-
-	if ( 'variations' in error ) {
-		wpError.code = 'variable_product_no_variation_prices';
-		wpError.message = error.variations as string;
-	} else {
-		const errorMessage = Object.values( error ).find(
-			( value ) => value !== undefined
-		) as string | undefined;
-
-		if ( errorMessage !== undefined ) {
-			wpError.code = 'product_form_field_error';
-			wpError.message = errorMessage;
-		}
-	}
-
-	return wpError;
 }
 
 export function useProductManager< T = Product >( postType: string ) {

--- a/packages/js/product-editor/src/hooks/use-product-scheduled/use-product-scheduled.ts
+++ b/packages/js/product-editor/src/hooks/use-product-scheduled/use-product-scheduled.ts
@@ -3,16 +3,19 @@
  */
 import { useEntityProp } from '@wordpress/core-data';
 import { getDate, isInTheFuture, date as parseDate } from '@wordpress/date';
-import { Product, ProductStatus, ProductVariation } from '@woocommerce/data';
+import type { ProductStatus } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { formatScheduleDatetime, getSiteDatetime } from '../../utils';
+import { useProductManager } from '../use-product-manager';
 
 export const TIMEZONELESS_FORMAT = 'Y-m-d\\TH:i:s';
 
 export function useProductScheduled( postType: string ) {
+	const { isSaving, save } = useProductManager( postType );
+
 	const [ date ] = useEntityProp< string >(
 		'postType',
 		postType,
@@ -29,12 +32,7 @@ export function useProductScheduled( postType: string ) {
 
 	const siteDate = getSiteDatetime( gmtDate );
 
-	async function schedule(
-		publish: (
-			productOrVariation?: Partial< Product | ProductVariation >
-		) => Promise< Product | ProductVariation | undefined >,
-		value?: string
-	) {
+	async function schedule( value?: string ) {
 		const newSiteDate = getDate( value ?? null );
 		const newGmtDate = parseDate( TIMEZONELESS_FORMAT, newSiteDate, 'GMT' );
 
@@ -45,13 +43,14 @@ export function useProductScheduled( postType: string ) {
 			status = 'publish';
 		}
 
-		return publish( {
+		return save( {
 			status,
 			date_created_gmt: newGmtDate,
 		} );
 	}
 
 	return {
+		isScheduling: isSaving,
 		isScheduled: editedStatus === 'future' || isInTheFuture( siteDate ),
 		date: siteDate,
 		formattedDate: formatScheduleDatetime( gmtDate ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43047

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-pre-publish-modal` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` > `Add new` from the left side menu
4. Then add a `Name` to the product
5. From the dropdown menu right next to the `Publish` button a new menu item should be shown `Move to trash` 
<img width="575" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/88c2a54f-ec47-495c-8bf9-5e3009923607">

6. When click it a notice at the bottom left corner of the screen should be shown that reads `Product successfully deleted`
7. After a short time a redirection to the product list page should be shown. From there the trashed product should be listed in the trash tab of that page.
8. From the trash tab the product can be edited by clicking on its name. By doing so a redirection to the product editor page should happen.
9. Once there notice that the `Move to trash` item is not longer visible from the dropdown menu of the `Publish`/`Update` button. 
<img width="580" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/e8b16e3c-7105-4cef-8ce0-10119f426a34">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
