### PR TITLE
Products: Improve type safety of get_attributes

### DIFF
--- a/plugins/woocommerce/changelog/update-product-attributes-getter
+++ b/plugins/woocommerce/changelog/update-product-attributes-getter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the product get_attributes method only returns valid attribute objects in its array

--- a/plugins/woocommerce/changelog/update-product-attributes-getter
+++ b/plugins/woocommerce/changelog/update-product-attributes-getter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Ensure the product get_attributes method only returns valid attribute objects in its array
+Avoid fatal error in `find_matching_product_variation` method if an attribute is not an instance of WC_Product_Attribute

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -528,12 +528,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return WC_Product_Attribute[]
 	 */
 	public function get_attributes( $context = 'view' ) {
-		$attributes = $this->get_prop( 'attributes', $context );
-
-		return array_filter(
-			$attributes,
-			fn( $attribute ) => $attribute instanceof WC_Product_Attribute
-		);
+		return $this->get_prop( 'attributes', $context );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -525,10 +525,15 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * Returns product attributes.
 	 *
 	 * @param  string $context What the value is for. Valid values are view and edit.
-	 * @return array
+	 * @return WC_Product_Attribute[]
 	 */
 	public function get_attributes( $context = 'view' ) {
-		return $this->get_prop( 'attributes', $context );
+		$attributes = $this->get_prop( 'attributes', $context );
+
+		return array_filter(
+			$attributes,
+			fn( $attribute ) => $attribute instanceof WC_Product_Attribute
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1105,7 +1105,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		// Get attributes to match in meta.
 		foreach ( $product->get_attributes() as $attribute ) {
-			if ( ! $attribute->get_variation() ) {
+			if ( ! $attribute instanceof WC_Product_Attribute || ! $attribute->get_variation() ) {
 				continue;
 			}
 			$meta_attribute_names[] = 'attribute_' . sanitize_title( $attribute->get_name() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -1082,5 +1082,22 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $children[2], $match );
+
+		// Invalid attributes should not cause a fatal error.
+		$callback = function( $atts ) {
+			$atts['invalid']  = 'invalid attribute';
+			$atts['invalid2'] = 'another invalid attribute';
+			return $atts;
+		};
+
+		add_filter( 'woocommerce_product_get_attributes', $callback );
+		$match = $data_store->find_matching_product_variation(
+			$product,
+			array(
+				'attribute_pa_size' => 'large',
+			)
+		);
+		$this->assertEquals( $children[1], $match );
+		remove_filter( 'woocommerce_product_get_attributes', $callback );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
@@ -109,39 +109,6 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the attributes getter only returns valid WC_Product_Attribute instances.
-	 *
-	 * @since 8.8.0
-	 */
-	public function test_get_product_attributes_sanitization() {
-		$attributes = array();
-		$attribute  = new WC_Product_Attribute();
-		$attribute->set_id( 0 );
-		$attribute->set_name( 'Test Attribute' );
-		$attribute->set_options( array( 'Fish', 'Fingers' ) );
-		$attribute->set_position( 0 );
-		$attribute->set_visible( true );
-		$attribute->set_variation( false );
-		$attributes['test-attribute'] = $attribute;
-
-		$product = ProductHelper::create_simple_product();
-		$product->set_attributes( $attributes );
-		$product->save();
-
-		$callback = function( $atts ) {
-			$atts['invalid']  = 'invalid attribute';
-			$atts['invalid2'] = 'another invalid attribute';
-			return $atts;
-		};
-
-		add_filter( 'woocommerce_product_get_attributes', $callback );
-		$actual_attributes = $product->get_attributes();
-		$this->assertCount( 1, $actual_attributes );
-		$this->assertTrue( reset( $actual_attributes ) instanceof WC_Product_Attribute );
-		remove_filter( 'woocommerce_product_get_attributes', $callback );
-	}
-
-	/**
 	 * Test the onbackorder stock status.
 	 *
 	 * @since 3.3.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds a sanitization step to the get_attributes method that ensures the return array only contains valid WC_Product_Attribute objects. Because anything that's retrieved by get_prop() can be filtered, there was the possibility that values could be added to the attributes array that were not valid, causing fatal errors like the following:

`Uncaught Error: Call to a member function get_variation() on string`

### How to test the changes in this Pull Request:

1. Add a new product.
1. Set it as a variable product.
1. Add an attribute with two or three values.
1. Go to the variations tab and click the button to generate variations.
1. Save the product.
1. Add this code snippet to your test site:
    ```php
	add_filter(
		'woocommerce_product_get_attributes',
		function ( $attributes ) {
			$attributes[] = 'test';
			return $attributes;
		}
	);
    ```
1. Refresh the edit screen for the product you just created.
1. On trunk, you should see an error message where the product variations metabox would be. On this branch, there should be no error.
1. Also ensure the new unit test passes.