### PR TITLE
Prevent backup post from being deleted when HPOS is authoritative

### DIFF
--- a/plugins/woocommerce/changelog/fix-42746
+++ b/plugins/woocommerce/changelog/fix-42746
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add some safeguards against programmatic removal of orders due to sync when HPOS is active.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -903,11 +903,11 @@ ORDER BY orders.id ASC
 	}
 
 	private function maybe_prevent_deletion_of_post( $delete, $post ) {
-		if ( $this->custom_orders_table_is_authoritative() && $this->data_store->order_exists( $post->ID ) ) {
-			return false;
+		if ( self::PLACEHOLDER_ORDER_POST_TYPE !== $post->post_type && $this->custom_orders_table_is_authoritative() && $this->data_store->order_exists( $post->ID ) ) {
+			$delete = false;
 		}
 
-		return null;
+		return $delete;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -902,6 +902,18 @@ ORDER BY orders.id ASC
 		return 'Synchronizes orders between posts and custom order tables.';
 	}
 
+	/**
+	 * Prevents deletion of order backup posts (regardless of sync setting) when HPOS is authoritative and the order
+	 * still exists in HPOS.
+	 * This should help with edge cases where wp_delete_post() would delete the HPOS record too or backfill would sync
+	 * incorrect data from an order with no metadata from the posts table.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @param WP_Post|false|null $delete Whether to go forward with deletion.
+	 * @param WP_Post            $post   Post object.
+	 * @return WP_Post|false|null
+	 */
 	private function maybe_prevent_deletion_of_post( $delete, $post ) {
 		if ( self::PLACEHOLDER_ORDER_POST_TYPE !== $post->post_type && $this->custom_orders_table_is_authoritative() && $this->data_store->order_exists( $post->ID ) ) {
 			$delete = false;

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -206,13 +206,24 @@ class DataSynchronizerTests extends HposTestCase {
 	 * change should propagate across to the other table.
 	 */
 	public function test_order_deletions_propagate_with_sync_enabled(): void {
-		// Sync enabled and COT authoritative.
+		// Sync enabled.
 		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
-		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
 
+		// COT authoritative.
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+		$order = OrderHelper::create_order();
+
+		// Deleting the backup post while COT is authoritative shouldn't delete the COT version.
+		wp_delete_post( $order->get_id(), true );
+		$this->assertNotFalse( wc_get_order( $order->get_id() ) );
+
+		// Deleting the backup post while posts is authoritative should delete everything.
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
 		$order = OrderHelper::create_order();
 		wp_delete_post( $order->get_id(), true );
+		$this->assertFalse( wc_get_order( $order->get_id() ) );
 
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
 		$this->assertFalse(
 			wc_get_order( $order->get_id() ),
 			'After the order post record was deleted, the order was also deleted from COT.'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is authoritative, calling `wp_delete_post()` on a backup post also removes the HPOS order. By default, this shouldn't happen, but it can happen when, for example, sync is temporarily disabled and the backup post is kept in the trash, which will get autoremoved once WP empties the trash (and thus also deleting the HPOS order).

There are other implications as a few caches and stats are updated when an order is removed, and a post with `shop_order` as type would trigger this even when HPOS is set as datastore and the "true" order hasn't been deleted.

While those are some edge cases, they could happen. This PR short-circuits `wp_delete_post()` so that when HPOS is authoritative, any attempts to delete the backup post are not successful. This only applies to non placeholder posts, as placeholder posts won't trigger the cascade of operations that might be problematic here.

It's worth mentioning that our sync code doesn't consider missing backup posts as truly missing and will let you switch datastores freely, which can result in an incorrect "view" of the orders on your site. That's addressed in #45332, but this PR will at least make sure that can't happen again.

Closes #42746.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is configured as datastore and that compatibility mode is enabled in WC > Settings > Features > Advanced.
2. Ensure your test site has a few orders. Create as necessary.
3. Choose an order ID and run `wp eval "wp_delete_post( <ORDER_ID> );"`.
4. Confirm that the order still exists on the HPOS side and, in particular, in the order stats table (which proves that the post deletion hooks did not run):
   ```
    wp db query "SELECT * FROM $(wp db prefix)wc_order_stats WHERE order_id = <ORDER_ID>"
   ```
5. Change datastore to posts in WC > Settings > Features > Advanced.
6. Run `wp eval "wp_delete_post( <ORDER_ID> );"` again and confirm that the order has been removed, and also from the HPOS tables (and stats table):
   ```
    wp db query "SELECT * FROM $(wp db prefix)wc_orders WHERE id = <ORDER_ID>"
    wp db query "SELECT * FROM $(wp db prefix)wc_order_stats WHERE order_id = <ORDER_ID>"
   ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
