### PR TITLE
Add a filter for the items to apply coupons array.

### DIFF
--- a/plugins/woocommerce/changelog/45791-tweak-45790
+++ b/plugins/woocommerce/changelog/45791-tweak-45790
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+WC_Discount: Add a filter for the items to apply coupons array.

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -333,6 +333,18 @@ class WC_Discounts {
 
 			$items_to_apply[] = $item_to_apply;
 		}
+
+		/**
+		 * Filters the items that a coupon should be applied to.
+		 *
+		 * This filter allows you to modify the items that a coupon will be applied to before the discount calculations take place.
+		 *
+		 * @param array            $items_to_apply The items that the coupon will be applied to.
+		 * @param WC_Coupon        $coupon The coupon object.
+		 * @param WC_Discounts     $this The discounts instance.
+		 *
+		 * @return array The modified list of items that the coupon should be applied to.
+		 */
 		return apply_filters( 'woocommerce_coupon_get_items_to_apply', $items_to_apply, $coupon, $this );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -333,7 +333,7 @@ class WC_Discounts {
 
 			$items_to_apply[] = $item_to_apply;
 		}
-		return $items_to_apply;
+		return apply_filters( 'woocommerce_coupon_get_items_to_apply', $items_to_apply, $coupon, $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -339,6 +339,7 @@ class WC_Discounts {
 		 *
 		 * This filter allows you to modify the items that a coupon will be applied to before the discount calculations take place.
 		 *
+		 * @since 8.8.0
 		 * @param array            $items_to_apply The items that the coupon will be applied to.
 		 * @param WC_Coupon        $coupon The coupon object.
 		 * @param WC_Discounts     $this The discounts instance.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

I am working on an issue where fixed_cart coupon needs to be applied to only a subset of the cart items. The items to apply coupon array is built by [get_items_to_apply_coupon](https://github.com/woocommerce/woocommerce/blob/f2d828f49aa4ef6b7433f93681a4c8d47f7e9572/plugins/woocommerce/includes/class-wc-discounts.php#L263) method in WC_Discounts class.

I propose a filter in get_items_to_apply_coupon modify the items to apply coupons to.

Closes #45790 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


You can use the filter in your child's theme's function.php file.

``` PHP
add_filter( 'woocommerce_coupon_get_items_to_apply',  'get_items_to_apply' , 10, 2 );
function get_items_to_apply ($items_to_apply, $coupon ) {

                // Any Product ID to exclude
		$excluded_product_ids = array ( 25 ); // Replace with your test product ID.

		return array_filter( $items_to_apply, function( $item ) use ( $excluded_product_ids ) {
			return ! in_array( $item->product->get_id(), $excluded_product_ids );
		} );

	}

```

1. Check out this branch.
2. Create a fixed cart coupon
3. Add a few items in your cart, including the product exclude in the filter usage (above).
4. Navigate to WP Admin > WC > Orders and take a look at the order. Discount is displayed as applied to only the product allowed to accept discounts.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
WC_Discount: Add a filter for the items to apply coupons array.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
