### PR TITLE
Try to account for and re-create backup posts when syncing orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-42746-part-2
+++ b/plugins/woocommerce/changelog/fix-42746-part-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Make sure backup posts are restored during sync when HPOS is enabled.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -681,11 +681,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		if ( is_null( get_post( $order->get_id() ) ) ) {
 			// Attempt to create the backup post if missing.
 			unset( $post_data['ID'] );
-			$post_data['import_id']        = $order->get_id();
+			$post_data['import_id'] = $order->get_id();
 
 			$updated = wp_insert_post( $post_data, true, false );
 		} else {
-			$updated   = wp_update_post( $post_data, true );
+			$updated = wp_update_post( $post_data, true );
 		}
 
 		remove_filter( 'wp_insert_post_data', array( $this, 'update_post_modified_data' ) );

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -677,17 +677,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			'order_modified'     => ! is_null( $order->get_date_modified() ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getOffsetTimestamp() ) : '',
 			'order_modified_gmt' => ! is_null( $order->get_date_modified() ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getTimestamp() ) : '',
 		);
-
-		if ( is_null( get_post( $order->get_id() ) ) ) {
-			// Attempt to create the backup post if missing.
-			unset( $post_data['ID'] );
-			$post_data['import_id'] = $order->get_id();
-
-			$updated = wp_insert_post( $post_data, true, false );
-		} else {
-			$updated = wp_update_post( $post_data, true );
-		}
-
+		$updated   = wp_update_post( $post_data );
 		remove_filter( 'wp_insert_post_data', array( $this, 'update_post_modified_data' ) );
 		return $updated;
 	}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -677,7 +677,17 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			'order_modified'     => ! is_null( $order->get_date_modified() ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getOffsetTimestamp() ) : '',
 			'order_modified_gmt' => ! is_null( $order->get_date_modified() ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getTimestamp() ) : '',
 		);
-		$updated   = wp_update_post( $post_data );
+
+		if ( is_null( get_post( $order->get_id() ) ) ) {
+			// Attempt to create the backup post if missing.
+			unset( $post_data['ID'] );
+			$post_data['import_id']        = $order->get_id();
+
+			$updated = wp_insert_post( $post_data, true, false );
+		} else {
+			$updated   = wp_update_post( $post_data, true );
+		}
+
 		remove_filter( 'wp_insert_post_data', array( $this, 'update_post_modified_data' ) );
 		return $updated;
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -442,7 +442,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 *
 	 * @return int
 	 */
-	public function get_current_orders_pending_sync_count_cached() : int {
+	public function get_current_orders_pending_sync_count_cached(): int {
 		return $this->get_current_orders_pending_sync_count( true );
 	}
 
@@ -483,14 +483,14 @@ class DataSynchronizer implements BatchProcessorInterface {
 			return 0;
 		}
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare,WordPress.DB.PreparedSQL.NotPrepared --
+		// -- $order_post_type_placeholder, $orders_table, self::PLACEHOLDER_ORDER_POST_TYPE are all safe to use in queries.
 		if ( ! $this->get_table_exists() ) {
 			$count = $wpdb->get_var(
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $order_post_type_placeholder is prepared.
 				$wpdb->prepare(
 					"SELECT COUNT(*) FROM $wpdb->posts where post_type in ( $order_post_type_placeholder )",
 					$order_post_types
 				)
-				// phpcs:enable
 			);
 			return $count;
 		}
@@ -507,7 +507,6 @@ WHERE (posts.post_type IS NULL OR posts.post_type = '" . self::PLACEHOLDER_ORDER
 			);
 			$operator                 = '>';
 		} else {
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $order_post_type_placeholder is prepared.
 			$missing_orders_count_sql = $wpdb->prepare(
 				"
 SELECT COUNT(1) FROM $wpdb->posts posts
@@ -518,11 +517,10 @@ WHERE
   AND orders.id IS NULL",
 				$order_post_types
 			);
-			// phpcs:enable
+
 			$operator = '<';
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $missing_orders_count_sql is prepared.
 		$sql = $wpdb->prepare(
 			"
 SELECT(
@@ -604,10 +602,9 @@ SELECT(
 		$order_post_types             = wc_get_order_types( 'cot-migration' );
 		$order_post_type_placeholders = implode( ', ', array_fill( 0, count( $order_post_types ), '%s' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare,WordPress.DB.PreparedSQL.NotPrepared
 		switch ( $type ) {
 			case self::ID_TYPE_MISSING_IN_ORDERS_TABLE:
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $order_post_type_placeholders is prepared.
 				$sql = $wpdb->prepare(
 					"
 SELECT posts.ID FROM $wpdb->posts posts
@@ -619,7 +616,6 @@ WHERE
 ORDER BY posts.ID ASC",
 					$order_post_types
 				);
-				// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				break;
 			case self::ID_TYPE_MISSING_IN_POSTS_TABLE:
 				$sql = $wpdb->prepare(
@@ -635,7 +631,7 @@ ORDER BY posts.ID ASC",
 				break;
 			case self::ID_TYPE_DIFFERENT_UPDATE_DATE:
 				$operator = $this->custom_orders_table_is_authoritative() ? '>' : '<';
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $order_post_type_placeholders is prepared.
+
 				$sql = $wpdb->prepare(
 					"
 SELECT orders.id FROM $orders_table orders
@@ -647,7 +643,6 @@ ORDER BY orders.id ASC
 ",
 					$order_post_types
 				);
-				// phpcs:enable
 				break;
 			case self::ID_TYPE_DELETED_FROM_ORDERS_TABLE:
 				return $this->get_deleted_order_ids( true, $limit );
@@ -656,7 +651,7 @@ ORDER BY orders.id ASC
 			default:
 				throw new \Exception( 'Invalid $type, must be one of the ID_TYPE_... constants.' );
 		}
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable
 
 		// phpcs:ignore WordPress.DB
 		return array_map( 'intval', $wpdb->get_col( $sql . " LIMIT $limit" ) );
@@ -701,7 +696,7 @@ ORDER BY orders.id ASC
 	 *
 	 * @param array $batch Batch details.
 	 */
-	public function process_batch( array $batch ) : void {
+	public function process_batch( array $batch ): void {
 		if ( empty( $batch ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -499,9 +499,9 @@ class DataSynchronizer implements BatchProcessorInterface {
 			$missing_orders_count_sql = $wpdb->prepare(
 				"
 SELECT COUNT(1) FROM $wpdb->posts posts
-INNER JOIN $orders_table orders ON posts.id=orders.id
-WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'
- AND orders.status not in ( 'auto-draft' )
+RIGHT JOIN $orders_table orders ON posts.ID=orders.id
+WHERE (posts.post_type IS NULL OR posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "')
+ AND orders.status NOT IN ( 'auto-draft' )
  AND orders.type IN ($order_post_type_placeholder)",
 				$order_post_types
 			);
@@ -511,7 +511,7 @@ WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'
 			$missing_orders_count_sql = $wpdb->prepare(
 				"
 SELECT COUNT(1) FROM $wpdb->posts posts
-LEFT JOIN $orders_table orders ON posts.id=orders.id
+LEFT JOIN $orders_table orders ON posts.ID=orders.id
 WHERE
   posts.post_type in ($order_post_type_placeholder)
   AND posts.post_status != 'auto-draft'
@@ -624,12 +624,12 @@ ORDER BY posts.ID ASC",
 			case self::ID_TYPE_MISSING_IN_POSTS_TABLE:
 				$sql = $wpdb->prepare(
 					"
-SELECT posts.ID FROM $wpdb->posts posts
-INNER JOIN $orders_table orders ON posts.id=orders.id
-WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'
-AND orders.status not in ( 'auto-draft' )
+SELECT orders.id FROM $wpdb->posts posts
+RIGHT JOIN $orders_table orders ON posts.ID=orders.id
+WHERE (posts.post_type IS NULL OR posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "')
+AND orders.status NOT IN ( 'auto-draft' )
 AND orders.type IN ($order_post_type_placeholders)
-ORDER BY posts.id ASC",
+ORDER BY posts.ID ASC",
 					$order_post_types
 				);
 				break;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -593,6 +593,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		// Attempt to create the backup post if missing.
 		if ( $order->get_id() && is_null( get_post( $order->get_id() ) ) ) {
 			if ( ! $this->maybe_create_backup_post( $order, 'backfill' ) ) {
+				// translators: %d is an order ID.
 				$this->error_logger->warning( sprintf( __( 'Unable to create backup post for order %d.', 'woocommerce' ), $order->get_id() ) );
 			}
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -589,6 +589,14 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		}
 
 		self::$backfilling_order_ids[] = $order->get_id();
+
+		// Attempt to create the backup post if missing.
+		if ( $order->get_id() && is_null( get_post( $order->get_id() ) ) ) {
+			if ( ! $this->maybe_create_backup_post( $order, 'backfill' ) ) {
+				$this->error_logger->warning( sprintf( __( 'Unable to create backup post for order %d.', 'woocommerce' ), $order->get_id() ) );
+			}
+		}
+
 		$this->update_order_meta_from_object( $order );
 		$order_class = get_class( $order );
 		$post_order  = new $order_class();
@@ -1825,20 +1833,10 @@ FROM $order_meta_table
 	 * @since 6.8.0
 	 */
 	protected function persist_order_to_db( &$order, bool $force_all_fields = false ) {
-		$context   = ( 0 === absint( $order->get_id() ) ) ? 'create' : 'update';
-		$data_sync = wc_get_container()->get( DataSynchronizer::class );
+		$context = ( 0 === absint( $order->get_id() ) ) ? 'create' : 'update';
 
 		if ( 'create' === $context ) {
-			$post_id = wp_insert_post(
-				array(
-					'post_type'     => $data_sync->data_sync_is_enabled() ? $order->get_type() : $data_sync::PLACEHOLDER_ORDER_POST_TYPE,
-					'post_status'   => 'draft',
-					'post_parent'   => $order->get_changes()['parent_id'] ?? $order->get_data()['parent_id'] ?? 0,
-					'post_date'     => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getOffsetTimestamp() ),
-					'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
-				)
-			);
-
+			$post_id = $this->maybe_create_backup_post( $order, 'create' );
 			if ( ! $post_id ) {
 				throw new \Exception( esc_html__( 'Could not create order in posts table.', 'woocommerce' ) );
 			}
@@ -1872,6 +1870,33 @@ FROM $order_meta_table
 		$this->update_address_index_meta( $order, $changes );
 		$default_taxonomies = $this->init_default_taxonomies( $order, array() );
 		$this->set_custom_taxonomies( $order, $default_taxonomies );
+	}
+
+	/**
+	 * Takes care of creating the backup post in the posts table (placeholder or actual order post, depending on sync settings).
+	 *
+	 * @since 8.8.0
+	 *
+	 * @param \WC_Abstract_Order $order   The order.
+	 * @param string             $context The context: either 'create' or 'backfill'.
+	 * @return int The new post ID.
+	 */
+	protected function maybe_create_backup_post( &$order, string $context ): int {
+		$data_sync = wc_get_container()->get( DataSynchronizer::class );
+
+		$data = array(
+			'post_type'     => $data_sync->data_sync_is_enabled() ? $order->get_type() : $data_sync::PLACEHOLDER_ORDER_POST_TYPE,
+			'post_status'   => 'draft',
+			'post_parent'   => $order->get_changes()['parent_id'] ?? $order->get_data()['parent_id'] ?? 0,
+			'post_date'     => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getOffsetTimestamp() ),
+			'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
+		);
+
+		if ( 'backfill' === $context && $order->get_id() ) {
+			$data['import_id'] = $order->get_id();
+		}
+
+		return wp_insert_post( $order );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -595,6 +595,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 			if ( ! $this->maybe_create_backup_post( $order, 'backfill' ) ) {
 				// translators: %d is an order ID.
 				$this->error_logger->warning( sprintf( __( 'Unable to create backup post for order %d.', 'woocommerce' ), $order->get_id() ) );
+				return;
 			}
 		}
 
@@ -1901,7 +1902,7 @@ FROM $order_meta_table
 			$data['import_id'] = $order->get_id();
 		}
 
-		return wp_insert_post( $order );
+		return wp_insert_post( $data );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -593,7 +593,10 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		$order_class = get_class( $order );
 		$post_order  = new $order_class();
 		$post_order->set_id( $order->get_id() );
-		$cpt_data_store->read( $post_order );
+
+		if ( $cpt_data_store->order_exists( $order->get_id() ) ) {
+			$cpt_data_store->read( $post_order );
+		}
 
 		// This compares the order data to the post data and set changes array for props that are changed.
 		$post_order->set_props( $order->get_data() );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1892,7 +1892,11 @@ FROM $order_meta_table
 			'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 		);
 
-		if ( 'backfill' === $context && $order->get_id() ) {
+		if ( 'backfill' === $context ) {
+			if ( ! $order->get_id() ) {
+				return 0;
+			}
+
 			$data['import_id'] = $order->get_id();
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is authoritative and an order that exists on the HPOS side has no matching backup post in the posts table, that order is not counted when determining whether datastores are in sync or not.

Even though this shouldn't happen under normal circumstances, it can happen due to situations described in #42746 (such as automated trashing of an order post when sync was temporarily disabled) or just by direct manipulation of the database.

Those scenarios might be unlikely, but are problematic. For example, if the backup post is missing for an HPOS order, merchants will still be able to switch datastores freely, even though their contents no longer match.

This PR makes our sync queries "notice" those missing orders (in the posts table) and also adds some code that will attempt to re-crate the backup post if necessary when backfilling.

Related to #42746.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is configured as datastore in WC > Settings > Advanced > Features and that compatibility mode is disabled.
2. Ensure your site has a few orders. If necessary, create some or use [Smooth Generator](https://github.com/woocommerce/wc-smooth-generator) for a smoother testing experience. Make note of some order IDs.
4. Make sure things are in sync by running `wp wc cot sync`.
5. Go to WC > Settings > Advanced > Features and confirm that you can freely switch between the posts and HPOS datastores.
6. Delete the backup post for one of the orders by running the following command:
   ```
   wp db query "DELETE FROM $(wp db prefix)posts WHERE ID = <order_id>"
   ```
   
   **Note:** We can't use `wp post delete` anymore because in #45330 we introduced a filter that prevents removal of backup posts when HPOS is authoritative.
7. Go back to WC > Settings > Advanced > Features and confirm that you can't switch datastores and there's 1 order pending sync.
8. Run `wp wc cot sync`.
9. Confirm that the backup post was re-created by running `wp post exists <order_id>`.
10. Optionally, repeat steps 1-6 on `trunk` to confirm that you can switch datastores despite the manual removal of an order and also that running `wp wc cot sync` doesn't re-create the backup post.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
