### PR TITLE
Revert " Temporarily commented out failing date package test due to the February 29th issue"

### DIFF
--- a/packages/js/date/changelog/fix-date-test
+++ b/packages/js/date/changelog/fix-date-test
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Temporarily commented out a test due to February 29th issue
-
-

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -828,9 +828,9 @@ describe( 'getCurrentDates', () => {
 			.startOf( 'month' )
 			.subtract( 1, 'year' )
 			.format( isoDateFormat );
-		// const todayLastYear = moment()
-		// 	.subtract( 1, 'year' )
-		// 	.format( isoDateFormat );
+		const todayLastYear = moment()
+			.subtract( 1, 'year' )
+			.format( isoDateFormat );
 		const currentDates = getCurrentDates( query );
 
 		// Ensure default period is 'month'
@@ -845,10 +845,9 @@ describe( 'getCurrentDates', () => {
 		expect( currentDates.secondary.after.format( isoDateFormat ) ).toBe(
 			startOfMonthYearAgo
 		);
-		// Temporarily commented out due to February 29th issue
-		// expect( currentDates.secondary.before.format( isoDateFormat ) ).toBe(
-		// 	todayLastYear
-		// );
+		expect( currentDates.secondary.before.format( isoDateFormat ) ).toBe(
+			todayLastYear
+		);
 	} );
 } );
 


### PR DESCRIPTION
Reverts woocommerce/woocommerce#45202

Revert the commit since it's March now, and the test should pass.

1. Run `pnpm run --filter @woocommerce/date test:js`
2. Observe that tests pass

As discussed in Slack, we should fix the test properly so it doesn't need skipping every 4 years when we're working on  https://github.com/woocommerce/woocommerce/issues/32259