### PR TITLE
[CYS on Core] Add the color palettes for the Nokul, Highline and Luminate themes in the Intro Screen

### DIFF
--- a/plugins/woocommerce/changelog/45105-45104-cys-on-core-add-the-color-paletes-for-the-nokul-highline-and-luminate-themes
+++ b/plugins/woocommerce/changelog/45105-45104-cys-on-core-add-the-color-paletes-for-the-nokul-highline-and-luminate-themes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Customize Your Store: Add the color palettes for the Nokul, Highline and Luminate themes in the intro screen.

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -313,8 +313,29 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 			array(
 				'name'           => 'Luminate',
 				'price'          => '$79/year',
-				'color_palettes' => array(),
-				'total_palettes' => 0,
+				'color_palettes' => array(
+					array(
+						'title'     => 'Primary',
+						'primary'   => '#242a2e',
+						'secondary' => '#242a2e',
+					),
+					array(
+						'title'     => 'Lite',
+						'primary'   => '#f6f5f2',
+						'secondary' => '#f6f5f2',
+					),
+					array(
+						'title'     => 'Grey',
+						'primary'   => '#a5a5a5',
+						'secondary' => '#a5a5a5',
+					),
+					array(
+						'title'     => 'Lite Grey',
+						'primary'   => '#e4e4e1',
+						'secondary' => '#e4e4e1',
+					),
+				),
+				'total_palettes' => 5,
 				'slug'           => 'luminate',
 				'thumbnail_url'  => 'https://woo.com/wp-content/uploads/2022/07/Featured-image-538x403-2.png',
 				'link_url'       => 'https://woo.com/products/luminate/',

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -343,8 +343,29 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 			array(
 				'name'           => 'Nokul',
 				'price'          => '$79/year',
-				'color_palettes' => array(),
-				'total_palettes' => 0,
+				'color_palettes' => array(
+					array(
+						'title'     => 'Foreground and background',
+						'primary'   => '#000000',
+						'secondary' => '#f1eee2',
+					),
+					array(
+						'title'     => 'Foreground and secondary',
+						'primary'   => '#000000',
+						'secondary' => '#999999',
+					),
+					array(
+						'title'     => 'Foreground and accent',
+						'primary'   => '#000000',
+						'secondary' => '#d82f16',
+					),
+					array(
+						'title'     => 'Primary and background',
+						'primary'   => '#d9d0bf',
+						'secondary' => '#f1eee2',
+					),
+				),
+				'total_palettes' => 6,
 				'slug'           => 'nokul',
 				'thumbnail_url'  => 'https://woo.com/wp-content/uploads/2022/11/Product-logo.jpg',
 				'link_url'       => 'https://woo.com/products/nokul/',

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -283,8 +283,29 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 			array(
 				'name'           => 'Highline',
 				'price'          => '$79/year',
-				'color_palettes' => array(),
-				'total_palettes' => 0,
+				'color_palettes' => array(
+					array(
+						'title'     => 'Primary',
+						'primary'   => '#211f1d',
+						'secondary' => '#211f1d',
+					),
+					array(
+						'title'     => 'Additional color',
+						'primary'   => '#aaaaaa',
+						'secondary' => '#aaaaaa',
+					),
+					array(
+						'title'     => 'Accent Background',
+						'primary'   => '#b04b3c',
+						'secondary' => '#b04b3c',
+					),
+					array(
+						'title'     => 'Secondary Background',
+						'primary'   => '#dabfa1',
+						'secondary' => '#dabfa1',
+					),
+				),
+				'total_palettes' => 9,
 				'slug'           => 'highline',
 				'thumbnail_url'  => 'https://woo.com/wp-content/uploads/2023/12/Featured-image-538x403-1.png',
 				'link_url'       => 'https://woo.com/products/highline/',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Based on the color palettes (or duotone whenever available) for [Luminate](https://woo.com/products/luminate/), [Nokul](https://woo.com/products/nokul/), and [Highline](https://woo.com/products/highline/) themes, update the CYS intro screen to list them.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45104

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the WooCommerce Beta Tester plugin if you don't have it enabled yet
2. On your Dashboard, head over to Tools > WCA Test Helper > Features and enable the customize-store
3. Access your Dashboard and head over to WooCommerce > Home
4. Click on the "Customize Your Store" button
5. Make sure you see the following themes are listed with the relevant color palettes (or duotones) displayed:

<img width="867" alt="Screenshot 2024-02-26 at 03 07 42" src="https://github.com/woocommerce/woocommerce/assets/15730971/610b9f45-bd5a-4ada-8a29-f2329a39112d">

6. If you want to confirm the correct font pairings, the relevant themes can be downloaded from https://woo.com/my-account/downloads/ (any a11n should have access to all premium themes).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Customize Your Store: Add the color palettes for the Nokul, Highline and Luminate themes in the intro screen.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
