### PR TITLE
[HPOS CLI] Add support for backfilling specific properties or metadata

### DIFF
--- a/plugins/woocommerce/changelog/fix-41910
+++ b/plugins/woocommerce/changelog/fix-41910
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for partial backfilling from or to the HPOS datastore using the CLI.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -317,7 +317,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				/**
 				 * Fires immediately after an order is trashed.
 				 *
-				 * @since
+				 * @since 2.7.0
 				 *
 				 * @param int      $order_id ID of the order that has been trashed.
 				 */

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -654,6 +654,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * Given an initialized order object, update the post/postmeta records.
 	 *
 	 * @param WC_Abstract_Order $order Order object.
+	 *
 	 * @return bool Whether the order was updated.
 	 */
 	public function update_order_from_object( $order ) {

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -654,10 +654,16 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * Given an initialized order object, update the post/postmeta records.
 	 *
 	 * @param WC_Abstract_Order $order Order object.
+	 * @param array             $args  Arguments to control the update.
 	 *
 	 * @return bool Whether the order was updated.
 	 */
-	public function update_order_from_object( $order ) {
+	public function update_order_from_object( $order, $args = array() ) {
+		// Args are not supported by default.
+		if ( ! empty( $args ) ) {
+			return false;
+		}
+
 		if ( ! $order->get_id() ) {
 			return false;
 		}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -654,16 +654,9 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * Given an initialized order object, update the post/postmeta records.
 	 *
 	 * @param WC_Abstract_Order $order Order object.
-	 * @param array             $args  Arguments to control the update.
-	 *
 	 * @return bool Whether the order was updated.
 	 */
-	public function update_order_from_object( $order, $args = array() ) {
-		// Args are not supported by default.
-		if ( ! empty( $args ) ) {
-			return false;
-		}
-
+	public function update_order_from_object( $order ) {
 		if ( ! $order->get_id() ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1063,6 +1063,10 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 				$hpos_value = is_a( $hpos_value, \WC_DateTime::class ) ? $hpos_value->format( DATE_ATOM ) : $hpos_value;
 				$cpt_value  = is_a( $cpt_value, \WC_DateTime::class ) ? $cpt_value->format( DATE_ATOM ) : $cpt_value;
 
+				// Format for NULL.
+				$hpos_value = is_null( $hpos_value ) ? '' : $hpos_value;
+				$cpt_value  = is_null( $cpt_value ) ? '' : $cpt_value;
+
 				return array(
 					'property' => $key,
 					'hpos'     => $hpos_value,

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1113,6 +1113,12 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 *   - posts
 	 * ---
 	 *
+	 * [--meta_keys=<meta_keys>]
+	 * : Comma separated list of meta keys to backfill.
+	 *
+	 * [--props=<props>]
+	 * : Comma separated list of order properties to backfill.
+	 *
 	 * @since 8.6.0
 	 *
 	 * @param array $args       Positional arguments passed to the command.
@@ -1140,8 +1146,14 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			WP_CLI::error( __( 'Please use different source (--from) and destination (--to) datastores.', 'woocommerce' ) );
 		}
 
+		$fields = array_intersect_key( $assoc_args, array_flip( array( 'meta_keys', 'props' ) ) );
+		foreach ( $fields as &$field_names ) {
+			$field_names = is_string( $field_names ) ? array_map( 'trim', explode( ',', $field_names ) ) : $field_names;
+			$field_names = array_unique( array_filter( array_filter( $field_names, 'is_string' ) ) );
+		}
+
 		try {
-			$legacy_handler->backfill_order_to_datastore( $order_id, $from, $to );
+			$legacy_handler->backfill_order_to_datastore( $order_id, $from, $to, $fields );
 		} catch ( \Exception $e ) {
 			WP_CLI::error(
 				sprintf(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -426,6 +426,7 @@ class LegacyDataHandler {
 			}
 
 			$dest_order->set_props( $new_values );
+			$dest_order->apply_changes();
 			$datastore->update_order_from_object( $dest_order, 'hpos' === $destination_data_store ? array( 'props' => $fields['props'] ) : array() );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -372,13 +372,13 @@ class LegacyDataHandler {
 	 * @return string[] Property names.
 	 */
 	private function get_order_base_props(): array {
-		return array_column(
-			call_user_func_array(
-				'array_merge',
-				array_values( $this->data_store->get_all_order_column_mappings() )
-			),
-			'name'
-		);
+		$base_props = array();
+
+		foreach ( $this->data_store->get_all_order_column_mappings() as $mapping ) {
+			$base_props = array_merge( $base_props, array_column( $mapping, 'name' ) );
+		}
+
+		return $base_props;
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -384,9 +384,9 @@ class LegacyDataHandler {
 			);
 
 			$dest_order->set_props( $new_values );
-			$dest_order->apply_changes();
 
 			if ( 'hpos' === $destination_data_store ) {
+				$dest_order->apply_changes();
 				$limit_cb = function( $rows, $order ) use ( $dest_order, $fields ) {
 					if ( $dest_order->get_id() === $order->get_id() ) {
 						$rows = $this->limit_hpos_update_to_props( $rows, $fields['props'] );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -444,7 +444,7 @@ class LegacyDataHandler {
 
 	/**
 	 * Filters a set of HPOS row updates to those matching a specific set of order properties.
-	 * Hooked onto 'woocommerce_orders_table_datastore_db_rows_for_order'.
+	 * Called via the `woocommerce_orders_table_datastore_db_rows_for_order` filter in `backfill_order_to_datastore`.
 	 *
 	 * @param array    $rows  Details for the db update.
 	 * @param string[] $props Order property names.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -344,147 +344,62 @@ class LegacyDataHandler {
 			} elseif ( 'hpos' === $destination_data_store ) {
 				$this->posts_to_cot_migrator->migrate_orders( array( $src_order->get_id() ) );
 			}
-		} else {
-			// Backfill a set of meta or props.
-			$dest_order = $this->get_order_from_datastore( $src_order->get_id(), $destination_data_store );
 
-			if ( ! empty( $fields['meta_keys'] ) ) {
-				$this->backfill_partial_order_meta( $src_order, $dest_order, $fields['meta_keys'] );
-			}
-
-			if ( ! empty( $fields['props'] ) ) {
-				$this->backfill_partial_order_props( $src_order, $dest_order, $fields['props'] );
-			}
+			return;
 		}
-	}
 
-	/**
-	 * Backfills order metadata from one order to another.
-	 *
-	 * @since 8.8.0
-	 *
-	 * @param \WC_Abstract_Order $src_order  Source order.
-	 * @param \WC_Abstract_Order $dest_order Destination order.
-	 * @param string[]           $meta_keys  Metakey names.
-	 * @return void
-	 * @throws \Exception When an error occurs.
-	 */
-	private function backfill_partial_order_meta( \WC_Abstract_Order &$src_order, \WC_Abstract_Order &$dest_order, array $meta_keys = array() ) {
-		$internal_meta_keys = array_unique(
-			array_merge(
-				$src_order->get_data_store()->get_internal_meta_keys(),
-				$dest_order->get_data_store()->get_internal_meta_keys()
-			)
-		);
+		$dest_order = $this->get_order_from_datastore( $src_order->get_id(), $destination_data_store );
 
-		$possibly_internal_keys = array_intersect( $internal_meta_keys, $meta_keys );
-		if ( ! empty( $possibly_internal_keys ) ) {
-			throw new \Exception(
-				sprintf(
-					// translators: %s is a comma separated list of metakey names.
-					_n(
-						'%s is an internal meta key. Use --props to set it.',
-						'%s are internal meta keys. Use --props to set them.',
-						count( $possibly_internal_keys ),
-						'woocommerce'
-					),
-					implode( ', ', $possibly_internal_keys )
+		// Backfill meta.
+		if ( ! empty( $fields['meta_keys'] ) ) {
+			$internal_meta_keys = array_unique(
+				array_merge(
+					$src_order->get_data_store()->get_internal_meta_keys(),
+					$dest_order->get_data_store()->get_internal_meta_keys()
 				)
 			);
-		}
 
-		foreach ( $meta_keys as $meta_key ) {
-			$dest_order->delete_meta_data( $meta_key );
+			$possibly_internal_keys = array_intersect( $internal_meta_keys, $fields['meta_keys'] );
+			if ( ! empty( $possibly_internal_keys ) ) {
+				throw new \Exception(
+					sprintf(
+						// translators: %s is a comma separated list of metakey names.
+						_n(
+							'%s is an internal meta key. Use --props to set it.',
+							'%s are internal meta keys. Use --props to set them.',
+							count( $possibly_internal_keys ),
+							'woocommerce'
+						),
+						implode( ', ', $possibly_internal_keys )
+					)
+				);
+			}
 
-			foreach ( $src_order->get_meta( $meta_key, false, 'edit' ) as $meta ) {
-				$dest_order->add_meta_data( $meta_key, $meta->value );
+			foreach ( $fields['meta_keys'] as $meta_key ) {
+				$dest_order->delete_meta_data( $meta_key );
+
+				foreach ( $src_order->get_meta( $meta_key, false, 'edit' ) as $meta ) {
+					$dest_order->add_meta_data( $meta_key, $meta->value );
+				}
 			}
 
 			$dest_order->save_meta_data();
 		}
-	}
 
-	/**
-	 * Backfills order properties from one order to another.
-	 *
-	 * @since 8.8.0.
-	 *
-	 * @param \WC_Abstract_Order $src_order  Source order.
-	 * @param \WC_Abstract_Order $dest_order Destination order.
-	 * @param string[]           $props      Property names.
-	 * @return void
-	 * @throws \Exception When an error occurs.
-	 */
-	private function backfill_partial_order_props( \WC_Abstract_Order &$src_order, \WC_Abstract_Order &$dest_order, array $props = array() ) {
-		$invalid_props = array_filter(
-			$props,
-			function ( $prop_name ) use ( $src_order ) {
-				return ! in_array( $prop_name, $this->get_order_base_props(), true ) || ! method_exists( $src_order, "get_{$prop_name}" );
-			}
-		);
-
-		if ( ! empty( $invalid_props ) ) {
-			throw new \Exception(
-				sprintf(
-					// translators: %s is a list of order property names.
-					_n(
-						'%s is not a valid order property.',
-						'%s are not valid order properties.',
-						count( $invalid_props ),
-						'woocommerce'
-					),
-					implode( ', ', $invalid_props )
-				)
-			);
-		}
-
-		$new_values = array_combine(
-			$props,
-			array_map(
-				fn( $prop_name ) => $src_order->{"get_{$prop_name}"}(),
-				$props
-			)
-		);
-		$dest_order->set_props( $new_values );
-
-		if ( is_a( $dest_order->get_data_store()->get_current_class_name(), get_class( $this->data_store ), true ) ) {
-			// HPOS update.
-			$db_rows = (
-				function() use ( $dest_order ) {
-					return $this->get_db_rows_for_order( $dest_order, 'update', true );
-				}
-			)->call( $this->data_store, $dest_order );
-
-			$allowed_column_names = $this->get_hpos_columns_for_props( $props );
-			$db_util              = wc_get_container()->get( DatabaseUtil::class );
-
-			foreach ( $db_rows as $db_update ) {
-				// Prevent update of columns not associated to the chosen props.
-				if ( ! array_intersect_key( $db_update['data'], array_flip( $allowed_column_names ) ) ) {
-					continue;
-				}
-
-				$allowed_column_names_with_ids = array_merge(
-					$allowed_column_names,
-					array( 'id', 'order_id', 'address_type' )
-				);
-
-				$db_update['data']   = array_intersect_key( $db_update['data'], array_flip( $allowed_column_names_with_ids ) );
-				$db_update['format'] = array_intersect_key( $db_update['format'], array_flip( $allowed_column_names_with_ids ) );
-
-				ksort( $db_update['data'] );
-				ksort( $db_update['format'] );
-
-				$db_util->insert_on_duplicate_key_update( $db_update['table'], $db_update['data'], array_values( $db_update['format'] ) );
-			}
-		} else {
-			// CPT update.
-			$cpt_datastore = $this->data_store->get_cpt_data_store_instance();
-			if ( ! $cpt_datastore || ! method_exists( $cpt_datastore, 'update_order_from_object' ) ) {
-				throw new \Exception( __( 'The current backup datastore does not support updating orders from HPOS.', 'woocommerce' ) );
+		// Backfill props.
+		if ( ! empty( $fields['props'] ) ) {
+			if ( 'posts' === $destination_data_store ) {
+				$datastore = $this->data_store->get_cpt_data_store_instance();
+			} elseif ( 'hpos' === $destination_data_store ) {
+				$datastore = $this->data_store;
 			}
 
-			$cpt_datastore->update_order_from_object( $dest_order );
+			if ( ! $datastore || ! method_exists( $datastore, 'update_order_from_object' ) ) {
+				throw new \Exception( __( 'The backup datastore does not support updating orders.', 'woocommerce' ) );
+			}
+
+			$dest_order->set_props( $src_order->get_data() );
+			$datastore->update_order_from_object( $dest_order, array( 'props' => $fields['props'] ) );
 		}
 	}
 
@@ -522,30 +437,6 @@ class LegacyDataHandler {
 		}
 
 		return $base_props;
-	}
-
-	/**
-	 * Returns a mapping of order property => column name (as in HPOS tables) for a set of order properties.
-	 *
-	 * @since 8.8.0
-	 *
-	 * @param array $props Order properties to fetch column names for.
-	 * @return string[string] Array of column names indexed by order property name.
-	 */
-	private function get_hpos_columns_for_props( array $props = array() ) : array {
-		$result = array();
-
-		foreach ( $this->data_store->get_all_order_column_mappings() as &$mapping ) {
-			foreach ( $mapping as $column_name => &$column_data ) {
-				if ( ! isset( $column_data['name'] ) || ! in_array( $column_data['name'], $props, true ) ) {
-					continue;
-				}
-
-				$result[ $column_data['name'] ] = $column_name;
-			}
-		}
-
-		return $result;
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -644,37 +644,6 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 			)
 		);
 
-		if ( $args['props'] ) {
-			// Check props are valid.
-			$invalid_props = array();
-			$new_values    = array();
-
-			foreach ( (array) $args['props'] as $prop_name ) {
-				if ( ! method_exists( $order, "get_{$prop_name}" ) ) {
-					$invalid_props[] = $prop_name;
-				} else {
-					$new_values[ $prop_name ] = $order->{"get_{$prop_name}"}();
-				}
-			}
-
-			if ( ! empty( $invalid_props ) ) {
-				throw new \Exception(
-					sprintf(
-						// translators: %s is a list of order property names.
-						_n(
-							'%s is not a valid order property.',
-							'%s are not valid order properties.',
-							count( $invalid_props ),
-							'woocommerce'
-						),
-						implode( ', ', $invalid_props )
-					)
-				);
-			}
-		} else {
-			$new_values = $order->get_data();
-		}
-
 		$hpos_order = new \WC_Order();
 		$hpos_order->set_id( $order->get_id() );
 		$this->read( $hpos_order );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -634,7 +634,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 *
 	 * @param \WC_Abstract_Order $order Source order.
 	 * @param array              $args  Update args.
-	 * @throws \Exception When an error occurs.
+	 * @return bool Whether the order was updated.
 	 */
 	public function update_order_from_object( $order, $args = array() ) {
 		$args = wp_parse_args(
@@ -647,11 +647,11 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		$hpos_order = new \WC_Order();
 		$hpos_order->set_id( $order->get_id() );
 		$this->read( $hpos_order );
-		$hpos_order->set_props( $new_values );
+		$hpos_order->set_props( $order->get_data() );
 
 		if ( ! $args['props'] ) {
 			$hpos_order->save();
-			return;
+			return true;
 		}
 
 		$allowed_columns = $this->get_column_names_for_props( $args['props'] );
@@ -676,6 +676,8 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 
 			$this->database_util->insert_on_duplicate_key_update( $db_update['table'], $db_update['data'], array_values( $db_update['format'] ) );
 		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -630,6 +630,86 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	}
 
 	/**
+	 * Updates an order (in this datastore) from another order object.
+	 *
+	 * @param \WC_Abstract_Order $order Source order.
+	 * @param array              $args  Update args.
+	 * @throws \Exception When an error occurs.
+	 */
+	public function update_order_from_object( $order, $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'props' => array(),
+			)
+		);
+
+		if ( $args['props'] ) {
+			// Check props are valid.
+			$invalid_props = array();
+			$new_values    = array();
+
+			foreach ( (array) $args['props'] as $prop_name ) {
+				if ( ! method_exists( $order, "get_{$prop_name}" ) ) {
+					$invalid_props[] = $prop_name;
+				} else {
+					$new_values[ $prop_name ] = $order->{"get_{$prop_name}"}();
+				}
+			}
+
+			if ( ! empty( $invalid_props ) ) {
+				throw new \Exception(
+					sprintf(
+						// translators: %s is a list of order property names.
+						_n(
+							'%s is not a valid order property.',
+							'%s are not valid order properties.',
+							count( $invalid_props ),
+							'woocommerce'
+						),
+						implode( ', ', $invalid_props )
+					)
+				);
+			}
+		} else {
+			$new_values = $order->get_data();
+		}
+
+		$hpos_order = new \WC_Order();
+		$hpos_order->set_id( $order->get_id() );
+		$this->read( $hpos_order );
+		$hpos_order->set_props( $new_values );
+
+		if ( ! $args['props'] ) {
+			$hpos_order->save();
+			return;
+		}
+
+		$allowed_columns = $this->get_column_names_for_props( $args['props'] );
+		$db_rows         = $this->get_db_rows_for_order( $hpos_order, 'update', true );
+
+		foreach ( $db_rows as $db_update ) {
+			// Prevent accidental update of another prop by limiting columns to explicitly requested props.
+			if ( ! array_intersect_key( $db_update['data'], array_flip( $allowed_columns ) ) ) {
+				continue;
+			}
+
+			$allowed_column_names_with_ids = array_merge(
+				$allowed_columns,
+				array( 'id', 'order_id', 'address_type' )
+			);
+
+			$db_update['data']   = array_intersect_key( $db_update['data'], array_flip( $allowed_column_names_with_ids ) );
+			$db_update['format'] = array_intersect_key( $db_update['format'], array_flip( $allowed_column_names_with_ids ) );
+
+			ksort( $db_update['data'] );
+			ksort( $db_update['format'] );
+
+			$this->database_util->insert_on_duplicate_key_update( $db_update['table'], $db_update['data'], array_values( $db_update['format'] ) );
+		}
+	}
+
+	/**
 	 * Get information about whether permissions are granted yet.
 	 *
 	 * @param \WC_Order $order Order object.
@@ -3009,4 +3089,29 @@ CREATE TABLE $meta_table (
 
 		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) && ( ! is_object( $meta ) || ! in_array( $meta->key, $this->ephemeral_meta_keys, true ) );
 	}
+
+	/**
+	 * Returns a mapping of order property => column name (as in HPOS tables) for a set of order properties.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @param array $props Order properties to fetch column names for.
+	 * @return array<string,string> Array of column names indexed by order property name.
+	 */
+	protected function get_column_names_for_props( array $props = array() ) : array {
+		$result = array();
+
+		foreach ( $this->get_all_order_column_mappings() as &$mapping ) {
+			foreach ( $mapping as $column_name => &$column_data ) {
+				if ( ! isset( $column_data['name'] ) || ! in_array( $column_data['name'], $props, true ) ) {
+					continue;
+				}
+
+				$result[ $column_data['name'] ] = $column_name;
+			}
+		}
+
+		return $result;
+	}
+
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -531,7 +531,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 *
 	 * @return string Alias.
 	 */
-	private function get_order_table_alias() : string {
+	private function get_order_table_alias(): string {
 		return 'o';
 	}
 
@@ -540,7 +540,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 *
 	 * @return string Alias.
 	 */
-	private function get_op_table_alias() : string {
+	private function get_op_table_alias(): string {
 		return 'p';
 	}
 
@@ -551,7 +551,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 *
 	 * @return string Alias.
 	 */
-	private function get_address_table_alias( string $type ) : string {
+	private function get_address_table_alias( string $type ): string {
 		return 'billing' === $type ? 'b' : 's';
 	}
 
@@ -1140,7 +1140,7 @@ WHERE
 	 * @param int $order_id The order id to check.
 	 * @return bool True if an order exists with the given name.
 	 */
-	public function order_exists( $order_id ) : bool {
+	public function order_exists( $order_id ): bool {
 		global $wpdb;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -1179,7 +1179,7 @@ WHERE
 		$data      = $this->get_order_data_for_ids( $order_ids );
 
 		if ( count( $data ) !== count( $order_ids ) ) {
-			throw new \Exception( __( 'Invalid order IDs in call to read_multiple()', 'woocommerce' ) );
+			throw new \Exception( esc_html__( 'Invalid order IDs in call to read_multiple()', 'woocommerce' ) );
 		}
 
 		$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
@@ -1223,7 +1223,7 @@ WHERE
 	 *
 	 * @return bool Whether the order should be synced.
 	 */
-	private function should_sync_order( \WC_Abstract_Order $order ) : bool {
+	private function should_sync_order( \WC_Abstract_Order $order ): bool {
 		$draft_order    = in_array( $order->get_status(), array( 'draft', 'auto-draft' ), true );
 		$already_synced = in_array( $order->get_id(), self::$reading_order_ids, true );
 		return ! $draft_order && ! $already_synced;
@@ -1260,7 +1260,7 @@ WHERE
 	 *
 	 * @return array Filtered meta data.
 	 */
-	public function filter_raw_meta_data( &$object, $raw_meta_data ) {
+	public function filter_raw_meta_data( &$object, $raw_meta_data ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
 		$filtered_meta_data = parent::filter_raw_meta_data( $object, $raw_meta_data );
 		$allowed_keys       = array(
 			'_billing_address_index',
@@ -1268,7 +1268,7 @@ WHERE
 		);
 		$allowed_meta       = array_filter(
 			$raw_meta_data,
-			function( $meta ) use ( $allowed_keys ) {
+			function ( $meta ) use ( $allowed_keys ) {
 				return in_array( $meta->meta_key, $allowed_keys, true );
 			}
 		);
@@ -1837,7 +1837,7 @@ FROM $order_meta_table
 			);
 
 			if ( ! $post_id ) {
-				throw new \Exception( __( 'Could not create order in posts table.', 'woocommerce' ) );
+				throw new \Exception( esc_html__( 'Could not create order in posts table.', 'woocommerce' ) );
 			}
 
 			$order->set_id( $post_id );
@@ -1861,7 +1861,7 @@ FROM $order_meta_table
 
 			if ( false === $result ) {
 				// translators: %s is a table name.
-				throw new \Exception( sprintf( __( 'Could not persist order to database table "%s".', 'woocommerce' ), $update['table'] ) );
+				throw new \Exception( esc_html( sprintf( __( 'Could not persist order to database table "%s".', 'woocommerce' ), $update['table'] ) ) );
 			}
 		}
 
@@ -2164,7 +2164,7 @@ FROM $order_meta_table
 				/**
 				 * Fires immediately after an order is deleted.
 				 *
-				 * @since
+				 * @since 2.7.0
 				 *
 				 * @param int $order_id ID of the order that has been deleted.
 				 */
@@ -2189,7 +2189,7 @@ FROM $order_meta_table
 				/**
 				 * Fires immediately after an order is trashed.
 				 *
-				 * @since
+				 * @since 2.7.0
 				 *
 				 * @param int $order_id ID of the order that has been trashed.
 				 */
@@ -2250,7 +2250,7 @@ FROM $order_meta_table
 	 *
 	 * @return void
 	 */
-	private function upshift_or_delete_child_orders( $order ) : void {
+	private function upshift_or_delete_child_orders( $order ): void {
 		global $wpdb;
 
 		$order_table     = self::get_orders_table_name();
@@ -2755,7 +2755,6 @@ FROM $order_meta_table
 		if ( $save ) {
 			$order->save_meta_data();
 		}
-
 	}
 
 	/**
@@ -2923,7 +2922,7 @@ CREATE TABLE $meta_table (
 	 * @param  WC_Data $object WC_Data object.
 	 * @return array
 	 */
-	public function read_meta( &$object ) {
+	public function read_meta( &$object ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
 		$raw_meta_data = $this->data_store_meta->read_meta( $object );
 		return $this->filter_raw_meta_data( $object, $raw_meta_data );
 	}
@@ -2936,7 +2935,7 @@ CREATE TABLE $meta_table (
 	 *
 	 * @return bool
 	 */
-	public function delete_meta( &$object, $meta ) {
+	public function delete_meta( &$object, $meta ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
 		global $wpdb;
 
 		if ( $this->should_backfill_post_record() && isset( $meta->id ) ) {
@@ -2984,7 +2983,7 @@ CREATE TABLE $meta_table (
 	 *
 	 * @return int|bool  meta ID or false on failure
 	 */
-	public function add_meta( &$object, $meta ) {
+	public function add_meta( &$object, $meta ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
 		$add_meta        = $this->data_store_meta->add_meta( $object, $meta );
 		$meta->id        = $add_meta;
 		$changes_applied = $this->after_meta_change( $object, $meta );
@@ -3006,7 +3005,7 @@ CREATE TABLE $meta_table (
 	 *
 	 * @return bool The number of rows updated, or false on error.
 	 */
-	public function update_meta( &$object, $meta ) {
+	public function update_meta( &$object, $meta ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
 		$update_meta     = $this->data_store_meta->update_meta( $object, $meta );
 		$changes_applied = $this->after_meta_change( $object, $meta );
 
@@ -3072,5 +3071,4 @@ CREATE TABLE $meta_table (
 		 */
 		return apply_filters( 'woocommerce_orders_table_datastore_should_save_after_meta_change', $should_save );
 	}
-
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -3059,6 +3059,10 @@ CREATE TABLE $meta_table (
 		$current_time      = $this->legacy_proxy->call_function( 'current_time', 'mysql', 1 );
 		$current_date_time = new \WC_DateTime( $current_time, new \DateTimeZone( 'GMT' ) );
 
+		$should_save =
+			$order->get_date_modified() < $current_date_time && empty( $order->get_changes() )
+			&& ( ! is_object( $meta ) || ! in_array( $meta->key, $this->ephemeral_meta_keys, true ) );
+
 		/**
 		 * Allows code to skip a full order save() when metadata is changed.
 		 *
@@ -3066,10 +3070,7 @@ CREATE TABLE $meta_table (
 		 *
 		 * @param bool $should_save Whether to trigger a full save after metadata is changed.
 		 */
-		return apply_filters(
-			'woocommerce_orders_table_datastore_should_save_after_meta_change',
-			$order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) && ( ! is_object( $meta ) || ! in_array( $meta->key, $this->ephemeral_meta_keys, true ) )
-		);
+		return apply_filters( 'woocommerce_orders_table_datastore_should_save_after_meta_change', $should_save );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataHandlerTests.php
@@ -189,4 +189,60 @@ class LegacyDataHandlerTests extends WC_Unit_Test_Case {
 		$this->assertEquals( $order_hpos->get_meta( 'meta_key' ), $order_cpt->get_meta( 'meta_key' ) );
 	}
 
+	/**
+	 * Checks that partial backfills from/to either datastore work correctly.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @return void
+	 */
+	public function test_datastore_partial_backfill() {
+		// Test order.
+		$this->enable_cot_sync();
+		$order = new \WC_Order();
+		$order->set_status( 'on-hold' );
+		$order->add_meta_data( 'my_meta', 'hpos+posts' );
+		$order->save();
+		$this->disable_cot_sync();
+
+		$order_hpos = $this->sut->get_order_from_datastore( $order->get_id(), 'hpos' );
+		$order_hpos->set_status( 'completed' );
+		$order_hpos->set_billing_first_name( 'Mr. HPOS' );
+		$order_hpos->update_meta_data( 'my_meta', 'hpos' );
+		$order_hpos->save();
+
+		// Fetch the posts version and make sure it's different.
+		$order_cpt = $this->sut->get_order_from_datastore( $order->get_id(), 'posts' );
+		$this->assertNotEquals( $order_hpos->get_billing_first_name(), $order_cpt->get_billing_first_name() );
+		$this->assertNotEquals( $order_hpos->get_status(), $order_cpt->get_status() );
+		$this->assertNotEquals( $order_hpos->get_meta( 'my_meta' ), $order_cpt->get_meta( 'my_meta' ) );
+
+		// Backfill "my_meta" to posts and confirm it has been backfilled.
+		$this->sut->backfill_order_to_datastore( $order->get_id(), 'hpos', 'posts', array( 'meta_keys' => array( 'my_meta' ) ) );
+		$order_cpt = $this->sut->get_order_from_datastore( $order->get_id(), 'posts' );
+		$this->assertNotEquals( $order_hpos->get_billing_first_name(), $order_cpt->get_billing_first_name() );
+		$this->assertNotEquals( $order_hpos->get_status(), $order_cpt->get_status() );
+		$this->assertEquals( $order_hpos->get_meta( 'my_meta' ), $order_cpt->get_meta( 'my_meta' ) );
+
+		// Backfill status and confirm it has been backfilled.
+		$this->sut->backfill_order_to_datastore( $order->get_id(), 'hpos', 'posts', array( 'props' => array( 'status' ) ) );
+		$order_cpt = $this->sut->get_order_from_datastore( $order->get_id(), 'posts' );
+		$this->assertNotEquals( $order_hpos->get_billing_first_name(), $order_cpt->get_billing_first_name() );
+		$this->assertEquals( $order_hpos->get_status(), $order_cpt->get_status() );
+
+		// Update the CPT version now.
+		$order_cpt->set_billing_first_name( 'Mr. Post' );
+		$order_cpt->save();
+
+		// Re-load the HPOS version and confirm billing first name is different.
+		$order_hpos = $this->sut->get_order_from_datastore( $order->get_id(), 'hpos' );
+		$this->assertNotEquals( $order_hpos->get_billing_first_name(), $order_cpt->get_billing_first_name() );
+
+		// Backfill name and confirm.
+		$this->sut->backfill_order_to_datastore( $order->get_id(), 'posts', 'hpos', array( 'props' => array( 'billing_first_name' ) ) );
+		$order_hpos = $this->sut->get_order_from_datastore( $order->get_id(), 'hpos' );
+		$this->assertEquals( $order_hpos->get_billing_first_name(), $order_cpt->get_billing_first_name() );
+		$this->assertEquals( $order_hpos->get_status(), $order_cpt->get_status() );
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In #44281 we introduced the `wp wc hpos backfill` command which allows backfilling an order from/to the HPOS or posts datastore, regardless of which datastore is currently active. This allows merchants to fix one off errors where some data might've been modified outside of the CRUD layer.

While this works ok, sometimes there might be a need to sync just some specific metadata or properties from/to either datastore instead of the whole order. This PR introduces `--meta-keys` and `--props` arguments to `wp wc hpos backfill` which do precisely that.
While ideally orders would be backfilled in their entirety, this at least provides a last resort for some possible tricky cases.

Closes #41910.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is set as datastore in WC > Settings > Advanced > Features and also that sync (compatibility mode) is disabled.
   **Note:** It shouldn't really matter which datastore is set and we'll test syncing both ways, but this will make testing instructions more straightforward.
2. Make sure your site has at least one order with billing details. Take note of its ID.
3. Run `wp wc cot sync` to ensure that things are 100% synced between datastores.
4. Open the order from step 2 for editing:
   - Change its status to any status.
   - Change the billing first name to any value you like.
   - Add some metadata using the metadata metabox ("Custom Fields") and make a note of the "Name" you used for the field.
5. Run `wp wc hpos diff <order_id>` and confirm that the changes made above are listed as differences.
6. Run `wp wc hpos backfill <order_id> --from=hpos --to=posts --props=billing_first_name` to backfill the billing first name alone.
7. Run `wp wc hpos diff <order_id>` again and confirm that the status is no longer listed as being different. This proves that the `--props` arg limited the backfill to only that prop (leaving "status" and meta alone).
8. Let's add some metadata to the posts version with `wp post meta update <order_id> my_posts_meta my_meta_value`.
9. Run `wp wc hpos diff <order_id>` to confirm that the new meta is listed as a difference (with a value only on the 'post' side).
10. Let's migrate `my_posts_meta` from the post to the HPOS order by running `wp wc hpos backfill <order_id> --from=posts --to=hpos --meta_keys=my_posts_meta`. Run `wp wc hpos diff <order_id>` to confirm that this difference has now disappeared.
11. Now let's migrate the HPOS meta you added on step 4 by running `wp wc hpos backfill <order_id> --from=posts --to=hpos --meta_keys=<meta_key>`. Again, verify that the difference is gone with `wp wc hpos diff <order_id>`.
12. Finally, let's backfill a property (in this case, the status, which we've left alone thus far) from posts to HPOS: `wp wc hpos backfill <order_id> --from=posts --to=hpos --props=status`. Verify once more with `wp wc hpos diff <order_id>`.
13. Thank you for following such long testing instructions. You're a beautiful person 😸.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
