### PR TITLE
[e2e tests] Disable the task list reminder bar in products list

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-product-list-quick-actions
+++ b/plugins/woocommerce/changelog/e2e-fix-product-list-quick-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix issues with quick actions in products list

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-delete.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-delete.spec.js
@@ -25,6 +25,14 @@ baseTest.describe( 'Products > Delete Product', () => {
 				} );
 			}
 		},
+		page: async ( { page, wcAdminApi }, use ) => {
+			// Disable the task list reminder bar, it can interfere with the quick actions
+			await wcAdminApi.post( 'options', {
+				woocommerce_task_list_reminder_bar_hidden: 'yes',
+			} );
+
+			await use( page );
+		},
 	} );
 
 	test( 'can delete a product from edit view', async ( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45751

The task list reminder bar pops up in the products list, sometimes right after the hover action over a product that made the quick actions visible. This changes the layout enough for the quick action to be hidden again, breaking tests.
Disabling the bar in these tests by setting `woocommerce_task_list_reminder_bar_hidden` to `yes` should help with this.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

e2e tests in CI pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>