### PR TITLE
Update example plugin in Activity Notes docs to correct further issues

### DIFF
--- a/plugins/woocommerce-admin/docs/examples/activity-panel-inbox.md
+++ b/plugins/woocommerce-admin/docs/examples/activity-panel-inbox.md
@@ -60,6 +60,7 @@ Here’s a short example plugin that adds a new activity panel inbox note on plu
  * Version: 1.0.1
  */
 
+use Automattic\WooCommerce\Admin\Notes\Notes as Notes;
 use Automattic\WooCommerce\Admin\Notes\Note as Note;
 
 class WooCommerce_Activity_Panel_Inbox_Example_Plugin_One {
@@ -107,8 +108,6 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_One {
 			'activated_formatted' => $activated_time_formatted,
 		) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_layout('plain');
-		$note->set_image('');
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'wapi-example-plugin-one' );
 		$note->set_layout('plain');
@@ -131,7 +130,7 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_One {
 	 * Removes any notes this plugin created.
 	 */
 	public static function remove_activity_panel_inbox_notes() {
-		if ( ! class_exists( 'Notes' ) ) {
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 			return;
 		}
 
@@ -148,6 +147,7 @@ function wapi_example_one_deactivate() {
 	WooCommerce_Activity_Panel_Inbox_Example_Plugin_One::remove_activity_panel_inbox_notes();
 }
 register_deactivation_hook( __FILE__, 'wapi_example_one_deactivate' );
+
 ```
 
 ### Updating Inbox Items
@@ -165,6 +165,9 @@ Here’s a short example plugin that updates an activity panel inbox note:
  * Text Domain: wapi-example-plugin-two
  * Version: 1.0.0
  */
+ 
+use Automattic\WooCommerce\Admin\Notes\Notes as Notes;
+use Automattic\WooCommerce\Admin\Notes\Note as Note;
 
 class WooCommerce_Activity_Panel_Inbox_Example_Plugin_Two {
 	const NOTE_NAME = 'wapi-example-plugin-two';
@@ -173,7 +176,7 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_Two {
 	 * Adds a note to the merchant' inbox.
 	 */
 	public static function add_or_update_activity_panel_inbox_note() {
-		if ( ! class_exists( 'Notes' ) ) {
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 			return;
 		}
 
@@ -205,8 +208,6 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_Two {
 		) );
 
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_layout('plain');
-		$note->set_image('');
 		$note->set_name( self::NOTE_NAME );
 		$note->set_layout('plain');
 		$note->set_image('');
@@ -219,7 +220,7 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_Two {
 	 * Removes any notes this plugin created.
 	 */
 	public static function remove_activity_panel_inbox_notes() {
-		if ( ! class_exists( 'Notes' ) ) {
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 			return;
 		}
 
@@ -236,6 +237,7 @@ function wapi_example_two_deactivate() {
 	WooCommerce_Activity_Panel_Inbox_Example_Plugin_Two::remove_activity_panel_inbox_notes();
 }
 register_deactivation_hook( __FILE__, 'wapi_example_two_deactivate' );
+
 ```
 
 #### Using the REST API

--- a/plugins/woocommerce/changelog/update-activity-panel-inbox-md
+++ b/plugins/woocommerce/changelog/update-activity-panel-inbox-md
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Minor changes to example plugin code in Markdown file.
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR further improves the document describing demo plugins which show how to send an Activity Panel Inbox note to a WooCommerce store. We improved the example in https://github.com/woocommerce/woocommerce/pull/44504, but ChatGPT highlighted a few more things we could've fixed.

- Adds namespacing for `Automattic\WooCommerce\Admin\Notes\Notes` class. We use both `Notes` and `Note` class.
- Uses namespacing in `class_exists` checks.
- Deletes duplicate code.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**This is a documentation change, so doesn't need testing.** 

I'm including the steps below so anybody who's interested can verify that the updated code in the documentation works.

1. Create a PHP file in the `wp-content/plugins` folder of your WooCommerce test site and paste in the contents of the first example plugin. This creates a plugin called "WooCommerce Activity Panel Inbox Example Plugin One".
2. Activate the plugin in your plugins admin.

<img width="500" src="https://github.com/woocommerce/woocommerce/assets/1647564/6024dbc8-0dc9-4ce4-9136-73d8bb6eadee">

8. Note that a new record is added to `wp_wc_admin_notes`. 
9. Go to a page like `/wp-admin/admin.php?page=wc-settings`.
10. Click on the "Activity" button in the top right of your screen.
11. Note that the note appears in the Activity Panel Inbox.

<img width="500" src="https://github.com/woocommerce/woocommerce/assets/1647564/8e96cd14-d465-4bb0-99a3-e768f68d52fc">

12. Deactivate the plugin, replace the code with the second example and reactivate it.
13. A new record should e added to `wp_wc_admin_notes`.
14. Refresh `/wp-admin/admin.php?page=wc-settings`.
15. You should see a new note in the Activity Panel Inbox.

<img width="468" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/a53c55ea-b874-43db-9607-39e4c454eafd">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

More updates to example plugin code in `activity-panel-inbox.md` to include namespacing.

</details>
