### PR TITLE
Try: Add product module dependencies

### DIFF
--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -15,6 +15,7 @@
 		"marketing": true,
 		"minified-js": false,
 		"mobile-app-banner": true,
+		"modular-products": false,
 		"navigation": true,
 		"new-product-management-experience": false,
 		"onboarding": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -15,6 +15,7 @@
 		"marketing": true,
 		"minified-js": true,
 		"mobile-app-banner": true,
+		"modular-products": true,
 		"navigation": true,
 		"new-product-management-experience": false,
 		"onboarding": true,

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
@@ -47,6 +47,15 @@ abstract class WC_Product_Module {
 	abstract public static function get_slug();
 
 	/**
+	 * Get pass through methods.
+	 *
+	 * @return string
+	 */
+	public static function get_passthrough_methods() {
+		return array();
+	}
+
+	/**
 	 * Get the product property that determines if this module is enabled or not.
 	 * Defaults to the module slug.
 	 *

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
@@ -19,6 +19,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class WC_Product_Module {
 
 	/**
+	 * Stores product data.
+	 *
+	 * @var array
+	 */
+	protected $extra_data = [];
+
+	/**
 	 * The product.
 	 *
 	 * @var WC_Product
@@ -93,6 +100,15 @@ abstract class WC_Product_Module {
 			array_keys( WC()->product_modules()->get_all_modules() ),
 			static::get_compatible_modules(),
 		);
+	}
+
+	/**
+	 * Get extra store data.
+	 *
+	 * @return array
+	 */
+	public function get_extra_data() {
+		return $this->extra_data;
 	}
 
 	public static function add_hooks() {}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
@@ -23,7 +23,7 @@ abstract class WC_Product_Module {
 	 *
 	 * @var array
 	 */
-	protected $extra_data = [];
+	protected $extra_data = array();
 
 	/**
 	 * The product.
@@ -109,6 +109,15 @@ abstract class WC_Product_Module {
 	 */
 	public function get_extra_data() {
 		return $this->extra_data;
+	}
+
+	/**
+	 * Check if this module is active in the product.
+	 *
+	 * @return bool
+	 */
+	private function is_active() {
+		$this->product->is_module_active( self::get_slug() );
 	}
 
 	public static function add_hooks() {}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product-module.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * WooCommerce product module base class.
+ *
+ * @package WooCommerce\Abstracts
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Abstract Product Module Class
+ *
+ * The WooCommerce product class handles individual product data.
+ *
+ * @package WooCommerce\Abstracts
+ */
+abstract class WC_Product_Module {
+
+	/**
+	 * The product.
+	 *
+	 * @var WC_Product
+	 */
+	protected $product;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct( $product ) {
+		$this->product = $product;
+	}
+
+	/**
+	 * Get product name.
+	 *
+	 * @return string
+	 */
+	abstract public static function get_name();
+
+	/**
+	 * Get product module slug.
+	 *
+	 * @return string
+	 */
+	abstract public static function get_slug();
+
+	/**
+	 * Get the product property that determines if this module is enabled or not.
+	 * Defaults to the module slug.
+	 *
+	 * @return string
+	 */
+	public static function get_product_property() {
+		return static::get_slug();
+	}
+
+	/**
+	 * Get the value the product property should be when enabled.
+	 *
+	 * @return string
+	 */
+	public static function get_product_property_enabled_value() {
+		return 'yes';
+	}
+
+	/**
+	 * Get compatible modules.
+	 *
+	 * @return array
+	 */
+	public static function get_compatible_modules() {
+		return WC()->product_modules()->get_simple_product_modules();
+	}
+
+	/**
+	 * Get incompatible modules.
+	 *
+	 * @return array
+	 */
+	public static function get_incompatible_modules() {
+		return array_diff(
+			array_keys( WC()->product_modules()->get_all_modules() ),
+			static::get_compatible_modules(),
+		);
+	}
+
+	public static function add_hooks() {}
+
+}

--- a/plugins/woocommerce/includes/class-wc-data-store.php
+++ b/plugins/woocommerce/includes/class-wc-data-store.php
@@ -49,6 +49,7 @@ class WC_Data_Store {
 		'payment-token'         => 'WC_Payment_Token_Data_Store',
 		'product'               => 'WC_Product_Data_Store_CPT',
 		'product-grouped'       => 'WC_Product_Grouped_Data_Store_CPT',
+		'product-modular'       => 'WC_Product_Modular_Data_Store_CPT',
 		'product-variable'      => 'WC_Product_Variable_Data_Store_CPT',
 		'product-variation'     => 'WC_Product_Variation_Data_Store_CPT',
 		'shipping-zone'         => 'WC_Shipping_Zone_Data_Store',
@@ -106,6 +107,7 @@ class WC_Data_Store {
 		} else {
 			throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
 		}
+
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-factory.php
+++ b/plugins/woocommerce/includes/class-wc-product-factory.php
@@ -42,16 +42,6 @@ class WC_Product_Factory {
 
 		$classname = self::get_product_classname( $product_id, $product_type );
 
-		// @todo Need a new feature flag here.
-		if ( $product_type === 'ModularProduct' || true ) {
-			$modules = WC()->product_modules()->get_all_modules();
-			try {
-				return new WC_Product_Modular( $product_id, $modules );
-			} catch ( Exception $e ) {
-				return false;
-			}
-		}
-
 		try {
 			return new $classname( $product_id, $deprecated );
 		} catch ( Exception $e ) {

--- a/plugins/woocommerce/includes/class-wc-product-factory.php
+++ b/plugins/woocommerce/includes/class-wc-product-factory.php
@@ -42,6 +42,16 @@ class WC_Product_Factory {
 
 		$classname = self::get_product_classname( $product_id, $product_type );
 
+		// @todo Need a new feature flag here.
+		if ( $product_type === 'ModularProduct' || true ) {
+			$modules = WC()->product_modules()->get_all_modules();
+			try {
+				return new WC_Product_Modular( $product_id, $modules );
+			} catch ( Exception $e ) {
+				return false;
+			}
+		}
+
 		try {
 			return new $classname( $product_id, $deprecated );
 		} catch ( Exception $e ) {

--- a/plugins/woocommerce/includes/class-wc-product-modular.php
+++ b/plugins/woocommerce/includes/class-wc-product-modular.php
@@ -23,6 +23,13 @@ class WC_Product_Modular extends WC_Product {
     private $modules = array();
 
     /**
+	 * Active modules.
+	 *
+	 * @var array
+	 */
+    private $active_modules = array();
+
+    /**
 	 * Aliased methods.
 	 *
 	 * @var array
@@ -96,15 +103,15 @@ class WC_Product_Modular extends WC_Product {
 	 * @param string $module_slug Module slug.
 	 */
 	public function activate_module( $module_slug ) {
-		$modules       = $this->get_prop( 'modules' );
-		$module_exists = (bool) WC()->product_modules()->get_module( $module_slug );
+		$active_modules = $this->active_modules;
+		$module_exists  = (bool) WC()->product_modules()->get_module( $module_slug );
 
 		// @todo Could optionally do some compatibility checking here and throw warnings or disable other modules.
-		if ( $module_exists && ! in_array( $module_slug, $modules ) ) {
-			$modules[] = $module_slug;
+		if ( $module_exists && ! in_array( $module_slug, $active_modules ) ) {
+			$active_modules[] = $module_slug;
 		}
 
-		$this->set_prop( 'modules', $modules );
+		$this->active_modules = $active_modules;
 	}
 
 	/**
@@ -113,8 +120,17 @@ class WC_Product_Modular extends WC_Product {
 	 * @param string $module_slug Module slug.
 	 */
 	public function deactivate_module( $module_slug ) {
-		$modules       = $this->get_prop( 'modules' );
-		$this->set_prop( 'modules', array_diff( $modules, array( $module_slug ) ) );
+		$modules              = $this->get_prop( 'modules' );
+		$this->active_modules = array_diff( $modules, array( $module_slug ) );
 	}
+
+    /**
+     * Check if module is active.
+     *
+     * @return bool
+     */
+    public function is_module_active( $module_slug ) {
+        return in_array( $module_slug, $this->active_modules, true );
+    }
 
 }

--- a/plugins/woocommerce/includes/class-wc-product-modular.php
+++ b/plugins/woocommerce/includes/class-wc-product-modular.php
@@ -57,8 +57,10 @@ class WC_Product_Modular extends WC_Product {
 	 * @param int|WC_Product|object $product Product to init.
 	 * @param array                 $modules Modules to instantiate with the product.
 	 */
-	public function __construct( $product = 0, $modules = array() ) {
+	public function __construct( $product = 0 ) {
 		parent::__construct( $product );
+        $modules          = WC()->product_modules()->get_all_modules();
+		$this->data_store = WC_Data_Store::load( 'product-modular' );
 
         foreach ( $modules as $module_class_name ) {
             $module                        = new $module_class_name( $this );
@@ -79,7 +81,12 @@ class WC_Product_Modular extends WC_Product {
 	 * @return string
 	 */
 	public function get_type() {
-		// @todo Possibly return deprecated type to allow backwards compatibility.
+        foreach ( $this->active_modules as $module_slug ) {
+            if ( isset( $this->modules[ $module_slug ] ) && method_exists( $this->modules[ $module_slug ], 'get_deprecated_product_type' ) ) {
+                return $this->modules[ $module_slug ]::get_deprecated_product_type();
+            }
+        }
+
 		return 'modular';
 	}
 

--- a/plugins/woocommerce/includes/class-wc-product-modular.php
+++ b/plugins/woocommerce/includes/class-wc-product-modular.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Modular Product
+ *
+ * The WooCommerce product class handles individual product data.
+ *
+ * @version 3.0.0
+ * @package WooCommerce\Classes\Products
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Modular product class.
+ */
+class WC_Product_Modular extends WC_Product {
+
+    /**
+	 * Modules.
+	 *
+	 * @var array
+	 */
+    private $modules = array();
+
+    /**
+	 * Get the product if ID is passed, otherwise the product is new and empty.
+	 * This class should NOT be instantiated, but the wc_get_product() function
+	 * should be used. It is possible, but the wc_get_product() is preferred.
+	 *
+	 * @param int|WC_Product|object $product Product to init.
+	 * @param array                 $modules Modules to instantiate with the product.
+	 */
+	public function __construct( $product = 0, $modules = array() ) {
+		parent::__construct( $product );
+
+        foreach ( $modules as $module ) {
+            $this->modules[ $module::get_slug() ] = new $module( $this );
+        }
+	}
+
+	/**
+	 * Get internal type.
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+		// @todo Possibly return deprecated type to allow backwards compatibility.
+		return 'modular';
+	}
+
+    /**
+     * Get a module by slug.
+     *
+     * @param string $slug Module slug.
+     * @return WC_Product_Module|false
+     */
+    public function get_module( $slug ) {
+        if ( isset( $this->modules[ $slug ] ) ) {
+            return $this->modules[ $slug ];
+        }
+
+        return false;
+    }
+
+}

--- a/plugins/woocommerce/includes/class-wc-product-modules.php
+++ b/plugins/woocommerce/includes/class-wc-product-modules.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * WooCommerce Product Modules
+ *
+ * Loads the product modules via hooks for use in the store.
+ *
+ * @version 2.2.0
+ * @package WooCommerce\Classes\Products
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product modules class.
+ */
+class WC_Product_Modules {
+
+	/**
+	 * Product modules classes.
+	 *
+	 * @var array
+	 */
+	public $product_modules = array();
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var WC_Product_modules
+	 */
+	protected static $_instance = null;
+
+	/**
+	 * Main WC_Product_modules Instance.
+	 *
+	 * @return WC_Product_modules Main instance
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Initialize product modules.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+    /**
+	 * Default modules for all products.
+	 *
+	 * @var array
+	 */
+	public function get_base_product_modules() {
+        return apply_filters(
+            'woocommerce_base_product_modules',
+            array(
+                WC_Product_Module_Downloadable::get_slug(),
+                WC_Product_Module_Shippable::get_slug(),
+                WC_Product_Module_Virtual::get_slug(),
+            )
+        );
+    }
+
+	/**
+	 * Load gateways and hook in functions.
+	 */
+	public function init() {
+		include_once WC_ABSPATH . 'includes/products/modules/class-wc-product-module-variable.php';
+
+		$product_modules = array(
+            WC_Product_Module_Variable::class,
+		);
+
+		$product_modules = apply_filters( 'woocommerce_product_modules', $product_modules );
+
+		foreach ( $product_modules as $module ) {
+			if ( is_string( $module ) && class_exists( $module ) ) {
+				$this->product_modules[ $module::get_slug() ] = $module;
+			}
+        }
+	}
+
+    /**
+     * Get a module by slug.
+     *
+     * @param string $slug Module slug.
+     * @return WC_Product_Module
+     */
+    public function get_module( $slug ) {
+        if ( isset( $this->product_modules[ $slug ] ) ) {
+            return $this->product_modules[ $slug ];
+        }
+
+        return null;
+    }
+
+	/**
+	 * Get all product modules.
+	 *
+	 * @return array
+	 */
+	public function get_all_modules() {
+		return $this->product_modules;
+	}
+
+}

--- a/plugins/woocommerce/includes/class-wc-product-modules.php
+++ b/plugins/woocommerce/includes/class-wc-product-modules.php
@@ -78,6 +78,7 @@ class WC_Product_Modules {
 
 		foreach ( $product_modules as $module ) {
 			if ( is_string( $module ) && class_exists( $module ) ) {
+				$module::init();
 				$this->product_modules[ $module::get_slug() ] = $module;
 			}
         }

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -535,6 +535,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-deprecated-hooks.php';
 		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-session.php';
 		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-privacy.php';
+		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-product-module.php';
 
 		/**
 		 * Core classes.
@@ -1162,5 +1163,14 @@ final class WooCommerce {
 	 */
 	public function get_global( string $global_name ) {
 		return wc_get_container()->get( LegacyProxy::class )->get_global( $global_name );
+	}
+
+	/**
+	 * Get modules class.
+	 *
+	 * @return WC_Product_Modules
+	 */
+	public function product_modules() {
+		return WC_Product_Modules::instance();
 	}
 }

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -589,6 +589,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php';
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php';
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-grouped-data-store-cpt.php';
+		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-modular-data-store-cpt.php';
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-variable-data-store-cpt.php';
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-variation-data-store-cpt.php';
 		include_once WC_ABSPATH . 'includes/data-stores/abstract-wc-order-item-type-data-store.php';

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-modular-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-modular-data-store-cpt.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * WC_Product_Data_Store_CPT class file.
+ *
+ * @package WooCommerce\Classes
+ */
+
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\DownloadPermissionsAdjuster;
+use Automattic\WooCommerce\Utilities\NumberUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Product Data Store: Stored in CPT.
+ *
+ * @version  3.0.0
+ */
+class WC_Product_Modular_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store_Interface, WC_Product_Data_Store_Interface {
+
+	/**
+	 * Make sure we store the product type and version (to track data changes).
+	 *
+	 * @param WC_Product $product Product object.
+	 * @since 3.0.0
+	 */
+	protected function update_version_and_type( &$product ) {
+		$old_type = WC_Product_Factory::get_product_type( $product->get_id() );
+		// @todo We might want to offer a way to break out of this type.
+		$new_type = 'modular';
+
+		wp_set_object_terms( $product->get_id(), $new_type, 'product_type' );
+		update_post_meta( $product->get_id(), '_product_version', Constants::get_constant( 'WC_VERSION' ) );
+
+		// Action for the transition.
+		if ( $old_type !== $new_type ) {
+			$this->updated_props[] = 'product_type';
+			do_action( 'woocommerce_product_type_changed', $product, $old_type, $new_type );
+		}
+	}
+
+}

--- a/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
+++ b/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
@@ -13,6 +13,15 @@ defined( 'ABSPATH' ) || exit;
 class WC_Product_Module_Variable extends WC_Product_Module {
 
 	/**
+	 * Stores product data.
+	 *
+	 * @var array
+	 */
+	protected $extra_data = array(
+		'variable_data_key' => 'example_default',
+	);
+
+	/**
 	 * Contains a reference to the data store for this class.
 	 *
 	 * @since 3.0.0

--- a/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
+++ b/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
@@ -82,6 +82,15 @@ class WC_Product_Module_Variable extends WC_Product_Module {
 	}
 
 	/**
+	 * Get the deprecated product type.
+	 *
+	 * @return string
+	 */
+	public static function get_deprecated_product_type() {
+		return 'variable';
+	}
+
+	/**
 	 * Check if the product is variable.
 	 *
 	 * @return bool

--- a/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
+++ b/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
@@ -46,6 +46,13 @@ class WC_Product_Module_Variable extends WC_Product_Module {
 	}
 
 	/**
+	 * Initialize the module.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_product_add_to_cart_text', array( __CLASS__, 'add_to_cart_text' ), 10, 2 );
+	}
+
+	/**
 	 * Get the name.
 	 *
 	 * @return string
@@ -63,14 +70,24 @@ class WC_Product_Module_Variable extends WC_Product_Module {
 		return 'variable';
 	}
 
+	/**
+	 * Get the product passthrough methods.
+	 *
+	 * @return array
+	 */
 	public static function get_passthrough_methods() {
 		return array(
 			'is_variable'
 		);
 	}
 
+	/**
+	 * Check if the product is variable.
+	 *
+	 * @return bool
+	 */
 	public function is_variable() {
-		return true;
+		return $this->product->is_module_active( 'variable' );
 	}
 
 	/**
@@ -124,6 +141,19 @@ class WC_Product_Module_Variable extends WC_Product_Module {
 	 */
 	public function set_visible_children( $visible_children ) {
 		$this->visible_children = array_filter( wp_parse_id_list( (array) $visible_children ) );
+	}
+
+	/**
+	 * Get the add to cart button text.
+	 *
+	 * @return string
+	 */
+	public static function add_to_cart_text( $text, $product ) {
+		if ( ! $product->is_module_active( self::get_slug() ) ) {
+			return $text;
+		}
+
+		return $product->is_purchasable() ? __( 'Select options', 'woocommerce' ) : __( 'Add variation', 'woocommerce' );
 	}
 
 }

--- a/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
+++ b/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Variable product module.
+ *
+ * @package WooCommerce\Classes\Products
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Variable product module class.
+ */
+class WC_Product_Module_Variable extends WC_Product_Module {
+
+	/**
+	 * Contains a reference to the data store for this class.
+	 *
+	 * @since 3.0.0
+	 * @var object
+	 */
+	protected $data_store;
+
+	/**
+	 * Array of children variation IDs. Determined by children.
+	 *
+	 * @var array
+	 */
+	protected $children = null;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct( $product ) {
+		parent::__construct( $product );
+
+		$this->data_store = WC_Data_Store::load( 'product-variable' );
+	}
+
+	/**
+	 * Get the name.
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return 'Variable';
+	}
+
+    /**
+	 * Get the slug.
+	 *
+	 * @return string
+	 */
+	public static function get_slug() {
+		return 'variable';
+	}
+
+	/**
+	 * Get compatible modules.
+	 */
+	public static function get_compatible_modules() {
+		return array_merge(
+			array_keys( WC()->product_modules()->get_base_product_modules() ),
+		);
+	}
+
+	/**
+	 * Return a products child ids.
+	 *
+	 * This is lazy loaded as it's not used often and does require several queries.
+	 *
+	 * @param bool|string $visible_only Visible only.
+	 * @return array Children ids
+	 */
+	public function get_children( $visible_only = '' ) {
+		if ( is_bool( $visible_only ) ) {
+			wc_deprecated_argument( 'visible_only', '3.0', 'WC_Product_Variable::get_visible_children' );
+
+			return $visible_only ? $this->get_visible_children() : $this->get_children();
+		}
+
+		if ( null === $this->children ) {
+			$children = $this->data_store->read_children( $this->product );
+			$this->set_children( $children['all'] );
+			$this->set_visible_children( $children['visible'] );
+		}
+
+		return apply_filters( 'woocommerce_get_children', $this->children, $this->product, false );
+	}
+
+	/**
+	 * Sets an array of children for the product.
+	 *
+	 * @since 3.0.0
+	 * @param array $children Children products.
+	 */
+	public function set_children( $children ) {
+		$this->children = array_filter( wp_parse_id_list( (array) $children ) );
+	}
+
+	/**
+	 * Sets an array of visible children only.
+	 *
+	 * @since 3.0.0
+	 * @param array $visible_children List of visible children products.
+	 */
+	public function set_visible_children( $visible_children ) {
+		$this->visible_children = array_filter( wp_parse_id_list( (array) $visible_children ) );
+	}
+
+}

--- a/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
+++ b/plugins/woocommerce/includes/products/modules/class-wc-product-module-variable.php
@@ -54,6 +54,16 @@ class WC_Product_Module_Variable extends WC_Product_Module {
 		return 'variable';
 	}
 
+	public static function get_passthrough_methods() {
+		return array(
+			'is_variable'
+		);
+	}
+
+	public function is_variable() {
+		return true;
+	}
+
 	/**
 	 * Get compatible modules.
 	 */

--- a/plugins/woocommerce/src/Admin/Features/ModularProducts.php
+++ b/plugins/woocommerce/src/Admin/Features/ModularProducts.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * WooCommerce Modular Products
+ */
+
+namespace Automattic\WooCommerce\Admin\Features;
+
+/**
+ * Modular products.
+ */
+class ModularProducts {
+
+	/**
+	 * Hook into WooCommerce.
+	 */
+	public function __construct() {
+        add_filter( 'woocommerce_product_class', array( $this, 'maybe_revert_to_simple_product' ) );
+	}
+
+    /**
+     * Revert to the simple product class in legacy experiences.
+     *
+     * @param string $classname Classname.
+     * @return string Classname.
+     */
+    public function maybe_revert_to_simple_product( $classname ) {
+        if ( isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
+            return 'WC_Product_Simple';
+        }
+
+        return $classname;
+    }
+
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -66,6 +66,10 @@ class RedirectionController {
 		$digital_product     = $product->is_downloadable() || $product->is_virtual();
 		$product_template_id = $product->get_meta( '_product_template_id' );
 
+		if ( is_a( $product, 'WC_Product_Modular' ) ) {
+			return true;
+		}
+
 		foreach ( $this->product_templates as $product_template ) {
 			if ( is_null( $product_template->get_layout_template_id() ) ) {
 				continue;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a POC showing how we can break product type functionality into reusable modules that work together.  The primary focus of this PR is to create a strategy for transitioning to this new way of handling products without breaking backwards compatiblity.

This strategy works by creating a new product type `WC_Product_Modular` that allows "modules" (pieces of functionality previously used in product types) to be activated or deactivated.  This doesn't get added to the product type selector, but is settable via REST API so it could be used exclusively in the new product editor.  It also does the following:

* Allowing `get_type` to return the deprecated type slug from a module so that extensions relying on this check can continue using it without things breaking.
* Always forcing the product to remain as a `WC_Product_Modular` unless we're in the legacy editor where it gets converted back to a `WC_Product_Simple`
* Allows adding data to the product via modules and setting default product data
* Allowing specified methods to pass through from the product to the module (e.g., `$product->is_variable()` can pass through to `$variable_module_instance->is_variable()`.  This is mostly in place to allow backwards compatibility if someone checks the `get_type` of a product and uses a method without checking if that method exists.
* Initialize hooks related to product modules.


### How to test the changes in this Pull Request:

1.  Add the following snippet:
```php
$product = new \WC_Product_Modular();
```
2. Call the passthrough method to see that it works:
```php
error_log( $product->is_variable() );
```
3. Check that you can get modules and call thier methods which in turn uses their own data stores.
```php
error_log( print_r( $product->get_module('variable')->get_children(), true ) );
```
4. Check that modules can be activated and this affects the `get_type` return
```php
error_log( $product->get_type() ); // Should be `modular`
$product->activate_module('variable');
error_log( $product->get_type() ); // Should be `variable`
```
5. Persist the product
```php
$product->set_name( 'Test product - modular' );
$product->save();
```
6. Get the product and check that it's an instance of `WC_Product_Modular` and not saved as a variable product despite the previous `get_type` result
```php
$product = wc_get_product( YOUR_PRODUCT_ID );
error_log( get_class( $product ) );
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
