### PR TITLE
Fix multiple warning in blocks in Atomic

### DIFF
--- a/packages/js/product-editor/changelog/fix-multiple_warning_in_blocks
+++ b/packages/js/product-editor/changelog/fix-multiple_warning_in_blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Set product editor blocks multiple support to true.

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/block.json
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/block.json
@@ -20,7 +20,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/generic/pricing/block.json
+++ b/packages/js/product-editor/src/blocks/generic/pricing/block.json
@@ -25,7 +25,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/generic/taxonomy/block.json
+++ b/packages/js/product-editor/src/blocks/generic/taxonomy/block.json
@@ -5,7 +5,7 @@
 	"title": "Taxonomy",
 	"category": "widgets",
 	"description": "A block that displays a taxonomy field, allowing searching, selection, and creation of new items",
-	"keywords": [ "taxonomy"],
+	"keywords": [ "taxonomy" ],
 	"textdomain": "default",
 	"attributes": {
 		"slug": {
@@ -36,7 +36,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/attributes/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/attributes/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/block.json
@@ -21,7 +21,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/images/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/images/block.json
@@ -31,7 +31,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-email/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-email/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/name/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/name/block.json
@@ -20,7 +20,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/password/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/password/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
@@ -26,7 +26,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
@@ -22,7 +22,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/summary/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/block.json
@@ -47,7 +47,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false

--- a/packages/js/product-editor/src/blocks/product-fields/tag/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/tag/block.json
@@ -23,7 +23,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,

--- a/packages/js/product-editor/src/blocks/product-fields/variation-options/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-options/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"align": false,
 		"html": false,
-		"multiple": false,
+		"multiple": true,
 		"reusable": false,
 		"inserter": false,
 		"lock": false,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This changes the `multiple` to true for all product editor blocks, as they are able to be used across the editor multiple times.
This hides a warning that shows up on Atomic sites.
Before:
![Screen Shot 2024-02-29 at 8 32 25 AM](https://github.com/woocommerce/woocommerce/assets/2240960/25cfad91-bc9c-4bbb-b638-ef47aee587e8)

After:
<img width="922" alt="Screenshot 2024-03-04 at 10 42 06 AM" src="https://github.com/woocommerce/woocommerce/assets/2240960/55a727db-bf71-4a24-95fb-36098e9eb695">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an Atomic WordPress site, using the business plan so you can set up hosting configurations.
2. Install WooCommerce and enable the new product editor under **Advanced > Features** settings
3. Go to **Products > Add new > Organization** and notice the `This block can only be used once.` warning
4. Now disable and remove WooCommerce
5. Set up your hosting configuration under **Settings > Hosting configuration**
6. Set up this repo: https://github.com/xristos3490/rsync-toolkit#installation
7. Sync this branch of WooCommerce with the WordPress.com site you created
8. Go back to **Products > Add new > Organization** and notice how the `This block can only be used once.` warning isn't present anymore.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
