### PR TITLE
[Experimental] Display the formatted price in price filter text input fields

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/components/price-slider.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/components/price-slider.tsx
@@ -34,7 +34,7 @@ export const PriceSlider = ( { attributes }: EditProps ) => {
 		<input
 			className="min"
 			type="text"
-			value={ minPrice }
+			value={ formattedMinPrice }
 			onChange={ onChange }
 		/>
 	) : (
@@ -45,7 +45,7 @@ export const PriceSlider = ( { attributes }: EditProps ) => {
 		<input
 			className="max"
 			type="text"
-			value={ maxPrice }
+			value={ formattedMaxPrice }
 			onChange={ onChange }
 		/>
 	) : (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/frontend.ts
@@ -61,10 +61,22 @@ store< PriceFilterStore >( 'woocommerce/product-filter-price', {
 	},
 	actions: {
 		updateProducts: ( event: HTMLElementEvent< HTMLInputElement > ) => {
+			const { decimalSeparator } = getCurrency();
 			const context = getContext< PriceFilterContext >();
 			const { minRange, minPrice, maxPrice, maxRange } = context;
 			const type = event.target.name;
-			const value = parseFloat( event.target.value );
+			const value = parseInt(
+				event.target.value
+					.replace(
+						new RegExp( `[^0-9\\${ decimalSeparator }]+`, 'g' ),
+						''
+					)
+					.replace(
+						new RegExp( `\\${ decimalSeparator }`, 'g' ),
+						'.'
+					),
+				10
+			);
 
 			const currentMinPrice =
 				type === 'min'

--- a/plugins/woocommerce/changelog/fix-45315
+++ b/plugins/woocommerce/changelog/fix-45315
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: [Experimental] Display the formatted price in price filter text input fields
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -164,11 +164,12 @@ final class ProductFilterPrice extends AbstractBlock {
 					class="min"
 					name="min"
 					type="text"
-					value="%d"
-					data-wc-bind--value="context.minPrice"
+					value="%s"
+					data-wc-bind--value="state.formattedMinPrice"
 					data-wc-on--change="actions.updateProducts"
+					pattern=""
 				/>',
-				esc_attr( $min_price )
+				wp_strip_all_tags( $formatted_min_price )
 			) : sprintf(
 				'<span data-wc-text="state.formattedMinPrice">%s</span>',
 				// Not escaped, as this is HTML.
@@ -181,11 +182,11 @@ final class ProductFilterPrice extends AbstractBlock {
 					class="max"
 					name="max"
 					type="text"
-					value="%d"
-					data-wc-bind--value="context.maxPrice"
+					value="%s"
+					data-wc-bind--value="state.formattedMaxPrice"
 					data-wc-on--change="actions.updateProducts"
 				/>',
-				esc_attr( $max_price )
+				wp_strip_all_tags( $formatted_max_price )
 			) : sprintf(
 				'<span data-wc-text="state.formattedMaxPrice">%s</span>',
 				// Not escaped, as this is HTML.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45315.

This PR updates the new price filter block to display the formatted price as the value of the text input fields.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit Product Catalog template.
2. Use the Product Collection block for the main loop.
3. Add the `Product Filter: Price (Beta)` to the template.
4. On the front end, see the price value in the input field is formatted using the store price format.
5. Try updating the price of the input field, see the URL updated with the integer value of the entered price. The value is reformatted to the correct price format without decimal (we use integer only for filter price).
6. Try to break the input, type incorrect/invalid price, see the URL, and input value are still updated with correct price. Here is some test case ideas, give the store price format is right `$` with a space, using `,` as the decimal (so the formatted price should look like `12,95 $`):

Test price | Expected Formatted Price | Value in URL
-- | -- | --
$ 12 | 12 $ | 12
12.4,24 $ | 124 $ | 124
$12 | 12 $ | 12
13$ | 13 $ | 13
13- | 13 $ | 13
20,3-$ | 20 $ | 20
34,8*(@#*%&$ | 34 $ | 34

7. Try different price format setting, see the testing instructions still apply.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
