### PR TITLE
WC Admin: Ensure `is_super_admin` REST field contains the correct value

### DIFF
--- a/plugins/woocommerce/changelog/fix-42893-super-admin
+++ b/plugins/woocommerce/changelog/fix-42893-super-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the is_super_admin REST field contains the correct value

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -41,8 +41,12 @@ class WCAdminUser {
 			'user',
 			'is_super_admin',
 			array(
-				'get_callback' => function() {
-					return is_super_admin();
+				'get_callback' => function( $user ) {
+					if ( ! isset( $user['id'] ) || 0 === $user['id'] ) {
+						return false;
+					}
+
+					return is_super_admin( $user['id'] );
 				},
 				'schema'       => null,
 			)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a user ID parameter to the is_super_admin() check so that it will return the value of the specified user rather than the current user.

Fixes #42893

### How to test the changes in this Pull Request:

1. Ensure your test site has multiple users, some of which are not Administrators.
1. Make a request to `wp-json/wp/v2/users`. In the returned JSON, each user object should have an `is_super_admin` field. Check that the boolean value in each object is accurate. (It should only be set to `true` for admins on a single site, or super admins on a multisite network.)
