### PR TITLE
Re-introduce 44084 and 44790 with back-compat

### DIFF
--- a/plugins/woocommerce/changelog/fix-43879
+++ b/plugins/woocommerce/changelog/fix-43879
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Don't load REST API when generating possible routes.

--- a/plugins/woocommerce/changelog/fix-44080
+++ b/plugins/woocommerce/changelog/fix-44080
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Follow up fixup to unreleased change, no changelog necessary.
+
+

--- a/plugins/woocommerce/changelog/re-44879
+++ b/plugins/woocommerce/changelog/re-44879
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+[Performance] Don't load REST API when hydrating blocks requests.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -473,7 +473,7 @@ abstract class AbstractBlock {
 		 */
 		$routes = apply_filters(
 			'woocommerce_blocks_pre_get_routes_from_namespace',
-			[],
+			array(),
 			$namespace,
 			'view'
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -463,6 +463,25 @@ abstract class AbstractBlock {
 	 * @return array
 	 */
 	protected function get_routes_from_namespace( $namespace ) {
+		/**
+		 * Gives opportunity to return routes without invoking the compute intensive REST API.
+		 *
+		 * @since 8.7.0
+		 * @param array  $routes    Array of routes.
+		 * @param string $namespace Namespace for routes.
+		 * @param string $context   Context, can be edit or view.
+		 */
+		$routes = apply_filters(
+			'woocommerce_blocks_pre_get_routes_from_namespace',
+			[],
+			$namespace,
+			'view'
+		);
+
+		if ( ! empty( $routes ) ) {
+			return $routes;
+		}
+
 		$rest_server     = rest_get_server();
 		$namespace_index = $rest_server->get_namespace_index(
 			[

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -60,30 +60,29 @@ class Hydration {
 
 		$preloaded_data = array();
 
-		try {
-			$response = $this->get_response_from_controller( $controller_class, $path );
-		} catch ( \Exception $e ) {
-			// This is executing in frontend of the site, a failure in hydration should not stop the site from working.
-			wc_get_logger()->warning(
-				'Error in hydrating REST API request: ' . $e->getMessage(),
-				array(
-					'source'    => 'blocks-hydration',
-					'data'      => array(
-						'path'       => $path,
-						'controller' => $controller_class,
-					),
-					'backtrace' => true,
-				)
-			);
-
-			$response = false;
-		}
-
-		if ( $response ) {
-			$preloaded_data = array(
-				'body'    => $response->get_data(),
-				'headers' => $response->get_headers(),
-			);
+		if ( null !== $controller_class ) {
+			try {
+				$response = $this->get_response_from_controller( $controller_class, $path );
+				if ( $response ) {
+					$preloaded_data = array(
+						'body'    => $response->get_data(),
+						'headers' => $response->get_headers(),
+					);
+				}
+			} catch ( \Exception $e ) {
+				// This is executing in frontend of the site, a failure in hydration should not stop the site from working.
+				wc_get_logger()->warning(
+					'Error in hydrating REST API request: ' . $e->getMessage(),
+					array(
+						'source'    => 'blocks-hydration',
+						'data'      => array(
+							'path'       => $path,
+							'controller' => $controller_class,
+						),
+						'backtrace' => true,
+					)
+				);
+			}
 		} else {
 			// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
 			$preloaded_requests = rest_preload_api_request( [], $path );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -67,7 +67,24 @@ class Hydration {
 				$schema_controller->get( $controller_class::SCHEMA_TYPE, $controller_class::SCHEMA_VERSION )
 			);
 
-			$response       = $controller->get_response( $request );
+			$response = $controller->get_response( $request );
+			$handler  = is_callable( array( $controller, 'get_args' ) ) ? $controller->get_args() : [];
+
+			/**
+			 * For backward compatibility with WC 8.6 and earlier, we manually call this filter that is otherwise called by WP's REST API. This provides the opportunity for 3PD plugins to hook into and change the response data.
+			 *
+			 * See `rest_request_before_callbacks` filter in WP core's `class-wp-rest-server.php`.
+			 *
+			 * @since 8.7.0
+			 *
+			 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response Result to send to the client.
+			 *                                                                   Usually a WP_REST_Response or WP_Error.
+			 * @param array                                            $handler  Route handler used for the request.
+			 * @param WP_REST_Request                                  $request  Request used to generate the response.
+			 *
+			 */
+			$response = apply_filters( 'rest_request_after_callbacks', $response, $handler, $request );
+
 			$preloaded_data = array(
 				'body'    => $response->get_data(),
 				'headers' => $response->get_headers(),

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -140,7 +140,7 @@ class Hydration {
 
 		/**
 		 * For backward compatibility with WC 8.6 and earlier, we manually call this filter that is otherwise called by WP's REST API. This provides the opportunity for 3PD plugins to hook into and change the response data.
-		 *
+		 * Note that altering the Store API final response is something we discourage and won't ultimately support. This will be deprecated in favor of better, more integrated solutions.
 		 * See `rest_request_before_callbacks` filter in WP core's `class-wp-rest-server.php`.
 		 *
 		 * @since 8.7.0

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -2,6 +2,9 @@
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\StoreApi\RoutesController;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\StoreApi;
 
 /**
  * Service class that handles hydration of API data for blocks.
@@ -38,17 +41,69 @@ class Hydration {
 	 * @return array Response data.
 	 */
 	public function get_rest_api_response_data( $path = '' ) {
-		$this->cache_store_notices();
+		if ( ! str_starts_with( $path, '/wc/store' ) ) {
+			return [];
+		}
+
+		$available_routes = StoreApi::container()->get( RoutesController::class )->get_all_routes( 'v1', true );
+		$controller_class = $this->match_route_to_handler( $path, $available_routes );
+
+		/**
+		 * We disable nonce check to support endpoints such as checkout. The caveat here is that we need to be careful to only support GET requests. No other request type should be processed without nonce check. Additionally, no GET request can modify data as part of hydration request, for example adding items to cart.
+		 *
+		 * Long term, we should consider validating nonce here, instead of disabling it temporarily.
+		 */
 		$this->disable_nonce_check();
 
-		// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
-		$preloaded_requests = rest_preload_api_request( [], $path );
+		$this->cache_store_notices();
+
+		$preloaded_data = array();
+
+		if ( null !== $controller_class ) {
+			$request           = new \WP_REST_Request( 'GET', $path );
+			$schema_controller = StoreApi::container()->get( SchemaController::class );
+			$controller        = new $controller_class(
+				$schema_controller,
+				$schema_controller->get( $controller_class::SCHEMA_TYPE, $controller_class::SCHEMA_VERSION )
+			);
+
+			$response       = $controller->get_response( $request );
+			$preloaded_data = array(
+				'body'    => $response->get_data(),
+				'headers' => $response->get_headers(),
+			);
+		} else {
+			// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
+			$preloaded_requests = rest_preload_api_request( [], $path );
+			$preloaded_data     = $preloaded_requests[ $path ] ?? [];
+		}
 
 		$this->restore_cached_store_notices();
 		$this->restore_nonce_check();
 
 		// Returns just the single preloaded request, or an empty array if it doesn't exist.
-		return $preloaded_requests[ $path ] ?? [];
+		return $preloaded_data;
+	}
+
+	/**
+	 * Inspired from WP core's `match_request_to_handler`, this matches a given path from available route regexes.
+	 * However, unlike WP core, this does not check against query params, request method etc.
+	 *
+	 * @param string $path The path to match.
+	 * @param array  $available_routes Available routes in { $regex1 => $contoller_class1, ... } format.
+	 *
+	 * @return string|null
+	 */
+	private function match_route_to_handler( $path, $available_routes ) {
+		$matched_route = null;
+		foreach ( $available_routes as $route_path => $controller ) {
+			$match = preg_match( '@^' . $route_path . '$@i', $path );
+			if ( $match ) {
+				$matched_route = $controller;
+				break;
+			}
+		}
+		return $matched_route;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/BusinessDescription.php
@@ -30,6 +30,15 @@ class BusinessDescription extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/ai/business-description';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Images.php
@@ -30,6 +30,15 @@ class Images extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/ai/images';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Patterns.php
@@ -34,6 +34,15 @@ class Patterns extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/ai/patterns';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Product.php
@@ -31,6 +31,15 @@ class Product extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/ai/product';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/Products.php
@@ -32,6 +32,15 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/ai/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreInfo.php
@@ -32,6 +32,15 @@ class StoreInfo extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/ai/store-info';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AI/StoreTitle.php
@@ -45,6 +45,15 @@ class StoreTitle extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/ai/store-title';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -30,6 +30,15 @@ class Batch extends AbstractRoute implements RouteInterface {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/batch';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
@@ -18,6 +18,15 @@ class Cart extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -20,6 +20,15 @@ class CartAddItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/add-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
@@ -20,6 +20,15 @@ class CartApplyCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/apply-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
@@ -27,6 +27,15 @@ class CartCoupons extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/coupons';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
@@ -27,6 +27,15 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/coupons/(?P<code>[\w-]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php
@@ -27,6 +27,15 @@ class CartExtensions extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/extensions';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItems.php
@@ -27,6 +27,15 @@ class CartItems extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/items';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartItemsByKey.php
@@ -27,6 +27,15 @@ class CartItemsByKey extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/items/(?P<key>[\w-]{32})';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
@@ -20,6 +20,15 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/remove-coupon';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -23,6 +23,15 @@ class CartRemoveItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/remove-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -20,6 +20,15 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/select-shipping-rate';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -25,6 +25,15 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/update-customer';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -18,6 +18,15 @@ class CartUpdateItem extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/cart/update-item';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -44,6 +44,15 @@ class Checkout extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/checkout';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -41,6 +41,15 @@ class CheckoutOrder extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/checkout/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Order.php
@@ -51,6 +51,15 @@ class Order extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/order/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -20,6 +20,15 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/attributes/(?P<attribute_id>[\d]+)/terms';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
@@ -25,6 +25,15 @@ class ProductAttributes extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/attributes';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
@@ -27,6 +27,15 @@ class ProductAttributesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/attributes/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
@@ -25,6 +25,15 @@ class ProductCategories extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/categories';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
@@ -27,6 +27,15 @@ class ProductCategoriesById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/categories/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -30,6 +30,15 @@ class ProductCollectionData extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/collection-data';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -28,6 +28,15 @@ class ProductReviews extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/reviews';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
@@ -18,6 +18,15 @@ class ProductTags extends AbstractTermsRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/tags';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
@@ -28,6 +28,15 @@ class Products extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -27,6 +27,15 @@ class ProductsById extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/(?P<id>[\d]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -27,6 +27,15 @@ class ProductsBySlug extends AbstractRoute {
 	 * @return string
 	 */
 	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
 		return '/products/(?P<slug>[\S]+)';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -124,12 +124,12 @@ class RoutesController {
 	 * @return string[] List of route paths.
 	 */
 	public function get_all_routes( $version = 'v1', $controller = false ) {
-		$routes = [];
+		$routes = array();
 
 		foreach ( $this->routes[ $version ] as $key => $route_class ) {
 
 			if ( ! method_exists( $route_class, 'get_path_regex' ) ) {
-				throw new \Exception( "{$route_class} route does not have a get_path_regex method" );
+				throw new \Exception( esc_html( "{$route_class} route does not have a get_path_regex method" ) );
 			}
 
 			$route_path = '/' . trailingslashit( self::$api_namespace ) . $version . $route_class::get_path_regex();

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -22,6 +22,13 @@ class RoutesController {
 	protected $routes = [];
 
 	/**
+	 * Namespace for the API.
+	 *
+	 * @var string
+	 */
+	private static $api_namespace = 'wc/store';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param SchemaController $schema_controller Schema controller class passed to each route.
@@ -76,8 +83,8 @@ class RoutesController {
 	 * Register all Store API routes. This includes routes under specific version namespaces.
 	 */
 	public function register_all_routes() {
-		$this->register_routes( 'v1', 'wc/store' );
-		$this->register_routes( 'v1', 'wc/store/v1' );
+		$this->register_routes( 'v1', self::$api_namespace );
+		$this->register_routes( 'v1', self::$api_namespace . '/v1' );
 		$this->register_routes( 'private', 'wc/private' );
 	}
 
@@ -102,6 +109,35 @@ class RoutesController {
 			$this->schema_controller,
 			$this->schema_controller->get( $route::SCHEMA_TYPE, $route::SCHEMA_VERSION )
 		);
+	}
+
+	/**
+	 * Get a route path without instantiating the corresponding RoutesController object.
+	 *
+	 * @throws \Exception If the schema does not exist.
+	 *
+	 * @param string $version API Version being requested.
+	 * @param string $controller Whether to return controller name. If false, returns empty array. Note:
+	 * When $controller param is true, the output should not be used directly in front-end code, to prevent class names from leaking. It's not a security issue necessarily, but it's not a good practice.
+	 * When $controller param is false, it currently returns and empty array. But it can be modified in future to return include more details about the route info that can be used in frontend.
+	 *
+	 * @return string[] List of route paths.
+	 */
+	public function get_all_routes( $version = 'v1', $controller = false ) {
+		$routes = [];
+
+		foreach ( $this->routes[ $version ] as $key => $route_class ) {
+
+			if ( ! method_exists( $route_class, 'get_path_regex' ) ) {
+				throw new \Exception( "{$route_class} route does not have a get_path_regex method" );
+			}
+
+			$route_path = '/' . trailingslashit( self::$api_namespace ) . $version . $route_class::get_path_regex();
+
+			$routes[ $route_path ] = $controller ? $route_class : array();
+		}
+
+		return $routes;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -35,6 +35,24 @@ final class StoreApi {
 			},
 			11
 		);
+
+		add_action(
+			'woocommerce_blocks_pre_get_routes_from_namespace',
+			function( $routes, $namespace, $context ) {
+				if ( 'wc/store/v1' !== $namespace ) {
+					return array();
+				}
+
+				$routes = array_merge(
+					$routes,
+					self::container()->get( RoutesController::class )->get_all_routes( 'v1' )
+				);
+
+				return $routes;
+			},
+			10,
+			3
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -40,7 +40,7 @@ final class StoreApi {
 			'woocommerce_blocks_pre_get_routes_from_namespace',
 			function( $routes, $namespace, $context ) {
 				if ( 'wc/store/v1' !== $namespace ) {
-					return array();
+					return $routes;
 				}
 
 				$routes = array_merge(

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -22,7 +22,7 @@ final class StoreApi {
 	public function init() {
 		add_action(
 			'rest_api_init',
-			function() {
+			function () {
 				self::container()->get( Legacy::class )->init();
 				self::container()->get( RoutesController::class )->register_all_routes();
 			}
@@ -30,7 +30,7 @@ final class StoreApi {
 		// Runs on priority 11 after rest_api_default_filters() which is hooked at 10.
 		add_action(
 			'rest_api_init',
-			function() {
+			function () {
 				self::container()->get( Authentication::class )->init();
 			},
 			11
@@ -38,8 +38,8 @@ final class StoreApi {
 
 		add_action(
 			'woocommerce_blocks_pre_get_routes_from_namespace',
-			function( $routes, $namespace, $context ) {
-				if ( 'wc/store/v1' !== $namespace ) {
+			function ( $routes, $ns ) {
+				if ( 'wc/store/v1' !== $ns ) {
 					return $routes;
 				}
 
@@ -51,7 +51,7 @@ final class StoreApi {
 				return $routes;
 			},
 			10,
-			3
+			2
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/Hydration.php
@@ -42,9 +42,18 @@ class Hydration extends TestCase {
 
 		$request_callback_filter_called = false;
 		add_filter(
-			'rest_request_after_callbacks',
+			'woocommerce_hydration_request_after_callbacks',
 			function ( $response ) use ( &$request_callback_filter_called ) {
 				$request_callback_filter_called = true;
+				return $response;
+			}
+		);
+
+		$dispatch_filter_called = false;
+		add_filter(
+			'woocommerce_hydration_dispatch_request',
+			function ( $response ) use ( &$dispatch_filter_called ) {
+				$dispatch_filter_called = true;
 				return $response;
 			}
 		);
@@ -53,6 +62,7 @@ class Hydration extends TestCase {
 
 		$this->assertFalse( $api_loaded );
 		$this->assertTrue( $request_callback_filter_called );
+		$this->assertTrue( $dispatch_filter_called );
 
 		$this->assertArrayHasKey( 'body', $response );
 		$this->assertArrayHasKey( 'headers', $response );

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/Hydration.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Blocks\Library;
+
+use Automattic\WooCommerce\Blocks\Package;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test \Automattic\WooCommerce\Blocks\Domain\Services\Hydration class.
+ */
+class Hydration extends TestCase {
+
+	/**
+	 * System under test.
+	 *
+	 * @var \Automattic\WooCommerce\Blocks\Domain\Services\Hydration
+	 */
+	private $sut;
+
+	/**
+	 * Setup.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = Package::container()->get( \Automattic\WooCommerce\Blocks\Domain\Services\Hydration::class );
+	}
+
+
+	/**
+	 * @testDox REST API response is returned without loading entire REST server.
+	 */
+	public function test_rest_api_response_data_from_store_api() {
+		$path = '/wc/store/v1/cart';
+
+		$api_loaded = false;
+		add_action(
+			'rest_api_init',
+			function () use ( &$api_loaded ) {
+				$api_loaded = true;
+			}
+		);
+
+		$request_callback_filter_called = false;
+		add_filter(
+			'rest_request_after_callbacks',
+			function ( $response ) use ( &$request_callback_filter_called ) {
+				$request_callback_filter_called = true;
+				return $response;
+			}
+		);
+
+		$response = $this->sut->get_rest_api_response_data( $path );
+
+		$this->assertFalse( $api_loaded );
+		$this->assertTrue( $request_callback_filter_called );
+
+		$this->assertArrayHasKey( 'body', $response );
+		$this->assertArrayHasKey( 'headers', $response );
+
+		// Verify few keys from headers and body.
+		$this->assertArrayHasKey( 'Cart-Token', $response['headers'] );
+		$this->assertArrayHasKey( 'items', $response['body'] );
+		$this->assertArrayHasKey( 'coupons', $response['body'] );
+	}
+
+	/**
+	 * @testDox Controllers outside store API are not supported for hydration.
+	 */
+	public function test_rest_api_response_data_outside_store_api() {
+		$path = '/wc/orders';
+
+		$response = $this->sut->get_rest_api_response_data( $path );
+
+		$this->assertEmpty( $response );
+	}
+
+	/**
+	 * @testDox Store API controllers that don't implement GET methods should not return anything.
+	 */
+	public function test_rest_api_response_data_no_get_handler() {
+		$path = '/wc/store/v1/checkout/1';
+
+		$response = $this->sut->get_rest_api_response_data( $path );
+
+		$this->assertEmpty( $response );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We reverted #44080  and #44790 in #44876 earlier after we discovered some backward compatibility issues, given that after removing the REST API, we were not calling the `rest_request_after_callbacks` anymore. This PR aims to re-introduce those changes with appropriate backward compatibility.

Note that we call here `rest_request_after_callbacks` manually, which is generally called in a REST request lifecycle. While we do it here for backward compatibility, it is also important to note that we are not calling other REST lifecycle hooks such as `rest_request_before_callbacks` or `rest_dispatch_request`. Upon auditing usage of these hooks, it looks like only `rest_request_after_callbacks` is used in the context of changing the response of an API request, which is relevant to us.

Alternatively, we can choose to not add this hook, in which case the 3pd plugins currently hoping to change the store API data would need to find some other way to modify this information.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Similar to previous PRs, this needs exploratory testing, especially on cart and checkout blocks. To test, complete a checkout using cart and checkout blocks on any theme.

Additionally, we should also test the back compat and verify if the `rest_request_after_callbacks` filter is being executed like so:

1. Add this as a code snippet to hook on to the rest filter:
```php
<?php
/**
 * Plugin Name: API Profiler
 */

add_filter( 'rest_request_after_callbacks', function () {
	$e = new \Exception;
	js_console_log( array(
		'message' => 'REST API after callback',
		'stack' => $e->getTraceAsString(),
	));

} );

function js_console_log( $data ) {
	?>
	<script>
		console.log( <?php echo json_encode( $data ); ?> );
	</script>
	<?php
}
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
