### PR TITLE
Product Editor: Fix editor crash when clicking in editor margin when summary or description fields are focused

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-crashes-text-area-toolbar
+++ b/packages/js/product-editor/changelog/fix-product-editor-crashes-text-area-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: Workaround a Gutenberg bug that resulted in a crash when clicking in the margin of the editor when the summary or description fields were focused, by reverting the changes that were made in #44166.

--- a/packages/js/product-editor/src/blocks/generic/tab/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/tab/editor.scss
@@ -4,19 +4,6 @@
 	}
 }
 
-.wp-block-woocommerce-product-tab {
-	padding-left: calc( 2 * $gap );
-	padding-right: calc( 2 * $gap );
-
-	@include breakpoint(">782px") {
-		padding-left: 0;
-		padding-right: 0;
-		max-width: 650px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-}
-
 .woocommerce-product-tabs {
 	.wp-block-woocommerce-product-tab__button:focus:not( :disabled ) {
 		box-shadow: none;

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -6,7 +6,12 @@ import { useWooBlockProps } from '@woocommerce/block-templates';
 import { createElement } from '@wordpress/element';
 import { BaseControl, TextareaControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { BlockControls, RichText } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+import {
+	BlockControls,
+	RichText,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import classNames from 'classnames';
 
 /**
@@ -20,6 +25,7 @@ import type {
 import AligmentToolbarButton from './toolbar/toolbar-button-alignment';
 import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { Label } from '../../../components/label/label';
+import React from 'react';
 
 export function TextAreaBlockEdit( {
 	attributes,
@@ -60,6 +66,23 @@ export function TextAreaBlockEdit( {
 	const [ content, setContent ] = useProductEntityProp< string >( property, {
 		postType,
 	} );
+
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+
+	function handleBlur(
+		event:
+			| React.FocusEvent< 'p', Element >
+			| React.FocusEvent< HTMLTextAreaElement >
+	) {
+		const isToolbar = event.relatedTarget?.closest(
+			'.block-editor-block-contextual-toolbar'
+		);
+		if ( ! isToolbar ) {
+			clearSelectedBlock();
+		}
+	}
 
 	function setAlignment( value: TextAreaBlockEditAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );
@@ -120,6 +143,7 @@ export function TextAreaBlockEdit( {
 						placeholder={ placeholder }
 						required={ required }
 						disabled={ disabled }
+						onBlur={ handleBlur }
 					/>
 				) }
 
@@ -130,6 +154,7 @@ export function TextAreaBlockEdit( {
 						placeholder={ placeholder }
 						required={ required }
 						disabled={ disabled }
+						onBlur={ handleBlur }
 					/>
 				) }
 			</BaseControl>

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -6,12 +6,7 @@ import { useWooBlockProps } from '@woocommerce/block-templates';
 import { createElement } from '@wordpress/element';
 import { BaseControl, TextareaControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
-import {
-	BlockControls,
-	RichText,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { BlockControls, RichText } from '@wordpress/block-editor';
 import classNames from 'classnames';
 
 /**
@@ -23,9 +18,9 @@ import type {
 	TextAreaBlockEditProps,
 } from './types';
 import AligmentToolbarButton from './toolbar/toolbar-button-alignment';
+import { useClearSelectedBlockOnBlur } from '../../../hooks/use-clear-selected-block-on-blur';
 import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { Label } from '../../../components/label/label';
-import React from 'react';
 
 export function TextAreaBlockEdit( {
 	attributes,
@@ -67,22 +62,10 @@ export function TextAreaBlockEdit( {
 		postType,
 	} );
 
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore No types for this exist yet.
-	const { clearSelectedBlock } = useDispatch( blockEditorStore );
-
-	function handleBlur(
-		event:
-			| React.FocusEvent< 'p', Element >
-			| React.FocusEvent< HTMLTextAreaElement >
-	) {
-		const isToolbar = event.relatedTarget?.closest(
-			'.block-editor-block-contextual-toolbar'
-		);
-		if ( ! isToolbar ) {
-			clearSelectedBlock();
-		}
-	}
+	// This is a workaround to hide the toolbar when the block is blurred.
+	// This is a temporary solution until using Gutenberg 18 with the
+	// fix from https://github.com/WordPress/gutenberg/pull/59800
+	const { handleBlur: hideToolbar } = useClearSelectedBlockOnBlur();
 
 	function setAlignment( value: TextAreaBlockEditAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );
@@ -143,7 +126,7 @@ export function TextAreaBlockEdit( {
 						placeholder={ placeholder }
 						required={ required }
 						disabled={ disabled }
-						onBlur={ handleBlur }
+						onBlur={ hideToolbar }
 					/>
 				) }
 
@@ -154,7 +137,7 @@ export function TextAreaBlockEdit( {
 						placeholder={ placeholder }
 						required={ required }
 						disabled={ disabled }
-						onBlur={ handleBlur }
+						onBlur={ hideToolbar }
 					/>
 				) }
 			</BaseControl>

--- a/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
@@ -23,6 +23,7 @@ import { ParagraphRTLControl } from './paragraph-rtl-control';
 import { SummaryAttributes } from './types';
 import { ALIGNMENT_CONTROLS } from './constants';
 import { ProductEditorBlockEditProps } from '../../../types';
+import { useClearSelectedBlockOnBlur } from '../../../hooks/use-clear-selected-block-on-blur';
 
 export function SummaryBlockEdit( {
 	attributes,
@@ -43,6 +44,11 @@ export function SummaryBlockEdit( {
 		context.postType || 'product',
 		attributes.property
 	);
+
+	// This is a workaround to hide the toolbar when the block is blurred.
+	// This is a temporary solution until using Gutenberg 18 with the
+	// fix from https://github.com/WordPress/gutenberg/pull/59800
+	const { handleBlur: hideToolbar } = useClearSelectedBlockOnBlur();
 
 	function handleAlignmentChange( value: SummaryAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );
@@ -114,6 +120,7 @@ export function SummaryBlockEdit( {
 						} ) }
 						dir={ direction }
 						allowedFormats={ allowedFormats }
+						onBlur={ hideToolbar }
 					/>
 				</div>
 			</BaseControl>

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -147,7 +147,17 @@
 
 	.block-editor-block-list__layout {
 		&.is-root-container {
+			padding-left: 0;
+			padding-right: 0;
 			padding-bottom: 128px;
+			margin-left: calc(2 * $gap);
+			margin-right: calc(2 * $gap);
+
+			@include breakpoint(">782px") {
+				max-width: 650px;
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 
 		.block-editor-block-list__block {

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -10,3 +10,4 @@ export { useProductTemplate as __experimentalUseProductTemplate } from './use-pr
 export { useProductScheduled as __experimentalUseProductScheduled } from './use-product-scheduled';
 export { useProductManager as __experimentalUseProductManager } from './use-product-manager';
 export { useMetaboxHiddenProduct as __experimentalUseMetaboxHiddenProduct } from './use-metabox-hidden-product';
+export { useClearSelectedBlockOnBlur as __experimentalClearSelectedBlockOnBlur } from './use-clear-selected-block-on-blur';

--- a/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/index.ts
+++ b/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/index.ts
@@ -1,0 +1,1 @@
+export * from './use-clear-selected-block-on-blur';

--- a/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/use-clear-selected-block-on-blur.ts
+++ b/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/use-clear-selected-block-on-blur.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+// This is a workaround to hide the toolbar when the block is blurred.
+// This is a temporary solution until using Gutenberg 18 with the
+// fix from https://github.com/WordPress/gutenberg/pull/59800
+export const useClearSelectedBlockOnBlur = () => {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+
+	function handleBlur( event: {
+		relatedTarget: ( EventTarget & Element ) | null;
+	} ) {
+		const isToolbar = event.relatedTarget?.closest(
+			'.block-editor-block-contextual-toolbar'
+		);
+
+		if ( ! isToolbar ) {
+			clearSelectedBlock();
+		}
+	}
+
+	return {
+		handleBlur,
+	};
+};

--- a/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/use-clear-selected-block-on-blur.ts
+++ b/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/use-clear-selected-block-on-blur.ts
@@ -15,7 +15,7 @@ export const useClearSelectedBlockOnBlur = () => {
 	function handleBlur( event: {
 		relatedTarget: ( EventTarget & Element ) | null;
 	} ) {
-		const isToolbar = event.relatedTarget?.closest(
+		const isToolbar = event?.relatedTarget?.closest(
 			'.block-editor-block-contextual-toolbar'
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR reverts the changes made in #44166, in order to provide a workaround to a **Gutenberg 17.9.0** bug that caused the product editor to crash when clicking on the margins when the summary or description fields were focused.

Once Gutenberg 18 is used, this workaround can be removed and the changes from #44166 can be used again (GB fix: https://github.com/WordPress/gutenberg/pull/59800). 

Fixes #45522.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**), and the **Gutenberg 17.9.0** plugin activated...

1. Go to **Products** > **Add New**
1. Click on summary or description field to focus it.
2. Click on margin of editor.
3. Verify the editor does not crash and that the toolbar for the summary or description field is hidden.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
