### PR TITLE
Fix organization tab e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-test-organization-tab-selector
+++ b/plugins/woocommerce/changelog/fix-e2e-test-organization-tab-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix organization tab e2e tests #45692

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
@@ -44,18 +44,22 @@ test.describe( 'General tab', () => {
 				)
 				.last()
 				.fill( productData.summary );
-			await page
-				.locator(
-					'[id^="wp-block-woocommerce-product-regular-price-field"]'
-				)
-				.first()
-				.fill( productData.productPrice );
-			await page
-				.locator(
-					'[id^="wp-block-woocommerce-product-sale-price-field"]'
-				)
-				.first()
-				.fill( productData.salePrice );
+
+			await clickOnTab( 'Pricing', page );
+
+			const regularPrice = page
+				.locator( 'input[name="regular_price"]' )
+				.first();
+			await regularPrice.waitFor( { state: 'visible' } );
+			await regularPrice.click();
+			await regularPrice.fill( productData.productPrice );
+
+			const salePrice = page
+				.locator( 'input[name="sale_price"]' )
+				.first();
+			await salePrice.waitFor( { state: 'visible' } );
+			await salePrice.click();
+			await salePrice.fill( productData.salePrice );
 
 			await clickOnTab( 'Organization', page );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The PRs https://github.com/woocommerce/woocommerce/pull/45532 and https://github.com/woocommerce/woocommerce/pull/45495 were accepted and merged today. However, the first PR tests need the price and sale fields under the General tab, and the second one moves those fields. That makes some E2E tests fail.

This PR fixes that problem.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run our E2E tests. All the tests should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
