### PR TITLE
Improve local pickup flow

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -67,8 +67,6 @@ const GeneralSettings = () => {
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
 									<a
 										href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping` }
-										target="_blank"
-										rel="noopener noreferrer"
 									/>
 								),
 							}

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -59,7 +59,7 @@ const GeneralSettings = () => {
 					<StyledNotice status="warning" isDismissible={ false }>
 						{ createInterpolateElement(
 							__(
-								'Enabling this will produce duplicate options at checkout. Remove the local pickup shipping method from your <a>shipping zones</a>.',
+								"By enabling Local Pickup with more valuable features for your store, it's recommended that you remove the legacy Local Pickup option from your <a>shipping zones</a>.",
 								'woocommerce'
 							),
 							{

--- a/plugins/woocommerce/changelog/45614-update-41534-improve-local-pickup-flow
+++ b/plugins/woocommerce/changelog/45614-update-41534-improve-local-pickup-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improve messages around the use of the legacy and the new Local Pickup shipping methods.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4275,8 +4275,8 @@ table.wc_shipping {
 		}
 	}
 
-	.wc-shipping-zone-method-input-help-text-container {
-		min-height: 40px;
+	.wc-shipping-legacy-local-pickup-help-text-container {
+		margin: 1.5em 0;
 	}
 
 	.wc-shipping-zone-method-input-help-text {

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -1,4 +1,7 @@
 <?php
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
+
 /**
  * Shipping zone admin
  *
@@ -197,7 +200,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							$methods_placed_in_order = array_merge( $methods_placed_in_order, array_values( $methods ) );
 
+
 							foreach ( $methods_placed_in_order as $method ) {
+								if ( CartCheckoutUtils::is_checkout_block_default() && ! ShippingController::is_legacy_local_pickup_active() && 'local_pickup' === $method->id ) {
+									continue;
+								}
+
 								if ( ! $method->supports( 'shipping-zones' ) ) {
 									continue;
 								}
@@ -214,7 +222,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 								echo '<div id=' . esc_attr( $method->id ) . '-description class="wc-shipping-zone-method-input-help-text"><span>' . wp_kses_post( wpautop( $method->get_method_description() ) ) . '</span></div>';
 							}
-							echo '</div>'
+
+							if ( CartCheckoutUtils::is_checkout_block_default() ) {
+								if ( ShippingController::is_legacy_local_pickup_active() ) {
+									echo '<div>Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in the <a href="/admin.php?page=wc-settings&tab=shipping&section=pickup_location">Local pickup settings page</a>.</div>';
+								} else {
+									echo '<div>Local pickup: set up pickup locations in the <a href="/admin.php?page=wc-settings&tab=shipping&section=pickup_location">Local pickup settings page</a>.</div>';
+								}
+							}
+
+							echo '</div>';
+
 							?>
 						</fieldset>
 					</form>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -228,30 +228,36 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 								echo '<div id=' . esc_attr( $method->id ) . '-description class="wc-shipping-zone-method-input-help-text"><span>' . wp_kses_post( wpautop( $method->get_method_description() ) ) . '</span></div>';
 							}
 
+							echo '</div>';
+
 							if ( CartCheckoutUtils::is_checkout_block_default() ) {
+								echo '<p class="wc-shipping-legacy-local-pickup-help-text-container">';
+
 								if ( ShippingController::is_legacy_local_pickup_active() ) {
 									printf(
+										wp_kses(
 										/* translators: %s: Local pickup settings page URL. */
-										esc_html__(
-											'Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in  the <a href="%s">Local pickup settings page</a>.',
-											'woocommerce'
+											__( 'Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in the <a href="%s">Local pickup settings page</a>.', 'woocommerce' ),
+											array( 'a' => array( 'href' => array() ) )
 										),
 										esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=pickup_location' ) )
 									);
+
 								} else {
 									printf(
+										wp_kses(
 										/* translators: %s: Local pickup settings page URL. */
-										esc_html__(
-											'Local pickup: Set up pickup locations in the <a href="%s">Local pickup settings page</a>.',
-											'woocommerce'
+											__( 'Local pickup: Set up pickup locations in the <a href="%s">Local pickup settings page</a>.', 'woocommerce' ),
+											array( 'a' => array( 'href' => array() ) )
 										),
 										esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=pickup_location' ) )
 									);
-
 								}
+
+								echo '</p>';
 							}
 
-							echo '</div>';
+
 
 							?>
 						</fieldset>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -228,8 +228,6 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 								echo '<div id=' . esc_attr( $method->id ) . '-description class="wc-shipping-zone-method-input-help-text"><span>' . wp_kses_post( wpautop( $method->get_method_description() ) ) . '</span></div>';
 							}
 
-							echo '</div>';
-
 							if ( CartCheckoutUtils::is_checkout_block_default() ) {
 								echo '<p class="wc-shipping-legacy-local-pickup-help-text-container">';
 
@@ -256,6 +254,8 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 
 								echo '</p>';
 							}
+
+							echo '</div>';
 
 							?>
 						</fieldset>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -257,8 +257,6 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 								echo '</p>';
 							}
 
-
-
 							?>
 						</fieldset>
 					</form>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -1,4 +1,5 @@
-<?php
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
+
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
 
@@ -18,7 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<span class="wc-shipping-zone-name"><?php echo esc_html( $zone->get_zone_name() ? $zone->get_zone_name() : __( 'Zone', 'woocommerce' ) ); ?></span>
 </h2>
 
-<?php do_action( 'woocommerce_shipping_zone_before_methods_table', $zone ); ?>
+<?php
+// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+do_action( 'woocommerce_shipping_zone_before_methods_table', $zone );
+?>
 
 <table class="form-table wc-shipping-zone-settings">
 	<tbody>
@@ -93,7 +97,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</tbody>
 </table>
 
-<?php do_action( 'woocommerce_shipping_zone_after_methods_table', $zone ); ?>
+<?php
+// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
+?>
 
 <p class="submit">
 	<button type="submit" name="submit" id="submit" class="button button-primary button-large wc-shipping-zone-method-save" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>" disabled><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
@@ -200,7 +207,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							$methods_placed_in_order = array_merge( $methods_placed_in_order, array_values( $methods ) );
 
-
 							foreach ( $methods_placed_in_order as $method ) {
 								if ( CartCheckoutUtils::is_checkout_block_default() && ! ShippingController::is_legacy_local_pickup_active() && 'local_pickup' === $method->id ) {
 									continue;
@@ -225,22 +231,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							if ( CartCheckoutUtils::is_checkout_block_default() ) {
 								if ( ShippingController::is_legacy_local_pickup_active() ) {
-									echo sprintf(
-										__(
-											/* translators: %s: Local pickup settings page URL. */
+									printf(
+										/* translators: %s: Local pickup settings page URL. */
+										esc_html__(
 											'Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in  the <a href="%s">Local pickup settings page</a>.',
 											'woocommerce'
 										),
-										esc_url(admin_url('admin.php?page=wc-settings&tab=shipping&section=pickup_location'))
+										esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=pickup_location' ) )
 									);
 								} else {
-									echo sprintf(
-										__(
-											/* translators: %s: Local pickup settings page URL. */
+									printf(
+										/* translators: %s: Local pickup settings page URL. */
+										esc_html__(
 											'Local pickup: Set up pickup locations in the <a href="%s">Local pickup settings page</a>.',
 											'woocommerce'
 										),
-										esc_url(admin_url('admin.php?page=wc-settings&tab=shipping&section=pickup_location'))
+										esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=pickup_location' ) )
 									);
 
 								}

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -225,9 +225,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							if ( CartCheckoutUtils::is_checkout_block_default() ) {
 								if ( ShippingController::is_legacy_local_pickup_active() ) {
-									echo '<div>Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in the <a href="/admin.php?page=wc-settings&tab=shipping&section=pickup_location">Local pickup settings page</a>.</div>';
+									echo sprintf(
+										__(
+											/* translators: %s: Local pickup settings page URL. */
+											'Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in  the <a href="%s">Local pickup settings page</a>.',
+											'woocommerce'
+										),
+										esc_url(admin_url('admin.php?page=wc-settings&tab=shipping&section=pickup_location'))
+									);
 								} else {
-									echo '<div>Local pickup: set up pickup locations in the <a href="/admin.php?page=wc-settings&tab=shipping&section=pickup_location">Local pickup settings page</a>.</div>';
+									echo sprintf(
+										__(
+											/* translators: %s: Local pickup settings page URL. */
+											'Local pickup: Set up pickup locations in the <a href="%s">Local pickup settings page</a>.',
+											'woocommerce'
+										),
+										esc_url(admin_url('admin.php?page=wc-settings&tab=shipping&section=pickup_location'))
+									);
+
 								}
 							}
 

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -1,13 +1,12 @@
-<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
-
-use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
-use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
-
+<?php
 /**
  * Shipping zone admin
  *
  * @package WooCommerce\Admin\Shipping
  */
+
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -410,27 +410,4 @@ class WC_Shipping {
 		wc_deprecated_function( 'sort_shipping_methods', '2.6' );
 		return $this->shipping_methods;
 	}
-
-	/**
-	 * Check if legacy local pickup is activated in any of the shipping zones or in the Rest of the World zone.
-	 *
-	 * @return bool
-	 */
-	public function is_legacy_local_pickup_active() {
-		$shipping_zones      = WC_Shipping_Zones::get_zones();
-		$shipping_zones['0'] = array(
-			'zone_name'        => __( 'Rest of the World', 'woocommerce' ),
-			'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
-		);
-
-		foreach ( $shipping_zones as $zone ) {
-			foreach ( $zone['shipping_methods'] as $method ) {
-				if ( 'local_pickup' === $method->id && $method->is_enabled() ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
 }

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -423,8 +423,8 @@ class WC_Shipping {
 			'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
 		);
 
-		foreach ( $shipping_zones as $zone_id => $zone ) {
-			foreach ( $zone['shipping_methods'] as $method_id => $method ) {
+		foreach ( $shipping_zones as $zone ) {
+			foreach ( $zone['shipping_methods'] as $method ) {
 				if ( 'local_pickup' === $method->id && $method->is_enabled() ) {
 					return true;
 				}

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -410,4 +410,27 @@ class WC_Shipping {
 		wc_deprecated_function( 'sort_shipping_methods', '2.6' );
 		return $this->shipping_methods;
 	}
+
+	/**
+	 * Check if legacy local pickup is activated in any of the shipping zones or in the Rest of the World zone.
+	 *
+	 * @return bool
+	 */
+	public function is_legacy_local_pickup_active() {
+		$shipping_zones      = WC_Shipping_Zones::get_zones();
+		$shipping_zones['0'] = array(
+			'zone_name'        => __( 'Rest of the World', 'woocommerce' ),
+			'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
+		);
+
+		foreach ( $shipping_zones as $zone_id => $zone ) {
+			foreach ( $zone['shipping_methods'] as $method_id => $method ) {
+				if ( 'local_pickup' === $method->id && $method->is_enabled() ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -501,9 +501,11 @@ class ShippingController {
 	 * @return bool
 	 */
 	public static function is_legacy_local_pickup_active() {
-		$rest_of_the_world = \WC_Shipping_Zones::get_zone_by( 'zone_id', 0 );
-		$shipping_zones    = \WC_Shipping_Zones::get_zones();
-		array_unshift( $shipping_zones, $rest_of_the_world->get_data() );
+		$rest_of_the_world                          = \WC_Shipping_Zones::get_zone_by( 'zone_id', 0 );
+		$shipping_zones                             = \WC_Shipping_Zones::get_zones();
+		$rest_of_the_world_data                     = $rest_of_the_world->get_data();
+		$rest_of_the_world_data['shipping_methods'] = $rest_of_the_world->get_shipping_methods();
+		array_unshift( $shipping_zones, $rest_of_the_world_data );
 
 		foreach ( $shipping_zones as $zone ) {
 			foreach ( $zone['shipping_methods'] as $method ) {

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -496,35 +496,25 @@ class ShippingController {
 	/**
 	 * Check if legacy local pickup is activated in any of the shipping zones or in the Rest of the World zone.
 	 *
+	 * @since 8.8.0
+	 *
 	 * @return bool
 	 */
 	public static function is_legacy_local_pickup_active() {
-		$has_legacy_pickup = false;
+		$shipping_zones      = WC_Shipping_Zones::get_zones();
+		$shipping_zones['0'] = array(
+			'zone_name'        => __( 'Rest of the World', 'woocommerce' ),
+			'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
+		);
 
-		// Get all shipping zones.
-		$shipping_zones              = \WC_Shipping_Zones::get_zones( 'admin' );
-		$international_shipping_zone = new \WC_Shipping_Zone( 0 );
-
-		// Loop through each shipping zone.
-		foreach ( $shipping_zones as $shipping_zone ) {
-			// Get all registered rates for this shipping zone.
-			$shipping_methods = $shipping_zone['shipping_methods'];
-			// Loop through each registered rate.
-			foreach ( $shipping_methods as $shipping_method ) {
-				if ( 'local_pickup' === $shipping_method->id && 'yes' === $shipping_method->enabled ) {
-					$has_legacy_pickup = true;
-					break 2;
+		foreach ( $shipping_zones as $zone ) {
+			foreach ( $zone['shipping_methods'] as $method ) {
+				if ( 'local_pickup' === $method->id && $method->is_enabled() ) {
+					return true;
 				}
 			}
 		}
 
-		foreach ( $international_shipping_zone->get_shipping_methods( true ) as $shipping_method ) {
-			if ( 'local_pickup' === $shipping_method->id ) {
-				$has_legacy_pickup = true;
-				break;
-			}
-		}
-
-		return $has_legacy_pickup;
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -159,7 +159,7 @@ class ShippingController {
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			foreach ( $settings as $index => $setting ) {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['desc'] .= sprintf(
+					$settings[ $index ]['desc'] = sprintf(
 						/* translators: %s: URL to the documentation. */
 						__( 'Not available when using the <a href="%s">Local pickup options powered by the Checkout block</a>.', 'woocommerce' ),
 						'https://woo.com/document/woocommerce-blocks-local-pickup/'

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -159,7 +159,11 @@ class ShippingController {
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			foreach ( $settings as $index => $setting ) {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['desc']    .= ' (' . __( 'Not available when using the <a href="https://woo.com/document/woocommerce-blocks-local-pickup/">Local pickup options powered by the Checkout block</a>.', 'woocommerce' ) . ')';
+					$settings[ $index ]['desc'] .= sprintf(
+						/* translators: %s: URL to the documentation. */
+						__( 'Not available when using the <a href="%s">Local pickup options powered by the Checkout block</a>.', 'woocommerce' ),
+						'https://woo.com/document/woocommerce-blocks-local-pickup/'
+					);
 					$settings[ $index ]['disabled'] = true;
 					$settings[ $index ]['value']    = 'no';
 					break;

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -501,11 +501,9 @@ class ShippingController {
 	 * @return bool
 	 */
 	public static function is_legacy_local_pickup_active() {
-		$shipping_zones      = WC_Shipping_Zones::get_zones();
-		$shipping_zones['0'] = array(
-			'zone_name'        => __( 'Rest of the World', 'woocommerce' ),
-			'shipping_methods' => WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods(),
-		);
+		$rest_of_the_world = \WC_Shipping_Zones::get_zone_by( 'zone_id', 0 );
+		$shipping_zones    = \WC_Shipping_Zones::get_zones();
+		array_unshift( $shipping_zones, $rest_of_the_world->get_data() );
 
 		foreach ( $shipping_zones as $zone ) {
 			foreach ( $zone['shipping_methods'] as $method ) {

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -159,7 +159,7 @@ class ShippingController {
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			foreach ( $settings as $index => $setting ) {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['desc']    .= ' (' . __( 'Not available when using WooCommerce Blocks Local Pickup', 'woocommerce' ) . ')';
+					$settings[ $index ]['desc']    .= ' (' . __( 'Not available when using the <a href="https://woo.com/document/woocommerce-blocks-local-pickup/">Local pickup options powered by the Checkout block</a>.', 'woocommerce' ) . ')';
 					$settings[ $index ]['disabled'] = true;
 					$settings[ $index ]['value']    = 'no';
 					break;

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -492,4 +492,39 @@ class ShippingController {
 
 		return $served;
 	}
+
+	/**
+	 * Check if legacy local pickup is activated in any of the shipping zones or in the Rest of the World zone.
+	 *
+	 * @return bool
+	 */
+	public function is_legacy_local_pickup_active() {
+		$has_legacy_pickup = false;
+
+		// Get all shipping zones.
+		$shipping_zones              = \WC_Shipping_Zones::get_zones( 'admin' );
+		$international_shipping_zone = new \WC_Shipping_Zone( 0 );
+
+		// Loop through each shipping zone.
+		foreach ( $shipping_zones as $shipping_zone ) {
+			// Get all registered rates for this shipping zone.
+			$shipping_methods = $shipping_zone['shipping_methods'];
+			// Loop through each registered rate.
+			foreach ( $shipping_methods as $shipping_method ) {
+				if ( 'local_pickup' === $shipping_method->id && 'yes' === $shipping_method->enabled ) {
+					$has_legacy_pickup = true;
+					break 2;
+				}
+			}
+		}
+
+		foreach ( $international_shipping_zone->get_shipping_methods( true ) as $shipping_method ) {
+			if ( 'local_pickup' === $shipping_method->id ) {
+				$has_legacy_pickup = true;
+				break;
+			}
+		}
+
+		return $has_legacy_pickup;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -498,7 +498,7 @@ class ShippingController {
 	 *
 	 * @return bool
 	 */
-	public function is_legacy_local_pickup_active() {
+	public static function is_legacy_local_pickup_active() {
 		$has_legacy_pickup = false;
 
 		// Get all shipping zones.

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -15,12 +15,6 @@ class CartCheckoutUtils {
 		if ( wc_current_theme_is_fse_theme() ) {
 			// Ignore the pages and check the templates.
 			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'cart' ), 'wp_template' );
-
-			// If there is no template file, we're using default which does use the block.
-			if ( empty( $templates_from_db ) ) {
-				return true;
-			}
-
 			foreach ( $templates_from_db as $template ) {
 				if ( has_block( 'woocommerce/cart', $template->content ) ) {
 					return true;
@@ -40,12 +34,6 @@ class CartCheckoutUtils {
 		if ( wc_current_theme_is_fse_theme() ) {
 			// Ignore the pages and check the templates.
 			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'checkout' ), 'wp_template' );
-
-			// If there is no template file, we're using default which does use the block.
-			if ( empty( $templates_from_db ) ) {
-				return true;
-			}
-
 			foreach ( $templates_from_db as $template ) {
 				if ( has_block( 'woocommerce/checkout', $template->content ) ) {
 					return true;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41534.

This PR introduces the following changes, as mentioned in the acceptance criteria in #41534:

1. On `WooCommerce » Shipping » Shipping zones`, show **Local pickup: set up pickup locations in the [Local pickup settings page](wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location).** when the Checkout block is enabled and no legacy Local Pickup method is active.
2. On `WooCommerce » Shipping » Shipping zones`, show **Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in the [Local pickup settings page](wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location).** when the Checkout block is enabled and at least one legacy Local Pickup method is active.
3. On `WooCommerce » Shipping » Shipping settings`, change the copy to **Not available when using the [Local pickup options powered by the Checkout block](https://woo.com/document/woocommerce-blocks-local-pickup/)**.
4. On `WooCommerce » Shipping » Local pickup`, change the copy to **By enabling Local Pickup with more valuable features for your store, it's recommended that you remove the legacy Local Pickup option from your [shipping zones](wp-admin/admin.php?page=wc-settings&tab=shipping&section).**


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions.

#### Modal message with no active legacy Local Pickup methods.

1. Install and activate the [Twenty Twenty-Four](https://wordpress.org/themes/twentytwentyfour/) theme.
2. Go to `WooCommerce » Settings » Advanced` and define a page with the Checkout block as the default checkout page.
3. Go to `WooCommerce » Settings » Shipping » Shipping zones`.
4. Ensure that the legacy Local Pickup method isn't active for any of the shipping zones, including the Rest of the World shipping zone.
5. Save the settings (if necessary) and refresh the page.
6. Click on the `edit` link to add shipping method.
7. Click the `Add shipping method` button.
8. Verify that the Local Pickup shipping method is not visible.
9. Verify that the text **"Local pickup: Set up pickup locations in the [Local pickup settings page](https://store.test/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location)."** is visible below the available shipping methods.
10. Go to `WooCommerce » Settings » Advanced` and define a page with the shortcode checkout as the default checkout page.
11. Verify that the Local Pickup shipping method is visible.
12. Verify that the text **"Local pickup: Set up pickup locations in the [Local pickup settings page](https://store.test/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location)."** is not visible below the available shipping methods.
13. Repeat these tests with the [Storefront](https://wordpress.org/themes/storefront/) theme.
14. Verify that the using the Storefront theme shows the same results as using the Twenty Twenty-Four theme.

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="621" alt="Screenshot 2024-03-15 at 16 19 03" src="https://github.com/woocommerce/woocommerce/assets/3323310/30975e7a-4a0e-4a12-a007-44c5540ce38c">
</td>
<td valign="top">After:
<br><br>
<img width="627" alt="Screenshot 2024-03-15 at 15 56 33" src="https://github.com/woocommerce/woocommerce/assets/3323310/fa5c5c90-22a8-4781-b18d-9a23de4b1b65">
</td>
</tr>
</table>

#### Modal message with active legacy Local Pickup methods.

1. Install and activate the [Twenty Twenty-Four](https://wordpress.org/themes/twentytwentyfour/) theme.
2. Go to `WooCommerce » Settings » Advanced` and define a page with the shortcode checkout as the default checkout page.
4. Go to `WooCommerce » Settings » Shipping » Shipping zones`.
5. Add the legacy Local Pickup method for one of the shipping zones or for the Rest of the World shipping zone.
6. Save the settings and refresh the page.
7. Go to `WooCommerce » Settings » Advanced` and define a page with the Checkout block as the default checkout page.
8. Go back to `WooCommerce » Settings » Shipping » Shipping zones`.
9. Click on the `edit` link to add shipping method.
10. Click the `Add shipping method` button.
11. Verify that the Local Pickup shipping method is still visible.
12. Verify that the text **"Explore a new enhanced delivery method that allows you to easily offer one or more pickup locations to your customers in the [Local pickup settings page](https://store.test/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location)."** is visible below the available shipping methods.
13. Go to `WooCommerce » Settings » Advanced` and define a page with the shortcode checkout as the default checkout page.
14. Verify that the Local Pickup shipping method is visible.
15. Verify that the text **"Local pickup: Set up pickup locations in the [Local pickup settings page](https://store.test/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location)."** is not visible below the available shipping methods.
16. Repeat these tests with the [Storefront](https://wordpress.org/themes/storefront/) theme.
17. Verify that the using the Storefront theme shows the same results as using the Twenty Twenty-Four theme.

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="621" alt="Screenshot 2024-03-15 at 16 19 03" src="https://github.com/woocommerce/woocommerce/assets/3323310/30975e7a-4a0e-4a12-a007-44c5540ce38c">
</td>
<td valign="top">After:
<br><br>
<img width="624" alt="Screenshot 2024-03-15 at 15 57 00" src="https://github.com/woocommerce/woocommerce/assets/3323310/230265a2-edfc-456f-a176-8843da6d7a2a">
</td>
</tr>
</table>

#### Shipping settings copy

1. Go to `WooCommerce » Settings » Advanced` and define a page with the Checkout block as the default checkout page.
2. Go to `WooCommerce » Settings » Shipping » Local pickup`.
3. Enable the Local Pickup option.
18. Go to `WooCommerce » Settings » Shipping » Shipping settings`.
19. Verify that the second option in the Calculations settings shows **Not available when using the [Local pickup options powered by the Checkout block](https://woo.com/document/woocommerce-blocks-local-pickup/)**.

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1007" alt="Screenshot 2024-03-15 at 16 20 59" src="https://github.com/woocommerce/woocommerce/assets/3323310/b81ac3e5-49ca-4ea3-b25a-278852e95238">
</td>
<td valign="top">After:
<br><br>
<img width="824" alt="Screenshot 2024-03-15 at 15 21 25" src="https://github.com/woocommerce/woocommerce/assets/3323310/38cc0f7d-74cd-4a7f-a9b8-067c19a2a86b">
</td>
</tr>
</table>

<br class="Apple-interchange-newline">Not available when using the [Local pickup options powered by the Checkout block](https://woo.com/document/woocommerce-blocks-local-pickup/).

#### Local pickup settings copy

1. Go to `WooCommerce » Settings » Advanced` and define a page with the Checkout block as the default checkout page.
2. Go to `WooCommerce » Settings » Shipping » Shipping zones`.
3. Add the legacy Local Pickup method for one of the shipping zones or for the Rest of the World shipping zone.
4. Go to `WooCommerce » Settings » Shipping » Local pickup`. 
5. Verify that copy above the `Enable local pickup` option shows **By enabling Local Pickup with more valuable features for your store, it's recommended that you remove the legacy Local Pickup option from your [shipping zones](wp-admin/admin.php?page=wc-settings&tab=shipping&section).**

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="732" alt="Screenshot 2024-03-15 at 16 20 15" src="https://github.com/woocommerce/woocommerce/assets/3323310/7e7e268d-5181-4d31-b32b-fad59659811a">

</td>
<td valign="top">After:
<br><br>
<img width="734" alt="Screenshot 2024-03-15 at 15 54 27" src="https://github.com/woocommerce/woocommerce/assets/3323310/ac81b8da-071c-426a-bd24-88fca971bcff">
</td>
</tr>
</table>


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Improve messages around the use of the legacy and the new Local Pickup shipping methods.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
