### PR TITLE
Add Japan and UAE to get_recommendation_priority

### DIFF
--- a/plugins/woocommerce/changelog/add-jp-and-ae-recommendations
+++ b/plugins/woocommerce/changelog/add-jp-and-ae-recommendations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Recommend WooPayments for users in Japan and UAE

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -1213,6 +1213,7 @@ class DefaultPaymentGateways {
 				'payoneer-checkout',
 			),
 			'JP' => array(
+				'woocommerce_payments',
 				'stripe',
 				'ppcp-gateway',
 				'square_credit_card',
@@ -1227,6 +1228,7 @@ class DefaultPaymentGateways {
 			'ZA' => array( 'payfast', 'paystack' ),
 			'NG' => array( 'paystack' ),
 			'GH' => array( 'paystack' ),
+			'AE' => array( 'woocommerce_payments' ),
 		);
 
 		// If the country code is not in the list, return default priority.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooPayments has been supporting Japan and UAE for some time now https://github.com/woocommerce/woocommerce/pull/39431

This change is to make sure we recommend WooPayments first for users in these countries.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testing is not needed for this change.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
