### PR TITLE
Ensure that each <CheckboxControl> component has a unique ID

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -165,6 +165,7 @@ describe( 'Testing cart', () => {
 	} );
 
 	it( 'Ensures checkbox labels have unique IDs', async () => {
+		// Set required settings
 		allSettings.checkoutAllowsGuest = true;
 		allSettings.checkoutAllowsSignup = true;
 		dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 0 );
@@ -184,5 +185,10 @@ describe( 'Testing cart', () => {
 		// Ensure all IDs are unique
 		const uniqueIds = new Set( ids );
 		expect( uniqueIds.size ).toBe( ids.length );
+
+		// Restore initial settings
+		allSettings.checkoutAllowsGuest = undefined;
+		allSettings.checkoutAllowsSignup = undefined;
+		dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 1 );
 	} );
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -165,10 +165,12 @@ describe( 'Testing cart', () => {
 	} );
 
 	it( 'Ensures checkbox labels have unique IDs', async () => {
-		// Set required settings
-		allSettings.checkoutAllowsGuest = true;
-		allSettings.checkoutAllowsSignup = true;
-		dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 0 );
+		await act( async () => {
+			// Set required settings
+			allSettings.checkoutAllowsGuest = true;
+			allSettings.checkoutAllowsSignup = true;
+			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 0 );
+		} );
 
 		// Render the CheckoutBlock
 		render( <CheckoutBlock /> );
@@ -186,9 +188,11 @@ describe( 'Testing cart', () => {
 		const uniqueIds = new Set( ids );
 		expect( uniqueIds.size ).toBe( ids.length );
 
-		// Restore initial settings
-		allSettings.checkoutAllowsGuest = undefined;
-		allSettings.checkoutAllowsSignup = undefined;
-		dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 1 );
+		await act( async () => {
+			// Restore initial settings
+			allSettings.checkoutAllowsGuest = undefined;
+			allSettings.checkoutAllowsSignup = undefined;
+			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 1 );
+		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/45655-add-42046-CheckboxControl-e2e-tests
+++ b/plugins/woocommerce/changelog/45655-add-42046-CheckboxControl-e2e-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add an e2e test to ensure that each <CheckboxControl> component has a unique ID.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42046.

A while ago, we noticed that not all checkbox labels in the Checkout block had unique IDs. This led to the fact that when clicking one checkbox label, another section was triggered. In #42046, I shared the following observation:

These are the checkboxes and their IDs in incognito mode:

<table>
<tr>
<th valign="top">Checkbox:</th>
<th valign="top">ID:</th>
</tr>
<tr>
<td valign="top">

`Create an account?`

</td>
<td valign="top">

`checkbox-control-0`

</td>
</tr>
<tr>
<td valign="top">

`Use same address for billing`

</td>
<td valign="top">

`checkbox-control-1`

</td>
</tr>
<tr>
<td valign="top">

`Add a note to your order`

</td>
<td valign="top">

`checkbox-control-0`

</td>
</tr>
</table>

These are the checkboxes and their IDs in logged-in mode:

<table>
<tr>
<th valign="top">Checkbox:</th>
<th valign="top">ID:</th>
</tr>
<tr>
<td valign="top">

`Use same address for billing`

</td>
<td valign="top">

`checkbox-control-0`

</td>
</tr>
<tr>
<td valign="top">

`Add a note to your order`

</td>
<td valign="top">

`checkbox-control-0`

</td>
</tr>
</table>

 @senadir addressed this issue in https://github.com/woocommerce/woocommerce-blocks/pull/12015. In this issue, I've added e2e tests, which allow us to detect potential problems in an early stage. By default, the Checkout block can show the following four checkboxes:

1. `Create an account?`
2. `Use same address for billing`
3. `Add a note to your order`
4. `You must accept our Terms and Conditions and Privacy Policy to continue with your purchase.`

Our e2e test environment already shows the second, third, and fourth checkbox by default. To fully test all checkboxes, I ensured that the first checkbox `Create an account?` is also visible. To do that, this PR introduced the following changes:

- Allow guests to place an order → `allSettings.checkoutAllowsGuest = true;`
- Allow account creation during the checkout → `allSettings.checkoutAllowsSignup = true;`
- Set the customer ID to 0 → `dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 0 );`

Only if all three conditions are met, the `Create an account?` checkbox becomes visible. The PR also restores the initial values after executing the test.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify that all JS tests are passing.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add an e2e test to ensure that each <CheckboxControl> component has a unique ID.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->


</details>