### PR TITLE
Product Editor: Remove editable outline

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-remove-editable-outline
+++ b/packages/js/product-editor/changelog/fix-product-editor-remove-editable-outline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove editable outline for blocks in the product editor.

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -157,6 +157,13 @@
 		.block-editor-block-list__block fieldset {
 			min-width: 0;
 		}
+
+		/* Remove the outline for the block when it is editable */
+		.block-editor-block-list__block.has-editable-outline {
+			&::after {
+				display: none;
+			}
+		}
 	}
 }
 

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -150,18 +150,24 @@
 			padding-bottom: 128px;
 		}
 
-		.block-editor-block-list__block:not([contenteditable]):focus:after {
-			display: none; // use important or increase specificity.
-		}
+		.block-editor-block-list__block {
+			/* Remove the outline for the block when it is focused */
+			&:not([contenteditable]):focus {
+				&::after {
+					display: none;
+				}
+			}
 
-		.block-editor-block-list__block fieldset {
-			min-width: 0;
-		}
+			/* Address overflow issue */
+			fieldset {
+				min-width: 0;
+			}
 
-		/* Remove the outline for the block when it is editable */
-		.block-editor-block-list__block.has-editable-outline {
-			&::after {
-				display: none;
+			/* Remove the outline for the block when it is editable */
+			&.has-editable-outline {
+				&::after {
+					display: none;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the "editable outline" that the core editor applies to editable blocks when the root block is locked (which is the case for the product editor).

#### Before

https://github.com/woocommerce/woocommerce/assets/2098816/946b2fe0-672e-4baa-abf6-206306660c67

#### After

https://github.com/woocommerce/woocommerce/assets/2098816/67dd032b-d211-4952-87b1-3db0d724e7f0



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**), and the latest **Gutenberg** plugin installed...

1. Go to **Products** > **Add New**
2. Click just under the Sale Price field and verify no outlines appear on the form.
3. Switch tabs and verify no outlines appear on the form, especially around the pricing fields.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
