### PR TITLE
Don't return from `WC_Admin_Marketplace_Promotions::fetch_marketplace_promotions` if we get an empty or bad response

### DIFF
--- a/plugins/woocommerce/changelog/45786-update-19763-marketplace-promotions-empty-array
+++ b/plugins/woocommerce/changelog/45786-update-19763-marketplace-promotions-empty-array
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fixes bug in the fetching of marketplace promotions, which means that an empty response from the API isn't saved in the promotions transient.
-

--- a/plugins/woocommerce/changelog/45786-update-19763-marketplace-promotions-empty-array
+++ b/plugins/woocommerce/changelog/45786-update-19763-marketplace-promotions-empty-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fixes bug in the fetching of marketplace promotions, which means that an empty response from the API isn't saved in the promotions transient.
+

--- a/plugins/woocommerce/changelog/update-19763-marketplace-promotions-empty-array
+++ b/plugins/woocommerce/changelog/update-19763-marketplace-promotions-empty-array
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fixes bug in the fetching of marketplace promotions, which means that an empty response from the API isn't saved in the promotions transient.
-
-

--- a/plugins/woocommerce/changelog/update-19763-marketplace-promotions-empty-array
+++ b/plugins/woocommerce/changelog/update-19763-marketplace-promotions-empty-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes bug in the fetching of marketplace promotions, which means that an empty response from the API isn't saved in the promotions transient.
+
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -104,8 +104,6 @@ class WC_Admin_Marketplace_Promotions {
 			 * @since 8.7
 			 */
 			do_action( 'woocommerce_page_wc-addons_connection_error', $raw_promotions->get_error_message() );
-
-			return;
 		}
 
 		$response_code = (int) wp_remote_retrieve_response_code( $raw_promotions );
@@ -116,20 +114,18 @@ class WC_Admin_Marketplace_Promotions {
 			 * @since 8.7
 			 */
 			do_action( 'woocommerce_page_wc-addons_connection_error', $response_code );
-
-			return;
 		}
 
 		$promotions = json_decode( wp_remote_retrieve_body( $raw_promotions ), true );
-		if ( empty( $promotions ) || ! is_array( $promotions ) ) {
+		if ( ! is_array( $promotions ) ) {
+			$promotions = array();
+
 			/**
 			 * Allows connection error to be handled.
 			 *
 			 * @since 8.7
 			 */
-			do_action( 'woocommerce_page_wc-addons_connection_error', 'Empty or malformed response' );
-
-			return;
+			do_action( 'woocommerce_page_wc-addons_connection_error', 'Malformed response' );
 		}
 		// phpcs:enable WordPress.NamingConventions.ValidHookName.UseUnderscores
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Removing return statements from conditions in `WC_Admin_Marketplace_Promotions::fetch_marketplace_promotions`. 

I [introduced](https://github.com/woocommerce/woocommerce/pull/45628/commits/ae4dddb48de684eff15bbfa1d814e2cd82d97d97) return statements to the error-handling conditions in this method in https://github.com/woocommerce/woocommerce/pull/45628. With these, if the marketplace gets a good response from the API and then later a bad or empty response, it will fail to update the promotions transient, meaning that notices and menu bubbles may persist in stores after we've removed them from the API. We check the dates of promotions, so existing ones should disappear when they expire, but it's a good idea to clear this data if the API returns an empty response or if there's an error fetching it.

Closes 19763-gh-Automattic/woocommerce.com.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This assumes you're testing on a local `wp-env` environment. If you want to test on a JN or other external site, please see the test steps on https://github.com/woocommerce/woocommerce/pull/45628.

1. Check out this branch locally.
2. Edit `plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php` and replace the `PROMOTIONS_API_URL` value `https://woo.com/wp-json/wccom-extensions/3.0/promotions` with `https://gist.githubusercontent.com/andfinally/acd8646151c0108f92979c985c20a0d8/raw/`. This is a gist with dummy data that is valid until 31 March.
3. On line 21, change the frequency of the scheduled action to five minutes:

```php
const SCHEDULED_ACTION_INTERVAL = 5 * MINUTE_IN_SECONDS;
```
4. Run `nvm use`.
5. Do `cd plugins/woocommerce`.
6. Run `pnpm -- wp-env start` to start wp-env.
7. run `pnpm --filter='@woocommerce/plugin-woocommerce' build`.
8. Visit the [pending scheduled actions page](http://localhost:8888/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending) and search for `woocommerce_marketplace_fetch_promotions`. Note that the action is pending.
9. After 5 minutes or so, the action should run. (You may need to jog it by viewing a page on your test site.)
10. The menu bubble should appear on the `WooCommerce > Extensions` menu item, and the notice should appear on the default Marketplace page `http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions`. (It also appears on the Themes and other tabs on that page – that's intentional.)

<p>
<img width="1242" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1649788/cdfbf86f-7af5-4a14-966b-a1e694a15c23">
</p>

11. Edit `class-wc-admin-marketplace-promotions.php` again and change the `PROMOTIONS_API_URL` to `https://gist.githubusercontent.com/andfinally/1c687ed2ed55cf78e9a8ee8d9fa5c205/raw/`. This is a second gist, which returns an empty array.
12. Wait for the scheduled action to run again.
13. The notice and menu bubble should not be shown.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Fixes bug in the fetching of marketplace promotions, which means that an empty response from the API isn't saved in the promotions transient.

</details>