### PR TITLE
Update woo connect plugin installation URL

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/constants.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/constants.ts
@@ -18,4 +18,4 @@ export const MARKETPLACE_COLLABORATION_PATH =
 	'/document/managing-woocommerce-com-subscriptions/#transfer-a-woocommerce-com-subscription';
 export const WP_ADMIN_PLUGIN_LIST_URL = ADMIN_URL + '/plugins.php';
 export const WOO_CONNECT_PLUGIN_DOWNLOAD_URL =
-	'https://woo.com/woocom-plugin/download/';
+	'https://woo.com/woo-update-manager/download/';

--- a/plugins/woocommerce-admin/client/marketplace/components/constants.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/constants.ts
@@ -17,7 +17,5 @@ export const MARKETPLACE_COLLABORATION_PATH =
 	MARKETPLACE_HOST +
 	'/document/managing-woocommerce-com-subscriptions/#transfer-a-woocommerce-com-subscription';
 export const WP_ADMIN_PLUGIN_LIST_URL = ADMIN_URL + '/plugins.php';
-export const WOO_CONNECT_PLUGIN_INSTALL_URL =
-	'https://woo.com/woocom-plugin/install/';
 export const WOO_CONNECT_PLUGIN_DOWNLOAD_URL =
 	'https://woo.com/woocom-plugin/download/';

--- a/plugins/woocommerce-admin/client/marketplace/components/constants.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/constants.ts
@@ -18,4 +18,4 @@ export const MARKETPLACE_COLLABORATION_PATH =
 	'/document/managing-woocommerce-com-subscriptions/#transfer-a-woocommerce-com-subscription';
 export const WP_ADMIN_PLUGIN_LIST_URL = ADMIN_URL + '/plugins.php';
 export const WOO_CONNECT_PLUGIN_DOWNLOAD_URL =
-	'https://woo.com/woo-update-manager/download/';
+	'https://woo.com/products/woo-update-manager/';

--- a/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/install-woo-connect-modal.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/install-woo-connect-modal.tsx
@@ -8,10 +8,8 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { Subscription } from '../my-subscriptions/types';
-import {
-	WOO_CONNECT_PLUGIN_INSTALL_URL,
-	WOO_CONNECT_PLUGIN_DOWNLOAD_URL,
-} from '../constants';
+import { WOO_CONNECT_PLUGIN_DOWNLOAD_URL } from '../constants';
+import { getAdminSetting } from '../../../utils/admin-settings';
 
 interface ConnectProps {
 	subscription: Subscription;
@@ -19,6 +17,7 @@ interface ConnectProps {
 }
 
 export default function InstallWooConnectModal( props: ConnectProps ) {
+	const wccomSettings = getAdminSetting( 'wccomHelper', {} );
 	return (
 		<Modal
 			title={ __( 'Install Woo Connect', 'woocommerce' ) }
@@ -46,7 +45,7 @@ export default function InstallWooConnectModal( props: ConnectProps ) {
 					{ __( 'Download', 'woocommerce' ) }
 				</Button>
 				<Button
-					href={ WOO_CONNECT_PLUGIN_INSTALL_URL }
+					href={ wccomSettings?.wooConnectInstallUrl }
 					variant="primary"
 				>
 					{ __( 'Install', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/install-woo-connect-modal.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/install-woo-connect-modal.tsx
@@ -20,7 +20,7 @@ export default function InstallWooConnectModal( props: ConnectProps ) {
 	const wccomSettings = getAdminSetting( 'wccomHelper', {} );
 	return (
 		<Modal
-			title={ __( 'Install Woo Connect', 'woocommerce' ) }
+			title={ __( 'Install Woo Update Manager', 'woocommerce' ) }
 			onRequestClose={ props.onClose }
 			focusOnMount={ true }
 			className="woocommerce-marketplace__header-account-modal"
@@ -31,7 +31,7 @@ export default function InstallWooConnectModal( props: ConnectProps ) {
 				{ sprintf(
 					// translators: %s is the product version number (e.g. 1.0.2).
 					__(
-						'Version %s is available. To enable this update you need to install the Woo Connect plugin. You can also download and install it manually in your stores.',
+						'Version %s is available. To enable this update you need to install the Woo Update Manager plugin. You can also download and install it manually in your stores.',
 						'woocommerce'
 					),
 					props.subscription.version

--- a/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/plugin-install-notice.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/plugin-install-notice.tsx
@@ -24,7 +24,7 @@ export default function PluginInstallNotice() {
 		! wccomSettings?.wooConnectInstalled
 	) {
 		const message = __(
-			'Please install the Woo Connect plugin to keep getting updates and streamlined support for your Woo.com subscriptions. You can also download and install it manually in your stores.',
+			'Please install the Woo Update Manager plugin to keep getting updates and streamlined support for your Woo.com subscriptions. You can also download and install it manually in your stores.',
 			'woocommerce'
 		);
 		return (
@@ -36,7 +36,7 @@ export default function PluginInstallNotice() {
 							href={ wccomSettings?.wooConnectInstallUrl }
 							variant="secondary"
 						>
-							{ __( 'Install Woo Connect', 'woocommerce' ) }
+							{ __( 'Install Woo Update Manager', 'woocommerce' ) }
 						</Button>
 						<Button
 							href={ WOO_CONNECT_PLUGIN_DOWNLOAD_URL }
@@ -53,7 +53,7 @@ export default function PluginInstallNotice() {
 		! wccomSettings?.wooConnectActive
 	) {
 		const message = __(
-			'Please activate the Woo Connect plugin to keep getting updates and streamlined support for your Woo.com subscriptions.',
+			'Please activate the Woo Update Manager plugin to keep getting updates and streamlined support for your Woo.com subscriptions.',
 			'woocommerce'
 		);
 		return (
@@ -65,7 +65,7 @@ export default function PluginInstallNotice() {
 							href={ WP_ADMIN_PLUGIN_LIST_URL }
 							variant="secondary"
 						>
-							{ __( 'Activate Woo Connect', 'woocommerce' ) }
+							{ __( 'Activate Woo Update Manager', 'woocommerce' ) }
 						</Button>
 					</div>
 				</Notice>

--- a/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/plugin-install-notice.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/plugin-install-notice.tsx
@@ -9,7 +9,6 @@ import { __ } from '@wordpress/i18n';
 import { getAdminSetting } from '../../../utils/admin-settings';
 import {
 	WP_ADMIN_PLUGIN_LIST_URL,
-	WOO_CONNECT_PLUGIN_INSTALL_URL,
 	WOO_CONNECT_PLUGIN_DOWNLOAD_URL,
 } from '../constants';
 import './woo-connect-plugin.scss';
@@ -34,7 +33,7 @@ export default function PluginInstallNotice() {
 					{ message }
 					<div className="components-notice__buttons">
 						<Button
-							href={ WOO_CONNECT_PLUGIN_INSTALL_URL }
+							href={ wccomSettings?.wooConnectInstallUrl }
 							variant="secondary"
 						>
 							{ __( 'Install Woo Connect', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/woo-connect-plugin.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/woo-connect-plugin/woo-connect-plugin.scss
@@ -46,16 +46,12 @@
 	}
 }
 
-.woocommerce-marketplace__woo-connect-plugin__notice {
-	&:last-child {
-		margin-bottom: $grid-unit-50;
-	}
+.woocommerce-marketplace__woo-connect-plugin__notices {
+	margin-bottom: $grid-unit-50;
 }
 
 .woocommerce-marketplace__discover {
-	.woocommerce-marketplace__woo-connect-plugin__notice {
-		&:last-child {
-			margin-bottom: $grid-unit-05;
-		}
+	.woocommerce-marketplace__woo-connect-plugin__notices {
+		margin-bottom: 0px;
 	}
 }

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -58,6 +58,7 @@ class WC_Helper_Admin {
 			'installedProducts'      => $installed_products,
 			'wooConnectInstalled'    => WC_Helper_Plugin::is_plugin_installed(),
 			'wooConnectActive'       => WC_Helper_Plugin::is_plugin_active(),
+			'wooConnectInstallUrl'   => WC_Helper_Plugin::generate_install_url(),
 		);
 
 		return $settings;

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-plugin.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Helper_Plugin {
 	const WOO_UPDATE_MANAGER_PLUGIN_MAIN_FILE = 'woo-marketplace/woo-marketplace.php';
-	const WOO_UPDATE_MANAGER_DOWNLOAD_URL     = 'https://woo.com/woo-update-manager/download/';
+	const WOO_UPDATE_MANAGER_DOWNLOAD_URL     = 'https://woo.com/products/woo-update-manager/';
 
 	/**
 	 * Loads the class, runs on init.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-plugin.php
@@ -16,7 +16,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Contains the logic to manage the Woo Marketplace plugin.
  */
 class WC_Helper_Plugin {
-	const WOO_MARKETPLACE_PLUGIN_MAIN_FILE = 'woo-marketplace/woo-marketplace.php';
+	const WOO_UPDATE_MANAGER_PLUGIN_MAIN_FILE = 'woo-marketplace/woo-marketplace.php';
+	const WOO_UPDATE_MANAGER_DOWNLOAD_URL     = 'https://woo.com/woo-update-manager/download/';
+
+	/**
+	 * Loads the class, runs on init.
+	 *
+	 * @return void
+	 */
+	public static function load(): void {
+		add_action( 'admin_init', array( __CLASS__, 'configure_admin_notices' ) );
+	}
 
 	/**
 	 * Check if the marketplace plugin is active.
@@ -24,7 +34,7 @@ class WC_Helper_Plugin {
 	 * @return bool
 	 */
 	public static function is_plugin_active(): bool {
-		return is_plugin_active_for_network( self::WOO_MARKETPLACE_PLUGIN_MAIN_FILE ) || is_plugin_active( self::WOO_MARKETPLACE_PLUGIN_MAIN_FILE );
+		return is_plugin_active_for_network( self::WOO_UPDATE_MANAGER_PLUGIN_MAIN_FILE ) || is_plugin_active( self::WOO_UPDATE_MANAGER_PLUGIN_MAIN_FILE );
 	}
 
 	/**
@@ -33,7 +43,7 @@ class WC_Helper_Plugin {
 	 * @return bool
 	 */
 	public static function is_plugin_installed(): bool {
-		return file_exists( WP_PLUGIN_DIR . '/' . self::WOO_MARKETPLACE_PLUGIN_MAIN_FILE );
+		return file_exists( WP_PLUGIN_DIR . '/' . self::WOO_UPDATE_MANAGER_PLUGIN_MAIN_FILE );
 	}
 
 	/**
@@ -89,4 +99,59 @@ class WC_Helper_Plugin {
 			$url
 		);
 	}
+
+	/**
+	 * Configure admin notices.
+	 *
+	 * @return void
+	 */
+	public static function configure_admin_notices(): void {
+		if ( self::is_plugin_installed() ) {
+			return;
+		}
+
+		if ( ! self::is_loading_plugin_management_page() ) {
+			return;
+		}
+
+		add_action( 'admin_notices', array( __CLASS__, 'show_install_notice_on_plugin_management_page' ) );
+	}
+
+	/**
+	 * Show a notice on the plugins management page to install the Woo Update Manager plugin.
+	 *
+	 * @return void
+	 */
+	public static function show_install_notice_on_plugin_management_page(): void {
+		printf(
+			'<div class="notice notice-error is-dismissible"><p>%s</p></div>',
+			sprintf(
+				wp_kses(
+				/* translators: 1: Woo Update Manager plugin install URL 2: Woo Update Manager plugin download URL */
+					__(
+						'Please <a href="%1$s">Install the Woo Update Manager</a> plugin to keep getting updates and streamlined support for your Woo.com subscriptions. You can also <a href="%2$s">download</a> and install it manually.',
+						'woocommerce'
+					),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				),
+				esc_url( self::generate_install_url() ),
+				esc_url( self::WOO_UPDATE_MANAGER_DOWNLOAD_URL )
+			)
+		);
+	}
+
+	/**
+	 * Check if the current page is the plugin management page.
+	 *
+	 * @return bool
+	 */
+	protected static function is_loading_plugin_management_page(): bool {
+		return 'plugins.php' === wp_parse_url( basename( get_self_link() ), PHP_URL_PATH );
+	}
 }
+
+WC_Helper_Plugin::load();

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-plugin.php
@@ -53,12 +53,20 @@ class WC_Helper_Plugin {
 	 */
 	public static function generate_install_url(): string {
 		/**
-		 * Filter the base URL used to install the Woo Connect plugin.
+		 * Filter the base URL used to install the Woo Update Manager plugin.
 		 *
 		 * @since 8.7.0
 		 */
 		$install_url_base = apply_filters( 'woo_com_base_url', 'https://woo.com/' );
-		$install_url      = $install_url_base . 'in-app-purchase/install-woo-connect';
+
+		/**
+		 * Filter the id of the Woo Update Manager plugin.
+		 *
+		 * @since 8.7.0
+		 */
+		$woo_update_manager_plugin_id = apply_filters( 'woo_update_manager_plugin_id', 18734003334043 );
+
+		$install_url = $install_url_base . 'auto-install/step/init/' . $woo_update_manager_plugin_id . '/';
 
 		return self::add_auth_parameters( $install_url );
 	}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -186,7 +186,7 @@ class WC_Helper_Updater {
 						),
 					)
 				),
-				'https://woo.com/woocom-plugin/install/',
+				esc_url( WC_Helper_Plugin::generate_install_url() ),
 			);
 			return;
 		}

--- a/plugins/woocommerce/includes/admin/helper/views/html-notice-woo-updater-not-installed.php
+++ b/plugins/woocommerce/includes/admin/helper/views/html-notice-woo-updater-not-installed.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Helper Admin Notice - Woo Updater Plugin is not Installed.
+ *
+ * @package WooCommerce\Views
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+<div id="message" class="error woocommerce-message">
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'woo_updater_not_installed' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+	<p>
+	<?php
+		echo wp_kses_post(
+			sprintf(
+				/* translators: 1: Woo Update Manager plugin install URL 2: Woo Update Manager plugin download URL */
+				__(
+					'Please <a href="%1$s">Install the Woo Update Manager</a> plugin to keep getting updates and streamlined support for your Woo.com subscriptions. You can also <a href="%2$s">download</a> and install it manually.',
+					'woocommerce'
+				),
+				esc_url( WC_Helper_Plugin::generate_install_url() ),
+				esc_url( WC_Helper_Plugin::WOO_UPDATE_MANAGER_DOWNLOAD_URL )
+			)
+		);
+		?>
+	</p>
+</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Change the name of the Woo Connect plugin to Woo Update Manager on all the places (my-subscriptions tab / modals / plugin update notices / admin notices)
- Add an admin notice on WC admin pages to notify the user about Woo Update Manager plugin.
- Change the install URL structure to include the product id of the Woo Updater plugin.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Follow the instructions provided under https://github.com/woocommerce/woocommerce/pullname is updated to/44279 (section : Testing Notifications)
3. Note that the plugin name is updated to `Woo Update Manager`
4. Note that the installation URL updated to `https://woo.com/auto-install/step/init/:product_id/`
5. Note that a dismissible admin notice displayed for the user under WC admin pages.

#### Testing on customer site with woocommerce.test
1. Use this WC [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/14423394/woocommerce.zip) to test.
2. Add the following filter on customer mu-plugins to change installation URL to `woocommerce.test`
```
add_filter( 'woo_com_base_url', function( $base ) {
	return 'https://woocommerce.test/';
} );
```
3. Add the following filter on customer mu-plugins to change the Woo Update Manager plugin id.
```
add_filter( 'woo_update_manager_plugin_id', function( $product_id ) {
	return <your_local_product_id>;
} );
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
