### PR TITLE
Try fixing additional checkout fields E2E test

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-advanced-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-advanced-controls/index.tsx
@@ -8,6 +8,7 @@ import { InspectorAdvancedControls } from '@wordpress/block-editor';
  */
 import ForcePageReloadControl from './force-page-reload-control';
 import type { ProductCollectionEditComponentProps } from '../../types';
+import { Block } from 'assets/js/atomic/blocks/product-elements/price/block';
 
 export default function ProductCollectionAdvancedInspectorControls(
 	props: ProductCollectionEditComponentProps

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-advanced-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-advanced-controls/index.tsx
@@ -8,7 +8,6 @@ import { InspectorAdvancedControls } from '@wordpress/block-editor';
  */
 import ForcePageReloadControl from './force-page-reload-control';
 import type { ProductCollectionEditComponentProps } from '../../types';
-import { Block } from 'assets/js/atomic/blocks/product-elements/price/block';
 
 export default function ProductCollectionAdvancedInspectorControls(
 	props: ProductCollectionEditComponentProps

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
@@ -166,9 +166,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.check();
 
-			await checkoutPageObject.page.waitForRequest( ( req ) => {
-				return req.url().includes( 'batch' );
-			} );
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.page
 				.getByRole( 'group', {
@@ -177,9 +175,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.uncheck();
 
-			await checkoutPageObject.page.waitForRequest( ( req ) => {
-				return req.url().includes( 'batch' );
-			} );
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.waitForCheckoutToFinishUpdating();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
@@ -265,8 +265,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
-
 			// Fill select fields "manually" (Not part of "fillInCheckoutWithTestData"). This is a workaround for select
 			// fields until we recreate the Combobox component. This is because the aria-label includes the value so getting
 			// by label alone is not reliable unless we know the value.
@@ -283,8 +281,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'How wide is your road?' )
 				.fill( 'narrow' );
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
-
 			// Change the shipping and billing select fields again.
 			await checkoutPageObject.page
 				.getByRole( 'group', {
@@ -298,7 +294,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'How wide is your road?' )
 				.fill( 'super-wide' );
-
 			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.page

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
@@ -280,6 +280,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'How wide is your road?' )
 				.fill( 'narrow' );
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			// Change the shipping and billing select fields again.
 			await checkoutPageObject.page

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
@@ -265,11 +265,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
-			const batchRequest = checkoutPageObject.page.waitForResponse(
-				( response ) => {
-					return response.url().indexOf( 'wc/store/v1/batch' ) !== -1;
-				}
-			);
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			// Fill select fields "manually" (Not part of "fillInCheckoutWithTestData"). This is a workaround for select
 			// fields until we recreate the Combobox component. This is because the aria-label includes the value so getting
@@ -286,13 +282,8 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'How wide is your road?' )
 				.fill( 'narrow' );
-			await batchRequest;
 
-			const batchRequest2 = checkoutPageObject.page.waitForResponse(
-				( response ) => {
-					return response.url().indexOf( 'wc/store/v1/batch' ) !== -1;
-				}
-			);
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			// Change the shipping and billing select fields again.
 			await checkoutPageObject.page
@@ -308,7 +299,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'How wide is your road?' )
 				.fill( 'super-wide' );
 
-			await batchRequest2;
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.page
 				.getByLabel( 'Would you like a free gift with your order?' )
@@ -381,6 +372,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				)
 				.first()
 				.click();
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.placeOrder();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
@@ -265,6 +265,12 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
+			const batchRequest = checkoutPageObject.page.waitForResponse(
+				( response ) => {
+					return response.url().indexOf( 'wc/store/v1/batch' ) !== -1;
+				}
+			);
+
 			// Fill select fields "manually" (Not part of "fillInCheckoutWithTestData"). This is a workaround for select
 			// fields until we recreate the Combobox component. This is because the aria-label includes the value so getting
 			// by label alone is not reliable unless we know the value.
@@ -280,9 +286,13 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'How wide is your road?' )
 				.fill( 'narrow' );
-			await checkoutPageObject.page.waitForResponse( ( response ) => {
-				return response.url().indexOf( 'wc/store/v1/batch' ) !== -1;
-			} );
+			await batchRequest;
+
+			const batchRequest2 = checkoutPageObject.page.waitForResponse(
+				( response ) => {
+					return response.url().indexOf( 'wc/store/v1/batch' ) !== -1;
+				}
+			);
 
 			// Change the shipping and billing select fields again.
 			await checkoutPageObject.page
@@ -298,9 +308,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'How wide is your road?' )
 				.fill( 'super-wide' );
 
-			await checkoutPageObject.page.waitForResponse( ( response ) => {
-				return response.url().indexOf( 'wc/store/v1/batch' ) !== -1;
-			} );
+			await batchRequest2;
 
 			await checkoutPageObject.page
 				.getByLabel( 'Would you like a free gift with your order?' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -268,6 +268,22 @@ export class CheckoutPage {
 		}
 	}
 
+	async waitForCustomerDataUpdate() {
+		// Wait for data to start updating.
+		await this.page.waitForFunction( () => {
+			return !! window.wp.data
+				.select( 'wc/store/cart' )
+				.isCustomerDataUpdating();
+		} );
+
+		// Wait for data to finish updating
+		await this.page.waitForFunction( () => {
+			return ! window.wp.data
+				.select( 'wc/store/cart' )
+				.isCustomerDataUpdating();
+		} );
+	}
+
 	async editShippingDetails() {
 		const editButton = this.page.locator(
 			'.wc-block-checkout__shipping-fields .wc-block-components-address-address-wrapper:not(.is-editing) .wc-block-components-address-card__edit'

--- a/plugins/woocommerce/changelog/try-checkout-e2e-fix-opr
+++ b/plugins/woocommerce/changelog/try-checkout-e2e-fix-opr
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This is an E2E test update - no need to call out in the changelog.
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is based on @kmanijak 's efforts in https://github.com/woocommerce/woocommerce/pull/45704 so thanks Karol.

In this PR I have added a new util to the `checkoutPageObject` called `waitForCustomerDataUpdate`. This waits for the data store to signal processing has begun, then waits for it to signal processing has ended. This seems to be more robust than waiting for network requests.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure additional fields E2E tests pass.
2. Try running E2E tests locally in different orders, e.g.:


```sh
cd plugins/woocommerce-blocks
pnpm env:restart
pnpm test:e2e:side-effects -- /tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
pnpm test:e2e:side-effects -- /tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
```

then 

```sh
cd plugins/woocommerce-blocks
pnpm env:restart
pnpm test:e2e:side-effects -- /tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
pnpm test:e2e:side-effects -- /tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
```

Feel free to mix in other "unrelated" tests between them too to test that out.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
