### PR TITLE
Use state name in Checkout block address card

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/utils/address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/address.ts
@@ -3,9 +3,11 @@
  */
 import prepareFormFields from '@woocommerce/base-components/cart-checkout/form/prepare-form-fields';
 import { isEmail } from '@wordpress/url';
-import type {
-	CartResponseBillingAddress,
-	CartResponseShippingAddress,
+import {
+	isString,
+	type CartResponseBillingAddress,
+	type CartResponseShippingAddress,
+	isObject,
 } from '@woocommerce/types';
 import { ShippingAddress, BillingAddress } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -149,14 +151,13 @@ export const formatShippingAddress = (
 	if ( Object.values( address ).length === 0 ) {
 		return null;
 	}
-	const formattedCountry =
-		typeof SHIPPING_COUNTRIES[ address.country ] === 'string'
-			? decodeEntities( SHIPPING_COUNTRIES[ address.country ] )
-			: '';
+	const formattedCountry = isString( SHIPPING_COUNTRIES[ address.country ] )
+		? decodeEntities( SHIPPING_COUNTRIES[ address.country ] )
+		: '';
 
 	const formattedState =
-		typeof SHIPPING_STATES[ address.country ] === 'object' &&
-		typeof SHIPPING_STATES[ address.country ][ address.state ] === 'string'
+		isObject( SHIPPING_STATES[ address.country ] ) &&
+		isString( SHIPPING_STATES[ address.country ][ address.state ] )
 			? decodeEntities(
 					SHIPPING_STATES[ address.country ][ address.state ]
 			  )

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -3,9 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ALLOWED_COUNTRIES, ALLOWED_STATES } from '@woocommerce/block-settings';
-import type {
-	CartShippingAddress,
-	CartBillingAddress,
+import {
+	type CartShippingAddress,
+	type CartBillingAddress,
+	isObject,
+	isString,
 } from '@woocommerce/types';
 import { FormFieldsConfig } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -26,14 +28,13 @@ const AddressCard = ( {
 	target: string;
 	fieldConfig: FormFieldsConfig;
 } ): JSX.Element | null => {
-	const formattedCountry =
-		typeof ALLOWED_COUNTRIES[ address.country ] === 'string'
-			? decodeEntities( ALLOWED_COUNTRIES[ address.country ] )
-			: '';
+	const formattedCountry = isString( ALLOWED_COUNTRIES[ address.country ] )
+		? decodeEntities( ALLOWED_COUNTRIES[ address.country ] )
+		: '';
 
 	const formattedState =
-		typeof ALLOWED_STATES[ address.country ] === 'object' &&
-		typeof ALLOWED_STATES[ address.country ][ address.state ] === 'string'
+		isObject( ALLOWED_STATES[ address.country ] ) &&
+		isString( ALLOWED_STATES[ address.country ][ address.state ] )
 			? decodeEntities(
 					ALLOWED_STATES[ address.country ][ address.state ]
 			  )

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ALLOWED_COUNTRIES } from '@woocommerce/block-settings';
+import { ALLOWED_COUNTRIES, ALLOWED_STATES } from '@woocommerce/block-settings';
 import type {
 	CartShippingAddress,
 	CartBillingAddress,
 } from '@woocommerce/types';
 import { FormFieldsConfig } from '@woocommerce/settings';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -25,6 +26,19 @@ const AddressCard = ( {
 	target: string;
 	fieldConfig: FormFieldsConfig;
 } ): JSX.Element | null => {
+	const formattedCountry =
+		typeof ALLOWED_COUNTRIES[ address.country ] === 'string'
+			? decodeEntities( ALLOWED_COUNTRIES[ address.country ] )
+			: '';
+
+	const formattedState =
+		typeof ALLOWED_STATES[ address.country ] === 'object' &&
+		typeof ALLOWED_STATES[ address.country ][ address.state ] === 'string'
+			? decodeEntities(
+					ALLOWED_STATES[ address.country ][ address.state ]
+			  )
+			: address.state;
+
 	return (
 		<div className="wc-block-components-address-card">
 			<address>
@@ -36,11 +50,9 @@ const AddressCard = ( {
 						address.address_1,
 						! fieldConfig.address_2.hidden && address.address_2,
 						address.city,
-						address.state,
+						formattedState,
 						address.postcode,
-						ALLOWED_COUNTRIES[ address.country ]
-							? ALLOWED_COUNTRIES[ address.country ]
-							: address.country,
+						formattedCountry,
 					]
 						.filter( ( field ) => !! field )
 						.map( ( field, index ) => (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { ReactElement } from 'react';
 import classnames from 'classnames';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { useStoreEvents } from '@woocommerce/base-context/hooks';
@@ -10,7 +11,7 @@ const FrontendBlock = ( {
 	children,
 	className,
 }: {
-	children: JSX.Element[];
+	children: ReactElement[];
 	className?: string;
 } ): JSX.Element => {
 	const { dispatchCheckoutEvent } = useStoreEvents();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
@@ -10,7 +10,7 @@ const FrontendBlock = ( {
 	children,
 	className,
 }: {
-	children: JSX.Element;
+	children: JSX.Element[];
 	className?: string;
 } ): JSX.Element => {
 	const { dispatchCheckoutEvent } = useStoreEvents();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/block.tsx
@@ -5,7 +5,7 @@ import { OrderSummary } from '@woocommerce/base-components/cart-checkout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { TotalsWrapper } from '@woocommerce/blocks-components';
 
-const Block = ( { className }: { className: string } ): JSX.Element => {
+const Block = ( { className = '' }: { className?: string } ): JSX.Element => {
 	const { cartItems } = useStoreCart();
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { previewCart } from '@woocommerce/resource-previews';
+import { dispatch } from '@wordpress/data';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { default as fetchMock } from 'jest-fetch-mock';
+
+/**
+ * Internal dependencies
+ */
+import Fields from '../inner-blocks/checkout-fields-block/frontend';
+import ExpressPayment from '../inner-blocks/checkout-express-payment-block/block';
+import ContactInformation from '../inner-blocks/checkout-contact-information-block/frontend';
+import ShippingMethod from '../inner-blocks/checkout-shipping-method-block/frontend';
+import PickupOptions from '../inner-blocks/checkout-pickup-options-block/frontend';
+import ShippingAddress from '../inner-blocks/checkout-shipping-address-block/frontend';
+import BillingAddress from '../inner-blocks/checkout-billing-address-block/frontend';
+import ShippingMethods from '../inner-blocks/checkout-shipping-methods-block/frontend';
+import Payment from '../inner-blocks/checkout-payment-block/frontend';
+import AdditionalInformation from '../inner-blocks/checkout-additional-information-block/frontend';
+import OrderNote from '../inner-blocks/checkout-order-note-block/block';
+import Terms from '../inner-blocks/checkout-terms-block/frontend';
+import { termsCheckboxDefaultText } from '../inner-blocks/checkout-terms-block/constants';
+import Actions from '../inner-blocks/checkout-actions-block/frontend';
+import Totals from '../inner-blocks/checkout-totals-block/frontend';
+import OrderSummary from '../inner-blocks/checkout-order-summary-block/frontend';
+import CartItems from '../inner-blocks/checkout-order-summary-cart-items/frontend';
+import CouponForm from '../inner-blocks/checkout-order-summary-coupon-form/block';
+import Subtotal from '../inner-blocks/checkout-order-summary-subtotal/frontend';
+import Fee from '../inner-blocks/checkout-order-summary-fee/frontend';
+import Discount from '../inner-blocks/checkout-order-summary-discount/frontend';
+import Shipping from '../inner-blocks/checkout-order-summary-shipping/frontend';
+import Taxes from '../inner-blocks/checkout-order-summary-taxes/frontend';
+
+import { defaultCartState } from '../../../data/cart/default-state';
+import { allSettings } from '../../../settings/shared/settings-init';
+
+import Checkout from '../block';
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useResizeObserver: jest.fn().mockReturnValue( [ null, { width: 0 } ] ),
+} ) );
+
+jest.mock( '@wordpress/element', () => {
+	return {
+		...jest.requireActual( '@wordpress/element' ),
+		useId: () => {
+			return 'mock-id';
+		},
+	};
+} );
+
+const CheckoutBlock = () => {
+	return (
+		<Checkout attributes={ {} }>
+			<Fields>
+				<ShippingAddress />
+				<ExpressPayment />
+				<ContactInformation />
+				<BillingAddress />
+				<ShippingMethod />
+				<PickupOptions />
+				<ShippingMethods />
+				<Payment />
+				<AdditionalInformation />
+				<OrderNote />
+				<Terms checkbox={ true } text={ termsCheckboxDefaultText } />
+				<Actions />
+			</Fields>
+			<Totals>
+				<OrderSummary>
+					<CartItems />
+					<CouponForm />
+					<Subtotal />
+					<Fee />
+					<Discount />
+					<Shipping />
+					<Taxes />
+				</OrderSummary>
+			</Totals>
+		</Checkout>
+	);
+};
+
+describe( 'Testing cart', () => {
+	beforeEach( () => {
+		act( () => {
+			fetchMock.mockResponse( ( req ) => {
+				if ( req.url.match( /wc\/store\/v1\/cart/ ) ) {
+					return Promise.resolve( JSON.stringify( previewCart ) );
+				}
+				if ( req.url.match( /wc\/store\/v1\/checkout/ ) ) {
+					return Promise.resolve( JSON.stringify( previewCart ) );
+				}
+				return Promise.resolve( '' );
+			} );
+			// need to clear the store resolution state between tests.
+			dispatch( storeKey ).invalidateResolutionForStore();
+			dispatch( storeKey ).receiveCart( defaultCartState.cartData );
+		} );
+	} );
+
+	afterEach( () => {
+		fetchMock.resetMocks();
+	} );
+
+	it( 'renders checkout if there are items in the cart', async () => {
+		render( <CheckoutBlock /> );
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+
+		expect( screen.getByText( /Place Order/i ) ).toBeInTheDocument();
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'Renders the address card if the address is filled', async () => {
+		act( () => {
+			const cartWithAddress = {
+				...previewCart,
+				shipping_address: {
+					first_name: 'First Name',
+					last_name: 'Last Name',
+					company: '',
+					address_1: 'Address 1',
+					address_2: '',
+					city: 'Toronto',
+					state: 'ON',
+					postcode: 'M4W 1A6',
+					country: 'CA',
+					phone: '',
+				},
+				billing_address: {
+					first_name: 'First Name',
+					last_name: 'Last Name',
+					company: '',
+					address_1: 'Address 1',
+					address_2: '',
+					city: 'Toronto',
+					state: 'ON',
+					postcode: 'M4W 1A6',
+					country: 'CA',
+					phone: '',
+					email: '',
+				},
+			};
+			fetchMock.mockResponse( ( req ) => {
+				if ( req.url.match( /wc\/store\/v1\/cart/ ) ) {
+					return Promise.resolve( JSON.stringify( cartWithAddress ) );
+				}
+				return Promise.resolve( '' );
+			} );
+		} );
+		render( <CheckoutBlock /> );
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Edit address' } )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByText( 'Ontario', {
+				selector: '.wc-block-components-address-card span',
+			} )
+		).toBeInTheDocument();
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -35,7 +35,6 @@ import Shipping from '../inner-blocks/checkout-order-summary-shipping/frontend';
 import Taxes from '../inner-blocks/checkout-order-summary-taxes/frontend';
 
 import { defaultCartState } from '../../../data/cart/default-state';
-import { allSettings } from '../../../settings/shared/settings-init';
 
 import Checkout from '../block';
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -91,9 +91,6 @@ describe( 'Testing cart', () => {
 				if ( req.url.match( /wc\/store\/v1\/cart/ ) ) {
 					return Promise.resolve( JSON.stringify( previewCart ) );
 				}
-				if ( req.url.match( /wc\/store\/v1\/checkout/ ) ) {
-					return Promise.resolve( JSON.stringify( previewCart ) );
-				}
 				return Promise.resolve( '' );
 			} );
 			// need to clear the store resolution state between tests.

--- a/plugins/woocommerce-blocks/tests/js/setup-globals.js
+++ b/plugins/woocommerce-blocks/tests/js/setup-globals.js
@@ -208,6 +208,13 @@ global.wcSettings = {
 			index: 100,
 		},
 	},
+	checkoutData: {
+		order_id: 100,
+		status: 'checkout-draft',
+		order_key: 'wc_order_mykey',
+		order_number: '100',
+		customer_id: 1,
+	},
 };
 
 global.jQuery = () => ( {

--- a/plugins/woocommerce/changelog/add-use-state-name-in-address-card
+++ b/plugins/woocommerce/changelog/add-use-state-name-in-address-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Use state names in Checkout Block address cards.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When we introduced the address card, we didn't take into account that we should use state names, not codes, in building the address. This caused some countries like Algeria and Japan to show the things like DZ-31 instead of Oran.

I also added integration test for this, and setup Checkout to be used with integration tests.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45583

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In Checkout, use a Japanese address, fill the whole address form.
2. Refresh the page, make sure the address card shows the state name and not some XX-XX code.

| Before | After |
|--------|--------|
|<img width="515" alt="image" src="https://github.com/woocommerce/woocommerce/assets/6165348/725f9300-fd85-46db-a1fb-4f2b1c25f0ec"> |<img width="531" alt="image" src="https://github.com/woocommerce/woocommerce/assets/6165348/05c4e82c-9c94-4ef2-a288-b32b7ccb28e9">| 