### PR TITLE
Install the Legacy REST API plugin on WooCommerce upgrade if needed

### DIFF
--- a/plugins/woocommerce/changelog/pr-45570
+++ b/plugins/woocommerce/changelog/pr-45570
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Install the Legacy REST API plugin on WooCommerce upgrade if needed

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -265,6 +265,28 @@ class WC_Admin_Notices {
 	}
 
 	/**
+	 * Remove a given set of notices.
+	 *
+	 * An array of notice names or a regular expression string can be passed, in the later case
+	 * all the notices whose name matches the regular expression will be removed.
+	 *
+	 * @param array|string $names_array_or_regex An array of notice names, or a string representing a regular expression.
+	 * @param bool         $force_save Force saving inside this method instead of at the 'shutdown'.
+	 * @return void
+	 */
+	public static function remove_notices( $names_array_or_regex, $force_save = false ) {
+		if ( ! is_array( $names_array_or_regex ) ) {
+			$names_array_or_regex = array_filter( self::get_notices(), fn( $notice_name ) => 1 === preg_match( $names_array_or_regex, $notice_name ) );
+		}
+		self::set_notices( array_diff( self::get_notices(), $names_array_or_regex ) );
+
+		if ( $force_save ) {
+			// Adding early save to prevent more race conditions with notices.
+			self::store_notices();
+		}
+	}
+
+	/**
 	 * See if a notice is being shown.
 	 *
 	 * @param string $name Notice name.
@@ -391,7 +413,7 @@ class WC_Admin_Notices {
 					$notice_html = get_option( 'woocommerce_admin_notice_' . $notice );
 
 					if ( $notice_html ) {
-						include dirname( __FILE__ ) . '/views/html-notice-custom.php';
+						include __DIR__ . '/views/html-notice-custom.php';
 					}
 				}
 			}
@@ -413,12 +435,12 @@ class WC_Admin_Notices {
 
             // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) {
-				include dirname( __FILE__ ) . '/views/html-notice-updating.php';
+				include __DIR__ . '/views/html-notice-updating.php';
 			} else {
-				include dirname( __FILE__ ) . '/views/html-notice-update.php';
+				include __DIR__ . '/views/html-notice-update.php';
 			}
 		} else {
-			include dirname( __FILE__ ) . '/views/html-notice-updated.php';
+			include __DIR__ . '/views/html-notice-updated.php';
 		}
 	}
 
@@ -463,7 +485,7 @@ class WC_Admin_Notices {
 		}
 
 		if ( $outdated ) {
-			include dirname( __FILE__ ) . '/views/html-notice-template-check.php';
+			include __DIR__ . '/views/html-notice-template-check.php';
 		} else {
 			self::remove_notice( 'template_files' );
 		}
@@ -486,7 +508,7 @@ class WC_Admin_Notices {
 		}
 
 		if ( $enabled ) {
-			include dirname( __FILE__ ) . '/views/html-notice-legacy-shipping.php';
+			include __DIR__ . '/views/html-notice-legacy-shipping.php';
 		} else {
 			self::remove_notice( 'template_files' );
 		}
@@ -502,7 +524,7 @@ class WC_Admin_Notices {
 			$method_count  = wc_get_shipping_method_count();
 
 			if ( $product_count->publish > 0 && 0 === $method_count ) {
-				include dirname( __FILE__ ) . '/views/html-notice-no-shipping-methods.php';
+				include __DIR__ . '/views/html-notice-no-shipping-methods.php';
 			}
 
 			if ( $method_count > 0 ) {
@@ -515,7 +537,7 @@ class WC_Admin_Notices {
 	 * Notice shown when regenerating thumbnails background process is running.
 	 */
 	public static function regenerating_thumbnails_notice() {
-		include dirname( __FILE__ ) . '/views/html-notice-regenerating-thumbnails.php';
+		include __DIR__ . '/views/html-notice-regenerating-thumbnails.php';
 	}
 
 	/**
@@ -526,7 +548,7 @@ class WC_Admin_Notices {
 			return;
 		}
 
-		include dirname( __FILE__ ) . '/views/html-notice-secure-connection.php';
+		include __DIR__ . '/views/html-notice-secure-connection.php';
 	}
 
 	/**
@@ -541,7 +563,7 @@ class WC_Admin_Notices {
 			return;
 		}
 
-		include dirname( __FILE__ ) . '/views/html-notice-regenerating-lookup-table.php';
+		include __DIR__ . '/views/html-notice-regenerating-lookup-table.php';
 	}
 
 	/**
@@ -628,7 +650,7 @@ class WC_Admin_Notices {
 			return;
 		}
 
-		include dirname( __FILE__ ) . '/views/html-notice-maxmind-license-key.php';
+		include __DIR__ . '/views/html-notice-maxmind-license-key.php';
 	}
 
 	/**
@@ -642,7 +664,7 @@ class WC_Admin_Notices {
 			return;
 		}
 
-		include dirname( __FILE__ ) . '/views/html-notice-redirect-only-download.php';
+		include __DIR__ . '/views/html-notice-redirect-only-download.php';
 	}
 
 	/**
@@ -656,7 +678,7 @@ class WC_Admin_Notices {
 			return;
 		}
 
-		include dirname( __FILE__ ) . '/views/html-notice-uploads-directory-is-unprotected.php';
+		include __DIR__ . '/views/html-notice-uploads-directory-is-unprotected.php';
 	}
 
 	/**
@@ -671,7 +693,7 @@ class WC_Admin_Notices {
 			self::remove_notice( 'base_tables_missing' );
 		}
 
-		include dirname( __FILE__ ) . '/views/html-notice-base-table-missing.php';
+		include __DIR__ . '/views/html-notice-base-table-missing.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1204,7 +1204,7 @@ class WC_Install {
 
 		wp_clean_plugins_cache();
 		if ( isset( get_plugins()[ $plugin_name ] ) ) {
-			if ( ! get_option( 'woocommerce_autoinstalled_plugins', array() )[ $plugin_name ] ) {
+			if ( ! ( get_option( 'woocommerce_autoinstalled_plugins', array() )[ $plugin_name ] ?? null ) ) {
 				// The plugin was installed manually so let's not interfere.
 				return;
 			}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1218,7 +1218,7 @@ class WC_Install {
 			$install_ok = true;
 		} else {
 			$install_result = wc_get_container()->get( PluginInstaller::class )->install_plugin(
-				'https://downloads.wordpress.org/plugin/woocommerce-legacy-rest-api.1.0.1.zip',
+				'https://downloads.wordpress.org/plugin/woocommerce-legacy-rest-api.latest-stable.zip',
 				array(
 					'info_link' => 'https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/',
 				)

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1204,6 +1204,9 @@ class WC_Install {
 		$plugin_name = 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php';
 
 		wp_clean_plugins_cache();
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		if ( isset( get_plugins()[ $plugin_name ] ) ) {
 			if ( ! ( get_site_option( 'woocommerce_autoinstalled_plugins', array() )[ $plugin_name ] ?? null ) ) {
 				// The plugin was installed manually so let's not interfere.

--- a/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
@@ -136,6 +136,9 @@ class PluginInstaller implements RegisterHooksInterface {
 		$result = array( 'messages' => $skin->get_upgrade_messages() );
 
 		if ( $install_ok ) {
+			if ( ! function_exists( 'get_plugins' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
 			$plugin_name    = $upgrader->plugin_info();
 			$plugin_version = get_plugins()[ $plugin_name ]['Version'];
 

--- a/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
@@ -66,6 +66,9 @@ class PluginInstaller implements RegisterHooksInterface {
 	 * - 'date', ISO-formatted installation date.
 	 * - 'metadata', as supplied (except the 'plugin_name' key) and only if not empty.
 	 *
+	 * If the plugin is already in the process of being installed (can happen in multisite), the returned array
+	 * will contain only one key: 'already_installing', with a value of true.
+	 *
 	 * @param string $plugin_url URL or file path of the plugin to install.
 	 * @param array  $metadata Metadata to store if the installation succeeds.
 	 * @return array Information about the installation result.
@@ -73,9 +76,24 @@ class PluginInstaller implements RegisterHooksInterface {
 	 */
 	public function install_plugin( string $plugin_url, array $metadata = array() ): array {
 		$this->installing_plugin = true;
+
+		$plugins_being_installed = get_site_option( 'woocommerce_autoinstalling_plugins', array() );
+		if ( in_array( $plugin_url, $plugins_being_installed, true ) ) {
+			return array( 'already_installing' => true );
+		}
+		$plugins_being_installed[] = $plugin_url;
+		update_site_option( 'woocommerce_autoinstalling_plugins', $plugins_being_installed );
+
 		try {
 			return $this->install_plugin_core( $plugin_url, $metadata );
 		} finally {
+			$plugins_being_installed = array_diff( $plugins_being_installed, array( $plugin_url ) );
+			if ( empty( $plugins_being_installed ) ) {
+				delete_site_option( 'woocommerce_autoinstalling_plugins' );
+			} else {
+				update_site_option( 'woocommerce_autoinstalling_plugins', $plugins_being_installed );
+			}
+
 			$this->installing_plugin = false;
 		}
 	}
@@ -130,14 +148,16 @@ class PluginInstaller implements RegisterHooksInterface {
 				$plugin_data['metadata'] = $metadata;
 			}
 
+			$auto_installed_plugins                 = get_site_option( 'woocommerce_autoinstalled_plugins', array() );
+			$auto_installed_plugins[ $plugin_name ] = $plugin_data;
+			update_site_option( 'woocommerce_autoinstalled_plugins', $auto_installed_plugins );
+
 			$post_install = function () use ( $plugin_name, $plugin_version, $installed_by, $plugin_url, $plugin_data ) {
-				$auto_installed_plugins                 = get_option( 'woocommerce_autoinstalled_plugins', array() );
-				$auto_installed_plugins[ $plugin_name ] = $plugin_data;
-				$log_context                            = array(
+				$log_context = array(
 					'source'        => 'plugin_auto_installs',
 					'recorded_data' => $plugin_data,
 				);
-				update_option( 'woocommerce_autoinstalled_plugins', $auto_installed_plugins );
+
 				wc_get_logger()->info( "Plugin $plugin_name v{$plugin_version} installed by $installed_by, source: $plugin_url", $log_context );
 			};
 		} else {
@@ -151,37 +171,23 @@ class PluginInstaller implements RegisterHooksInterface {
 			};
 		}
 
-		$this->run_callback_in_all_sites( $post_install );
+		if ( is_multisite() ) {
+			// We log the install in the main site, unless the main site doesn't have WooCommerce installed;
+			// in that case we fallback to logging in the current site.
+			switch_to_blog( get_main_site_id() );
+			if ( self::woocommerce_is_active_in_current_site() ) {
+				$post_install();
+				restore_current_blog();
+			} else {
+				restore_current_blog();
+				$post_install();
+			}
+		} else {
+			$post_install();
+		}
 
 		$result['install_ok'] = $install_ok ?? false;
 		return $result;
-	}
-
-	/**
-	 * Run a callback in each existing site (if multisite) or just once (if single site).
-	 *
-	 * @param callable $callback The callback to run.
-	 */
-	private static function run_callback_in_all_sites( callable $callback ) {
-		if ( ! is_multisite() ) {
-			$callback();
-			return;
-		}
-
-		foreach ( get_sites() as $site ) {
-			switch_to_blog( $site->blog_id );
-
-			if ( ! self::woocommerce_is_active_in_current_site() ) {
-				restore_current_blog();
-				continue;
-			}
-
-			try {
-				$callback();
-			} finally {
-				restore_current_blog();
-			}
-		}
 	}
 
 	/**
@@ -221,7 +227,7 @@ class PluginInstaller implements RegisterHooksInterface {
 			return;
 		}
 
-		$auto_installed_plugins_info = get_option( 'woocommerce_autoinstalled_plugins', array() );
+		$auto_installed_plugins_info = get_site_option( 'woocommerce_autoinstalled_plugins', array() );
 		$current_plugin_info         = $auto_installed_plugins_info[ $plugin_file ] ?? null;
 		if ( is_null( $current_plugin_info ) || $current_plugin_info['version'] !== $plugin_data['Version'] ) {
 			return;
@@ -270,7 +276,7 @@ class PluginInstaller implements RegisterHooksInterface {
 			return;
 		}
 
-		$auto_installed_plugins = get_option( 'woocommerce_autoinstalled_plugins' );
+		$auto_installed_plugins = get_site_option( 'woocommerce_autoinstalled_plugins' );
 		if ( ! $auto_installed_plugins ) {
 			return;
 		}
@@ -291,9 +297,9 @@ class PluginInstaller implements RegisterHooksInterface {
 		$new_auto_installed_plugins = array_diff_key( $auto_installed_plugins, array_flip( $updated_auto_installed_plugin_names ) );
 
 		if ( empty( $new_auto_installed_plugins ) ) {
-			delete_option( 'woocommerce_autoinstalled_plugins' );
+			delete_site_option( 'woocommerce_autoinstalled_plugins' );
 		} else {
-			update_option( 'woocommerce_autoinstalled_plugins', $new_auto_installed_plugins );
+			update_site_option( 'woocommerce_autoinstalled_plugins', $new_auto_installed_plugins );
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
@@ -138,13 +138,19 @@ class WebhookUtil {
 	/**
 	 * Gets the count of webhooks that are configured to use the Legacy REST API to compose their payloads.
 	 *
+	 * @param bool $clear_cache If true, the previously cached value of the count will be discarded if it exists.
+	 *
 	 * @return int
 	 */
-	public function get_legacy_webhooks_count(): int {
+	public function get_legacy_webhooks_count( bool $clear_cache = false ): int {
 		global $wpdb;
 
 		$cache_key = WC_Cache_Helper::get_cache_prefix( 'webhooks' ) . 'legacy_count';
-		$count     = wp_cache_get( $cache_key, 'webhooks' );
+		if ( $clear_cache ) {
+			wp_cache_delete( $cache_key, 'webhooks' );
+		}
+
+		$count = wp_cache_get( $cache_key, 'webhooks' );
 
 		if ( false === $count ) {
 			$count = absint( $wpdb->get_var( "SELECT count( webhook_id ) FROM {$wpdb->prefix}wc_webhooks WHERE `api_version` < 1;" ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As part of [the Legacy REST API removal from WooCommerce core](https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/), this pull request installs [the dedicated extension](https://github.com/woocommerce/woocommerce-legacy-rest-api) from [the WordPress.org](https://wordpress.org/plugins/woocommerce-legacy-rest-api/) directory. This happens during the WooCommerce install process if all of the following is true:

1. It's an upgrade (not a new WooCommerce install).
2. The Legacy REST API plugin isn't installed already (activation status is not checked).
3. The `woocommerce_skip_legacy_rest_api_plugin_auto_install` filter doesn't return `true`.
4. **Either** the Legacy REST API is installed in the site, **or** there's at least one webhook that uses the Legacy REST API code for the payload (disabled webhooks also count).

Upon install an activation, or if the process fails, an admin notice and a log entry are added.

In multisite setups it's possible that the Legacy REST API plugin install process is already in progress when the WooCommerce install process of a given site starts (it was started during the WooCommerce install process of another site). If that's the case an scheduled action is created to try again the plugin activation process within 10 seconds.

This pull request also includes changes in the `PluginInstaller` class:

- A site-wide `woocommerce_autoinstalling_plugins` option is now used to temporarily store the URLs of the plugins that are in process of being installed.
- The `woocommerce_autoinstalled_plugins` option is now a site-wide option.
- The log entry to indicate plugin install success or failure is now created only in the main site if multisite (if the main site
  doesn't have WooCommerce active, the log entry is created in the current site as a fallback).

### How to test the changes in this Pull Request:

#### Preparation

Since the plugin install happens at WooCommerce upgrade time, there's no straightforward to test multiple times without completely uninstalling WooCommerce or creating a new site every time. However you'll be able to cleanly start over the testing with the help of the following snippet (you can install it with [the code snippets plugin](https://wordpress.org/plugins/code-snippets/)):

```php
function reset_all_things() {
	global $wpdb;
	update_option("woocommerce_version", "8.6.30");
	$wpdb->query("delete from {$wpdb->prefix}usermeta where meta_key like 'dismissed%'");
	WC_Admin_Notices::remove_all_notices();
	WC_Admin_notices::store_notices();
}
``` 

So for testing the first time you need to start by installing an older version of WooCommerce firts, but then the "start over" procedure would be:

1. Uninstall the Legacy REST API plugin (if it's installed).
2. `wp eval 'reset_all_things();'`
3. Reinstall WooCommerce by uploading the .zip file again (there's no need to install an older version first).

**Beware!** Remember that when you dismiss an admin notification the page URL gets `?wc-hide-notice=...` appended in the address bar of the browser. Take care of deleting this part before reloading the page.

#### Testing the normal flow

1. Start with a WooCommerce site that has the Legacy REST API active (in WooCommerce - Settings - Advanced - Legacy API) and [the Legacy REST API extension](https://github.com/woocommerce/woocommerce-legacy-rest-api) manually installed (but not active).
2. Install a WooCommerce .zip file generated from this pull request.
3. Note that nothing changed (there are no new admin notices or log entries).
4. Start over with a site that doesn't have the the Legacy REST API extension installed and doesn't have the Legacy REST API active (either an "out of the box" new WooCommerce install, or the same site after the "start over" procedure including deleting the extension and disabling the Legacy REST API).
5. Install the WooCommerce .zip again and verify that again, there are no new admin notices or log entries.
6. Start over again, this time without installing the Legacy REST API extension but enabling the Legacy REST API in the site.
7. Install the WooCommerce .zip again and notice how the Legacy REST API plugin is installed and active (with the "installed by WooCommerce" notice underneath) and there's a new admin notice informing about the install (with links, verify that they work as expected), as well as two new log entries (one for the plugin install and another one for the plugin activation) in WooCommerce - Status - Logs:

![image](https://github.com/woocommerce/woocommerce/assets/937723/fc7be89a-15aa-4540-ba5e-64d49d24aa15)

![image](https://github.com/woocommerce/woocommerce/assets/937723/78277537-a9c0-40aa-8dc4-0bad68551655)

![image](https://github.com/woocommerce/woocommerce/assets/937723/24efe662-b4e3-4ed6-97c4-e8ce93d7e5c5)

8. Start over again, this time without installing the Legacy REST API extension, **not** enabling the Legacy REST API, and creating a webook that uses the Legacy REST API code for the payload (WooCommcerce - Settings - Advanced - Webhooks - Add webhook, select "Legacy API v3" in the "API version" dropdown, the contents for the rest of the fields is irrelevant). The result is the same as in the previous run: the extension gets installed and activated, and the admin notice and the log entries get created.

#### Testing error conditions

In order to easily test error conditions we'll need to do small code changes in the `WC_Install::maybe_install_legacy_api_plugin` method (`includes/class-wc-install.php` file), either in the source itself before the .zip file is created, or by opening and modifying the file directly in the .zip file.

First, do the following replacement to simulate failure when trying to install the extension:

```php
// Find this...
$install_result = wc_get_container()->get( PluginInstaller::class )->install_plugin(...

// ...replace with this:
$install_result = ['install_ok' => false];
```

Try one of the procedures that install the extension (e.g. extenstion not previously installed, Legacy REST API enabled), this time the extension won't get installed and the admin notification will look like this:

![WooCommerce failed to install the Legacy REST API plugin](https://github.com/woocommerce/woocommerce/assets/937723/fcef92a0-6f5a-4b1a-96c6-885502cb4706)

Now start over and repeat, but this time with this code change:

```php
// Find this...
$activation_result = activate_plugin($plugin_name);

// ...replace with this:
$activation_result = new \WP_Error('oh_no', 'oh no!!!', ['oh' => 'no']);
```

This time the plugin gets installed but not activated, and the admin notification will look like this:

![WooCommerce failed to activate the Legacy REST API plugin](https://github.com/woocommerce/woocommerce/assets/937723/57affa0d-a6c9-4e0a-b4da-eeaa46563b87)

There's also an extra log entry:

![WooCommerce failed to activate the Legacy REST API plugin (log)](https://github.com/woocommerce/woocommerce/assets/937723/ea2109a5-9a25-44cc-b022-2327efebac89)

#### Testing in multisite

To test in multisite keep in mind that plugins are installed at the whole network level but activated at the individual site level. As for the "start over" snippet, you only need to install it in the main site, and you'll need a modified version:

```php
function reset_all_things() {
	global $wpdb;
	foreach(get_sites() as $site) {
		switch_to_blog($site->blog_id);
		update_option("woocommerce_version", "8.6.30");
		$wpdb->query("delete from {$wpdb->prefix}usermeta where meta_key like 'dismissed%'");
		WC_Admin_Notices::remove_all_notices();
		WC_Admin_notices::store_notices();
		restore_current_blog();
	}
}
``` 

Create a multisite with a total of four sites (create three additional sites in My Sites - Network Admin - Sites):

![image](https://github.com/woocommerce/woocommerce/assets/937723/5a73f5a0-d483-49aa-b317-66152cfceec2)

Then install an older WooCommerce (**don't** click "Network activate" after the install) and configure each site as follows:

Site 1: Just activate WooCommerce.
Site 2: Activate WooCommerce and enable the Legacy REST API.
Site 3: Activate WooCommerce and create a webhook that uses the Legacy REST API code for the payload.
Site 4: Do nothing (leave WooCommerce inactive).

Now upgrade WooCommerce and verify that:

* In sites 1 and 4 the Legacy REST API extension is installed but inactive. Also in site 1 there are no new admin notices or log entries (in site 4 that doesn't apply since it has no active WooCommerce).
* In sites 2 and 3 the extension is installed and active, and the admin notice and log entries have been created as expected.

For sites 2 and 3 verify also that the internal links in the admin notices point to the correct site.

#### Testing the scheduled action

Testing that a scheduled action is indeed created when the plugin activation can't be performed immediately is tricky, but it can be achieved easily by tweaking the code. In `PluginInstaller::install_plugin` add the following lines right after the `update_site_option( 'woocommerce_autoinstalling_plugins', $plugins_being_installed );` line to simulate a very slow plugin install process:

```php
$time = time();
while(time() < $time+30);
```

Then repeat the multisite testing, loading site 2 and site 3 at the same time. You should see that the first site gets the plugin activated immediately but for the other site you need a few reloads, and after that there's a completed `woocommerce_activate_legacy_rest_api_plugin` action listed in WooCommerce - Status - Scheduled actions.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
