### PR TITLE
Handle taxes not being enabled and customized tax classes

### DIFF
--- a/packages/js/product-editor/changelog/add-43232
+++ b/packages/js/product-editor/changelog/add-43232
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create woocommerce/product-select-field block

--- a/packages/js/product-editor/src/blocks/generic/select/README.md
+++ b/packages/js/product-editor/src/blocks/generic/select/README.md
@@ -1,0 +1,98 @@
+# woocommerce/product-select-field
+
+A reusable select field for the product editor.
+
+## Attributes
+
+### label
+
+-   **Type:** `String`
+-   **Required:** `Yes`
+
+Label that appears on top of the field.
+
+### property
+
+-   **Type:** `String`
+-   **Required:** `Yes`
+
+Property in which the value is stored.
+
+### help
+
+-   **Type:** `String`
+-   **Required:** `No`
+
+Help text that appears below the field.
+
+### multiple
+
+-   **Type:** `Boolean`
+-   **Required:** `No`
+
+Indicates where the select is of multiple choices or not.
+
+### placeholder
+
+-   **Type:** `String`
+-   **Required:** `No`
+
+Placeholder text that appears in the field when it's empty.
+
+### disabled
+
+-   **Type:** `Boolean`
+-   **Required:** `No`
+
+Indicates and enforces that the field is disabled.
+
+### options
+
+-   **Type:** `Array`
+-   **Items:** `Object`
+    -   `value`
+        -   **Type:** `String`
+        -   **Required:** `Yes`
+    -   `label`
+        -   **Type:** `String`
+        -   **Required:** `Yes`
+    -   `disabled`
+        -   **Type:** `Boolean`
+        -   **Required:** `No`
+-   **Required:** `No`
+
+Refers to the options of the select field.
+
+## Usage
+
+Here's a snippet that adds tax classes as options to the
+single selection field:
+
+```php
+$section->add_block(
+  array(
+    'id'         => 'unique-block-id',
+    'blockName'  => 'woocommerce/product-select-field',
+    'order'      => 13,
+    'attributes' => array(
+      'label'    => 'Tax class',
+      'property' => 'tax_class',
+      'help'     => 'Apply a tax rate if this product qualifies for tax reduction or exemption.',
+      'options'  => array(
+        array(
+          'value' => 'Standard rate',
+          'label' => '',
+        ),
+        array(
+          'value' => 'Reduced rate',
+          'label' => 'reduced-rate',
+        ),
+        array(
+          'value' => 'Zero rate',
+          'label' => 'zero-rate',
+        ),
+      ),
+    ),
+  )
+);
+```

--- a/packages/js/product-editor/src/blocks/generic/select/block.json
+++ b/packages/js/product-editor/src/blocks/generic/select/block.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-select-field",
+	"title": "Product select field",
+	"category": "woocommerce",
+	"description": "A select field for use in the product editor.",
+	"keywords": [ "products", "select" ],
+	"textdomain": "default",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"property": {
+			"type": "string"
+		},
+		"placeholder": {
+			"type": "string"
+		},
+		"help": {
+			"type": "string"
+		},
+		"disabled": {
+			"type": "boolean"
+		},
+		"multiple": {
+			"type": "boolean",
+			"default": false
+		},
+		"options": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"label": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					},
+					"disabled": {
+						"type": "boolean",
+						"default": false
+					}
+				}
+			},
+			"default": []
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"usesContext": [ "postType" ]
+}

--- a/packages/js/product-editor/src/blocks/generic/select/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/select/edit.tsx
@@ -4,7 +4,6 @@
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { SelectControl } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/blocks/generic/select/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/select/edit.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { SelectControl } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useProductEntityProp from '../../../hooks/use-product-entity-prop';
+import { sanitizeHTML } from '../../../utils/sanitize-html';
+import type { ProductEditorBlockEditProps } from '../../../types';
+import type { SelectBlockAttributes } from './types';
+
+export function Edit( {
+	attributes,
+	context: { postType },
+}: ProductEditorBlockEditProps< SelectBlockAttributes > ) {
+	const blockProps = useWooBlockProps( attributes );
+
+	const { property, label, placeholder, help, disabled, options, multiple } =
+		attributes;
+
+	const [ value, setValue ] = useProductEntityProp< string | string[] >(
+		property,
+		{
+			postType,
+			fallbackValue: '',
+		}
+	);
+
+	function renderHelp() {
+		if ( help ) {
+			return <span dangerouslySetInnerHTML={ sanitizeHTML( help ) } />;
+		}
+	}
+
+	return (
+		<div { ...blockProps }>
+			<SelectControl
+				value={ value }
+				disabled={ disabled }
+				label={ label }
+				onChange={ setValue }
+				help={ renderHelp() }
+				placeholder={ placeholder }
+				options={ options }
+				multiple={ multiple as never }
+			/>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/generic/select/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/select/index.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { registerProductEditorBlockType } from '../../../utils';
+
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { Edit } from './edit';
+import { SelectBlockAttributes } from './types';
+
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< SelectBlockAttributes >;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: Edit,
+};
+
+export const init = () =>
+	registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );

--- a/packages/js/product-editor/src/blocks/generic/select/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/select/types.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import type { BlockAttributes } from '@wordpress/blocks';
+import { SelectControl } from '@wordpress/components';
+
+export interface SelectBlockAttributes extends BlockAttributes {
+	property: string;
+	label: string;
+	help?: string;
+	placeholder?: string;
+	disabled?: boolean;
+	multiple?: boolean;
+	options?: SelectControl.Option[];
+}

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -39,3 +39,4 @@ export { init as initText } from './generic/text';
 export { init as initNumber } from './generic/number';
 export { init as initLinkedProductList } from './generic/linked-product-list';
 export { init as initTextArea } from './generic/text-area';
+export { init as initSelect } from './generic/select';

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
@@ -26,6 +26,7 @@ import {
  */
 import { useValidation } from '../../../contexts/validation-context';
 import { useCurrencyInputProps } from '../../../hooks/use-currency-input-props';
+import { sanitizeHTML } from '../../../utils/sanitize-html';
 import { SalePriceBlockAttributes } from './types';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { Label } from '../../../components/label/label';
@@ -52,18 +53,11 @@ export function Edit( {
 		onChange: setRegularPrice,
 	} );
 
-	const interpolatedHelp = help
-		? createInterpolateElement( help, {
-				PricingTab: (
-					<Link
-						href={ getNewPath( { tab: 'pricing' } ) }
-						onClick={ () => {
-							recordEvent( 'product_pricing_help_click' );
-						} }
-					/>
-				),
-		  } )
-		: null;
+	function renderHelp() {
+		if ( help ) {
+			return <span dangerouslySetInnerHTML={ sanitizeHTML( help ) } />;
+		}
+	}
 
 	const regularPriceId = useInstanceId(
 		BaseControl,
@@ -115,7 +109,7 @@ export function Edit( {
 				help={
 					regularPriceValidationError
 						? regularPriceValidationError
-						: interpolatedHelp
+						: renderHelp()
 				}
 				className={ classNames( {
 					'has-error': regularPriceValidationError,

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
@@ -3,17 +3,10 @@
  */
 import classNames from 'classnames';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { Link } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
-import { getNewPath } from '@woocommerce/navigation';
-import { recordEvent } from '@woocommerce/tracks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
-import {
-	createElement,
-	createInterpolateElement,
-	useEffect,
-} from '@wordpress/element';
+import { createElement, useEffect } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import {
 	BaseControl,
@@ -24,12 +17,12 @@ import {
 /**
  * Internal dependencies
  */
+import { Label } from '../../../components/label/label';
 import { useValidation } from '../../../contexts/validation-context';
 import { useCurrencyInputProps } from '../../../hooks/use-currency-input-props';
 import { sanitizeHTML } from '../../../utils/sanitize-html';
-import { SalePriceBlockAttributes } from './types';
-import { ProductEditorBlockEditProps } from '../../../types';
-import { Label } from '../../../components/label/label';
+import type { ProductEditorBlockEditProps } from '../../../types';
+import type { SalePriceBlockAttributes } from './types';
 
 export function Edit( {
 	attributes,

--- a/plugins/woocommerce/changelog/add-43232
+++ b/plugins/woocommerce/changelog/add-43232
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Hide tax fields when taxes are disabled in product and variations

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -41,6 +41,7 @@ class BlockRegistry {
 		'woocommerce/product-text-area-field',
 		'woocommerce/product-number-field',
 		'woocommerce/product-linked-list-field',
+		'woocommerce/product-select-field',
 	);
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -194,6 +194,8 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	 * Adds the pricing group blocks to the template.
 	 */
 	private function add_pricing_group_blocks() {
+		$is_calc_taxes_enabled = wc_tax_enabled();
+
 		$pricing_group = $this->get_group_by_id( $this::GROUP_IDS['PRICING'] );
 		$pricing_group->add_block(
 			array(
@@ -251,6 +253,12 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 					'name'       => 'regular_price',
 					'label'      => __( 'Regular price', 'woocommerce' ),
 					'isRequired' => true,
+					'help'       => $is_calc_taxes_enabled ? null : sprintf(
+					/* translators: %1$s: store settings link opening tag. %2$s: store settings link closing tag.*/
+						__( 'Per your %1$sstore settings%2$s, taxes are not enabled.', 'woocommerce' ),
+						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=general' ) . '" target="_blank" rel="noreferrer">',
+						'</a>'
+					),
 				),
 			)
 		);
@@ -282,41 +290,26 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 			)
 		);
 
-		$product_pricing_section->add_block(
-			array(
-				'id'         => 'product-tax-class',
-				'blockName'  => 'woocommerce/product-radio-field',
-				'order'      => 40,
-				'attributes' => array(
-					'title'       => __( 'Tax class', 'woocommerce' ),
-					'description' => sprintf(
-					/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
-						__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s.', 'woocommerce' ),
-						'<a href="https://woo.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class" target="_blank" rel="noreferrer">',
-						'</a>'
+		if ( $is_calc_taxes_enabled ) {
+			$product_pricing_section->add_block(
+				array(
+					'id'         => 'product-tax-class',
+					'blockName'  => 'woocommerce/product-select-field',
+					'order'      => 40,
+					'attributes' => array(
+						'label'    => __( 'Tax class', 'woocommerce' ),
+						'help'     => sprintf(
+						/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
+							__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s', 'woocommerce' ),
+							'<a href="https://woo.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class" target="_blank" rel="noreferrer">',
+							'</a>'
+						),
+						'property' => 'tax_class',
+						'options'  => SimpleProductTemplate::get_tax_classes( 'product_variation' ),
 					),
-					'property'    => 'tax_class',
-					'options'     => array(
-						array(
-							'label' => __( 'Same as main product', 'woocommerce' ),
-							'value' => 'parent',
-						),
-						array(
-							'label' => __( 'Standard', 'woocommerce' ),
-							'value' => '',
-						),
-						array(
-							'label' => __( 'Reduced rate', 'woocommerce' ),
-							'value' => 'reduced-rate',
-						),
-						array(
-							'label' => __( 'Zero rate', 'woocommerce' ),
-							'value' => 'zero-rate',
-						),
-					),
-				),
-			)
-		);
+				)
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -549,6 +549,8 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 	 * Adds the pricing group blocks to the template.
 	 */
 	private function add_pricing_group_blocks() {
+		$is_calc_taxes_enabled = wc_tax_enabled();
+
 		$pricing_group = $this->get_group_by_id( $this::GROUP_IDS['PRICING'] );
 		$pricing_group->add_block(
 			array(
@@ -604,6 +606,12 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'attributes' => array(
 					'name'  => 'regular_price',
 					'label' => __( 'List price', 'woocommerce' ),
+					'help'  => $is_calc_taxes_enabled ? null : sprintf(
+					/* translators: %1$s: store settings link opening tag. %2$s: store settings link closing tag.*/
+						__( 'Per your %1$sstore settings%2$s, taxes are not enabled.', 'woocommerce' ),
+						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=general' ) . '" target="_blank" rel="noreferrer">',
+						'</a>'
+					),
 				),
 			)
 		);
@@ -634,65 +642,81 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'order'     => 20,
 			)
 		);
-		$product_pricing_section->add_block(
-			array(
-				'id'         => 'product-sale-tax',
-				'blockName'  => 'woocommerce/product-radio-field',
-				'order'      => 30,
-				'attributes' => array(
-					'title'    => __( 'Charge sales tax on', 'woocommerce' ),
-					'property' => 'tax_status',
-					'options'  => array(
-						array(
-							'label' => __( 'Product and shipping', 'woocommerce' ),
-							'value' => 'taxable',
-						),
-						array(
-							'label' => __( 'Only shipping', 'woocommerce' ),
-							'value' => 'shipping',
-						),
-						array(
-							'label' => __( "Don't charge tax", 'woocommerce' ),
-							'value' => 'none',
+
+		if ( $is_calc_taxes_enabled ) {
+			$product_pricing_section->add_block(
+				array(
+					'id'         => 'product-sale-tax',
+					'blockName'  => 'woocommerce/product-radio-field',
+					'order'      => 30,
+					'attributes' => array(
+						'title'    => __( 'Charge sales tax on', 'woocommerce' ),
+						'property' => 'tax_status',
+						'options'  => array(
+							array(
+								'label' => __( 'Product and shipping', 'woocommerce' ),
+								'value' => 'taxable',
+							),
+							array(
+								'label' => __( 'Only shipping', 'woocommerce' ),
+								'value' => 'shipping',
+							),
+							array(
+								'label' => __( "Don't charge tax", 'woocommerce' ),
+								'value' => 'none',
+							),
 						),
 					),
-				),
-			)
-		);
-		$pricing_advanced_block = $product_pricing_section->add_block(
-			array(
-				'id'         => 'product-pricing-advanced',
-				'blockName'  => 'woocommerce/product-collapsible',
-				'order'      => 40,
-				'attributes' => array(
-					'toggleText'       => __( 'Advanced', 'woocommerce' ),
-					'initialCollapsed' => true,
-					'persistRender'    => true,
-				),
-			)
-		);
-		$pricing_advanced_block->add_block(
-			array(
-				'id'         => 'product-tax-class',
-				'blockName'  => 'woocommerce/product-select-field',
-				'order'      => 10,
-				'attributes' => array(
-					'label'    => __( 'Tax class', 'woocommerce' ),
-					'help'     => sprintf(
-					/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
-						__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s', 'woocommerce' ),
-						'<a href="https://woo.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class" target="_blank" rel="noreferrer">',
-						'</a>'
+				)
+			);
+			$pricing_advanced_block = $product_pricing_section->add_block(
+				array(
+					'id'         => 'product-pricing-advanced',
+					'blockName'  => 'woocommerce/product-collapsible',
+					'order'      => 40,
+					'attributes' => array(
+						'toggleText'       => __( 'Advanced', 'woocommerce' ),
+						'initialCollapsed' => true,
+						'persistRender'    => true,
 					),
-					'property' => 'tax_class',
-					'options'  => $this->get_tax_classes(),
-				),
-			)
-		);
+				)
+			);
+			$pricing_advanced_block->add_block(
+				array(
+					'id'         => 'product-tax-class',
+					'blockName'  => 'woocommerce/product-select-field',
+					'order'      => 10,
+					'attributes' => array(
+						'label'    => __( 'Tax class', 'woocommerce' ),
+						'help'     => sprintf(
+						/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
+							__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s', 'woocommerce' ),
+							'<a href="https://woo.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class" target="_blank" rel="noreferrer">',
+							'</a>'
+						),
+						'property' => 'tax_class',
+						'options'  => self::get_tax_classes(),
+					),
+				)
+			);
+		}
 	}
 
-	private function get_tax_classes() {
+	/**
+	 * Get the tax classes as select options.
+	 * 
+	 * @param string $post_type The post type.
+	 * @return array Array of options.
+	 */
+	public static function get_tax_classes( $post_type = 'product' ) {
 		$tax_classes = array();
+
+		if ( 'product_variation' === $post_type ) {
+			$tax_classes[] = array(
+				'label' => __( 'Same as main product', 'woocommerce' ),
+				'value' => 'parent',
+			);
+		}
 
 		// Add standard class.
 		$tax_classes[] = array(
@@ -700,12 +724,12 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			'value' => '',
 		);
 
-		$classes = WC_Tax::get_tax_classes();
+		$classes = WC_Tax::get_tax_rate_classes();
 
-		foreach ( $classes as $class ) {
+		foreach ( $classes as $tax_class ) {
 			$tax_classes[] = array(
-				'label' => $class,
-				'value' => sanitize_title( $class ),
+				'label' => $tax_class->name,
+				'value' => $tax_class->slug,
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -704,7 +704,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 
 	/**
 	 * Get the tax classes as select options.
-	 * 
+	 *
 	 * @param string $post_type The post type.
 	 * @return array Array of options.
 	 */

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\Features\ProductBlockEditor\ProductTem
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\ProductFormTemplateInterface;
+use WC_Tax;
 
 /**
  * Simple Product Template.
@@ -673,34 +674,42 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		$pricing_advanced_block->add_block(
 			array(
 				'id'         => 'product-tax-class',
-				'blockName'  => 'woocommerce/product-radio-field',
+				'blockName'  => 'woocommerce/product-select-field',
 				'order'      => 10,
 				'attributes' => array(
-					'title'       => __( 'Tax class', 'woocommerce' ),
-					'description' => sprintf(
+					'label'    => __( 'Tax class', 'woocommerce' ),
+					'help'     => sprintf(
 					/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
-						__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s.', 'woocommerce' ),
+						__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s', 'woocommerce' ),
 						'<a href="https://woo.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class" target="_blank" rel="noreferrer">',
 						'</a>'
 					),
-					'property'    => 'tax_class',
-					'options'     => array(
-						array(
-							'label' => __( 'Standard', 'woocommerce' ),
-							'value' => '',
-						),
-						array(
-							'label' => __( 'Reduced rate', 'woocommerce' ),
-							'value' => 'reduced-rate',
-						),
-						array(
-							'label' => __( 'Zero rate', 'woocommerce' ),
-							'value' => 'zero-rate',
-						),
-					),
+					'property' => 'tax_class',
+					'options'  => $this->get_tax_classes(),
 				),
 			)
 		);
+	}
+
+	private function get_tax_classes() {
+		$tax_classes = array();
+
+		// Add standard class.
+		$tax_classes[] = array(
+			'label' => __( 'Standard rate', 'woocommerce' ),
+			'value' => '',
+		);
+
+		$classes = WC_Tax::get_tax_classes();
+
+		foreach ( $classes as $class ) {
+			$tax_classes[] = array(
+				'label' => $class,
+				'value' => sanitize_title( $class ),
+			);
+		}
+
+		return $tax_classes;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
@@ -34,6 +34,7 @@ class BlockRegistryTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-taxonomy-field' ), 'Taxonomy field not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-text-field' ), 'Text field not registered.' );
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-number-field' ), 'Number field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-select-field' ), 'Select field not registered.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43232

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=general` and make sure the `Enable tax rates and calculations` checkbox is checked.
3. Go to `Products` > `Add new`
4. Under the `Pricing` tab the tax fields should be shown and under the `Advanced` sub section the tax classes should be listed in a select control 
<img width="720" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/d0950174-d132-46a2-aac8-12baa5f421a3">

5. If you add more tax classes from `/wp-admin/admin.php?page=wc-settings&tab=tax` those classes should be listed in point 4
6. If you uncheck the `Enable tax rates and calculations` checkbox the fields related to taxes should not be visible anymore and a new message below the `Regular price` field should be shown. 
<img width="744" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/b8498913-0000-4bf3-8002-eaa1c5b991c5">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
