### PR TITLE
fix: line break for long email address

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/summary/style.scss
@@ -20,6 +20,7 @@
 				font-weight: bold;
 			}
 			> .wc-block-order-confirmation-summary-list-item__value {
+				line-break: anywhere;
 				font-weight: inherit;
 				display: block;
 			}

--- a/plugins/woocommerce/changelog/45220-fix-order-confirmation-with-long-email-address
+++ b/plugins/woocommerce/changelog/45220-fix-order-confirmation-with-long-email-address
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: long email address wrapping on order success page


### PR DESCRIPTION
## Description

The order confirmation page could expand the text beyond its boundaries when a long email address is used.

Would it be preferable to allow the browser to wrap the text?

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce-payments/issues/6833 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate a block-based theme, like Twenty Twentyfour or premium theme Tsubaki
2. Add a product to the cart, place the order with a long email address
3. You should land on the order success page
4. Check how the email address wraps on mobile

| Before | After |
|--------|--------|
| ![Screenshot 2024-02-29 at 4 37 32 PM](https://github.com/woocommerce/woocommerce/assets/273592/85a40121-c5bd-4eff-b9f4-7f24c0a601b5) Twenty Twentyfour | ![Screenshot 2024-02-29 at 4 37 46 PM](https://github.com/woocommerce/woocommerce/assets/273592/37a76082-d181-4164-bcd5-f97ec3cde2ed) |
| ![Screenshot 2024-02-29 at 4 44 01 PM](https://github.com/woocommerce/woocommerce/assets/273592/e9beebc5-afb0-4d55-93de-0cb034f74546) Tsubaki | ![Screenshot 2024-02-29 at 4 44 20 PM](https://github.com/woocommerce/woocommerce/assets/273592/c4f7e078-35d3-4179-a8fc-ae070882c711) | 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
fix: long email address wrapping on order success page
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
