### PR TITLE
CYS - Core: fix font load when user opts out of tracking

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
@@ -46,6 +46,13 @@ export const PreloadFonts = () => {
 		} ) => void
 	] = useGlobalSetting( 'typography.fontFamilies' );
 
+	// theme.json file font families
+	const [ baseFontFamilies ] = useGlobalSetting(
+		'typography.fontFamilies',
+		undefined,
+		'base'
+	);
+
 	const { context } = useContext( CustomizeStoreContext );
 
 	const { globalStylesId, installedFontFamilies } = useSelect( ( select ) => {
@@ -176,7 +183,7 @@ export const PreloadFonts = () => {
 				) ) }
 			{ isNoAIFlow( context.flowType ) && (
 				<FontFamiliesLoader
-					fontFamilies={ enabledFontFamilies.custom }
+					fontFamilies={ baseFontFamilies.theme }
 					iframeInstance={ iframeInstance }
 				/>
 			) }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
@@ -185,7 +185,7 @@ export const PreloadFonts = () => {
 				<FontFamiliesLoader
 					fontFamilies={ [
 						...baseFontFamilies.theme,
-						...enabledFontFamilies.theme,
+						...enabledFontFamilies.custom,
 					] }
 					iframeInstance={ iframeInstance }
 				/>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/preload-fonts.tsx
@@ -184,8 +184,8 @@ export const PreloadFonts = () => {
 			{ isNoAIFlow( context.flowType ) && (
 				<FontFamiliesLoader
 					fontFamilies={ [
+						...( enabledFontFamilies.custom ?? [] ),
 						...baseFontFamilies.theme,
-						...enabledFontFamilies.custom,
 					] }
 					iframeInstance={ iframeInstance }
 				/>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
@@ -488,7 +488,7 @@ export const FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING = [
 			elements: {
 				heading: {
 					typography: {
-						fontFamily: 'var(--wp--preset--font-family--cardo)',
+						fontFamily: 'var(--wp--preset--font-family--heading)',
 						fontStyle: 'normal',
 						fontWeight: '300',
 					},
@@ -496,41 +496,6 @@ export const FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING = [
 			},
 			typography: {
 				fontFamily: 'var(--wp--preset--font-family--system-sans-serif)',
-			},
-		},
-	},
-	{
-		title: 'Jost + Instrument Sans',
-		version: 2,
-		lookAndFeel: [] as Look[],
-		settings: {
-			typography: {
-				fontFamilies: {
-					theme: [
-						{
-							fontFamily: 'Jost',
-							slug: 'jost',
-						},
-						{
-							fontFamily: 'Instrument Sans',
-							slug: 'instrument-sans',
-						},
-					],
-				},
-			},
-		},
-		styles: {
-			elements: {
-				heading: {
-					typography: {
-						fontFamily: 'var(--wp--preset--font-family--jost)',
-						fontStyle: 'normal',
-						fontWeight: '100 900',
-					},
-				},
-			},
-			typography: {
-				fontFamily: 'var(--wp--preset--font-family--instrument-sans)',
 			},
 		},
 	},
@@ -558,14 +523,14 @@ export const FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING = [
 			elements: {
 				heading: {
 					typography: {
-						fontFamily: 'var(--wp--preset--font-family--inter)',
+						fontFamily: 'var(--wp--preset--font-family--body)',
 						fontStyle: 'normal',
 						fontWeight: '300',
 					},
 				},
 			},
 			typography: {
-				fontFamily: 'var(--wp--preset--font-family--cardo)',
+				fontFamily: 'var(--wp--preset--font-family--heading)',
 			},
 		},
 	},

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
@@ -474,7 +474,8 @@ export const FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING = [
 					theme: [
 						{
 							fontFamily: 'Cardo',
-							slug: 'cardo',
+							// Use the theme-defined variable: https://github.com/WordPress/twentytwentyfour/blob/trunk/theme.json#L240
+							slug: 'heading',
 						},
 						{
 							fontFamily: 'System Sans-serif',
@@ -509,11 +510,13 @@ export const FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING = [
 					theme: [
 						{
 							fontFamily: 'Inter',
-							slug: 'inter',
+							// Use the theme-defined variable: https://github.com/WordPress/twentytwentyfour/blob/trunk/theme.json#L215
+							slug: 'body',
 						},
 						{
 							fontFamily: 'Cardo',
-							slug: 'cardo',
+							// Use the theme-defined variable: https://github.com/WordPress/twentytwentyfour/blob/trunk/theme.json#L240
+							slug: 'heading',
 						},
 					],
 				},

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
@@ -55,19 +55,19 @@ export const FontFamiliesLoader = ( {
 		};
 	} );
 
-	const themeUrl =
-		site?.url + '/wp-content/themes/' + currentTheme?.stylesheet;
-
 	useEffect( () => {
-		if ( ! Array.isArray( fontFamilies ) ) {
+		if ( ! Array.isArray( fontFamilies ) || ! site ) {
 			return;
 		}
+
+		const themeUrl =
+			site?.url + '/wp-content/themes/' + currentTheme?.stylesheet;
 		fontFamilies.forEach( async ( fontFamily ) => {
 			fontFamily.fontFace?.forEach( async ( fontFace ) => {
-				const srcFont = getDisplaySrcFromFontFace(
-					fontFace.src,
-					themeUrl
-				);
+				const src = Array.isArray( fontFace.src )
+					? fontFace.src[ 0 ]
+					: fontFace.src;
+				const srcFont = getDisplaySrcFromFontFace( src, themeUrl );
 				const dataSource = `url(${ srcFont })`;
 				const newFont = new FontFace( fontFace.fontFamily, dataSource, {
 					style: fontFace.fontStyle,
@@ -85,7 +85,13 @@ export const FontFamiliesLoader = ( {
 				}
 			} );
 		} );
-	}, [ fontFamilies, iframeInstance, onLoad, themeUrl ] );
+	}, [
+		currentTheme?.stylesheet,
+		fontFamilies,
+		iframeInstance,
+		onLoad,
+		site,
+	] );
 
 	return <></>;
 };

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -62,36 +62,6 @@ export const FontPairing = () => {
 		}
 	];
 
-	// const baseFontFamilies = useSelect( ( select ) => {
-	// 	// @ts-ignore no types exist yet.
-	// 	const { __experimentalGetCurrentThemeGlobalStylesVariations } =
-	// 		select( coreStore );
-
-	// 	const variations =
-	// 		__experimentalGetCurrentThemeGlobalStylesVariations() ?? [];
-
-	// 	return variations.reduce(
-	// 		(
-	// 			acc: Array< FontFamily >,
-	// 			variation: {
-	// 				settings: {
-	// 					typography: {
-	// 						fontFamilies: { theme: Array< FontFamily > };
-	// 					};
-	// 				};
-	// 			}
-	// 		) => {
-	// 			if ( variation.settings?.typography?.fontFamilies.theme ) {
-	// 				return acc.concat(
-	// 					variation.settings.typography.fontFamilies.theme
-	// 				);
-	// 			}
-	// 			return acc;
-	// 		},
-	// 		[] as Array< FontFamily >
-	// 	);
-	// }, [] );
-
 	const { context } = useContext( CustomizeStoreContext );
 	const aiOnline = context.flowType === FlowType.AIOnline;
 	const isFontLibraryAvailable = context.isFontLibraryAvailable;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -51,6 +51,47 @@ export const FontPairing = () => {
 		Array< FontFamily >
 	];
 
+	// theme.json file font families
+	const [ baseFontFamilies ] = useGlobalSetting(
+		'typography.fontFamilies',
+		undefined,
+		'base'
+	) as [
+		{
+			theme: Array< FontFamily >;
+		}
+	];
+
+	// const baseFontFamilies = useSelect( ( select ) => {
+	// 	// @ts-ignore no types exist yet.
+	// 	const { __experimentalGetCurrentThemeGlobalStylesVariations } =
+	// 		select( coreStore );
+
+	// 	const variations =
+	// 		__experimentalGetCurrentThemeGlobalStylesVariations() ?? [];
+
+	// 	return variations.reduce(
+	// 		(
+	// 			acc: Array< FontFamily >,
+	// 			variation: {
+	// 				settings: {
+	// 					typography: {
+	// 						fontFamilies: { theme: Array< FontFamily > };
+	// 					};
+	// 				};
+	// 			}
+	// 		) => {
+	// 			if ( variation.settings?.typography?.fontFamilies.theme ) {
+	// 				return acc.concat(
+	// 					variation.settings.typography.fontFamilies.theme
+	// 				);
+	// 			}
+	// 			return acc;
+	// 		},
+	// 		[] as Array< FontFamily >
+	// 	);
+	// }, [] );
+
 	const { context } = useContext( CustomizeStoreContext );
 	const aiOnline = context.flowType === FlowType.AIOnline;
 	const isFontLibraryAvailable = context.isFontLibraryAvailable;
@@ -71,7 +112,30 @@ export const FontPairing = () => {
 		}
 
 		if ( ! trackingAllowed || ! isFontLibraryAvailable ) {
-			return FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING;
+			return FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING.map(
+				( pair ) => {
+					const fontFamilies = pair.settings.typography.fontFamilies;
+
+					const fonts = baseFontFamilies.theme.filter(
+						( baseFontFamily ) =>
+							fontFamilies.theme.some(
+								( themeFont ) =>
+									themeFont.fontFamily === baseFontFamily.name
+							)
+					);
+
+					return {
+						...pair,
+						settings: {
+							typography: {
+								fontFamilies: {
+									theme: fonts,
+								},
+							},
+						},
+					};
+				}
+			);
 		}
 
 		return FONT_PAIRINGS_WHEN_AI_IS_OFFLINE.map( ( pair ) => {
@@ -96,6 +160,7 @@ export const FontPairing = () => {
 	}, [
 		aiOnline,
 		aiSuggestions?.lookAndFeel,
+		baseFontFamilies,
 		context.flowType,
 		custom,
 		isFontLibraryAvailable,

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/fonts.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/fonts.ts
@@ -187,7 +187,9 @@ export const installFontFace = async (
 	index: number
 ) => {
 	const { fontFamilyId, ...font } = data;
-	const fontFaceAssets = await downloadFontFaceAssets( font.src );
+	const fontFaceAssets = await downloadFontFaceAssets(
+		Array.isArray( font.src ) ? font.src[ 0 ] : font.src
+	);
 	const formData = new FormData();
 
 	const fontFile = await makeFontFacesFormData(

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -5,6 +5,7 @@ import { Sender } from 'xstate';
 import { recordEvent } from '@woocommerce/tracks';
 import apiFetch from '@wordpress/api-fetch';
 import { resolveSelect, dispatch } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 // @ts-expect-error -- No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
@@ -27,7 +28,11 @@ import {
 	getFontFamiliesAndFontFaceToInstall,
 } from './fonts';
 import { COLOR_PALETTES } from '../assembler-hub/sidebar/global-styles/color-palette-variations/constants';
-import { FONT_PAIRINGS_WHEN_AI_IS_OFFLINE } from '../assembler-hub/sidebar/global-styles/font-pairing-variations/constants';
+import {
+	FONT_PAIRINGS_WHEN_AI_IS_OFFLINE,
+	FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING,
+} from '../assembler-hub/sidebar/global-styles/font-pairing-variations/constants';
+import { DesignWithoutAIStateMachineContext } from './types';
 
 const assembleSite = async () => {
 	await updateTemplate( {
@@ -150,10 +155,21 @@ const createProducts = async () => {
 	}
 };
 
-const updateGlobalStylesWithDefaultValues = async () => {
+const updateGlobalStylesWithDefaultValues = async (
+	context: DesignWithoutAIStateMachineContext
+) => {
 	// We are using the first color palette and font pairing that are displayed on the color/font picker on the sidebar.
 	const colorPalette = COLOR_PALETTES[ 0 ];
-	const fontPairing = FONT_PAIRINGS_WHEN_AI_IS_OFFLINE[ 0 ];
+
+	const allowTracking =
+		( await resolveSelect( OPTIONS_STORE_NAME ).getOption(
+			'woocommerce_allow_tracking'
+		) ) === 'yes';
+
+	const fontPairing =
+		context.isFontLibraryAvailable && allowTracking
+			? FONT_PAIRINGS_WHEN_AI_IS_OFFLINE[ 0 ]
+			: FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING[ 0 ];
 
 	// @ts-expect-error No types for this exist yet.
 	const { invalidateResolutionForStoreSelector } = dispatch( coreStore );

--- a/plugins/woocommerce-admin/client/customize-store/types/font.ts
+++ b/plugins/woocommerce-admin/client/customize-store/types/font.ts
@@ -19,5 +19,5 @@ export type FontFace = {
 	fontStretch?: string;
 	fontStyle: string;
 	fontWeight: string;
-	src: string;
+	src: Array< string > | string;
 };

--- a/plugins/woocommerce/changelog/45185-45138-cys-core-font-preview-and-site-preview-fail-to-load-fonts-when-user-opts-out-of-tracking
+++ b/plugins/woocommerce/changelog/45185-45138-cys-core-font-preview-and-site-preview-fail-to-load-fonts-when-user-opts-out-of-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Core: fix font load when user opts out of tracking.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

As a spec, we had to add the "Instrument Sans + Jost" font pair. The issue is that these fonts are loaded in a different variation of the TT4. Currently, we are using the default one. With the default variation, [only Inter and Cargo fonts are loaded.](https://github.com/WordPress/twentytwentyfour/blob/trunk/theme.json#L198).

Adding the "Instrument Sans + Jost" font pair could be complex. Should we work on it?

cc @verofasulo @nefeline @albarin 

EDIT: @verofasulo confirmed that we can avoid to work to implement the  "Instrument Sans + Jost" font pair. p1709138640335519/1709039848.913899-slack-C053716F2H2

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45138.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the WooCommerce Beta Tester plugin if you don't have it enabled yet
2. On your Dashboard, head over to Tools > WCA Test Helper > Features and enable the `customize-store`
3. Ensure you have the Gutenberg plugin installed from the latest trunk (or install it from this zip file: [gutenberg.zip](https://github.com/woocommerce/woocommerce/files/14384613/gutenberg.zip)
4. Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and ensure that the `Allow usage of WooCommerce to be tracked` **isn't** enabled.
5. Visit the `/wp-admin/admin.php?page=wc-admin&path=/customize-store`.
6. Follow the process.
7. On the sidebar, click on `Choose your Fonts`. 
8. Ensure that only `Cardo/System sans-serif` and `Inter/Cardo` are visible.
9. For each preview, ensure that the right fonts are rendered:

| Header | Header |
|--------|--------|
|![image](https://github.com/woocommerce/woocommerce/assets/4463174/76efe4b6-c900-4493-abca-56a3fbefd809)|![oBWTjB.png](https://github.com/woocommerce/woocommerce/assets/4463174/1fd82170-7336-4ff5-969c-c30d5bd379b8) | 

10. Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and enable the tracking.
11. Visit the `/wp-admin/admin.php?page=wc-admin&path=/customize-store`.
12. Follow the process.
13. On the sidebar, click on `Choose your Fonts`.
14. Ensure that more than two font pairs are visible.
15. For each preview, ensure that the right fonts are rendered.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - Core: fix font load when user opts out of tracking.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>