### PR TITLE
Add E2E test for Merchant Checkout Block flow

### DIFF
--- a/plugins/woocommerce/changelog/e2e-add-merchant-checkout-block
+++ b/plugins/woocommerce/changelog/e2e-add-merchant-checkout-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: add test for merchant checkout block

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
@@ -1,0 +1,132 @@
+const { test, expect } = require( '@playwright/test' );
+const { disableWelcomeModal } = require( '../../utils/editor' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+
+const transformedCheckoutBlockTitle = `Transformed Checkout ${ Date.now() }`;
+const transformedCheckoutBlockSlug = transformedCheckoutBlockTitle
+	.replace( / /gi, '-' )
+	.toLowerCase();
+
+const simpleProductName = 'Very Simple Product';
+const singleProductPrice = '999.00';
+
+let productId;
+
+test.describe( 'Transform Classic Checkout To Checkout Block', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+
+	test.beforeAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		// add product
+		await api
+			.post( 'products', {
+				name: simpleProductName,
+				type: 'simple',
+				regular_price: singleProductPrice,
+			} )
+			.then( ( response ) => {
+				productId = response.data.id;
+			} );
+	} );
+
+	test.afterAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api.delete( `products/${ productId }`, {
+			force: true,
+		} );
+	} );
+
+	test( 'can transform classic checkout to checkout block', async ( {
+		page,
+	} ) => {
+		// go to create a new page
+		await page.goto( 'wp-admin/post-new.php?post_type=page' );
+
+		await disableWelcomeModal( { page } );
+
+		// fill page title
+		await page
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( transformedCheckoutBlockTitle );
+
+		// add classic checkout block
+		await page.getByRole( 'textbox', { name: 'Add title' } ).click();
+		await page.getByLabel( 'Add block' ).click();
+		await page
+			.getByPlaceholder( 'Search', { exact: true } )
+			.fill( 'classic checkout' );
+		await page
+			.getByRole( 'option' )
+			.filter( { hasText: 'Classic Checkout' } )
+			.click();
+
+		// transform into blocks
+		await expect(
+			page.locator(
+				'.wp-block-woocommerce-classic-shortcode__placeholder-copy'
+			)
+		).toBeVisible();
+		await page
+			.getByRole( 'button' )
+			.filter( { hasText: 'Transform into blocks' } )
+			.click();
+		await expect( page.getByLabel( 'Dismiss this notice' ) ).toContainText(
+			'Classic shortcode transformed to blocks.'
+		);
+
+		// set terms & conditions and privacy policy as mandatory option
+		await page.locator( '.wc-block-checkout__terms' ).click();
+		await page.getByLabel( 'Require checkbox' ).click();
+
+		// save and publish the page
+		await page
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+		await expect(
+			page.getByText( `${ transformedCheckoutBlockTitle } is now live.` )
+		).toBeVisible();
+
+		// go to frontend to verify transformed checkout block
+		// before that add product to cart to be able to visit checkout page
+		await page.goto( `/cart/?add-to-cart=${ productId }` );
+		await page.goto( transformedCheckoutBlockSlug );
+		await expect(
+			page.getByRole( 'heading', { name: transformedCheckoutBlockTitle } )
+		).toBeVisible();
+		await expect(
+			page
+				.getByRole( 'group', { name: 'Contact information' } )
+				.locator( 'legend' )
+		).toBeVisible();
+		await expect(
+			page.locator( '.wp-block-woocommerce-checkout-order-summary-block' )
+		).toBeVisible();
+		await expect(
+			page.locator( '.wc-block-components-address-form' ).first()
+		).toBeVisible();
+
+		// verify existence of the terms & conditions and privacy policy checkbox
+		await expect(
+			page.getByText(
+				'You must accept our Terms and Conditions and Privacy Policy to continue with your purchase.'
+			)
+		).toBeVisible();
+		await expect( page.locator( '#terms-and-conditions' ) ).toBeVisible();
+		await page.locator( '#terms-and-conditions' ).check();
+		await expect( page.locator( '#terms-and-conditions' ) ).toBeChecked();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # [638](https://github.com/woocommerce/woocommerce-quality/issues/638) and [641](https://github.com/woocommerce/woocommerce-quality/issues/641)
This is half the [milestone](https://github.com/woocommerce/woocommerce-quality/milestone/16). I will make another PR to cover the rest 2 flows.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this locally
2. Run: `pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/create-checkout-block.spec.js`
3. Make sure it is passing

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
