### PR TITLE
Edit Custom Fields for New Product Editor

### DIFF
--- a/packages/js/product-editor/changelog/add-44169-edit
+++ b/packages/js/product-editor/changelog/add-44169-edit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Edit Custom Fields for New Product Editor

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/block.json
@@ -21,7 +21,5 @@
 		"inserter": false,
 		"lock": false,
 		"__experimentalToolbar": false
-	},
-	"usesContext": [ "postType" ],
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/editor.scss
@@ -1,2 +1,0 @@
-.wp-block-woocommerce-product-custom-fields-field {
-}

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -1,7 +1,6 @@
 @import "product-fields/attributes/editor.scss";
 @import "product-fields/description/editor.scss";
 @import "product-fields/catalog-visibility/editor.scss";
-@import "product-fields/custom-fields/editor.scss";
 @import "product-fields/custom-fields-toggle/editor.scss";
 @import "product-fields/downloads/editor.scss";
 @import "product-fields/images/editor.scss";

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -34,6 +34,7 @@ export function CustomFields( { className, ...props }: CustomFieldsProps ) {
 
 	function handleEditModalUpdate( customField: Metadata< string > ) {
 		updateCustomField( customField );
+		setSelectedCustomField( undefined );
 	}
 
 	function handleEditModalCancel() {

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { createElement, Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 
@@ -9,47 +10,86 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { useCustomFields } from '../../hooks/use-custom-fields';
+import { EditModal } from './edit-modal';
 import { EmptyState } from './empty-state';
+import type { Metadata } from '../../types';
 import type { CustomFieldsProps } from './types';
 
 export function CustomFields( { className, ...props }: CustomFieldsProps ) {
-	const { customFields } = useCustomFields();
+	const { customFields, updateCustomField } = useCustomFields();
+	const [ selectedCustomField, setSelectedCustomField ] =
+		useState< Metadata< string > >();
 
 	if ( customFields.length === 0 ) {
 		return <EmptyState />;
 	}
 
+	function customFieldEditButtonClickHandler(
+		customField: Metadata< string >
+	) {
+		return function handleCustomFieldEditButtonClick() {
+			setSelectedCustomField( customField );
+		};
+	}
+
+	function handleEditModalUpdate( customField: Metadata< string > ) {
+		updateCustomField( customField );
+	}
+
+	function handleEditModalCancel() {
+		setSelectedCustomField( undefined );
+	}
+
 	return (
-		<table
-			{ ...props }
-			className={ classNames(
-				'woocommerce-product-custom-fields__table',
-				className
-			) }
-		>
-			<thead>
-				<tr className="woocommerce-product-custom-fields__table-row">
-					<th>{ __( 'Name', 'woocommerce' ) }</th>
-					<th>{ __( 'Value', 'woocommerce' ) }</th>
-					<th>{ __( 'Actions', 'woocommerce' ) }</th>
-				</tr>
-			</thead>
-			<tbody>
-				{ customFields.map( ( customField ) => (
-					<tr
-						className="woocommerce-product-custom-fields__table-row"
-						key={ customField.id ?? customField.key }
-					>
-						<td className="woocommerce-product-custom-fields__table-datacell">
-							{ customField.key }
-						</td>
-						<td className="woocommerce-product-custom-fields__table-datacell">
-							{ customField.value }
-						</td>
-						<td className="woocommerce-product-custom-fields__table-datacell"></td>
+		<>
+			<table
+				{ ...props }
+				className={ classNames(
+					'woocommerce-product-custom-fields__table',
+					className
+				) }
+			>
+				<thead>
+					<tr className="woocommerce-product-custom-fields__table-row">
+						<th>{ __( 'Name', 'woocommerce' ) }</th>
+						<th>{ __( 'Value', 'woocommerce' ) }</th>
+						<th>{ __( 'Actions', 'woocommerce' ) }</th>
 					</tr>
-				) ) }
-			</tbody>
-		</table>
+				</thead>
+				<tbody>
+					{ customFields.map( ( customField ) => (
+						<tr
+							className="woocommerce-product-custom-fields__table-row"
+							key={ customField.id ?? customField.key }
+						>
+							<td className="woocommerce-product-custom-fields__table-datacell">
+								{ customField.key }
+							</td>
+							<td className="woocommerce-product-custom-fields__table-datacell">
+								{ customField.value }
+							</td>
+							<td className="woocommerce-product-custom-fields__table-datacell">
+								<Button
+									variant="tertiary"
+									onClick={ customFieldEditButtonClickHandler(
+										customField
+									) }
+								>
+									{ __( 'Edit', 'woocommerce' ) }
+								</Button>
+							</td>
+						</tr>
+					) ) }
+				</tbody>
+			</table>
+
+			{ selectedCustomField && (
+				<EditModal
+					initialValue={ selectedCustomField }
+					onUpdate={ handleEditModalUpdate }
+					onCancel={ handleEditModalCancel }
+				/>
+			) }
+		</>
 	);
 }

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -1,30 +1,97 @@
 /**
  * External dependencies
  */
-import { Modal } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { createElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import { TextControl } from '../../text-control';
 import type { Metadata } from '../../../types';
 import type { EditModalProps } from './types';
+import { FocusEvent } from 'react';
+
+function validateName( value: string ) {
+	if ( value.startsWith( '_' ) ) {
+		return __(
+			'The name cannot begin with the underscore (_) character.',
+			'woocommerce'
+		);
+	}
+}
 
 export function EditModal( {
 	initialValue,
 	onUpdate,
 	onCancel,
+	...props
 }: EditModalProps ) {
 	const [ value, setValue ] = useState< Metadata< string > >( initialValue );
+	const [ validationError, setValidationError ] = useState< string >();
 
 	function renderTitle() {
 		return sprintf( __( 'Edit %s', 'woocommerce' ), value.key );
 	}
 
+	function handleNameChange( key: string ) {
+		setValue( ( current ) => ( { ...current, key } ) );
+	}
+
+	function handleNameBlur( event: FocusEvent< HTMLInputElement > ) {
+		setValidationError( validateName( event.target.value ) );
+	}
+
+	function handleValueChange( value: string ) {
+		setValue( ( current ) => ( { ...current, value } ) );
+	}
+
+	function handleUpdateButtonClick() {
+		const error = validateName( value.key );
+		if ( error ) {
+			setValidationError( error );
+			return;
+		}
+
+		onUpdate( value );
+	}
+
 	return (
-		<Modal title={ renderTitle() } onRequestClose={ onCancel }>
-			Hello
+		<Modal
+			shouldCloseOnClickOutside={ false }
+			{ ...props }
+			title={ renderTitle() }
+			onRequestClose={ onCancel }
+			className={ classNames(
+				'woocommerce-product-custom-fields__edit-modal',
+				props.className
+			) }
+		>
+			<TextControl
+				label={ __( 'Name', 'woocommerce' ) }
+				error={ validationError }
+				value={ value.key }
+				onChange={ handleNameChange }
+				onBlur={ handleNameBlur }
+			/>
+
+			<TextControl
+				label={ __( 'Value', 'woocommerce' ) }
+				value={ value.value }
+				onChange={ handleValueChange }
+			/>
+
+			<div className="woocommerce-product-custom-fields__edit-modal-actions">
+				<Button variant="secondary" onClick={ onCancel }>
+					{ __( 'Cancel', 'woocommerce' ) }
+				</Button>
+
+				<Button variant="primary" onClick={ handleUpdateButtonClick }>
+					{ __( 'Update', 'woocommerce' ) }
+				</Button>
+			</div>
 		</Modal>
 	);
 }

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import { Button, Modal } from '@wordpress/components';
-import { createElement, useState } from '@wordpress/element';
+import { createElement, useState, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
+import type { FocusEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import classNames from 'classnames';
 import { TextControl } from '../../text-control';
 import type { Metadata } from '../../../types';
 import type { EditModalProps } from './types';
-import { FocusEvent } from 'react';
 
 function validateName( value: string ) {
 	if ( value.startsWith( '_' ) ) {
@@ -31,6 +31,7 @@ export function EditModal( {
 }: EditModalProps ) {
 	const [ value, setValue ] = useState< Metadata< string > >( initialValue );
 	const [ validationError, setValidationError ] = useState< string >();
+	const nameTextRef = useRef< HTMLInputElement >( null );
 
 	function renderTitle() {
 		return sprintf( __( 'Edit %s', 'woocommerce' ), value.key );
@@ -41,7 +42,8 @@ export function EditModal( {
 	}
 
 	function handleNameBlur( event: FocusEvent< HTMLInputElement > ) {
-		setValidationError( validateName( event.target.value ) );
+		const error = validateName( event.target.value );
+		setValidationError( error );
 	}
 
 	function handleValueChange( value: string ) {
@@ -52,6 +54,7 @@ export function EditModal( {
 		const error = validateName( value.key );
 		if ( error ) {
 			setValidationError( error );
+			nameTextRef.current?.focus();
 			return;
 		}
 
@@ -70,6 +73,7 @@ export function EditModal( {
 			) }
 		>
 			<TextControl
+				ref={ nameTextRef }
 				label={ __( 'Name', 'woocommerce' ) }
 				error={ validationError }
 				value={ value.key }

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -29,16 +29,21 @@ export function EditModal( {
 	onCancel,
 	...props
 }: EditModalProps ) {
-	const [ value, setValue ] = useState< Metadata< string > >( initialValue );
+	const [ customField, setCustomField ] =
+		useState< Metadata< string > >( initialValue );
 	const [ validationError, setValidationError ] = useState< string >();
 	const nameTextRef = useRef< HTMLInputElement >( null );
 
 	function renderTitle() {
-		return sprintf( __( 'Edit %s', 'woocommerce' ), value.key );
+		return sprintf(
+			/* translators: %s: the name of the custom field */
+			__( 'Edit %s', 'woocommerce' ),
+			customField.key
+		);
 	}
 
 	function handleNameChange( key: string ) {
-		setValue( ( current ) => ( { ...current, key } ) );
+		setCustomField( ( current ) => ( { ...current, key } ) );
 	}
 
 	function handleNameBlur( event: FocusEvent< HTMLInputElement > ) {
@@ -47,18 +52,18 @@ export function EditModal( {
 	}
 
 	function handleValueChange( value: string ) {
-		setValue( ( current ) => ( { ...current, value } ) );
+		setCustomField( ( current ) => ( { ...current, value } ) );
 	}
 
 	function handleUpdateButtonClick() {
-		const error = validateName( value.key );
+		const error = validateName( customField.key );
 		if ( error ) {
 			setValidationError( error );
 			nameTextRef.current?.focus();
 			return;
 		}
 
-		onUpdate( value );
+		onUpdate( customField );
 	}
 
 	return (
@@ -76,14 +81,14 @@ export function EditModal( {
 				ref={ nameTextRef }
 				label={ __( 'Name', 'woocommerce' ) }
 				error={ validationError }
-				value={ value.key }
+				value={ customField.key }
 				onChange={ handleNameChange }
 				onBlur={ handleNameBlur }
 			/>
 
 			<TextControl
 				label={ __( 'Value', 'woocommerce' ) }
-				value={ value.value }
+				value={ customField.value }
 				onChange={ handleValueChange }
 			/>
 

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { createElement, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { Metadata } from '../../../types';
+import type { EditModalProps } from './types';
+
+export function EditModal( {
+	initialValue,
+	onUpdate,
+	onCancel,
+}: EditModalProps ) {
+	const [ value, setValue ] = useState< Metadata< string > >( initialValue );
+
+	function renderTitle() {
+		return sprintf( __( 'Edit %s', 'woocommerce' ), value.key );
+	}
+
+	return (
+		<Modal title={ renderTitle() } onRequestClose={ onCancel }>
+			Hello
+		</Modal>
+	);
+}

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/index.ts
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/index.ts
@@ -1,0 +1,2 @@
+export * from './edit-modal';
+export * from './types';

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/style.scss
@@ -1,0 +1,9 @@
+.woocommerce-product-custom-fields__edit-modal {
+	&-actions {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 12px;
+		margin-top: $grid-unit-40;
+	}
+}

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/style.scss
@@ -1,9 +1,15 @@
 .woocommerce-product-custom-fields__edit-modal {
+	min-width: 75%;
+
 	&-actions {
 		display: flex;
 		align-items: center;
 		justify-content: flex-end;
 		gap: 12px;
 		margin-top: $grid-unit-40;
+	}
+
+	.components-base-control {
+		width: 100%;
 	}
 }

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { Metadata } from '../../../types';
+
+export type EditModalProps = {
+	initialValue: Metadata< string >;
+	onUpdate( value: Metadata< string > ): void;
+	onCancel(): void;
+};

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/types.ts
@@ -1,9 +1,17 @@
 /**
+ * External dependencies
+ */
+import { Modal } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { Metadata } from '../../../types';
 
-export type EditModalProps = {
+export type EditModalProps = Omit<
+	Modal.Props,
+	'title' | 'onRequestClose' | 'children'
+> & {
 	initialValue: Metadata< string >;
 	onUpdate( value: Metadata< string > ): void;
 	onCancel(): void;

--- a/packages/js/product-editor/src/components/custom-fields/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/style.scss
@@ -23,12 +23,13 @@
 		&-datacell {
 			padding-top: $grid-unit-30;
 			padding-bottom: $grid-unit-30;
+			overflow: hidden;
 
 			&:last-child {
 				display: flex;
 				align-items: center;
 				justify-content: flex-end;
-				padding: 0;
+				padding: 0 2px 0 0;
 				gap: $grid-unit;
 			}
 		}

--- a/packages/js/product-editor/src/components/custom-fields/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/style.scss
@@ -1,4 +1,5 @@
 @import "./empty-state/style.scss";
+@import "./edit-modal/style.scss";
 
 .woocommerce-product-custom-fields {
 	&__table {

--- a/packages/js/product-editor/src/components/text-control/style.scss
+++ b/packages/js/product-editor/src/components/text-control/style.scss
@@ -1,0 +1,12 @@
+.woocommerce-product-text-control {
+	&.has-error {
+		.components-input-control__container
+			.components-input-control__backdrop {
+			border-color: $studio-red-50;
+		}
+
+		.components-base-control__help {
+			color: $studio-red-50;
+		}
+	}
+}

--- a/packages/js/product-editor/src/components/text-control/text-control.tsx
+++ b/packages/js/product-editor/src/components/text-control/text-control.tsx
@@ -33,9 +33,13 @@ export const TextControl = forwardRef( function ForwardedTextControl(
 		<InputControl
 			{ ...props }
 			ref={ ref }
-			className={ classNames( className, {
-				'has-error': error,
-			} ) }
+			className={ classNames(
+				'woocommerce-product-text-control',
+				className,
+				{
+					'has-error': error,
+				}
+			) }
 			label={
 				<Label
 					label={ label }

--- a/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
@@ -37,5 +37,16 @@ export function useCustomFields<
 		setMetas( [ ...internalMetas, ...newValue ] );
 	}
 
-	return { customFields, setCustomFields };
+	function updateCustomField( customField: T ) {
+		setCustomFields( ( current ) =>
+			current.map( ( field ) => {
+				if ( customField.id && field.id === customField.id ) {
+					return customField;
+				}
+				return field;
+			} )
+		);
+	}
+
+	return { customFields, setCustomFields, updateCustomField };
 }

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -49,6 +49,7 @@
 @import "components/require-password/styles.scss";
 @import "components/schedule-publish-modal/style.scss";
 @import "components/custom-fields/style.scss";
+@import "components/text-control/style.scss";
 
 /* Field Blocks */
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #44169
Depends on #45360

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new product from the classic editor, add some custom fields and save its id.
1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/product/{id}&tab=organization`. Replace the `{id}` with the one saved in point 1.
4. You should see the `Organization` tab
6. Under the `Custom fields` section the list of the custom fields added in point 1 should be shown 
<img width="720" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/3430ccc4-9c18-42b2-a79d-308989c8d329">

7. Each row should show an `Edit` button
8. When click it a new `Edit ...` modal should be shown so the custom field could be edited 
<img width="668" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/9ff2b7f0-d998-4b62-8806-800b130f1a8a">

9. Change the name and value of the custom field and then click `Update`
10. The modal should close and the changes should be reflected on the table
11. The update the product and after refreshing the page the changes should persist.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
