### PR TITLE
Cache marketing task is_complete() method result

### DIFF
--- a/plugins/woocommerce/changelog/update-cache-marketing-task-is-complete
+++ b/plugins/woocommerce/changelog/update-cache-marketing-task-is-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Cache marketing task is_complete() method result

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -11,6 +11,13 @@ use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init as RemoteFre
  */
 class Marketing extends Task {
 	/**
+	 * Used to cache is_complete() method result.
+	 *
+	 * @var null
+	 */
+	private $is_complete_result = null;
+
+	/**
 	 * ID.
 	 *
 	 * @return string
@@ -61,7 +68,11 @@ class Marketing extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return self::has_installed_extensions();
+		if ( null === $this->is_complete_result ) {
+			$this->is_complete_result = self::has_installed_extensions();
+		}
+
+		return $this->is_complete_result;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since `is_complete` is called multiple times in a single request, we have cached `is_complete` for payment and tax tasks in https://github.com/woocommerce/woocommerce/pull/35065. This PR caches the result for marketing task as well.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Skip core profiler
2. Go to WooCommerce > Home
3. Click on "Get more sales" task
4. Click on "Google Listings & Ads" button
5. Go to WooCommerce > Home
6. Observe that "Get more sales" task is completed

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
