### PR TITLE
Fix: LegacyProxy::get_instance_of throws when trying to get an instance of a non-Woo namespaced class

### DIFF
--- a/plugins/woocommerce/changelog/45178-fix_legacy_proxy_get_instance_of
+++ b/plugins/woocommerce/changelog/45178-fix_legacy_proxy_get_instance_of
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix LegacyProxy::get_instance_of throwing an error when trying to get an instance of a non-Woo namespaced class.

--- a/plugins/woocommerce/src/Proxies/LegacyProxy.php
+++ b/plugins/woocommerce/src/Proxies/LegacyProxy.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Proxies;
 
 use Automattic\WooCommerce\Internal\DependencyManagement\Definition;
+use Automattic\WooCommerce\Utilities\StringUtil;
 use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
@@ -31,12 +32,12 @@ class LegacyProxy {
 	 * @param mixed  ...$args Parameters to be passed to the class constructor or to the appropriate internal 'get_instance_of_' method.
 	 *
 	 * @return object The instance of the class.
-	 * @throws \Exception The requested class belongs to the `src` directory, or there was an error creating an instance of the class.
+	 * @throws \Exception The requested class has a namespace starting with ' Automattic\WooCommerce', or there was an error creating an instance of the class.
 	 */
 	public function get_instance_of( string $class_name, ...$args ) {
-		if ( false !== strpos( $class_name, '\\' ) ) {
+		if ( StringUtil::starts_with( $class_name, 'Automattic\\WooCommerce\\' ) ) {
 			throw new \Exception(
-				'The LegacyProxy class is not intended for getting instances of classes in the src directory, please use ' .
+				'The LegacyProxy class is not intended for getting instances of classes whose namespace starts with \'Automattic\\WooCommerce\', please use ' .
 				Definition::INJECTION_METHOD . ' method injection or the instance of ' . ContainerInterface::class . ' for that.'
 			);
 		}

--- a/plugins/woocommerce/tests/php/src/Proxies/ExampleClasses/ClassWithNonWooNamespace.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/ExampleClasses/ClassWithNonWooNamespace.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Foo\Bar;
+
+/**
+ * Class whose namespace doesn't start with 'Automattic\WooCommerce'.
+ */
+class ClassWithNonWooNamespace {
+
+}

--- a/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Tests\Proxies;
 use Automattic\WooCommerce\Internal\DependencyManagement\Definition;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses\DependencyClass;
+use Foo\Bar\ClassWithNonWooNamespace;
 
 /**
  * Tests for LegacyProxy
@@ -28,13 +29,21 @@ class LegacyProxyTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'get_instance_of' throws an exception when trying to use it to get an instance of a namespaced class.
+	 * @testdox 'get_instance_of' throws an exception when trying to use it to get an instance of a namespaced class if the namespace starts with 'Automattic\WooCommerce'.
 	 */
-	public function test_get_instance_of_throws_when_trying_to_get_a_namespaced_class() {
+	public function test_get_instance_of_throws_when_trying_to_get_a_woo_namespaced_class() {
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'The LegacyProxy class is not intended for getting instances of classes in the src directory, please use ' . Definition::INJECTION_METHOD . ' method injection or the instance of Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface for that.' );
+		$this->expectExceptionMessage( 'The LegacyProxy class is not intended for getting instances of classes whose namespace starts with \'Automattic\\WooCommerce\', please use ' . Definition::INJECTION_METHOD . ' method injection or the instance of Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface for that.' );
 
 		$this->sut->get_instance_of( DependencyClass::class );
+	}
+
+	/**
+	 * @testdox 'get_instance_of' can be used to get an instance of a namespaced class if the namespace doesn't start with 'Automattic\WooCommerce'.
+	 */
+	public function test_get_instance_of_can_be_used_to_get_a_non_woo_namespaced_class() {
+		$object = $this->sut->get_instance_of( ClassWithNonWooNamespace::class );
+		$this->assertInstanceOf( ClassWithNonWooNamespace::class, $object );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `get_instance_of` method of the `LegacyProxy` class isn't intended to retrieve instances of classes that live in the `src` directory (the dependency injection container should be used for these instead), and will throw an exception if that is attempted. However, in order to check if it should throw it just checks if the class name has a namespace; this will cause a false positive for namespaced classes defined outside of WooCommerce.

This pull request fixes this: the method will throw only if the full class name starts with `Automattic\WooCommerce\`.

### How to test the changes in this Pull Request:

The bug was discovered after merging https://github.com/woocommerce/woocommerce/pull/44833: there are plugins that register namespaced REST API controllers and cause the exception. Thus for testing the fix we'll use the following code:

```php
<?php

namespace Foo\Bar;

class Fizz {
	public function register_routes() {
		register_rest_route( 'fizz', '/buzz', [[
			'methods' => \WP_REST_Server::READABLE,
			'callback'  => fn($request) => 'Buzz!',
			'permission_callback' => fn($request) => true,
		]]);
	}
}

add_filter('woocommerce_rest_api_get_rest_namespaces', function($classes) {
	$classes['fizz'] = [\Foo\Bar\Fizz::class];
	return $classes;
});
```

To setup this code:

* If you are testing locally: put the code in a new `fizz.php` file in the root directory of the plugin, and add the following at the end of the `woocommerce.php` file: `include __DIR__ . '/fizz.php';`
* If you are testing using a remote server: install [the Code Snippets plugin](https://wordpress.org/plugins/code-snippets/) and add the code in a new snippet.

Once the code is prepared, run the following in the command line (or perform the equivalent request with Postman or a similar tool):

```
curl <site root>/wp-json/fizz/buzz
```

* Without the fix this will result in an error, and the server logs will show the following error: _GET /wp-json/fizz/buzz - Uncaught Exception: The LegacyProxy class is not intended for getting instances of classes in the src directory, please use init method injection or the instance of Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface for that._
* With the fix the response will be the string `"Buzz!"`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix LegacyProxy::get_instance_of throwing an error when trying to get an instance of a non-Woo namespaced class.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
