### PR TITLE
Handle posts > HPOS redirect more gracefully when backup post is missing

### DIFF
--- a/plugins/woocommerce/changelog/fix-44177
+++ b/plugins/woocommerce/changelog/fix-44177
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Gracefully handle posts to HPOS redirect when backup post no longer exists.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -130,7 +130,16 @@ class PostsRedirectionController {
 		$redirect_from_types   = wc_get_order_types( 'admin-menu' );
 		$redirect_from_types[] = 'shop_order_placehold';
 
-		if ( ! $post_id || ! in_array( get_post_type( $post_id ), $redirect_from_types, true ) || ! isset( $_GET['action'] ) ) {
+		$order_type = get_post_type( $post_id );
+		if ( ! $order_type ) {
+			// Attempt to determine whether this is a valid order on the HPOS side before bailing out.
+			$datastore = new \WC_Data_Store( 'order' );
+			if ( $datastore->has_callable( 'get_order_type' ) ) {
+				$order_type = $datastore->get_order_type( $post_id );
+			}
+		}
+
+		if ( ! $post_id || ! in_array( $order_type, $redirect_from_types, true ) || ! isset( $_GET['action'] ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -134,7 +134,8 @@ class PostsRedirectionController {
 		$redirect_from_types   = wc_get_order_types( 'admin-menu' );
 		$redirect_from_types[] = 'shop_order_placehold';
 
-		$order_type = get_post_type( $post_id ) ?: OrderUtil::get_order_type( $post_id );
+		$post_type  = get_post_type( $post_id );
+		$order_type = $post_type ? $post_type : OrderUtil::get_order_type( $post_id );
 		if ( ! in_array( $order_type, $redirect_from_types, true ) || ! isset( $_GET['action'] ) ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is authoritative, we automatically redirect admin URLs for order posts to the corresponding HPOS one. For example, `/wp-admin/post.php?post=123&action=edit` gets turned into `/wp-admin/admin.php?page=wc-orders&action=edit&id=123`.

This works correctly when the order post exists, but was producing a 500 error when not.

This is sort of an edge case as we don't endorse removal of the backup post / placeholder post, but we've seen some users doing that after migrating to HPOS anyways.

This PR adds an additional check so that the redirect succeeds in those cases (as long as the HPOS order exists).

Closes #44177.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is configured as datastore in WC > Settings > Advanced > Features and that compatibility mode is disabled.
2. Ensure your site has a few orders. If necessary, create some or use [Smooth Generator](https://github.com/woocommerce/wc-smooth-generator) for a smoother testing experience. Make note of some order IDs.
3. Delete the backup post for one of the orders by running the following command:
   ```
   wp db query "DELETE FROM $(wp db prefix)posts WHERE ID = <order_id>"
   ```
4. Visit `https://yoursite.test/wp-admin/post.php?post=<order_id>&action=edit` and confirm that you're redirected to the (HPOS) order edit screen.
5. Visit `https://yoursite.test/wp-admin/post.php?post=<post_id>&action=edit` with a `<post_id>` that has no corresponding post and confirm that you see an error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
