### PR TITLE
Replace the Draft tag with a Scheduled tag in the product header

### DIFF
--- a/packages/js/product-editor/changelog/fix-45667
+++ b/packages/js/product-editor/changelog/fix-45667
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace the Draft tag with a Scheduled tag in the product header

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -125,11 +125,19 @@ export function Header( {
 
 	function getVisibilityTags() {
 		const tags = [];
-		if ( productStatus === 'draft' || productStatus === 'future' ) {
+		if ( productStatus === 'draft' ) {
 			tags.push(
 				<Tag
 					key={ 'draft-tag' }
 					label={ __( 'Draft', 'woocommerce' ) }
+				/>
+			);
+		}
+		if ( productStatus === 'future' ) {
+			tags.push(
+				<Tag
+					key={ 'scheduled-tag' }
+					label={ __( 'Scheduled', 'woocommerce' ) }
 				/>
 			);
 		}

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -4,6 +4,7 @@
 import { MouseEvent } from 'react';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
+import { isInTheFuture } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import type { Product } from '@woocommerce/data';
 
@@ -28,10 +29,16 @@ export function usePublish< T = Product >( {
 	const { isValidating, isDirty, isPublishing, publish } =
 		useProductManager( productType );
 
-	const [ status, , prevStatus ] = useEntityProp< Product[ 'status' ] >(
+	const [ , , prevStatus ] = useEntityProp< Product[ 'status' ] >(
 		'postType',
 		productType,
 		'status'
+	);
+
+	const [ editedDate ] = useEntityProp< string >(
+		'postType',
+		productType,
+		'date_created_gmt'
 	);
 
 	const isBusy = isPublishing || isValidating;
@@ -53,7 +60,7 @@ export function usePublish< T = Product >( {
 	function getButtonText() {
 		if (
 			window.wcAdminFeatures[ 'product-pre-publish-modal' ] &&
-			status === 'future'
+			isInTheFuture( editedDate )
 		) {
 			return __( 'Schedule', 'woocommerce' );
 		}

--- a/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
+++ b/packages/js/product-editor/src/components/prepublish-panel/prepublish-panel.tsx
@@ -10,6 +10,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { closeSmall } from '@wordpress/icons';
 import classnames from 'classnames';
 import type { Product } from '@woocommerce/data';
+import { isInTheFuture } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -30,10 +31,10 @@ export function PrepublishPanel( {
 		'woocommerce'
 	),
 }: PrepublishPanelProps ) {
-	const [ editedDate, , date ] = useEntityProp< string >(
+	const [ editedDate ] = useEntityProp< string >(
 		'postType',
 		productType,
-		'date_created'
+		'date_created_gmt'
 	);
 
 	const [ productStatus, , prevStatus ] = useEntityProp<
@@ -47,7 +48,7 @@ export function PrepublishPanel( {
 			? productStatus === 'publish'
 			: true;
 
-	if ( editedDate !== date ) {
+	if ( isInTheFuture( editedDate ) ) {
 		title = __( 'Are you ready to schedule this product?', 'woocommerce' );
 		description = __(
 			'Your product will be published at the specified date and time.',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45667

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New
3. Add a product `Name` and press `Publish`.
4. From the pre publish modal shown in the right side of the screen go to the `Publish` section and select a date in the future.
5. The product header should show `Scheduled` tag and the pre publish panel header title should reads `Are you ready to schedule this product?` 
<img width="795" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/16ab2b94-7dd2-4299-a4f5-b1585034f794">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
