### PR TITLE
Add source property to legacy editor

### DIFF
--- a/plugins/woocommerce/changelog/dev-39449_add_source_prop_to_legacy_editor
+++ b/plugins/woocommerce/changelog/dev-39449_add_source_prop_to_legacy_editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add source property to legacy editor #45515

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -16,6 +16,12 @@ require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
  * This class adds actions to track usage of WooCommerce Products.
  */
 class WC_Products_Tracking {
+
+	/**
+	 * Tracks source.
+	 */
+	const TRACKS_SOURCE = 'product-legacy-editor';
+
 	/**
 	 * Init tracking.
 	 */
@@ -118,9 +124,13 @@ class WC_Products_Tracking {
 			return;
 		}
 
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
+		$source     = apply_filters( 'woocommerce_product_source', self::TRACKS_SOURCE );
 		$properties = array(
 			'product_id' => $product_id,
+			'source'     => $source,
 		);
+		/* phpcs: enable */
 
 		WC_Tracks::record_event( 'product_edit', $properties );
 	}
@@ -331,7 +341,7 @@ class WC_Products_Tracking {
 			'product_type_options' => $product_type_options_string,
 			'purchase_note'        => $product->get_purchase_note() ? 'yes' : 'no',
 			'sale_price'           => $product->get_sale_price() ? 'yes' : 'no',
-			'source'               => apply_filters( 'woocommerce_product_source', '' ),
+			'source'               => apply_filters( 'woocommerce_product_source', self::TRACKS_SOURCE ),
 			'short_description'    => $product->get_short_description() ? 'yes' : 'no',
 			'tags'                 => count( $product->get_tag_ids() ),
 			'upsells'              => ! empty( $product->get_upsell_ids() ) ? 'yes' : 'no',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a `source` property to the legacy editor Tracks event after publishing or updating a product.

Closes #39449.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In a brand new JN site, enable the legacy product editor.
2. Go to WooCommerce > Settings > Advanced > Woo.com and enable tracking.
3. Go to Products > Add New
4. Create a new product. Then, modify it and press `Update`.
5. Go to WooCommerce > Status > Logs
6. Select the `tracks` file and look for the events: `wcadmin_product_add_publish` and `wcadmin_product_edit`. They should send the prop `source` with the value `product-legacy-editor`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
