### PR TITLE
Sync Local Pickup title between Checkout block and shipping settings UI and vice/versa

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
@@ -172,6 +172,10 @@ const Block = ( {
 		'shippingCostRequiresAddress',
 		false
 	);
+	const localPickupTextFromSettings = getSetting< string >(
+		'localPickupText',
+		localPickupText || defaultLocalPickupText
+	);
 
 	return (
 		<RadioGroup
@@ -197,7 +201,7 @@ const Block = ( {
 				multiple={ shippingRates.length > 1 }
 				showPrice={ showPrice }
 				showIcon={ showIcon }
-				toggleText={ localPickupText || defaultLocalPickupText }
+				toggleText={ localPickupTextFromSettings }
 			/>
 		</RadioGroup>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -11,7 +11,7 @@ import {
 	__experimentalRadioGroup as RadioGroup,
 } from '@wordpress/components';
 import { Icon, store, shipping } from '@wordpress/icons';
-import { ADMIN_URL } from '@woocommerce/settings';
+import { ADMIN_URL, getSetting } from '@woocommerce/settings';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 import {
 	InspectorControls,
@@ -23,6 +23,7 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import ExternalLinkCard from '@woocommerce/editor-components/external-link-card';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -163,6 +164,16 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element | null => {
+	useEffect( () => {
+		const localPickupTitle = getSetting< string >(
+			'localPickupText',
+			attributes.localPickupText
+		);
+		setAttributes( { localPickupText: localPickupTitle } );
+		// Disable the exhaustive deps rule because we only want to run this on first mount to set the attribute, not
+		// each time the attribute changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ setAttributes ] );
 	const { setPrefersCollection } = useDispatch( CHECKOUT_STORE_KEY );
 	const { prefersCollection } = useSelect( ( select ) => {
 		const checkoutStore = select( CHECKOUT_STORE_KEY );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { Notice } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { REGULAR_PRICED_PRODUCT_NAME } from '../checkout/constants';
+
+test.describe( 'Merchant → Local Pickup Settings', () => {
+	test.beforeEach( async ( { localPickupUtils } ) => {
+		await localPickupUtils.deleteLocations();
+		await localPickupUtils.addPickupLocation( {
+			location: {
+				name: 'Automattic, Inc.',
+				address: '60 29th Street, Suite 343',
+				city: 'San Francisco',
+				postcode: '94110',
+				state: 'US:CA',
+				details: 'American entity',
+			},
+		} );
+		await localPickupUtils.disableLocalPickupCosts();
+		await localPickupUtils.enableLocalPickup();
+	} );
+
+	test.afterEach( async ( { localPickupUtils } ) => {
+		await localPickupUtils.deleteLocations();
+		await localPickupUtils.disableLocalPickupCosts();
+		await localPickupUtils.setTitle( 'Local Pickup' );
+		await localPickupUtils.enableLocalPickup();
+	} );
+
+	test( 'Updating the title in WC Settings updates the local pickup text in the block and vice/versa', async ( {
+		page,
+		localPickupUtils,
+		admin,
+		editor,
+		editorUtils,
+		frontendUtils,
+	} ) => {
+		// First update the title via the site editor then check the local pickup settings.
+		await admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//page-checkout',
+			postType: 'wp_template',
+		} );
+		await editor.canvas.click( 'body' );
+
+		const block = await editorUtils.getBlockByName(
+			'woocommerce/checkout-shipping-method-block'
+		);
+		await editor.selectBlocks( block );
+		const fakeInput = editor.canvas.getByLabel( 'Local Pickup' );
+		await fakeInput.click();
+
+		const isMacOS = process.platform === 'darwin'; // darwin is macOS
+
+		// eslint-disable-next-line playwright/no-conditional-in-test
+		if ( isMacOS ) {
+			await fakeInput.press( 'Meta+a' );
+		} else {
+			await fakeInput.press( 'Control+a' );
+		}
+		await fakeInput.press( 'Backspace' );
+		await fakeInput.pressSequentially( 'This is a test' );
+		await editor.canvas.getByText( 'This is a test' ).isVisible();
+		await editor.saveSiteEditorEntities();
+		await localPickupUtils.openLocalPickupSettings();
+		await expect( page.getByLabel( 'Title' ) ).toHaveValue(
+			'This is a test'
+		);
+
+		// Now update the title via local pickup settings and check it reflects in the site editor and front end.
+		await localPickupUtils.setTitle( 'Edited from settings page' );
+		await localPickupUtils.saveLocalPickupSettings();
+
+		await admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//page-checkout',
+			postType: 'wp_template',
+		} );
+		await editor.canvas.click( 'body' );
+		await expect(
+			editor.canvas.getByText( 'Edited from settings page' )
+		).toBeVisible();
+
+		await frontendUtils.emptyCart();
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+		await frontendUtils.goToCheckout();
+
+		await expect(
+			page.getByText( 'Edited from settings page' )
+		).toBeVisible();
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -27,9 +27,7 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 
 	test.afterEach( async ( { localPickupUtils } ) => {
 		await localPickupUtils.deleteLocations();
-		await localPickupUtils.disableLocalPickupCosts();
 		await localPickupUtils.setTitle( 'Local Pickup' );
-		await localPickupUtils.enableLocalPickup();
 	} );
 
 	test( 'Updating the title in WC Settings updates the local pickup text in the block and vice/versa', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-import { Notice } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -43,7 +43,7 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
 		} );
-		await editor.canvas.click( 'body' );
+		await editorUtils.enterEditMode();
 
 		const block = await editorUtils.getBlockByName(
 			'woocommerce/checkout-shipping-method-block'
@@ -79,7 +79,8 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
 		} );
-		await editor.canvas.click( 'body' );
+		await editorUtils.enterEditMode();
+
 		await expect(
 			editor.canvas.getByText( 'Edited from settings page' )
 		).toBeVisible();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -27,7 +27,7 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 
 	test.afterEach( async ( { localPickupUtils } ) => {
 		await localPickupUtils.deleteLocations();
-		await localPickupUtils.setTitle( 'Local Pickup' );
+		await localPickupUtils.setLocalPickupTitle( 'Local Pickup' );
 	} );
 
 	test( 'Updating the title in WC Settings updates the local pickup text in the block and vice/versa', async ( {
@@ -70,7 +70,9 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		);
 
 		// Now update the title via local pickup settings and check it reflects in the site editor and front end.
-		await localPickupUtils.setTitle( 'Edited from settings page' );
+		await localPickupUtils.setLocalPickupTitle(
+			'Edited from settings page'
+		);
 		await localPickupUtils.saveLocalPickupSettings();
 
 		await admin.visitSiteEditor( {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
@@ -4,6 +4,7 @@
 import { Page } from '@playwright/test';
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 import { cli } from '@woocommerce/e2e-utils';
+import { Notice } from '@wordpress/notices';
 
 type Location = {
 	name: string;
@@ -32,6 +33,17 @@ export class LocalPickupUtils {
 
 	async saveLocalPickupSettings() {
 		await this.page.getByRole( 'button', { name: 'Save changes' } ).click();
+		await this.page.waitForFunction( () => {
+			return window.wp.data
+				.select( 'core/notices' )
+				.getNotices()
+				.some(
+					( notice: Notice ) =>
+						notice.status === 'success' &&
+						notice.content ===
+							'Local Pickup settings have been saved.'
+				);
+		} );
 	}
 
 	async enableLocalPickup() {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
@@ -60,6 +60,12 @@ export class LocalPickupUtils {
 		await this.saveLocalPickupSettings();
 	}
 
+	async setTitle( title: string ) {
+		await this.openLocalPickupSettings();
+		await this.page.getByLabel( 'Title' ).fill( title );
+		await this.saveLocalPickupSettings();
+	}
+
 	async disableLocalPickupCosts() {
 		await this.openLocalPickupSettings();
 

--- a/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
@@ -33,17 +33,12 @@ export class LocalPickupUtils {
 
 	async saveLocalPickupSettings() {
 		await this.page.getByRole( 'button', { name: 'Save changes' } ).click();
-		await this.page.waitForFunction( () => {
-			return window.wp.data
-				.select( 'core/notices' )
-				.getNotices()
-				.some(
-					( notice: Notice ) =>
-						notice.status === 'success' &&
-						notice.content ===
-							'Local Pickup settings have been saved.'
-				);
-		} );
+
+		// Wait for the snackbar to appear with the success notice showing.
+		await this.page
+			.getByLabel( 'Dismiss this notice' )
+			.getByText( 'Local Pickup settings have been saved.' )
+			.isVisible();
 	}
 
 	async enableLocalPickup() {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
@@ -4,7 +4,6 @@
 import { Page } from '@playwright/test';
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 import { cli } from '@woocommerce/e2e-utils';
-import { Notice } from '@wordpress/notices';
 
 type Location = {
 	name: string;

--- a/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
@@ -72,12 +72,6 @@ export class LocalPickupUtils {
 		await this.saveLocalPickupSettings();
 	}
 
-	async setTitle( title: string ) {
-		await this.openLocalPickupSettings();
-		await this.page.getByLabel( 'Title' ).fill( title );
-		await this.saveLocalPickupSettings();
-	}
-
 	async disableLocalPickupCosts() {
 		await this.openLocalPickupSettings();
 
@@ -85,6 +79,12 @@ export class LocalPickupUtils {
 			.getByLabel( 'Add a price for customers who choose local pickup' )
 			.uncheck();
 
+		await this.saveLocalPickupSettings();
+	}
+
+	async setLocalPickupTitle( title: string ) {
+		await this.openLocalPickupSettings();
+		await this.page.getByLabel( 'Title' ).fill( title );
 		await this.saveLocalPickupSettings();
 	}
 

--- a/plugins/woocommerce/changelog/update-local-pickup-title
+++ b/plugins/woocommerce/changelog/update-local-pickup-title
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Sync local pickup title between Checkout page and shipping settings UI

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -288,11 +288,11 @@ class Checkout extends AbstractBlock {
 	 * Recurse through the blocks to find the shipping methods block, then get the value of the localPickupText attribute from it.
 	 *
 	 * @param array $blocks The block(s) to search for the local pickup text.
-	 * @return void|string  The local pickup text if found, otherwise void.
+	 * @return null|string  The local pickup text if found, otherwise void.
 	 */
 	private function find_local_pickup_text_in_checkout_block( $blocks ) {
 		if ( ! is_array( $blocks ) ) {
-			return;
+			return null;
 		}
 		foreach ( $blocks as $block ) {
 			if ( ! empty( $block['blockName'] ) && 'woocommerce/checkout-shipping-method-block' === $block['blockName'] ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -278,6 +278,7 @@ class Checkout extends AbstractBlock {
 
 		$post_blocks = parse_blocks( $post->post_content );
 		$title       = $this->find_local_pickup_text_in_checkout_block( $post_blocks );
+
 		if ( $title ) {
 			$pickup_location_settings['title'] = $title;
 			update_option( 'woocommerce_pickup_location_settings', $pickup_location_settings );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -42,7 +42,7 @@ class Checkout extends AbstractBlock {
 			}
 		);
 
-		add_action( 'save_post', [ $this, 'update_local_pickup_title' ], 10, 2 );
+		add_action( 'save_post', array( $this, 'update_local_pickup_title' ), 10, 2 );
 	}
 
 	/**
@@ -350,7 +350,7 @@ class Checkout extends AbstractBlock {
 
 		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
 		$this->asset_data_registry->add( 'localPickupEnabled', wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' ), true );
-		$this->asset_data_registry->add( 'localPickupText', wc_clean( $pickup_location_settings['title'] ) ??  __( 'Local Pickup', 'woocommerce' ), true );
+		$this->asset_data_registry->add( 'localPickupText', wc_clean( $pickup_location_settings['title'] ) ?? __( 'Local Pickup', 'woocommerce' ), true );
 
 		$is_block_editor = $this->is_block_editor();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -243,6 +243,31 @@ class Checkout extends AbstractBlock {
 	}
 
 	/**
+	 * Recurse through the blocks to find the shipping methods block, then get the value of the localPickupText attribute from it.
+	 *
+	 * @param $blocks array The block(s) to search for the local pickup text.
+	 * @return void|string  The local pickup text if found, otherwise void.
+	 */
+	private function find_local_pickup_text_in_checkout_block( $blocks ) {
+		if ( ! is_array( $blocks ) ) {
+			return;
+		}
+		foreach ( $blocks as $block ) {
+			if ( ! empty ( $block['blockName'] ) && 'woocommerce/checkout-shipping-method-block' === $block['blockName'] ) {
+				if ( ! empty( $block['attrs']['localPickupText'] ) ) {
+					return $block['attrs']['localPickupText'];
+				}
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$answer = $this->find_local_pickup_text_in_checkout_block( $block['innerBlocks'] );
+				if ( $answer ) {
+					return $answer;
+				}
+			}
+		}
+	}
+
+	/**
 	 * Extra data passed through from server to client for block.
 	 *
 	 * @param array $attributes  Any attributes that currently are available from the block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -252,8 +252,9 @@ class Checkout extends AbstractBlock {
 	 * @return void
 	 */
 	public function update_local_pickup_title( $post_id, $post ) {
+
+		// This is not a proper save action, maybe an autosave, so don't continue.
 		if ( empty( $post->post_status ) || 'inherit' === $post->post_status ) {
-			// This is not a proper save action, maybe an autosave, so don't continue.
 			return;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -283,6 +283,7 @@ class Checkout extends AbstractBlock {
 
 		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
 		$this->asset_data_registry->add( 'localPickupEnabled', wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' ), true );
+		$this->asset_data_registry->add( 'localPickupText', wc_clean( $pickup_location_settings['title'] ) ??  __( 'Local Pickup', 'woocommerce' ), true );
 
 		$is_block_editor = $this->is_block_editor();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -247,12 +247,12 @@ class Checkout extends AbstractBlock {
 	/**
 	 * Update the local pickup title in WooCommerce Settings when the checkout page containing a Checkout block is saved.
 	 *
-	 * @param $post_id int  The post ID.
-	 * @param $post    WP_Post The post object.
+	 * @param int      $post_id The post ID.
+	 * @param \WP_Post $post    The post object.
 	 * @return void
 	 */
 	public function update_local_pickup_title( $post_id, $post ) {
-		if ( empty( $post->post_status ) || 'inherit' === $post->post_status  ) {
+		if ( empty( $post->post_status ) || 'inherit' === $post->post_status ) {
 			// This is not a proper save action, maybe an autosave, so don't continue.
 			return;
 		}
@@ -263,10 +263,10 @@ class Checkout extends AbstractBlock {
 			return;
 		}
 
-		if ( ( ! empty( $post->post_type ) && ! empty( $post->post_name ) && $post->post_name !== 'page-checkout' && $post->post_type === 'wp_template' ) || false === has_block( 'woocommerce/checkout', $post ) ) {
+		if ( ( ! empty( $post->post_type ) && ! empty( $post->post_name ) && 'page-checkout' !== $post->post_name && 'wp_template' === $post->post_type ) || false === has_block( 'woocommerce/checkout', $post ) ) {
 			return;
 		}
-		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
+		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', array() );
 
 		if ( ! isset( $pickup_location_settings['title'] ) ) {
 			return;
@@ -277,7 +277,7 @@ class Checkout extends AbstractBlock {
 		}
 
 		$post_blocks = parse_blocks( $post->post_content );
-		$title = $this->find_local_pickup_text_in_checkout_block( $post_blocks );
+		$title       = $this->find_local_pickup_text_in_checkout_block( $post_blocks );
 		if ( $title ) {
 			$pickup_location_settings['title'] = $title;
 			update_option( 'woocommerce_pickup_location_settings', $pickup_location_settings );
@@ -287,7 +287,7 @@ class Checkout extends AbstractBlock {
 	/**
 	 * Recurse through the blocks to find the shipping methods block, then get the value of the localPickupText attribute from it.
 	 *
-	 * @param $blocks array The block(s) to search for the local pickup text.
+	 * @param array $blocks The block(s) to search for the local pickup text.
 	 * @return void|string  The local pickup text if found, otherwise void.
 	 */
 	private function find_local_pickup_text_in_checkout_block( $blocks ) {
@@ -295,7 +295,7 @@ class Checkout extends AbstractBlock {
 			return;
 		}
 		foreach ( $blocks as $block ) {
-			if ( ! empty ( $block['blockName'] ) && 'woocommerce/checkout-shipping-method-block' === $block['blockName'] ) {
+			if ( ! empty( $block['blockName'] ) && 'woocommerce/checkout-shipping-method-block' === $block['blockName'] ) {
 				if ( ! empty( $block['attrs']['localPickupText'] ) ) {
 					return $block['attrs']['localPickupText'];
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces some changes that will cause the local pickup title to save to the settings UI when edited in the block, and save to the block when edited in the settings UI.

To facilitate the sync from settings -> editor/front-end, the current local pickup title is output in the asset data registry (accessible via `wc.wcSettings`) this value is used by the block to render the title.

To handle syncing from editor -> settings UI, the `post_saved` action is hooked and we check if the post being saved is the checkout template, or the checkout page. If so, then the title text from the `Local Pickup` selector is extracted and saved to the settings.

This PR also adds E2E tests which checks the sync between editor/frontend and settings UI and vice/versa.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45160.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a block theme such as Twenty Twenty-Four. 
2. Go to WooCommerce -> Settings -> Shipping -> Local Pickup.
3. Add a location and enable local pickup.
4. Change the title of local pickup to something different.
5. Open the Checkout page template in the Site editor.
6. Ensure you can see the updated local pickup title from step 4.
<img width="538" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/76857093-a768-4699-a2f0-f5a9355d5dee">

7. Click into the local pickup selector and edit the title to something different.
8. Save the template and then go back to WooCommerce -> Settings -> Shipping -> Local Pickup.
9. Ensure the title shown here is the same as what you entered in the site editor.

https://www.loom.com/share/9324af6dd240411c839e944ac09ae367

1. Use a classic theme, such as storefront.
2. Repeat the steps above, but instead of going to the site editor, go to Pages -> then to your checkout page.

#### Edge case testing

1. Add a new page - insert the checkout block and edit the local pickup title.
2. Ensure it does **not** update the local pickup title in the settings UI. (this is because it only applies to the designated Checkout page).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
