### PR TITLE
Fix broken CSS classes and update JS unit snapshots

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
@@ -85,7 +85,7 @@ const TotalsFooterItem = ( {
 
 	const priceComponent = (
 		<FormattedMonetaryAmount
-			className="wc-block-components-totals-item__value"
+			className="wc-block-components-totals-footer-item-tax-value"
 			currency={ currency }
 			value={ parseInt( totalPrice, 10 ) }
 		/>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/footer-item/test/__snapshots__/index.tsx.snap
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/footer-item/test/__snapshots__/index.tsx.snap
@@ -10,11 +10,15 @@ exports[`TotalsFooterItem Does not show the "including %s of tax" line if tax is
     >
       Total
     </span>
-    <span
-      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    <div
+      class="wc-block-components-totals-item__value"
     >
-      £85.00
-    </span>
+      <span
+        class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-footer-item-tax-value"
+      >
+        £85.00
+      </span>
+    </div>
     <div
       class="wc-block-components-totals-item__description"
     />
@@ -32,11 +36,15 @@ exports[`TotalsFooterItem Does not show the "including %s of tax" line if tax is
     >
       Total
     </span>
-    <span
-      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    <div
+      class="wc-block-components-totals-item__value"
     >
-      £85.00
-    </span>
+      <span
+        class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-footer-item-tax-value"
+      >
+        £85.00
+      </span>
+    </div>
     <div
       class="wc-block-components-totals-item__description"
     />
@@ -54,11 +62,15 @@ exports[`TotalsFooterItem Shows the "including %s TAX LABEL" line with single ta
     >
       Total
     </span>
-    <span
-      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    <div
+      class="wc-block-components-totals-item__value"
     >
-      £85.00
-    </span>
+      <span
+        class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-footer-item-tax-value"
+      >
+        £85.00
+      </span>
+    </div>
     <div
       class="wc-block-components-totals-item__description"
     >
@@ -82,11 +94,15 @@ exports[`TotalsFooterItem Shows the "including %s TAX LABELS" line with multiple
     >
       Total
     </span>
-    <span
-      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    <div
+      class="wc-block-components-totals-item__value"
     >
-      £85.00
-    </span>
+      <span
+        class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-footer-item-tax-value"
+      >
+        £85.00
+      </span>
+    </div>
     <div
       class="wc-block-components-totals-item__description"
     >
@@ -110,11 +126,15 @@ exports[`TotalsFooterItem Shows the "including %s of tax" line if tax is greater
     >
       Total
     </span>
-    <span
-      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    <div
+      class="wc-block-components-totals-item__value"
     >
-      £85.00
-    </span>
+      <span
+        class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-footer-item-tax-value"
+      >
+        £85.00
+      </span>
+    </div>
     <div
       class="wc-block-components-totals-item__description"
     >

--- a/plugins/woocommerce-blocks/packages/components/totals/item/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/totals/item/index.tsx
@@ -26,7 +26,11 @@ const TotalsItemValue = ( {
 	currency,
 }: Partial< TotalsItemProps > ): ReactElement | null => {
 	if ( isValidElement( value ) ) {
-		return <>{ value }</>;
+		return (
+			<div className="wc-block-components-totals-item__value">
+				{ value }
+			</div>
+		);
 	}
 
 	return Number.isFinite( value ) ? (

--- a/plugins/woocommerce/changelog/45732-fix-45170-broken-CSS-styles
+++ b/plugins/woocommerce/changelog/45732-fix-45170-broken-CSS-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix broken CSS styles of the `totalValue` filter.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45575.

This PR fixes broken CSS styles due to wrongly fixing JS unit tests. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the [Simple Custom CSS and JS](https://wordpress.org/plugins/custom-css-js/) plugin.
2. Go to `/wp-admin/edit.php?post_type=custom-css-js` and add the following code snippet:

```js
const { registerCheckoutFilters } = window.wc.blocksCheckout;

const modifyTotalsPrice = ( defaultValue, extensions, args, validation ) => {
	return "Pay <price/> now";
};

registerCheckoutFilters( 'my-extension', {
	totalValue: modifyTotalsPrice,
} );
```

> [!IMPORTANT]
> Make sure to run the script in the footer as it requires other dependencies to load first.

3. Go to the frontend and add a product to the cart.
4. Go to the cart page and verify that `Pay TOTAL_PRICE now` appears as seen on the after screenshot below.
5. Go to the checkout page and verify that `Pay TOTAL_PRICE now` appears as seen on the after screenshot below.

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="380" alt="Screenshot 2024-03-20 at 12 51 46" src="https://github.com/woocommerce/woocommerce/assets/3323310/854d1a9a-500c-4fc7-9d81-1374d820fe14">
</td>
<td valign="top">After:
<br><br>
<img width="388" alt="Screenshot 2024-03-20 at 13 35 48" src="https://github.com/woocommerce/woocommerce/assets/3323310/cb384134-0d22-444e-b761-96338e3cb394">
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix broken CSS styles of the `totalValue` filter.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
