### PR TITLE
CYS - Core: fix wp-admin page visible when click on start designing

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -224,6 +224,9 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 						setOpenDesignChangeWarningModal={
 							setOpenDesignChangeWarningModal
 						}
+						redirectToCYSFlow={ () =>
+							sendEvent( 'DESIGN_WITHOUT_AI' )
+						}
 						sendEvent={ sendEvent }
 					/>
 

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -234,10 +234,6 @@ export const NoAIBanner = ( {
 	}, [] );
 
 	const isDefaultTheme = currentTheme?.stylesheet === 'twentytwentyfour';
-	const customizeStoreDesignUrl = addQueryArgs( `${ ADMIN_URL }admin.php`, {
-		page: 'wc-admin',
-		path: '/customize-store/design',
-	} );
 
 	return (
 		<>
@@ -261,7 +257,7 @@ export const NoAIBanner = ( {
 			{ isModalOpen && (
 				<ThemeSwitchWarningModal
 					setIsModalOpen={ setIsModalOpen }
-					customizeStoreDesignUrl={ customizeStoreDesignUrl }
+					redirectToCYSFlow={ redirectToCYSFlow }
 				/>
 			) }
 		</>

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';
 import { getNewPath } from '@woocommerce/navigation';
@@ -17,7 +16,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { Intro } from '.';
 import { IntroSiteIframe } from './intro-site-iframe';
-import { ADMIN_URL, getAdminSetting } from '~/utils/admin-settings';
+import { getAdminSetting } from '~/utils/admin-settings';
 import { navigateOrParent } from '../utils';
 import { ThemeSwitchWarningModal } from '~/customize-store/intro/warning-modals';
 

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -219,7 +219,11 @@ export const ThemeHasModsBanner = ( {
 	);
 };
 
-export const NoAIBanner = () => {
+export const NoAIBanner = ( {
+	redirectToCYSFlow,
+}: {
+	redirectToCYSFlow: () => void;
+} ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	interface Theme {
 		stylesheet?: string;
@@ -249,7 +253,7 @@ export const NoAIBanner = () => {
 					if ( ! isDefaultTheme ) {
 						setIsModalOpen( true );
 					} else {
-						window.location.href = customizeStoreDesignUrl;
+						redirectToCYSFlow();
 					}
 				} }
 				showAIDisclaimer={ false }

--- a/plugins/woocommerce-admin/client/customize-store/intro/warning-modals.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/warning-modals.tsx
@@ -197,10 +197,10 @@ export const StartOverWarningModal = ( {
 
 export const ThemeSwitchWarningModal = ( {
 	setIsModalOpen,
-	customizeStoreDesignUrl,
+	redirectToCYSFlow,
 }: {
 	setIsModalOpen: ( arg0: boolean ) => void;
-	customizeStoreDesignUrl: string;
+	redirectToCYSFlow: () => void;
 } ) => {
 	return (
 		<Modal
@@ -231,11 +231,11 @@ export const ThemeSwitchWarningModal = ( {
 				</Button>
 				<Button
 					onClick={ () => {
-						window.location.href = customizeStoreDesignUrl;
 						setIsModalOpen( false );
 						recordEvent(
 							'customize_your_store_agree_to_theme_switch_click'
 						);
+						redirectToCYSFlow();
 					} }
 					variant="primary"
 				>

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/element';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import { Product, ProductType } from '../product-list/types';
 import { appendURLParams } from '../../utils/functions';
 import { ADMIN_URL, getAdminSetting } from '~/utils/admin-settings';
 import { NoAIBanner } from '~/customize-store/intro/intro-banners';
-import { addQueryArgs } from '@wordpress/url';
 
 export default function ProductListContent( props: {
 	products: Product[];

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
@@ -21,6 +21,7 @@ import { Product, ProductType } from '../product-list/types';
 import { appendURLParams } from '../../utils/functions';
 import { ADMIN_URL, getAdminSetting } from '~/utils/admin-settings';
 import { NoAIBanner } from '~/customize-store/intro/intro-banners';
+import { addQueryArgs } from '@wordpress/url';
 
 export default function ProductListContent( props: {
 	products: Product[];
@@ -119,7 +120,22 @@ export default function ProductListContent( props: {
 								} ),
 							} }
 						/>
-						{ index === bannerPosition && <NoAIBanner /> }
+						{ index === bannerPosition && (
+							<NoAIBanner
+								redirectToCYSFlow={ () => {
+									const customizeStoreDesignUrl =
+										addQueryArgs(
+											`${ ADMIN_URL }admin.php`,
+											{
+												page: 'wc-admin',
+												path: '/customize-store/design',
+											}
+										);
+									window.location.href =
+										customizeStoreDesignUrl;
+								} }
+							/>
+						) }
 					</Fragment>
 				) ) }
 			</div>

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -161,7 +161,9 @@ export default function Products( props: ProductsProps ) {
 			{ isModalOpen && (
 				<ThemeSwitchWarningModal
 					setIsModalOpen={ setIsModalOpen }
-					customizeStoreDesignUrl={ customizeStoreDesignUrl }
+					redirectToCYSFlow={ () => {
+						window.location.href = customizeStoreDesignUrl;
+					} }
 				/>
 			) }
 			<ProductListContent

--- a/plugins/woocommerce/changelog/45586-45542-cys-core-wp-admin-screen-visible-for-a-moment-after-clicking-start-designing-1
+++ b/plugins/woocommerce/changelog/45586-45542-cys-core-wp-admin-screen-visible-for-a-moment-after-clicking-start-designing-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Core: fix wp-admin page visible when click on start designing


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45542.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have the WooCommerce Beta Tester plugin installed and activated
2. Under Tools > WCA Test Helper > Features, make sure `customize-store` is enabled
3. Under Tools > WCA Test Helper > Tools, click on `Reset Customize Your Store`
4. Head over to WooCommerce > Extensions > Themes `wp-admin/admin.php?page=wc-admin&tab=themes&path=%2Fextensions`
5. Make sure you can visualize the Design your own button. If the current active theme is TT4, it directs users to the assembler, if not, the theme switch warning modal is displayed to confirm the user wants to proceed to the CYS flow and change their current active theme.
6. Click on `wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fintro`.
7. Start the flow.
8. Ensure that the wp-admin page isn't visible for a second (check the video attached to the issue).
9. Go on `/wp-admin`
10. Under Tools > WCA Test Helper > Tools, click on `Reset Customize Your Store`
11. Switch to TT3.
12. Start the flow.
13. Ensure that the wp-admin page isn't visible for a second (check the video attached to the issue).


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - Core: fix wp-admin page visible when click on start designing

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
