### PR TITLE
Product Editor: Handle loading of product editor when global settings are not available on initial render

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-loading-global
+++ b/packages/js/product-editor/changelog/fix-product-editor-loading-global
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+BlockEditor loads global settings itself instead of having them passed in. Handles case where global is set after initial render.

--- a/packages/js/product-editor/src/components/block-editor/types.ts
+++ b/packages/js/product-editor/src/components/block-editor/types.ts
@@ -6,12 +6,10 @@
  * Internal dependencies
  */
 import { ProductEditorContext } from '../../types';
-import { ProductEditorSettings } from '../editor';
 
 export type BlockEditorProps = {
 	context: Partial< ProductEditorContext >;
 	postType: string;
 	productId: number;
-	settings?: ProductEditorSettings;
 	setIsEditorLoading: ( isEditorLoading: boolean ) => void;
 };

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -37,11 +37,7 @@ import { EditorProps } from './types';
 import { store as productEditorUiStore } from '../../store/product-editor-ui';
 import { PrepublishPanel } from '../prepublish-panel/prepublish-panel';
 
-export function Editor( {
-	product,
-	productType = 'product',
-	settings,
-}: EditorProps ) {
+export function Editor( { product, productType = 'product' }: EditorProps ) {
 	const [ isEditorLoading, setIsEditorLoading ] = useState( true );
 	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
 
@@ -77,7 +73,6 @@ export function Editor( {
 									content={
 										<>
 											<BlockEditor
-												settings={ settings }
 												postType={ productType }
 												productId={ productId }
 												context={ {

--- a/packages/js/product-editor/src/components/editor/types.ts
+++ b/packages/js/product-editor/src/components/editor/types.ts
@@ -31,5 +31,4 @@ export type ProductEditorSettings = Partial<
 export type EditorProps = {
 	product?: Pick< Product, 'id' | 'type' > | null;
 	productType?: string;
-	settings?: ProductEditorSettings;
 };

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -5,7 +5,6 @@ import {
 	__experimentalEditor as Editor,
 	__experimentalInitBlocks as initBlocks,
 	__experimentalWooProductMoreMenuItem as WooProductMoreMenuItem,
-	ProductEditorSettings,
 	productApiFetchMiddleware,
 	TRACKS_SOURCE,
 	__experimentalProductMVPCESFooter as FeedbackBar,
@@ -25,8 +24,6 @@ import { useProductEntityRecord } from './hooks/use-product-entity-record';
 import BlockEditorTourWrapper from './tour/block-editor/block-editor-tour-wrapper';
 import { MoreMenuFill } from './fills/product-block-editor-fills';
 import './product-page.scss';
-
-declare const productBlockEditorSettings: ProductEditorSettings;
 
 productApiFetchMiddleware();
 
@@ -100,10 +97,7 @@ export default function ProductPage() {
 
 	return (
 		<>
-			<Editor
-				product={ product }
-				settings={ productBlockEditorSettings || {} }
-			/>
+			<Editor product={ product } />
 		</>
 	);
 }

--- a/plugins/woocommerce-admin/client/products/product-variation-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-page.tsx
@@ -5,7 +5,6 @@ import {
 	__experimentalEditor as Editor,
 	__experimentalInitBlocks as initBlocks,
 	__experimentalWooProductMoreMenuItem as WooProductMoreMenuItem,
-	ProductEditorSettings,
 	productApiFetchMiddleware,
 	TRACKS_SOURCE,
 	__experimentalVariationSwitcherFooter as VariationSwitcherFooter,
@@ -24,8 +23,6 @@ import { MoreMenuFill } from './fills/product-block-editor-fills';
 import { useProductVariationEntityRecord } from './hooks/use-product-variation-entity-record';
 import { DeleteVariationMenuItem } from './fills/more-menu-items';
 import './product-page.scss';
-
-declare const productBlockEditorSettings: ProductEditorSettings;
 
 productApiFetchMiddleware();
 
@@ -81,11 +78,7 @@ export default function ProductPage() {
 
 	return (
 		<>
-			<Editor
-				product={ variation }
-				productType="product_variation"
-				settings={ productBlockEditorSettings || {} }
-			/>
+			<Editor product={ variation } productType="product_variation" />
 			<WooFooterItem order={ 0 }>
 				<>
 					<VariationSwitcherFooter

--- a/plugins/woocommerce/changelog/fix-product-editor-loading-global
+++ b/plugins/woocommerce/changelog/fix-product-editor-loading-global
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor pages do not pass global settings into Editor. Product Editor is responsible for loading settings itself.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR moves the accessing of the global `window.productBlockEditorSettings` object from the product pages to the `BlockEditor` component itself, and also puts in place handling to account for timing issues where the global may not be set when the `BlockEditor` is initially rendered.

As mentioned in #45461, we have seen intermittent issues on Woo Express sites where the product editor would fail to load because of this. Sometimes, simply refreshing the page would fix the issue. It is believed that this issue is *not* specific to Woo Express, and this may have even been seen locally in a dev environment once before this issue was explicitly known.

Closes #45461.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Verify the product editor loads.
3. Refresh the page.
4. Verify the product editor loads.
5. Try refreshing again and again.
6. Try activating/deactivating additional plugins, especially the WooCommerce Beta Tester, to try and see if you can trigger the loading failure. Unfortunately, this is a timing issue and is not 100% reproducible, so it is difficult to verify with 100% certainty that it is fixed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
