### PR TITLE
Ensure address field is in address schema before sanitizing/validating it

### DIFF
--- a/plugins/woocommerce/changelog/fix-address-api-warnings
+++ b/plugins/woocommerce/changelog/fix-address-api-warnings
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Prevent warnings when checking out with additional checkout fields

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -119,7 +119,9 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$sanitization_util = new SanitizationUtils();
 		$address           = (array) $address;
 		$field_schema      = $this->get_properties();
-		$address           = array_reduce(
+		// omit all keys from address that are not in the schema. This should account for email.
+		$address = array_intersect_key( $address, $field_schema );
+		$address = array_reduce(
 			array_keys( $address ),
 			function( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
 				switch ( $key ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -122,9 +122,6 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$address           = array_reduce(
 			array_keys( $address ),
 			function( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
-				if ( ! isset( $field_schema[ $key ] ) ) {
-					return $carry;
-				}
 				switch ( $key ) {
 					case 'country':
 						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
@@ -171,7 +168,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		// correct format, and finally the second validation step is to ensure the correctly-formatted values
 		// match what we expect (postcode etc.).
 		foreach ( $address as $key => $value ) {
-			if ( isset( $schema[ $key ] ) && is_wp_error( rest_validate_value_from_schema( $value, $schema[ $key ], $key ) ) ) {
+			if ( is_wp_error( rest_validate_value_from_schema( $value, $schema[ $key ], $key ) ) ) {
 				$errors->add(
 					'invalid_' . $key,
 					sprintf(

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -122,6 +122,9 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$address           = array_reduce(
 			array_keys( $address ),
 			function( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
+				if ( ! isset( $field_schema[ $key ] ) ) {
+					return $carry;
+				}
 				switch ( $key ) {
 					case 'country':
 						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
@@ -168,7 +171,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		// correct format, and finally the second validation step is to ensure the correctly-formatted values
 		// match what we expect (postcode etc.).
 		foreach ( $address as $key => $value ) {
-			if ( is_wp_error( rest_validate_value_from_schema( $value, $schema[ $key ], $key ) ) ) {
+			if ( isset( $schema[ $key ] ) && is_wp_error( rest_validate_value_from_schema( $value, $schema[ $key ], $key ) ) ) {
 				$errors->add(
 					'invalid_' . $key,
 					sprintf(

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -123,8 +123,6 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			array_keys( $address ),
 			function( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
 				if ( ! isset( $field_schema[ $key ] ) ) {
-					// Sanitize text field since we have no info about what it *should* be. Sanitizing it is safer than leaving it alone.
-					$carry[ $key ] = sanitize_text_field( $address[ $key ] );
 					return $carry;
 				}
 				switch ( $key ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -123,6 +123,8 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			array_keys( $address ),
 			function( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
 				if ( ! isset( $field_schema[ $key ] ) ) {
+					// Sanitize text field since we have no info about what it *should* be. Sanitizing it is safer than leaving it alone.
+					$carry[ $key ] = sanitize_text_field( $address[ $key ] );
 					return $carry;
 				}
 				switch ( $key ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -50,6 +50,15 @@ class Cart extends ControllerTestCase {
 					'weight'        => 10,
 				)
 			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 4',
+					'stock_status'  => 'instock',
+					'regular_price' => 10,
+					'weight'        => 10,
+					'virtual'       => true,
+				)
+			),
 		);
 
 		// Add product #3 as a cross-sell for product #1.
@@ -397,6 +406,44 @@ class Cart extends ControllerTestCase {
 		);
 	}
 
+	public function test_update_customer_virtual_cart() {
+		// Add a virtual item to cart.
+		wc_empty_cart();
+		$this->keys   = array();
+		$this->keys[] = wc()->cart->add_to_cart( $this->products[3]->get_id() );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-customer' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address' => (object) array(
+					'first_name' => 'Han',
+					'last_name'  => 'Solo',
+					'address_1'  => 'Test address 1',
+					'address_2'  => 'Test address 2',
+					'city'       => 'Test City',
+					'state'      => 'AL',
+					'postcode'   => '90210',
+					'country'    => 'US',
+					'email'      => 'testaccount@test.com',
+				),
+			)
+		);
+
+		$this->assertAPIResponse(
+			$request,
+			200,
+			array(
+				'shipping_rates' => array(),
+			)
+		);
+		// Restore cart for other tests.
+		wc_empty_cart();
+		$this->keys   = array();
+		$this->keys[] = wc()->cart->add_to_cart( $this->products[0]->get_id(), 2 );
+		$this->keys[] = wc()->cart->add_to_cart( $this->products[1]->get_id() );
+		wc()->cart->apply_coupon( $this->coupon->get_code() );
+	}
 
 	/**
 	 * Test applying coupon to cart.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -406,6 +406,9 @@ class Cart extends ControllerTestCase {
 		);
 	}
 
+	/**
+	 * Test updating customer with a virtual cart only, this should test the address copying functionality.
+	 */
 	public function test_update_customer_virtual_cart() {
 		// Add a virtual item to cart.
 		wc_empty_cart();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

During checkout, if the customer's address has additional keys passed to it that aren't present in the address schema it will produce a warning.

The issue was caused by a bug from code in which we copied billing to shipping but forgot to remove email; this issue was there for 3+ years; it only surfaced lately because previously, we would statically sanitize each field ([code here](https://github.com/woocommerce/woocommerce-blocks/pull/12073/files#diff-59ea05fbdf17384f18882d317962d0df8ddf4f919e181033ff2f516aa55b0e8eL94-L104.))

This PR uses `array_intersect()` to ensure the supplied data matches the schema, removing unexpected properties.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Regression testing

1. Install [additional-checkout-fields-tester-main-2 (1).zip](https://github.com/woocommerce/woocommerce/files/14525935/additional-checkout-fields-tester-main-2.1.zip)
2. Add an item to your cart, go to the Checkout Block and fill in the form, including all additional fields.
3. Ensure the fields show up on the order confirmation page and order admin screen as you entered them.
4. Repeat, try adding <script> tags and other HTML, ensure that it's sanitized and does not result in actual HTML rendered on the order confirmation page or order admin screen.

### Developer testing

1. Install [additional-checkout-fields-tester-main-2 (1).zip](https://github.com/woocommerce/woocommerce/files/14525935/additional-checkout-fields-tester-main-2.1.zip)
2. Check out and watch the server logs. Ensure you see no warnings.
3. Add fields to the address (both addresses) that are not registered
4. Ensure no warnings are shown when checking out.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>