### PR TITLE
Change checkbox label to be inline-flex to limit the width to the content

### DIFF
--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/style.scss
@@ -5,7 +5,7 @@
 
 	label {
 		align-items: flex-start;
-		display: flex;
+		display: inline-flex;
 		position: relative;
 		cursor: pointer;
 		@include font-size(small);

--- a/plugins/woocommerce/changelog/45603-product-filters-clickable-area
+++ b/plugins/woocommerce/changelog/45603-product-filters-clickable-area
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+Comment: Limit checkbox clickable area from being out of bounds
+

--- a/plugins/woocommerce/changelog/45603-product-filters-clickable-area
+++ b/plugins/woocommerce/changelog/45603-product-filters-clickable-area
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
-Comment: Limit checkbox clickable area from being out of bounds
 
+Limit checkbox clickable area from being out of bounds

--- a/plugins/woocommerce/changelog/45603-product-filters-clickable-area
+++ b/plugins/woocommerce/changelog/45603-product-filters-clickable-area
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
+Comment: Limit checkbox clickable area from being out of bounds
 
-Limit checkbox clickable area from being out of bounds


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45390

This PR changes the `.wc-block-components-checkbox label` from `display:flex` to `display:inline-flex` so that the label's width is limited to the inner contents width so not to fill the width of its parent container. This way the clickable area is predictable and not "out of bounds".

Note:

Because this change potentially effects all elements that is using the class `.wc-block-components-checkbox`, we have to potentially test all checkboxes that uses it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add all the product filters to a post/page (active, stock, rating, attributes). Both legacy and beta ones. Be sure to add these within the Product Collection (beta) group if you're using that block.
2. Save and go to frontend.
3. Check that you cannot click on the blank space next to the filters to check the box. You have to click either the label or the checkbox itself.
4. Add a product to the cart and go to checkout.
5. For the checkbox "Add a note to your order". Ensure you can only click on the label and the checkbox itself and nothing outside of that.
6. As stated above there may be other places where I didn't think of. If you know where else there are checkboxes, please also test those.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Limit checkbox clickable area from being out of bounds

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->


</details>
