### PR TITLE
Tax task - Make postcode optional for countries without postcodes

### DIFF
--- a/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
+++ b/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
@@ -375,6 +375,7 @@ export function StoreAddress( {
 
 			{ ! locale?.address_1?.hidden && (
 				<TextControl
+					id={ 'woocommerce-store-address-form-address_1' }
 					label={
 						locale?.address_1?.label ||
 						__( 'Address', 'woocommerce' )
@@ -386,6 +387,7 @@ export function StoreAddress( {
 
 			{ ! locale?.postcode?.hidden && (
 				<TextControl
+					id={ 'woocommerce-store-address-form-postcode' }
 					label={
 						locale?.postcode?.label ||
 						__( 'Post code', 'woocommerce' )
@@ -397,6 +399,7 @@ export function StoreAddress( {
 
 			{ ! locale?.city?.hidden && (
 				<TextControl
+					id={ 'woocommerce-store-address-form-city' }
 					label={ locale?.city?.label || __( 'City', 'woocommerce' ) }
 					{ ...getInputProps( 'city' ) }
 					autoComplete="address-level2"

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
@@ -459,7 +459,7 @@ Object {
                     <input
                       autocomplete="address-line1"
                       class="components-text-control__input"
-                       id="woocommerce-store-address-form-address_1"
+                      id="woocommerce-store-address-form-address_1"
                       placeholder="Address"
                       type="text"
                       value=""

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
@@ -144,7 +144,7 @@ Object {
                       <input
                         autocomplete="address-line1"
                         class="components-text-control__input"
-                        id="inspector-text-control-0"
+                        id="woocommerce-store-address-form-address_1"
                         placeholder="Address"
                         type="text"
                         value=""
@@ -168,7 +168,7 @@ Object {
                       <input
                         autocomplete="postal-code"
                         class="components-text-control__input"
-                        id="inspector-text-control-1"
+                        id="woocommerce-store-address-form-postcode"
                         placeholder="Post code"
                         type="text"
                         value=""
@@ -192,7 +192,7 @@ Object {
                       <input
                         autocomplete="address-level2"
                         class="components-text-control__input"
-                        id="inspector-text-control-2"
+                        id="woocommerce-store-address-form-city"
                         placeholder="City"
                         type="text"
                         value=""
@@ -459,7 +459,7 @@ Object {
                     <input
                       autocomplete="address-line1"
                       class="components-text-control__input"
-                      id="inspector-text-control-0"
+                       id="woocommerce-store-address-form-address_1"
                       placeholder="Address"
                       type="text"
                       value=""
@@ -483,7 +483,7 @@ Object {
                     <input
                       autocomplete="postal-code"
                       class="components-text-control__input"
-                      id="inspector-text-control-1"
+                      id="woocommerce-store-address-form-postcode"
                       placeholder="Post code"
                       type="text"
                       value=""
@@ -507,7 +507,7 @@ Object {
                     <input
                       autocomplete="address-level2"
                       class="components-text-control__input"
-                      id="inspector-text-control-2"
+                      id="woocommerce-store-address-form-city"
                       placeholder="City"
                       type="text"
                       value=""

--- a/plugins/woocommerce-admin/client/task-lists/fills/tax/components/store-location.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/tax/components/store-location.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { SETTINGS_STORE_NAME, COUNTRIES_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -21,17 +21,27 @@ import {
 const validateLocationForm = ( values: FormValues ) => {
 	const errors = defaultValidate( values );
 
-	if ( ! values.addressLine1.trim().length ) {
+	if (
+		document.getElementById( 'woocommerce-store-address-form-address_1' ) &&
+		! values.addressLine1.trim().length
+	) {
 		errors.addressLine1 = __( 'Please enter an address', 'woocommerce' );
 	}
 
-	if ( ! values.postCode.trim().length ) {
+	if (
+		document.getElementById( 'woocommerce-store-address-form-postcode' ) &&
+		! values.postCode.trim().length
+	) {
 		errors.postCode = __( 'Please enter a post code', 'woocommerce' );
 	}
 
-	if ( ! values.city.trim().length ) {
+	if (
+		document.getElementById( 'woocommerce-store-address-form-city' ) &&
+		! values.city.trim().length
+	) {
 		errors.city = __( 'Please enter a city', 'woocommerce' );
 	}
+
 	return errors;
 };
 
@@ -63,7 +73,14 @@ export const StoreLocation: React.FC< {
 		if (
 			isResolving ||
 			isUpdating ||
-			! hasCompleteAddress( generalSettings || {} )
+			! hasCompleteAddress(
+				generalSettings || {},
+				Boolean(
+					document.getElementById(
+						'woocommerce-store-address-form-postcode'
+					)
+				)
+			)
 		) {
 			return;
 		}

--- a/plugins/woocommerce-admin/client/task-lists/fills/tax/components/store-location.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/tax/components/store-location.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME, COUNTRIES_STORE_NAME } from '@woocommerce/data';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/plugins/woocommerce-admin/client/task-lists/fills/tax/utils.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/tax/utils.ts
@@ -18,14 +18,18 @@ export const AUTOMATION_PLUGINS = [ 'woocommerce-services' ];
  * @param {Object} generalSettings.woocommerce_store_postcode  Store postal code.
  */
 export const hasCompleteAddress = (
-	generalSettings: Record< string, string >
+	generalSettings: Record< string, string >,
+	requiresPostcode = true
 ): boolean => {
 	const {
 		woocommerce_store_address: storeAddress,
 		woocommerce_default_country: defaultCountry,
 		woocommerce_store_postcode: storePostCode,
 	} = generalSettings;
-	return Boolean( storeAddress && defaultCountry && storePostCode );
+	if ( requiresPostcode ) {
+		return Boolean( storeAddress && defaultCountry && storePostCode );
+	}
+	return Boolean( storeAddress && defaultCountry );
 };
 
 /**

--- a/plugins/woocommerce/changelog/45367-fix-44805-cannot-configure-tax-rate
+++ b/plugins/woocommerce/changelog/45367-fix-44805-cannot-configure-tax-rate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Tax task  - do not require postcode input for countries without postcode.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44805  

This PR updates the tax task to bypass postcode validation when the user is configuring tax for a country without postcodes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a new JN site with this branch.
2. Choose UAE as store country during the onboarding.
3. Go to `WooCommerce -> Home` and click on `Add tax rates` task.
4. Enter address and city.
5. Clicking on `Continue` button should progress to the next step.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Tax task  - do not require postcode input for countries without postcode.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
