### PR TITLE
CYS - Core: fix Product Rating block renders

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -16,6 +16,8 @@ import { useQuery } from '@woocommerce/navigation';
 // @ts-expect-error No types for this exist yet.
 import useSiteEditorSettings from '@wordpress/edit-site/build-module/components/block-editor/use-site-editor-settings';
 import { useCallback, useContext, useMemo } from '@wordpress/element';
+// @ts-expect-error No types for this exist yet.
+import { store as editSiteStore } from '@wordpress/edit-site/build-module/store';
 
 /**
  * Internal dependencies
@@ -78,8 +80,16 @@ export const BlockEditorContainer = () => {
 		[]
 	);
 
+	const { templateType } = useSelect( ( select ) => {
+		const { getEditedPostType } = unlock( select( editSiteStore ) );
+
+		return {
+			templateType: getEditedPostType(),
+		};
+	}, [] );
+
 	const [ blocks, , onChange ] = useEditorBlocks(
-		'wp_template',
+		templateType,
 		currentTemplate?.id ?? ''
 	);
 

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -80,6 +80,8 @@ export const BlockEditorContainer = () => {
 		[]
 	);
 
+	// This is necessary to avoid this issue: https://github.com/woocommerce/woocommerce/issues/45593
+	// Related PR: https://github.com/woocommerce/woocommerce/pull/45600
 	const { templateType } = useSelect( ( select ) => {
 		const { getEditedPostType } = unlock( select( editSiteStore ) );
 

--- a/plugins/woocommerce/changelog/45600-45593-cys-on-core-product-rating-block-not-rendering
+++ b/plugins/woocommerce/changelog/45600-45593-cys-on-core-product-rating-block-not-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Core: fix Product Rating block renders


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This regression has been introduced with https://github.com/woocommerce/woocommerce/pull/45196, and it is reproducible only when JetPack is installed. 
I'm not sure why this happens, but I guess that `getEditedPostType` triggers the rendering of the Editor, and this fixes the issue.



Closes #45593.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have the WooCommerce Beta Tester plugin installed and activated.
2. Ensure you have Jetpack plugin installed.
3. Under Tools > WCA Test Helper > Features, make sure customize-store is enabled.
4. Under Tools > WCA Test Helper > Tools, click on Reset Customize Your Store.
5. Head over to WooCommerce > Home > Customize your store.
6. Click on "Start designing" and proceed to the Pattern Assembler.
7. Ensure that this error is not visible:
![image](https://github.com/woocommerce/woocommerce/assets/4463174/733a06ef-4cd1-44d9-b0d8-85309b283d62)
8. Instead, ensure that the Product Rating is visible.



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - Core: fix Product Rating block renders

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
