### PR TITLE
Prevent possible type error during `WC_Install::create_options()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-type-error-create-options
+++ b/plugins/woocommerce/changelog/fix-type-error-create-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible type error during install routine.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -163,7 +163,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 */
 		public function get_sections() {
 			$sections = $this->get_own_sections();
-			return apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );
+			return (array) apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -163,6 +163,12 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 */
 		public function get_sections() {
 			$sections = $this->get_own_sections();
+			/**
+			 * Filters the sections for this settings page.
+			 *
+			 * @since 2.2.0
+			 * @param array $sections The sections for this settings page.
+			 */
 			return (array) apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds a type cast so that `$settings_page->get_sections()` always returns an array, which prevents a possible fatal error during install in cases where some code might be misusing the `woocommerce_get_sections_<id>` filter.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a snippet with the following code to your site:
   ```php
   <?php
   add_filter( 'woocommerce_get_sections_general', '__return_null' );
   ```
1. We're going to "fake" an update in this conditions:
   ```
   wp option update woocommerce_version 8.7.9 &&  wp transient delete wc_installing
   ```
1. Open a page on your site to trigger the install routine.
1. No fatal error should appear.
1. Confirm WC has been updated by running `wp option get woocommerce_version`, which should output `8.8.0`.
1. (Optional) Run 2-3 on `trunk` and verify that a fatal error does occur in that case.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
