### PR TITLE
Reduce calls to wp_count_posts( 'product' ) from OnboardingTasks

### DIFF
--- a/plugins/woocommerce/changelog/45125-update-reduce-count-products
+++ b/plugins/woocommerce/changelog/45125-update-reduce-count-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Reduce calls to wp_count_posts( 'product' ) from OnboardingTasks

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -394,11 +394,12 @@ abstract class Task {
 	 * Track task completion if task is viewable.
 	 */
 	public function possibly_track_completion() {
-		if ( ! $this->is_complete() ) {
+		if ( $this->has_previously_completed() ) {
 			return;
 		}
 
-		if ( $this->has_previously_completed() ) {
+		// Expensive check.
+		if ( ! $this->is_complete() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/43768.

We are calling wp_count_posts( 'product' ) on each admin request. This PR reduces the calls via transient caching.

Besides, similar to tasklist improvement in https://github.com/woocommerce/woocommerce/pull/44442, improves task performance by having cheaper check first.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Home`
2. Run `wp transient get woocommerce_product_task_product_count_transient`, observe it returns `0`
3. Click on `Add products`
4. Observe the product task is shown
5. Add a physical product and publish
6. Go back to the Home screen
7. Observe the product task is completed
8. Run `wp transient get woocommerce_product_task_product_count_transient`, observe it returns `1`
9. Go to `/wp-admin/edit.php?post_type=product`
10. Delete the product
11.  Run `wp transient get woocommerce_product_task_product_count_transient`, observe it returns `0`
12. Go back to the Home screen
13. Observe the product task is incomplete.
14. Go to `/wp-admin/edit.php?post_status=trash&post_type=product`
15. Restore product
16.  Run `wp transient get woocommerce_product_task_product_count_transient`, observe it returns `1`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Reduce calls to wp_count_posts( 'product' ) from OnboardingTasks

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
