### PR TITLE
Pass some context information to `woocommerce_blocks_hook_compatibility_additional_data` hook

### DIFF
--- a/plugins/woocommerce/changelog/44447-enhancement-please-improve-woocommerce_blocks_hook_compatibility_additional_data-filter-hook
+++ b/plugins/woocommerce/changelog/44447-enhancement-please-improve-woocommerce_blocks_hook_compatibility_additional_data-filter-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Compatibility Layer: pass additional context to woocommerce_blocks_hook_compatibility_additional_data hook which is a class name in which it was called

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -136,7 +136,7 @@ abstract class AbstractTemplateCompatibility {
 				remove_action( $hook, $callback, $priority );
 			}
 		}
-		$class_name = basename( str_replace('\\', '/', get_class($this) ) );
+		$class_name = basename( str_replace( '\\', '/', get_class( $this ) ) );
 
 		/**
 		 * When extensions implement their equivalent blocks of the template

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -136,6 +136,7 @@ abstract class AbstractTemplateCompatibility {
 				remove_action( $hook, $callback, $priority );
 			}
 		}
+		$class_name = basename( str_replace('\\', '/', get_class($this) ) );
 
 		/**
 		 * When extensions implement their equivalent blocks of the template
@@ -161,8 +162,10 @@ abstract class AbstractTemplateCompatibility {
 		 *
 		 * @since 9.5.0
 		 * @param array $data Additional hooked data. Default to empty
+		 * @param string $class_name Class name within which the hook is called.
+		 * Either ArchiveProductTemplatesCompatibility or SingleProductTemplateCompatibility.
 		 */
-		$additional_hook_data = apply_filters( 'woocommerce_blocks_hook_compatibility_additional_data', array() );
+		$additional_hook_data = apply_filters( 'woocommerce_blocks_hook_compatibility_additional_data', array(), $class_name );
 
 		if ( empty( $additional_hook_data ) || ! is_array( $additional_hook_data ) ) {
 			return;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/44447.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In your theme's functions.php add a following code

```
function comp_layer_callback( $arr, $classname ) {
	echo $classname;
}

add_filter( 'woocommerce_blocks_hook_compatibility_additional_data', 'comp_layer_callback', 10, 3 );
```

2. Go to Editor and Clear Customisations on templates:
- Product Catalog
- Single Product
3. Visit each of them and make sure you use a blockified template. If it's a classic template, enter the efit mode and click "Transform into blocks"
4. Save if necessary
5. Go to frontend `/shop`
6. **Expected:** You should see at the top of the page`ArchiveProductTemplatesCompatibility` (it can be repeated multiple times)
7. Click one of the products
8. **Expected:** You should see at the top of the page`SingleProductTemplateCompatibility` (it can be repeated multiple times)

Example: 
<img width="884" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/719df982-4181-4238-8a55-a0755ef62099">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
