### PR TITLE
Exclude the Legacy REST API plugin from the feature compatibility UI

### DIFF
--- a/plugins/woocommerce/changelog/pr-45610
+++ b/plugins/woocommerce/changelog/pr-45610
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Exclude the Legacy REST API plugin from the feature compatibility UI

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -77,6 +77,13 @@ class FeaturesController {
 	private $force_allow_enabling_plugins = false;
 
 	/**
+	 * List of plugins excluded from feature compatibility warnings in UI.
+	 *
+	 * @var string[]
+	 */
+	private $plugins_excluded_from_compatibility_ui;
+
+	/**
 	 * Creates a new instance of the class.
 	 */
 	public function __construct() {
@@ -180,10 +187,10 @@ class FeaturesController {
 					'is_experimental' => true,
 					'disable_ui'      => false,
 					'is_legacy'       => true,
-					'disabled'        => function() {
+					'disabled'        => function () {
 						return version_compare( get_bloginfo( 'version' ), '6.2', '<' );
 					},
-					'desc_tip'        => function() {
+					'desc_tip'        => function () {
 						$string = '';
 						if ( version_compare( get_bloginfo( 'version' ), '6.2', '<' ) ) {
 							$string = __(
@@ -262,6 +269,8 @@ class FeaturesController {
 	final public function init( LegacyProxy $proxy, PluginUtil $plugin_util ) {
 		$this->proxy       = $proxy;
 		$this->plugin_util = $plugin_util;
+
+		$this->plugins_excluded_from_compatibility_ui = $plugin_util->get_plugins_excluded_from_compatibility_ui();
 	}
 
 	/**
@@ -285,7 +294,7 @@ class FeaturesController {
 		if ( ! $include_experimental ) {
 			$features = array_filter(
 				$features,
-				function( $feature ) {
+				function ( $feature ) {
 					return ! $feature['is_experimental'];
 				}
 			);
@@ -422,7 +431,7 @@ class FeaturesController {
 	 * @param bool   $enabled_features_only True to return only names of enabled plugins.
 	 * @return array An array having a 'compatible' and an 'incompatible' key, each holding an array of feature ids.
 	 */
-	public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ) : array {
+	public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ): array {
 		$this->verify_did_woocommerce_init( __FUNCTION__ );
 
 		$features = $this->get_feature_definitions();
@@ -457,7 +466,7 @@ class FeaturesController {
 	 * @param bool   $active_only True to return only active plugins.
 	 * @return array An array having a 'compatible' and an 'incompatible' key, each holding an array of plugin names.
 	 */
-	public function get_compatible_plugins_for_feature( string $feature_id, bool $active_only = false ) : array {
+	public function get_compatible_plugins_for_feature( string $feature_id, bool $active_only = false ): array {
 		$this->verify_did_woocommerce_init( __FUNCTION__ );
 
 		$woo_aware_plugins = $this->plugin_util->get_woocommerce_aware_plugins( $active_only );
@@ -572,7 +581,7 @@ class FeaturesController {
 		$is_default_key            = preg_match( '/^woocommerce_feature_([a-zA-Z0-9_]+)_enabled$/', $option, $matches );
 		$features_with_custom_keys = array_filter(
 			$this->get_feature_definitions(),
-			function( $feature ) {
+			function ( $feature ) {
 				return ! empty( $feature['option_key'] );
 			}
 		);
@@ -649,13 +658,16 @@ class FeaturesController {
 
 		$features = $this->get_features( true );
 
-		$feature_ids              = array_keys( $features );
-		usort( $feature_ids, function( $feature_id_a, $feature_id_b ) use ( $features ) {
-			return ( $features[ $feature_id_b ]['order'] ?? 0 ) <=> ( $features[ $feature_id_a ]['order'] ?? 0 );
-		} );
+		$feature_ids = array_keys( $features );
+		usort(
+			$feature_ids,
+			function ( $feature_id_a, $feature_id_b ) use ( $features ) {
+				return ( $features[ $feature_id_b ]['order'] ?? 0 ) <=> ( $features[ $feature_id_a ]['order'] ?? 0 );
+			}
+		);
 		$experimental_feature_ids = array_filter(
 			$feature_ids,
-			function( $feature_id ) use ( $features ) {
+			function ( $feature_id ) use ( $features ) {
 				return $features[ $feature_id ]['is_experimental'] ?? false;
 			}
 		);
@@ -709,7 +721,7 @@ class FeaturesController {
 		if ( $this->verify_did_woocommerce_init() ) {
 			// Allow feature setting properties to be determined dynamically just before being rendered.
 			$feature_settings = array_map(
-				function( $feature_setting ) {
+				function ( $feature_setting ) {
 					foreach ( $feature_setting as $prop => $value ) {
 						if ( is_callable( $value ) ) {
 							$feature_setting[ $prop ] = call_user_func( $value );
@@ -894,6 +906,8 @@ class FeaturesController {
 	private function get_incompatible_plugins( $feature_id, $list ) {
 		$incompatibles = array();
 
+		$list = array_diff_key( $list, array_flip( $this->plugins_excluded_from_compatibility_ui ) );
+
 		// phpcs:enable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput
 		foreach ( array_keys( $list ) as $plugin_name ) {
 			if ( ! $this->plugin_util->is_woocommerce_aware_plugin( $plugin_name ) || ! $this->proxy->call_function( 'is_plugin_active', $plugin_name ) ) {
@@ -903,7 +917,7 @@ class FeaturesController {
 			$compatibility     = $this->get_compatible_features_for_plugin( $plugin_name );
 			$incompatible_with = array_filter(
 				array_merge( $compatibility['incompatible'], $compatibility['uncertain'] ),
-				function( $feature_id ) {
+				function ( $feature_id ) {
 					return ! $this->is_legacy_feature( $feature_id );
 				}
 			);
@@ -941,12 +955,13 @@ class FeaturesController {
 		}
 
 		$incompatible_plugins = false;
+		$relevant_plugins     = array_diff( $this->plugin_util->get_woocommerce_aware_plugins( true ), $this->plugins_excluded_from_compatibility_ui );
 
-		foreach ( $this->plugin_util->get_woocommerce_aware_plugins( true ) as $plugin ) {
+		foreach ( $relevant_plugins as $plugin ) {
 			$compatibility     = $this->get_compatible_features_for_plugin( $plugin, true );
 			$incompatible_with = array_filter(
 				array_merge( $compatibility['incompatible'], $compatibility['uncertain'] ),
-				function( $feature_id ) {
+				function ( $feature_id ) {
 					return ! $this->is_legacy_feature( $feature_id );
 				}
 			);
@@ -1060,6 +1075,10 @@ class FeaturesController {
 	private function handle_plugin_list_rows( $plugin_file, $plugin_data ) {
 		global $wp_list_table;
 
+		if ( in_array( $plugin_file, $this->plugins_excluded_from_compatibility_ui, true ) ) {
+			return;
+		}
+
 		if ( 'incompatible_with_feature' !== ArrayUtil::get_value_or_default( $_GET, 'plugin_status' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
@@ -1078,7 +1097,7 @@ class FeaturesController {
 		$incompatible_features      = array_values(
 			array_filter(
 				$incompatible_features,
-				function( $feature_id ) {
+				function ( $feature_id ) {
 					return ! $this->is_legacy_feature( $feature_id );
 				}
 			)

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -39,7 +39,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		add_action(
 			'woocommerce_register_feature_definitions',
-			function( $features_controller ) {
+			function ( $features_controller ) {
 				$this->reset_features_list( $this->sut );
 
 				$features = array(
@@ -187,7 +187,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		// No option for experimental2.
 
 		$actual = array_map(
-			function( $feature ) {
+			function ( $feature ) {
 				return array_intersect_key(
 					$feature,
 					array( 'is_enabled' => '' )
@@ -491,7 +491,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	public function test_get_compatible_enabled_features_for_registered_plugin() {
 		add_action(
 			'woocommerce_register_feature_definitions',
-			function( $features_controller ) {
+			function ( $features_controller ) {
 				$this->reset_features_list( $this->sut );
 
 				$features = array(
@@ -813,6 +813,10 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			public function get_woocommerce_aware_plugins( bool $active_only = false ): array {
 				return $this->active_plugins;
 			}
+
+			public function get_plugins_excluded_from_compatibility_ui() {
+				return array();
+			}
 		};
 
 		$this->register_legacy_proxy_function_mocks(
@@ -828,7 +832,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		add_action(
 			'woocommerce_register_feature_definitions',
-			function( $features_controller ) use ( $local_sut ) {
+			function ( $features_controller ) use ( $local_sut ) {
 				$this->reset_features_list( $local_sut );
 
 				$features = array(
@@ -897,6 +901,10 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			public function get_woocommerce_aware_plugins( bool $active_only = false ): array {
 				return $this->active_plugins;
 			}
+
+			public function get_plugins_excluded_from_compatibility_ui() {
+				return array();
+			}
 		};
 		// phpcs:enable
 
@@ -912,7 +920,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		add_action(
 			'woocommerce_register_feature_definitions',
-			function( $features_controller ) use ( $local_sut ) {
+			function ( $features_controller ) use ( $local_sut ) {
 				$this->reset_features_list( $local_sut );
 
 				$features = array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As part of [the Legacy REST API removal from WooCommerce core](https://developer.woo.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/) we are encouraging WooCommerce admins to install [the dedicated Legacy REST API extension](https://wordpress.org/plugins/woocommerce-legacy-rest-api/) and we plan to install it automatically as needed too. However the extension declares itself incompatible with HPOS (since the Legacy REST API itself is) but this is causing some confussion ("How come that you recommend us to install an extension and then you recommend us not to activate it?").

This pull request excludes the Legacy REST API extension from the feature compatibility UI, this means that the `get_compatible_*` methods in `FeaturesController` will still list the extension as incompatible with HPOS but the extension won't be considered as incompatible in the WooCommerce admin UI (plugins page and features page). The implemented mechanism is extensible: it depends on a new `PluginUtil::get_plugins_excluded_from_compatibility_ui` method that for now is returning a hardcoded array with only the Legacy REST API plugin name (in the future we could add more names to the array, or even add a dedicated filter, if needed).

### How to test the changes in this Pull Request:

1. Install WooCommerce with this fix in a new site.
2. Install [the dedicated Legacy REST API extension](https://wordpress.org/plugins/woocommerce-legacy-rest-api/).
3. Verify that the _"WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features_" notice is **not** appearing.
4. Go to the features settings page (WooCommerce - Settings - Advanced - Features).
5. Verify that the _"1 incompatible plugin detected"_ warning is **not** appearing in the "Order data storage" section.
6. Now install another HPOS-incompatible plugin, for example [WooCommerce Square](https://wordpress.org/plugins/woocommerce-square/advanced/). Make sure to download the ZIP file for a version before 3.3.0, as that version started declaring HPOS compatibility. 
7. Now the _"WooCommerce has detected..."_ notice should appear in the plugins page.
8. Click the "Review the details" link in the notice, the incompatible plugins page will open and it should list **only** the Square plugin.
9. Go to the features settings page, the "Order data storage" section should show this warning: _"1 Incompatible plugin detected (WooCommerce Square)"_; specifically, the warning should have the number 1 and the mentioned plugin should be the Square one.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
