### PR TITLE
[CYS on Core] Ensure the "Didn’t find a theme you like" text is displayed exclusively at the bottom of the themes card

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
@@ -2,13 +2,11 @@
  * External dependencies
  */
 import {
-	createInterpolateElement,
 	Fragment,
 	useEffect,
 	useState,
 } from '@wordpress/element';
 import classnames from 'classnames';
-import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -138,30 +136,6 @@ export default function ProductListContent( props: {
 						) }
 					</Fragment>
 				) ) }
-			</div>
-			<div
-				className={
-					'woocommerce-marketplace__browse-wp-theme-directory'
-				}
-			>
-				<b>{ __( 'Didn’t find a theme you like?', 'woocommerce' ) }</b>
-				{ createInterpolateElement(
-					__(
-						' Browse the <a>WordPress.org theme directory</a> to discover more.',
-						'woocommerce'
-					),
-					{
-						a: (
-							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a
-								href={
-									ADMIN_URL +
-									'theme-install.php?search=e-commerce'
-								}
-							/>
-						),
-					}
-				) }
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	Fragment,
-	useEffect,
-	useState,
-} from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import classnames from 'classnames';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -118,22 +114,23 @@ export default function ProductListContent( props: {
 								} ),
 							} }
 						/>
-						{ index === bannerPosition && (
-							<NoAIBanner
-								redirectToCYSFlow={ () => {
-									const customizeStoreDesignUrl =
-										addQueryArgs(
-											`${ ADMIN_URL }admin.php`,
-											{
-												page: 'wc-admin',
-												path: '/customize-store/design',
-											}
-										);
-									window.location.href =
-										customizeStoreDesignUrl;
-								} }
-							/>
-						) }
+						{ index === bannerPosition &&
+							props.type === 'theme' && (
+								<NoAIBanner
+									redirectToCYSFlow={ () => {
+										const customizeStoreDesignUrl =
+											addQueryArgs(
+												`${ ADMIN_URL }admin.php`,
+												{
+													page: 'wc-admin',
+													path: '/customize-store/design',
+												}
+											);
+										window.location.href =
+											customizeStoreDesignUrl;
+									} }
+								/>
+							) }
 					</Fragment>
 				) ) }
 			</div>

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useContext, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useContext,
+	useState,
+} from '@wordpress/element';
 import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
@@ -173,6 +177,34 @@ export default function Products( props: ProductsProps ) {
 				searchTerm={ props.searchTerm }
 				category={ category }
 			/>
+			{ props.type === 'theme' && (
+				<div
+					className={
+						'woocommerce-marketplace__browse-wp-theme-directory'
+					}
+				>
+					<b>
+						{ __( 'Didn’t find a theme you like?', 'woocommerce' ) }
+					</b>
+					{ createInterpolateElement(
+						__(
+							' Browse the <a>WordPress.org theme directory</a> to discover more.',
+							'woocommerce'
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<a
+									href={
+										ADMIN_URL +
+										'theme-install.php?search=e-commerce'
+									}
+								/>
+							),
+						}
+					) }
+				</div>
+			) }
 			{ showAllButton && (
 				<Button
 					className={ viewAllButonClassName }

--- a/plugins/woocommerce/changelog/45706-fix-themes-card-footer-copy-being-displayed-on-discover-card
+++ b/plugins/woocommerce/changelog/45706-fix-themes-card-footer-copy-being-displayed-on-discover-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure the "Didn’t find a theme you like" text and the "Design your own" banner are displayed exclusively at the bottom of the themes tab on WooCommerce > Extensions.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure the "Didn’t find a theme you like" text and the "Design your own" banner are displayed exclusively at the bottom of the themes tab on WooCommerce > Extensions.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45705

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to WooCommerce > Extensions > Themes `wp-admin/admin.php?page=wc-admin&tab=themes&path=%2Fextensions`
2. Ensure you see the "design your own" banner and the `Didn’t find a theme you like? Browse the WordPress.org theme directory to discover more.` text at the bottom of the page:

<img width="1871" alt="Screenshot 2024-03-19 at 12 59 02" src="https://github.com/woocommerce/woocommerce/assets/15730971/2668b923-fd58-4a2e-89bc-2d32fb64c44a">

<img width="1869" alt="Screenshot 2024-03-19 at 12 59 25" src="https://github.com/woocommerce/woocommerce/assets/15730971/d430b73e-a89d-4acc-b0f0-47a8b8f5a0b5">

4. Head over to WooCommerce > Extensions > Discover: make sure **you don't see** the afore mentioned banner and text
5. Head over to WooCommerce > Extensions > Browse: make sure **you don't see** the afore mentioned banner and text
6. Head over to WooCommerce > Extensions > My subscriptions: make sure **you don't see** the afore mentioned banner and text

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure the "Didn’t find a theme you like" text and the "Design your own" banner are displayed exclusively at the bottom of the themes tab on WooCommerce > Extensions.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
