### PR TITLE
[Experimental] Product Filter - Price (Beta) block: Fix Filter is not applied when using the numeric inputs

### DIFF
--- a/plugins/woocommerce/changelog/45327-fix-45228-filter-is-not-applied-when-using-the-numeric-inputs
+++ b/plugins/woocommerce/changelog/45327-fix-45228-filter-is-not-applied-when-using-the-numeric-inputs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix an issue where the price filter was not applied when using the numeric inputs.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -163,6 +163,7 @@ final class ProductFilterPrice extends AbstractBlock {
 			sprintf(
 				'<input
 					class="min"
+					name="min"
 					type="text"
 					value="%d"
 					data-wc-bind--value="context.minPrice"
@@ -179,6 +180,7 @@ final class ProductFilterPrice extends AbstractBlock {
 			sprintf(
 				'<input
 					class="max"
+					name="max"
 					type="text"
 					value="%d"
 					data-wc-bind--value="context.maxPrice"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, the price filter only applies when using the price slider range. Entering values in the numeric inputs now does not trigger the filter.

This PR fixes this issue by adding a name attribute to the min and max input fields. This allows the block to identify which input is being edited and apply the corresponding changes.



<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45228.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Product Catalog template - or any archive template).
2. Click on "Edit" to open the WordPress editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block". Click on it.
4. Search for "Product Filter: Price (Beta)" in the block inserter or browse the available blocks until you find them.
5. Click on the "Product Filter: Price (Beta)" block to add it to your content.
6. Click on Save to save the changes.
7. Visit the Shop page (https://linktoyourstore.com/shop/).
8. Move the price slider and make sure the filters are being applied to the products.
9. Try inputting any number in the Max or Min inputs and make sure the filters are correctly applied to the page/products.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fix an issue where the price filter was not applied when using the numeric inputs. 

</details>
