### PR TITLE
Require manage_woocommerce option for /connect-jetpack endpoint

### DIFF
--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -105,7 +105,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 				array(
 					'methods'             => 'GET',
 					'callback'            => array( $this, 'get_jetpack_authorization_url' ),
-					'permission_callback' => array( $this, 'can_install_plugins' ),
+					'permission_callback' => array( $this, 'can_manage_woocommerce' ),
 					'args'                => array(
 						'redirect_url' => array(
 							'description'       => 'The URL to redirect to after authorization',
@@ -261,6 +261,23 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 			return new WP_Error(
 				'woocommerce_rest_cannot_update',
 				__( 'Sorry, you cannot manage plugins.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether the current user has permission to manage woocommerce
+	 *
+	 * @return WP_Error|boolean
+	 */
+	public function can_manage_woocommerce() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return new WP_Error(
+				'woocommerce_rest_cannot_update',
+				__( 'Sorry, you cannot manage woocommerce settings.', 'woocommerce' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}

--- a/plugins/woocommerce/src/Admin/API/Plugins.php
+++ b/plugins/woocommerce/src/Admin/API/Plugins.php
@@ -151,7 +151,12 @@ class Plugins extends \WC_REST_Data_Controller {
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'connect_jetpack' ),
-					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'permission_callback' => function() {
+						if ( ! current_user_can( 'manage_woocommerce' ) ) {
+							return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage Jetpack connections.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+						}
+						return true;
+					},
 				),
 				'schema' => array( $this, 'get_connect_schema' ),
 			)

--- a/plugins/woocommerce/tests/php/src/Admin/API/OnboardingPluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/OnboardingPluginsTest.php
@@ -138,6 +138,35 @@ class OnboardingPluginsTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 404, $response->get_status() );
 	}
 
+	public function test_jetpack_auth_requires_manage_woocommerce() {
+		$this->useUserWithoutPluginsPermission();
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/jetpack-authorization-url' );
+		$request->set_param('redirect_url', 'test');
+		$request->set_param('from', 'test');
+
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+
+		$user = $this->factory->user->create(
+			array(
+				'role' => 'shop_manager',
+			)
+		);
+
+		wp_set_current_user( $user );
+
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/jetpack-authorization-url' );
+		$request->set_param('redirect_url', 'test');
+		$request->set_param('from', 'test');
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		// We'll get an error from the endpoint since Jetpack isn't installed.
+		// We just want to make sure we're passing the permission check.
+		$this->assertTrue( $response->get_status() !== 403 );
+	}
+
 	/**
 	 * Test permissions.
 	 *

--- a/plugins/woocommerce/tests/php/src/Admin/API/PluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/PluginsTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Test the API controller class that handles the marketing campaigns REST response.
+ *
+ * @package WooCommerce\Admin\Tests\Admin\API
+ */
+
+namespace Automattic\WooCommerce\Tests\Admin\API;
+
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * MarketingCampaigns API controller test.
+ *
+ * @class MarketingCampaignsTest.
+ */
+class PluginsTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * Endpoint.
+	 *
+	 * @var string
+	 */
+	const ENDPOINT = '/wc-admin/plugins/';
+
+
+	public function test_connect_jetpack_requires_manage_woocommerce() {
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT . 'connect-jetpack' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+
+		$user = $this->factory->user->create(
+			array(
+				'role' => 'shop_manager',
+			)
+		);
+
+		wp_set_current_user( $user );
+
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT . 'connect-jetpack' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		// We'll get an error from the endpoint since Jetpack isn't installed.
+		// We just want to make sure we're passing the permission check.
+		$this->assertTrue( $response->get_status() !== 401 );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35409 

This PR replaces `install_plugins` permission by `manage_woocommerce` to allow shop managers to connect their sites to Jetpack.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the included unit tests.
2. Create a new JN site. Do not start/skip the core profiler.
3. Add a new user as a shop manager.
4. Logout and sign-in as the user you just created.
5. Start the core profiler and proceed to the end.
6. Confirm you're still able to connect to Jetpack.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
