### PR TITLE
Launch Your Store:  Add status dropdown functionality

### DIFF
--- a/plugins/woocommerce-admin/client/header/index.js
+++ b/plugins/woocommerce-admin/client/header/index.js
@@ -100,7 +100,7 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 		}
 	}, [ isEmbedded, sections, siteTitle ] );
 
-	const { isLoading, launchStatus, launchYourStoreEnabled } =
+	const { isLoading, launchYourStoreEnabled, comingSoon, storePagesOnly } =
 		useLaunchYourStore();
 	const showLaunchYourStoreStatus = launchYourStoreEnabled && ! isLoading;
 
@@ -137,7 +137,10 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 				</Text>
 
 				{ showLaunchYourStoreStatus && (
-					<LaunchYourStoreStatus status={ launchStatus } />
+					<LaunchYourStoreStatus
+						comingSoon={ comingSoon }
+						storePagesOnly={ storePagesOnly }
+					/>
 				) }
 
 				<WooHeaderItem.Slot fillProps={ { isEmbedded, query } } />

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.js
@@ -14,9 +14,13 @@ import './style.scss';
 
 export const LaunchYourStoreStatus = ( { comingSoon, storePagesOnly } ) => {
 	const isComingSoon = comingSoon && comingSoon === 'yes';
-	const dropdownText = isComingSoon
-		? __( 'Coming soon', 'woocommerce' )
-		: __( 'Live', 'woocommerce' );
+	const isStorePagesOnly =
+		isComingSoon && storePagesOnly && storePagesOnly === 'yes';
+	const comingSoonText = isStorePagesOnly
+		? __( 'Coming soon - Store pages only', 'woocommerce' )
+		: __( 'Coming soon', 'woocommerce' );
+	const liveText = __( 'Live', 'woocommerce' );
+	const dropdownText = isComingSoon ? comingSoonText : liveText;
 	return (
 		<div className="woocommerce-lys-status">
 			<div className="woocommerce-lys-status-pill-wrapper">

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Icon, moreVertical } from '@wordpress/icons';
+import { Dropdown, Button, MenuGroup, MenuItem } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,10 +13,31 @@ export const LaunchYourStoreStatus = () => {
 	return (
 		<div className="woocommerce-lys-status">
 			<div className="woocommerce-lys-status-pill-wrapper">
-				<div className="woocommerce-lys-status-pill">
-					<span>Coming soon</span>
-					<Icon icon={ moreVertical } size={ 18 } />
-				</div>
+				<Dropdown
+					className="woocommerce-lys-status-dropdown"
+					focusOnMount={ true }
+					popoverProps={ { placement: 'bottom-start' } }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button onClick={ onToggle } aria-expanded={ isOpen }>
+							<div className="woocommerce-lys-status-pill">
+								<span>Coming soon</span>
+								<Icon icon={ moreVertical } size={ 18 } />
+							</div>
+						</Button>
+					) }
+					renderContent={ () => (
+						<>
+							<MenuGroup>
+								<MenuItem href="https://developer.wordpress.org/block-editor/reference-guides/components/button/">
+									Manage site visibility
+								</MenuItem>
+								<MenuItem href="https://developer.wordpress.org/block-editor/reference-guides/components/button/">
+									Customize "Coming soon" page
+								</MenuItem>
+							</MenuGroup>
+						</>
+					) }
+				/>
 			</div>
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.js
@@ -54,7 +54,8 @@ export const LaunchYourStoreStatus = ( { comingSoon, storePagesOnly } ) => {
 								{ isComingSoon && (
 									<MenuItem
 										href={ getAdminLink(
-											'admin.php?page=wc-settings' // For now, waiting on the actual link
+											// For now, waiting on the actual link. See https://github.com/woocommerce/team-ghidorah/issues/289.
+											'admin.php?page=wc-settings'
 										) }
 									>
 										Customize "Coming soon" page

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.js
@@ -1,16 +1,22 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Icon, moreVertical } from '@wordpress/icons';
 import { Dropdown, Button, MenuGroup, MenuItem } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/settings';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-export const LaunchYourStoreStatus = () => {
+export const LaunchYourStoreStatus = ( { comingSoon, storePagesOnly } ) => {
+	const isComingSoon = comingSoon && comingSoon === 'yes';
+	const dropdownText = isComingSoon
+		? __( 'Coming soon', 'woocommerce' )
+		: __( 'Live', 'woocommerce' );
 	return (
 		<div className="woocommerce-lys-status">
 			<div className="woocommerce-lys-status-pill-wrapper">
@@ -20,8 +26,13 @@ export const LaunchYourStoreStatus = () => {
 					popoverProps={ { placement: 'bottom-start' } }
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Button onClick={ onToggle } aria-expanded={ isOpen }>
-							<div className="woocommerce-lys-status-pill">
-								<span>Coming soon</span>
+							<div
+								className={ classnames(
+									'woocommerce-lys-status-pill',
+									{ 'is-live': ! isComingSoon }
+								) }
+							>
+								<span>{ dropdownText }</span>
 								<Icon icon={ moreVertical } size={ 18 } />
 							</div>
 						</Button>
@@ -36,13 +47,15 @@ export const LaunchYourStoreStatus = () => {
 								>
 									Manage site visibility
 								</MenuItem>
-								<MenuItem
-									href={ getAdminLink(
-										'admin.php?page=wc-settings' // For now, waiting on the actual link
-									) }
-								>
-									Customize "Coming soon" page
-								</MenuItem>
+								{ isComingSoon && (
+									<MenuItem
+										href={ getAdminLink(
+											'admin.php?page=wc-settings' // For now, waiting on the actual link
+										) }
+									>
+										Customize "Coming soon" page
+									</MenuItem>
+								) }
 							</MenuGroup>
 						</>
 					) }

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.js
@@ -3,6 +3,7 @@
  */
 import { Icon, moreVertical } from '@wordpress/icons';
 import { Dropdown, Button, MenuGroup, MenuItem } from '@wordpress/components';
+import { getAdminLink } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -28,10 +29,18 @@ export const LaunchYourStoreStatus = () => {
 					renderContent={ () => (
 						<>
 							<MenuGroup>
-								<MenuItem href="https://developer.wordpress.org/block-editor/reference-guides/components/button/">
+								<MenuItem
+									href={ getAdminLink(
+										'admin.php?page=wc-settings'
+									) }
+								>
 									Manage site visibility
 								</MenuItem>
-								<MenuItem href="https://developer.wordpress.org/block-editor/reference-guides/components/button/">
+								<MenuItem
+									href={ getAdminLink(
+										'admin.php?page=wc-settings' // For now, waiting on the actual link
+									) }
+								>
 									Customize "Coming soon" page
 								</MenuItem>
 							</MenuGroup>

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.js
@@ -49,7 +49,10 @@ export const LaunchYourStoreStatus = ( { comingSoon, storePagesOnly } ) => {
 										'admin.php?page=wc-settings'
 									) }
 								>
-									Manage site visibility
+									{ __(
+										'Manage site visibility',
+										'woocommerce'
+									) }
 								</MenuItem>
 								{ isComingSoon && (
 									<MenuItem
@@ -58,7 +61,10 @@ export const LaunchYourStoreStatus = ( { comingSoon, storePagesOnly } ) => {
 											'admin.php?page=wc-settings'
 										) }
 									>
-										Customize "Coming soon" page
+										{ __(
+											'Customize "Coming soon" page',
+											'woocommerce'
+										) }
 									</MenuItem>
 								) }
 							</MenuGroup>

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.js
@@ -57,7 +57,7 @@ export const LaunchYourStoreStatus = ( { comingSoon, storePagesOnly } ) => {
 								{ isComingSoon && (
 									<MenuItem
 										href={ getAdminLink(
-											// For now, waiting on the actual link. See https://github.com/woocommerce/team-ghidorah/issues/289.
+											// For now, waiting on the actual link.
 											'admin.php?page=wc-settings'
 										) }
 									>

--- a/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
@@ -19,3 +19,9 @@
 	border-radius: 4px;
 	height: 24px;
 }
+
+.woocommerce-lys-status-dropdown .components-button {
+	padding: 0;
+	height: auto;
+	border-radius: 4px;
+}

--- a/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
@@ -23,8 +23,8 @@
 		background-color: #e6f2e8;
 		color: #005c12;
 
-		&:before {
-			content: "";
+		&::before {
+			content: '';
 			width: 6px;
 			height: 6px;
 			border-radius: 3px;

--- a/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
@@ -18,6 +18,20 @@
 	line-height: 20px;
 	border-radius: 4px;
 	height: 24px;
+
+	&.is-live {
+		background-color: #e6f2e8;
+		color: #005c12;
+
+		&:before {
+			content: "";
+			width: 6px;
+			height: 6px;
+			border-radius: 3px;
+			background-color: #005c12;
+			margin-right: 4px;
+		}
+	}
 }
 
 .woocommerce-lys-status-dropdown .components-button {

--- a/plugins/woocommerce/changelog/45606-add-lys-status-dropdown
+++ b/plugins/woocommerce/changelog/45606-add-lys-status-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Updates unreleased component from launch your store
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45111

This PR adds functionality to the Launch Your Store Status chip

<img width="196" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/c5f32a00-e665-4d4e-812c-fb7a4c21743e">

<br/>

<img width="370" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/9505ece3-28b6-4114-915d-4869df1d7165">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site
2. Turn on the feature flag Tools > WCA Test Helper > Features > launch-your-store
3. Visit Settings screen `/wp-admin/admin.php?page=wc-settings`
4. Play around with Site Visibility settings and see the status pill react accordingly. Designs will match 0BWMerqRR1f468EwC7g5tg-fi-858-55937
5. Note the `Customize "Coming soon" page` link temporarily just links to settings.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Updates unreleased component from launch your store

</details>
