### PR TITLE
Add filter hook to allow currently hardcoded 10 minute checkout draft stock reservation to be filtered

### DIFF
--- a/plugins/woocommerce/changelog/45246-trunk
+++ b/plugins/woocommerce/changelog/45246-trunk
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add `woocommerce_draft_order_hold_stock_minutes` filter hook to allow duration of stock reservation to hold stock for draft orders on checkout entry.
+Add `woocommerce_hold_stock_minutes_checkout_draft filter` hook to allow duration of stock reservation for checkout draft orders to be filtered

--- a/plugins/woocommerce/changelog/45246-trunk
+++ b/plugins/woocommerce/changelog/45246-trunk
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add `woocommerce_reserve_stock_for_order` filter hook to allow an order to be included/excluded from stock reservation.
+Add `woocommerce_order_hold_stock_minutes` filter hook to allow the number of minutes stock in an order should be reserved for to be filtered.

--- a/plugins/woocommerce/changelog/45246-trunk
+++ b/plugins/woocommerce/changelog/45246-trunk
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add `woocommerce_hold_stock_minutes_checkout_draft filter` hook to allow duration of stock reservation for checkout draft orders to be filtered
+Add `woocommerce_draft_order_hold_stock_minutes` filter hook to allow duration of stock reservation to hold stock for draft orders on checkout entry.

--- a/plugins/woocommerce/changelog/45246-trunk
+++ b/plugins/woocommerce/changelog/45246-trunk
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add `woocommerce_hold_stock_minutes_checkout_draft filter` hook to allow duration of stock reservation for checkout draft orders to be filtered
+Add `woocommerce_draft_order_hold_stock_minutes` filter hook to allow duration of stock reservation to hold stock for draft orders on checkout entry

--- a/plugins/woocommerce/changelog/45246-trunk
+++ b/plugins/woocommerce/changelog/45246-trunk
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `woocommerce_hold_stock_minutes_checkout_draft filter` hook to allow duration of stock reservation for checkout draft orders to be filtered

--- a/plugins/woocommerce/changelog/45246-trunk
+++ b/plugins/woocommerce/changelog/45246-trunk
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add `woocommerce_draft_order_hold_stock_minutes` filter hook to allow duration of stock reservation to hold stock for draft orders on checkout entry
+Add `woocommerce_reserve_stock_for_order` filter hook to allow an order to be included/excluded from stock reservation.

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -68,7 +68,19 @@ final class ReserveStock {
 	public function reserve_stock_for_order( $order, $minutes = 0 ) {
 		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
 
-		if ( ! $minutes || ! $this->is_enabled() ) {
+		/**
+		 * Filters whether an order should allow stock to be reserved.
+		 *
+		 * This hook allows an order to be included/excluded from stock reservation, useful if a third party developer wants to exclude an order from having any stock reserved if the order meets certain criteria.
+		 *
+		 * @since 8.8.0
+		 *
+		 * @param bool $reserve_stock_for_order If true, products in the order will have stock reserved if available. Default: true.
+		 * @param \WC_Order $order Order object.
+		 */
+		$reserve_stock_for_order = apply_filters( 'woocommerce_reserve_stock_for_order', true, $order );
+
+		if ( ! $minutes || ! $reserve_stock_for_order || ! $this->is_enabled() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -67,20 +67,19 @@ final class ReserveStock {
 	 */
 	public function reserve_stock_for_order( $order, $minutes = 0 ) {
 		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
-
 		/**
-		 * Filters whether an order should allow stock to be reserved.
+		 * Filters the number of minutes an order should reserve stock for.
 		 *
-		 * This hook allows an order to be included/excluded from stock reservation, useful if a third party developer wants to exclude an order from having any stock reserved if the order meets certain criteria.
+		 * This hook allows the number of minutes stock in an order should be reserved for to be filtered, useful for third party developers to increase/reduce the number of minutes, or to exclude an order entirely if the order meets certain criteria.
 		 *
 		 * @since 8.8.0
 		 *
-		 * @param bool $reserve_stock_for_order If true, products in the order will have stock reserved if available. Default: true.
+		 * @param int       $minutes How long to reserve stock for the order in minutes. Defaults to woocommerce_hold_stock_minutes or 10 if block checkout entry.
 		 * @param \WC_Order $order Order object.
 		 */
-		$reserve_stock_for_order = apply_filters( 'woocommerce_reserve_stock_for_order', true, $order );
+		$minutes = (int) apply_filters( 'woocommerce_order_hold_stock_minutes', $minutes, $order );
 
-		if ( ! $minutes || ! $reserve_stock_for_order || ! $this->is_enabled() ) {
+		if ( ! $minutes || ! $this->is_enabled() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -70,7 +70,7 @@ final class ReserveStock {
 		/**
 		 * Filters the number of minutes an order should reserve stock for.
 		 *
-		 * This hook allows the number of minutes stock in an order should be reserved for to be filtered, useful for third party developers to increase/reduce the number of minutes, or to exclude an order entirely if the order meets certain criteria.
+		 * This hook allows the number of minutes that stock in an order should be reserved for to be filtered, useful for third party developers to increase/reduce the number of minutes if the order meets certain criteria, or to exclude an order from stock reservation using a zero value.
 		 *
 		 * @since 8.8.0
 		 *

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -401,7 +401,7 @@ class Checkout extends AbstractCartRoute {
 			 *
 			 * @since 8.8.0
 			 *
-			 * @param integer $minutes Minutes to hold stock for draft orders.
+			 * @param integer $minutes Minutes to hold stock for draft orders on checkout entry.
 			 */
 
 			$draft_order_hold_stock_minutes = apply_filters( 'woocommerce_draft_order_hold_stock_minutes', 10 );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -404,7 +404,7 @@ class Checkout extends AbstractCartRoute {
 			 * @param integer $minutes Minutes to hold stock for draft orders on checkout entry.
 			 */
 
-			$draft_order_hold_stock_minutes = apply_filters( 'woocommerce_draft_order_hold_stock_minutes', 10 );
+			$draft_order_hold_stock_minutes = (int) apply_filters( 'woocommerce_draft_order_hold_stock_minutes', 10 );
 
 			$duration      = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : $draft_order_hold_stock_minutes;
 			$reserve_stock->reserve_stock_for_order( $this->order, $duration );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -391,9 +391,24 @@ class Checkout extends AbstractCartRoute {
 		 * If POSTing to the checkout (attempting to pay), set the timeout to 60 mins (using the woocommerce_hold_stock_minutes option).
 		 */
 		try {
+
 			$reserve_stock = new ReserveStock();
-			$duration      = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : apply_filters( 'woocommerce_hold_stock_minutes_checkout_draft', 10 );
+
+			/**
+			 * Filters the hold stock duration in minutes for draft orders on checkout entry.
+			 *
+			 * This hook filters the duration in minutes that stock is held for draft orders on checkout entry, it allows a third party to amend the duration to increase/reduce the time the stock is held for draft orders on checkout entry.
+			 *
+			 * @since 8.8.0
+			 *
+			 * @param integer $minutes Minutes to hold stock for draft orders.
+			 */
+
+			$draft_order_hold_stock_minutes = apply_filters( 'woocommerce_draft_order_hold_stock_minutes', 10 );
+
+			$duration      = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : $draft_order_hold_stock_minutes;
 			$reserve_stock->reserve_stock_for_order( $this->order, $duration );
+
 		} catch ( ReserveStockException $e ) {
 			throw new RouteException(
 				$e->getErrorCode(),

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -392,7 +392,7 @@ class Checkout extends AbstractCartRoute {
 		 */
 		try {
 
-			$reserve_stock = new ReserveStock();
+			$draft_order_hold_stock_minutes_default = 10;
 
 			/**
 			 * Filters the hold stock duration in minutes for draft orders on checkout entry.
@@ -403,8 +403,10 @@ class Checkout extends AbstractCartRoute {
 			 *
 			 * @param integer $minutes Minutes to hold stock for draft orders on checkout entry.
 			 */
-			$draft_order_hold_stock_minutes = (int) apply_filters( 'woocommerce_draft_order_hold_stock_minutes', 10 );
+			$draft_order_hold_stock_minutes = (int) apply_filters( 'woocommerce_draft_order_hold_stock_minutes', $draft_order_hold_stock_minutes_default );
+			$draft_order_hold_stock_minutes = ( $draft_order_hold_stock_minutes >= 0 ? $draft_order_hold_stock_minutes : $draft_order_hold_stock_minutes_default );
 
+			$reserve_stock = new ReserveStock();
 			$duration = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : $draft_order_hold_stock_minutes;
 			$reserve_stock->reserve_stock_for_order( $this->order, $duration );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -403,10 +403,9 @@ class Checkout extends AbstractCartRoute {
 			 *
 			 * @param integer $minutes Minutes to hold stock for draft orders on checkout entry.
 			 */
-
 			$draft_order_hold_stock_minutes = (int) apply_filters( 'woocommerce_draft_order_hold_stock_minutes', 10 );
 
-			$duration      = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : $draft_order_hold_stock_minutes;
+			$duration = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : $draft_order_hold_stock_minutes;
 			$reserve_stock->reserve_stock_for_order( $this->order, $duration );
 
 		} catch ( ReserveStockException $e ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -392,7 +392,7 @@ class Checkout extends AbstractCartRoute {
 		 */
 		try {
 			$reserve_stock = new ReserveStock();
-			$duration      = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : 10;
+			$duration      = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : apply_filters( 'woocommerce_hold_stock_minutes_checkout_draft', 10 );
 			$reserve_stock->reserve_stock_for_order( $this->order, $duration );
 		} catch ( ReserveStockException $e ) {
 			throw new RouteException(

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -391,25 +391,9 @@ class Checkout extends AbstractCartRoute {
 		 * If POSTing to the checkout (attempting to pay), set the timeout to 60 mins (using the woocommerce_hold_stock_minutes option).
 		 */
 		try {
-
-			$draft_order_hold_stock_minutes_default = 10;
-
-			/**
-			 * Filters the hold stock duration in minutes for draft orders on checkout entry.
-			 *
-			 * This hook filters the duration in minutes that stock is held for draft orders on checkout entry, it allows a third party to amend the duration to increase/reduce the time the stock is held for draft orders on checkout entry.
-			 *
-			 * @since 8.8.0
-			 *
-			 * @param integer $minutes Minutes to hold stock for draft orders on checkout entry.
-			 */
-			$draft_order_hold_stock_minutes = (int) apply_filters( 'woocommerce_draft_order_hold_stock_minutes', $draft_order_hold_stock_minutes_default );
-			$draft_order_hold_stock_minutes = ( $draft_order_hold_stock_minutes >= 0 ? $draft_order_hold_stock_minutes : $draft_order_hold_stock_minutes_default );
-
 			$reserve_stock = new ReserveStock();
-			$duration = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : $draft_order_hold_stock_minutes;
+			$duration      = $request->get_method() === 'POST' ? (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) : 10;
 			$reserve_stock->reserve_stock_for_order( $this->order, $duration );
-
 		} catch ( ReserveStockException $e ) {
 			throw new RouteException(
 				$e->getErrorCode(),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45245 

Note: We originally committed a filter hook for the hardcoded 10 minute reserve stock on block checkout entry, however due to reviews since then we have opted for a filter in `Automattic\WooCommerce\Checkout\Helpers` in the `ReserveStock::reserve_stock_for_order()`.

The proposed newer filter was then reviewed and recommended we amend to a minutes based filter, and hence this is now a `woocommerce_order_hold_stock_minutes` filter hook.

Testing instructions below updated.

<!-- Begin testing instructions -->

**Snippet for testing:**

```
function test_woocommerce_order_hold_stock_minutes( $minutes, $order ) {

	return 0;

}
add_filter( 'woocommerce_order_hold_stock_minutes', 'test_woocommerce_order_hold_stock_minutes', 10, 2 );
```

**Test based on WooCommerce hold stock minutes setting:**

1. First determine that stock is being reserved without the snippet
2. Ensure WooCommerce > Settings > Inventory > Manage stock enabled and set to hold stock for 60 minutes
3. Create a simple product with manage stock on and stock quantity 10
4. Add the product to block cart with quantity 1
5. Place order
6. View order
7. In order notes and/or by checking wp_wc_reserve_stock database table see that stock reserved for 60 minutes (it may also show an earlier 10 minutes note due to the checkout entry draft hardcoded 10 minute stock reserve)
8. Add the snippet
9. Repeat the above steps, this time there shouldn't be any stock reservation (you can also test with a minute level by returning one in the snippet instead of 0)

**Test based on block checkout entry hold stock minutes (this uses a hardcoded 10 minutes not the hold stock setting):**

1. First determine that stock is being reserved for checkout drafts without the snippet
2. Ensure WooCommerce > Settings > Inventory > Manage stock enabled and set to hold stock for 60 minutes (this gets ignored for this test due to the hardcoded 10 minutes)
3. Create a simple product with manage stock on and stock quantity 10
4. Add the product to block cart with quantity 1
5. Go to the checkout page but don't place the order (generates a draft order)
6. View the draft order
7. In order notes and/or by checking wp_wc_reserve_stock database table see that stock reserved for 10 minutes
8. Add the snippet
9. Ensure you empty cart and trash then delete the draft order just to ensure you are back to a clean slate, repeat the above steps, this time there shouldn't be any stock reservation (you can also test with a minute level by returning one in the snippet instead of 0)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add `woocommerce_order_hold_stock_minutes` filter hook to allow the number of minutes stock in an order should be reserved for to be filtered.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
