### PR TITLE
Allow JSON schema string 

### DIFF
--- a/packages/php/remote-specs-validation/changelog/accept-json-schema-string
+++ b/packages/php/remote-specs-validation/changelog/accept-json-schema-string
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Accept JSON schema string as constructor argument instead of file path -- this is more fleixble.

--- a/packages/php/remote-specs-validation/composer.json
+++ b/packages/php/remote-specs-validation/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/remote-specs-validation",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Remote specs testing suite",
 	"type": "library",
 	"license": "GPL-3.0-or-later",

--- a/packages/php/remote-specs-validation/src/RemoteSpecValidator.php
+++ b/packages/php/remote-specs-validation/src/RemoteSpecValidator.php
@@ -16,6 +16,14 @@ class RemoteSpecValidator {
 	 */
 	private $schema;
 
+	private static $supported_bundles = [
+		'remote-inbox-notification' => 'remote-inbox-notification.json',
+		'wc-pay-promotions'   => 'wc-pay-promotions.json',
+		'shipping-partner-suggestions' => 'shipping-partner-suggestions.json',
+		'payment-gateway-suggestions' => 'payment-gateway-suggestions.json',
+		'obw-free-extensions' => 'obw-free-extensions.json',
+	];
+
 	public function __construct( $json_schema_string ) {
 		$this->schema = $json_schema_string;
 	}
@@ -32,20 +40,16 @@ class RemoteSpecValidator {
 	 * @throws \InvalidArgumentException If the bundle is not supported.
 	 */
 	public static function create_from_bundle( $bundle ) {
-		$supported_bundles = [
-			'remote-inbox-notification' => 'remote-inbox-notification.json',
-			'wc-pay-promotions'   => 'wc-pay-promotions.json',
-			'shipping-partner-suggestions' => 'shipping-partner-suggestions.json',
-			'payment-gateway-suggestions' => 'payment-gateway-suggestions.json',
-			'obw-free-extensions' => 'obw-free-extensions.json',
-		];
+		return new self( static::get_bundle_json( $bundle ) );
+	}
 
-		if ( ! array_key_exists( $bundle, $supported_bundles ) ) {
+	public static function get_bundle_json( $bundle) {
+		if ( ! array_key_exists( $bundle, static::$supported_bundles ) ) {
 			throw new \InvalidArgumentException( "Unsupported bundle: $bundle. ".
-				"Supported bundles are: " . implode( ', ', array_keys( $supported_bundles ) ) );
+			                                     "Supported bundles are: " . implode( ', ', array_keys( static::$supported_bundles ) ) );
 		}
 
-		return static::create_from_file( __DIR__ . "/../bundles/{$supported_bundles[$bundle]}" );
+		return file_get_contents( __DIR__ . "/../bundles/" . static::$supported_bundles[ $bundle ] );
 	}
 
 	/**

--- a/packages/php/remote-specs-validation/src/RemoteSpecValidator.php
+++ b/packages/php/remote-specs-validation/src/RemoteSpecValidator.php
@@ -16,8 +16,12 @@ class RemoteSpecValidator {
 	 */
 	private $schema;
 
-	public function __construct( $json_schema_path ) {
-		$this->schema = json_decode( file_get_contents( $json_schema_path ) );
+	public function __construct( $json_schema_string ) {
+		$this->schema = $json_schema_string;
+	}
+
+	public static function create_from_file( $json_schema_path ) {
+		return new self( json_decode( file_get_contents( $json_schema_path ) ) );
 	}
 
 	/**
@@ -41,7 +45,7 @@ class RemoteSpecValidator {
 				"Supported bundles are: " . implode( ', ', array_keys( $supported_bundles ) ) );
 		}
 
-		return new self( __DIR__ . "/../bundles/{$supported_bundles[$bundle]}" );
+		return static::create_from_file( __DIR__ . "/../bundles/{$supported_bundles[$bundle]}" );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the Remote Spec Validation package to accept a JSON schema string as a constructor argument instead of a JSON schema file path, allowing the use of already loaded JSON schemas. It also adds `get_bundle_json` to use the included bundles somewhere else when needed.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Running `./vendor/bin/phpunit` should be sufficient

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
