### PR TITLE
[e2e tests] Fix page conversion failing in global setup

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-convert-pages-to-shortcode
+++ b/plugins/woocommerce/changelog/e2e-fix-convert-pages-to-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix global setup failing when there are more than 20 pages in site

--- a/plugins/woocommerce/tests/e2e-pw/utils/site.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/site.js
@@ -214,7 +214,7 @@ const deleteAllTaxRates = async () => {
 /**
  * Reset the test site. Useful when running E2E tests on a hosted test site to reset it to a somewhat pristine state prior to running tests.
  *
- * @param {string} cKey Consumer key
+ * @param {string} cKey    Consumer key
  * @param {string} cSecret Consumer secret
  */
 const reset = async ( cKey, cSecret ) => {
@@ -241,13 +241,6 @@ const reset = async ( cKey, cSecret ) => {
  * Convert Cart and Checkout pages to shortcode.
  */
 const useCartCheckoutShortcodes = async ( baseURL, userAgent, admin ) => {
-	/**
-	 * A WordPress page.
-	 * @typedef {Object} WPPage
-	 * @property {number} id
-	 * @property {string} slug
-	 */
-
 	const { request: apiRequest } = require( '@playwright/test' );
 	const { encodeCredentials } = require( './plugin-utils' );
 
@@ -264,16 +257,16 @@ const useCartCheckoutShortcodes = async ( baseURL, userAgent, admin ) => {
 	const request = await apiRequest.newContext( options );
 
 	// List all pages
-	const response_list = await request.get( '/wp-json/wp/v2/pages', {
-		data: {
-			_fields: [ 'id', 'slug' ],
-		},
-		failOnStatusCode: true,
-	} );
+	const response_list = await request.get(
+		'/wp-json/wp/v2/pages?slug=cart,checkout',
+		{
+			data: {
+				_fields: [ 'id', 'slug' ],
+			},
+			failOnStatusCode: true,
+		}
+	);
 
-	/**
-	 * @type {WPPage[]}
-	 */
 	const list = await response_list.json();
 
 	// Find the cart and checkout pages


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45130.

The conversion of the `cart` and `checkout` pages to shortcodes happening in the global setup is failing if there are more than 20 pages in the site. The are tests creating pages and failing to clean them up which quickly adds pages in the site creating the precondition for this failure.

The function uses the REST API to get the two pages ids, with default pagination (20). If there are more pages the cart and checkout pages are not found in the response, failing the setup.

This PR updates the method to filter the pages by slug, thus ensuring only the required pages are returned.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create more than 20 pages.
2. Run any e2e test (this should run the global-setup) => there should be no error, tests are passing.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
