### PR TITLE
exclude gglobalstep from community contributors automation

### DIFF
--- a/.github/workflows/scripts/is-community-contributor.js
+++ b/.github/workflows/scripts/is-community-contributor.js
@@ -6,7 +6,7 @@ const core = require( '@actions/core' );
 // this won't work.
 const octokit = new Octokit();
 
-const ignoredUsernames = [ 'dependabot[bot]' ];
+const ignoredUsernames = [ 'dependabot[bot]', 'gglobalstep' ];
 const checkIfIgnoredUsername = ( username ) =>
 	ignoredUsernames.includes( username );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds [Global Step](https://github.com/gglobalstep) to the list of users excluded from the community contributor labeling automation.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Compare username & code review.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
