### PR TITLE
Show the "Design your own" banner when editing a theme which is not TT4

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -306,6 +306,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 									target: 'success',
 									actions: [
 										'assignThemeData',
+										'assignActiveTheme',
 										'assignCustomizeStoreCompleted',
 										'assignCurrentThemeIsAiGenerated',
 									],

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -36,6 +36,20 @@ export const assignThemeData = assign<
 	},
 } );
 
+export const assignActiveTheme = assign<
+	customizeStoreStateMachineContext,
+	customizeStoreStateMachineEvents
+>( {
+	intro: ( context, event ) => {
+		const activeTheme = (
+			event as DoneInvokeEvent< {
+				activeTheme: string;
+			} >
+		 ).data.activeTheme;
+		return { ...context.intro, activeTheme };
+	},
+} );
+
 export const recordTracksDesignWithAIClicked = () => {
 	recordEvent( 'customize_your_store_intro_design_with_ai_click' );
 };

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
 import interpolateComponents from '@automattic/interpolate-components';

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -75,6 +75,7 @@ type ModalStatus = keyof typeof MODAL_COMPONENTS;
 export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 	const {
 		intro: {
+			activeTheme,
 			themeData,
 			customizeStoreTaskCompleted,
 			currentThemeIsAiGenerated,
@@ -96,14 +97,7 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 	let modalStatus: ModalStatus = 'no-modal';
 	let bannerStatus: BannerStatus = 'default';
 
-	interface Theme {
-		stylesheet?: string;
-	}
-
-	const currentTheme = useSelect( ( select ) => {
-		return select( 'core' ).getCurrentTheme() as Theme;
-	}, [] );
-	const isDefaultTheme = currentTheme?.stylesheet === 'twentytwentyfour';
+	const isDefaultTheme = activeTheme === 'twentytwentyfour';
 
 	switch ( true ) {
 		case isNetworkOffline:

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -100,9 +100,9 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 		stylesheet?: string;
 	}
 
-	const currentTheme = useSelect((select) => {
-		return select('core').getCurrentTheme() as Theme;
-	}, []);
+	const currentTheme = useSelect( ( select ) => {
+		return select( 'core' ).getCurrentTheme() as Theme;
+	}, [] );
 	const isDefaultTheme = currentTheme?.stylesheet === 'twentytwentyfour';
 
 	switch ( true ) {
@@ -116,7 +116,9 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 			! customizeStoreTaskCompleted:
 			bannerStatus = FlowType.noAI;
 			break;
-		case context.flowType === FlowType.noAI && customizeStoreTaskCompleted && !isDefaultTheme:
+		case context.flowType === FlowType.noAI &&
+			customizeStoreTaskCompleted &&
+			! isDefaultTheme:
 			bannerStatus = FlowType.noAI;
 			break;
 		case context.flowType === FlowType.noAI && customizeStoreTaskCompleted:

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
 import interpolateComponents from '@automattic/interpolate-components';
@@ -95,6 +96,15 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 	let modalStatus: ModalStatus = 'no-modal';
 	let bannerStatus: BannerStatus = 'default';
 
+	interface Theme {
+		stylesheet?: string;
+	}
+
+	const currentTheme = useSelect((select) => {
+		return select('core').getCurrentTheme() as Theme;
+	}, []);
+	const isDefaultTheme = currentTheme?.stylesheet === 'twentytwentyfour';
+
 	switch ( true ) {
 		case isNetworkOffline:
 			bannerStatus = 'network-offline';
@@ -104,6 +114,9 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 			break;
 		case context.flowType === FlowType.noAI &&
 			! customizeStoreTaskCompleted:
+			bannerStatus = FlowType.noAI;
+			break;
+		case context.flowType === FlowType.noAI && customizeStoreTaskCompleted && !isDefaultTheme:
 			bannerStatus = FlowType.noAI;
 			break;
 		case context.flowType === FlowType.noAI && customizeStoreTaskCompleted:

--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -4,7 +4,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * External dependencies
  */
-import { resolveSelect } from '@wordpress/data';
+import { resolveSelect, useSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -105,9 +105,16 @@ export const fetchIntroData = async () => {
 
 	const customizeStoreTaskCompleted = task?.isComplete;
 
+	interface Theme {
+		stylesheet?: string;
+	}
+
+	const theme = ( await resolveSelect( 'core' ).getCurrentTheme() ) as Theme;
+
 	return {
 		customizeStoreTaskCompleted,
 		themeData,
+		activeTheme: theme.stylesheet || '',
 		currentThemeIsAiGenerated,
 	};
 };

--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -4,7 +4,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * External dependencies
  */
-import { resolveSelect, useSelect } from '@wordpress/data';
+import { resolveSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
 

--- a/plugins/woocommerce/changelog/45481-44725-add-customize-button-modal-2
+++ b/plugins/woocommerce/changelog/45481-44725-add-customize-button-modal-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+CYS - Show the "Design your own" banner when editing a different theme than TT4 in the CYS flow.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the "switch theme warning modal" to the `Edit your custom theme` Intro page. The modal will only show when the active theme is NOT Twenty Twenty Four.

Closes https://github.com/woocommerce/woocommerce/issues/44725

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the `WooCommerce Beta Tester` plugin is installed and activated (available on this monorepo).
2. Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag.
3. Click on `Tools` and run the `Reset Customize Your Store` and the `Delete all products` commands.
5. Enable the TT4 theme.
6. Switch to another block theme.
7. Visit the `wp-admin/admin.php?page=wc-admin&path=/customize-store`.
8. Make sure you see the `Design your own` banner.
9. Click on the `Start designing` button.
10. Make sure you see this modal.
<img width="392" alt="Screenshot 2024-03-08 at 15 26 45" src="https://github.com/woocommerce/woocommerce/assets/186112/5fadff6f-1b45-456b-abb6-a5698d6f3a62">

11. Check that clicking `Cancel` closes the modal.
12. Check that clicking on `Design a new theme` goes through the flow to the assembler.
13. Make sure the theme is switched to TT4.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Show the "Design your own" banner when editing a different theme than TT4 in the CYS flow.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
