### PR TITLE
Add support for FI and SE postcode validation + Update tests

### DIFF
--- a/plugins/woocommerce/changelog/feature-postcode-validation
+++ b/plugins/woocommerce/changelog/feature-postcode-validation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for FI and SE postcode validation

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -70,6 +70,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^(DK-)?([1-24-9]\d{3}|3[0-8]\d{2})$/', $postcode );
 				break;
 			case 'ES':
+			case 'FI':
 			case 'FR':
 			case 'IT':
 				$valid = (bool) preg_match( '/^([0-9]{5})$/i', $postcode );
@@ -101,6 +102,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^([0-9]{2})([-])([0-9]{3})$/', $postcode );
 				break;
 			case 'CZ':
+			case 'SE':
 			case 'SK':
 				$valid = (bool) preg_match( "/^($country-)?([0-9]{3})(\s?)([0-9]{2})$/", $postcode );
 				break;

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -71,6 +71,7 @@ class WC_Validation {
 				break;
 			case 'ES':
 			case 'FI':
+			case 'EE':			
 			case 'FR':
 			case 'IT':
 				$valid = (bool) preg_match( '/^([0-9]{5})$/i', $postcode );

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -71,7 +71,7 @@ class WC_Validation {
 				break;
 			case 'ES':
 			case 'FI':
-			case 'EE':			
+			case 'EE':
 			case 'FR':
 			case 'IT':
 				$valid = (bool) preg_match( '/^([0-9]{5})$/i', $postcode );

--- a/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
@@ -18,7 +18,22 @@ class WC_Validation_Test extends \WC_Unit_Test_Case {
 			array( true, 'CZ-115 03', 'CZ' ),
 		);
 
-		return array_merge( $cz );
+		$se = array(
+			array( true, '123 45', 'SE' ),
+			array( true, '12345', 'SE' ),
+			array( false, '12 345', 'SE' ),
+			array( false, 'ABC 45', 'SE' ),
+		);
+
+		$li = array(
+			array( true, '9482', 'LI' ),
+			array( true, '9495', 'LI' ),
+			array( false, '8512', 'LI' ),
+			array( false, '0123', 'LI' ),
+			array( false, '948A', 'LI' ),
+		);
+
+		return array_merge( $cz, $se, $li );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- #### Add support for FI and SE postcode validation
- #### Add tests for SE and LI postcode validation

**Note:** This will also test CZ and SK postcodes as they use the same format as SE.

**Note:** Tests for FI already exist in legacy test class `WC_Tests_Validation::data_provider_test_is_postcode` as FI has the same format as IT.

**Question:** Should all postcodes formatted with `wc_format_postcode` pass validation?
I added support for ISO 3166-1-alpha-2 prefixes to some postcodes in this PR: https://github.com/woocommerce/woocommerce/pull/45478. I've yet to add support for validating them to this PR. Should I?

##### Documentation on the updated formats:

###### Sweden
https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/sweEn.pdf
https://en.wikipedia.org/wiki/Postal_codes_in_Sweden
`NNN NN`

###### Finland
https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/finEn.pdf
https://en.wikipedia.org/wiki/Postal_codes_in_Finland
`NNNNN`

###### Estonia
https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/estEn.pdf
`NNNNN`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Run tests `WC_Validation_Test`
2. Run legacy tests `WC_Tests_Validation`

Additionally, this PR can also be tested by doing checkout with the following countries:

1. Checkout an order with a six-digit PIN code, and the country selected is Finland, Estonia, or Sweden. You won't be able to checkout. 
2. Update the pincode to be 5 digits. This time you will be able to checkout.
