### PR TITLE
Blocks E2E: Allow manually triggering the workflow

### DIFF
--- a/.github/workflows/blocks-playwright.yml
+++ b/.github/workflows/blocks-playwright.yml
@@ -6,6 +6,9 @@ on:
             - 'plugins/woocommerce/src/Blocks/**'
             - 'plugins/woocommerce/templates/**'
             - 'plugins/woocommerce/patterns/**'
+    # Allow manually triggering the workflow.
+    workflow_dispatch:
+
 
 env:
     FORCE_COLOR: 1

--- a/plugins/woocommerce/changelog/tweak-blocks-e2e-allow-manual-trigger
+++ b/plugins/woocommerce/changelog/tweak-blocks-e2e-allow-manual-trigger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Allow manually triggering the Blocks E2E workflow


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Enable manual triggering of the Blocks E2E Tests workflow to eliminate the need for pushing dummy commits when it fails to trigger automatically (like in https://github.com/woocommerce/woocommerce/pull/45381 😄).

### How to test the changes in this Pull Request:

This won't be testable until it's merged. :)
Once it's merged, though, follow [these instructions](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) to trigger this workflow manually.