### PR TITLE
Use WC built-in Action Scheduler to fetch in-app promotions

### DIFF
--- a/plugins/woocommerce/changelog/fix-19763-marketplace-promotions
+++ b/plugins/woocommerce/changelog/fix-19763-marketplace-promotions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Using ActionScheduler to schedule fetching of in-app marketplace promotions.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -30,19 +30,28 @@ class WC_Admin_Marketplace_Promotions {
 	 * Shows notice and adds menu badge to WooCommerce Extensions item
 	 * if the promotions API requests them.
 	 *
-	 * This method is called from WC_Admin when it is instantiated in
+	 * WC_Admin calls this method when it is instantiated during
 	 * is_admin requests.
 	 *
 	 * @return void
 	 */
     public static function init() {
+		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
+
+		/**
+		 * Filter to suppress the requests for and showing of marketplace promotions.
+		 * @since 8.8
+		 */
+		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
+			return;
+		}
+
 		// Add the callback for our scheduled action.
 		if ( ! has_action( self::SCHEDULED_ACTION_HOOK, array( __CLASS__, 'fetch_marketplace_promotions' ) ) ) {
 			add_action( self::SCHEDULED_ACTION_HOOK, array( __CLASS__, 'fetch_marketplace_promotions' ) );
 		}
 
 		add_action( 'init', array( __CLASS__, 'schedule_promotion_fetch' ), 10 );
-        register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
 
 		if (
 			defined( 'DOING_AJAX' ) && DOING_AJAX

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -279,11 +279,11 @@ class WC_Admin_Marketplace_Promotions {
 	 * Return the markup for a menu item bubble with a given text and optional additional attributes.
 	 *
 	 * @param string $bubble_text Text of bubble.
-	 * @param array $attributes Optional. Additional attributes for the bubble, such as class or style.
+	 * @param array  $attributes Optional. Additional attributes for the bubble, such as class or style.
 	 *
 	 * @return string
 	 */
-	private static function append_bubble( $bubble_text, $attributes = [] ) {
+	private static function append_bubble( $bubble_text, $attributes = array() ) {
 		$default_attributes = array(
 			'class' => 'awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge',
 			'style' => '',

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -276,18 +276,18 @@ class WC_Admin_Marketplace_Promotions {
 	}
 
 	/**
-	* Return the markup for a menu item bubble with a given text and optional additional attributes.
-	*
-	* @param string $bubble_text Text of bubble.
-	* @param array $attributes Optional. Additional attributes for the bubble, such as class or style.
-	*
-	* @return string
+	 * Return the markup for a menu item bubble with a given text and optional additional attributes.
+	 *
+	 * @param string $bubble_text Text of bubble.
+	 * @param array $attributes Optional. Additional attributes for the bubble, such as class or style.
+	 *
+	 * @return string
 	 */
 	private static function append_bubble( $bubble_text, $attributes = [] ) {
-		$default_attributes = [
+		$default_attributes = array(
 			'class' => 'awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge',
 			'style' => '',
-		];
+		);
 
 		$attributes = wp_parse_args( $attributes, $default_attributes );
 		$class_attr = ! empty( $attributes['class'] ) ? sprintf( 'class="%s"', esc_attr( $attributes['class'] ) ) : '';

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -43,7 +43,7 @@ class WC_Admin_Marketplace_Promotions {
 		 * @since 8.8
 		 */
 		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
-			self::clear_scheduled_event();
+			add_action( 'init', array( __CLASS__, 'clear_scheduled_event' ), 10 );
 
 			return;
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -43,6 +43,8 @@ class WC_Admin_Marketplace_Promotions {
 		 * @since 8.8
 		 */
 		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
+			self::clear_scheduled_event();
+
 			return;
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -67,7 +67,7 @@ class WC_Admin_Marketplace_Promotions {
 	/**
 	 * Schedule the action to fetch promotions data.
 	 */
-    public static function schedule_promotion_fetch() {
+	public static function schedule_promotion_fetch() {
 		// Schedule the action twice a day using Action Scheduler
 		if ( false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK ) ) {
 			as_schedule_recurring_action( time(), 12 * HOUR_IN_SECONDS, self::SCHEDULED_ACTION_HOOK );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -119,7 +119,7 @@ class WC_Admin_Marketplace_Promotions {
 		if ( $promotions ) {
 			// Filter out any expired promotions.
 			$promotions = self::get_active_promotions( $promotions );
-			set_transient( self::TRANSIENT_NAME, $promotions, DAY_IN_SECONDS );
+			set_transient( self::TRANSIENT_NAME, $promotions, 12 * HOUR_IN_SECONDS );
 		}
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -43,7 +43,7 @@ class WC_Admin_Marketplace_Promotions {
 		 * @since 8.8
 		 */
 		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
-			add_action( 'init', array( __CLASS__, 'clear_scheduled_event' ), 10 );
+			add_action( 'init', array( __CLASS__, 'clear_scheduled_event' ), 13 );
 
 			return;
 		}
@@ -53,7 +53,9 @@ class WC_Admin_Marketplace_Promotions {
 			add_action( self::SCHEDULED_ACTION_HOOK, array( __CLASS__, 'fetch_marketplace_promotions' ) );
 		}
 
-		add_action( 'init', array( __CLASS__, 'schedule_promotion_fetch' ), 10 );
+		if ( is_admin() ) {
+			add_action( 'init', array( __CLASS__, 'schedule_promotion_fetch' ), 12 );
+		}
 
 		if (
 			defined( 'DOING_AJAX' ) && DOING_AJAX
@@ -291,3 +293,7 @@ class WC_Admin_Marketplace_Promotions {
 	}
 }
 
+// Fetch list of promotions from Woo.com for WooCommerce admin UI.
+if ( ! has_action( 'init', array( 'WC_Admin_Marketplace_Promotions', 'init' ) ) ) {
+	add_action( 'init', array( 'WC_Admin_Marketplace_Promotions', 'init' ), 11 );
+}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -35,7 +35,7 @@ class WC_Admin_Marketplace_Promotions {
 	 *
 	 * @return void
 	 */
-    public static function init() {
+	public static function init() {
 		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
 
 		/**
@@ -61,18 +61,18 @@ class WC_Admin_Marketplace_Promotions {
 		}
 
 		self::$locale = ( self::$locale ?? get_user_locale() ) ?? 'en_US';
-        self::maybe_show_bubble_promotions();
-    }
+		self::maybe_show_bubble_promotions();
+	}
 
 	/**
 	 * Schedule the action to fetch promotions data.
 	 */
     public static function schedule_promotion_fetch() {
-        // Schedule the action twice a day using Action Scheduler
-        if ( false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK ) ) {
-            as_schedule_recurring_action( time(), 12 * HOUR_IN_SECONDS, self::SCHEDULED_ACTION_HOOK );
-        }
-    }
+		// Schedule the action twice a day using Action Scheduler
+		if ( false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK ) ) {
+			as_schedule_recurring_action( time(), 12 * HOUR_IN_SECONDS, self::SCHEDULED_ACTION_HOOK );
+		}
+	}
 
 	/**
 	 * Get promotions to show in the Woo in-app marketplace and load them into a transient

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -40,6 +40,7 @@ class WC_Admin_Marketplace_Promotions {
 
 		/**
 		 * Filter to suppress the requests for and showing of marketplace promotions.
+		 *
 		 * @since 8.8
 		 */
 		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
@@ -73,7 +74,7 @@ class WC_Admin_Marketplace_Promotions {
 	 * Schedule the action to fetch promotions data.
 	 */
 	public static function schedule_promotion_fetch() {
-		// Schedule the action twice a day using Action Scheduler
+		// Schedule the action twice a day using Action Scheduler.
 		if ( false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK ) ) {
 			as_schedule_recurring_action( time(), 12 * HOUR_IN_SECONDS, self::SCHEDULED_ACTION_HOOK );
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -274,14 +274,26 @@ class WC_Admin_Marketplace_Promotions {
 	}
 
 	/**
-	 * Return the markup for a menu item bubble with a given text.
-	 *
-	 * @param string $bubble_text Text of bubble.
-	 *
-	 * @return string
+	* Return the markup for a menu item bubble with a given text and optional additional attributes.
+	*
+	* @param string $bubble_text Text of bubble.
+	* @param array $attributes Optional. Additional attributes for the bubble, such as class or style.
+	*
+	* @return string
 	 */
-	private static function append_bubble( $bubble_text ) {
-		return ' <span class="awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge">' . esc_html( $bubble_text ) . '</span>';
+	private static function append_bubble( $bubble_text, $attributes = [] ) {
+		$default_attributes = [
+			'class' => 'awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge',
+			'style' => '',
+		];
+
+		$attributes = wp_parse_args( $attributes, $default_attributes );
+		$class_attr = ! empty( $attributes['class'] ) ? sprintf( 'class="%s"', esc_attr( $attributes['class'] ) ) : '';
+		$style_attr = ! empty( $attributes['style'] ) ? sprintf( 'style="%s"', esc_attr( $attributes['style'] ) ) : '';
+
+		$bubble_html = sprintf( ' <span %s %s>%s</span>', $class_attr, $style_attr, esc_html( $bubble_text ) );
+
+		return $bubble_html;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -15,9 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Admin_Marketplace_Promotions {
 
-	const TRANSIENT_NAME        = 'woocommerce_marketplace_promotions';
-	const SCHEDULED_ACTION_HOOK = 'woocommerce_marketplace_fetch_promotions';
-	const PROMOTIONS_API_URL    = 'https://woo.com/wp-json/wccom-extensions/3.0/promotions';
+	const TRANSIENT_NAME            = 'woocommerce_marketplace_promotions';
+	const SCHEDULED_ACTION_HOOK     = 'woocommerce_marketplace_fetch_promotions';
+	const PROMOTIONS_API_URL        = 'https://woo.com/wp-json/wccom-extensions/3.0/promotions';
+	const SCHEDULED_ACTION_INTERVAL = 12 * HOUR_IN_SECONDS;
+
 	/**
 	 * The user's locale, for example en_US.
 	 *
@@ -76,7 +78,7 @@ class WC_Admin_Marketplace_Promotions {
 	public static function schedule_promotion_fetch() {
 		// Schedule the action twice a day using Action Scheduler.
 		if ( false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK ) ) {
-			as_schedule_recurring_action( time(), 12 * HOUR_IN_SECONDS, self::SCHEDULED_ACTION_HOOK );
+			as_schedule_recurring_action( time(), self::SCHEDULED_ACTION_INTERVAL, self::SCHEDULED_ACTION_HOOK );
 		}
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -58,6 +58,7 @@ class WC_Admin_Marketplace_Promotions {
 		if (
 			defined( 'DOING_AJAX' ) && DOING_AJAX
 			|| defined( 'DOING_CRON' ) && DOING_CRON
+			|| defined( 'WP_CLI' ) && WP_CLI
 		) {
 			return;
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -39,9 +39,6 @@ class WC_Admin {
 		if ( isset( $_GET['page'] ) && 'wc-addons' === $_GET['page'] ) {
 			add_filter( 'admin_body_class', array( 'WC_Admin_Addons', 'filter_admin_body_classes' ) );
 		}
-
-		// Fetch list of promotions from Woo.com for WooCommerce admin UI. We need to fire earlier than admin_init so we can filter menu items.
-		WC_Admin_Marketplace_Promotions::init();
 	}
 
 	/**
@@ -80,9 +77,6 @@ class WC_Admin {
 		// Marketplace suggestions & related REST API.
 		include_once __DIR__ . '/marketplace-suggestions/class-wc-marketplace-suggestions.php';
 		include_once __DIR__ . '/marketplace-suggestions/class-wc-marketplace-updater.php';
-
-		// Marketplace promotions.
-		include_once __DIR__ . '/class-wc-admin-marketplace-promotions.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -41,7 +41,7 @@ class WC_Admin {
 		}
 
 		// Fetch list of promotions from Woo.com for WooCommerce admin UI. We need to fire earlier than admin_init so we can filter menu items.
-		add_action( 'woocommerce_init', array( 'WC_Admin_Marketplace_Promotions', 'init_marketplace_promotions' ) );
+		WC_Admin_Marketplace_Promotions::init();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -681,6 +681,10 @@ final class WooCommerce {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
 		}
 
+		if ( $this->is_request( 'admin') || $this->is_request( 'cron' ) ) {
+			include_once WC_ABSPATH . 'includes/admin/class-wc-admin-marketplace-promotions.php';
+		}
+
 		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.
 		$in_post_editor = doing_action( 'load-post.php' ) || doing_action( 'load-post-new.php' );
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -681,7 +681,7 @@ final class WooCommerce {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
 		}
 
-		if ( $this->is_request( 'admin') || $this->is_request( 'cron' ) ) {
+		if ( $this->is_request( 'admin' ) || $this->is_request( 'cron' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin-marketplace-promotions.php';
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/44655 and related PRs, we introduced logic to fetch data from a new Woo.com endpoint and show notices on the WooCommerce Marketplace pages, as well as a bubble on the `WooCommerce > Extensions` menu item. That logic, based on events scheduled with `wp_schedule_event`, didn't run on JN and other external sites, so the notices weren't shown. In this PR, we are using ActionScheduler to schedule the event with `as_schedule_recurring_action`.

Closes 19763-gh-Automattic/woocommerce.com.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### If you're using a local `wp-env` environment

1. Check out this branch locally.
2. Edit `plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php` and replace the `PROMOTIONS_API_URL` value `https://woo.com/wp-json/wccom-extensions/3.0/promotions` with `https://gist.githubusercontent.com/andfinally/acd8646151c0108f92979c985c20a0d8/raw/`. This is a gist with dummy data that is valid until 31 March.
3. On line 21, change the frequency of the scheduled action to five minutes:

```php
const SCHEDULED_ACTION_INTERVAL = 5 * MINUTE_IN_SECONDS;
```
4. Run `nvm use`.
5. Do `cd plugins/woocommerce`.
6. Run `pnpm -- wp-env start` to start wp-env.
7. run `pnpm --filter='@woocommerce/plugin-woocommerce' build`.
8. Visit the [pending scheduled actions page](http://localhost:8888/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending) and search for `woocommerce_marketplace_fetch_promotions`. Note that the action is pending.
9. After 5 minutes or so, the action should run. (You may need to jog it by viewing a page on your test site.)
10. The menu bubble should appear on the `WooCommerce > Extensions` menu item, and the notice should appear on the default Marketplace page `http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions`. (It also appears on the Themes and other tabs on that page – that's intentional.)

<p>
<img width="1242" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1649788/cdfbf86f-7af5-4a14-966b-a1e694a15c23">
</p>

11. Edit `class-wc-admin-marketplace-promotions.php` again and change the `PROMOTIONS_API_URL` to `https://gist.githubusercontent.com/andfinally/8ffca3fe3844fee6e146a80e563f00bb/raw/`. This is a second gist, where the expiry dates for the promotions have passed.
12. Wait for the scheduled action to run again.
13. The notice and menu bubble should not be shown.

#### If you're using a JN or other external site

1. Do the steps 1-5 as for the local environment.
2. Comment out this line in `plugins/woocommerce/bin/build-zip.sh`. This skips a memory-intensive process in the WooCommerce zip build that is irrelevant to this change.

```
pnpm --filter=@woocommerce/plugin-woocommerce makepot || exit "$?"
```

3. Run the zip build: `pnpm --filter='@woocommerce/plugin-woocommerce' build:zip`.
4. When the build is complete, you should see the resulting `woocommerce.zip` plugin file in `plugins/woocommerce`. Install the plugin in your external site.
5. The menu bubble should appear on the `WooCommerce > Extensions` menu item, and the notice should appear on the `wp-admin/admin.php?page=wc-admin&path=%2Fextensions` page.
6. Change the `PROMOTIONS_API_URL` to `https://gist.githubusercontent.com/andfinally/8ffca3fe3844fee6e146a80e563f00bb/raw/`. This is a second gist, where the expiry dates for the promotions have passed. If you have SSH access to your site, you can make this change directly in the PHP file.
7. Otherwise, build the zip again as in step 3, deactivate and delete the WooCommerce plugin on your site, and install the new zip.
8. Wait for the scheduled action to run. The notice and menu item badge should no longer appear.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>