### PR TITLE
Fix/customer analytics guest name empty

### DIFF
--- a/plugins/woocommerce-admin/client/analytics/report/customers/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/customers/table.js
@@ -5,7 +5,7 @@ import { __, _n } from '@wordpress/i18n';
 import { Fragment, useContext } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { Tooltip } from '@wordpress/components';
-import { Date, Link } from '@woocommerce/components';
+import { Date, Link, Pill } from '@woocommerce/components';
 import { formatValue } from '@woocommerce/number';
 import { getAdminLink } from '@woocommerce/settings';
 import { defaultTableDateFormat } from '@woocommerce/date';
@@ -142,15 +142,18 @@ function CustomersReportTable( {
 			} = customer;
 			const countryName = getCountryName( country );
 
+			const customerName =
+				userId === 0 && name === ' ' ? <Pill>Guest</Pill> : name;
+
 			const customerNameLink = userId ? (
 				<Link
 					href={ getAdminLink( 'user-edit.php?user_id=' + userId ) }
 					type="wp-admin"
 				>
-					{ name }
+					{ customerName }
 				</Link>
 			) : (
-				name
+				customerName
 			);
 
 			const dateLastActiveDisplay = dateLastActive ? (

--- a/plugins/woocommerce-admin/client/analytics/report/customers/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/customers/table.js
@@ -143,7 +143,11 @@ function CustomersReportTable( {
 			const countryName = getCountryName( country );
 
 			const customerName =
-				userId === 0 && name === ' ' ? <Pill>Guest</Pill> : name;
+				userId === 0 && name === ' ' ? (
+					<Pill>{ __( 'Guest', 'woocommerce' ) }</Pill>
+				) : (
+					name
+				);
 
 			const customerNameLink = userId ? (
 				<Link

--- a/plugins/woocommerce-admin/client/analytics/report/customers/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/customers/table.js
@@ -143,7 +143,7 @@ function CustomersReportTable( {
 			const countryName = getCountryName( country );
 
 			const customerName =
-				userId === 0 && name === ' ' ? (
+				userId === 0 && name.trim() === '' ? (
 					<Pill>{ __( 'Guest', 'woocommerce' ) }</Pill>
 				) : (
 					name

--- a/plugins/woocommerce/changelog/fix-customer-analytics-guest-name-empty
+++ b/plugins/woocommerce/changelog/fix-customer-analytics-guest-name-empty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Replace empty customer names with 'Guest' in Customer Analytics screen


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39813 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to `WooCommerce` -> `Orders` -> `Add Order` -> `Create`.
2. Create an order with a `Guest` customer and status `Processing`.
3. Go to `WooCommerce` -> `Customers`.
4. Now, you'll notice `Guest` displayed instead of an empty customer name.

<!-- End testing instructions -->

![Customers-‹-WooCommerce-‹-—-WooCommerce](https://github.com/woocommerce/woocommerce/assets/8348824/fa9928f8-1558-45fa-9e67-1e70470590bc)
