### PR TITLE
Add new task (Connect to Woo.com task) in WC onboarding

### DIFF
--- a/plugins/woocommerce/changelog/add-store-connect-to-woocom
+++ b/plugins/woocommerce/changelog/add-store-connect-to-woocom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a new task (connect to Woo.com) in WC onboarding tasklist

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -165,6 +165,7 @@ class TaskLists {
 					),
 				),
 				'tasks'   => array(
+					'StoreConnect',
 					'AdditionalPayments',
 					'GetMobileApp',
 				),

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
@@ -41,7 +41,7 @@ class StoreConnect extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '2 minutes', 'woocommerce' );
+		return '';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
@@ -23,7 +23,7 @@ class StoreConnect extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Connect store to Woo.com', 'woocommerce' );
+		return __( 'Manage your Woo.com Marketplace subscriptions', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
@@ -54,6 +54,15 @@ class StoreConnect extends Task {
 	}
 
 	/**
+	 * Always dismissable.
+	 *
+	 * @return bool
+	 */
+	public function is_dismissable() {
+		return true;
+	}
+
+	/**
 	 * Action URL.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreConnect.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
+/**
+ * Connect store to Woo.com Task
+ */
+class StoreConnect extends Task {
+	/**
+	 * ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'connect-store';
+	}
+
+	/**
+	 * Title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return __( 'Connect store to Woo.com', 'woocommerce' );
+	}
+
+	/**
+	 * Content.
+	 *
+	 * @return string
+	 */
+	public function get_content() {
+		return '';
+	}
+
+	/**
+	 * Time.
+	 *
+	 * @return string
+	 */
+	public function get_time() {
+		return __( '2 minutes', 'woocommerce' );
+	}
+
+	/**
+	 * Task completion.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return \WC_Helper::is_site_connected();
+	}
+
+	/**
+	 * Action URL.
+	 *
+	 * @return string
+	 */
+	public function get_action_url() {
+		return admin_url( 'admin.php?page=wc-admin&tab=my-subscriptions&path=/extensions' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a new task into the WC core onboarding tasklist titled "Connect Store to Woo.com". Completing this task will navigate users to Extensions > My Subscriptions, where they can seamlessly link their store with Woo.com.

<!-- Begin testing instructions -->

### If you haven't configured your development environment for WooCommerce development, please refer to this documentation.
- https://github.com/woocommerce/woocommerce/blob/trunk/README.md#getting-started
- https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md#plugin-development-environments

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to the Woocommerce home page.
2. You'll notice a section titled "Things to do next."
3. Within this section, you'll find the newly added task labelled "Manage your [Woo.com](http://woo.com/) Marketplace subscriptions."
4. Clicking on this task will direct you to the Extensions > My Subscriptions page.
5. From there, customers can seamlessly connect their store to Woo.com.

Scenario for connected store

1. If the store is connected with woo.com, there will be a blue check mark with Task. 


