### PR TITLE
[Experimental] Fix: add an unique id to each list item to prevent diffing issue

### DIFF
--- a/plugins/woocommerce/changelog/fix-45300
+++ b/plugins/woocommerce/changelog/fix-45300
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: [Experimental] Fix: add an unique id to each list item to prevent diffing issue
+
+

--- a/plugins/woocommerce/src/Blocks/InteractivityComponents/CheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/InteractivityComponents/CheckboxList.php
@@ -43,13 +43,13 @@ class CheckboxList {
 							// translators: %s: checkbox label.
 							$i18n_label = sprintf( __( 'Checkbox: %s', 'woocommerce' ), $item['aria_label'] ?? '' );
 							?>
-							<li>
+							<li data-wc-key="<?php echo esc_attr( $item['id'] ); ?>">
 								<div class="wc-block-components-checkbox">
 									<label for="<?php echo esc_attr( $item['id'] ); ?>">
-										<input 
-											id="<?php echo esc_attr( $item['id'] ); ?>" 
-											class="wc-block-components-checkbox__input" 
-											type="checkbox" 
+										<input
+											id="<?php echo esc_attr( $item['id'] ); ?>"
+											class="wc-block-components-checkbox__input"
+											type="checkbox"
 											aria-invalid="false"
 											aria-label="<?php echo esc_attr( $i18n_label ); ?>"
 											data-wc-on--change--select-item="actions.selectCheckboxItem"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR adds `data-wc-key` directive to each list item to prevent diffing issue after navigation.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45300.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With default sample data, add the Product Filter: Attribute (Beta) to the product catalog template..
2. Choose the Color with FILTER CONDITIONS set to All.
3. On the Shop page, select Green color.
4. See only Green color select, not Red as described in #45300.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
