### PR TITLE
Fixed link to new subscriptions page

### DIFF
--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -483,7 +483,7 @@ class WC_Helper_Updater {
 			sprintf(
 				// translators: %s: URL of WooCommerce.com subscriptions tab.
 				__( 'Please visit the <a href="%s" target="_blank">subscriptions page</a> and renew to continue receiving updates.', 'woocommerce' ),
-				esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) )
+				esc_url( admin_url( 'admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions' ) )
 			)
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Purpose of PR
Closes #47040 47040 by changing a link to the new version of the Subscriptions/Extensions page.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Make sure you have a Premium WooCommerce.com extension installed and that it's out of date.
2. Also, make sure you are connected with a Woo.com account that has a valid license for that plugin. This is needed to let Woo detect that there is an update available.
3. Go to WooCommerce → Extentions → My Subscriptions and make sure that the plugin's license is not active/connected.
If the plugin is connected already, fully disconnect the Woo.com account and connect again (this should disconnect the plugin). Alternatively, go to https://mytestsite.com/wp-admin/admin.php?page=wc-addons&section=helper&filter=update-available and deactivate the plugin's license.
4. Go to the plugins page and select the Update Now link under the plugin.
5. Verify that the link "subscriptions page" points to https://mytestsite.com/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions (and not the old link https://mytestsite.com/wp-admin/admin.php?page=wc-addons&section=helper )