### PR TITLE
Update product editor experiment name and enable pre-publish panel by default

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -16,7 +16,7 @@ import { createNoticesFromResponse } from '../../../lib/notices';
 import { getAdminSetting } from '~/utils/admin-settings';
 
 const EXPERIMENT_NAME =
-	'woocommerce_product_creation_experience_empty_state_updates_202403_v1';
+	'woocommerce_product_creation_experience_prepublish_panel_202404_v1';
 
 export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );

--- a/plugins/woocommerce/changelog/dev-45736_enable_prepublish_modal_feature
+++ b/plugins/woocommerce/changelog/dev-45736_enable_prepublish_modal_feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update product editor experiment name and enable pre-publish panel by default #45745

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -24,7 +24,7 @@
 		"product-external-affiliate": true,
 		"product-grouped": true,
 		"product-linked": true,
-		"product-pre-publish-modal": false,
+		"product-pre-publish-modal": true,
 		"product-custom-fields": false,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -74,6 +74,13 @@ test.describe( 'General tab', () => {
 				} )
 				.click();
 
+			await page
+				.locator( '.woocommerce-product-publish-panel__header' )
+				.getByRole( 'button', {
+					name: 'Publish',
+				} )
+				.click();
+
 			const element = page.locator( 'div.components-snackbar__content' );
 			const textContent = await element.innerText();
 
@@ -114,6 +121,13 @@ test.describe( 'General tab', () => {
 				.fill( productData.productPrice );
 			await page
 				.locator( '.woocommerce-product-header__actions' )
+				.getByRole( 'button', {
+					name: 'Publish',
+				} )
+				.click();
+
+			await page
+				.locator( '.woocommerce-product-publish-panel__header' )
 				.getByRole( 'button', {
 					name: 'Publish',
 				} )

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -173,6 +173,13 @@ test.describe( 'Variations tab', () => {
 				} )
 				.click();
 
+			await page
+				.locator( '.woocommerce-product-publish-panel__header' )
+				.getByRole( 'button', {
+					name: 'Publish',
+				} )
+				.click();
+
 			const element = page.locator( 'div.components-snackbar__content' );
 			if ( Array.isArray( element ) ) {
 				await expect( await element[ 0 ].innerText() ).toMatch(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
@@ -67,10 +67,7 @@ test.describe.serial( 'Disable block product editor', () => {
 		} catch ( e ) {}
 
 		// turn off block product editor from the header
-		await page
-			.locator( '.components-dropdown-menu' )
-			.getByRole( 'button', { name: 'Options' } )
-			.click();
+		await page.locator( 'button[aria-label="Options"]' ).click();
 		await page
 			.getByRole( 'menuitem', {
 				name: 'Turn off the new product form',

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
@@ -114,6 +114,13 @@ test.describe( 'General tab', () => {
 				} )
 				.click();
 
+			await page
+				.locator( '.woocommerce-product-publish-panel__header' )
+				.getByRole( 'button', {
+					name: 'Publish',
+				} )
+				.click();
+
 			const element = page.locator( 'div.components-snackbar__content' );
 			const textContent = await element.innerText();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updates the experiment name for the latest WC Release and enables the pre-publish panel by default.

Partially addresses https://github.com/woocommerce/woocommerce/issues/45736.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the ExPlat experiment `woocommerce_product_creation_experience_prepublish_panel_202404_v1` and choose the variation you want to test.
2. When hovering over any Bookmarklet link of control or treatment variation, a popover should appear with instructions to try one of the variations.
3. Be sure to save the suggested link to your browser bookmarks.
4. Go to WooCommerce > Home and go through the OBW or skip.
5. Go to `/wp-admin/admin.php?page=wc-admin` and click on the second item to add a new product.
6. Click on the bookmark saved in step 3.
7. After clicking the saved bookmark, a modal with this title should be shown ExPlat: Successful Assignment
    Close the modal. 
8. Click on one of those: physical, variable, digital, grouped, and external product type ( try to test at least a couple ). 
    If you chose the "control" variation, you should see the classic product editor (which doesn't have a pre-publish panel).
    If you selected the "treatment" variation, you should see the Publish dropdown and pre-publish panel after pressing `Publish`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
