### PR TITLE
Adjust labelling of refund line items in refund emails and order summaries.

### DIFF
--- a/plugins/woocommerce/changelog/fix-24346-refund-line-items
+++ b/plugins/woocommerce/changelog/fix-24346-refund-line-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Adjusts the way refunds are displayed (including in emails), to make it clearer that the line item is indeed a refund.

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2302,9 +2302,15 @@ class WC_Order extends WC_Abstract_Order {
 		$refunds = $this->get_refunds();
 		if ( $refunds ) {
 			foreach ( $refunds as $id => $refund ) {
+				$reason = trim( $refund->get_reason() );
+
+				if ( strlen( $reason ) > 0 ) {
+					$reason = "<br><small>$reason</small>";
+				}
+
 				$total_rows[ 'refund_' . $id ] = array(
-					'label' => $refund->get_reason() ? $refund->get_reason() : __( 'Refund', 'woocommerce' ) . ':',
-					'value' => wc_price( '-' . $refund->get_amount(), array( 'currency' => $this->get_currency() ) ),
+					'label' => __( 'Refund', 'woocommerce' ) . ':',
+					'value' => wc_price( '-' . $refund->get_amount(), array( 'currency' => $this->get_currency() ) ) . $reason,
 				);
 			}
 		}


### PR DESCRIPTION
This is an incremental (but still imperfect) fix for #24346.

<div align="center"><img width="869" alt="Modified email template (for order refunds)" src="https://github.com/woocommerce/woocommerce/assets/3594411/159413b8-60e2-4c91-a43d-1b6e6d5578b1"></div>

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Up until now, if a refund reason is supplied then (in the context of order refund emails, and also the order summary found via the **My Account** area), the refund reason is used in place of any sort of label. So, instead of seeing an entry like this (which we get if there is no reason):

```
| Refund:             |  -$5.00  |
```

We see something like:

```
| Not as described:    |  -$5.00  |
```

This may or may not make much sense, depending on the actual refund text. With this change, we essentially always use **Refund** as the label/descriptor, and if a reason is provided then we place it under the refund amount (see also the above screenshot):

```
| Refund:    |  -$5.00            |
|            |  Not as described  |
```

Closes #24346.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Repeat these steps, with and without this change and compare and contrast the differences:

1. Select an existing order, or create one. You should use an existing customer account for this.
2. Refund an order entirely or partially. Provide a reason (though you may also want to run some checks without providing a reason).
3. Examine the refund details in:
    - The refund email.
    - The order summary found via the **My Account** page.

In most cases, with this change, I think it is clearer that the refund line item is indeed a refund.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

Some notes:

- I'm using `<small>` to wrap the refund reason. I don't know that that is *optimal*, but it is also a pattern we are already using.
- The original issue suggested adding the refund reason text to the left-hand column. However, this looked a bit jarring to me (and we have less opportunity to use HTML to style it appropriately).
- This approach also avoids disruptions to existing translations.