### PR TITLE
[Product Block Editor]: register `metadata` attribute for all blocks

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-register-metadata-block-attribute
+++ b/packages/js/product-editor/changelog/update-product-editor-register-metadata-block-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: update Name field block name

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -234,6 +234,7 @@ export function NameBlockEdit( {
 						onCancel={ () => setShowProductLinkEditModal( false ) }
 						onSaved={ () => setShowProductLinkEditModal( false ) }
 						saveHandler={ async ( updatedSlug ) => {
+							// @ts-expect-error There are no types for this.
 							const { slug, permalink }: Product =
 								await saveEntityRecord( 'postType', 'product', {
 									id: product.id,

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -43,7 +43,7 @@ import { ProductEditorBlockEditProps } from '../../../types';
 import { AUTO_DRAFT_NAME } from '../../../utils';
 import { NameBlockAttributes } from './types';
 
-export function Edit( {
+export function NameBlockEdit( {
 	attributes,
 	clientId,
 }: ProductEditorBlockEditProps< NameBlockAttributes > ) {
@@ -234,7 +234,6 @@ export function Edit( {
 						onCancel={ () => setShowProductLinkEditModal( false ) }
 						onSaved={ () => setShowProductLinkEditModal( false ) }
 						saveHandler={ async ( updatedSlug ) => {
-							// @ts-expect-error There are no types for this.
 							const { slug, permalink }: Product =
 								await saveEntityRecord( 'postType', 'product', {
 									id: product.id,

--- a/packages/js/product-editor/src/blocks/product-fields/name/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/name/index.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import metadata from './block.json';
-import { Edit } from './edit';
+import { NameBlockEdit } from './edit';
 import { registerProductEditorBlockType } from '../../../utils';
 
 const { name } = metadata;
@@ -11,7 +11,7 @@ export { metadata, name };
 
 export const settings = {
 	example: {},
-	edit: Edit,
+	edit: NameBlockEdit,
 };
 
 export const init = () =>

--- a/plugins/woocommerce/changelog/update-product-editor-register-metadata-block-attribute
+++ b/plugins/woocommerce/changelog/update-product-editor-register-metadata-block-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: register `metadata` attribute for all blocks

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -425,6 +425,7 @@ class Init {
 	 * This is a fallback/temporary solution until
 	 * the Gutenberg core version registers the metadata attribute.
 	 * @see https://github.com/WordPress/gutenberg/blob/6aaa3686ae67adc1a6a6b08096d3312859733e1b/lib/compat/wordpress-6.5/blocks.php#L27-L47
+	 * ToDo: Remove this method once the Gutenberg core version registers the metadata attribute.
 	 *
 	 * @param array $args Array of arguments for registering a block type.
 	 * @return array $args

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -78,6 +78,8 @@ class Init {
 			add_action( 'rest_api_init', array( $this, 'register_layout_templates' ) );
 			add_action( 'rest_api_init', array( $this, 'register_user_metas' ) );
 
+			add_filter( 'register_block_type_args', array( $this, 'register_metadata_attribute' ) );
+
 			// Make sure the block registry is initialized so that core blocks are registered.
 			BlockRegistry::get_instance();
 
@@ -416,5 +418,30 @@ class Init {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Registers the metadata block attribute for all block types.
+	 * This is a fallback/temporary solution until
+	 * the Gutenberg core version registers the metadata attribute.
+	 * @see https://github.com/WordPress/gutenberg/blob/6aaa3686ae67adc1a6a6b08096d3312859733e1b/lib/compat/wordpress-6.5/blocks.php#L27-L47
+	 *
+	 * @param array $args Array of arguments for registering a block type.
+	 * @return array $args
+	 */
+	public function register_metadata_attribute( $args ) {
+		// Setup attributes if needed.
+		if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
+			$args['attributes'] = array();
+		}
+
+		// Add metadata attribute if it doesn't exist.
+		if ( ! array_key_exists( 'metadata', $args['attributes'] ) ) {
+			$args['attributes']['metadata'] = array(
+				'type' => 'object',
+			);
+		}
+
+		return $args;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -424,8 +424,9 @@ class Init {
 	 * Registers the metadata block attribute for all block types.
 	 * This is a fallback/temporary solution until
 	 * the Gutenberg core version registers the metadata attribute.
+	 *
 	 * @see https://github.com/WordPress/gutenberg/blob/6aaa3686ae67adc1a6a6b08096d3312859733e1b/lib/compat/wordpress-6.5/blocks.php#L27-L47
-	 * ToDo: Remove this method once the Gutenberg core version registers the metadata attribute.
+	 * To do: Remove this method once the Gutenberg core version registers the metadata attribute.
 	 *
 	 * @param array $args Array of arguments for registering a block type.
 	 * @return array $args

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -215,6 +215,16 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'attributes' => array(
 					'name'      => 'Product name',
 					'autoFocus' => true,
+					'metadata'  => array(
+						'bindings' => array(
+							'value' => array (
+								'source' => 'woocommerce/entity-product',
+								'args'   => array (
+									'prop' => 'name',
+								),
+							),
+						),
+					),
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -217,9 +217,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'autoFocus' => true,
 					'metadata'  => array(
 						'bindings' => array(
-							'value' => array (
+							'value' => array(
 								'source' => 'woocommerce/entity-product',
-								'args'   => array (
+								'args'   => array(
 									'prop' => 'name',
 								),
 							),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the `metadata` attribute to all blocks, following [the core's implementation](https://github.com/WordPress/gutenberg/blob/6aaa3686ae67adc1a6a6b08096d3312859733e1b/lib/compat/wordpress-6.5/blocks.php#L27-L47). This ensures that the attribute is included even when the current version of Gutenberg doesn't support it.

_Additionally, it registers the `metadata` attribute value for the Name field block. It'll be used in a follow-up._

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45656

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new Product Editor
2. Create/edit a product
3. Select the `Name` field block (click on it)
4. Open the dev console of your browser
5. Print the block attributes by running the following code

```js
wp.data.select( 'core/block-editor' ).getBlockAttributes(
    wp.data.select( 'core/block-editor' ).getSelectedBlock()?.clientId,
)
```
6. Ensure the block has the `metadata` attribute:
<img width="347" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/c19810b7-3c8a-4253-b25f-b9bdee49d242">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
