### PR TITLE
[CYS on Core] Display the theme switch modal if the current active theme is not TT4 when editing a theme

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -371,32 +371,55 @@ export const ExistingAiThemeBanner = ( {
 	);
 };
 
-export const ExistingNoAiThemeBanner = () => {
+export const ExistingNoAiThemeBanner = ( {
+	sendEvent,
+}: {
+	sendEvent: React.ComponentProps< typeof Intro >[ 'sendEvent' ];
+} ) => {
 	const siteUrl = getAdminSetting( 'siteUrl' ) + '?cys-hide-admin-bar=1';
 
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	interface Theme {
+		stylesheet?: string;
+	}
+
+	const currentTheme = useSelect( ( select ) => {
+		return select( 'core' ).getCurrentTheme() as Theme;
+	}, [] );
+
+	const isDefaultTheme = currentTheme?.stylesheet === 'twentytwentyfour';
+
 	return (
-		<BaseIntroBanner
-			bannerTitle={ __( 'Edit your custom theme', 'woocommerce' ) }
-			bannerText={ __(
-				'Continue to customize your store using the store designer. Change your color palette, fonts, page layouts, and more.',
-				'woocommerce'
+		<>
+			<BaseIntroBanner
+				bannerTitle={ __( 'Edit your custom theme', 'woocommerce' ) }
+				bannerText={ __(
+					'Continue to customize your store using the store designer. Change your color palette, fonts, page layouts, and more.',
+					'woocommerce'
+				) }
+				bannerClass="existing-no-ai-theme-banner"
+				buttonIsLink={ false }
+				bannerButtonOnClick={ () => {
+					recordEvent( 'customize_your_store_intro_customize_click' );
+					if ( ! isDefaultTheme ) {
+						setIsModalOpen( true );
+					} else {
+						sendEvent( {
+							type: 'DESIGN_WITHOUT_AI',
+						} );
+					}
+				} }
+				bannerButtonText={ __( 'Customize your theme', 'woocommerce' ) }
+				showAIDisclaimer={ false }
+				previewBanner={ <IntroSiteIframe siteUrl={ siteUrl } /> }
+			/>
+			{ isModalOpen && (
+				<SwitchThemeWarningModal
+					sendEvent={ sendEvent }
+					setIsModalOpen={ setIsModalOpen }
+				/>
 			) }
-			bannerClass="existing-no-ai-theme-banner"
-			buttonIsLink={ false }
-			bannerButtonOnClick={ () => {
-				recordEvent( 'customize_your_store_intro_customize_click' );
-				navigateOrParent(
-					window,
-					getNewPath(
-						{ customizing: true },
-						'/customize-store/assembler-hub',
-						{}
-					)
-				);
-			} }
-			bannerButtonText={ __( 'Customize your theme', 'woocommerce' ) }
-			showAIDisclaimer={ false }
-			previewBanner={ <IntroSiteIframe siteUrl={ siteUrl } /> }
-		></BaseIntroBanner>
+		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -19,6 +19,59 @@ import { IntroSiteIframe } from './intro-site-iframe';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { navigateOrParent } from '../utils';
 
+const SwitchThemeWarningModal = ( {
+	setIsModalOpen,
+	sendEvent,
+}: {
+	setIsModalOpen: ( value: boolean ) => void;
+	sendEvent: React.ComponentProps< typeof Intro >[ 'sendEvent' ];
+} ) => {
+	return (
+		<Modal
+			className={
+				'woocommerce-customize-store__theme-switch-warning-modal'
+			}
+			title={ __(
+				'Are you sure you want to design a new theme?',
+				'woocommerce'
+			) }
+			onRequestClose={ () => setIsModalOpen( false ) }
+			shouldCloseOnClickOutside={ false }
+		>
+			<p>
+				{ __(
+					'Your active theme will be changed and you could lose any changes you’ve made to it.',
+					'woocommerce'
+				) }
+			</p>
+			<div className="woocommerce-customize-store__theme-switch-warning-modal-footer">
+				<Button
+					onClick={ () => {
+						setIsModalOpen( false );
+					} }
+					variant="link"
+				>
+					{ __( 'Cancel', 'woocommerce' ) }
+				</Button>
+				<Button
+					onClick={ () => {
+						sendEvent( {
+							type: 'DESIGN_WITHOUT_AI',
+						} );
+						setIsModalOpen( false );
+						recordEvent(
+							'customize_your_store_agree_to_theme_switch_click'
+						);
+					} }
+					variant="primary"
+				>
+					{ __( 'Design a new theme', 'woocommerce' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
 export const BaseIntroBanner = ( {
 	bannerTitle,
 	bannerText,
@@ -255,48 +308,10 @@ export const NoAIBanner = ( {
 				showAIDisclaimer={ false }
 			/>
 			{ isModalOpen && (
-				<Modal
-					className={
-						'woocommerce-customize-store__theme-switch-warning-modal'
-					}
-					title={ __(
-						'Are you sure you want to design a new theme?',
-						'woocommerce'
-					) }
-					onRequestClose={ () => setIsModalOpen( false ) }
-					shouldCloseOnClickOutside={ false }
-				>
-					<p>
-						{ __(
-							'Your active theme will be changed and you could lose any changes you’ve made to it.',
-							'woocommerce'
-						) }
-					</p>
-					<div className="woocommerce-customize-store__theme-switch-warning-modal-footer">
-						<Button
-							onClick={ () => {
-								setIsModalOpen( false );
-							} }
-							variant="link"
-						>
-							{ __( 'Cancel', 'woocommerce' ) }
-						</Button>
-						<Button
-							onClick={ () => {
-								sendEvent( {
-									type: 'DESIGN_WITHOUT_AI',
-								} );
-								setIsModalOpen( false );
-								recordEvent(
-									'customize_your_store_agree_to_theme_switch_click'
-								);
-							} }
-							variant="primary"
-						>
-							{ __( 'Design a new theme', 'woocommerce' ) }
-						</Button>
-					</div>
-				</Modal>
+				<SwitchThemeWarningModal
+					sendEvent={ sendEvent }
+					setIsModalOpen={ setIsModalOpen }
+				/>
 			) }
 		</>
 	);

--- a/plugins/woocommerce/changelog/45434-44725-add-customize-button-modal
+++ b/plugins/woocommerce/changelog/45434-44725-add-customize-button-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+CYS - Show a warning modal when editing a different theme than TT4 from the CYS flow.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the "switch theme warning modal" to the `Edit your custom theme` Intro page. The modal will only show when the active theme is NOT Twenty Twenty Four.

Closes https://github.com/woocommerce/woocommerce/issues/44725

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the `WooCommerce Beta Tester` plugin is installed and activated (available on this monorepo).
2. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
3. Click on `Tools` and run the `Reset Customize Your Store` and the `Delete all products` commands.
5. Enable the TT4 theme.
6. Switch to another block theme.
7. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
8. Click on the `Customize your theme`.
9. Make sure you see this modal.
<img width="392" alt="Screenshot 2024-03-08 at 15 26 45" src="https://github.com/woocommerce/woocommerce/assets/186112/5fadff6f-1b45-456b-abb6-a5698d6f3a62">

10. Check that clicking `Cancel` closes the modal.
11. Check that clicking on `Design a new theme` goes through the flow to the assembler.
12. Make sure the theme is switched to TT4.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Show a warning modal when editing a different theme than TT4 from the CYS flow.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
