### PR TITLE
Task List: Avoid fetching tasks on non-visible lists

### DIFF
--- a/plugins/woocommerce/changelog/45498-fix-task-list-data
+++ b/plugins/woocommerce/changelog/45498-fix-task-list-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix previously unreleased change
+

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -740,14 +740,6 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$lists = is_array( $task_list_ids ) && count( $task_list_ids ) > 0 ? TaskLists::get_lists_by_ids( $task_list_ids ) : TaskLists::get_lists();
 
-		// We have no use for hidden lists, it's expensive to compute individual tasks completion.
-		$lists = array_filter(
-			$lists,
-			function( $list ) {
-				return ! $list->is_hidden();
-			}
-		);
-
 		$json = array_map(
 			function( $list ) {
 				return $list->sort_tasks()->get_json();

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -414,10 +414,14 @@ class TaskList {
 	public function get_json() {
 		$this->possibly_track_completion();
 		$tasks_json = array();
-		foreach ( $this->tasks as $task ) {
-			$json = $task->get_json();
-			if ( $json['canView'] ) {
-				$tasks_json[] = $json;
+
+		// We have no use for hidden lists, it's expensive to compute individual tasks completion.
+		if ( $this->is_visible() ) {
+			foreach ( $this->tasks as $task ) {
+				$json = $task->get_json();
+				if ( $json['canView'] ) {
+					$tasks_json[] = $json;
+				}
 			}
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
@@ -57,12 +57,15 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 		$this->assertNotEmpty( TaskLists::get_list( 'test' ) );
 	}
 
+	/**
+	 * Tests that hidden task lists don't return their tasks.
+	 */
 	public function test_tasklists_get_json_hidden_list() {
 		// Create a new task list.
 		$task_list = new TaskList(
 			array(
-				'id'       => 'test',
-				'title'    => 'Test',
+				'id'    => 'test',
+				'title' => 'Test',
 			)
 		);
 
@@ -70,11 +73,11 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 		$task = new TestTask(
 			$task_list,
 			array(
-				'id'       => 'wc-unit-test_tasklists_get_json_hidden_list',
+				'id' => 'wc-unit-test_tasklists_get_json_hidden_list',
 			)
 		);
 
-		// Add task to task list
+		// Add task to task list.
 		$task_list->add_task( $task );
 
 		// Hide the task list.
@@ -90,12 +93,15 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 		$this->assertTrue( $json['isHidden'] );
 	}
 
+	/**
+	 * Tests that visible tasks do return their tasks.
+	 */
 	public function test_tasklists_get_json_visible_list() {
 		// Create a new task list.
 		$task_list = new TaskList(
 			array(
-				'id'       => 'test',
-				'title'    => 'Test',
+				'id'    => 'test',
+				'title' => 'Test',
 			)
 		);
 
@@ -103,14 +109,14 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 		$task = new TestTask(
 			$task_list,
 			array(
-				'id'       => 'wc-unit-test_tasklists_get_json_visible_list',
+				'id' => 'wc-unit-test_tasklists_get_json_visible_list',
 			)
 		);
 
-		// Add task to task list
+		// Add task to task list.
 		$task_list->add_task( $task );
 
-		// Make sure the list is visible
+		// Make sure the list is visible.
 		$task_list->unhide();
 
 		// Get the task list as JSON.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
@@ -56,4 +56,70 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 		// Assert that the new task list is added.
 		$this->assertNotEmpty( TaskLists::get_list( 'test' ) );
 	}
+
+	public function test_tasklists_get_json_hidden_list() {
+		// Create a new task list.
+		$task_list = new TaskList(
+			array(
+				'id'       => 'test',
+				'title'    => 'Test',
+			)
+		);
+
+		// Create a new task.
+		$task = new TestTask(
+			$task_list,
+			array(
+				'id'       => 'wc-unit-test_tasklists_get_json_hidden_list',
+			)
+		);
+
+		// Add task to task list
+		$task_list->add_task( $task );
+
+		// Hide the task list.
+		$task_list->hide();
+
+		// Get the task list as JSON.
+		$json = $task_list->get_json();
+
+		// Assert that the task list is empty because it is hidden.
+		$this->assertEmpty( $json['tasks'] );
+
+		// Assert list is hidden.
+		$this->assertTrue( $json['isHidden'] );
+	}
+
+	public function test_tasklists_get_json_visible_list() {
+		// Create a new task list.
+		$task_list = new TaskList(
+			array(
+				'id'       => 'test',
+				'title'    => 'Test',
+			)
+		);
+
+		// Create a new task.
+		$task = new TestTask(
+			$task_list,
+			array(
+				'id'       => 'wc-unit-test_tasklists_get_json_visible_list',
+			)
+		);
+
+		// Add task to task list
+		$task_list->add_task( $task );
+
+		// Make sure the list is visible
+		$task_list->unhide();
+
+		// Get the task list as JSON.
+		$json = $task_list->get_json();
+
+		// Assert that the task list has one task.
+		$this->assertCount( 1, $json['tasks'] );
+
+		// Assert we have the task we added.
+		$this->assertEquals( 'wc-unit-test_tasklists_get_json_visible_list', $json['tasks'][0]['id'] );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
@@ -26,6 +26,16 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tear down
+	 */
+	public function tearDown(): void {
+		TaskLists::clear_lists();
+		TaskLists::init_default_lists();
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Tests that the "woocommerce_admin_experimental_onboarding_tasklists" filter is able to append tasks to any tasklist.
 	 */
 	public function test_default_tasklists_can_be_add_by_onboarding_filter() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/44703

Changes in https://github.com/woocommerce/woocommerce/pull/44442 removed lists that were hidden from the response of `/onboarding/tasks` API endpoint in order to prevent fetching tasks that are not relevant. However, the UI still uses data about the list itself such as `isHidden`.

This PR skips fetching tasks when the list is not visible, but still returns data concerning the list itself.

The assumption is the tasks will not be required when not visible. Is there a scenario where this assumption fails?

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create JN test site.
4. Add some products and create an order.
5. Go to "Woocommerce > Home" page.
6. Click on ellipsis menu on Setup list.
7. Click on "Hide setup list"
8. Observe that you are able to see "Task Management Area" and "Store Management" panels.
9. Now reload the page.
10. Observe that, "Task Management Area" and "Store Management" panels appear again after reloading the page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Fix previously unreleased change
</details>
