### PR TITLE
Custom Fields for New Product Editor

### DIFF
--- a/packages/js/product-editor/changelog/add-44169
+++ b/packages/js/product-editor/changelog/add-44169
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create woocommerce/product-custom-fields-toggle-field block

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -1,4 +1,5 @@
 export { init as initCatalogVisibility } from './product-fields/catalog-visibility';
+export { init as initCustomFieldsToogle } from './product-fields/custom-fields-toggle';
 export { init as initCheckbox } from './generic/checkbox';
 export { init as initCollapsible } from './generic/collapsible';
 export { init as initConditional } from './generic/conditional';

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-custom-fields-toggle-field",
+	"title": "Product custom fields toggle control",
+	"category": "woocommerce",
+	"description": "The product custom fields toggle.",
+	"keywords": [ "products", "custom", "fields" ],
+	"textdomain": "default",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": true,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"usesContext": [ "postType" ],
+	"editorStyle": "file:./editor.css"
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { Spinner, ToggleControl } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { TRACKS_SOURCE } from '../../../constants';
+import { useMetaboxHiddenProduct } from '../../../hooks/use-metabox-hidden-product';
+import { ProductEditorBlockEditProps } from '../../../types';
+import { CustomFieldsToggleBlockAttributes } from './types';
+
+const METABOX_HIDDEN_VALUE = 'postcustom';
+
+export function Edit( {
+	attributes,
+}: ProductEditorBlockEditProps< CustomFieldsToggleBlockAttributes > ) {
+	const { label, _templateBlockId } = attributes;
+	const blockProps = useWooBlockProps( attributes );
+	const { isLoading, metaboxhiddenProduct, saveMetaboxhiddenProduct } =
+		useMetaboxHiddenProduct();
+
+	function isChecked() {
+		return (
+			metaboxhiddenProduct &&
+			! metaboxhiddenProduct.some(
+				( value ) => value === METABOX_HIDDEN_VALUE
+			)
+		);
+	}
+
+	async function handleChange( checked: boolean ) {
+		const values = checked
+			? metaboxhiddenProduct.filter(
+					( value ) => value !== METABOX_HIDDEN_VALUE
+			  )
+			: [ ...metaboxhiddenProduct, METABOX_HIDDEN_VALUE ];
+
+		recordEvent( 'product_custom_fields_toggle_click', {
+			block_id: _templateBlockId,
+			source: TRACKS_SOURCE,
+			metaboxhidden_product: values,
+		} );
+
+		await saveMetaboxhiddenProduct( values );
+	}
+
+	return (
+		<div { ...blockProps }>
+			<ToggleControl
+				label={ label }
+				checked={ isChecked() }
+				disabled={ isLoading }
+				onChange={ handleChange }
+			/>
+
+			{ isLoading && <Spinner /> }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/editor.scss
@@ -1,0 +1,9 @@
+.wp-block-woocommerce-product-custom-fields-toggle-field {
+	display: flex;
+	gap: $grid-unit;
+	align-items: center;
+
+	.components-spinner {
+		margin: 0;
+	}
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
+
+const { name, ...metadata } = blockConfiguration;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: Edit,
+};
+
+export function init() {
+	return registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/types.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface CustomFieldsToggleBlockAttributes extends BlockAttributes {
+	label: string;
+}

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -1,6 +1,7 @@
 @import "product-fields/attributes/editor.scss";
 @import "product-fields/description/editor.scss";
 @import "product-fields/catalog-visibility/editor.scss";
+@import "product-fields/custom-fields-toggle/editor.scss";
 @import "product-fields/downloads/editor.scss";
 @import "product-fields/images/editor.scss";
 @import "product-fields/inventory-sku/editor.scss";

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -8,3 +8,4 @@ export { default as __experimentalUseProductMetadata } from './use-product-metad
 export { useProductTemplate as __experimentalUseProductTemplate } from './use-product-template';
 export { useProductScheduled as __experimentalUseProductScheduled } from './use-product-scheduled';
 export { useProductManager as __experimentalUseProductManager } from './use-product-manager';
+export { useMetaboxHiddenProduct as __experimentalUseMetaboxHiddenProduct } from './use-metabox-hidden-product';

--- a/packages/js/product-editor/src/hooks/use-metabox-hidden-product/index.ts
+++ b/packages/js/product-editor/src/hooks/use-metabox-hidden-product/index.ts
@@ -1,0 +1,1 @@
+export * from './use-metabox-hidden-product';

--- a/packages/js/product-editor/src/hooks/use-metabox-hidden-product/use-metabox-hidden-product.ts
+++ b/packages/js/product-editor/src/hooks/use-metabox-hidden-product/use-metabox-hidden-product.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { WCUser, useUser } from '@woocommerce/data';
+import { useEntityProp } from '@wordpress/core-data';
+import { dispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+
+export function useMetaboxHiddenProduct() {
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const { user, isRequesting } = useUser();
+	const [
+		metaboxhiddenProduct,
+		setMetaboxhiddenProduct,
+		prevMetaboxhiddenProduct,
+	] = useEntityProp< string[] >(
+		'root',
+		'user',
+		'metaboxhidden_product',
+		user.id
+	);
+
+	async function saveMetaboxhiddenProduct(
+		value: string[]
+	): Promise< WCUser< 'capabilities' > > {
+		try {
+			setIsSaving( true );
+
+			const { saveEntityRecord } = dispatch( 'core' );
+			const currentUser: WCUser< 'capabilities' > =
+				( await saveEntityRecord( 'root', 'user', {
+					id: user.id,
+					metaboxhidden_product: value,
+				} ) ) as never;
+
+			return currentUser;
+		} finally {
+			setIsSaving( false );
+		}
+	}
+
+	return {
+		isLoading: ( isRequesting as boolean ) || isSaving,
+		metaboxhiddenProduct,
+		prevMetaboxhiddenProduct,
+		setMetaboxhiddenProduct,
+		saveMetaboxhiddenProduct,
+	};
+}

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -26,6 +26,7 @@ declare global {
 			'product-grouped': boolean;
 			'product-linked': boolean;
 			'product-pre-publish-modal': boolean;
+			'product-custom-fields': boolean;
 			'remote-inbox-notifications': boolean;
 			'remote-free-extensions': boolean;
 			settings: boolean;

--- a/plugins/woocommerce/changelog/add-44169
+++ b/plugins/woocommerce/changelog/add-44169
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Register woocommerce/product-custom-fields-toggle-field block

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -25,6 +25,7 @@
 		"product-grouped": true,
 		"product-linked": true,
 		"product-pre-publish-modal": false,
+		"product-custom-fields": false,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -26,6 +26,7 @@
 		"product-grouped": true,
 		"product-linked": true,
 		"product-pre-publish-modal": true,
+		"product-custom-fields": true,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"settings": false,

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -48,6 +48,7 @@ class BlockRegistry {
 	 */
 	const PRODUCT_FIELDS_BLOCKS = array(
 		'woocommerce/product-catalog-visibility-field',
+		'woocommerce/product-custom-fields-toggle-field',
 		'woocommerce/product-description-field',
 		'woocommerce/product-downloads-field',
 		'woocommerce/product-images-field',

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -76,6 +76,7 @@ class Init {
 			add_action( 'current_screen', array( $this, 'set_current_screen_to_block_editor_if_wc_admin' ) );
 
 			add_action( 'rest_api_init', array( $this, 'register_layout_templates' ) );
+			add_action( 'rest_api_init', array( $this, 'register_user_metas' ) );
 
 			// Make sure the block registry is initialized so that core blocks are registered.
 			BlockRegistry::get_instance();
@@ -378,5 +379,38 @@ class Init {
 		);
 
 		$this->redirection_controller->set_product_templates( $this->product_templates );
+	}
+
+	/**
+	 * Register user metas.
+	 */
+	public function register_user_metas() {
+		$field = 'metaboxhidden_product';
+
+		register_rest_field(
+			'user',
+			$field,
+			array(
+				'get_callback'    => function ( $object ) use ( $field ) {
+					// Get field as single value from post meta.
+					return get_user_meta( $object['id'], $field, true );
+				},
+				'update_callback' => function ( $value, $object ) use ( $field ) {
+					// Update the field/meta value.
+					update_user_meta( $object->ID, $field, $value );
+				},
+				'schema'          => array(
+					'type'        => 'array',
+					'description' => __( 'The metaboxhidden_product meta from the user metas.', 'woocommerce' ),
+					'items'       => array(
+						'type' => 'string',
+					),
+					'arg_options' => array(
+						'sanitize_callback' => 'wp_parse_list',
+						'validate_callback' => 'rest_validate_request_arg',
+					),
+				),
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -385,19 +385,22 @@ class Init {
 	 * Register user metas.
 	 */
 	public function register_user_metas() {
-		$field = 'metaboxhidden_product';
-
 		register_rest_field(
 			'user',
-			$field,
+			'metaboxhidden_product',
 			array(
-				'get_callback'    => function ( $object ) use ( $field ) {
-					// Get field as single value from post meta.
-					return get_user_meta( $object['id'], $field, true );
+				'get_callback'    => function ( $object, $attr ) {
+					$hidden = get_user_meta( $object['id'], $attr, true );
+
+					if ( is_array( $hidden ) ) {
+						return $hidden;
+					}
+
+					return array( 'postcustom' );
 				},
-				'update_callback' => function ( $value, $object ) use ( $field ) {
+				'update_callback' => function ( $value, $object, $attr ) {
 					// Update the field/meta value.
-					update_user_meta( $object->ID, $field, $value );
+					update_user_meta( $object->ID, $attr, $value );
 				},
 				'schema'          => array(
 					'type'        => 'array',

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -569,16 +569,18 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			)
 		);
 
-		$product_catalog_section->add_block(
-			array(
-				'id'         => 'product-custom-fields-toggle',
-				'blockName'  => 'woocommerce/product-custom-fields-toggle-field',
-				'order'      => 20,
-				'attributes' => array(
-					'label' => __( 'Show custom fields', 'woocommerce' ),
-				),
-			)
-		);
+		if ( Features::is_enabled( 'product-custom-fields' ) ) {
+			$product_catalog_section->add_block(
+				array(
+					'id'         => 'product-custom-fields-toggle',
+					'blockName'  => 'woocommerce/product-custom-fields-toggle-field',
+					'order'      => 20,
+					'attributes' => array(
+						'label' => __( 'Show custom fields', 'woocommerce' ),
+					),
+				)
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -568,6 +568,17 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'order'     => 10,
 			)
 		);
+
+		$product_catalog_section->add_block(
+			array(
+				'id'         => 'product-custom-fields-toggle',
+				'blockName'  => 'woocommerce/product-custom-fields-toggle-field',
+				'order'      => 20,
+				'attributes' => array(
+					'label' => __( 'Show custom fields', 'woocommerce' ),
+				),
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
@@ -43,6 +43,7 @@ class BlockRegistryTest extends WC_Unit_Test_Case {
 		$block_registry = BlockRegistry::get_instance();
 
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-catalog-visibility-field' ), 'Catalog visibility field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-custom-fields-toggle-field' ), 'Custom fields toggle field not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-description-field' ), 'Description field not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-downloads-field' ), 'Downloads field not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-images-field' ), 'Images field not registered.' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially close #44169

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` -> `Add new` from the left menu to create a new product
4. Then go to the `Organization` tab
5. At the end of the page a new `Show custom fields` toggle should be shown
6. Changing it should persist into the user metadata just like in the classic editor 
![image](https://github.com/woocommerce/woocommerce/assets/13334210/9d462189-f48c-47f9-88e8-20bf6c694f66)

NOTE: this PR does not show the custom fields yet. This PR is only about the toggle. The list of custom fields will be implemented in follow up PRs.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
