### PR TITLE
Blocks E2E: Do not report slow tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
@@ -26,6 +26,8 @@ const config: ExtendedPlaywrightTestConfig = {
 	testDir: 'tests',
 	retries: CI ? 2 : 0,
 	workers: 1,
+	// Don't report slow test "files", as we're running our tests in serial.
+	reportSlowTests: null,
 	reporter: process.env.CI
 		? [ [ 'github' ], [ 'list' ], [ 'html' ] ]
 		: 'list',

--- a/plugins/woocommerce/changelog/45375-tweak-disable-report-slow-tests
+++ b/plugins/woocommerce/changelog/45375-tweak-disable-report-slow-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Disable the `reportSlowTests` option for blocks' E2E tests.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, we're seeing a lot of `Slow Test` warnings in both CI and local test reports, e.g.:

<img width="908" alt="Screenshot 2024-03-07 at 12 20 16" src="https://github.com/woocommerce/woocommerce/assets/1451471/39275fc6-9797-4590-81ca-a03e3fefc78a">

<img width="1207" alt="Screenshot 2024-03-07 at 11 18 17" src="https://github.com/woocommerce/woocommerce/assets/1451471/ade4cd60-5c0f-48b0-b016-982994d402e1">

Let's disable Playwright's slow test reporting, as it can be confusing because we're not running our tests in parallel.

This setting is also consistent with the [core config](https://github.com/WordPress/gutenberg/blob/9d3e76bf627b16bae392b2bad691b882cc24548f/packages/scripts/config/playwright.config.js#L20-L21).

### How to test the changes in this Pull Request:

Ensure there are no more slow test reports.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Disable the `reportSlowTests` option for blocks' E2E tests.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
