### PR TITLE
Add a filter `woocommerce_admin_terms_metabox_datalimit` to change the data-limit value for the attributes term box

### DIFF
--- a/plugins/woocommerce/changelog/fix-37548
+++ b/plugins/woocommerce/changelog/fix-37548
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adding a filter to fix the 50 term limitation in product edit page

--- a/plugins/woocommerce/changelog/fix-37548
+++ b/plugins/woocommerce/changelog/fix-37548
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Adding a filter to fix the 50 term limitation in product edit page
+Add a filter to adjust the 50 terms limitation in the product edit page.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -37,11 +37,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				if ( 'select' === $attribute_taxonomy->attribute_type ) {
 					$attribute_orderby = ! empty( $attribute_taxonomy->attribute_orderby ) ? $attribute_taxonomy->attribute_orderby : 'name';
-					$term_limit = apply_filters('woocommerce_admin_terms_metabox_datalimit', 50);
+					/**
+					* Filter the length (number of terms) rendered in the list.
+					*
+					* @since 8.6.0
+					* @param int $term_limit The maximum number of terms to display in the list.
+					*/
+					$term_limit = absint( apply_filters( 'woocommerce_admin_terms_metabox_datalimit', 50 ) );
 					?>
 					<select multiple="multiple"
 							data-minimum_input_length="0"
-							data-limit="<?php echo esc_attr($term_limit); ?>" data-return_id="id"
+							data-limit="<?php echo esc_attr( $term_limit ); ?>" data-return_id="id"
 							data-placeholder="<?php esc_attr_e( 'Select values', 'woocommerce' ); ?>"
 							data-orderby="<?php echo esc_attr( $attribute_orderby ); ?>"
 							class="multiselect attribute_values wc-taxonomy-term-search"

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					/**
 					* Filter the length (number of terms) rendered in the list.
 					*
-					* @since 8.6.0
+					* @since 8.8.0
 					* @param int $term_limit The maximum number of terms to display in the list.
 					*/
 					$term_limit = absint( apply_filters( 'woocommerce_admin_terms_metabox_datalimit', 50 ) );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -37,10 +37,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				if ( 'select' === $attribute_taxonomy->attribute_type ) {
 					$attribute_orderby = ! empty( $attribute_taxonomy->attribute_orderby ) ? $attribute_taxonomy->attribute_orderby : 'name';
+					$term_limit = apply_filters('woocommerce_admin_terms_metabox_datalimit', 50);
 					?>
 					<select multiple="multiple"
 							data-minimum_input_length="0"
-							data-limit="50" data-return_id="id"
+							data-limit="<?php echo esc_attr($term_limit); ?>" data-return_id="id"
 							data-placeholder="<?php esc_attr_e( 'Select values', 'woocommerce' ); ?>"
 							data-orderby="<?php echo esc_attr( $attribute_orderby ); ?>"
 							class="multiselect attribute_values wc-taxonomy-term-search"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a copy of #41411. Based on [the discussion](https://github.com/woocommerce/woocommerce/pull/41411#issuecomment-1884009834) I preferred to take the PR over to get the CI checks sorted. All props to @Babylon1999. 

Closes #37548.

The current attribute term list in the product editor imposes a limitation of 50 terms creating inconvenience for merchants with attributes exceeding this limit. Consequently, they are unable to search for terms from the drop-down menu.

This proposed solution allows for a flexible adjustment of the term limit by introducing a filter, `woocommerce_admin_terms_metabox_datalimit`, which will allow to modify the data-limit variable. This approach eliminates the need to edit the plugin files directly, providing a more streamlined and customizable solution.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a product with 60 terms
2. If you check the drop-down list in All Product > Product > Attributes, it will be limited to 50
3. To increase the limit to 60 or more, add the following in the functions.php file:

```
function example_callback() {
    return 60;
}
add_filter( 'woocommerce_admin_terms_metabox_datalimit', 'example_callback' );
```

Testing instructions and PR description taken over from the original PR. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
