### PR TITLE
Add gap between quantity field and add to cart button when stacked

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
@@ -14,6 +14,7 @@
 		display: inline-block;
 		float: none;
 		margin-right: 4px;
+		margin-bottom: 10px;
 		vertical-align: middle;
 
 		.qty {
@@ -22,4 +23,8 @@
 			text-align: center;
 		}
 	}
+}
+
+.woocommerce div.product .wc-block-add-to-cart-form form.cart button.single_add_to_cart_button {
+	margin-bottom: 10px;
 }

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
@@ -14,7 +14,6 @@
 		display: inline-block;
 		float: none;
 		margin-right: 4px;
-		margin-bottom: 10px;
 		vertical-align: middle;
 
 		.qty {
@@ -23,6 +22,10 @@
 			text-align: center;
 		}
 	}
+}
+
+.woocommerce div.product .wc-block-add-to-cart-form form.cart .quantity {
+	margin-bottom: 10px;
 }
 
 .woocommerce div.product .wc-block-add-to-cart-form form.cart button.single_add_to_cart_button {

--- a/plugins/woocommerce/changelog/45758-add-to-cart-spacing
+++ b/plugins/woocommerce/changelog/45758-add-to-cart-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adds spacing between quantity field and add to cart button when stacked


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/43795

This PR adds `margin-bottom: 10px;` to the `quantity field` and the `add to cart` button so that when they're stacked, there is a visual spacing between them for better experience.

Note that the added CSS is very specific because themes are styling it so it has to be a higher specificity than the themes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the frontend and a single product.
2. Ensure you see the quantity field and add to cart button next to each other.
3. Reduce your browser window size until the add to cart button is stacked below the quantity field.
4. Ensure you see a nice spacing between the two fields.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds spacing between quantity field and add to cart button when stacked

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
</details>
