### PR TITLE
Blocks E2E: Fix guest user handling in checkout tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.side_effects.spec.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect, test as base } from '@woocommerce/e2e-playwright-utils';
-import { adminFile, guestFile } from '@woocommerce/e2e-utils';
+import { guestFile } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -20,8 +20,6 @@ const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
 } );
 
 test.describe( 'Merchant → Shipping', () => {
-	test.use( { storageState: adminFile } );
-
 	test( 'Merchant can enable shipping calculator and hide shipping costs before address is entered', async ( {
 		page,
 		shippingUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect, test as base } from '@woocommerce/e2e-playwright-utils';
-import { adminFile } from '@woocommerce/e2e-utils';
 import {
 	installPluginFromPHPFile,
 	uninstallPluginFromPHPFile,
@@ -24,7 +23,6 @@ const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
 } );
 
 test.describe( 'Merchant → Additional Checkout Fields', () => {
-	test.use( { storageState: adminFile } );
 	test.beforeAll( async () => {
 		await installPluginFromPHPFile(
 			`${ __dirname }/additional-checkout-fields-plugin.php`

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
@@ -439,39 +439,41 @@ test.describe( 'Shopper → Checkout block → Place Order', () => {
 } );
 
 test.describe( 'Checkout Form Errors', () => {
-	test.use( { storageState: guestFile } );
+	test.describe( 'Guest user', () => {
+		test.use( { storageState: guestFile } );
 
-	test( 'User can see errors when form is incomplete', async ( {
-		frontendUtils,
-		page,
-	} ) => {
-		await frontendUtils.emptyCart();
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
+		test( 'can see errors when form is incomplete', async ( {
+			frontendUtils,
+			page,
+		} ) => {
+			await frontendUtils.emptyCart();
+			await frontendUtils.goToShop();
+			await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+			await frontendUtils.goToCheckout();
 
-		await page.getByLabel( 'Email address' ).clear();
-		await page.getByRole( 'button', { name: 'Place order' } ).click();
+			await page.getByLabel( 'Email address' ).clear();
+			await page.getByRole( 'button', { name: 'Place order' } ).click();
 
-		// Verify that all required fields show the correct warning.
-		await expect(
-			page.getByText( 'Please enter a valid email address' )
-		).toBeVisible();
-		await expect(
-			page.getByText( 'Please enter a valid first name' )
-		).toBeVisible();
-		await expect(
-			page.getByText( 'Please enter a valid last name' )
-		).toBeVisible();
-		await expect(
-			page.getByText( 'Please enter a valid address' )
-		).toBeVisible();
-		await expect(
-			page.getByText( 'Please enter a valid city' )
-		).toBeVisible();
-		await expect(
-			page.getByText( 'Please enter a valid zip code' )
-		).toBeVisible();
+			// Verify that all required fields show the correct warning.
+			await expect(
+				page.getByText( 'Please enter a valid email address' )
+			).toBeVisible();
+			await expect(
+				page.getByText( 'Please enter a valid first name' )
+			).toBeVisible();
+			await expect(
+				page.getByText( 'Please enter a valid last name' )
+			).toBeVisible();
+			await expect(
+				page.getByText( 'Please enter a valid address' )
+			).toBeVisible();
+			await expect(
+				page.getByText( 'Please enter a valid city' )
+			).toBeVisible();
+			await expect(
+				page.getByText( 'Please enter a valid zip code' )
+			).toBeVisible();
+		} );
 	} );
 } );
 
@@ -530,79 +532,82 @@ test.describe( 'Billing Address Form', () => {
 		phone: '',
 	};
 
-	test( 'Ensure billing is empty and shipping address is filled for guest user', async ( {
-		frontendUtils,
-		page,
-		checkoutPageObject,
-	} ) => {
-		await frontendUtils.logout();
-		await frontendUtils.emptyCart();
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-		await checkoutPageObject.fillShippingDetails( shippingTestData );
-		await page.getByLabel( 'Use same address for billing' ).uncheck();
+	test.describe( 'Guest user', () => {
+		test.use( { storageState: guestFile } );
 
-		// Check shipping fields are filled.
-		for ( const [ key, value ] of Object.entries( shippingTestData ) ) {
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			switch ( key ) {
-				case 'firstname':
-					await expect(
-						page.locator( '#shipping-first_name' )
-					).toHaveValue( value );
-					break;
-				case 'lastname':
-					await expect(
-						page.locator( '#shipping-last_name' )
-					).toHaveValue( value );
-					break;
-				case 'country':
-					await expect(
-						page.locator( '#shipping-country input' )
-					).toHaveValue( value );
-					break;
-				case 'addressfirstline':
-					await expect(
-						page.locator( '#shipping-address_1' )
-					).toHaveValue( value );
-					break;
-				case 'addresssecondline':
-					await expect(
-						page.locator( '#shipping-address_2' )
-					).toHaveValue( value );
-					break;
-				case 'state':
-					await expect(
-						page.locator( '#shipping-state input' )
-					).toHaveValue( value );
-					break;
-				default:
-					await expect(
-						page.locator( `#shipping-${ key }` )
-					).toHaveValue( value );
-			}
-		}
+		test( 'Ensure billing is empty and shipping address is filled', async ( {
+			frontendUtils,
+			page,
+			checkoutPageObject,
+		} ) => {
+			await frontendUtils.emptyCart();
+			await frontendUtils.goToShop();
+			await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+			await frontendUtils.goToCheckout();
+			await checkoutPageObject.fillShippingDetails( shippingTestData );
+			await page.getByLabel( 'Use same address for billing' ).uncheck();
 
-		// Check billing fields are empty.
-		for ( const [ key, value ] of Object.entries( billingTestData ) ) {
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			switch ( key ) {
-				case 'country':
-					await expect(
-						page.locator( '#billing-country input' )
-					).toHaveValue( value );
-					break;
-				case 'state':
-					await expect(
-						page.locator( '#billing-state input' )
-					).toHaveValue( value );
-					break;
-				default:
-					await expect(
-						page.locator( `#billing-${ key }` )
-					).toHaveValue( value );
+			// Check shipping fields are filled.
+			for ( const [ key, value ] of Object.entries( shippingTestData ) ) {
+				// eslint-disable-next-line playwright/no-conditional-in-test
+				switch ( key ) {
+					case 'firstname':
+						await expect(
+							page.locator( '#shipping-first_name' )
+						).toHaveValue( value );
+						break;
+					case 'lastname':
+						await expect(
+							page.locator( '#shipping-last_name' )
+						).toHaveValue( value );
+						break;
+					case 'country':
+						await expect(
+							page.locator( '#shipping-country input' )
+						).toHaveValue( value );
+						break;
+					case 'addressfirstline':
+						await expect(
+							page.locator( '#shipping-address_1' )
+						).toHaveValue( value );
+						break;
+					case 'addresssecondline':
+						await expect(
+							page.locator( '#shipping-address_2' )
+						).toHaveValue( value );
+						break;
+					case 'state':
+						await expect(
+							page.locator( '#shipping-state input' )
+						).toHaveValue( value );
+						break;
+					default:
+						await expect(
+							page.locator( `#shipping-${ key }` )
+						).toHaveValue( value );
+				}
 			}
-		}
+
+			// Check billing fields are empty.
+			for ( const [ key, value ] of Object.entries( billingTestData ) ) {
+				// eslint-disable-next-line playwright/no-conditional-in-test
+				switch ( key ) {
+					case 'country':
+						await expect(
+							page.locator( '#billing-country input' )
+						).toHaveValue( value );
+						break;
+					case 'state':
+						await expect(
+							page.locator( '#billing-state input' )
+						).toHaveValue( value );
+						break;
+					default:
+						await expect(
+							page.locator( `#billing-${ key }` )
+						).toHaveValue( value );
+				}
+			}
+		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
@@ -470,8 +470,7 @@ test.describe( 'Checkout Form Errors (guest user)', () => {
 test.describe( 'Billing Address Form', () => {
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
-	// To make sure the company field is visible in the billing address form, we need to enable it in the editor.
-	test.beforeEach( async ( { editor, admin, editorUtils } ) => {
+	test( 'Enable company field', async ( { editor, admin, editorUtils } ) => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
@@ -522,78 +521,82 @@ test.describe( 'Billing Address Form', () => {
 		phone: '',
 	};
 
-	test( 'Ensure billing is empty and shipping address is filled', async ( {
-		frontendUtils,
-		page,
-		checkoutPageObject,
-	} ) => {
-		await frontendUtils.emptyCart();
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-		await checkoutPageObject.fillShippingDetails( shippingTestData );
-		await page.getByLabel( 'Use same address for billing' ).uncheck();
+	test.describe( 'Guest user', () => {
+		test.use( { storageState: guestFile } );
 
-		// Check shipping fields are filled.
-		for ( const [ key, value ] of Object.entries( shippingTestData ) ) {
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			switch ( key ) {
-				case 'firstname':
-					await expect(
-						page.locator( '#shipping-first_name' )
-					).toHaveValue( value );
-					break;
-				case 'lastname':
-					await expect(
-						page.locator( '#shipping-last_name' )
-					).toHaveValue( value );
-					break;
-				case 'country':
-					await expect(
-						page.locator( '#shipping-country input' )
-					).toHaveValue( value );
-					break;
-				case 'addressfirstline':
-					await expect(
-						page.locator( '#shipping-address_1' )
-					).toHaveValue( value );
-					break;
-				case 'addresssecondline':
-					await expect(
-						page.locator( '#shipping-address_2' )
-					).toHaveValue( value );
-					break;
-				case 'state':
-					await expect(
-						page.locator( '#shipping-state input' )
-					).toHaveValue( value );
-					break;
-				default:
-					await expect(
-						page.locator( `#shipping-${ key }` )
-					).toHaveValue( value );
-			}
-		}
+		test( 'Ensure billing is empty and shipping address is filled', async ( {
+			frontendUtils,
+			page,
+			checkoutPageObject,
+		} ) => {
+			await frontendUtils.emptyCart();
+			await frontendUtils.goToShop();
+			await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+			await frontendUtils.goToCheckout();
+			await checkoutPageObject.fillShippingDetails( shippingTestData );
+			await page.getByLabel( 'Use same address for billing' ).uncheck();
 
-		// Check billing fields are empty.
-		for ( const [ key, value ] of Object.entries( billingTestData ) ) {
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			switch ( key ) {
-				case 'country':
-					await expect(
-						page.locator( '#billing-country input' )
-					).toHaveValue( value );
-					break;
-				case 'state':
-					await expect(
-						page.locator( '#billing-state input' )
-					).toHaveValue( value );
-					break;
-				default:
-					await expect(
-						page.locator( `#billing-${ key }` )
-					).toHaveValue( value );
+			// Check shipping fields are filled.
+			for ( const [ key, value ] of Object.entries( shippingTestData ) ) {
+				// eslint-disable-next-line playwright/no-conditional-in-test
+				switch ( key ) {
+					case 'firstname':
+						await expect(
+							page.locator( '#shipping-first_name' )
+						).toHaveValue( value );
+						break;
+					case 'lastname':
+						await expect(
+							page.locator( '#shipping-last_name' )
+						).toHaveValue( value );
+						break;
+					case 'country':
+						await expect(
+							page.locator( '#shipping-country input' )
+						).toHaveValue( value );
+						break;
+					case 'addressfirstline':
+						await expect(
+							page.locator( '#shipping-address_1' )
+						).toHaveValue( value );
+						break;
+					case 'addresssecondline':
+						await expect(
+							page.locator( '#shipping-address_2' )
+						).toHaveValue( value );
+						break;
+					case 'state':
+						await expect(
+							page.locator( '#shipping-state input' )
+						).toHaveValue( value );
+						break;
+					default:
+						await expect(
+							page.locator( `#shipping-${ key }` )
+						).toHaveValue( value );
+				}
 			}
-		}
+
+			// Check billing fields are empty.
+			for ( const [ key, value ] of Object.entries( billingTestData ) ) {
+				// eslint-disable-next-line playwright/no-conditional-in-test
+				switch ( key ) {
+					case 'country':
+						await expect(
+							page.locator( '#billing-country input' )
+						).toHaveValue( value );
+						break;
+					case 'state':
+						await expect(
+							page.locator( '#billing-state input' )
+						).toHaveValue( value );
+						break;
+					default:
+						await expect(
+							page.locator( `#billing-${ key }` )
+						).toHaveValue( value );
+				}
+			}
+		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
@@ -40,14 +40,8 @@ const blockData: BlockData = {
 	},
 };
 
-test.describe( 'Shopper → Account', () => {
-	// Become a logged out user.
-	test.use( {
-		storageState: {
-			origins: [],
-			cookies: [],
-		},
-	} );
+test.describe( 'Shopper → Account (guest user)', () => {
+	test.use( { storageState: guestFile } );
 
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.rest( {
@@ -337,7 +331,7 @@ test.describe( 'Shipping and Billing Addresses', () => {
 	} );
 } );
 
-test.describe( 'Shopper → Checkout block → Shipping', () => {
+test.describe( 'Shopper → Checkout block → Shipping (customer user)', () => {
 	test.use( { storageState: customerFile } );
 
 	test( 'Shopper can choose free shipping, flat rate shipping, and can have different billing and shipping addresses', async ( {
@@ -410,9 +404,7 @@ test.describe( 'Shopper → Checkout block → Shipping', () => {
 	} );
 } );
 
-// We only check if guest user can place an order because we already checked if logged in user can
-// place an order in the previous test
-test.describe( 'Shopper → Checkout block → Place Order', () => {
+test.describe( 'Shopper → Checkout block → Place Order (guest user)', () => {
 	test.use( { storageState: guestFile } );
 
 	test( 'Guest user can place order', async ( {
@@ -438,46 +430,46 @@ test.describe( 'Shopper → Checkout block → Place Order', () => {
 	} );
 } );
 
-test.describe( 'Checkout Form Errors', () => {
-	test.describe( 'Guest user', () => {
-		test.use( { storageState: guestFile } );
+test.describe( 'Checkout Form Errors (guest user)', () => {
+	test.use( { storageState: guestFile } );
 
-		test( 'can see errors when form is incomplete', async ( {
-			frontendUtils,
-			page,
-		} ) => {
-			await frontendUtils.emptyCart();
-			await frontendUtils.goToShop();
-			await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-			await frontendUtils.goToCheckout();
+	test( 'can see errors when form is incomplete', async ( {
+		frontendUtils,
+		page,
+	} ) => {
+		await frontendUtils.emptyCart();
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+		await frontendUtils.goToCheckout();
 
-			await page.getByLabel( 'Email address' ).clear();
-			await page.getByRole( 'button', { name: 'Place order' } ).click();
+		await page.getByLabel( 'Email address' ).clear();
+		await page.getByRole( 'button', { name: 'Place order' } ).click();
 
-			// Verify that all required fields show the correct warning.
-			await expect(
-				page.getByText( 'Please enter a valid email address' )
-			).toBeVisible();
-			await expect(
-				page.getByText( 'Please enter a valid first name' )
-			).toBeVisible();
-			await expect(
-				page.getByText( 'Please enter a valid last name' )
-			).toBeVisible();
-			await expect(
-				page.getByText( 'Please enter a valid address' )
-			).toBeVisible();
-			await expect(
-				page.getByText( 'Please enter a valid city' )
-			).toBeVisible();
-			await expect(
-				page.getByText( 'Please enter a valid zip code' )
-			).toBeVisible();
-		} );
+		// Verify that all required fields show the correct warning.
+		await expect(
+			page.getByText( 'Please enter a valid email address' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Please enter a valid first name' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Please enter a valid last name' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Please enter a valid address' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Please enter a valid city' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Please enter a valid zip code' )
+		).toBeVisible();
 	} );
 } );
 
-test.describe( 'Billing Address Form', () => {
+test.describe( 'Billing Address Form (guest user)', () => {
+	test.use( { storageState: guestFile } );
+
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
 	// To make sure the company field is visible in the billing address form, we need to enable it in the editor.
@@ -532,82 +524,78 @@ test.describe( 'Billing Address Form', () => {
 		phone: '',
 	};
 
-	test.describe( 'Guest user', () => {
-		test.use( { storageState: guestFile } );
+	test( 'Ensure billing is empty and shipping address is filled', async ( {
+		frontendUtils,
+		page,
+		checkoutPageObject,
+	} ) => {
+		await frontendUtils.emptyCart();
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+		await frontendUtils.goToCheckout();
+		await checkoutPageObject.fillShippingDetails( shippingTestData );
+		await page.getByLabel( 'Use same address for billing' ).uncheck();
 
-		test( 'Ensure billing is empty and shipping address is filled', async ( {
-			frontendUtils,
-			page,
-			checkoutPageObject,
-		} ) => {
-			await frontendUtils.emptyCart();
-			await frontendUtils.goToShop();
-			await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-			await frontendUtils.goToCheckout();
-			await checkoutPageObject.fillShippingDetails( shippingTestData );
-			await page.getByLabel( 'Use same address for billing' ).uncheck();
-
-			// Check shipping fields are filled.
-			for ( const [ key, value ] of Object.entries( shippingTestData ) ) {
-				// eslint-disable-next-line playwright/no-conditional-in-test
-				switch ( key ) {
-					case 'firstname':
-						await expect(
-							page.locator( '#shipping-first_name' )
-						).toHaveValue( value );
-						break;
-					case 'lastname':
-						await expect(
-							page.locator( '#shipping-last_name' )
-						).toHaveValue( value );
-						break;
-					case 'country':
-						await expect(
-							page.locator( '#shipping-country input' )
-						).toHaveValue( value );
-						break;
-					case 'addressfirstline':
-						await expect(
-							page.locator( '#shipping-address_1' )
-						).toHaveValue( value );
-						break;
-					case 'addresssecondline':
-						await expect(
-							page.locator( '#shipping-address_2' )
-						).toHaveValue( value );
-						break;
-					case 'state':
-						await expect(
-							page.locator( '#shipping-state input' )
-						).toHaveValue( value );
-						break;
-					default:
-						await expect(
-							page.locator( `#shipping-${ key }` )
-						).toHaveValue( value );
-				}
+		// Check shipping fields are filled.
+		for ( const [ key, value ] of Object.entries( shippingTestData ) ) {
+			// eslint-disable-next-line playwright/no-conditional-in-test
+			switch ( key ) {
+				case 'firstname':
+					await expect(
+						page.locator( '#shipping-first_name' )
+					).toHaveValue( value );
+					break;
+				case 'lastname':
+					await expect(
+						page.locator( '#shipping-last_name' )
+					).toHaveValue( value );
+					break;
+				case 'country':
+					await expect(
+						page.locator( '#shipping-country input' )
+					).toHaveValue( value );
+					break;
+				case 'addressfirstline':
+					await expect(
+						page.locator( '#shipping-address_1' )
+					).toHaveValue( value );
+					break;
+				case 'addresssecondline':
+					await expect(
+						page.locator( '#shipping-address_2' )
+					).toHaveValue( value );
+					break;
+				case 'state':
+					await expect(
+						page.locator( '#shipping-state input' )
+					).toHaveValue( value );
+					break;
+				default:
+					await expect(
+						page.locator( `#shipping-${ key }` )
+					).toHaveValue( value );
 			}
+		}
 
-			// Check billing fields are empty.
-			for ( const [ key, value ] of Object.entries( billingTestData ) ) {
-				// eslint-disable-next-line playwright/no-conditional-in-test
-				switch ( key ) {
-					case 'country':
-						await expect(
-							page.locator( '#billing-country input' )
-						).toHaveValue( value );
-						break;
-					case 'state':
-						await expect(
-							page.locator( '#billing-state input' )
-						).toHaveValue( value );
-						break;
-					default:
-						await expect(
-							page.locator( `#billing-${ key }` )
-						).toHaveValue( value );
-				}
+		// Check billing fields are empty.
+		for ( const [ key, value ] of Object.entries( billingTestData ) ) {
+			// eslint-disable-next-line playwright/no-conditional-in-test
+			switch ( key ) {
+				case 'country':
+					await expect(
+						page.locator( '#billing-country input' )
+					).toHaveValue( value );
+					break;
+				case 'state':
+					await expect(
+						page.locator( '#billing-state input' )
+					).toHaveValue( value );
+					break;
+				default:
+					await expect(
+						page.locator( `#billing-${ key }` )
+					).toHaveValue( value );
 			}
-		} );
+		}
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
@@ -467,9 +467,7 @@ test.describe( 'Checkout Form Errors (guest user)', () => {
 	} );
 } );
 
-test.describe( 'Billing Address Form (guest user)', () => {
-	test.use( { storageState: guestFile } );
-
+test.describe( 'Billing Address Form', () => {
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
 	// To make sure the company field is visible in the billing address form, we need to enable it in the editor.

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -286,9 +286,9 @@ export class CheckoutPage {
 		const billingForm = this.page.getByRole( 'group', {
 			name: 'Billing address',
 		} );
-		const companyInputField = billingForm.getByLabel( 'Company' );
 
-		if ( await companyInputField.isVisible() ) {
+		if ( customerBillingDetails.company ) {
+			const companyInputField = billingForm.getByLabel( 'Company' );
 			await companyInputField.fill( customerBillingDetails.company );
 		}
 
@@ -301,9 +301,6 @@ export class CheckoutPage {
 		const city = billingForm.getByLabel( 'City' );
 		const phone = billingForm.getByLabel( 'Phone' );
 
-		// Using locator here since the label of this form changes depending on the country.
-		const postcode = billingForm.locator( '#billing-postcode' );
-
 		await email.fill( customerBillingDetails.email );
 		await firstName.fill( customerBillingDetails.firstname );
 		await lastName.fill( customerBillingDetails.lastname );
@@ -313,21 +310,25 @@ export class CheckoutPage {
 		await city.fill( customerBillingDetails.city );
 		await phone.fill( customerBillingDetails.phone );
 
-		let state = billingForm.getByLabel( 'State', {
-			exact: true,
-		} );
-
-		if ( ! ( await state.isVisible() ) ) {
-			state = billingForm.getByLabel( 'Province', {
+		if ( customerBillingDetails.state ) {
+			const state = billingForm.getByLabel( 'State', {
 				exact: true,
 			} );
+			const province = billingForm.getByLabel( 'Province', {
+				exact: true,
+			} );
+			const county = billingForm.getByLabel( 'County' );
+
+			await state
+				.or( province )
+				.or( county )
+				.fill( customerBillingDetails.state );
 		}
 
-		if ( await state.isVisible() ) {
-			await state.fill( customerBillingDetails.state );
-		}
-
-		if ( await postcode.isVisible() ) {
+		if ( customerBillingDetails.postcode ) {
+			// Using locator here since the label of this form changes depending
+			// on the country.
+			const postcode = billingForm.locator( '#billing-postcode' );
 			await postcode.fill( customerBillingDetails.postcode );
 		}
 
@@ -338,7 +339,7 @@ export class CheckoutPage {
 		}
 
 		// Blur active field to trigger customer address update.
-		await this.page.evaluate( 'document.activeElement.blur()' );
+		await this.page.keyboard.press( 'Escape' );
 	}
 
 	async fillShippingDetails(
@@ -349,9 +350,9 @@ export class CheckoutPage {
 		const shippingForm = this.page.getByRole( 'group', {
 			name: 'Shipping address',
 		} );
-		const companyInputField = shippingForm.getByLabel( 'Company' );
 
-		if ( await companyInputField.isVisible() ) {
+		if ( customerShippingDetails.company ) {
+			const companyInputField = shippingForm.getByLabel( 'Company' );
 			await companyInputField.fill( customerShippingDetails.company );
 		}
 
@@ -363,9 +364,6 @@ export class CheckoutPage {
 		const city = shippingForm.getByLabel( 'City' );
 		const phone = shippingForm.getByLabel( 'Phone' );
 
-		// Using locator here since the label of this form changes depending on the country.
-		const postcode = shippingForm.locator( '#shipping-postcode' );
-
 		await firstName.fill( customerShippingDetails.firstname );
 		await lastName.fill( customerShippingDetails.lastname );
 		await country.fill( customerShippingDetails.country );
@@ -374,21 +372,25 @@ export class CheckoutPage {
 		await city.fill( customerShippingDetails.city );
 		await phone.fill( customerShippingDetails.phone );
 
-		let state = shippingForm.getByLabel( 'State', {
-			exact: true,
-		} );
-
-		if ( ! ( await state.isVisible() ) ) {
-			state = shippingForm.getByLabel( 'Province', {
+		if ( customerShippingDetails.state ) {
+			const state = shippingForm.getByLabel( 'State', {
 				exact: true,
 			} );
+			const province = shippingForm.getByLabel( 'Province', {
+				exact: true,
+			} );
+			const county = shippingForm.getByLabel( 'County' );
+
+			await state
+				.or( province )
+				.or( county )
+				.fill( customerShippingDetails.state );
 		}
 
-		if ( await state.isVisible() ) {
-			await state.fill( customerShippingDetails.state );
-		}
-
-		if ( await postcode.isVisible() ) {
+		if ( customerShippingDetails.postcode ) {
+			// Using locator here since the label of this form changes depending
+			// on the country.
+			const postcode = shippingForm.locator( '#shipping-postcode' );
 			await postcode.fill( customerShippingDetails.postcode );
 		}
 
@@ -415,10 +417,6 @@ export class CheckoutPage {
 			) )
 		) {
 			await shipping.click();
-			await this.page.waitForResponse( ( request ) => {
-				const url = request.url();
-				return url.includes( 'wc/store/v1/batch' );
-			} );
 			await this.page.waitForFunction( () => {
 				return ! window.wp.data
 					.select( 'wc/store/cart' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
@@ -125,11 +125,11 @@ test.describe( 'Shopper → Order Confirmation (guest user)', () => {
 	test.use( { storageState: guestFile } );
 
 	test( 'Place order', async ( { frontendUtils, pageObject, page } ) => {
-		await page.goto( '/my-account', { waitUntil: 'commit' } );
+		await page.goto( '/my-account' );
 
-		// Verify that the user is logged out.
 		await expect(
-			page.getByRole( 'heading', { name: 'Login' } )
+			page.getByRole( 'heading', { name: 'Login' } ),
+			'User is not logged out'
 		).toBeVisible();
 
 		await frontendUtils.emptyCart();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
-import { adminFile, guestFile } from '@woocommerce/e2e-utils';
+import { guestFile } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -38,8 +38,6 @@ const test = base.extend< { pageObject: CheckoutPage } >( {
 } );
 
 test.describe( 'Shopper → Order Confirmation (logged in user)', () => {
-	test.use( { storageState: adminFile } );
-
 	test.beforeEach( async ( { admin, editorUtils, localPickupUtils } ) => {
 		await localPickupUtils.disableLocalPickup();
 
@@ -56,17 +54,13 @@ test.describe( 'Shopper → Order Confirmation (logged in user)', () => {
 		await localPickupUtils.enableLocalPickup();
 	} );
 
-	test( 'Place order as a logged in user', async ( {
-		frontendUtils,
-		pageObject,
-		page,
-	} ) => {
+	test( 'Place order', async ( { frontendUtils, pageObject, page } ) => {
 		await frontendUtils.emptyCart();
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
 		await frontendUtils.addToCart( SIMPLE_VIRTUAL_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
-		await expect(
+		expect(
 			await pageObject.selectAndVerifyShippingOption(
 				FREE_SHIPPING_NAME,
 				FREE_SHIPPING_PRICE
@@ -130,11 +124,7 @@ test.describe( 'Shopper → Order Confirmation (logged in user)', () => {
 test.describe( 'Shopper → Order Confirmation (guest user)', () => {
 	test.use( { storageState: guestFile } );
 
-	test( 'Place order as guest user', async ( {
-		frontendUtils,
-		pageObject,
-		page,
-	} ) => {
+	test( 'Place order', async ( { frontendUtils, pageObject, page } ) => {
 		await page.goto( '/my-account', { waitUntil: 'commit' } );
 
 		// Verify that the user is logged out.
@@ -147,7 +137,7 @@ test.describe( 'Shopper → Order Confirmation (guest user)', () => {
 		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
 
-		await expect(
+		expect(
 			await pageObject.selectAndVerifyShippingOption(
 				FREE_SHIPPING_NAME,
 				FREE_SHIPPING_PRICE
@@ -164,8 +154,6 @@ test.describe( 'Shopper → Order Confirmation (guest user)', () => {
 } );
 
 test.describe( 'Shopper → Order Confirmation → Local Pickup', () => {
-	test.use( { storageState: adminFile } );
-
 	test( 'Confirm shipping address section is hidden, but billing is visible', async ( {
 		pageObject,
 		frontendUtils,
@@ -213,8 +201,6 @@ test.describe( 'Shopper → Order Confirmation → Local Pickup', () => {
 } );
 
 test.describe( 'Shopper → Order Confirmation → Downloadable Products', () => {
-	test.use( { storageState: adminFile } );
-
 	let confirmationPageUrl: string;
 
 	test.beforeEach( async ( { frontendUtils, pageObject } ) => {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -76,15 +76,6 @@ export class FrontendUtils {
 		} );
 	}
 
-	async logout() {
-		await this.page.goto( '/my-account', {
-			waitUntil: 'domcontentloaded',
-		} );
-		await this.page.click(
-			'.woocommerce-MyAccount-navigation-link--customer-logout a'
-		);
-	}
-
 	async emptyCart() {
 		const cartResponse = await this.requestUtils.request.get(
 			'/wp-json/wc/store/cart'

--- a/plugins/woocommerce/changelog/fix-e2e-logged-out-user-handling
+++ b/plugins/woocommerce/changelog/fix-e2e-logged-out-user-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix guest user handling in failing Side Effects E2E tests


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related: https://github.com/woocommerce/woocommerce/pull/44347/files#r1526255938

Fix flaky tests where the admin is logged out instead of using the guest storage state. Logging out via UI affects other tests as the user stays logged out.

Example error that should no longer happen:

<img width="1485" alt="Screenshot 2024-03-15 at 13 27 26" src="https://github.com/woocommerce/woocommerce/assets/1451471/46b51a71-b8b6-4ce4-bf6a-a6a3bd3a5f33">
 

### How to test the changes in this Pull Request:

All affected tests should pass.