### PR TITLE
[e2e tests] Improve test stability by using a stricter locator when checking product variation

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-create-variable-product-test
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-create-variable-product-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix variable product flakiness

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -53,7 +53,7 @@ test.describe( 'Variations tab', () => {
 			'The block product editor is not being tested'
 		);
 
-		test( 'can create a variation option and publish the product', async ( {
+		test.only( 'can create a variation option and publish the product', async ( {
 			page,
 		} ) => {
 			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
@@ -94,45 +94,19 @@ test.describe( 'Variations tab', () => {
 
 			await expect( attributeColumn ).toHaveValue( 'Size' );
 
-			await page
-				.locator( '//input[@placeholder="Search or create value"]' )
-				.fill( attributesData.options[ 0 ] );
+			for ( const option of attributesData.options ) {
+				await page
+					.locator(
+						'.woocommerce-new-attribute-modal__table-attribute-value-column .woocommerce-experimental-select-control__input'
+					)
+					.fill( option );
 
-			await page
-				.locator( `text=Create "${ attributesData.options[ 0 ] }"` )
-				.click();
+				await page.locator( `text=Create "${ option }"` ).click();
 
-			await expect(
-				page.getByText( attributesData.options[ 0 ] ).first()
-			).toBeVisible();
-
-			await page
-				.locator(
-					'.woocommerce-new-attribute-modal__table-attribute-value-column .woocommerce-experimental-select-control__input'
-				)
-				.fill( attributesData.options[ 1 ] );
-
-			await page
-				.locator( `text=Create "${ attributesData.options[ 1 ] }"` )
-				.click();
-
-			await expect(
-				page.getByText( attributesData.options[ 1 ] ).first()
-			).toBeVisible();
-
-			await page
-				.locator(
-					'.woocommerce-new-attribute-modal__table-attribute-value-column .woocommerce-experimental-select-control__input'
-				)
-				.fill( attributesData.options[ 2 ] );
-
-			await page
-				.locator( `text=Create "${ attributesData.options[ 2 ] }"` )
-				.click();
-
-			await expect(
-				page.getByText( attributesData.options[ 2 ] ).first()
-			).toBeVisible();
+				await expect(
+					page.locator( '.woocommerce-attribute-term-field' )
+				).toContainText( option );
+			}
 
 			await page
 				.locator( '.woocommerce-new-attribute-modal__buttons' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`can create a variation option and publish the product` sometimes fails because the first element matching the created size ('Small') can be hidden and the test expects it to be visible. [Example](https://github.com/woocommerce/woocommerce/actions/runs/8341743943/job/22829231655#step:5:1222).
Updating the assertion to check that the variation input field contains the expected text would hopefully fix the issue.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

`pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
