### PR TITLE
Add an image to multiple variations using Quick updates

### DIFF
--- a/packages/js/product-editor/changelog/add-42015_allow_upload_image_for_variations
+++ b/packages/js/product-editor/changelog/add-42015_allow_upload_image_for_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add an image to multiple variations using Quick updates #45774

--- a/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
@@ -27,6 +27,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { PlaceHolder } from './place-holder';
 import { SectionActions } from '../../../components/block-slot-fill';
+import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
 
 type UploadImage = {
 	id?: number;
@@ -37,16 +38,6 @@ export interface Image {
 	src: string;
 	name: string;
 	alt: string;
-}
-
-function mapUploadImageToImage( upload: UploadImage ): Image | null {
-	if ( ! upload.id ) return null;
-	return {
-		id: upload.id,
-		name: upload.title,
-		src: upload.url,
-		alt: upload.alt,
-	};
 }
 
 export function ImageBlockEdit( {

--- a/packages/js/product-editor/src/components/variations-table/add-image-menu-item/add-image-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/add-image-menu-item/add-image-menu-item.tsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { MenuItem } from '@wordpress/components';
+import { createElement, useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { MediaUpload } from '@wordpress/media-utils';
+import { recordEvent } from '@woocommerce/tracks';
+import { ProductVariationImage } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { VariationActionsMenuItemProps } from '../types';
+import { TRACKS_SOURCE } from '../../../constants';
+import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
+
+const DEFAULT_ALLOWED_MEDIA_TYPES = [ 'image' ];
+const MODAL_CLASS_NAME = 'woocommerce-add-image-menu-item__upload_image_modal';
+const MODAL_WRAPPER_CLASS_NAME =
+	'woocommerce-add-image-menu-item__upload_image_modal_wrapper';
+
+export function AddImageMenuItem( {
+	selection,
+	onChange,
+	onClose,
+}: VariationActionsMenuItemProps ) {
+	const [ uploadFilesModalOpen, setUploadFilesModalOpen ] = useState( false );
+
+	function handleMediaUploadSelect(
+		value: {
+			id?: number;
+		} & Record< string, string >
+	) {
+		const ids = selection.map( ( { id } ) => id );
+		const uploadedImage = mapUploadImageToImage(
+			value
+		) as ProductVariationImage;
+
+		recordEvent( 'product_variations_menu_add_image', {
+			source: TRACKS_SOURCE,
+			action: 'add_image_to_variation',
+			variation_id: ids,
+		} );
+
+		onChange(
+			selection.map( ( { id } ) => ( {
+				id,
+				image: uploadedImage,
+			} ) )
+		);
+		onClose();
+	}
+
+	function uploadFilesClickHandler( openMediaUploadModal: () => void ) {
+		return function handleUploadFilesClick() {
+			openMediaUploadModal();
+			setUploadFilesModalOpen( true );
+		};
+	}
+
+	useEffect(
+		function addUploadModalClass() {
+			const modal = document.querySelector( `.${ MODAL_CLASS_NAME }` );
+			const dialog = modal?.closest( '[role="dialog"]' );
+			const wrapper = dialog?.parentElement;
+
+			wrapper?.classList.add( MODAL_WRAPPER_CLASS_NAME );
+
+			return () => {
+				wrapper?.classList.remove( MODAL_WRAPPER_CLASS_NAME );
+			};
+		},
+		[ uploadFilesModalOpen ]
+	);
+
+	return (
+		<MediaUpload
+			onSelect={ handleMediaUploadSelect }
+			modalClass={ MODAL_CLASS_NAME }
+			allowedTypes={ DEFAULT_ALLOWED_MEDIA_TYPES }
+			multiple={ false }
+			render={ ( { open } ) => (
+				<MenuItem onClick={ uploadFilesClickHandler( open ) }>
+					{ __( 'Add image', 'woocommerce' ) }
+				</MenuItem>
+			) }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/add-image-menu-item/add-image-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/add-image-menu-item/add-image-menu-item.tsx
@@ -84,6 +84,9 @@ export function AddImageMenuItem( {
 			onSelect={ handleMediaUploadSelect }
 			modalClass={ MODAL_CLASS_NAME }
 			allowedTypes={ DEFAULT_ALLOWED_MEDIA_TYPES }
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore disabled prop exists
+			mode={ 'upload' }
 			multiple={ false }
 			render={ ( { open } ) => (
 				<MenuItem onClick={ uploadFilesClickHandler( open ) }>

--- a/packages/js/product-editor/src/components/variations-table/add-image-menu-item/add-image-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/add-image-menu-item/add-image-menu-item.tsx
@@ -26,18 +26,18 @@ export function AddImageMenuItem( {
 	onClose,
 }: VariationActionsMenuItemProps ) {
 	const [ uploadFilesModalOpen, setUploadFilesModalOpen ] = useState( false );
+	const ids = selection.map( ( { id } ) => id );
 
 	function handleMediaUploadSelect(
-		value: {
+		uploadedImage: {
 			id?: number;
 		} & Record< string, string >
 	) {
-		const ids = selection.map( ( { id } ) => id );
-		const uploadedImage = mapUploadImageToImage(
-			value
+		const image = mapUploadImageToImage(
+			uploadedImage
 		) as ProductVariationImage;
 
-		recordEvent( 'product_variations_menu_add_image', {
+		recordEvent( 'product_variations_menu_add_image_update', {
 			source: TRACKS_SOURCE,
 			action: 'add_image_to_variation',
 			variation_id: ids,
@@ -46,7 +46,7 @@ export function AddImageMenuItem( {
 		onChange(
 			selection.map( ( { id } ) => ( {
 				id,
-				image: uploadedImage,
+				image,
 			} ) )
 		);
 		onClose();
@@ -54,6 +54,11 @@ export function AddImageMenuItem( {
 
 	function uploadFilesClickHandler( openMediaUploadModal: () => void ) {
 		return function handleUploadFilesClick() {
+			recordEvent( 'product_variations_menu_add_image_select', {
+				source: TRACKS_SOURCE,
+				action: 'add_image_to_variation',
+				variation_id: ids,
+			} );
 			openMediaUploadModal();
 			setUploadFilesModalOpen( true );
 		};

--- a/packages/js/product-editor/src/components/variations-table/add-image-menu-item/index.ts
+++ b/packages/js/product-editor/src/components/variations-table/add-image-menu-item/index.ts
@@ -1,0 +1,1 @@
+export * from './add-image-menu-item';

--- a/packages/js/product-editor/src/components/variations-table/add-image-menu-item/style.scss
+++ b/packages/js/product-editor/src/components/variations-table/add-image-menu-item/style.scss
@@ -1,0 +1,14 @@
+$media-modal-z-index: calc(z-index(".components-popover") + 10000);
+$media-modal-backdrop-z-index: calc($media-modal-z-index - 1000);
+
+.woocommerce-add-image-menu-item {
+	&__upload_image_modal_wrapper {
+		.media-modal {
+			z-index: $media-modal-z-index;
+		}
+
+		.media-modal-backdrop {
+			z-index: $media-modal-backdrop-z-index;
+		}
+	}
+}

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -4,6 +4,7 @@
 @import "./table-empty-or-error-state/styles.scss";
 @import "./variations-filter/styles.scss";
 @import "./table-row-skeleton/styles.scss";
+@import "./add-image-menu-item/style.scss";
 
 .woocommerce-product-variations {
 	display: flex;

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menus/test/variation-actions.test.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menus/test/variation-actions.test.tsx
@@ -16,6 +16,26 @@ import { PRODUCT_STOCK_STATUS_KEYS } from '../../../../utils/get-product-stock-s
 jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
 } ) );
+
+jest.mock( '@wordpress/media-utils', () => ( {
+	MediaUpload: ( {
+		onSelect,
+		render: mockRender,
+	}: {
+		onSelect: ( { id, url }: { id: number; url: string } ) => void;
+		render: ( { open }: { open: () => void } ) => JSX.Element | null;
+	} ) => {
+		const mockOpenMediaUploadModal = () => {
+			const uploadedImageMock = {
+				id: 1,
+				url: 'https://example.com/image.jpg',
+			};
+			onSelect( uploadedImageMock );
+		};
+		return mockRender( { open: mockOpenMediaUploadModal } );
+	},
+} ) );
+
 const mockVariation = {
 	id: 10,
 	manage_stock: false,

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menus/test/variation-quick-update-menu-item.test.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menus/test/variation-quick-update-menu-item.test.tsx
@@ -19,6 +19,26 @@ import {
 jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
 } ) );
+
+jest.mock( '@wordpress/media-utils', () => ( {
+	MediaUpload: ( {
+		onSelect,
+		render: mockRender,
+	}: {
+		onSelect: ( { id, url }: { id: number; url: string } ) => void;
+		render: ( { open }: { open: () => void } ) => JSX.Element | null;
+	} ) => {
+		const mockOpenMediaUploadModal = () => {
+			const uploadedImageMock = {
+				id: 1,
+				url: 'https://example.com/image.jpg',
+			};
+			onSelect( uploadedImageMock );
+		};
+		return mockRender( { open: mockOpenMediaUploadModal } );
+	},
+} ) );
+
 const mockVariation = {
 	id: 10,
 	manage_stock: false,

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menus/variation-actions.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menus/variation-actions.tsx
@@ -20,6 +20,7 @@ import { DownloadsMenuItem } from '../downloads-menu-item';
 import { VariationQuickUpdateMenuItem } from './variation-quick-update-menu-item';
 import { UpdateStockMenuItem } from '../update-stock-menu-item';
 import { SetListPriceMenuItem } from '../set-list-price-menu-item';
+import { AddImageMenuItem } from '../add-image-menu-item';
 
 export function VariationActions( {
 	selection,
@@ -61,6 +62,11 @@ export function VariationActions( {
 							onClose={ onClose }
 						/>
 						<SetListPriceMenuItem
+							selection={ selection }
+							onChange={ onChange }
+							onClose={ onClose }
+						/>
+						<AddImageMenuItem
 							selection={ selection }
 							onChange={ onChange }
 							onClose={ onClose }

--- a/packages/js/product-editor/src/utils/map-upload-image-to-image.ts
+++ b/packages/js/product-editor/src/utils/map-upload-image-to-image.ts
@@ -1,0 +1,23 @@
+export type UploadImage = {
+	id?: number;
+} & Record< string, string >;
+
+export interface Image {
+	id: number;
+	src: string;
+	name: string;
+	alt: string;
+}
+
+/**
+ * Converts an uploaded image into an Image object.
+ */
+export function mapUploadImageToImage( upload: UploadImage ): Image | null {
+	if ( ! upload.id ) return null;
+	return {
+		id: upload.id,
+		name: upload.title,
+		src: upload.url,
+		alt: upload.alt,
+	};
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to upload an image to multiple variations by using `Quick updates`.

![Screen Recording on 2024-03-21 at 11-25-48](https://github.com/woocommerce/woocommerce/assets/1314156/ccbc817c-0dd9-4e8d-92bb-381cceed20b7)

Closes #42015.

**Acceptance criteria**

- [ ] Users can see `Add image` option in the `Quick update` dropdown menu.
- [ ] Clicking it opens the Media Library picker with the `Upload files` tab selected by default.
- [ ] We display a loading state while the variations are being updated.
- [ ] We display a snackbar when the image is uploaded (same as when other variations are updated).
- [ ] If selected variations already have images, selecting a new image will replace it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to `Products > Add New > Variations` and create some variations.
3. Select some variations and press `Quick update`.
4. Select `Add image` and pick (or update) an image. Only one image could be selected at a time.
5. The selected variations should now have the image selected in step 4.
6. Try selecting only one or all of them.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
