### PR TITLE
Tooltip: Fix max width of tooltip (used in Product Editor)

### DIFF
--- a/packages/js/components/changelog/fix-tooltip-max-width
+++ b/packages/js/components/changelog/fix-tooltip-max-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set maximum width on Tooltip.

--- a/packages/js/components/src/tooltip/style.scss
+++ b/packages/js/components/src/tooltip/style.scss
@@ -9,7 +9,12 @@
     &__text .components-popover__content {
         font-size: $default-font-size;
         padding: $gap;
-        width: max-content;
+		/* Allow tooltip to be wider than the default of `fit-content`
+		 * from the Popover component, but limit it to a reasonable
+		 * maximum width.
+		 */
+		width: auto;
+        max-width: 300px;
     }
 
 	&__text {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR limits the max width of the Tooltip component, used most commonly currently in the new product editor.

Before, if the tooltip's content didn't have an explicit width, it could become so large that it did not fit on the page:

<img width="1126" alt="Screenshot 2024-03-08 at 15 15 00" src="https://github.com/woocommerce/woocommerce/assets/2098816/54c5769b-b9c7-4eac-830e-8e8665d7db91">

Now, the max width is limited by default, so that consumers of the tooltip do not need to handle this themselves.

<img width="1126" alt="Screenshot 2024-03-08 at 15 18 57" src="https://github.com/woocommerce/woocommerce/assets/2098816/477d716e-e7d2-49c1-a74c-e7673d2a820c">

_Note: There appears to be a separate issue where the underlying Popover component used by the Tooltip does not reposition/resize itself as it should be ensure it is in the viewport. This should be investigated and addressed separately._

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Go to **Inventory** > **Advanced** and verify the tooltip on the "Limit purchases to 1 item per order" is limited in width.
3. Check out other tooltips and verify they look correct too (no regression).


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
