### PR TITLE
Fix publish dropdown visibility in new product after hiding pre-publish modal

### DIFF
--- a/packages/js/product-editor/changelog/fix-45589_publish_dropdown_not_visible
+++ b/packages/js/product-editor/changelog/fix-45589_publish_dropdown_not_visible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix publish dropdown visibility in new product after hiding pre-publish modal #45682

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -249,7 +249,8 @@ export function Header( {
 
 					<PublishButton
 						productType={ productType }
-						prePublish={ showPrepublishChecks }
+						isPrePublishPanelVisible={ showPrepublishChecks }
+						isPrePublishButton
 					/>
 
 					<WooHeaderItem.Slot name="product" />

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -250,7 +250,7 @@ export function Header( {
 					<PublishButton
 						productType={ productType }
 						isPrePublishPanelVisible={ showPrepublishChecks }
-						isPrePublishButton
+						isMenuButton
 					/>
 
 					<WooHeaderItem.Slot name="product" />

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -25,7 +25,8 @@ import type { PublishButtonProps } from './types';
 
 export function PublishButton( {
 	productType = 'product',
-	prePublish,
+	isPrePublishButton,
+	isPrePublishPanelVisible = true,
 	...props
 }: PublishButtonProps ) {
 	const { createErrorNotice } = useDispatch( 'core/notices' );
@@ -68,7 +69,7 @@ export function PublishButton( {
 	if (
 		productType === 'product' &&
 		window.wcAdminFeatures[ 'product-pre-publish-modal' ] &&
-		prePublish
+		isPrePublishButton
 	) {
 		function renderPublishButtonMenu(
 			menuProps: Dropdown.RenderProps
@@ -78,7 +79,11 @@ export function PublishButton( {
 			);
 		}
 
-		if ( editedStatus !== 'publish' && editedStatus !== 'future' ) {
+		if (
+			editedStatus !== 'publish' &&
+			editedStatus !== 'future' &&
+			isPrePublishPanelVisible
+		) {
 			function handlePrePublishButtonClick(
 				event: MouseEvent< HTMLButtonElement >
 			) {

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -25,7 +25,7 @@ import type { PublishButtonProps } from './types';
 
 export function PublishButton( {
 	productType = 'product',
-	isPrePublishButton,
+	isMenuButton,
 	isPrePublishPanelVisible = true,
 	...props
 }: PublishButtonProps ) {
@@ -69,7 +69,7 @@ export function PublishButton( {
 	if (
 		productType === 'product' &&
 		window.wcAdminFeatures[ 'product-pre-publish-modal' ] &&
-		isPrePublishButton
+		isMenuButton
 	) {
 		function renderPublishButtonMenu(
 			menuProps: Dropdown.RenderProps

--- a/packages/js/product-editor/src/components/header/publish-button/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/types.ts
@@ -8,6 +8,6 @@ export type PublishButtonProps = Omit<
 	'aria-disabled' | 'variant' | 'children'
 > & {
 	productType?: string;
-	isPrePublishButton?: boolean;
+	isMenuButton?: boolean;
 	isPrePublishPanelVisible?: boolean;
 };

--- a/packages/js/product-editor/src/components/header/publish-button/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/types.ts
@@ -8,5 +8,6 @@ export type PublishButtonProps = Omit<
 	'aria-disabled' | 'variant' | 'children'
 > & {
 	productType?: string;
-	prePublish?: boolean;
+	isPrePublishButton?: boolean;
+	isPrePublishPanelVisible?: boolean;
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an error after hiding the pre-publish modal (when unchecking the option `Always show pre-publish checks`). The dropdown part of the publish button was also hidden when creating a new product. That means there was no way for the user to schedule o delete a product.

Closes #45589.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the New product editor and the Prepublish sidebar (product-pre-publish-modal) under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Create a new product and uncheck `Always show pre-publish checks` in the pre-publish panel.
3. Create a new product.
4. The dropdown next to the publish button should be visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
