### PR TITLE
CYS - Core: fix: not mark Customize your store step as completed when the user switches theme

### DIFF
--- a/plugins/woocommerce/changelog/45762-fix-theme-mark-woo-express
+++ b/plugins/woocommerce/changelog/45762-fix-theme-mark-woo-express
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Core: fix: not mark `Customize your store`  step as completed when the user switches theme

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -25,7 +25,9 @@ class CustomizeStore extends Task {
 		global $_GET;
 		$theme_switch_via_cys_ai_loader = isset( $_GET['theme_switch_via_cys_ai_loader'] ) ? 1 === absint( $_GET['theme_switch_via_cys_ai_loader'] ) : false;
 		if ( ! $theme_switch_via_cys_ai_loader ) {
-			add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
+			if ( function_exists( 'wc_calypso_bridge_is_woo_express_plan' ) && wc_calypso_bridge_is_woo_express_plan() ) {
+				add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
+			}
 		}
 
 		// Hook to remove unwanted UI elements when users are viewing with ?cys-hide-admin-bar=true.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -21,15 +21,6 @@ class CustomizeStore extends Task {
 
 		add_action( 'show_admin_bar', array( $this, 'possibly_hide_wp_admin_bar' ) );
 
-		// Use "switch_theme" instead of "after_switch_theme" because the latter is fired after the next WP load and we don't want to trigger action when switching theme to TT3 via onboarding theme API.
-		global $_GET;
-		$theme_switch_via_cys_ai_loader = isset( $_GET['theme_switch_via_cys_ai_loader'] ) ? 1 === absint( $_GET['theme_switch_via_cys_ai_loader'] ) : false;
-		if ( ! $theme_switch_via_cys_ai_loader ) {
-			if ( function_exists( 'wc_calypso_bridge_is_woo_express_plan' ) && wc_calypso_bridge_is_woo_express_plan() ) {
-				add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
-			}
-		}
-
 		// Hook to remove unwanted UI elements when users are viewing with ?cys-hide-admin-bar=true.
 		add_action( 'wp_head', array( $this, 'possibly_remove_unwanted_ui_elements' ) );
 	}
@@ -218,13 +209,6 @@ class CustomizeStore extends Task {
 		if ( class_exists( 'Jetpack_Gutenberg' ) ) {
 			Jetpack_Gutenberg::enqueue_block_editor_assets();
 		}
-	}
-
-	/**
-	 * Mark task as complete.
-	 */
-	public function mark_task_as_complete() {
-		update_option( 'woocommerce_admin_customize_store_completed', 'yes' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, the `Customize your store` step is marked when the user switches the theme. We disabled this beavhiour on Core.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to WooCommerce > Home.
2. Ensure that the `Customize your store` step isn't marked.
3. Switch theme.
4. Head over to WooCommerce > Home.
5. Click on Customize your store.
4. Click on "Start designing" and proceed to the Pattern Assembler.
5. Clic on "Done".
6. Head over to WooCommerce > Home.
7. Ensure that the `Customize your store` step is marked.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Core: fix: not mark `Customize your store`  step as completed when the user switches theme

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
