### PR TITLE
New filter to set a custom precision value for the WC calculations

### DIFF
--- a/plugins/woocommerce/changelog/YordanSoares-trunk
+++ b/plugins/woocommerce/changelog/YordanSoares-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add filter to control rounding precision in internal calculations.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1899,11 +1899,11 @@ function wc_get_rounding_precision() {
 	 * Filter the rounding precision for internal WC calculations. This is different from the number of decimals used for display.
 	 * Generally, this filter can be used to decrease the precision, but if you choose to decrease, there maybe side effects such as off by one rounding errors for certain tax rate combinations.
 	 *
-	 * @since 8.9.0
+	 * @since 8.8.0
 	 *
 	 * @param int $precision The number of decimals to round to.
 	 */
-	return apply_filters( 'wc_get_rounding_precision', $precision );
+	return apply_filters( 'woocommerce_wc_get_rounding_precision', $precision );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1894,6 +1894,13 @@ function wc_get_rounding_precision() {
 	if ( $precision < absint( WC_ROUNDING_PRECISION ) ) {
 		$precision = absint( WC_ROUNDING_PRECISION );
 	}
+
+	/**
+	 * Filter the rounding precision for internal WC calculations. This is different from the number of decimals used for display.
+	 * Generally, this filter can be used to decrease the precision, but if you choose to decrease, there maybe side effects such off by one rounding errors for certain tax rate combinations.
+	 *
+	 * @param int $precision The number of decimals to round to.
+	 */
 	return apply_filters( 'wc_get_rounding_precision', $precision );
 }
 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1899,6 +1899,8 @@ function wc_get_rounding_precision() {
 	 * Filter the rounding precision for internal WC calculations. This is different from the number of decimals used for display.
 	 * Generally, this filter can be used to decrease the precision, but if you choose to decrease, there maybe side effects such off by one rounding errors for certain tax rate combinations.
 	 *
+	 * @since 8.9.0
+	 *
 	 * @param int $precision The number of decimals to round to.
 	 */
 	return apply_filters( 'wc_get_rounding_precision', $precision );

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1894,7 +1894,7 @@ function wc_get_rounding_precision() {
 	if ( $precision < absint( WC_ROUNDING_PRECISION ) ) {
 		$precision = absint( WC_ROUNDING_PRECISION );
 	}
-	return $precision;
+	return apply_filters( 'wc_get_rounding_precision', $precision );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1903,7 +1903,7 @@ function wc_get_rounding_precision() {
 	 *
 	 * @param int $precision The number of decimals to round to.
 	 */
-	return apply_filters( 'woocommerce_wc_get_rounding_precision', $precision );
+	return apply_filters( 'woocommerce_internal_rounding_precision', $precision );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1897,7 +1897,7 @@ function wc_get_rounding_precision() {
 
 	/**
 	 * Filter the rounding precision for internal WC calculations. This is different from the number of decimals used for display.
-	 * Generally, this filter can be used to decrease the precision, but if you choose to decrease, there maybe side effects such off by one rounding errors for certain tax rate combinations.
+	 * Generally, this filter can be used to decrease the precision, but if you choose to decrease, there maybe side effects such as off by one rounding errors for certain tax rate combinations.
 	 *
 	 * @since 8.9.0
 	 *


### PR DESCRIPTION
Copied over from #44139 with extra commits for CI

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new filter to set a custom precision value for the WC calculations: `wc_get_rounding_precision`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set the option "Yes, I will enter prices inclusive of tax" under WooCommerce > Settings > Tax > Prices entered with tax:
   
   ![image](https://github.com/woocommerce/woocommerce/assets/38109855/01a23986-702c-4712-84c1-7f352c97dc94)
2. Insert a row and enter 21% as a standard tax rate (it will help to generate a price with decimals and it is also an actual tax rate in several EU countries):
   
   ![image](https://github.com/woocommerce/woocommerce/assets/38109855/adc57de4-4f8a-4cb7-9a6d-461ebe8c9164)

3. Place a new order, selecting any product.
4. Edit the item within the order details screen, and check the decimal numbers:
   
   ![image](https://github.com/woocommerce/woocommerce/assets/38109855/341d481b-16a6-4b4a-b44b-71e73d4f0ab3)
5. Activate the following code snippet in the testing site:

```php
/**
 * WooCommerce:
 * Customize the precision value for WC calculations
 */
add_filter( 'woocommerce_internal_rounding_precision', function( $precision ) {
	return 2;
}, 10, 1 );
```
6. Place a second order, selecting the same product chosen for the first order.
7. Edit the item within the order details screen for the second order, and check the decimal numbers (they should be only 2 this time):
   
    ![image](https://github.com/woocommerce/woocommerce/assets/38109855/56c88d9d-d4eb-4337-85cc-45a0505dbc99)

<!-- End testing instructions -->

### Changelog entry

New filter to set a custom precision value for the WC calculations: `wc_get_rounding_precision`

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
</details>
