### PR TITLE
Product Editor: Disable description full editor when using an incompatible version of Gutenberg

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-description-editor-modal-disable-gb-crash
+++ b/packages/js/product-editor/changelog/fix-product-editor-description-editor-modal-disable-gb-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: Prevent description full editor usage if a version of Gutenberg plugin is installed that causes crashes.

--- a/packages/js/product-editor/src/blocks/product-fields/description/components/full-editor-toolbar-button.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/description/components/full-editor-toolbar-button.tsx
@@ -14,6 +14,26 @@ import { parse, rawHandler } from '@wordpress/blocks';
  */
 import { store } from '../../../../store/product-editor-ui';
 import { getContentFromFreeform } from '../edit';
+import { getGutenbergVersion } from '../../../../utils/get-gutenberg-version';
+
+// There is a bug in Gutenberg 17.9 that causes a crash in the full editor.
+// This should be fixed in Gutenberg 18.0 (see https://github.com/WordPress/gutenberg/pull/59800).
+// Once we only support Gutenberg 18.0 and above, we can remove this check.
+function isGutenbergVersionWithCrashInFullEditor() {
+	const gutenbergVersion = getGutenbergVersion();
+	return gutenbergVersion >= 17.9 && gutenbergVersion < 18.0;
+}
+
+function shouldForceFullEditor() {
+	return (
+		localStorage
+			.getItem(
+				'__unsupported_force_product_editor_description_full_editor'
+			)
+			?.trim()
+			.toLowerCase() === 'true'
+	);
+}
 
 export default function FullEditorToolbarButton( {
 	label = __( 'Edit Product description', 'woocommerce' ),
@@ -30,6 +50,27 @@ export default function FullEditorToolbarButton( {
 		<ToolbarButton
 			label={ label }
 			onClick={ () => {
+				if ( isGutenbergVersionWithCrashInFullEditor() ) {
+					if ( shouldForceFullEditor() ) {
+						// eslint-disable-next-line no-alert
+						alert(
+							__(
+								'The version of the Gutenberg plugin installed causes a crash in the full editor. You are proceeding at your own risk and may experience crashes.',
+								'woocommerce'
+							)
+						);
+					} else {
+						// eslint-disable-next-line no-alert
+						alert(
+							__(
+								'The version of the Gutenberg plugin installed causes a crash in the full editor. To prevent this, the full editor has been disabled.',
+								'woocommerce'
+							)
+						);
+						return;
+					}
+				}
+
 				let parsedBlocks = parse( description );
 				const freeformContent = getContentFromFreeform( parsedBlocks );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR prevents the description full editor from being used when a version of Gutenberg is installed that causes crashes (17.9.0).

There is a way to override this, if a user/tester really wants to use the full editor with a version of Gutenberg that will cause crashes:
    - Set the `__unsupported_force_product_editor_description_full_editor` local storage value to `true`

If Gutenberg is not installed or a compatible version of Gutenberg is installed, behavior is as usual... the full editor is available with no warning messages.

Closes #45630.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
1. Click on description field to focus it.
2. Click on the "Full editor" button in the toolbar.
3. Verify the following:
    - WordPress 6.4.3: No message shown; full editor available
    - WordPress 6.4.3 and Gutenberg 17.8.2: No message shown; full editor available
    - WordPress 6.4.3 and Gutenberg 17.9.0: Message shown that full editor is disabled
    - WordPress 6.5-RC2: No message show; full editor available (block toolbars do not appear, due to bug https://github.com/woocommerce/woocommerce/issues/43676; will work with WordPress 6.5 final release)
    - WordPress 6.5-RC2 and Gutenberg 17.8.2: No message shown; full editor available
    - WordPress 6.5-RC2 and Gutenberg 17.9.0: Message shown that full editor is disabled

<img width="1235" alt="Screenshot 2024-03-17 at 17 39 59" src="https://github.com/woocommerce/woocommerce/assets/2098816/db156817-9fec-442e-bfd8-6c9f85c238ab">

4. Set the following local storage value to `true`:
    - `__unsupported_force_product_editor_description_full_editor`
5. Verify that clicking on the "Full editor" button shows a warning message and then brings up the full editor when in the following environments (an incompatible version of Gutenberg installed):
    - WordPress 6.4.3 and Gutenberg 17.9.0
    - WordPress 6.5-RC2 and Gutenberg 17.9.0

<img width="1235" alt="Screenshot 2024-03-17 at 17 55 42" src="https://github.com/woocommerce/woocommerce/assets/2098816/fa36d23f-eda1-4a4d-8c24-e9b9d3bbc596">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
