### PR TITLE
[CYS] Fix the Opt-in modal buttons and checkbox styles

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/style.scss
@@ -241,6 +241,14 @@ body.woocommerce-customize-store.js.is-fullscreen-mode {
 
 	.core-profiler__checkbox {
 		padding: 16px 32px 16px 32px;
+
+		div {
+			display: flex;
+
+			.components-checkbox-control__input-container {
+				display: block;
+			}
+		}
 	}
 
 	.woocommerce-customize-store__design-change-warning-modal-footer {
@@ -250,7 +258,13 @@ body.woocommerce-customize-store.js.is-fullscreen-mode {
 		display: flex;
 		gap: 12px;
 		justify-content: flex-end;
+
+		button.is-link {
+			padding: 6px 12px;
+			text-decoration: none;
+		}
 	}
+
 }
 
 .woocommerce-onboarding-loader {

--- a/plugins/woocommerce/changelog/45444-fix-optin-modal-styles
+++ b/plugins/woocommerce/changelog/45444-fix-optin-modal-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Fix the "Opt in to usage tracking" modal buttons and checkbox styles.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the styles of the buttons and checkbox on the `Opt-in` modal for the fonts in the CYS flow.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `WooCommerce Beta Tester` plugin if you don't have it enabled yet.
2. On your Dashboard, head over to Tools > WCA Test Helper > Features and enable the `customize-store`.
3. Ensure the Gutenberg plugin is disabled.
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and disable the tracking.
5. Access your Dashboard and head over to `WooCommerce > Home`.
6. Click on the "Customize Your Store" button.
7. Click on "Start designing".
8. On the assembler, click on `Choose fonts`.
9. On the sidebar click on `opt in to usage tracking`.
10. Make sure you see the `Opt in to usage tracking` modal and that it looks like the `After` screenshot below.

| Before | After |
|--------|--------|
| <img width="491" alt="Screenshot 2024-03-08 at 16 05 53" src="https://github.com/woocommerce/woocommerce/assets/186112/20df00d6-6ff6-4e33-afab-e48d117e25d9"> | <img width="513" alt="Screenshot 2024-03-08 at 16 05 20" src="https://github.com/woocommerce/woocommerce/assets/186112/9bdc47c3-c50a-4c6b-9d02-c0e1d5cb3c10"> | 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Fix the "Opt in to usage tracking" modal buttons and checkbox styles.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
