### PR TITLE
Prevent fresh_site option from being set to 0 after WooCommerce installation

### DIFF
--- a/plugins/woocommerce/changelog/45232-update-45219-disable-fresh_site_deletion
+++ b/plugins/woocommerce/changelog/45232-update-45219-disable-fresh_site_deletion
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Prevent fresh_site option from being set to 0 after WooCommerce installation
+Prevent fresh_site option from being set to 0 after WooCommerce installation.

--- a/plugins/woocommerce/changelog/45232-update-45219-disable-fresh_site_deletion
+++ b/plugins/woocommerce/changelog/45232-update-45219-disable-fresh_site_deletion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Prevent fresh_site option from being set to 0 after WooCommerce installation

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -792,7 +792,7 @@ class WC_Install {
 	 * Create pages that the plugin relies on, storing page IDs in variables.
 	 */
 	public static function create_pages() {
-		// WordPress setse fresh_site to 0 after a page gets published.
+		// WordPress sets fresh_site to 0 after a page gets published.
 		// Prevent fresh_site option from being set to 0 so that we can use it for further customizations.
 		remove_action( 'publish_page', '_delete_option_fresh_site', 0 );
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -792,6 +792,10 @@ class WC_Install {
 	 * Create pages that the plugin relies on, storing page IDs in variables.
 	 */
 	public static function create_pages() {
+		// WordPress setse fresh_site to 0 after a page gets published.
+		// Prevent fresh_site option from being set to 0 so that we can use it for further customizations.
+		remove_action( 'publish_page', '_delete_option_fresh_site', 0 );
+
 		// Set the locale to the store locale to ensure pages are created in the correct language.
 		wc_switch_to_site_locale();
 

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -102,7 +102,7 @@ class WCAdminHelper {
 	 *
 	 * - The current user was registered less than 1 month ago.
 	 * - fresh_site option must be 1
-	 * 
+	 *
 	 * @return bool
 	 * @throws \Exception
 	 */

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -104,11 +104,10 @@ class WCAdminHelper {
 	 * - fresh_site option must be 1
 	 *
 	 * @return bool
-	 * @throws \Exception
 	 */
 	public static function is_site_fresh() {
 		$fresh_site = get_option( 'fresh_site' );
-		if ( $fresh_site !== '1' ) {
+		if ( '1' !== $fresh_site ) {
 			return false;
 		}
 
@@ -118,7 +117,7 @@ class WCAdminHelper {
 			return false;
 		}
 
-		$date = new \DateTime( $current_userdata->user_registered );
+		$date      = new \DateTime( $current_userdata->user_registered );
 		$month_ago = new \DateTime( '-1 month' );
 
 		return $date > $month_ago;

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -100,8 +100,9 @@ class WCAdminHelper {
 	/**
 	 * Test if the site is fresh. A fresh site must meet the following requirements.
 	 *
-	 * - The current user was registered a month ago.
+	 * - The current user was registered less than 1 month ago.
 	 * - fresh_site option must be 1
+	 * 
 	 * @return bool
 	 * @throws \Exception
 	 */

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -107,6 +107,11 @@ class WCAdminHelper {
 	 * @throws \Exception
 	 */
 	public static function is_site_fresh() {
+		$fresh_site = get_option( 'fresh_site' );
+		if ( $fresh_site !== '1' ) {
+			return false;
+		}
+
 		$current_userdata = get_userdata( get_current_user_id() );
 		// Return false if we can't get user meta data for some reason.
 		if ( ! $current_userdata ) {
@@ -116,6 +121,6 @@ class WCAdminHelper {
 		$date = new \DateTime( $current_userdata->user_registered );
 		$month_ago = new \DateTime( '-1 month' );
 
-		return get_option( 'fresh_site' ) === '1' && $date > $month_ago;
+		return $date > $month_ago;
 	}
 }

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -96,4 +96,25 @@ class WCAdminHelper {
 		}
 		return false;
 	}
+
+	/**
+	 * Test if the site is fresh. A fresh site must meet the following requirements.
+	 *
+	 * - The current user was registered a month ago.
+	 * - fresh_site option must be 1
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public static function is_site_fresh() {
+		$current_userdata = get_userdata( get_current_user_id() );
+		// Return false if we can't get user meta data for some reason.
+		if ( ! $current_userdata ) {
+			return false;
+		}
+
+		$date = new \DateTime( $current_userdata->user_registered );
+		$month_ago = new \DateTime( '-1 month' );
+
+		return get_option( 'fresh_site' ) === '1' && $date > $month_ago;
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -136,22 +136,36 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_is_fresh_site() {
-		update_option('fresh_site', '1');
+	public function test_is_fresh_site_user_registered_less_than_a_month() {
+		update_option( 'fresh_site', '1' );
 		$user = $this->factory->user->create(
 			array(
 				'role' => 'administrator',
 			)
 		);
-		wp_set_current_user($user);
+		wp_set_current_user( $user );
 		$this->assertTrue( WCAdminHelper::is_site_fresh() );
 
 		// Update registered date to January.
 		// The function should return false.
-		wp_update_user(array(
+		wp_update_user( array(
 			'ID' => $user,
 			'user_registered' => '2024-01-27 20:56:29'
-		));
+		) );
 		$this->assertFalse( WCAdminHelper::is_site_fresh() );
+	}
+
+	public function test_is_fresh_site_fresh_site_option_must_be_1() {
+		update_option( 'fresh_site', '0' );
+		$user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $user );
+		$this->assertFalse( WCAdminHelper::is_site_fresh() );
+
+		update_option( 'fresh_site', '1' );
+		$this->assertTrue( WCAdminHelper::is_site_fresh() );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -135,4 +135,23 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 			'2 month old store not within 6+ months?'  => array( 2 * MONTH_IN_SECONDS, 'month-6+', false ),
 		);
 	}
+
+	public function test_is_fresh_site() {
+		update_option('fresh_site', '1');
+		$user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user($user);
+		$this->assertTrue( WCAdminHelper::is_site_fresh() );
+
+		// Update registered date to January.
+		// The function should return false.
+		wp_update_user(array(
+			'ID' => $user,
+			'user_registered' => '2024-01-27 20:56:29'
+		));
+		$this->assertFalse( WCAdminHelper::is_site_fresh() );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -136,6 +136,9 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Test is_fresh_site with registered date.
+	 */
 	public function test_is_fresh_site_user_registered_less_than_a_month() {
 		update_option( 'fresh_site', '1' );
 		$user = $this->factory->user->create(
@@ -148,13 +151,18 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 
 		// Update registered date to January.
 		// The function should return false.
-		wp_update_user( array(
-			'ID' => $user,
-			'user_registered' => '2024-01-27 20:56:29'
-		) );
+		wp_update_user(
+			array(
+				'ID'              => $user,
+				'user_registered' => '2024-01-27 20:56:29',
+			)
+		);
 		$this->assertFalse( WCAdminHelper::is_site_fresh() );
 	}
 
+	/**
+	 * Test is_fresh_site with fresh_site option.
+	 */
 	public function test_is_fresh_site_fresh_site_option_must_be_1() {
 		update_option( 'fresh_site', '0' );
 		$user = $this->factory->user->create(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45219 .

This PR removes `_delete_option_fresh_site` hook to prevent `fresh_site` from being set to 0 after creating the default pages during WooCommerce installation. We'll use `fresh_site` for further customizations. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Create a JN site without WooCommerce
2. Build a zip locally by running `pnpm run build:zip` in `plugins/woocommerce` directory.
3. Once JN site is ready, upload woocommerce.zip and activate it.
4. SSH into the server and run `wp option get fresh_site` and confirm the value is still 1
<!-- End testing instructions -->

**is_fresh_site**

1. Take a look at the included unit test and make sure it passes.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent fresh_site option from being set to 0 after WooCommerce installation.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
