### PR TITLE
CYS - reduce editor instance re-render

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -1,0 +1,197 @@
+/* eslint-disable @woocommerce/dependency-group */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * External dependencies
+ */
+// @ts-ignore No types for this exist yet.
+import { store as blockEditorStore } from '@wordpress/block-editor';
+// @ts-ignore No types for this exist yet.
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+// @ts-ignore No types for this exist yet.
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+// @ts-ignore No types for this exist yet.
+import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
+// @ts-ignore No types for this exist yet.
+import { useQuery } from '@woocommerce/navigation';
+import useSiteEditorSettings from '@wordpress/edit-site/build-module/components/block-editor/use-site-editor-settings';
+import { useCallback, useContext, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { CustomizeStoreContext } from './';
+import { BlockEditor } from './block-editor';
+import { HighlightedBlockContext } from './context/highlighted-block-context';
+import { useEditorBlocks } from './hooks/use-editor-blocks';
+import { useScrollOpacity } from './hooks/use-scroll-opacity';
+
+const { useHistory } = unlock( routerPrivateApis );
+
+type Page = {
+	link: string;
+	title: { rendered: string; raw: string };
+	[ key: string ]: unknown;
+};
+
+const findPageIdByLinkOrTitle = ( event: MouseEvent, _pages: Page[] ) => {
+	const target = event.target as HTMLAnchorElement;
+	const clickedPage =
+		_pages.find( ( page ) => page.link === target.href ) ||
+		_pages.find( ( page ) => page.title.rendered === target.innerText );
+	return clickedPage ? clickedPage.id : null;
+};
+
+const findPageIdByBlockClientId = ( event: MouseEvent ) => {
+	const navLink = ( event.target as HTMLAnchorElement ).closest(
+		'.wp-block-navigation-link'
+	);
+	if ( navLink ) {
+		const blockClientId = navLink.getAttribute( 'data-block' );
+		const navLinkBlocks =
+			// @ts-ignore No types for this exist yet.
+			select( blockEditorStore ).getBlocksByClientId( blockClientId );
+
+		if ( navLinkBlocks && navLinkBlocks.length ) {
+			return navLinkBlocks[ 0 ].attributes.id;
+		}
+	}
+	return null;
+};
+
+// We only show the edit option when page count is <= MAX_PAGE_COUNT
+// Performance of Navigation Links is not good past this value.
+const MAX_PAGE_COUNT = 100;
+
+export const BlockEditorContainer = () => {
+	const history = useHistory();
+	const settings = useSiteEditorSettings();
+
+	const currentTemplate = useSelect(
+		( select ) =>
+			// @ts-expect-error No types for this exist yet.
+			select( coreStore ).__experimentalGetTemplateForLink( '/' ),
+		[]
+	);
+
+	const [ blocks, , onChange ] = useEditorBlocks(
+		'wp_template',
+		currentTemplate.id
+	);
+
+	const urlParams = useQuery();
+	const { currentState } = useContext( CustomizeStoreContext );
+
+	const scrollDirection =
+		urlParams.path === '/customize-store/assembler-hub/footer'
+			? 'bottomUp'
+			: 'topDown';
+
+	const previewOpacity = useScrollOpacity(
+		'.woocommerce-customize-store__block-editor iframe',
+		scrollDirection
+	);
+
+	// // See packages/block-library/src/page-list/edit.js.
+	const { records: pages } = useEntityRecords( 'postType', 'page', {
+		per_page: MAX_PAGE_COUNT,
+		_fields: [ 'id', 'link', 'menu_order', 'parent', 'title', 'type' ],
+		// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby
+		// values is resolved, update 'orderby' to [ 'menu_order', 'post_title' ] to provide a consistent
+		// sort.
+		orderby: 'menu_order',
+		order: 'asc',
+	} );
+
+	const onClickNavigationItem = useCallback(
+		( event: MouseEvent ) => {
+			// If the user clicks on a navigation item, we want to update the URL to reflect the page they are on.
+			// Because of bug in the block library (See https://github.com/woocommerce/team-ghidorah/issues/253#issuecomment-1665106817), we're not able to use href link to find the page ID. Instead, we'll use the link/title first, and if that doesn't work, we'll use the block client ID. It depends on the header block type to determine which one to use.
+			// This is a temporary solution until the block library is fixed.
+
+			const pageId =
+				findPageIdByLinkOrTitle( event, pages ) ||
+				findPageIdByBlockClientId( event );
+
+			if ( pageId ) {
+				history.push( {
+					...urlParams,
+					postId: pageId,
+					postType: 'page',
+				} );
+				return;
+			}
+
+			// Home page
+			const { postId, postType, ...params } = urlParams;
+			history.push( {
+				...params,
+			} );
+		},
+		[ history, urlParams, pages ]
+	);
+
+	const { highlightedBlockClientId } = useContext( HighlightedBlockContext );
+	const isHighlighting = highlightedBlockClientId !== null;
+	const additionalStyles = isHighlighting
+		? `
+		.wp-block.preview-opacity {
+			opacity: ${ previewOpacity };
+		}
+	`
+		: '';
+
+	const opacityClass = 'preview-opacity';
+
+	const renderedBlocks = useMemo(
+		() =>
+			blocks.map( ( block ) => {
+				if (
+					! isHighlighting ||
+					block.clientId === highlightedBlockClientId
+				) {
+					return {
+						...block,
+						attributes: {
+							...block.attributes,
+							className: block.attributes.className?.replace(
+								opacityClass,
+								''
+							),
+						},
+					};
+				}
+
+				return {
+					...block,
+					attributes: {
+						...block.attributes,
+						className:
+							block.attributes.className + ` ${ opacityClass }`,
+					},
+				};
+			} ),
+		[ blocks, highlightedBlockClientId, isHighlighting ]
+	);
+
+	const isScrollable = useMemo(
+		() =>
+			// Disable scrollable for transitional screen
+			! (
+				typeof currentState === 'object' &&
+				currentState.transitionalScreen === 'transitional'
+			),
+		[ currentState ]
+	);
+
+	return (
+		<BlockEditor
+			renderedBlocks={ renderedBlocks }
+			isScrollable={ isScrollable }
+			onChange={ onChange }
+			settings={ settings }
+			additionalStyles={ additionalStyles }
+			onClickNavigationItem={ onClickNavigationItem }
+		/>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -67,7 +67,11 @@ export const BlockEditorContainer = () => {
 	const history = useHistory();
 	const settings = useSiteEditorSettings();
 
-	const currentTemplate = useSelect(
+	const currentTemplate:
+		| {
+				id: string;
+		  }
+		| undefined = useSelect(
 		( select ) =>
 			// @ts-expect-error No types for this exist yet.
 			select( coreStore ).__experimentalGetTemplateForLink( '/' ),
@@ -76,7 +80,7 @@ export const BlockEditorContainer = () => {
 
 	const [ blocks, , onChange ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate.id
+		currentTemplate?.id ?? ''
 	);
 
 	const urlParams = useQuery();

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -3,17 +3,17 @@
 /**
  * External dependencies
  */
-// @ts-ignore No types for this exist yet.
+// @ts-expect-error No types for this exist yet.
 import { store as blockEditorStore } from '@wordpress/block-editor';
-// @ts-ignore No types for this exist yet.
+// @ts-expect-error No types for this exist yet.
 import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-// @ts-ignore No types for this exist yet.
+// @ts-expect-error No types for this exist yet.
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-// @ts-ignore No types for this exist yet.
+// @ts-expect-error No types for this exist yet.
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
-// @ts-ignore No types for this exist yet.
 import { useQuery } from '@woocommerce/navigation';
+// @ts-expect-error No types for this exist yet.
 import useSiteEditorSettings from '@wordpress/edit-site/build-module/components/block-editor/use-site-editor-settings';
 import { useCallback, useContext, useMemo } from '@wordpress/element';
 
@@ -49,7 +49,7 @@ const findPageIdByBlockClientId = ( event: MouseEvent ) => {
 	if ( navLink ) {
 		const blockClientId = navLink.getAttribute( 'data-block' );
 		const navLinkBlocks =
-			// @ts-ignore No types for this exist yet.
+			// @ts-expect-error No types for this exist yet.
 			select( blockEditorStore ).getBlocksByClientId( blockClientId );
 
 		if ( navLinkBlocks && navLinkBlocks.length ) {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
@@ -1,216 +1,54 @@
-/* eslint-disable @woocommerce/dependency-group */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 /**
  * External dependencies
  */
-// @ts-ignore No types for this exist yet.
-import { store as blockEditorStore } from '@wordpress/block-editor';
-// @ts-ignore No types for this exist yet.
-import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-// @ts-ignore No types for this exist yet.
-import { privateApis as routerPrivateApis } from '@wordpress/router';
-// @ts-ignore No types for this exist yet.
-import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
-// @ts-ignore No types for this exist yet.
-import useSiteEditorSettings from '@wordpress/edit-site/build-module/components/block-editor/use-site-editor-settings';
-import { useQuery } from '@woocommerce/navigation';
-import { useContext, useCallback, useMemo } from '@wordpress/element';
+import { BlockInstance } from '@wordpress/blocks';
+import { memo } from 'react';
 
 /**
  * Internal dependencies
  */
+
 import BlockPreview from './block-preview';
-import { useEditorBlocks } from './hooks/use-editor-blocks';
-import { useScrollOpacity } from './hooks/use-scroll-opacity';
-import { CustomizeStoreContext } from './';
-import { HighlightedBlockContext } from './context/highlighted-block-context';
 import Iframe from './iframe';
+import { ChangeHandler } from './hooks/use-editor-blocks';
 
-const { useHistory } = unlock( routerPrivateApis );
-
-type Page = {
-	link: string;
-	title: { rendered: string; raw: string };
-	[ key: string ]: unknown;
-};
-
-const findPageIdByLinkOrTitle = ( event: MouseEvent, _pages: Page[] ) => {
-	const target = event.target as HTMLAnchorElement;
-	const clickedPage =
-		_pages.find( ( page ) => page.link === target.href ) ||
-		_pages.find( ( page ) => page.title.rendered === target.innerText );
-	return clickedPage ? clickedPage.id : null;
-};
-
-const findPageIdByBlockClientId = ( event: MouseEvent ) => {
-	const navLink = ( event.target as HTMLAnchorElement ).closest(
-		'.wp-block-navigation-link'
-	);
-	if ( navLink ) {
-		const blockClientId = navLink.getAttribute( 'data-block' );
-		const navLinkBlocks =
-			// @ts-ignore No types for this exist yet.
-			select( blockEditorStore ).getBlocksByClientId( blockClientId );
-
-		if ( navLinkBlocks && navLinkBlocks.length ) {
-			return navLinkBlocks[ 0 ].attributes.id;
-		}
-	}
-	return null;
-};
-
-// We only show the edit option when page count is <= MAX_PAGE_COUNT
-// Performance of Navigation Links is not good past this value.
-const MAX_PAGE_COUNT = 100;
-
-export const BlockEditor = ( {} ) => {
-	const history = useHistory();
-	const settings = useSiteEditorSettings();
-
-	const currentTemplate = useSelect(
-		( select ) =>
-			// @ts-expect-error No types for this exist yet.
-			select( coreStore ).__experimentalGetTemplateForLink( '/' ),
-		[]
-	);
-
-	const [ blocks, , onChange ] = useEditorBlocks(
-		'wp_template',
-		currentTemplate.id
-	);
-
-	const urlParams = useQuery();
-	const { currentState } = useContext( CustomizeStoreContext );
-
-	const scrollDirection =
-		urlParams.path === '/customize-store/assembler-hub/footer'
-			? 'bottomUp'
-			: 'topDown';
-
-	const previewOpacity = useScrollOpacity(
-		'.woocommerce-customize-store__block-editor iframe',
-		scrollDirection
-	);
-
-	// // See packages/block-library/src/page-list/edit.js.
-	const { records: pages } = useEntityRecords( 'postType', 'page', {
-		per_page: MAX_PAGE_COUNT,
-		_fields: [ 'id', 'link', 'menu_order', 'parent', 'title', 'type' ],
-		// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby
-		// values is resolved, update 'orderby' to [ 'menu_order', 'post_title' ] to provide a consistent
-		// sort.
-		orderby: 'menu_order',
-		order: 'asc',
-	} );
-
-	const onClickNavigationItem = useCallback(
-		( event: MouseEvent ) => {
-			// If the user clicks on a navigation item, we want to update the URL to reflect the page they are on.
-			// Because of bug in the block library (See https://github.com/woocommerce/team-ghidorah/issues/253#issuecomment-1665106817), we're not able to use href link to find the page ID. Instead, we'll use the link/title first, and if that doesn't work, we'll use the block client ID. It depends on the header block type to determine which one to use.
-			// This is a temporary solution until the block library is fixed.
-
-			const pageId =
-				findPageIdByLinkOrTitle( event, pages ) ||
-				findPageIdByBlockClientId( event );
-
-			if ( pageId ) {
-				history.push( {
-					...urlParams,
-					postId: pageId,
-					postType: 'page',
-				} );
-				return;
-			}
-
-			// Home page
-			const { postId, postType, ...params } = urlParams;
-			history.push( {
-				...params,
-			} );
-		},
-		[ history, urlParams, pages ]
-	);
-
-	const { highlightedBlockClientId } = useContext( HighlightedBlockContext );
-	const isHighlighting = highlightedBlockClientId !== null;
-	const additionalStyles = isHighlighting
-		? `
-		.wp-block.preview-opacity {
-			opacity: ${ previewOpacity };
-		}
-	`
-		: '';
-
-	const opacityClass = 'preview-opacity';
-
-	const renderedBlocks = useMemo(
-		() =>
-			blocks.map( ( block ) => {
-				if (
-					! isHighlighting ||
-					block.clientId === highlightedBlockClientId
-				) {
-					return {
-						...block,
-						attributes: {
-							...block.attributes,
-							className: block.attributes.className?.replace(
-								opacityClass,
-								''
-							),
-						},
-					};
-				}
-
-				return {
-					...block,
-					attributes: {
-						...block.attributes,
-						className:
-							block.attributes.className + ` ${ opacityClass }`,
-					},
-				};
-			} ),
-		[ blocks, highlightedBlockClientId, isHighlighting ]
-	);
-
-	return (
-		<div className="woocommerce-customize-store__block-editor">
-			<div className={ 'woocommerce-block-preview-container' }>
-				<BlockPreview
-					blocks={ renderedBlocks }
-					onChange={
-						// We need to pass onChange for the logo screen so that logo block can be updated when we change the logo attributes in logo sidebar navigation screen component.
-						// We also need to pass onChange for the assembler hub screen so when a block set an attribute during the block initialization, the block editor will be updated.
-						// We also need to pass onChange when the homepage pattern is updated because the Product Collection block sets a dynamic attribute and we need to update the block editor.
-						// For other screens, we don't need to pass onChange. Otherwise, we'll get a race condition issue where the block editor will be updated twice: once from the onChange in the sidebar component, and once from the onChange in the block editor component.
-						[
-							'/customize-store/assembler-hub/logo',
-							'/customize-store/assembler-hub/homepage',
-							'/customize-store/assembler-hub',
-						].includes( urlParams.path )
-							? onChange
-							: undefined
-					}
-					settings={ settings }
-					additionalStyles={ additionalStyles }
-					isNavigable={ false }
-					isScrollable={
-						// Disable scrollable for transitional screen
-						! (
-							typeof currentState === 'object' &&
-							currentState.transitionalScreen === 'transitional'
-						)
-					}
-					onClickNavigationItem={ onClickNavigationItem }
-					// Don't use sub registry so that we can get the logo block from the main registry on the logo sidebar navigation screen component.
-					useSubRegistry={ false }
-					autoScale={ false }
-					setLogoBlockContext={ true }
-					CustomIframeComponent={ Iframe }
-				/>
+export const BlockEditor = memo(
+	( {
+		renderedBlocks,
+		settings,
+		additionalStyles,
+		isScrollable,
+		onClickNavigationItem,
+		onChange,
+	}: {
+		renderedBlocks: BlockInstance[];
+		settings: Record< string, unknown > & {
+			styles: string[];
+		};
+		additionalStyles: string;
+		isScrollable: boolean;
+		onClickNavigationItem: ( event: MouseEvent ) => void;
+		onChange: ChangeHandler;
+	} ) => {
+		return (
+			<div className="woocommerce-customize-store__block-editor">
+				<div className={ 'woocommerce-block-preview-container' }>
+					<BlockPreview
+						blocks={ renderedBlocks }
+						onChange={ onChange }
+						settings={ settings }
+						additionalStyles={ additionalStyles }
+						isNavigable={ false }
+						isScrollable={ isScrollable }
+						onClickNavigationItem={ onClickNavigationItem }
+						// Don't use sub registry so that we can get the logo block from the main registry on the logo sidebar navigation screen component.
+						useSubRegistry={ false }
+						autoScale={ false }
+						setLogoBlockContext={ true }
+						CustomIframeComponent={ Iframe }
+					/>
+				</div>
 			</div>
-		</div>
-	);
-};
+		);
+	}
+);

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/editor.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/editor.tsx
@@ -5,7 +5,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useEffect, useMemo } from '@wordpress/element';
+import { StrictMode, useEffect, useMemo } from '@wordpress/element';
 // @ts-ignore No types for this exist yet.
 import { InterfaceSkeleton } from '@wordpress/interface';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -23,8 +23,8 @@ import { GlobalStylesRenderer } from '@wordpress/edit-site/build-module/componen
 /**
  * Internal dependencies
  */
-import { BlockEditor } from './block-editor';
 import { editorIsLoaded } from '../utils';
+import { BlockEditorContainer } from './block-editor-container';
 
 export const Editor = ( { isLoading }: { isLoading: boolean } ) => {
 	const { context, hasPageContentFocus } = useSelect( ( select ) => {
@@ -84,7 +84,7 @@ export const Editor = ( { isLoading }: { isLoading: boolean } ) => {
 					content={
 						<>
 							<GlobalStylesRenderer />
-							<BlockEditor />
+							<BlockEditorContainer />
 						</>
 					}
 				/>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/editor.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/editor.tsx
@@ -5,7 +5,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { StrictMode, useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 // @ts-ignore No types for this exist yet.
 import { InterfaceSkeleton } from '@wordpress/interface';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -143,6 +143,7 @@ export const Layout = () => {
 	}
 
 	return (
+		// This causes the editor to re-render when the logo block ids change. Maybe we can find a better way to do this.
 		<LogoBlockContext.Provider
 			value={ {
 				logoBlockIds,

--- a/plugins/woocommerce/changelog/45458-45420-cys-headerfooter-pattern-arent-rendered-on-the-live-preview
+++ b/plugins/woocommerce/changelog/45458-45420-cys-headerfooter-pattern-arent-rendered-on-the-live-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - reduce editor instance re-render.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45420.
Partially fixes #45448.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

This PR request aims to optimize the block editor by minimizing unnecessary re-renders. The current issue involves suboptimal performance and the occurrence of unexpected bugs, mainly due to the block repeatedly re-instantiating itself. In response, I've refactored the code by centralizing the logic within a parent component, effectively streamlining the block editor component and enhancing overall efficiency. This change is crucial for maintaining a smoother editing experience and addressing potential issues stemming from excessive re-renders.

I think that there is space for more optimization, but at least for now, I don't think that it is worth spending time on it!



| Before | After |
|--------|--------|
|<video src=https://github.com/woocommerce/woocommerce/assets/4463174/d6ae11d6-910a-42d2-a643-4bc39c726f89 /> | <video src=https://github.com/woocommerce/woocommerce/assets/4463174/9f01de92-ce43-4344-b62e-57a7fbe2161f /> | 

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Ensure the WooCommerce Beta Tester plugin is installed and activated (available on this monorepo).
3. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
4. Install the last version of Gutenberg.
5. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
10. Open the network tools.
11. Disable the cache.
12. Follow the process.
13. Switch the header/footer patterns fastly (check #45420 to understand the issue)
14. Ensure that the pattern is still visible.
15. Click Done. You'll land on this URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
16. Access it again and click Done.
17. You'll land on this URL `/wp-admin/admin.php?page=wc-admin&customizing=true&path=%2Fcustomize-store%2Ftransitional`.
18. Ensure that the the transitional page is visible. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - reduce editor instance re-render.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>