### PR TITLE
[e2e tests] Fix command pallete test failing with Gutenberg active

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-command-pallete-with-gb-tests
+++ b/plugins/woocommerce/changelog/e2e-fix-command-pallete-with-gb-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix command palette test with Gutengerg

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -10,7 +10,7 @@ const clickOnCommandPaletteOption = async ( { page, optionName } ) => {
 	// Press `Ctrl` + `K` to open the command palette.
 	await page.keyboard.press( cmdKeyCombo );
 
-	await page.getByLabel( 'Command palette' ).fill( optionName );
+	await page.getByPlaceholder( 'Search for commands' ).fill( optionName );
 
 	// Click on the relevant option.
 	const option = page.getByRole( 'option', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -45,88 +45,86 @@ const test = baseTest.extend( {
 	},
 } );
 
-test.describe( 'Use Command Palette commands', () => {
-	test( 'can use the "Add new product" command', async ( { page } ) => {
-		await clickOnCommandPaletteOption( {
-			page,
-			optionName: 'Add new product',
-		} );
-
-		// Verify that the page has loaded.
-		await expect(
-			page.getByRole( 'heading', { name: 'Add new product' } )
-		).toBeVisible();
+test( 'can use the "Add new product" command', async ( { page } ) => {
+	await clickOnCommandPaletteOption( {
+		page,
+		optionName: 'Add new product',
 	} );
 
-	test( 'can use the "Add new order" command', async ( { page } ) => {
-		await clickOnCommandPaletteOption( {
-			page,
-			optionName: 'Add new order',
-		} );
+	// Verify that the page has loaded.
+	await expect(
+		page.getByRole( 'heading', { name: 'Add new product' } )
+	).toBeVisible();
+} );
 
-		// Verify that the page has loaded.
-		await expect(
-			page.getByRole( 'heading', { name: 'Add new order' } )
-		).toBeVisible();
+test( 'can use the "Add new order" command', async ( { page } ) => {
+	await clickOnCommandPaletteOption( {
+		page,
+		optionName: 'Add new order',
 	} );
 
-	test( 'can use the "Products" command', async ( { page } ) => {
-		await clickOnCommandPaletteOption( {
-			page,
-			optionName: 'Products',
-		} );
+	// Verify that the page has loaded.
+	await expect(
+		page.getByRole( 'heading', { name: 'Add new order' } )
+	).toBeVisible();
+} );
 
-		// Verify that the page has loaded.
-		await expect(
-			page.locator( 'h1' ).filter( { hasText: 'Products' } ).first()
-		).toBeVisible();
+test( 'can use the "Products" command', async ( { page } ) => {
+	await clickOnCommandPaletteOption( {
+		page,
+		optionName: 'Products',
 	} );
 
-	test( 'can use the "Orders" command', async ( { page } ) => {
-		await clickOnCommandPaletteOption( {
-			page,
-			optionName: 'Orders',
-		} );
+	// Verify that the page has loaded.
+	await expect(
+		page.locator( 'h1' ).filter( { hasText: 'Products' } ).first()
+	).toBeVisible();
+} );
 
-		// Verify that the page has loaded.
-		await expect(
-			page.locator( 'h1' ).filter( { hasText: 'Orders' } ).first()
-		).toBeVisible();
+test( 'can use the "Orders" command', async ( { page } ) => {
+	await clickOnCommandPaletteOption( {
+		page,
+		optionName: 'Orders',
 	} );
 
-	test( 'can use the product search command', async ( { page, product } ) => {
-		await clickOnCommandPaletteOption( {
-			page,
-			optionName: product.name,
-		} );
+	// Verify that the page has loaded.
+	await expect(
+		page.locator( 'h1' ).filter( { hasText: 'Orders' } ).first()
+	).toBeVisible();
+} );
 
-		// Verify that the page has loaded.
-		await expect( page.getByLabel( 'Product name' ) ).toHaveValue(
-			`${ product.name }`
-		);
+test( 'can use the product search command', async ( { page, product } ) => {
+	await clickOnCommandPaletteOption( {
+		page,
+		optionName: product.name,
 	} );
 
-	test( 'can use a settings command', async ( { page } ) => {
-		await clickOnCommandPaletteOption( {
-			page,
-			optionName: 'WooCommerce Settings: Products',
-		} );
+	// Verify that the page has loaded.
+	await expect( page.getByLabel( 'Product name' ) ).toHaveValue(
+		`${ product.name }`
+	);
+} );
 
-		// Verify that the page has loaded.
-		await expect( page.getByText( 'Shop pages' ) ).toBeVisible();
+test( 'can use a settings command', async ( { page } ) => {
+	await clickOnCommandPaletteOption( {
+		page,
+		optionName: 'WooCommerce Settings: Products',
 	} );
 
-	test( 'can use an analytics command', async ( { page } ) => {
-		await clickOnCommandPaletteOption( {
-			page,
-			optionName: 'WooCommerce Analytics: Products',
-		} );
+	// Verify that the page has loaded.
+	await expect( page.getByText( 'Shop pages' ) ).toBeVisible();
+} );
 
-		// Verify that the page has loaded.
-		await expect(
-			page.locator( 'h1' ).filter( { hasText: 'Products' } )
-		).toBeVisible();
-		const pageTitle = await page.title();
-		expect( pageTitle.includes( 'Products ‹ Analytics' ) ).toBeTruthy();
+test( 'can use an analytics command', async ( { page } ) => {
+	await clickOnCommandPaletteOption( {
+		page,
+		optionName: 'WooCommerce Analytics: Products',
 	} );
+
+	// Verify that the page has loaded.
+	await expect(
+		page.locator( 'h1' ).filter( { hasText: 'Products' } )
+	).toBeVisible();
+	const pageTitle = await page.title();
+	expect( pageTitle.includes( 'Products ‹ Analytics' ) ).toBeTruthy();
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -1,5 +1,5 @@
 const { test: baseTest, expect } = require( '../../fixtures' );
-const { goToPostEditor } = require( '../../utils/editor' );
+const { disableWelcomeModal } = require( '../../utils/editor' );
 
 // need to figure out whether tests are being run on a mac
 const macOS = process.platform === 'darwin';
@@ -38,12 +38,15 @@ const test = baseTest.extend( {
 		// Cleanup
 		await api.delete( `products/${ product.id }`, { force: true } );
 	},
+	page: async ( { page }, use ) => {
+		await page.goto( 'wp-admin/post-new.php' );
+		await disableWelcomeModal( { page } );
+		await use( page );
+	},
 } );
 
 test.describe( 'Use Command Palette commands', () => {
 	test( 'can use the "Add new product" command', async ( { page } ) => {
-		await goToPostEditor( { page } );
-
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Add new product',
@@ -56,8 +59,6 @@ test.describe( 'Use Command Palette commands', () => {
 	} );
 
 	test( 'can use the "Add new order" command', async ( { page } ) => {
-		await goToPostEditor( { page } );
-
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Add new order',
@@ -70,8 +71,6 @@ test.describe( 'Use Command Palette commands', () => {
 	} );
 
 	test( 'can use the "Products" command', async ( { page } ) => {
-		await goToPostEditor( { page } );
-
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Products',
@@ -84,8 +83,6 @@ test.describe( 'Use Command Palette commands', () => {
 	} );
 
 	test( 'can use the "Orders" command', async ( { page } ) => {
-		await goToPostEditor( { page } );
-
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Orders',
@@ -98,8 +95,6 @@ test.describe( 'Use Command Palette commands', () => {
 	} );
 
 	test( 'can use the product search command', async ( { page, product } ) => {
-		await goToPostEditor( { page } );
-
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: product.name,
@@ -112,8 +107,6 @@ test.describe( 'Use Command Palette commands', () => {
 	} );
 
 	test( 'can use a settings command', async ( { page } ) => {
-		await goToPostEditor( { page } );
-
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'WooCommerce Settings: Products',
@@ -124,8 +117,6 @@ test.describe( 'Use Command Palette commands', () => {
 	} );
 
 	test( 'can use an analytics command', async ( { page } ) => {
-		await goToPostEditor( { page } );
-
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'WooCommerce Analytics: Products',

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -21,8 +21,21 @@ const goToPostEditor = async ( { page } ) => {
 	await closeWelcomeModal( { page } );
 };
 
+const disableWelcomeModal = async ( { page } ) => {
+	const isWelcomeGuideActive = await page.evaluate( () =>
+		wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' )
+	);
+
+	if ( isWelcomeGuideActive ) {
+		await page.evaluate( () =>
+			wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' )
+		);
+	}
+};
+
 module.exports = {
 	closeWelcomeModal,
 	goToPageEditor,
 	goToPostEditor,
+	disableWelcomeModal,
 };

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -9,18 +9,6 @@ const closeWelcomeModal = async ( { page } ) => {
 	}
 };
 
-const goToPageEditor = async ( { page } ) => {
-	await page.goto( 'wp-admin/post-new.php?post_type=page' );
-
-	await closeWelcomeModal( { page } );
-};
-
-const goToPostEditor = async ( { page } ) => {
-	await page.goto( 'wp-admin/post-new.php' );
-
-	await closeWelcomeModal( { page } );
-};
-
 const disableWelcomeModal = async ( { page } ) => {
 	const isWelcomeGuideActive = await page.evaluate( () =>
 		wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' )
@@ -31,6 +19,18 @@ const disableWelcomeModal = async ( { page } ) => {
 			wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' )
 		);
 	}
+};
+
+const goToPageEditor = async ( { page } ) => {
+	await page.goto( 'wp-admin/post-new.php?post_type=page' );
+
+	await closeWelcomeModal( { page } );
+};
+
+const goToPostEditor = async ( { page } ) => {
+	await page.goto( 'wp-admin/post-new.php' );
+
+	await closeWelcomeModal( { page } );
 };
 
 module.exports = {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45124 .

Fixed tests `command-palette.spec.js` broken by a label change in Gutenberg.

I took this occasion to add some improvements to this spec:

- introduced fixtures to replace the beforeAll/afterAll hooks.
- added a new function to disable the editor welcome guide by setting a pref instead of waiting for the modal and clicking the close button. This shaves off 5 seconds useless waiting on every test.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The tests should pass with both Gutenberg active and inactive.

Locally:
1. Run without Gutengerng: `pnpm env:restart && pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/command-palette.spec.js`
2. Install Gutenberg
3. Run again: `pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/command-palette.spec.js`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
