### PR TITLE
Settings Slotfills: Normalize registration to avoid conflicts

### DIFF
--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -19,7 +19,7 @@ import { EmbeddedBodyLayout } from './embedded-body-layout';
 import './xstate.js';
 import { deriveWpAdminBackgroundColours } from './utils/derive-wp-admin-background-colours';
 import { possiblyRenderSettingsSlots } from './settings/settings-slots';
-import { registerConflictErrorFill } from './settings/conflict-error-slotfill';
+import { registerTaxSettingsConflictErrorFill } from './settings/conflict-error-slotfill';
 import { registerPaymentsSettingsBannerFill } from './payments/payments-settings-banner-slotfill';
 
 const appRoot = document.getElementById( 'root' );
@@ -66,8 +66,6 @@ if ( appRoot ) {
 	// Render notices just above the WP content div.
 	const wpBody = document.getElementById( 'wpbody-content' );
 
-	possiblyRenderSettingsSlots();
-
 	const wrap =
 		wpBody.querySelector( '.wrap.woocommerce' ) ||
 		document.querySelector( '#wpbody-content > .woocommerce' ) ||
@@ -86,7 +84,9 @@ if ( appRoot ) {
 		wpBody.insertBefore( embeddedBodyContainer, wrap.nextSibling )
 	);
 
-	registerConflictErrorFill();
+	possiblyRenderSettingsSlots();
+
+	registerTaxSettingsConflictErrorFill();
 	registerPaymentsSettingsBannerFill();
 }
 

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -16,10 +16,11 @@ import './stylesheets/_index.scss';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { PageLayout, EmbedLayout, PrimaryLayout as NoticeArea } from './layout';
 import { EmbeddedBodyLayout } from './embedded-body-layout';
-import { WcAdminPaymentsGatewaysBannerSlot } from './payments/payments-settings-banner-slotfill';
-import { WcAdminConflictErrorSlot } from './settings/conflict-error-slotfill.js';
 import './xstate.js';
 import { deriveWpAdminBackgroundColours } from './utils/derive-wp-admin-background-colours';
+import { possiblyRenderSettingsSlots } from './settings/settings-slots';
+import { registerConflictErrorFill } from './settings/conflict-error-slotfill';
+import { registerPaymentsSettingsBannerFill } from './payments/payments-settings-banner-slotfill';
 
 const appRoot = document.getElementById( 'root' );
 const embeddedRoot = document.getElementById( 'woocommerce-embedded-root' );
@@ -65,22 +66,7 @@ if ( appRoot ) {
 	// Render notices just above the WP content div.
 	const wpBody = document.getElementById( 'wpbody-content' );
 
-	const isWcAdminSettingsPaymentPage = document.getElementById(
-		'wc_payment_gateways_banner_slotfill'
-	);
-
-	if ( isWcAdminSettingsPaymentPage ) {
-		render(
-			WcAdminPaymentsGatewaysBannerSlot(),
-			isWcAdminSettingsPaymentPage
-		);
-	}
-
-	const isTaxPage = document.getElementById( 'wc_conflict_error_slotfill' );
-
-	if ( isTaxPage ) {
-		render( WcAdminConflictErrorSlot(), isTaxPage );
-	}
+	possiblyRenderSettingsSlots();
 
 	const wrap =
 		wpBody.querySelector( '.wrap.woocommerce' ) ||
@@ -99,6 +85,9 @@ if ( appRoot ) {
 		<EmbeddedBodyLayout />,
 		wpBody.insertBefore( embeddedBodyContainer, wrap.nextSibling )
 	);
+
+	registerConflictErrorFill();
+	registerPaymentsSettingsBannerFill();
 }
 
 // Render the CustomerEffortScoreTracksContainer only if

--- a/plugins/woocommerce-admin/client/payments/payments-settings-banner-slotfill.js
+++ b/plugins/woocommerce-admin/client/payments/payments-settings-banner-slotfill.js
@@ -1,17 +1,16 @@
 /**
  * External dependencies
  */
-import { createSlotFill, SlotFillProvider } from '@wordpress/components';
-import { registerPlugin, PluginArea } from '@wordpress/plugins';
+import { createSlotFill } from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
  */
 import { PaymentsBannerWrapper } from './payment-settings-banner';
+import { SETTINGS_SLOT_FILL_CONSTANT } from '../settings/settings-slots';
 
-const { Fill, Slot } = createSlotFill(
-	'__EXPERIMENTAL__WcAdminPaymentsGatewaysSettingsBanner'
-);
+const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 const PaymentsBannerFill = () => {
 	return (
 		<Fill>
@@ -20,18 +19,9 @@ const PaymentsBannerFill = () => {
 	);
 };
 
-export const WcAdminPaymentsGatewaysBannerSlot = () => {
-	return (
-		<>
-			<SlotFillProvider>
-				<Slot />
-				<PluginArea scope="woocommerce-settings" />
-			</SlotFillProvider>
-		</>
-	);
+export const registerPaymentsSettingsBannerFill = () => {
+	registerPlugin( 'woocommerce-admin-paymentsgateways-settings-banner', {
+		scope: 'woocommerce-payment-settings',
+		render: PaymentsBannerFill,
+	} );
 };
-
-registerPlugin( 'woocommerce-admin-paymentsgateways-settings-banner', {
-	scope: 'woocommerce-settings',
-	render: PaymentsBannerFill,
-} );

--- a/plugins/woocommerce-admin/client/payments/payments-settings-banner-slotfill.js
+++ b/plugins/woocommerce-admin/client/payments/payments-settings-banner-slotfill.js
@@ -21,7 +21,7 @@ const PaymentsBannerFill = () => {
 
 export const registerPaymentsSettingsBannerFill = () => {
 	registerPlugin( 'woocommerce-admin-paymentsgateways-settings-banner', {
-		scope: 'woocommerce-payment-settings',
+		scope: 'woocommerce-payments-settings',
 		render: PaymentsBannerFill,
 	} );
 };

--- a/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
+++ b/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
@@ -1,16 +1,10 @@
 /**
  * External dependencies
  */
-import { registerPlugin, PluginArea } from '@wordpress/plugins';
+import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import {
-	Button,
-	Card,
-	CardBody,
-	createSlotFill,
-	SlotFillProvider,
-} from '@wordpress/components';
+import { Button, Card, CardBody, createSlotFill } from '@wordpress/components';
 import { Icon, closeSmall } from '@wordpress/icons';
 import { useEffect, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
@@ -22,8 +16,9 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import './conflict-error-slotfill.scss';
 import warningIcon from './alert-triangle-icon.svg';
+import { SETTINGS_SLOT_FILL_CONSTANT } from './settings-slots';
 
-const { Fill, Slot } = createSlotFill( '__EXPERIMENTAL__WcAdminConflictError' );
+const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
 const LearnMore = () => (
 	<Button
@@ -40,7 +35,7 @@ const SettingsErrorFill = () => {
 
 	const [ pricesEnteredWithTaxSetting, setMainVal ] = useState(
 		document.forms.mainform.elements.woocommerce_prices_include_tax
-			.value === 'yes'
+			?.value === 'yes'
 			? 'incl'
 			: 'excl'
 	);
@@ -196,18 +191,9 @@ const SettingsErrorFill = () => {
 	);
 };
 
-export const WcAdminConflictErrorSlot = () => {
-	return (
-		<>
-			<SlotFillProvider>
-				<Slot />
-				<PluginArea scope="woocommerce-settings" />
-			</SlotFillProvider>
-		</>
-	);
+export const registerConflictErrorFill = () => {
+	registerPlugin( 'woocommerce-admin-tax-settings-conflict-warning', {
+		scope: 'woocommerce-tax-settings',
+		render: SettingsErrorFill,
+	} );
 };
-
-registerPlugin( 'woocommerce-admin-tax-settings-conflict-warning', {
-	scope: 'woocommerce-settings',
-	render: SettingsErrorFill,
-} );

--- a/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
+++ b/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
@@ -191,7 +191,7 @@ const SettingsErrorFill = () => {
 	);
 };
 
-export const registerConflictErrorFill = () => {
+export const registerTaxSettingsConflictErrorFill = () => {
 	registerPlugin( 'woocommerce-admin-tax-settings-conflict-warning', {
 		scope: 'woocommerce-tax-settings',
 		render: SettingsErrorFill,

--- a/plugins/woocommerce-admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce-admin/client/settings/settings-slots.js
@@ -13,7 +13,7 @@ const { Slot } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 export const possiblyRenderSettingsSlots = () => {
 	const slots = [
 		{
-			id: 'wc_payment_settings_slotfill',
+			id: 'wc_payments_settings_slotfill',
 			scope: 'woocommerce-payment-settings',
 		},
 		{ id: 'wc_tax_settings_slotfill', scope: 'woocommerce-tax-settings' },

--- a/plugins/woocommerce-admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce-admin/client/settings/settings-slots.js
@@ -17,6 +17,7 @@ export const possiblyRenderSettingsSlots = () => {
 			scope: 'woocommerce-payments-settings',
 		},
 		{ id: 'wc_tax_settings_slotfill', scope: 'woocommerce-tax-settings' },
+		{ id: 'wc_settings_slotfill', scope: 'woocommerce-settings' },
 	];
 
 	slots.forEach( ( slot ) => {

--- a/plugins/woocommerce-admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce-admin/client/settings/settings-slots.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { render } from '@wordpress/element';
+import { createSlotFill, SlotFillProvider } from '@wordpress/components';
+import { PluginArea } from '@wordpress/plugins';
+
+export const SETTINGS_SLOT_FILL_CONSTANT =
+	'__EXPERIMENTAL__WcAdminSettingsSlots';
+
+const { Slot } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
+
+export const possiblyRenderSettingsSlots = () => {
+	const slots = [
+		{
+			id: 'wc_payment_settings_slotfill',
+			scope: 'woocommerce-payment-settings',
+		},
+		{ id: 'wc_tax_settings_slotfill', scope: 'woocommerce-tax-settings' },
+	];
+
+	slots.forEach( ( slot ) => {
+		const slotDomElement = document.getElementById( slot.id );
+
+		if ( slotDomElement ) {
+			render(
+				<>
+					<SlotFillProvider>
+						<Slot />
+						<PluginArea scope={ slot.scope } />
+					</SlotFillProvider>
+				</>,
+				slotDomElement
+			);
+		}
+	} );
+};

--- a/plugins/woocommerce-admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce-admin/client/settings/settings-slots.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import { render } from '@wordpress/element';
 import { createSlotFill, SlotFillProvider } from '@wordpress/components';

--- a/plugins/woocommerce-admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce-admin/client/settings/settings-slots.js
@@ -14,7 +14,7 @@ export const possiblyRenderSettingsSlots = () => {
 	const slots = [
 		{
 			id: 'wc_payments_settings_slotfill',
-			scope: 'woocommerce-payment-settings',
+			scope: 'woocommerce-payments-settings',
 		},
 		{ id: 'wc_tax_settings_slotfill', scope: 'woocommerce-tax-settings' },
 	];

--- a/plugins/woocommerce/changelog/45152-fix-settings-slotfills
+++ b/plugins/woocommerce/changelog/45152-fix-settings-slotfills
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalize Slots on Settings pages by creating scopes for each page that has a Slot

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -39,6 +39,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			add_action( 'woocommerce_sections_' . $this->id, array( $this, 'output_sections' ) );
 			add_action( 'woocommerce_settings_' . $this->id, array( $this, 'output' ) );
 			add_action( 'woocommerce_settings_save_' . $this->id, array( $this, 'save' ) );
+			add_action( 'woocommerce_admin_field_add_settings_slot', array( $this, 'add_settings_slot' ) );
 		}
 
 		/**
@@ -59,6 +60,15 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 */
 		public function get_label() {
 			return $this->label;
+		}
+
+		/**
+		 * Creates the React mount point for settings slot.
+		 */
+		public function add_settings_slot() {
+			?>
+			<div id="wc_settings_slotfill"> </div>
+			<?php
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -112,7 +112,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 	 */
 	public function payment_gateways_banner() {
 		?>
-		<div id="wc_payment_gateways_banner_slotfill"> </div>
+		<div id="wc_payment_settings_slotfill"> </div>
 		<?php
 	}
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -112,7 +112,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 	 */
 	public function payment_gateways_banner() {
 		?>
-		<div id="wc_payment_settings_slotfill"> </div>
+		<div id="wc_payments_settings_slotfill"> </div>
 		<?php
 	}
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-tax.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-tax.php
@@ -44,7 +44,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 							<th scope="row" class="titledesc woocommerce_admin_tax_settings_slotfill_th">
 							</th>
 							<td class="forminp forminp-text woocommerce_admin_tax_settings_slotfill_td">
-		<div id="wc_conflict_error_slotfill"> </div>
+		<div id="wc_tax_settings_slotfill"> </div>
 	</td>
 	</tr>
 		<?php

--- a/plugins/woocommerce/includes/admin/settings/views/settings-tax.php
+++ b/plugins/woocommerce/includes/admin/settings/views/settings-tax.php
@@ -98,6 +98,7 @@ $settings = array(
 	),
 
 	array( 'type' => 'conflict_error' ), // React mount point for embedded banner slotfill.
+	array( 'type' => 'add_settings_slot' ), // React mount point for settings slotfill.
 
 	array(
 		'title'       => __( 'Price display suffix', 'woocommerce' ),

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
@@ -53,6 +53,8 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 		$settings               = $sut->get_settings_for_section( '' );
 		$settings_ids_and_types = $this->get_ids_and_types( $settings );
 
+		error_log( print_r( $settings_ids_and_types, true ) );
+
 		$expected = array(
 			'tax_options'                       => array( 'title', 'sectionend' ),
 			'woocommerce_prices_include_tax'    => 'radio',
@@ -64,7 +66,7 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_tax_display_cart'      => 'select',
 			'woocommerce_price_display_suffix'  => 'text',
 			'woocommerce_tax_total_display'     => 'select',
-			''                                  => 'conflict_error',
+			''                                  => array( 'conflict_error', 'add_settings_slot' ),
 		);
 
 		$this->assertEquals( $expected, $settings_ids_and_types );

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
@@ -53,8 +53,6 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 		$settings               = $sut->get_settings_for_section( '' );
 		$settings_ids_and_types = $this->get_ids_and_types( $settings );
 
-		error_log( print_r( $settings_ids_and_types, true ) );
-
 		$expected = array(
 			'tax_options'                       => array( 'title', 'sectionend' ),
 			'woocommerce_prices_include_tax'    => 'radio',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45142

Slots were created for taxes settings screens and payments screens and registered the same scope `woocommerce-settings`. This created a conflict whereby the Payments screen was also loading Fills intended for the tax screen.

Instead of changing the scope, I created two new scopes `woocommerce-payments-settings` and `woocommerce-tax-settings` to avoid loading Fills where they shouldn't be. In the unlikely scenario where someone out in the wild is using the `woocommerce-settings` scope, I added a Slot with that scope as well for backwards compatibility.

I also normalized some id names and restructured how we created Slots.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR touches two bits of functionality, test them separately.

Tax Settings page: https://github.com/woocommerce/woocommerce/pull/36010

1. Set up woocommerce and enable tax settings in general woocommerce settings
2. Go to tax settings tab
4. If any of the 3 tax display settings (Prices entered with tax , Display prices in the shop, Display prices during cart and checkout) differ, there should be a warning banner.
5. Clicking on "Use recommended settings" should change all the settings to be the same as the one set for "Prices entered with tax "

Payments Settings page: https://github.com/woocommerce/woocommerce/pull/34326

1. Set up a new store in WCPay-available countries such as US
2. Install WCPay plugin
3. Go to WooCommerce > Settings > Payment
4. Observe no errors in the console as seen in original issue https://github.com/woocommerce/woocommerce/issues/45142
5. Observe the payments banner is displayed

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Normalize Slots on Settings pages by creating scopes for each page that has a Slot

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
