### PR TITLE
POC: Add block bindings API to single product image DO NOT MERGE

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
@@ -25,6 +25,8 @@ import {
  */
 import { DEFAULT_INNER_BLOCKS, ALLOWED_INNER_BLOCKS } from '../constants';
 import metadata from '../block.json';
+import { VARIATION_NAME as PRODUCT_TITLE_VARIATION_NAME } from '../../product-query/variations/elements/product-title';
+import { VARIATION_NAME as PRODUCT_SUMMARY_VARIATION_NAME } from '../../product-query/variations/elements/product-summary';
 
 interface LayoutEditorProps {
 	isLoading: boolean;
@@ -48,6 +50,74 @@ const LayoutEditor = ( {
 			false
 		);
 	}, [ clientId, replaceInnerBlocks ] );
+
+	const defaultTemplate = () => {
+		if ( ! isLoading && product ) {
+			return [
+				[
+					'core/columns',
+					{},
+					[
+						[
+							'core/column',
+							{},
+							[
+								[
+									'core/image',
+									{
+										url: product?.images[ 0 ].src,
+										metadata: {
+											bindings: {
+												url: {
+													source: 'woo/data-binding',
+													args: {
+														key: 'product',
+														postId: product.id,
+													},
+												},
+											},
+										},
+									},
+								],
+							],
+						],
+						[
+							'core/column',
+							{},
+							[
+								[
+									'core/post-title',
+									{
+										headingLevel: 2,
+										isLink: true,
+										__woocommerceNamespace:
+											PRODUCT_TITLE_VARIATION_NAME,
+									},
+								],
+								[
+									'woocommerce/product-rating',
+									{ isDescendentOfSingleProductBlock: true },
+								],
+								[
+									'woocommerce/product-price',
+									{ isDescendentOfSingleProductBlock: true },
+								],
+								[
+									'core/post-excerpt',
+									{
+										__woocommerceNamespace:
+											PRODUCT_SUMMARY_VARIATION_NAME,
+									},
+								],
+								[ 'woocommerce/add-to-cart-form' ],
+								[ 'woocommerce/product-meta' ],
+							],
+						],
+					],
+				],
+			];
+		}
+	};
 
 	return (
 		<InnerBlockLayoutContextProvider
@@ -82,7 +152,7 @@ const LayoutEditor = ( {
 						value={ { postId: product?.id, postType: 'product' } }
 					>
 						<InnerBlocks
-							template={ DEFAULT_INNER_BLOCKS }
+							template={ defaultTemplate() }
 							allowedBlocks={ ALLOWED_INNER_BLOCKS }
 							templateLock={ false }
 						/>


### PR DESCRIPTION
This is a PoC code to demonstrate the use of the Block Bindings API on the Single Product Block (main image). It binds the URL attribute to a custom registered source.

### Test

Prereq:

Add this snippet of code to register the custom binding source:
```
add_action( 'init', 'woo_register_block_bindings' );

function woo_register_block_bindings() {
	register_block_bindings_source(
		'woo/data-binding',
		array(
			'label'              => __( 'Woo binding', 'woocommerce' ),
			'get_value_callback' => 'woo_bindings'
		)
	);
}
function woo_bindings( $source_args ) {
	if ( ! isset( $source_args['key'] )) {
		return false;
	}

	if ( 'product' === $source_args['key'] && isset( $source_args['postId'] ) ) {
		$product = wc_get_product( intval( $source_args['postId'] ) );

		return wp_get_attachment_image_url( $product->get_image_id(), 'full' );
	}

	return false;
}
```

Ensure you're running WP 6.5 nightly.

* Add a post and insert the Single Product block.
* Ensure you're seeing the correct image for the product you selected in the editor.
* Save and go to the frontend and ensure you're seeing the correct image for the product.