### PR TITLE
[Product Block Editor]: introduce `woocommerce/entity-product` source handler

### DIFF
--- a/packages/js/product-editor/changelog/update-introduce-product-entity-source-handler
+++ b/packages/js/product-editor/changelog/update-introduce-product-entity-source-handler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: introduce `woocommerce/entity-product` binding source handler

--- a/packages/js/product-editor/src/bindings-sources/entity/product/index.ts
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/index.ts
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	AttributeBindingProps,
+	BindingSourceHandlerProps,
+	BindingUseSourceProps,
+	BlockProps,
+	BoundBlockAttributes,
+} from '../../../bindings/types';
+import { WooEntitySourceArgs } from './types';
+
+/**
+ * Giving the block attributes,
+ * return the list of source props
+ *
+ * @param {BoundBlockAttributes} attributes - The block attributes.
+ * @return {string[]} The list of source props.
+ */
+export function getBlockBoundSourePropsList(
+	attributes: BoundBlockAttributes
+): string[] {
+	const bindings = attributes?.metadata?.bindings;
+	if ( ! bindings ) {
+		return [];
+	}
+
+	return Object.values( bindings ).map(
+		( binding: AttributeBindingProps ) => binding.args?.prop
+	);
+}
+
+/**
+ * React custom hook to bind a source to a block.
+ *
+ * @param {BlockProps}          blockProps - The block props.
+ * @param {WooEntitySourceArgs} sourceArgs - The source args.
+ * @return {BindingUseSourceProps} The source value and setter.
+ */
+const useSource = (
+	blockProps: BlockProps,
+	sourceArgs: WooEntitySourceArgs
+): BindingUseSourceProps => {
+	if ( typeof sourceArgs === 'undefined' ) {
+		throw new Error( 'The "args" argument is required.' );
+	}
+
+	if ( ! sourceArgs?.prop ) {
+		throw new Error( 'The "prop" argument is required.' );
+	}
+
+	const { prop, id } = sourceArgs;
+
+	const [ value, updateValue ] = useEntityProp(
+		'postType',
+		'product',
+		prop,
+		id
+	);
+
+	const updateValueHandler = useCallback(
+		( nextEntityPropValue: string ) => {
+			updateValue( nextEntityPropValue );
+		},
+		[ updateValue ]
+	);
+
+	return {
+		placeholder: null,
+		value,
+		updateValue: updateValueHandler,
+	};
+};
+
+/*
+ * Create the product-entity
+ * block binding source handler.
+ *
+ * source ID: `woocommerce/entity-product`
+ * args:
+ * - prop: The name of the entity property to bind.
+ *
+ * In the example below,
+ * the `content` attribute is bound to the `short_description` property.
+ * `product` entity and `postType` kind are defined by the context.
+ *
+ * ```
+ * metadata: {
+ *   bindings: {
+ *     content: {
+ *       source: 'woocommerce/entity-product',
+ *       args: {
+ *         prop: 'short_description',
+ *       },
+ *    },
+ * },
+ * ```
+ */
+export default {
+	name: 'woocommerce/entity-product',
+	label: __( 'Product Entity', 'woocommerce' ),
+	useSource,
+	lockAttributesEditing: true,
+} as BindingSourceHandlerProps< WooEntitySourceArgs >;

--- a/packages/js/product-editor/src/bindings-sources/entity/product/index.ts
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/index.ts
@@ -13,18 +13,18 @@ import type {
 	BindingUseSourceProps,
 	BlockProps,
 } from '../../../bindings/types';
-import { WooEntitySourceArgs } from './types';
+import type { WooCommerceEntityProductSourceArgs } from './types';
 
 /**
  * React custom hook to bind a source to a block.
  *
- * @param {BlockProps}          blockProps - The block props.
- * @param {WooEntitySourceArgs} sourceArgs - The source args.
+ * @param {BlockProps}                         blockProps - The block props.
+ * @param {WooCommerceEntityProductSourceArgs} sourceArgs - The source args.
  * @return {BindingUseSourceProps} The source value and setter.
  */
 const useSource = (
 	blockProps: BlockProps,
-	sourceArgs: WooEntitySourceArgs
+	sourceArgs: WooCommerceEntityProductSourceArgs
 ): BindingUseSourceProps => {
 	if ( typeof sourceArgs === 'undefined' ) {
 		throw new Error( 'The "args" argument is required.' );
@@ -86,4 +86,4 @@ export default {
 	label: __( 'Product Entity', 'woocommerce' ),
 	useSource,
 	lockAttributesEditing: true,
-} as BindingSourceHandlerProps< WooEntitySourceArgs >;
+} as BindingSourceHandlerProps< WooCommerceEntityProductSourceArgs >;

--- a/packages/js/product-editor/src/bindings-sources/entity/product/index.ts
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/index.ts
@@ -9,33 +9,11 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import type {
-	AttributeBindingProps,
 	BindingSourceHandlerProps,
 	BindingUseSourceProps,
 	BlockProps,
-	BoundBlockAttributes,
 } from '../../../bindings/types';
 import { WooEntitySourceArgs } from './types';
-
-/**
- * Giving the block attributes,
- * return the list of source props
- *
- * @param {BoundBlockAttributes} attributes - The block attributes.
- * @return {string[]} The list of source props.
- */
-export function getBlockBoundSourePropsList(
-	attributes: BoundBlockAttributes
-): string[] {
-	const bindings = attributes?.metadata?.bindings;
-	if ( ! bindings ) {
-		return [];
-	}
-
-	return Object.values( bindings ).map(
-		( binding: AttributeBindingProps ) => binding.args?.prop
-	);
-}
 
 /**
  * React custom hook to bind a source to a block.

--- a/packages/js/product-editor/src/bindings-sources/entity/product/test/test-use-source.js
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/test/test-use-source.js
@@ -8,12 +8,20 @@ import { renderHook } from '@testing-library/react-hooks';
  */
 import productEntitySourceHandler from '..';
 
+let mockState;
+
 jest.mock( '@wordpress/core-data', () => ( {
-	useEntityProp: jest.fn(),
+	useEntityProp: jest.fn().mockImplementation( ( kind, name, key ) => {
+		return mockState?.[ key ] ? mockState[ key ] : [];
+	} ),
 } ) );
 
 describe( 'useSource', () => {
 	let blockInstance;
+
+	mockState = {
+		external_property_name: [ 'External source property Value' ],
+	};
 
 	beforeEach( () => {
 		blockInstance = {
@@ -48,6 +56,19 @@ describe( 'useSource', () => {
 
 		expect( result.error ).toEqual(
 			new Error( 'The "prop" argument is required.' )
+		);
+	} );
+
+	it( 'return the value of the product entity property', () => {
+		const { useSource } = productEntitySourceHandler;
+		const { result } = renderHook( () =>
+			useSource( blockInstance, {
+				prop: 'external_property_name',
+			} )
+		);
+
+		expect( result.current.value ).toEqual(
+			'External source property Value'
 		);
 	} );
 } );

--- a/packages/js/product-editor/src/bindings-sources/entity/product/test/test-use-source.js
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/test/test-use-source.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import productEntitySourceHandler from '..';
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityProp: jest.fn(),
+} ) );
+
+describe( 'useSource', () => {
+	let blockInstance;
+
+	beforeEach( () => {
+		blockInstance = {
+			name: 'woocommerce/block-with-entity',
+			attributes: {
+				prop: 'value',
+			},
+			className: 'wp-block-woocommerce-block-with-entity',
+			context: {},
+			clientId: '<client-id-instance>',
+			isSelected: false,
+			setAttributes: jest.fn(),
+		};
+	} );
+
+	it( 'throws an error if sourceArgs is undefined', () => {
+		const { useSource } = productEntitySourceHandler;
+		const { result } = renderHook( () =>
+			useSource( blockInstance, undefined )
+		);
+
+		expect( result.error ).toEqual(
+			new Error( 'The "args" argument is required.' )
+		);
+	} );
+
+	it( 'throws an error if prop in sourceArgs is undefined', () => {
+		const { useSource } = productEntitySourceHandler;
+		const { result } = renderHook( () =>
+			useSource( blockInstance, { prop: undefined } )
+		);
+
+		expect( result.error ).toEqual(
+			new Error( 'The "prop" argument is required.' )
+		);
+	} );
+} );

--- a/packages/js/product-editor/src/bindings-sources/entity/product/types.ts
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/types.ts
@@ -1,0 +1,22 @@
+export type WooEntitySourceArgs = {
+	/*
+	 * The kind of entity to bind.
+	 * Default is `postType`.
+	 */
+	kind?: string;
+
+	/*
+	 * The name of the entity to bind.
+	 */
+	name?: string;
+
+	/*
+	 * The name of the entity property to bind.
+	 */
+	prop: string;
+
+	/*
+	 * The ID of the entity to bind.
+	 */
+	id?: string;
+};

--- a/packages/js/product-editor/src/bindings-sources/entity/product/types.ts
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/types.ts
@@ -1,15 +1,4 @@
-export type WooEntitySourceArgs = {
-	/*
-	 * The kind of entity to bind.
-	 * Default is `postType`.
-	 */
-	kind?: 'postType' | string;
-
-	/*
-	 * The name of the entity to bind.
-	 */
-	name?: string;
-
+export type WooCommerceEntityProductSourceArgs = {
 	/*
 	 * The name of the entity property to bind.
 	 */

--- a/packages/js/product-editor/src/bindings-sources/entity/product/types.ts
+++ b/packages/js/product-editor/src/bindings-sources/entity/product/types.ts
@@ -3,7 +3,7 @@ export type WooEntitySourceArgs = {
 	 * The kind of entity to bind.
 	 * Default is `postType`.
 	 */
-	kind?: string;
+	kind?: 'postType' | string;
 
 	/*
 	 * The name of the entity to bind.

--- a/packages/js/product-editor/src/bindings/types.ts
+++ b/packages/js/product-editor/src/bindings/types.ts
@@ -6,9 +6,6 @@ import {
 	// @ts-expect-error no exported member.
 	type ComponentType,
 } from '@wordpress/element';
-/**
- * Internal dependencies
- */
 
 export type AttributeBindingProps = {
 	source: string;
@@ -21,7 +18,6 @@ export type BoundBlockAttributes = BlockAttributes & {
 	metadata?: {
 		bindings: MetadataBindingsProps;
 	};
-	// attribute?: string;
 };
 
 export type BoundBlockEditInstance = CoreBlockEditProps< BoundBlockAttributes >;

--- a/packages/js/product-editor/src/bindings/types.ts
+++ b/packages/js/product-editor/src/bindings/types.ts
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import type { BlockEditProps, BlockAttributes } from '@wordpress/blocks';
+import {
+	// @ts-expect-error no exported member.
+	type ComponentType,
+} from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+
+export type AttributeBindingProps = {
+	source: string;
+	args: { prop: string };
+};
+
+export type MetadataBindingsProps = Record< string, AttributeBindingProps >;
+
+export type BoundBlockAttributes = BlockAttributes & {
+	metadata?: {
+		bindings: MetadataBindingsProps;
+	};
+	// attribute?: string;
+};
+
+export type BoundBlockEditInstance = CoreBlockEditProps< BoundBlockAttributes >;
+export type BoundBlockEditComponent = ComponentType< BoundBlockEditInstance >;
+
+/*
+ * Block Binding API
+ */
+export type BindingUseSourceProps = {
+	/*
+	 * The placeholder value for the source.
+	 */
+	placeholder: string | null;
+	/*
+	 * The value of the source.
+	 */
+	value: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	/*
+	 * Callback function to set the source value.
+	 */
+	updateValue: ( newValue: any ) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+};
+
+export interface BindingSourceHandlerProps< T > {
+	/*
+	 * The name of the binding source handler.
+	 */
+	name: string;
+
+	/*
+	 * The human-readable label for the binding source handler.
+	 */
+	label: string;
+
+	/*
+	 * React custom hook to bind a source to a block.
+	 */
+	useSource: (
+		blockProps: CoreBlockEditProps< BlockAttributes >,
+		sourceArgs: T
+	) => BindingUseSourceProps;
+
+	lockAttributesEditing: boolean;
+}
+
+/*
+ * Core Types
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface CoreBlockEditProps< T extends Record< string, any > >
+	extends BlockEditProps< T > {
+	readonly name: string;
+	readonly context: Record< string, string >;
+}
+
+export type BlockProps = CoreBlockEditProps< BlockAttributes >;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces the custom `woocommerce/entity-product` source handler. This is part of the Binding Integration implementation.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45421

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

I've added a few unit tests to check the handler API, which has not yet been consumed by other processes.

```cli
pnpm --filter=./packages/js/product-editor run test:js packages/js/product-editor/src/bindings-sources/entity/product
```

<img width="517" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/a153d8f1-90a8-420f-92d4-8180d770a086">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
