### PR TITLE
Fix double scroll bar in pre-publish panel

### DIFF
--- a/packages/js/product-editor/changelog/fix-45669_doulbe_scroll_bar_prepublish_panel
+++ b/packages/js/product-editor/changelog/fix-45669_doulbe_scroll_bar_prepublish_panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix double scroll bar in pre-publish panel #45671

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -52,7 +52,7 @@
 	}
 
 	&__content {
-		min-height: calc( 100% - #{ $header-height + 220px } );
+		min-height: calc( 100% - #{ $header-height + 222px } );
 		.editor-post-publish-panel__link {
 			font-weight: 400;
    			 padding-left: $gap-smallest;

--- a/packages/js/product-editor/src/components/prepublish-panel/style.scss
+++ b/packages/js/product-editor/src/components/prepublish-panel/style.scss
@@ -52,6 +52,7 @@
 	}
 
 	&__content {
+		// Ensure the pre-publish panel content accounts for the header and footer height.
 		min-height: calc( 100% - #{ $header-height + 222px } );
 		.editor-post-publish-panel__link {
 			font-weight: 400;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the double scroll bar in pre-publish panel.

Before

<img width="713" alt="Screenshot 2024-03-18 at 10 36 31 AM" src="https://github.com/woocommerce/woocommerce/assets/1314156/a4bd7bfa-1e27-4875-8e71-f1abf985c78b">

After

![Screen Recording on 2024-03-18 at 11-11-24](https://github.com/woocommerce/woocommerce/assets/1314156/82cd9cfe-bdd5-4355-8f2c-b6b68d4b3da9)

Closes #45669.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Add a product name and press `Publish`.
3. The pre-publish panel content should be shown without a scroll bar. It should only be visible when the content height in the panel is bigger than the page height.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
