### PR TITLE
Add Custom Fields for New Product Editor

### DIFF
--- a/packages/js/product-editor/changelog/add-44169-create
+++ b/packages/js/product-editor/changelog/add-44169-create
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Custom Fields for New Product Editor

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/edit.tsx
@@ -7,6 +7,7 @@ import { useWooBlockProps } from '@woocommerce/block-templates';
 /**
  * Internal dependencies
  */
+import { SectionActions } from '../../../components/block-slot-fill';
 import { CustomFields } from '../../../components/custom-fields';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { CustomFieldsBlockAttributes } from './types';
@@ -18,7 +19,11 @@ export function Edit( {
 
 	return (
 		<div { ...blockProps }>
-			<CustomFields />
+			<CustomFields
+				renderActionButtonsWrapper={ ( buttons ) => (
+					<SectionActions>{ buttons }</SectionActions>
+				) }
+			/>
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -1,0 +1,266 @@
+/**
+ * External dependencies
+ */
+import { Button, Modal } from '@wordpress/components';
+import { createElement, useState, useRef, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+import classNames from 'classnames';
+import type { FocusEvent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { TextControl } from '../../text-control';
+import type { Metadata } from '../../../types';
+import type { CreateModalProps } from './types';
+
+function validateName( value: string ) {
+	if ( ! value ) {
+		return __( 'The name is required.', 'woocommerce' );
+	}
+
+	if ( value.startsWith( '_' ) ) {
+		return __(
+			'The name cannot begin with the underscore (_) character.',
+			'woocommerce'
+		);
+	}
+}
+
+function validateValue( value: string ) {
+	if ( ! value ) {
+		return __( 'The value is required.', 'woocommerce' );
+	}
+}
+
+const DEFAULT_CUSTOM_FIELD = {
+	id: 1,
+	key: '',
+	value: '',
+} satisfies Metadata< string >;
+
+type ValidationErrors = {
+	[ id: string ]:
+		| {
+				name?: string;
+				value?: string;
+		  }
+		| undefined;
+};
+
+export function CreateModal( {
+	onCreate,
+	onCancel,
+	...props
+}: CreateModalProps ) {
+	const [ customFields, setCustomFields ] = useState< Metadata< string >[] >(
+		[ DEFAULT_CUSTOM_FIELD ]
+	);
+	const [ validationError, setValidationError ] =
+		useState< ValidationErrors >( {} );
+	const inputRefs = useRef< Record< string, HTMLInputElement | null > >( {} );
+
+	useEffect( function focusFirstNameInputOnMount() {
+		inputRefs.current[ `name${ DEFAULT_CUSTOM_FIELD.id }` ]?.focus();
+	}, [] );
+
+	function nameChangeHandler( customField: Metadata< string > ) {
+		return function handleNameChange( key: string ) {
+			setCustomFields( ( current ) =>
+				current.map( ( field ) =>
+					field.id === customField.id ? { ...field, key } : field
+				)
+			);
+		};
+	}
+
+	function nameBlurHandler( customField: Metadata< string > ) {
+		return function handleNameBlur(
+			event: FocusEvent< HTMLInputElement >
+		) {
+			const error = validateName( event.target.value );
+			setValidationError( ( current ) => ( {
+				...current,
+				[ `${ customField.id }` ]: {
+					name: error,
+					value: current?.[ `${ customField.id }` ]?.value,
+				},
+			} ) );
+		};
+	}
+
+	function valueChangeHandler( customField: Metadata< string > ) {
+		return function handleValueChange( value: string ) {
+			setCustomFields( ( current ) =>
+				current.map( ( field ) =>
+					field.id === customField.id ? { ...field, value } : field
+				)
+			);
+		};
+	}
+
+	function valueBlurHandler( customField: Metadata< string > ) {
+		return function handleValueBlur(
+			event: FocusEvent< HTMLInputElement >
+		) {
+			const error = validateValue( event.target.value );
+			setValidationError( ( current ) => ( {
+				[ `${ customField.id }` ]: {
+					name: current?.[ `${ customField.id }` ]?.name,
+					value: error,
+				},
+			} ) );
+		};
+	}
+
+	function removeCustomFieldButtonClickHandler(
+		customField: Metadata< string >
+	) {
+		if ( customFields.length <= 1 ) {
+			return undefined;
+		}
+
+		return function handleRemoveCustomFieldButtonClick() {
+			setCustomFields( ( current ) =>
+				current.filter( ( { id } ) => customField.id !== id )
+			);
+			setValidationError( ( current ) => ( {
+				...current,
+				[ `${ customField.id }` ]: undefined,
+			} ) );
+		};
+	}
+
+	function handleAddAnotherButtonClick() {
+		setCustomFields( ( current ) => {
+			const lastField = current[ current.length - 1 ];
+			return [
+				...current,
+				{ ...DEFAULT_CUSTOM_FIELD, id: ( lastField.id ?? 0 ) + 1 },
+			];
+		} );
+	}
+
+	function handleAddButtonClick() {
+		const { errors, hasErrors } = customFields.reduce(
+			( prev, customField ) => {
+				const errors = {
+					name: validateName( customField.key ),
+					value: validateValue( customField.value ?? '' ),
+				};
+				prev.errors[ `${ customField.id }` ] = errors;
+
+				if ( errors.name ) {
+					if ( ! prev.hasErrors ) {
+						inputRefs.current[ `name${ customField.id }` ]?.focus();
+					}
+					prev.hasErrors = true;
+				}
+
+				if ( errors.value ) {
+					if ( ! prev.hasErrors ) {
+						inputRefs.current[
+							`value${ customField.id }`
+						]?.focus();
+					}
+					prev.hasErrors = true;
+				}
+
+				return prev;
+			},
+			{ errors: {} as ValidationErrors, hasErrors: false }
+		);
+
+		if ( hasErrors ) {
+			setValidationError( errors );
+			return;
+		}
+
+		onCreate(
+			customFields.map( ( { id, ...customField } ) => customField )
+		);
+	}
+
+	return (
+		<Modal
+			shouldCloseOnClickOutside={ false }
+			title={ __( 'Add custom fields', 'woocommerce' ) }
+			onRequestClose={ onCancel }
+			{ ...props }
+			className={ classNames(
+				'woocommerce-product-custom-fields__create-modal',
+				props.className
+			) }
+		>
+			<ul className="woocommerce-product-custom-fields__create-modal-list">
+				{ customFields.map( ( customField ) => (
+					<li
+						key={ customField.id }
+						className="woocommerce-product-custom-fields__create-modal-list-item"
+					>
+						<TextControl
+							ref={ ( element ) => {
+								inputRefs.current[ `name${ customField.id }` ] =
+									element;
+							} }
+							label={ __( 'Name', 'woocommerce' ) }
+							error={
+								validationError[ `${ customField.id }` ]?.name
+							}
+							value={ customField.key }
+							onChange={ nameChangeHandler( customField ) }
+							onBlur={ nameBlurHandler( customField ) }
+						/>
+
+						<TextControl
+							ref={ ( element ) => {
+								inputRefs.current[
+									`value${ customField.id }`
+								] = element;
+							} }
+							label={ __( 'Value', 'woocommerce' ) }
+							error={
+								validationError[ `${ customField.id }` ]?.value
+							}
+							value={ customField.value }
+							onChange={ valueChangeHandler( customField ) }
+							onBlur={ valueBlurHandler( customField ) }
+						/>
+
+						<Button
+							icon={ closeSmall }
+							disabled={ customFields.length <= 1 }
+							aria-label={ __(
+								'Remove custom field',
+								'woocommerce'
+							) }
+							onClick={ removeCustomFieldButtonClickHandler(
+								customField
+							) }
+						/>
+					</li>
+				) ) }
+			</ul>
+
+			<div className="woocommerce-product-custom-fields__create-modal-add-another">
+				<Button
+					variant="tertiary"
+					onClick={ handleAddAnotherButtonClick }
+				>
+					{ __( '+ Add another', 'woocommerce' ) }
+				</Button>
+			</div>
+
+			<div className="woocommerce-product-custom-fields__create-modal-actions">
+				<Button variant="secondary" onClick={ onCancel }>
+					{ __( 'Cancel', 'woocommerce' ) }
+				</Button>
+
+				<Button variant="primary" onClick={ handleAddButtonClick }>
+					{ __( 'Add', 'woocommerce' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -127,10 +127,10 @@ export function CreateModal( {
 	function handleAddButtonClick() {
 		const { errors, hasErrors } = customFields.reduce(
 			( prev, customField ) => {
-				const errors = validate( customField );
-				prev.errors[ String( customField.id ) ] = errors;
+				const _errors = validate( customField );
+				prev.errors[ String( customField.id ) ] = _errors;
 
-				if ( errors.key ) {
+				if ( _errors.key ) {
 					if ( ! prev.hasErrors ) {
 						inputRefs.current[
 							String( customField.id )
@@ -139,7 +139,7 @@ export function CreateModal( {
 					prev.hasErrors = true;
 				}
 
-				if ( errors.value ) {
+				if ( _errors.value ) {
 					if ( ! prev.hasErrors ) {
 						inputRefs.current[
 							String( customField.id )

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/index.ts
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/index.ts
@@ -1,0 +1,2 @@
+export * from './create-modal';
+export * from './types';

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
@@ -1,0 +1,34 @@
+.woocommerce-product-custom-fields__create-modal {
+	min-width: 75%;
+
+	&-list {
+		&-item {
+			display: flex;
+			gap: $grid-unit-20;
+			border-bottom: 1px solid $gray-200;
+			padding-top: $grid-unit-30;
+			padding-bottom: $grid-unit;
+			margin-bottom: 0;
+
+			&:first-child {
+				padding-top: 0;
+			}
+
+			.components-base-control {
+				width: 100%;
+			}
+
+			.components-button {
+				margin-top: 20px;
+			}
+		}
+	}
+
+	&-actions {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 12px;
+		margin-top: $grid-unit-40;
+	}
+}

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/types.ts
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { Modal } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { Metadata } from '../../../types';
+
+export type CreateModalProps = Omit<
+	Modal.Props,
+	'title' | 'onRequestClose' | 'children'
+> & {
+	onCreate( value: Metadata< string >[] ): void;
+	onCancel(): void;
+};

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -15,7 +15,11 @@ import { EmptyState } from './empty-state';
 import type { Metadata } from '../../types';
 import type { CustomFieldsProps } from './types';
 
-export function CustomFields( { className, ...props }: CustomFieldsProps ) {
+export function CustomFields( {
+	className,
+	renderActionButtonsWrapper = ( buttons ) => buttons,
+	...props
+}: CustomFieldsProps ) {
 	const { customFields, updateCustomField } = useCustomFields();
 	const [ selectedCustomField, setSelectedCustomField ] =
 		useState< Metadata< string > >();
@@ -43,6 +47,12 @@ export function CustomFields( { className, ...props }: CustomFieldsProps ) {
 
 	return (
 		<>
+			{ renderActionButtonsWrapper(
+				<Button variant="secondary">
+					{ __( 'Add new', 'woocommerce' ) }
+				</Button>
+			) }
+
 			<table
 				{ ...props }
 				className={ classNames(

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { useCustomFields } from '../../hooks/use-custom-fields';
+import { CreateModal } from './create-modal';
 import { EditModal } from './edit-modal';
 import { EmptyState } from './empty-state';
 import type { Metadata } from '../../types';
@@ -20,12 +21,19 @@ export function CustomFields( {
 	renderActionButtonsWrapper = ( buttons ) => buttons,
 	...props
 }: CustomFieldsProps ) {
-	const { customFields, updateCustomField } = useCustomFields();
+	const { customFields, addCustomFields, updateCustomField } =
+		useCustomFields();
+
+	const [ showCreateModal, setShowCreateModal ] = useState( false );
 	const [ selectedCustomField, setSelectedCustomField ] =
 		useState< Metadata< string > >();
 
 	if ( customFields.length === 0 ) {
 		return <EmptyState />;
+	}
+
+	function handleAddNewButtonClick() {
+		setShowCreateModal( true );
 	}
 
 	function customFieldEditButtonClickHandler(
@@ -34,6 +42,15 @@ export function CustomFields( {
 		return function handleCustomFieldEditButtonClick() {
 			setSelectedCustomField( customField );
 		};
+	}
+
+	function handleCreateModalCreate( value: Metadata< string >[] ) {
+		addCustomFields( value );
+		setShowCreateModal( false );
+	}
+
+	function handleCreateModalCancel() {
+		setShowCreateModal( false );
 	}
 
 	function handleEditModalUpdate( customField: Metadata< string > ) {
@@ -48,7 +65,7 @@ export function CustomFields( {
 	return (
 		<>
 			{ renderActionButtonsWrapper(
-				<Button variant="secondary">
+				<Button variant="secondary" onClick={ handleAddNewButtonClick }>
 					{ __( 'Add new', 'woocommerce' ) }
 				</Button>
 			) }
@@ -93,6 +110,13 @@ export function CustomFields( {
 					) ) }
 				</tbody>
 			</table>
+
+			{ showCreateModal && (
+				<CreateModal
+					onCreate={ handleCreateModalCreate }
+					onCancel={ handleCreateModalCancel }
+				/>
+			) }
 
 			{ selectedCustomField && (
 				<EditModal

--- a/packages/js/product-editor/src/components/custom-fields/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/style.scss
@@ -1,5 +1,6 @@
-@import "./empty-state/style.scss";
+@import "./create-modal/style.scss";
 @import "./edit-modal/style.scss";
+@import "./empty-state/style.scss";
 
 .woocommerce-product-custom-fields {
 	&__table {

--- a/packages/js/product-editor/src/components/custom-fields/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/types.ts
@@ -1,4 +1,6 @@
 export type CustomFieldsProps = React.DetailedHTMLProps<
 	React.TableHTMLAttributes< HTMLTableElement >,
 	HTMLTableElement
->;
+> & {
+	renderActionButtonsWrapper?( buttons: React.ReactNode ): React.ReactNode;
+};

--- a/packages/js/product-editor/src/components/custom-fields/utils/validations/index.ts
+++ b/packages/js/product-editor/src/components/custom-fields/utils/validations/index.ts
@@ -1,0 +1,2 @@
+export * from './validate';
+export * from './types';

--- a/packages/js/product-editor/src/components/custom-fields/utils/validations/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/utils/validations/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import type { Metadata } from '../../../../types';
+
+export type ValidationError = Record< keyof Metadata< string >, string >;
+
+export type ValidationErrors = {
+	[ id: string ]: ValidationError | undefined;
+};

--- a/packages/js/product-editor/src/components/custom-fields/utils/validations/validate.ts
+++ b/packages/js/product-editor/src/components/custom-fields/utils/validations/validate.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { Metadata } from '../../../../types';
+import type { ValidationError } from './types';
+
+export function validate(
+	customField: Partial< Metadata< string > >
+): ValidationError {
+	const errors = {} as ValidationError;
+
+	if ( ! customField.key ) {
+		errors.key = __( 'The name is required.', 'woocommerce' );
+	} else if ( customField.key.startsWith( '_' ) ) {
+		errors.key = __(
+			'The name cannot begin with the underscore (_) character.',
+			'woocommerce'
+		);
+	}
+
+	if ( ! customField.value ) {
+		errors.value = __( 'The value is required.', 'woocommerce' );
+	}
+
+	return errors;
+}

--- a/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
@@ -37,6 +37,10 @@ export function useCustomFields<
 		setMetas( [ ...internalMetas, ...newValue ] );
 	}
 
+	function addCustomFields( value: T[] ) {
+		setCustomFields( ( current ) => [ ...current, ...value ] );
+	}
+
 	function updateCustomField( customField: T ) {
 		setCustomFields( ( current ) =>
 			current.map( ( field ) => {
@@ -48,5 +52,10 @@ export function useCustomFields<
 		);
 	}
 
-	return { customFields, setCustomFields, updateCustomField };
+	return {
+		customFields,
+		addCustomFields,
+		setCustomFields,
+		updateCustomField,
+	};
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44169

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` > `Add new`
4. Under the `Organization` tab turn on the `Show custom fields` toggle to see the `Custom fields` section
5. At the right side of the `Custom fields` title a new `Add new` button should be shown 
<img width="703" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/b4e56e9c-d86f-4880-888d-a4212d6a429d">

6. When clicking it a new `Add custom fields` modal should be shown so you can add one or many custom fields 
<img width="777" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/cc0cbd66-6f7b-47d6-a9f3-434880a538d3">

7. Clicking the `+ Add another` button should add another row of `Name`, `Value` fields corresponding to the new custom field.
8. Clicking `Add` button will add all custom fields to the table and hide the modal
9. Clicking `Cancel` only hides the modal

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
