### PR TITLE
Add wrapper that can sanitize using `wp_kses_post` rules, but also allows `style` elements

### DIFF
--- a/plugins/woocommerce/changelog/fix-40157-styled-post-content
+++ b/plugins/woocommerce/changelog/fix-40157-styled-post-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Adds support for sanitizing styled chunks of HTML (a slight expansion of normal `wp_kses_post` rules).

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Utilities\HtmlSanitizer;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -896,10 +897,11 @@ function wc_terms_and_conditions_page_content() {
 		return;
 	}
 
-	$page = get_post( $terms_page_id );
+	$sanitizer = wc_get_container()->get( HtmlSanitizer::class );
+	$page      = get_post( $terms_page_id );
 
 	if ( $page && 'publish' === $page->post_status && $page->post_content && ! has_shortcode( $page->post_content, 'woocommerce_checkout' ) ) {
-		echo '<div class="woocommerce-terms-and-conditions" style="display: none; max-height: 200px; overflow: auto;">' . wc_format_content( wp_kses_post( $page->post_content ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<div class="woocommerce-terms-and-conditions" style="display: none; max-height: 200px; overflow: auto;">' . wc_format_content( $sanitizer->styled_post_content( $page->post_content ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 

--- a/plugins/woocommerce/src/Internal/Utilities/HtmlSanitizer.php
+++ b/plugins/woocommerce/src/Internal/Utilities/HtmlSanitizer.php
@@ -36,7 +36,7 @@ class HtmlSanitizer {
 	 * Sanitizes a chunk of HTML, by following the same rules as `wp_kses_post()` but also allowing
 	 * the style element to be supplied.
 	 *
-	 * @param string $html
+	 * @param string $html The HTML to be sanitized.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Internal/Utilities/HtmlSanitizer.php
+++ b/plugins/woocommerce/src/Internal/Utilities/HtmlSanitizer.php
@@ -41,7 +41,7 @@ class HtmlSanitizer {
 	 * @return string
 	 */
 	public function styled_post_content( string $html ): string {
-		$rules = wp_kses_allowed_html( 'post' );
+		$rules          = wp_kses_allowed_html( 'post' );
 		$rules['style'] = true;
 		return wp_kses( $html, $rules );
 	}

--- a/plugins/woocommerce/src/Internal/Utilities/HtmlSanitizer.php
+++ b/plugins/woocommerce/src/Internal/Utilities/HtmlSanitizer.php
@@ -33,6 +33,20 @@ class HtmlSanitizer {
 	);
 
 	/**
+	 * Sanitizes a chunk of HTML, by following the same rules as `wp_kses_post()` but also allowing
+	 * the style element to be supplied.
+	 *
+	 * @param string $html
+	 *
+	 * @return string
+	 */
+	public function styled_post_content( string $html ): string {
+		$rules = wp_kses_allowed_html( 'post' );
+		$rules['style'] = true;
+		return wp_kses( $html, $rules );
+	}
+
+	/**
 	 * Sanitizes the HTML according to the provided rules.
 	 *
 	 * @see wp_kses()

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/HtmlSanitizerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/HtmlSanitizerTest.php
@@ -78,4 +78,29 @@ class HtmlSanitizerTest extends WC_Unit_Test_Case {
 	public function test_no_kses_rules_specified() {
 		$this->assertEquals( 'foo', $this->sut->sanitize( '<p>foo</p>', array() ) );
 	}
+
+	/**
+	 * Describes expected behavior for the sanitizer's styled_post_content method.
+	 * @return void
+	 */
+	public function test_styled_post_content(): void {
+		$initial_html = '
+			<style> p { color: teal; } </style>
+			<script> alert( "I am bad, and I live by my own rules." ); </script>
+			<div>
+				<p>Waltz, bad nymph, for quick jigs vex.</p>
+				<p>Two driven jocks help fax my big quiz.</p>
+				<a href="http://five.quacking">Five quacking zephyrs jolt my wax bed.</a>
+			</div>
+		';
+
+		$expected_output = str_replace( '<script>', '', $initial_html );
+		$expected_output = str_replace( '</script>', '', $expected_output );
+
+		$this->assertEquals(
+			$this->sut->styled_post_content( $initial_html ),
+			$expected_output,
+			'We retain the protections offered by wp_kses_post, but also allow the use of `style` elements.'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds convenience wrapper that essentially acts as `wp_kses_post()`, but adds support for `<style>` elements.

Closes #40157.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

> ✍🏼 When testing this, you need to use the a checkout page generated by the 'classic' `[woocommerce_checkout]` shortcode.

1. Edit your **Terms & Conditions** page (or, if you don't already have one, simply create a new page and set it as **Terms & Conditions** page via **WooCommerce ▸ Settings ▸ Advanced ▸ Page Setup**).
2. Within this page, edit a block *as HTML,* and insert a style element. Example:

```html
<style> p { color: green; } </style>
<p> These terms and conditions are important. </p>
```

4. Save your changes, then visit the storefront. Add a product to the cart and proceed to checkout.
5. Clicking on the Terms & Conditions link should result in that content being shown inline. With this change in place, you should not see any exposed CSS (previously, the contents of the `<style>` element would have been echoed):

<img width="1043" alt="Terms and conditions, as rendered within the checkout area." src="https://github.com/woocommerce/woocommerce/assets/3594411/32180d15-fff8-4d0c-821c-68fa7915812f">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
