### PR TITLE
Products: Avoid fatal during variation search

### DIFF
--- a/plugins/woocommerce/changelog/update-variation-safeguard
+++ b/plugins/woocommerce/changelog/update-variation-safeguard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid trying to find a product variation of a product variation

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1099,6 +1099,11 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @return int Matching variation ID or 0.
 	 */
 	public function find_matching_product_variation( $product, $match_attributes = array() ) {
+		if ( 'variation' === $product->get_type() ) {
+			// Can't get a variation of a variation.
+			return 0;
+		}
+
 		global $wpdb;
 
 		$meta_attribute_names = array();

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -1084,9 +1084,9 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( $children[2], $match );
 
 		// Test trying to get a variation of a variation.
-		$variation_product = wc_get_product( $children[0] );
-		$match = $data_store->find_matching_product_variation(
-			$variation_product,
+		$variation = wc_get_product( $children[0] );
+		$match     = $data_store->find_matching_product_variation(
+			$variation,
 			array(
 				'attribute_pa_size' => 'small',
 			)

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -1082,5 +1082,15 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $children[2], $match );
+
+		// Test trying to get a variation of a variation.
+		$variation_product = wc_get_product( $children[0] );
+		$match = $data_store->find_matching_product_variation(
+			$variation_product,
+			array(
+				'attribute_pa_size' => 'small',
+			)
+		);
+		$this->assertEquals( 0, $match );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Most product types' data objects store `WC_Product_Attribute` objects in their attributes property, whereas Product variation data objects store an associative array of key/value pairs in their attributes property. This is problematic because it means a fatal error can be thrown when code assumes that a product's attributes are objects with methods rather than simply strings.

Example error:

```
Uncaught Error: Call to a member function get_variation() on string
```

Ideally, attributes would work the same everywhere, but it would be challenging to fix that in the codebase without breaking backcompat. So instead, in this PR, we are simply adding some logic in the `find_matching_product_variation` method to ensure that we're not trying to retrieve a variation of a product object that is already a variation.

### How to test the changes in this Pull Request:

1. Create a variable product. On the Attributes tab, add an attribute to it with two or three values. Go to the Variations tab and click the button "Generate variations". Once they are generated, click the button to assign a price to all the variations. Publish the product. Note the IDs of the product and each of its variations (variation IDs are shown in the list on the Variations tab).
2. Now you're going to make some Ajax requests to your test site. You can either do this with your browser console, cURL, or with your favorite API client app (mine is [Bruno](https://www.usebruno.com/)). The request will look like this, but replace the parts in `{}` with the values you used when you created your product:
    ```
    curl --request POST \
      --url '{your test site host}/?wc-ajax=get_variation' \
      --header 'content-type: multipart/form-data' \
      --form product_id={product ID} \
      --form attribute_{attribute slug}={one of the attribute values}
    ```
3. First make this request using the main product's ID. You should get a response containing a string of JSON with the details of the variation that matches the attribute value you specified.
4. Now change `{product ID}` to the ID of one of the main product's variations. If you run the Ajax request on trunk, you should get a fatal error. If you run the request on this PR branch, you should get a response with `false` or `0`.
5. Ensure the new unit test added in this PR passes.