### PR TITLE
List Custom Fields for New Product Editor

### DIFF
--- a/packages/js/product-editor/changelog/add-44169-list
+++ b/packages/js/product-editor/changelog/add-44169-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create woocommerce/product-custom-fields block

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -1,4 +1,5 @@
 export { init as initCatalogVisibility } from './product-fields/catalog-visibility';
+export { init as initCustomFields } from './product-fields/custom-fields';
 export { init as initCustomFieldsToogle } from './product-fields/custom-fields-toggle';
 export { init as initCheckbox } from './generic/checkbox';
 export { init as initCollapsible } from './generic/collapsible';

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/block.json
@@ -22,6 +22,5 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"usesContext": [ "postType" ],
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
@@ -1,10 +1,14 @@
 /**
  * External dependencies
  */
-import { Spinner, ToggleControl } from '@wordpress/components';
-import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { recordEvent } from '@woocommerce/tracks';
+import {
+	// @ts-expect-error no exported member.
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { Spinner, ToggleControl } from '@wordpress/components';
+import { createElement, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,17 +25,25 @@ export function Edit( {
 }: ProductEditorBlockEditProps< CustomFieldsToggleBlockAttributes > ) {
 	const { label, _templateBlockId } = attributes;
 	const blockProps = useWooBlockProps( attributes );
+	const innerBlockProps = useInnerBlocksProps(
+		{
+			className:
+				'wp-block-woocommerce-product-custom-fields-toggle-field__inner-blocks',
+		},
+		{ templateLock: 'all' }
+	);
+
 	const { isLoading, metaboxhiddenProduct, saveMetaboxhiddenProduct } =
 		useMetaboxHiddenProduct();
 
-	function isChecked() {
+	const isChecked = useMemo( () => {
 		return (
 			metaboxhiddenProduct &&
 			! metaboxhiddenProduct.some(
 				( value ) => value === METABOX_HIDDEN_VALUE
 			)
 		);
-	}
+	}, [ metaboxhiddenProduct ] );
 
 	async function handleChange( checked: boolean ) {
 		const values = checked
@@ -51,14 +63,18 @@ export function Edit( {
 
 	return (
 		<div { ...blockProps }>
-			<ToggleControl
-				label={ label }
-				checked={ isChecked() }
-				disabled={ isLoading }
-				onChange={ handleChange }
-			/>
+			<div className="wp-block-woocommerce-product-custom-fields-toggle-field__content">
+				<ToggleControl
+					label={ label }
+					checked={ isChecked }
+					disabled={ isLoading }
+					onChange={ handleChange }
+				/>
 
-			{ isLoading && <Spinner /> }
+				{ isLoading && <Spinner /> }
+			</div>
+
+			{ isChecked && <div { ...innerBlockProps } /> }
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
@@ -3,12 +3,12 @@
  */
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { recordEvent } from '@woocommerce/tracks';
+import { Spinner, ToggleControl } from '@wordpress/components';
+import { createElement, useMemo } from '@wordpress/element';
 import {
 	// @ts-expect-error no exported member.
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-import { Spinner, ToggleControl } from '@wordpress/components';
-import { createElement, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/editor.scss
@@ -1,9 +1,15 @@
 .wp-block-woocommerce-product-custom-fields-toggle-field {
-	display: flex;
-	gap: $grid-unit;
-	align-items: center;
+	&__content {
+		display: flex;
+		gap: $grid-unit;
+		align-items: center;
 
-	.components-spinner {
-		margin: 0;
+		.components-spinner {
+			margin: 0;
+		}
+	}
+
+	&__inner-blocks {
+		margin-top: $grid-unit-60;
 	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-custom-fields",
+	"title": "Product custom fields control",
+	"category": "woocommerce",
+	"description": "The product custom fields.",
+	"keywords": [ "products", "custom", "fields" ],
+	"textdomain": "default",
+	"attributes": {
+		"name": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": true,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"usesContext": [ "postType" ],
+	"editorStyle": "file:./editor.css"
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/edit.tsx
@@ -7,6 +7,7 @@ import { useWooBlockProps } from '@woocommerce/block-templates';
 /**
  * Internal dependencies
  */
+import { CustomFields } from '../../../components/custom-fields';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { CustomFieldsBlockAttributes } from './types';
 
@@ -15,5 +16,9 @@ export function Edit( {
 }: ProductEditorBlockEditProps< CustomFieldsBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 
-	return <div { ...blockProps }></div>;
+	return (
+		<div { ...blockProps }>
+			<CustomFields />
+		</div>
+	);
 }

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/edit.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+
+/**
+ * Internal dependencies
+ */
+import { ProductEditorBlockEditProps } from '../../../types';
+import { CustomFieldsBlockAttributes } from './types';
+
+export function Edit( {
+	attributes,
+}: ProductEditorBlockEditProps< CustomFieldsBlockAttributes > ) {
+	const blockProps = useWooBlockProps( attributes );
+
+	return <div { ...blockProps }></div>;
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/editor.scss
@@ -1,0 +1,2 @@
+.wp-block-woocommerce-product-custom-fields-field {
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
+
+const { name, ...metadata } = blockConfiguration;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: Edit,
+};
+
+export function init() {
+	return registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );
+}

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/types.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface CustomFieldsBlockAttributes extends BlockAttributes {
+	label: string;
+}

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -1,6 +1,7 @@
 @import "product-fields/attributes/editor.scss";
 @import "product-fields/description/editor.scss";
 @import "product-fields/catalog-visibility/editor.scss";
+@import "product-fields/custom-fields/editor.scss";
 @import "product-fields/custom-fields-toggle/editor.scss";
 @import "product-fields/downloads/editor.scss";
 @import "product-fields/images/editor.scss";

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
+import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -13,7 +16,43 @@ import type { CustomFieldsProps } from './types';
 export function CustomFields( {}: CustomFieldsProps ) {
 	const [ customFields ] = useCustomFields();
 
-	console.log( customFields );
+	if ( customFields.length === 0 ) {
+		return <EmptyState />;
+	}
 
-	return <EmptyState />;
+	return (
+		<table className="woocommerce-product-custom-fields__table">
+			<thead>
+				<tr className="woocommerce-product-custom-fields__table-row">
+					<th>{ __( 'Name', 'woocommerce' ) }</th>
+					<th>{ __( 'Value', 'woocommerce' ) }</th>
+					<th>{ __( 'Actions', 'woocommerce' ) }</th>
+				</tr>
+			</thead>
+			<tbody>
+				{ customFields.map( ( customField ) => (
+					<tr
+						className="woocommerce-product-custom-fields__table-row"
+						key={ customField.id ?? customField.key }
+					>
+						<td className="woocommerce-product-custom-fields__table-datacell">
+							{ customField.key }
+						</td>
+						<td className="woocommerce-product-custom-fields__table-datacell">
+							{ customField.value }
+						</td>
+						<td className="woocommerce-product-custom-fields__table-datacell">
+							<Button
+								icon={ closeSmall }
+								aria-label={ __(
+									'Remove custom field',
+									'woocommerce'
+								) }
+							/>
+						</td>
+					</tr>
+				) ) }
+			</tbody>
+		</table>
+	);
 }

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -14,16 +12,10 @@ import { EmptyState } from './empty-state';
 import type { CustomFieldsProps } from './types';
 
 export function CustomFields( {}: CustomFieldsProps ) {
-	const { customFields, removeCustomField } = useCustomFields();
+	const { customFields } = useCustomFields();
 
 	if ( customFields.length === 0 ) {
 		return <EmptyState />;
-	}
-
-	function removeButtonClickHandler( key: string ) {
-		return function handleRemoveButtonClick() {
-			removeCustomField( key );
-		};
 	}
 
 	return (
@@ -47,18 +39,7 @@ export function CustomFields( {}: CustomFieldsProps ) {
 						<td className="woocommerce-product-custom-fields__table-datacell">
 							{ customField.value }
 						</td>
-						<td className="woocommerce-product-custom-fields__table-datacell">
-							<Button
-								icon={ closeSmall }
-								aria-label={ __(
-									'Remove custom field',
-									'woocommerce'
-								) }
-								onClick={ removeButtonClickHandler(
-									customField.key
-								) }
-							/>
-						</td>
+						<td className="woocommerce-product-custom-fields__table-datacell"></td>
 					</tr>
 				) ) }
 			</tbody>

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -3,6 +3,7 @@
  */
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import { useCustomFields } from '../../hooks/use-custom-fields';
 import { EmptyState } from './empty-state';
 import type { CustomFieldsProps } from './types';
 
-export function CustomFields( {}: CustomFieldsProps ) {
+export function CustomFields( { className, ...props }: CustomFieldsProps ) {
 	const { customFields } = useCustomFields();
 
 	if ( customFields.length === 0 ) {
@@ -19,7 +20,13 @@ export function CustomFields( {}: CustomFieldsProps ) {
 	}
 
 	return (
-		<table className="woocommerce-product-custom-fields__table">
+		<table
+			{ ...props }
+			className={ classNames(
+				'woocommerce-product-custom-fields__table',
+				className
+			) }
+		>
 			<thead>
 				<tr className="woocommerce-product-custom-fields__table-row">
 					<th>{ __( 'Name', 'woocommerce' ) }</th>

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -14,10 +14,16 @@ import { EmptyState } from './empty-state';
 import type { CustomFieldsProps } from './types';
 
 export function CustomFields( {}: CustomFieldsProps ) {
-	const [ customFields ] = useCustomFields();
+	const { customFields, removeCustomField } = useCustomFields();
 
 	if ( customFields.length === 0 ) {
 		return <EmptyState />;
+	}
+
+	function removeButtonClickHandler( key: string ) {
+		return function handleRemoveButtonClick() {
+			removeCustomField( key );
+		};
 	}
 
 	return (
@@ -47,6 +53,9 @@ export function CustomFields( {}: CustomFieldsProps ) {
 								aria-label={ __(
 									'Remove custom field',
 									'woocommerce'
+								) }
+								onClick={ removeButtonClickHandler(
+									customField.key
 								) }
 							/>
 						</td>

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useCustomFields } from '../../hooks/use-custom-fields';
+import { EmptyState } from './empty-state';
+import type { CustomFieldsProps } from './types';
+
+export function CustomFields( {}: CustomFieldsProps ) {
+	const [ customFields ] = useCustomFields();
+
+	console.log( customFields );
+
+	return <EmptyState />;
+}

--- a/packages/js/product-editor/src/components/custom-fields/empty-state/empty-state.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/empty-state/empty-state.tsx
@@ -18,35 +18,35 @@ export function EmptyState(
 		<div
 			{ ...props }
 			role="none"
-			className="wp-block-woocommerce-product-custom-fields__empty-state"
+			className="woocommerce-product-custom-fields__empty-state"
 		>
-			<div className="wp-block-woocommerce-product-custom-fields__empty-state-row">
+			<div className="woocommerce-product-custom-fields__empty-state-row">
 				<div>{ __( 'Custom field 1', 'woocommerce' ) }</div>
 				<div>
-					<div className="wp-block-woocommerce-product-custom-fields__empty-state-name" />
+					<div className="woocommerce-product-custom-fields__empty-state-name" />
 				</div>
 				<div>
-					<div className="wp-block-woocommerce-product-custom-fields__empty-state-actions" />
+					<div className="woocommerce-product-custom-fields__empty-state-actions" />
 				</div>
 			</div>
 
-			<div className="wp-block-woocommerce-product-custom-fields__empty-state-row">
+			<div className="woocommerce-product-custom-fields__empty-state-row">
 				<div>{ __( 'Custom field 2', 'woocommerce' ) }</div>
 				<div>
-					<div className="wp-block-woocommerce-product-custom-fields__empty-state-name" />
+					<div className="woocommerce-product-custom-fields__empty-state-name" />
 				</div>
 				<div>
-					<div className="wp-block-woocommerce-product-custom-fields__empty-state-actions" />
+					<div className="woocommerce-product-custom-fields__empty-state-actions" />
 				</div>
 			</div>
 
-			<div className="wp-block-woocommerce-product-custom-fields__empty-state-row">
+			<div className="woocommerce-product-custom-fields__empty-state-row">
 				<div>{ __( 'Custom field 3', 'woocommerce' ) }</div>
 				<div>
-					<div className="wp-block-woocommerce-product-custom-fields__empty-state-name" />
+					<div className="woocommerce-product-custom-fields__empty-state-name" />
 				</div>
 				<div>
-					<div className="wp-block-woocommerce-product-custom-fields__empty-state-actions" />
+					<div className="woocommerce-product-custom-fields__empty-state-actions" />
 				</div>
 			</div>
 		</div>

--- a/packages/js/product-editor/src/components/custom-fields/empty-state/empty-state.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/empty-state/empty-state.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+export function EmptyState(
+	props: React.DetailedHTMLProps<
+		React.HTMLAttributes< HTMLDivElement >,
+		HTMLDivElement
+	>
+) {
+	return (
+		<div
+			{ ...props }
+			role="none"
+			className="wp-block-woocommerce-product-custom-fields__empty-state"
+		>
+			<div className="wp-block-woocommerce-product-custom-fields__empty-state-row">
+				<div>{ __( 'Custom field 1', 'woocommerce' ) }</div>
+				<div>
+					<div className="wp-block-woocommerce-product-custom-fields__empty-state-name" />
+				</div>
+				<div>
+					<div className="wp-block-woocommerce-product-custom-fields__empty-state-actions" />
+				</div>
+			</div>
+
+			<div className="wp-block-woocommerce-product-custom-fields__empty-state-row">
+				<div>{ __( 'Custom field 2', 'woocommerce' ) }</div>
+				<div>
+					<div className="wp-block-woocommerce-product-custom-fields__empty-state-name" />
+				</div>
+				<div>
+					<div className="wp-block-woocommerce-product-custom-fields__empty-state-actions" />
+				</div>
+			</div>
+
+			<div className="wp-block-woocommerce-product-custom-fields__empty-state-row">
+				<div>{ __( 'Custom field 3', 'woocommerce' ) }</div>
+				<div>
+					<div className="wp-block-woocommerce-product-custom-fields__empty-state-name" />
+				</div>
+				<div>
+					<div className="wp-block-woocommerce-product-custom-fields__empty-state-actions" />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/components/custom-fields/empty-state/index.ts
+++ b/packages/js/product-editor/src/components/custom-fields/empty-state/index.ts
@@ -1,0 +1,1 @@
+export * from './empty-state';

--- a/packages/js/product-editor/src/components/custom-fields/empty-state/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/empty-state/style.scss
@@ -1,0 +1,59 @@
+.wp-block-woocommerce-product-custom-fields__empty-state {
+	@mixin skeleton {
+		@include placeholder();
+		background-color: $gray-200;
+		border-radius: $grid-unit-05;
+		width: $grid-unit-30;
+		height: $grid-unit;
+	}
+
+	border: 1px dashed $gray-400;
+	padding: 0 $grid-unit-30;
+	border-radius: 2px;
+
+	&-row {
+		display: grid;
+		grid-template-columns: 1.5fr 1fr 0.5fr;
+		height: $grid-unit-80;
+		align-items: center;
+		border-top: 1px solid $gray-100;
+
+		&:first-child {
+			border-top: none;
+
+			.wp-block-woocommerce-product-custom-fields__empty-state-name {
+				width: 140px;
+			}
+		}
+
+		&:nth-child(2) {
+			opacity: 0.7;
+
+			.wp-block-woocommerce-product-custom-fields__empty-state-name {
+				width: 75px;
+			}
+		}
+
+		&:nth-child(3) {
+			opacity: 0.5;
+
+			.wp-block-woocommerce-product-custom-fields__empty-state-name {
+				width: 114px;
+			}
+		}
+
+		:last-child {
+			display: flex;
+			justify-content: flex-end;
+		}
+	}
+
+	&-name {
+		@include skeleton();
+	}
+
+	&-actions {
+		@include skeleton();
+		width: $grid-unit-60;
+	}
+}

--- a/packages/js/product-editor/src/components/custom-fields/empty-state/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/empty-state/style.scss
@@ -1,4 +1,4 @@
-.wp-block-woocommerce-product-custom-fields__empty-state {
+.woocommerce-product-custom-fields__empty-state {
 	@mixin skeleton {
 		@include placeholder();
 		background-color: $gray-200;

--- a/packages/js/product-editor/src/components/custom-fields/empty-state/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/empty-state/style.scss
@@ -1,6 +1,5 @@
 .woocommerce-product-custom-fields__empty-state {
 	@mixin skeleton {
-		@include placeholder();
 		background-color: $gray-200;
 		border-radius: $grid-unit-05;
 		width: $grid-unit-30;
@@ -21,7 +20,7 @@
 		&:first-child {
 			border-top: none;
 
-			.wp-block-woocommerce-product-custom-fields__empty-state-name {
+			.woocommerce-product-custom-fields__empty-state-name {
 				width: 140px;
 			}
 		}
@@ -29,7 +28,7 @@
 		&:nth-child(2) {
 			opacity: 0.7;
 
-			.wp-block-woocommerce-product-custom-fields__empty-state-name {
+			.woocommerce-product-custom-fields__empty-state-name {
 				width: 75px;
 			}
 		}
@@ -37,7 +36,7 @@
 		&:nth-child(3) {
 			opacity: 0.5;
 
-			.wp-block-woocommerce-product-custom-fields__empty-state-name {
+			.woocommerce-product-custom-fields__empty-state-name {
 				width: 114px;
 			}
 		}

--- a/packages/js/product-editor/src/components/custom-fields/index.ts
+++ b/packages/js/product-editor/src/components/custom-fields/index.ts
@@ -1,0 +1,2 @@
+export * from './custom-fields';
+export * from './types';

--- a/packages/js/product-editor/src/components/custom-fields/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/style.scss
@@ -1,4 +1,35 @@
 @import "./empty-state/style.scss";
 
-.wp-block-woocommerce-product-custom-fields {
+.woocommerce-product-custom-fields {
+	&__table {
+		width: 100%;
+
+		thead {
+			@include screen-reader-only();
+		}
+
+		&-row {
+			display: grid;
+			grid-template-columns: 1fr 1fr 100px;
+			gap: $grid-unit-30;
+			border-bottom: 1px solid $gray-200;
+
+			&:last-child {
+				border-bottom: none;
+			}
+		}
+
+		&-datacell {
+			padding-top: $grid-unit-30;
+			padding-bottom: $grid-unit-30;
+
+			&:last-child {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				padding: 0;
+				gap: $grid-unit;
+			}
+		}
+	}
 }

--- a/packages/js/product-editor/src/components/custom-fields/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/style.scss
@@ -1,0 +1,4 @@
+@import "./empty-state/style.scss";
+
+.wp-block-woocommerce-product-custom-fields {
+}

--- a/packages/js/product-editor/src/components/custom-fields/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/types.ts
@@ -1,0 +1,1 @@
+export type CustomFieldsProps = {};

--- a/packages/js/product-editor/src/components/custom-fields/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/types.ts
@@ -1,1 +1,4 @@
-export type CustomFieldsProps = {};
+export type CustomFieldsProps = React.DetailedHTMLProps<
+	React.TableHTMLAttributes< HTMLTableElement >,
+	HTMLTableElement
+>;

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -95,3 +95,8 @@ export {
 	SchedulePublishModal as __experimentalSchedulePublishModal,
 	SchedulePublishModalProps,
 } from './schedule-publish-modal';
+
+export {
+	CustomFields as __experimentalCustomFields,
+	CustomFieldsProps,
+} from './custom-fields';

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useCustomFields as __experimentalUseCustomFields } from './use-custom-fields';
 export { useProductHelper as __experimentalUseProductHelper } from './use-product-helper';
 export { useFeedbackBar as __experimentalUseFeedbackBar } from './use-feedback-bar';
 export { useVariationsOrder as __experimentalUseVariationsOrder } from './use-variations-order';

--- a/packages/js/product-editor/src/hooks/use-custom-fields/index.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/index.ts
@@ -1,0 +1,1 @@
+export * from './use-custom-fields';

--- a/packages/js/product-editor/src/hooks/use-custom-fields/types.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { Metadata } from '../../types';
+
+export type DisjoinMetas< T extends Metadata< string > > = {
+	customFields: T[];
+	internalMetas: T[];
+};

--- a/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
@@ -37,11 +37,5 @@ export function useCustomFields<
 		setMetas( [ ...internalMetas, ...newValue ] );
 	}
 
-	function removeCustomField( key: T[ 'key' ] ) {
-		setCustomFields( ( current ) =>
-			current.filter( ( customField ) => customField.key !== key )
-		);
-	}
-
-	return { customFields, removeCustomField };
+	return { customFields, setCustomFields };
 }

--- a/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Dispatch, SetStateAction } from 'react';
+import type { SetStateAction } from 'react';
 import { useEntityProp } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 
@@ -9,11 +9,11 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import type { Metadata } from '../../types';
-import { disjoinMetas, isCustomField } from './utils';
+import { disjoinMetas } from './utils';
 
 export function useCustomFields<
 	T extends Metadata< string > = Metadata< string >
->(): [ T[], Dispatch< T[] > ] {
+>() {
 	const [ metas, setMetas ] = useEntityProp< T[] >(
 		'postType',
 		'product',
@@ -34,10 +34,14 @@ export function useCustomFields<
 		const newValue =
 			typeof value === 'function' ? value( customFields ) : value;
 
-		const newValueWithoutPrefix = newValue.filter( isCustomField );
-
-		setMetas( [ ...internalMetas, ...newValueWithoutPrefix ] );
+		setMetas( [ ...internalMetas, ...newValue ] );
 	}
 
-	return [ customFields, setCustomFields ];
+	function removeCustomField( key: T[ 'key' ] ) {
+		setCustomFields( ( current ) =>
+			current.filter( ( customField ) => customField.key !== key )
+		);
+	}
+
+	return { customFields, removeCustomField };
 }

--- a/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import type { Dispatch, SetStateAction } from 'react';
+import { useEntityProp } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { Metadata } from '../../types';
+import { disjoinMetas, isCustomField } from './utils';
+
+export function useCustomFields<
+	T extends Metadata< string > = Metadata< string >
+>(): [ T[], Dispatch< T[] > ] {
+	const [ metas, setMetas ] = useEntityProp< T[] >(
+		'postType',
+		'product',
+		'meta_data'
+	);
+
+	const { customFields, internalMetas } = useMemo(
+		function extractCustomFieldsFromMetas() {
+			return metas.reduce( disjoinMetas< T >, {
+				customFields: [],
+				internalMetas: [],
+			} );
+		},
+		[ metas ]
+	);
+
+	function setCustomFields( value: SetStateAction< T[] > ) {
+		const newValue =
+			typeof value === 'function' ? value( customFields ) : value;
+
+		const newValueWithoutPrefix = newValue.filter( isCustomField );
+
+		setMetas( [ ...internalMetas, ...newValueWithoutPrefix ] );
+	}
+
+	return [ customFields, setCustomFields ];
+}

--- a/packages/js/product-editor/src/hooks/use-custom-fields/utils/index.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/utils/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import type { Metadata } from '../../../types';
+import type { DisjoinMetas } from '../types';
+
+export function isCustomField< T extends Metadata< string > >( value: T ) {
+	return ! value.key.startsWith( '_' );
+}
+
+export function disjoinMetas< T extends Metadata< string > >(
+	state: DisjoinMetas< T >,
+	meta: T
+): DisjoinMetas< T > {
+	if ( isCustomField( meta ) ) {
+		state.customFields.push( meta );
+	} else {
+		state.internalMetas.push( meta );
+	}
+	return state;
+}

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -48,6 +48,7 @@
 @import "components/prepublish-panel/style.scss";
 @import "components/require-password/styles.scss";
 @import "components/schedule-publish-modal/style.scss";
+@import "components/custom-fields/style.scss";
 
 /* Field Blocks */
 

--- a/plugins/woocommerce/changelog/add-44169-list
+++ b/plugins/woocommerce/changelog/add-44169-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Register woocommerce/product-custom-fields block

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -48,6 +48,7 @@ class BlockRegistry {
 	 */
 	const PRODUCT_FIELDS_BLOCKS = array(
 		'woocommerce/product-catalog-visibility-field',
+		'woocommerce/product-custom-fields',
 		'woocommerce/product-custom-fields-toggle-field',
 		'woocommerce/product-description-field',
 		'woocommerce/product-downloads-field',

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -571,23 +571,27 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		);
 
 		if ( Features::is_enabled( 'product-custom-fields' ) ) {
-			$product_attributes_section->add_block(
+			$organization_group->add_section(
+				array(
+					'id'         => 'product-custom-fields-wrapper-section',
+					'order'      => 30,
+				)
+			)->add_block(
 				array(
 					'id'         => 'product-custom-fields-toggle',
 					'blockName'  => 'woocommerce/product-custom-fields-toggle-field',
-					'order'      => 20,
+					'order'      => 10,
 					'attributes' => array(
 						'label' => __( 'Show custom fields', 'woocommerce' ),
 					),
 				)
-			);
-
-			$product_attributes_section->add_block(
+			)->add_block(
 				array(
 					'id'         => 'product-custom-fields-section',
 					'blockName'  => 'woocommerce/product-section',
-					'order'      => 30,
+					'order'      => 10,
 					'attributes' => array(
+						'blockGap'    => 'unit-30',
 						'title'       => __( 'Custom fields', 'woocommerce' ),
 						'description' => sprintf(
 							/* translators: %1$s: Custom fields guide link opening tag. %2$s: Custom fields guide link closing tag. */

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -551,17 +551,18 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			)
 		);
 		// Attributes section.
-		$product_catalog_section = $organization_group->add_section(
+		$product_attributes_section = $organization_group->add_section(
 			array(
 				'id'         => 'product-attributes-section',
 				'order'      => 20,
 				'attributes' => array(
 					'title'       => __( 'Attributes', 'woocommerce' ),
 					'description' => __( 'Add descriptive pieces of information that customers can use to filter and search for this product. <a href="https://woo.com/document/managing-product-taxonomies/#product-attributes" target="_blank" rel="noreferrer">Learn more</a>.', 'woocommerce' ),
+					'blockGap'    => 'unit-40',
 				),
 			)
 		);
-		$product_catalog_section->add_block(
+		$product_attributes_section->add_block(
 			array(
 				'id'        => 'product-attributes',
 				'blockName' => 'woocommerce/product-attributes-field',
@@ -570,7 +571,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		);
 
 		if ( Features::is_enabled( 'product-custom-fields' ) ) {
-			$product_catalog_section->add_block(
+			$product_attributes_section->add_block(
 				array(
 					'id'         => 'product-custom-fields-toggle',
 					'blockName'  => 'woocommerce/product-custom-fields-toggle-field',
@@ -578,6 +579,29 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'attributes' => array(
 						'label' => __( 'Show custom fields', 'woocommerce' ),
 					),
+				)
+			);
+
+			$product_attributes_section->add_block(
+				array(
+					'id'         => 'product-custom-fields-section',
+					'blockName'  => 'woocommerce/product-section',
+					'order'      => 30,
+					'attributes' => array(
+						'title'       => __( 'Custom fields', 'woocommerce' ),
+						'description' => sprintf(
+							/* translators: %1$s: Custom fields guide link opening tag. %2$s: Custom fields guide link closing tag. */
+							__( 'Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or internal inventory organization. %1$sRead more about custom fields?%2$s', 'woocommerce' ),
+							'<a href="https://woo.com" target="_blank" rel="noreferrer">',
+							'</a>'
+						),
+					),
+				)
+			)->add_block(
+				array(
+					'id'        => 'product-custom-fields',
+					'blockName' => 'woocommerce/product-custom-fields',
+					'order'     => 10,
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -573,8 +573,8 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		if ( Features::is_enabled( 'product-custom-fields' ) ) {
 			$organization_group->add_section(
 				array(
-					'id'         => 'product-custom-fields-wrapper-section',
-					'order'      => 30,
+					'id'    => 'product-custom-fields-wrapper-section',
+					'order' => 30,
 				)
 			)->add_block(
 				array(

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -595,8 +595,8 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'title'       => __( 'Custom fields', 'woocommerce' ),
 						'description' => sprintf(
 							/* translators: %1$s: Custom fields guide link opening tag. %2$s: Custom fields guide link closing tag. */
-							__( 'Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or internal inventory organization. %1$sRead more about custom fields?%2$s', 'woocommerce' ),
-							'<a href="https://woo.com" target="_blank" rel="noreferrer">',
+							__( 'Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or internal inventory organization. %1$sRead more about custom fields%2$s', 'woocommerce' ),
+							'<a href="https://wordpress.org/documentation/article/assign-custom-fields/" target="_blank" rel="noreferrer">',
 							'</a>'
 						),
 					),

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
@@ -43,6 +43,7 @@ class BlockRegistryTest extends WC_Unit_Test_Case {
 		$block_registry = BlockRegistry::get_instance();
 
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-catalog-visibility-field' ), 'Catalog visibility field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-custom-fields' ), 'Custom fields not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-custom-fields-toggle-field' ), 'Custom fields toggle field not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-description-field' ), 'Description field not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-downloads-field' ), 'Downloads field not registered.' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially close #44169
Depends on #45291

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` -> `Add new` from the left menu to create a new product
4. Then go to the `Organization` tab
5. At the end of the page a new `Show custom fields` toggle should be shown
6. Clicking the toggle will show a new `Custom fields` section listing the custom fields that belong to the editing product metas
7. An empty state will be shown when there are no custom fields to show 
<img width="699" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/45ac940b-e764-4dd4-9718-c00c0d38f349">

8. You can add the custom fields from the classic editor and those ones will be listed here in the new editor
<img width="696" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/3400ca86-00da-49b0-a6ae-6633f6d881ca">


NOTE: `total_sales` is automatically added as a custom field to each product in the classic editor. This field is not added or shown automatically in the new editor for now.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
