### PR TITLE
Blocks E2E: Be more descriptive with the workflow titles

### DIFF
--- a/.github/workflows/blocks-playwright.yml
+++ b/.github/workflows/blocks-playwright.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
     e2e:
-        name: ${{ matrix.config.name }} (${{ matrix.shards.name }})
+        name: ${{ matrix.config.name }} [${{ matrix.shards.name }}]
         timeout-minutes: 60
         runs-on: ubuntu-latest
         defaults:
@@ -25,7 +25,7 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - name: Default Theme (Block)
+                    - name: Default (Block) Theme
                       file: playwright.config.ts
                       resultPath: test-results
                     - name: Classic Theme

--- a/.github/workflows/blocks-playwright.yml
+++ b/.github/workflows/blocks-playwright.yml
@@ -11,8 +11,8 @@ env:
     FORCE_COLOR: 1
 
 jobs:
-    PlaywrightE2ETests:
-        name: Playwright E2E tests - ${{ matrix.config.name }}
+    e2e:
+        name: ${{ matrix.config.name }} (${{ matrix.shards.name }})
         timeout-minutes: 60
         runs-on: ubuntu-latest
         defaults:
@@ -22,16 +22,16 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - name: Normal
+                    - name: Default Theme (Block)
                       file: playwright.config.ts
                       resultPath: test-results
-                    - name: Classic
+                    - name: Classic Theme
                       file: playwright.classic-theme.config.ts
                       resultPath: test-results-classic-theme
-                    - name: SideEffects
+                    - name: Side Effects
                       file: playwright.side-effects.config.ts
                       resultPath: test-results-side-effects
-                    - name: BlockThemeWithTemplates
+                    - name: Block Theme With Templates
                       file: playwright.block-theme-with-templates.config.ts
                       resultPath: test-results-block-theme-with-templates
                 shards:

--- a/plugins/woocommerce/changelog/tweak-blocks-e2e-workflow
+++ b/plugins/woocommerce/changelog/tweak-blocks-e2e-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Be more descriptive with Blocks E2E workflow titles


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Tweak the Blocks E2E job titles to make them more descriptive so they're easier to follow and debug:

- Remove the `Playwright E2E tests - ` prefix as it's already a `Run Blocks Playwright Tests` workflow.
- Rename `Normal` to `Default (Block) Theme` to reflect the env setup better.
- Rename `Classic` to `Classic Theme` for the same reason.
- Add shard numbers for correct sorting and easier navigation.

| Before | After |
| ------------- | ------------- |
| <img width="267" alt="Screenshot 2024-03-07 at 14 14 13" src="https://github.com/woocommerce/woocommerce/assets/1451471/24f3b498-63f0-4ac7-9f2b-dbe3ceba55bb"> | <img width="260" alt="Screenshot 2024-03-07 at 14 14 29" src="https://github.com/woocommerce/woocommerce/assets/1451471/5b4b0b10-5476-402c-bae3-0139cf802746"> |

### How to test the changes in this Pull Request:

Ensure the new titles are displayed correctly.