### PR TITLE
Product Editor: Fix crash when uploading files from variations list Quick Update menu

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-quick-update-upload-files
+++ b/packages/js/product-editor/changelog/fix-product-editor-quick-update-upload-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: "Upload files" quick update menu for variations does not crash variations list.

--- a/packages/js/product-editor/src/components/variations-table/downloads-menu-item/downloads-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/downloads-menu-item/downloads-menu-item.tsx
@@ -33,9 +33,12 @@ export function DownloadsMenuItem( {
 }: VariationActionsMenuItemProps ) {
 	const ids = selection.map( ( { id } ) => id );
 
-	const downloadsIds: number[] = selection[ 0 ].downloads.map(
-		( { id }: ProductDownload ) => Number.parseInt( id, 10 )
-	);
+	const downloadsIds: number[] =
+		selection?.length > 0
+			? selection[ 0 ].downloads.map( ( { id }: ProductDownload ) =>
+					Number.parseInt( id, 10 )
+			  )
+			: [];
 
 	const [ uploadFilesModalOpen, setUploadFilesModalOpen ] = useState( false );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the following issue with the new product editor:

1. Go to **Products** > **Add New**
2. On **Variations** tab, create variations
3. Select one or more variations and then select **Quick update** > **Downloads** > **Upload files**
4. Select or upload files and click **Select** to close the upload modal
5. Variations list crashes

![Screen Recording on 2024-03-20 at 09-22-05](https://github.com/woocommerce/woocommerce/assets/2098816/91095e19-9875-4c14-9a06-abb7dcb8b316)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. On **Variations** tab, create variations
3. Select one or more variations and then select **Quick update** > **Downloads** > **Upload files**
4. Select or upload files and click **Select** to close the upload modal
5. Verify variations list does not crash and that uploaded files were added to the variations (click **Edit** on individual variation in list after unselecting variations and verify file was added... see video below)

<img width="1263" alt="Screenshot 2024-03-20 at 12 30 06" src="https://github.com/woocommerce/woocommerce/assets/2098816/9001eafe-60de-47d1-b5b8-ce397e72ac37">

https://github.com/woocommerce/woocommerce/assets/2098816/f42a128c-aa01-4b4b-afbf-437eb4f3a5b6


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
