### PR TITLE
Fix broken import path that causes e2e to fail

### DIFF
--- a/plugins/woocommerce/changelog/45153-dev-fix-broken-import-e2e
+++ b/plugins/woocommerce/changelog/45153-dev-fix-broken-import-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a bug in e2e test import path.
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures' );
+const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
 const { disableWelcomeModal } = require( '../../utils/editor' );
 
 // need to figure out whether tests are being run on a mac


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There appears to be an incorrect import path in the Woo e2e tests that causes the e2e tests to fail. This corrects that import path

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. See CI pass in this PR (while it failed in runs like https://github.com/woocommerce/woocommerce/actions/runs/8059360540/job/22013644443?pr=44880)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fix a bug in e2e test import path.

</details>
