### PR TITLE
Adjust the WC_Admin_Notices to support multisite setups

### DIFF
--- a/plugins/woocommerce/changelog/pr-45349
+++ b/plugins/woocommerce/changelog/pr-45349
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adjust the WC_Admin_Notices to support multisite setups

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -21,7 +21,10 @@ class WC_Admin_Notices {
 	use AccessiblePrivateMethods;
 
 	/**
-	 * Stores notices.
+	 * Local notices cache.
+	 *
+	 * DON'T manipulate this field directly!
+	 * Always use get_notices and set_notices instead.
 	 *
 	 * @var array
 	 */
@@ -48,10 +51,18 @@ class WC_Admin_Notices {
 	);
 
 	/**
-	 * Constructor.
+	 * Stores a flag indicating if the code is running in a multisite setup.
+	 *
+	 * @var bool
+	 */
+	private static bool $is_multisite;
+
+	/**
+	 * Initializes the class.
 	 */
 	public static function init() {
-		self::$notices = get_option( 'woocommerce_admin_notices', array() );
+		self::$is_multisite = is_multisite();
+		self::set_notices( get_option( 'woocommerce_admin_notices', array() ) );
 
 		add_action( 'switch_theme', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
@@ -85,26 +96,50 @@ class WC_Admin_Notices {
 	}
 
 	/**
-	 * Store notices to DB
+	 * Store the locally cached notices to DB.
 	 */
 	public static function store_notices() {
 		update_option( 'woocommerce_admin_notices', self::get_notices() );
 	}
 
 	/**
-	 * Get notices
+	 * Get the value of the locally cached notices array for the current site.
 	 *
 	 * @return array
 	 */
 	public static function get_notices() {
-		return self::$notices;
+		if ( ! self::$is_multisite ) {
+			return self::$notices;
+		}
+
+		$blog_id = get_current_blog_id();
+		$notices = self::$notices[ $blog_id ] ?? null;
+		if ( ! is_null( $notices ) ) {
+			return $notices;
+		}
+
+		self::$notices[ $blog_id ] = get_option( 'woocommerce_admin_notices', array() );
+		return self::$notices[ $blog_id ];
 	}
 
 	/**
-	 * Remove all notices.
+	 * Set the locally cached notices array for the current site.
+	 *
+	 * @param array $notices New value for the locally cached notices array.
+	 */
+	private static function set_notices( array $notices ) {
+		if ( self::$is_multisite ) {
+			self::$notices[ get_current_blog_id() ] = $notices;
+		} else {
+			self::$notices = $notices;
+		}
+	}
+
+	/**
+	 * Remove all notices from the locally cached notices array.
 	 */
 	public static function remove_all_notices() {
-		self::$notices = array();
+		self::set_notices( array() );
 	}
 
 	/**
@@ -205,7 +240,7 @@ class WC_Admin_Notices {
 	 * @param bool   $force_save Force saving inside this method instead of at the 'shutdown'.
 	 */
 	public static function add_notice( $name, $force_save = false ) {
-		self::$notices = array_unique( array_merge( self::get_notices(), array( $name ) ) );
+		self::set_notices( array_unique( array_merge( self::get_notices(), array( $name ) ) ) );
 
 		if ( $force_save ) {
 			// Adding early save to prevent more race conditions with notices.
@@ -220,7 +255,7 @@ class WC_Admin_Notices {
 	 * @param bool   $force_save Force saving inside this method instead of at the 'shutdown'.
 	 */
 	public static function remove_notice( $name, $force_save = false ) {
-		self::$notices = array_diff( self::get_notices(), array( $name ) );
+		self::set_notices( array_diff( self::get_notices(), array( $name ) ) );
 		delete_option( 'woocommerce_admin_notice_' . $name );
 
 		if ( $force_save ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -244,12 +244,12 @@ class WC_Admin_Notices {
 	 * Hide a notice if the GET variable is set.
 	 */
 	public static function hide_notices() {
-		if ( isset( $_GET['wc-hide-notice'] ) && isset( $_GET['_wc_notice_nonce'] ) ) { // WPCS: input var ok, CSRF ok.
-			if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wc_notice_nonce'] ) ), 'woocommerce_hide_notices_nonce' ) ) { // WPCS: input var ok, CSRF ok.
+		if ( isset( $_GET['wc-hide-notice'] ) && isset( $_GET['_wc_notice_nonce'] ) ) {
+			if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wc_notice_nonce'] ) ), 'woocommerce_hide_notices_nonce' ) ) {
 				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
 			}
 
-			$notice_name = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
+			$notice_name = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) );
 
 			/**
 			 * Filter the capability required to dismiss a given notice.
@@ -376,7 +376,8 @@ class WC_Admin_Notices {
 		if ( WC_Install::needs_db_update() ) {
 			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
 
-			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
+            // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) {
 				include dirname( __FILE__ ) . '/views/html-notice-updating.php';
 			} else {
 				include dirname( __FILE__ ) . '/views/html-notice-update.php';
@@ -460,7 +461,8 @@ class WC_Admin_Notices {
 	 * No shipping methods.
 	 */
 	public static function no_shipping_methods_notice() {
-		if ( wc_shipping_enabled() && ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'shipping' !== $_GET['tab'] ) ) { // WPCS: input var ok, CSRF ok.
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( wc_shipping_enabled() && ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'shipping' !== $_GET['tab'] ) ) {
 			$product_count = wp_count_posts( 'product' );
 			$method_count  = wc_get_shipping_method_count();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `WC_Admin_Notices` uses a static array to cache the names of the existing notices locally (the `$notices` field). In multisite setups this will cause the sequence of calls `WC_Admin_Notices::add_custom_notice()` - `switch_to_blog()` -  `WC_Admin_Notices::store_notices()` to generate a `woocommerce_admin_notices` option in the second site with the values of the option names for the first site.

While this doesn't cause notices to actually appear in wrong sites (each notice gets an additional `woocommerce_admin_notice_<name>` that is created in the proper site and is needed for the notice to actually be displayed), it causes the `woocommerce_admin_notices` option to get unnecessary values, which can lead to confussion (and in extreme cases degrade the site performance).

This pull request fixes this by transforming the `$notices` field into an associative array where keys are site ids and values are arrays of notice names (for multisite only: for single site setups the original behavior is kept, so `$notices` is still a plain names array).

### How to test the changes in this Pull Request:

Create a site in multisite mode, add one additional site, run `wp shell` in the command line and execute this:

```php
WC_Admin_Notices::add_custom_notice('site_1', 'Notice in site 1');
WC_Admin_Notices::store_notices();
switch_to_blog(2);
WC_Admin_Notices::add_custom_notice('site_2', 'Notice in site 2');
WC_Admin_Notices::store_notices();
var_dump(get_option('woocommerce_admin_notices'));
```

Without this fix you'll get an array with two entries, `site_1` and `site_2`. With the fix you'll get an array with only `site_2`.

You can also browse the admin area of both sites and verify that each site is still displaying its own notice only.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
