### PR TITLE
[CYS] Improve logic to ensure that the font is active

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -115,9 +115,13 @@ export const VariationContainer = ( { variation, children } ) => {
 		// With the Font Library, the fontFamilies object contains an array of font families installed with the Font Library under the key 'custom'.
 		// We need to compare only the active theme font families, so we compare the theme font families with the current variation.
 		const { theme } = user.settings.typography.fontFamilies;
-		return variation.settings.typography?.fontFamilies.theme.every(
-			( { slug } ) =>
-				theme.some( ( { slug: themeSlug } ) => themeSlug === slug )
+		return (
+			variation.settings.typography?.fontFamilies.theme.every(
+				( { slug } ) =>
+					theme.some( ( { slug: themeSlug } ) => themeSlug === slug )
+			) &&
+			theme.length ===
+				variation.settings.typography?.fontFamilies.theme.length
 		);
 	}, [ user, variation ] );
 

--- a/plugins/woocommerce/changelog/45385-45380-cys-on-core-whenever-the-rubikinter-font-pairing-is-selected-it-also-highlights-interinter
+++ b/plugins/woocommerce/changelog/45385-45380-cys-on-core-whenever-the-rubikinter-font-pairing-is-selected-it-also-highlights-interinter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+[CYS] Improve logic to ensure that the font is active.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45380.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the WooCommerce Beta Tester plugin if you don't have it enabled yet
2. On your Dashboard, head over to Tools > WCA Test Helper > Features and enable the `customize-store`
3. Ensure you have the Gutenberg plugin installed.
4. Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`.
5. Ensure that `Allow usage of WooCommerce to be tracked` is NOT selected.
6. Visit the `/wp-admin/admin.php?page=wc-admin&path=/customize-store`.
7. Follow the process.
8. On the sidebar, click on "Choose your font".
9. For each font, select it and ensure that only the selected one has the blue blur effect around the preview.
9. Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`.
10. Ensure that `Allow usage of WooCommerce to be tracked` is selected.
11. Follow the steps 6-9.

### JN installation
1. Create a new WooCommerce installation with this version.
2. Ensure Jetpack is installed and your site is connected with JP.
3. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
5. Ensure the Woo AI plugin is installed and activated (available on this monorepo).
6. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
7. Head over to WooCommerce -> Home and click on "Start Customizing".
8. Follow the steps 6-9 of the above testing instructions.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[CYS] Improve logic to ensure that the font is active.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
