### PR TITLE
Link to discussion in custom fields API

### DIFF
--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -38,6 +38,9 @@ A common use-case for developers and merchants is to add a new field to the Chec
 
 This document will outline the steps an extension should take to register some additional checkout fields.
 
+> [!NOTE]  
+> Additional Checkout fields is still in the testing phases, use it to test the API and leave feedback in this [public discussion.](https://github.com/woocommerce/woocommerce/discussions/42995)
+
 ## Available field locations
 
 Additional checkout fields can be registered in three different places:

--- a/plugins/woocommerce/changelog/45193-docs-add-discussion-link-in-custom-fields-docs
+++ b/plugins/woocommerce/changelog/45193-docs-add-discussion-link-in-custom-fields-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Docs update.
+


### PR DESCRIPTION
This adds the discussion link in custom fields docs.

<img width="1078" alt="image" src="https://github.com/woocommerce/woocommerce/assets/6165348/395cbc75-2459-42e7-9210-25862d54b8ab">


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment Docs update.

</details>
