### PR TITLE
Do not trigger 'pre_update' logic for HPOS option when value remains unchanged

### DIFF
--- a/plugins/woocommerce/changelog/fix-45225
+++ b/plugins/woocommerce/changelog/fix-45225
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error when updating HPOS setting without changing value.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -311,6 +311,10 @@ class CustomOrdersTableController {
 			return $value;
 		}
 
+		if ( $old_value === $value ) {
+			return $value;
+		}
+
 		$this->order_cache->flush();
 		if ( ! $this->data_synchronizer->check_orders_table_exists() ) {
 			$this->data_synchronizer->create_database_tables();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We have some `pre_update_option` logic attached to the HPOS setting `woocommerce_custom_orders_table_enabled` (which enables HPOS) but this logic is executed regardless of whether the setting is actually changing value or not.

This can result in a confusing experience when a fatal error due to datastores being out of sync is triggered despite the datastore not being changed.

Closes #45225.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Settings > Advanced > Features and choose any datastore as order datastore. Make sure compatibility mode is _disabled_.
    If datastores are not in sync, run `wp wc cot sync` first if you want to change the current datastore.
2. Go to WC > Orders and create an order with any details.
3. Go back to WC > Settings > Advanced > Features and confirm that at least an order is reported as in need of sync and you are not allowed to change datastores.
4. Run the following command and confirm that it doesn't trigger any fatal error:
   ```
   wp eval "update_option( 'woocommerce_custom_orders_table_enabled', get_option( 'woocommerce_custom_orders_table_enabled' ) );"
   ```
   **Note:** This is triggering a fatal error on `trunk`, so optionally check that too.
5. Confirm that the following command _does_ trigger a fatal error (which would be an attempt to change datastores with orders out of sync):
   ```
   wp eval "update_option( 'woocommerce_custom_orders_table_enabled', wc_bool_to_string( ! wc_string_to_bool( get_option( 'woocommerce_custom_orders_table_enabled' ) ) ) );"
   ```
6. Run `wp wc cot sync` to sync orders.
7. Confirm that the command from step 5 no longer throws a fatal error.
8. You should've ended with a different datastore to the one you started with, so go to WC > Settings > Advanced > Features and change again or re-enable compatibility mode as necessary.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
