### PR TITLE
Add support for WooCommerce Analytics module in @woocommerce/explat

### DIFF
--- a/packages/js/explat/CHANGELOG.md
+++ b/packages/js/explat/CHANGELOG.md
@@ -1,13 +1,13 @@
-# Changelog 
+# Changelog
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0](https://www.npmjs.com/package/@woocommerce/packages/js/explat/v/2.3.0) - 2022-07-08 
+## [2.3.0](https://www.npmjs.com/package/@woocommerce/packages/js/explat/v/2.3.0) - 2022-07-08
 
 -   Patch - Fix fetchExperimentAssignment response
 -   Minor - Remove PHP and Composer dependencies for packaged JS packages
 
-## [2.2.0](https://www.npmjs.com/package/@woocommerce/packages/js/explat/v/2.2.0) - 2022-06-15 
+## [2.2.0](https://www.npmjs.com/package/@woocommerce/packages/js/explat/v/2.2.0) - 2022-06-15
 
 -   Patch - Added useExperiment example
 -   Patch - Standardize lint scripts: add lint:fix

--- a/packages/js/explat/README.md
+++ b/packages/js/explat/README.md
@@ -1,6 +1,6 @@
 # ExPlat
 
-This packages includes a component and utility functions that can be used to run A/B Tests in WooCommerce dashboard and reports pages.
+This packages includes a component and utility functions that can be used to run A/B Tests in WooCommerce dashboard, report pages, and frontend pages.
 
 ## Installation
 

--- a/packages/js/explat/changelog/45131-add-wca-support-to-explat
+++ b/packages/js/explat/changelog/45131-add-wca-support-to-explat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add support for WooCommerce Analytics.

--- a/packages/js/explat/changelog/add-wca-support-to-explat
+++ b/packages/js/explat/changelog/add-wca-support-to-explat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Support running A/B testing in WooCommerce frontend

--- a/packages/js/explat/src/anon.ts
+++ b/packages/js/explat/src/anon.ts
@@ -3,6 +3,11 @@
  */
 import cookie from 'cookie';
 
+/**
+ * Internal dependencies
+ */
+import { canTrack } from './assignment';
+
 let initializeAnonIdPromise: null | Promise< string | null > = null;
 const anonIdPollingIntervalMilliseconds = 50;
 const anonIdPollingIntervalMaxAttempts = 100; // 50 * 100 = 5000 = 5 seconds
@@ -53,7 +58,7 @@ export const initializeAnonId = async (): Promise< string | null > => {
 };
 
 export const getAnonId = async (): Promise< string | null > => {
-	if ( ! window.wcTracks?.isEnabled && ! window?._wca?.push ) {
+	if ( ! canTrack ) {
 		return null;
 	}
 

--- a/packages/js/explat/src/anon.ts
+++ b/packages/js/explat/src/anon.ts
@@ -53,7 +53,7 @@ export const initializeAnonId = async (): Promise< string | null > => {
 };
 
 export const getAnonId = async (): Promise< string | null > => {
-	if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
+	if ( ! window.wcTracks?.isEnabled && ! window?._wca?.push ) {
 		return null;
 	}
 

--- a/packages/js/explat/src/anon.ts
+++ b/packages/js/explat/src/anon.ts
@@ -53,7 +53,7 @@ export const initializeAnonId = async (): Promise< string | null > => {
 };
 
 export const getAnonId = async (): Promise< string | null > => {
-	if ( ! window.wcTracks?.isEnabled ) {
+	if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
 		return null;
 	}
 

--- a/packages/js/explat/src/assignment.ts
+++ b/packages/js/explat/src/assignment.ts
@@ -83,7 +83,7 @@ export const fetchExperimentAssignment = async ( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > => {
-	if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
+	if ( ! window.wcTracks?.isEnabled && ! window?._wca?.push ) {
 		throw new Error(
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);
@@ -111,7 +111,7 @@ export const fetchExperimentAssignmentWithAuth = async ( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > => {
-	if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
+	if ( ! window.wcTracks?.isEnabled && ! window?._wca?.push ) {
 		throw new Error(
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);

--- a/packages/js/explat/src/assignment.ts
+++ b/packages/js/explat/src/assignment.ts
@@ -83,7 +83,7 @@ export const fetchExperimentAssignment = async ( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > => {
-	if ( ! window.wcTracks?.isEnabled ) {
+	if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
 		throw new Error(
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);
@@ -111,7 +111,7 @@ export const fetchExperimentAssignmentWithAuth = async ( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > => {
-	if ( ! window.wcTracks?.isEnabled ) {
+	if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
 		throw new Error(
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);

--- a/packages/js/explat/src/assignment.ts
+++ b/packages/js/explat/src/assignment.ts
@@ -5,6 +5,9 @@ import { stringify } from 'qs';
 import { applyFilters } from '@wordpress/hooks';
 import apiFetch from '@wordpress/api-fetch';
 
+export const canTrack =
+	window.wcTracks?.isEnabled || window?._wca?.push !== undefined;
+
 const EXPLAT_VERSION = '0.1.0';
 
 type QueryParams = {
@@ -83,7 +86,7 @@ export const fetchExperimentAssignment = async ( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > => {
-	if ( ! window.wcTracks?.isEnabled && ! window?._wca?.push ) {
+	if ( ! canTrack ) {
 		throw new Error(
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);
@@ -111,7 +114,7 @@ export const fetchExperimentAssignmentWithAuth = async ( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > => {
-	if ( ! window.wcTracks?.isEnabled && ! window?._wca?.push ) {
+	if ( ! canTrack ) {
 		throw new Error(
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);

--- a/packages/js/explat/src/error.ts
+++ b/packages/js/explat/src/error.ts
@@ -26,7 +26,7 @@ export const logError = (
 		if ( isDevelopmentMode ) {
 			console.error( '[ExPlat] ', error.message, error ); // eslint-disable-line no-console
 		} else {
-			if ( ! window.wcTracks?.isEnabled ) {
+			if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
 				throw new Error(
 					`Tracking is disabled, can't send error to the server`
 				);

--- a/packages/js/explat/src/error.ts
+++ b/packages/js/explat/src/error.ts
@@ -26,7 +26,7 @@ export const logError = (
 		if ( isDevelopmentMode ) {
 			console.error( '[ExPlat] ', error.message, error ); // eslint-disable-line no-console
 		} else {
-			if ( ! window.wcTracks?.isEnabled && ! window._wca.push ) {
+			if ( ! window.wcTracks?.isEnabled && ! window?._wca?.push ) {
 				throw new Error(
 					`Tracking is disabled, can't send error to the server`
 				);

--- a/packages/js/explat/src/index.ts
+++ b/packages/js/explat/src/index.ts
@@ -20,11 +20,14 @@ declare global {
 			isEnabled: boolean;
 			enable?: ( cb: () => void ) => void;
 		};
+		_wca: {
+			push?: ( cb: () => void ) => void;
+		};
 	}
 }
 
 export const initializeExPlat = (): void => {
-	if ( window.wcTracks?.isEnabled ) {
+	if ( window.wcTracks?.isEnabled || window._wca.push !== undefined ) {
 		initializeAnonId().catch( ( e ) => logError( { message: e.message } ) );
 	}
 };

--- a/packages/js/explat/src/index.ts
+++ b/packages/js/explat/src/index.ts
@@ -12,6 +12,7 @@ import { logError } from './error';
 import {
 	fetchExperimentAssignment,
 	fetchExperimentAssignmentWithAuth,
+	canTrack,
 } from './assignment';
 import { getAnonId, initializeAnonId } from './anon';
 declare global {
@@ -27,7 +28,7 @@ declare global {
 }
 
 export const initializeExPlat = (): void => {
-	if ( window.wcTracks?.isEnabled || window?._wca?.push !== undefined ) {
+	if ( canTrack ) {
 		initializeAnonId().catch( ( e ) => logError( { message: e.message } ) );
 	}
 };

--- a/packages/js/explat/src/index.ts
+++ b/packages/js/explat/src/index.ts
@@ -27,7 +27,7 @@ declare global {
 }
 
 export const initializeExPlat = (): void => {
-	if ( window.wcTracks?.isEnabled || window._wca.push !== undefined ) {
+	if ( window.wcTracks?.isEnabled || window?._wca?.push !== undefined ) {
 		initializeAnonId().catch( ( e ) => logError( { message: e.message } ) );
 	}
 };

--- a/packages/js/explat/src/test/assignment-test.js
+++ b/packages/js/explat/src/test/assignment-test.js
@@ -1,3 +1,7 @@
+// Define that tracking is enabled before import
+// so that assignments can get the correct value.
+global.wcTracks.isEnabled = true;
+
 /**
  * External dependencies
  */
@@ -16,7 +20,6 @@ global.fetch = jest.fn().mockImplementation( () =>
 		status: 200,
 	} )
 );
-global.wcTracks.isEnabled = true;
 
 const fetchMock = jest.spyOn( global, 'fetch' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds support for WooCommerce Analytics module (wca) in @woocommerce/explat.

WCA is used to trigger track events for shoppers, the underlying technology is the same, as both of them use the same `tk_ai` cookie.

So in this PR, alongside checking for WCTracks Enabled, I also check if wca.push is defined, which is the trigger that confirms if we have permission to track or not.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45128

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This is tricky to test as it requires deploying an experiment and making sure it actually runs.

1. Add `"@woocommerce/tracks": "workspace:^",` as a dependency in `plugins/woocommerce-blocks/package.json`
2. In `plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx` import `{ Experiment }` from `'@woocommerce/explat'`;
3. Create 2 new elements inside your Block component:
```jsx
const placeOrderButton = (
		<PlaceOrderButton
			label="Default Button"
			fullWidth={ ! showReturnToCart }
		/>
	);

	const placeOrderButtonWithExperiment = (
		<PlaceOrderButton
			label="Experiment Button"
			fullWidth={ ! showReturnToCart }
		/>
	);
```
4. Replace the `PlaceOrderButton` call with this:
```jsx
<Experiment
	name="woocommerce_example_place_order_experiment"
	defaultExperience={ placeOrderButton }
	treatmentExperience={ placeOrderButtonWithExperiment }
	loadingExperience={ <div>⏳</div> }
/>
```
5. On a live, jetpack enabled website, visit Checkout.
6. You should not see any errors in console.
7. In network, there should be a request to `https://public-api.wordpress.com/wpcom/v2/experiments/` with a response saying `request not sampled`
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Add support for WooCommerce Analytics.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
