### PR TITLE
Try: Custom block insertion hooks

### DIFF
--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { parse, synchronizeBlocksWithTemplate } from '@wordpress/blocks';
+import { parse } from '@wordpress/blocks';
 import {
 	createElement,
 	useMemo,
@@ -12,12 +12,9 @@ import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
 import { PluginArea } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
-// @ts-expect-error -- No types for this exist yet.
 import { useLayoutTemplate } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
-// @ts-expect-error -- No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
-import { store as coreStore } from '@wordpress/core-data';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
@@ -33,6 +30,9 @@ import {
 // It doesn't seem to notice the External dependency block whn @ts-ignore is added.
 // eslint-disable-next-line @woocommerce/dependency-group
 import {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	store as coreStore,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore store should be included.
 	useEntityBlockEditor,
@@ -80,15 +80,17 @@ export function BlockEditor( {
 	}, [] );
 
 	const productFormTemplates = useSelect( ( select ) => {
-		// @ts-expect-error No types for this exist yet.
-		return select( coreStore ).getEntityRecords(
-			'postType',
-			'wp_template_part',
-			{
-				area: 'product-form',
-				post_type: 'wp_template_part',
-			}
-		) || [];
+		return (
+			// @ts-expect-error No types for this exist yet.
+			select( coreStore ).getEntityRecords(
+				'postType',
+				'wp_template_part',
+				{
+					area: 'product-form',
+					post_type: 'wp_template_part',
+				}
+			) || []
+		);
 	}, [] );
 
 	/**
@@ -179,7 +181,13 @@ export function BlockEditor( {
 		// the blocks by calling onChange.
 		//
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ layoutTemplate, settings, productTemplate, productId, productFormTemplates ] );
+	}, [
+		layoutTemplate,
+		settings,
+		productTemplate,
+		productId,
+		productFormTemplates,
+	] );
 
 	// Check if the Modal editor is open from the store.
 	const isModalEditorOpen = useSelect( ( select ) => {

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
@@ -8,15 +8,12 @@ namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 class HookedBlockExamples {
 
     public function init() {
-        add_filter( 'hooked_block_types', array( $this, 'add_sku_field' ), 10, 4 );
-        add_filter( 'hooked_block_types', array( $this, 'add_custom_product_tab_1' ), 10, 4 );
-        add_filter( 'hooked_block_woocommerce/product-tab', array( $this, 'add_custom_product_tab_1_data' ), 10, 5 );
-        add_filter( 'hooked_block_types', array( $this, 'add_custom_product_tab_2' ), 10, 4 );
-        add_filter( 'hooked_block_woocommerce/product-tab', array( $this, 'add_custom_product_tab_2_data' ), 10, 5 );
-        add_filter( 'hooked_block_types', array( $this, 'add_price_block_1' ), 10, 4 );
-        add_filter( 'hooked_block_types', array( $this, 'add_price_block_2' ), 10, 4 );
-        add_filter( 'hooked_block_woocommerce/product-regular-price-field', array( $this, 'add_price_block_2_data' ), 10, 5 );
-        add_filter( 'hooked_block_types', array( $this, 'add_block_to_hooked_block' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_sku_field' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_custom_product_tab_1' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_custom_product_tab_2' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_price_block_1' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_price_block_2' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_block_to_hooked_block' ), 10, 4 );
     }
 
     /**
@@ -25,16 +22,18 @@ class HookedBlockExamples {
      * This hook works because it is a unique block that doesn't require attributes and
      * is attached to another unique field that is not repeated.
      */
-    public function add_sku_field( $hooked_blocks, $position, $anchor_block, $context ) {
+    public function add_sku_field( $inserted_blocks, $anchor_block, $position, $context ) {
         if ( 
-            'woocommerce/product-name-field' === $anchor_block &&
+            'woocommerce/product-name-field' === $anchor_block['blockName'] &&
             'after' === $position &&
             'product-form' === $context->area
         ) {
-            $hooked_blocks[] = 'woocommerce/product-sku-field';
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-sku-field'
+            );
         }
     
-        return $hooked_blocks;
+        return $inserted_blocks;
     }
     
     /**
@@ -42,86 +41,47 @@ class HookedBlockExamples {
      *
      * This gets added, but later needs to be hooked to include attributes.
      */
-    public function add_custom_product_tab_1( $hooked_blocks, $position, $anchor_block, $context ) {
+    public function add_custom_product_tab_1( $inserted_blocks, $anchor_block, $position, $context ) {
         if ( 
-            'woocommerce/product-tab' === $anchor_block &&
+            'woocommerce/product-tab' === $anchor_block['blockName'] &&
+            'pricing' === $anchor_block['attrs']['id'] &&
             'after' === $position &&
             'product-form' === $context->area
         ) {
-            $hooked_blocks[] = 'woocommerce/product-tab';
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-tab',
+                'attrs'     => array(
+                    'id'    => 'custom_tab_1',
+                    'title' => 'Custom Tab 1',
+                )
+            );
         }
     
-        return $hooked_blocks;
+        return $inserted_blocks;
     }
     
     /**
-     * Add the data for the previously hooked "Custom tab 1"
-     *
-     * Despite requiring a number of checks, this one works a intended.
-     */
-    public function add_custom_product_tab_1_data( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
-        // Check if the block already has attrs to avoid altering other hooked blocks.
-        if ( ! empty( $parsed_hooked_block['attrs'] ) ) {
-            return $parsed_hooked_block;
-        }
-    
-        // Prevent this block from hooking after all product tabs.
-        if (
-            ! isset( $parsed_anchor_block['blockName'] ) ||
-            'woocommerce/product-tab' !== $parsed_anchor_block['blockName'] ||
-            ! isset( $parsed_anchor_block['attrs']['id'] ) ||
-            'pricing' !== $parsed_anchor_block['attrs']['id']
-        ) {
-            return null;
-        }
-    
-        $parsed_hooked_block['attrs']['id'] = 'custom_tab_1';
-        $parsed_hooked_block['attrs']['title'] = 'Custom Tab 1';
-        return $parsed_hooked_block;
-    }
-    
-    /**
-     * Add the product tab intended to be "Custom tab 1"
+     * Add the product tab intended to be "Custom tab 2"
      *
      * This gets added, but later needs to be hooked to include attributes.
      */
-    public function add_custom_product_tab_2( $hooked_blocks, $position, $anchor_block, $context ) {
+    public function add_custom_product_tab_2( $inserted_blocks, $anchor_block, $position, $context ) {
         if ( 
-            'woocommerce/product-tab' === $anchor_block &&
+            'woocommerce/product-tab' === $anchor_block['blockName'] &&
+            'pricing' === $anchor_block['attrs']['id'] &&
             'after' === $position &&
             'product-form' === $context->area
         ) {
-            $hooked_blocks[] = 'woocommerce/product-tab';
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-tab',
+                'attrs'     => array(
+                    'id'    => 'custom_tab_2',
+                    'title' => 'Custom Tab 2',
+                )
+            );
         }
     
-        return $hooked_blocks;
-    }
-    
-    /**
-     * Add the data for the previously hooked "Custom tab 2"
-     *
-     * This callback will return early since attributes will always
-     * be set by the `add_custom_product_tab_1_data` callback first.
-     */
-    public function add_custom_product_tab_2_data( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
-        // Check if the block already has attrs to avoid altering other hooked blocks.
-        if ( ! empty( $parsed_hooked_block['attrs'] ) ) {
-            return $parsed_hooked_block;
-        }
-    
-        // Prevent this block from hooking after all product tabs.
-        if (
-            ! isset( $parsed_anchor_block['blockName'] ) ||
-            'woocommerce/product-tab' !== $parsed_anchor_block['blockName'] ||
-            ! isset( $parsed_anchor_block['attrs']['id'] ) ||
-            'pricing' !== $parsed_anchor_block['attrs']['id']
-        ) {
-            return null;
-        }
-    
-        $parsed_hooked_block['attrs']['id'] = 'custom_tab_2';
-        $parsed_hooked_block['attrs']['title'] = 'Custom Tab 2';
-        return $parsed_hooked_block;
+        return $inserted_blocks;
     }
 
     /**
@@ -129,16 +89,18 @@ class HookedBlockExamples {
      *
      * This price block does not have attributes and will later be overwritten by a 2nd price block's attributes.
      */
-    public function add_price_block_1( $hooked_blocks, $position, $anchor_block, $context ) {
+    public function add_price_block_1( $inserted_blocks, $anchor_block, $position, $context ) {
         if ( 
-            'woocommerce/product-name-field' === $anchor_block &&
+            'woocommerce/product-name-field' === $anchor_block['blockName'] &&
             'after' === $position &&
             'product-form' === $context->area
         ) {
-            $hooked_blocks[] = 'woocommerce/product-regular-price-field';
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-regular-price-field',
+            );
         }
     
-        return $hooked_blocks;
+        return $inserted_blocks;
     }
 
     /**
@@ -146,40 +108,21 @@ class HookedBlockExamples {
      *
      * This price block does not have attributes and will later be overwritten by a 2nd price block's attributes.
      */
-    public function add_price_block_2( $hooked_blocks, $position, $anchor_block, $context ) {
+    public function add_price_block_2( $inserted_blocks, $anchor_block, $position, $context ) {
         if ( 
-            'woocommerce/product-name-field' === $anchor_block &&
+            'woocommerce/product-name-field' === $anchor_block['blockName'] &&
             'after' === $position &&
             'product-form' === $context->area
         ) {
-            $hooked_blocks[] = 'woocommerce/product-regular-price-field';
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-regular-price-field',
+                'attrs'     => array(
+                    'label' => 'Price block 2',
+                )
+            );
         }
     
-        return $hooked_blocks;
-    }
-
-    /**
-     * Add the data for the previously hooked "price block 2"
-     *
-     * This correctly sets data for price block 2 but also errantly sets
-     * attributes for price block 1 since it does not contain the optional attributes.
-     */
-    public function add_price_block_2_data( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
-        // Check if the block already has attrs to avoid altering other hooked blocks.
-        if ( ! empty( $parsed_hooked_block['attrs'] ) ) {
-            return $parsed_hooked_block;
-        }
-    
-        // Prevent this block from hooking after all product tabs.
-        if (
-            isset( $parsed_anchor_block['blockName'] ) &&
-            'woocommerce/product-name-field' !== $parsed_anchor_block['blockName']
-        ) {
-            return null;
-        }
-    
-        $parsed_hooked_block['attrs']['label'] = 'Price block 2';
-        return $parsed_hooked_block;
+        return $inserted_blocks;
     }
 
     /**
@@ -187,15 +130,17 @@ class HookedBlockExamples {
      * 
      * This will fail since block hooks don't run on blocks that were also hooked in.
      */
-    public function add_block_to_hooked_block(  $hooked_blocks, $position, $anchor_block, $context  ) {
+    public function add_block_to_hooked_block( $inserted_blocks, $anchor_block, $position, $context ) {
         if ( 
-            'woocommerce/product-regular-price-field' === $anchor_block &&
+            'woocommerce/product-regular-price-field' === $anchor_block['blockName'] &&
             'after' === $position &&
             'product-form' === $context->area
         ) {
-            $hooked_blocks[] = 'woocommerce/product-sale-price-field';
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-sale-price-field',
+            );
         }
     
-        return $hooked_blocks;
+        return $inserted_blocks;
     }
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
@@ -14,6 +14,9 @@ class HookedBlockExamples {
         add_filter( 'inserted_blocks', array( $this, 'add_price_block_1' ), 10, 4 );
         add_filter( 'inserted_blocks', array( $this, 'add_price_block_2' ), 10, 4 );
         add_filter( 'inserted_blocks', array( $this, 'add_block_to_hooked_block' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_block_first_child' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_section_block' ), 10, 4 );
+        add_filter( 'inserted_blocks', array( $this, 'add_section_inner_block' ), 10, 4 );
     }
 
     /**
@@ -97,6 +100,9 @@ class HookedBlockExamples {
         ) {
             $inserted_blocks[] = array(
                 'blockName' => 'woocommerce/product-regular-price-field',
+                'attrs'     => array(
+                    'label' => 'Price block 1'
+                )
             );
         }
     
@@ -117,7 +123,7 @@ class HookedBlockExamples {
             $inserted_blocks[] = array(
                 'blockName' => 'woocommerce/product-regular-price-field',
                 'attrs'     => array(
-                    'label' => 'Price block 2',
+                    'label' => 'Price block 2'
                 )
             );
         }
@@ -133,11 +139,89 @@ class HookedBlockExamples {
     public function add_block_to_hooked_block( $inserted_blocks, $anchor_block, $position, $context ) {
         if ( 
             'woocommerce/product-regular-price-field' === $anchor_block['blockName'] &&
+            'Price block 2' === $anchor_block['attrs']['label'] &&
             'after' === $position &&
             'product-form' === $context->area
         ) {
             $inserted_blocks[] = array(
                 'blockName' => 'woocommerce/product-sale-price-field',
+                'attrs'     => array(
+                    'label' => 'This block was added to an inserted block'
+                )
+            );
+        }
+    
+        return $inserted_blocks;
+    }
+
+    /**
+     * Add a block to a previously hooked block.
+     * 
+     * This will fail since block hooks don't run on blocks that were also hooked in.
+     */
+    public function add_block_first_child( $inserted_blocks, $anchor_block, $position, $context ) {
+        error_log('pos: ' . $position );
+        error_log(print_r($anchor_block,true));
+        if ( 
+            'woocommerce/product-tab' === $anchor_block['blockName'] &&
+            'pricing' === $anchor_block['attrs']['id'] &&
+            'first_child' === $position &&
+            'product-form' === $context->area
+        ) {
+            $inserted_blocks[] = array(
+                'blockName'  => 'woocommerce/product-checkbox-field',
+                'attrs' => array(
+                  'property' => 'status',
+                  'label'    => __( 'Hide in product catalog', 'woocommerce' ),
+                  'checkedValue'  => 'private',
+                  'uncheckedValue' => 'publish',
+                ),
+            );
+        }
+    
+        return $inserted_blocks;
+    }
+
+    /**
+     * Add a block to a previously hooked block.
+     * 
+     * This will fail since block hooks don't run on blocks that were also hooked in.
+     */
+    public function add_section_block( $inserted_blocks, $anchor_block, $position, $context ) {
+        if ( 
+            'woocommerce/product-tab' === $anchor_block['blockName'] &&
+            'custom_tab_1' === $anchor_block['attrs']['id'] &&
+            'last_child' === $position &&
+            'product-form' === $context->area
+        ) {
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-section',
+                'attrs'     => array(
+                    'title' => 'Custom section'
+                )
+            );
+        }
+    
+        return $inserted_blocks;
+    }
+
+    /**
+     * Add a block to a previously hooked block.
+     * 
+     * This will fail since block hooks don't run on blocks that were also hooked in.
+     */
+    public function add_section_inner_block( $inserted_blocks, $anchor_block, $position, $context ) {
+        if ( 
+            'woocommerce/product-section' === $anchor_block['blockName'] &&
+            'Custom section' === $anchor_block['attrs']['title'] &&
+            'first_child' === $position &&
+            'product-form' === $context->area
+        ) {
+            $inserted_blocks[] = array(
+                'blockName' => 'woocommerce/product-sale-price-field',
+                'attrs'     => array(
+                    'label' => 'This block is a nested block on an inserted block.'
+                )
             );
         }
     

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/HookedBlockExamples.php
@@ -160,8 +160,6 @@ class HookedBlockExamples {
      * This will fail since block hooks don't run on blocks that were also hooked in.
      */
     public function add_block_first_child( $inserted_blocks, $anchor_block, $position, $context ) {
-        error_log('pos: ' . $position );
-        error_log(print_r($anchor_block,true));
         if ( 
             'woocommerce/product-tab' === $anchor_block['blockName'] &&
             'pricing' === $anchor_block['attrs']['id'] &&


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR uses a custom callback for the before/after block visitors and introduces custom hooks to allow insertion of blocks.  It differs in the current block hooks in that:

* We can insert the entire block and block attributes in a single hook
* We have access to the entire anchor block and attributes for conditional insertion
* Inserted blocks can also be hooked onto to further insert blocks

<img width="758" alt="Screenshot 2024-02-23 at 5 30 51 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/ecb6bcd7-12ae-4aa2-be93-7dd7ac6eec7c">
<img width="765" alt="Screenshot 2024-02-23 at 5 30 46 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/01845255-89c4-4fab-a86e-9d824ee3f77b">



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install the latest WP 6.5 beta 2 release
2. Make sure the product editor is enabled under WooCommerce -> Settings -> Advanced -> Features.
3. Navigate to Products -> Add new
4. Note the inserted blocks

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
