### PR TITLE
Fix Shipping Task input visual issue on Firefox

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/shipping/shipping.scss
+++ b/plugins/woocommerce-admin/client/task-lists/fills/shipping/shipping.scss
@@ -41,6 +41,12 @@
 			font-size: 12px;
 		}
 
+		.components-base-control__field {
+			div.text-control-with-affixes {
+				align-items: baseline;
+			}
+		}
+
 		.text-control-with-affixes__prefix,
 		.text-control-with-affixes__suffix {
 			font-size: 16px;

--- a/plugins/woocommerce/changelog/45778-fix-44893-shipping-cost-task-input-layout-issue
+++ b/plugins/woocommerce/changelog/45778-fix-44893-shipping-cost-task-input-layout-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix input layout issue with shipping task in Firefox.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44893 .

This PR fixes input layout issue on the shipping task by adding align-items for flex items.

Before:

![307056434-2a9d2958-9049-41ac-8bfd-32c264bb6121](https://github.com/woocommerce/woocommerce/assets/4723145/2c033603-ecbb-4115-b110-46579094f714)

After:

![Screen Shot 2024-03-20 at 4 38 00 PM](https://github.com/woocommerce/woocommerce/assets/4723145/06b8c6ce-4ff4-406b-8ce0-fbe8ecd3c327)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch in Firefox.
2. Click `Skip guided setup` and choose `United Kingdom (UK)` on the next page.
3. Go to `WooCommerce -> Home` and click on `Get your products shipped` task.
4. Enter address, post, and city. Click on `Continue`
5. Confirm the input renders as expected.
6. In case you see partner options on `Review your shipping options` step, click your browser's back button to go to `WooCommerce -> Home` and then click the shipping task again. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix input layout issue with shipping task in Firefox.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
