### PR TITLE
Fix styling for select in Site Editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/combobox/style.scss
@@ -10,6 +10,11 @@
 		@include reset-typography();
 		@include reset-box();
 
+		// Fixes width in the editor.
+		.components-flex {
+			width: 100%;
+		}
+
 		.components-base-control__field {
 			@include reset-box();
 			position: relative;

--- a/plugins/woocommerce-blocks/assets/js/base/components/country-input/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/country-input/style.scss
@@ -4,9 +4,4 @@
 
 .wc-block-components-country-input {
 	margin-top: $gap;
-
-	// Fixes width in the editor.
-	.components-flex {
-		width: 100%;
-	}
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/state-input/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/state-input/style.scss
@@ -1,8 +1,3 @@
 .wc-block-components-state-input {
 	margin-top: $gap;
-
-	// Fixes width in the editor.
-	.components-flex {
-		width: 100%;
-	}
 }

--- a/plugins/woocommerce/changelog/45252-fix-select-styling-in-editor
+++ b/plugins/woocommerce/changelog/45252-fix-select-styling-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Styling issue for unreleased code.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes Combobox width in Site Editor. This only happens in the site editor because GB seems to be missing certain styles there for the Flex component.
Closes https://github.com/woocommerce/woocommerce/issues/45177

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate [additional-checkout-fields-tester-main.zip](https://github.com/woocommerce/woocommerce/files/14431643/additional-checkout-fields-tester-main-2.zip)
2. Install a block theme
3. In the WP Dashboard go to Appearance -> Editor -> Templates -> Page: Checkout (Note this also happens for Appearance -> Editor -> Pages -> Checkout)
4. Make sure all Selects are full width (Country, State, What is your main role...)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment Styling issue for unreleased code.

</details>
