### PR TITLE
don't show draft product in featured products block

### DIFF
--- a/plugins/woocommerce/changelog/dont-show-draft-product-in-featured-block
+++ b/plugins/woocommerce/changelog/dont-show-draft-product-in-featured-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Don't show a product in the featured products block if the status is other than published and the user doesn't have read capability for that product.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -22,7 +22,7 @@ class FeaturedProduct extends FeaturedItem {
 		$id = absint( $attributes['productId'] ?? 0 );
 
 		$product = wc_get_product( $id );
-		if ( ! $product ) {
+		if ( ! $product || $product->get_status() == 'draft' ) {
 			return null;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -22,7 +22,7 @@ class FeaturedProduct extends FeaturedItem {
 		$id = absint( $attributes['productId'] ?? 0 );
 
 		$product = wc_get_product( $id );
-		if ( ! $product || $product->get_status() == 'draft' ) {
+		if ( ! $product || 'publish' !== $product->get_status() ) {
 			return null;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -22,7 +22,7 @@ class FeaturedProduct extends FeaturedItem {
 		$id = absint( $attributes['productId'] ?? 0 );
 
 		$product = wc_get_product( $id );
-		if ( ! $product || 'publish' !== $product->get_status() ) {
+		if ( ! $product || ( 'publish' !== $product->get_status() && ! current_user_can( 'read_product', $id ) ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
This is a fix for the issue https://github.com/woocommerce/woocommerce/issues/42677

### Changes proposed in this Pull Request:

Part of [#42677](https://github.com/woocommerce/woocommerce/issues/42677)

### Steps to test
Based on the steps from [#42677](https://github.com/woocommerce/woocommerce/issues/42677).

1. Add a _Featured Product_ block to a post and select a product (ie: _Album_).
2. Edit the _Album_ product and set its status to _Draft_.
3. Reload the post in the frontend and verify the product no longer appears if you are not logged in (the product will still be visible if you are the admin user or have rights to see the products).
4. Edit the _Album_ product again marking it as _Needs review_, _Private_, etc. and verify it's only visible to non-logged-in users in the frontend when its status is _Published_.

Editor | Frontend (admin user) | Frontend (not logged-in)
--- | --- | ---
![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/6f6cf301-f293-4895-8319-4fea03128f57) | ![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/e5a8507f-78f6-4664-96e5-a6762b7e72a6) | ![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/35d8ed08-1c12-4610-be7c-00729c8ebe48)