### PR TITLE
add: lys xstate url handling

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/common.ts
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/common.ts
@@ -15,48 +15,48 @@ import { AnyEventObject } from 'xstate5';
  *
  * @param paramName The query parameter to listen for changes
  */
-export const createQueryParamsListener =
-	( paramName: string ) =>
-	( sendBack: ( event: AnyEventObject ) => void ) => {
-		let previousLocation: ReturnType< typeof getHistory >[ 'location' ];
-		const unlisten = getHistory().listen( ( { action, location } ) => {
-			if ( action === 'POP' ) {
-				const previousQuery = new URLSearchParams(
-					previousLocation.search
-				);
-				const currentQuery = new URLSearchParams( location.search );
-				if (
-					previousQuery.get( paramName ) !==
-					currentQuery.get( paramName )
-				) {
-					previousLocation = location;
-					sendBack( { type: 'EXTERNAL_URL_UPDATE' } );
-				}
+export const createQueryParamsListener = (
+	paramName: string,
+	sendBack: ( event: AnyEventObject ) => void
+) => {
+	let previousLocation: ReturnType< typeof getHistory >[ 'location' ] =
+		getHistory().location;
+	const unlisten = getHistory().listen( ( { action, location } ) => {
+		if ( action === 'POP' ) {
+			const previousQuery = new URLSearchParams(
+				previousLocation.search
+			);
+			const currentQuery = new URLSearchParams( location.search );
+			if (
+				previousQuery.get( paramName ) !== currentQuery.get( paramName )
+			) {
+				previousLocation = location;
+				sendBack( { type: 'EXTERNAL_URL_UPDATE' } );
 			}
-			previousLocation = location;
-		} );
+		}
+		previousLocation = location;
+	} );
 
-		return () => {
-			unlisten();
-		};
+	return () => {
+		unlisten();
 	};
+};
 
 type LaunchYourStoreQueryParams = {
 	sidebar?: string;
 	content?: string;
 };
 
-export const updateQueryParams = ( {
-	sidebar,
-	content,
-}: LaunchYourStoreQueryParams ) => {
+export const updateQueryParams = (
+	params: Partial< LaunchYourStoreQueryParams >
+) => {
 	const queryParams = getQuery() as LaunchYourStoreQueryParams;
-	const changes = Object.entries( { sidebar, content } ).reduce(
-		( acc: LaunchYourStoreQueryParams, [ key, value ] ) => {
+	const changes = Object.entries( params ).reduce(
+		( acc: Partial< LaunchYourStoreQueryParams >, [ key, value ] ) => {
+			// Check if the value is different from the current queryParams. Include if explicitly passed, even if it's undefined.
+			// This approach assumes that `params` can only have keys that are defined in LaunchYourStoreQueryParams.
 			if (
-				value !== null &&
-				value !== undefined &&
-				value !== queryParams[ key as keyof LaunchYourStoreQueryParams ]
+				queryParams[ key as keyof LaunchYourStoreQueryParams ] !== value
 			) {
 				acc[ key as keyof LaunchYourStoreQueryParams ] = value;
 			}

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/common.ts
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/common.ts
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import {
+	getHistory,
+	getQuery,
+	updateQueryString,
+} from '@woocommerce/navigation';
+import { AnyEventObject } from 'xstate5';
+
+/**
+ * This seemingly complex piece of code is just a function that creates a listener that
+ * sends off the EXTERNAL_URL_UPDATE event when the specified query parameter
+ * changes.
+ *
+ * @param paramName The query parameter to listen for changes
+ */
+export const createQueryParamsListener =
+	( paramName: string ) =>
+	( sendBack: ( event: AnyEventObject ) => void ) => {
+		let previousLocation: ReturnType< typeof getHistory >[ 'location' ];
+		const unlisten = getHistory().listen( ( { action, location } ) => {
+			if ( action === 'POP' ) {
+				const previousQuery = new URLSearchParams(
+					previousLocation.search
+				);
+				const currentQuery = new URLSearchParams( location.search );
+				if (
+					previousQuery.get( paramName ) !==
+					currentQuery.get( paramName )
+				) {
+					previousLocation = location;
+					sendBack( { type: 'EXTERNAL_URL_UPDATE' } );
+				}
+			}
+			previousLocation = location;
+		} );
+
+		return () => {
+			unlisten();
+		};
+	};
+
+type LaunchYourStoreQueryParams = {
+	sidebar?: string;
+	content?: string;
+};
+
+export const updateQueryParams = ( {
+	sidebar,
+	content,
+}: LaunchYourStoreQueryParams ) => {
+	const queryParams = getQuery() as LaunchYourStoreQueryParams;
+	const changes = Object.entries( { sidebar, content } ).reduce(
+		( acc: LaunchYourStoreQueryParams, [ key, value ] ) => {
+			if (
+				value !== null &&
+				value !== undefined &&
+				value !== queryParams[ key as keyof LaunchYourStoreQueryParams ]
+			) {
+				acc[ key as keyof LaunchYourStoreQueryParams ] = value;
+			}
+			return acc;
+		},
+		{}
+	);
+
+	if ( Object.keys( changes ).length > 0 ) {
+		updateQueryString( changes );
+	}
+};

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/xstate.tsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import { setup } from 'xstate5';
+import { fromCallback, setup } from 'xstate5';
 import React from 'react';
+import { getQuery } from '@woocommerce/navigation';
+
 /**
  * Internal dependencies
  */
@@ -10,6 +12,7 @@ import { LoadingPage } from './pages/loading';
 import { LaunchYourStoreSuccess } from './pages/launch-store-success';
 import { SitePreviewPage } from './pages/site-preview';
 import type { LaunchYourStoreComponentProps } from '..';
+import { createQueryParamsListener, updateQueryParams } from '../common';
 
 export type MainContentMachineContext = {
 	placeholder?: string; // remove this when we have some types to put here
@@ -22,18 +25,54 @@ export type MainContentMachineEvents =
 	| { type: 'SHOW_LAUNCH_STORE_SUCCESS' }
 	| { type: 'SHOW_LOADING' };
 
+const contentQueryParamListener = fromCallback( ( { sendBack } ) => {
+	return createQueryParamsListener( 'content' )( sendBack );
+} );
 export const mainContentMachine = setup( {
 	types: {} as {
 		context: MainContentMachineContext;
 		events: MainContentMachineEvents;
 	},
+	actions: {
+		updateQueryParams: (
+			_,
+			{ sidebar, content }: { sidebar?: string; content?: string }
+		) => {
+			updateQueryParams( { sidebar, content } );
+		},
+	},
+	guards: {
+		hasContentLocation: (
+			_,
+			{ contentLocation }: { contentLocation: string }
+		) => {
+			const { content } = getQuery() as { content?: string };
+			return !! content && content === contentLocation;
+		},
+	},
+	actors: {
+		contentQueryParamListener,
+	},
 } ).createMachine( {
 	id: 'mainContent',
-	initial: 'init',
+	initial: 'navigate',
 	context: {},
 	states: {
-		init: {
+		navigate: {
 			always: [
+				{
+					guard: {
+						type: 'hasContentLocation',
+						params: { contentLocation: 'site-preview' },
+					},
+				},
+				{
+					guard: {
+						type: 'hasContentLocation',
+						params: { contentLocation: 'launch-store-success' },
+					},
+					target: 'launchStoreSuccess',
+				},
 				{
 					target: '#sitePreview',
 				},
@@ -41,12 +80,24 @@ export const mainContentMachine = setup( {
 		},
 		sitePreview: {
 			id: 'sitePreview',
+			entry: [
+				{
+					type: 'updateQueryParams',
+					params: { content: 'site-preview' },
+				},
+			],
 			meta: {
 				component: SitePreviewPage,
 			},
 		},
 		launchStoreSuccess: {
 			id: 'launchStoreSuccess',
+			entry: [
+				{
+					type: 'updateQueryParams',
+					params: { content: 'launch-store-success' },
+				},
+			],
 			meta: {
 				component: LaunchYourStoreSuccess,
 			},
@@ -59,6 +110,9 @@ export const mainContentMachine = setup( {
 		},
 	},
 	on: {
+		EXTERNAL_URL_UPDATE: {
+			target: '.navigate',
+		},
 		SHOW_LAUNCH_STORE_SUCCESS: {
 			target: '#launchStoreSuccess',
 		},

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/xstate.tsx
@@ -26,7 +26,7 @@ export type MainContentMachineEvents =
 	| { type: 'SHOW_LOADING' };
 
 const contentQueryParamListener = fromCallback( ( { sendBack } ) => {
-	return createQueryParamsListener( 'content' )( sendBack );
+	return createQueryParamsListener( 'content', sendBack );
 } );
 export const mainContentMachine = setup( {
 	types: {} as {
@@ -36,9 +36,9 @@ export const mainContentMachine = setup( {
 	actions: {
 		updateQueryParams: (
 			_,
-			{ sidebar, content }: { sidebar?: string; content?: string }
+			params: { sidebar?: string; content?: string }
 		) => {
-			updateQueryParams( { sidebar, content } );
+			updateQueryParams( params );
 		},
 	},
 	guards: {
@@ -80,12 +80,6 @@ export const mainContentMachine = setup( {
 		},
 		sitePreview: {
 			id: 'sitePreview',
-			entry: [
-				{
-					type: 'updateQueryParams',
-					params: { content: 'site-preview' },
-				},
-			],
 			meta: {
 				component: SitePreviewPage,
 			},

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { ActorRefFrom, sendTo, setup } from 'xstate5';
+import { ActorRefFrom, sendTo, setup, fromCallback } from 'xstate5';
 import React from 'react';
 import classnames from 'classnames';
+import { getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import classnames from 'classnames';
 import { LaunchYourStoreHubSidebar } from './components/launch-store-hub';
 import type { LaunchYourStoreComponentProps } from '..';
 import type { mainContentMachine } from '../main-content/xstate';
+import { updateQueryParams, createQueryParamsListener } from '../common';
 
 export type SidebarMachineContext = {
 	externalUrl: string | null;
@@ -20,11 +22,17 @@ export type SidebarComponentProps = LaunchYourStoreComponentProps & {
 	context: SidebarMachineContext;
 };
 export type SidebarMachineEvents =
+	| { type: 'EXTERNAL_URL_UPDATE' }
 	| { type: 'OPEN_EXTERNAL_URL'; url: string }
 	| { type: 'OPEN_WC_ADMIN_URL'; url: string }
 	| { type: 'OPEN_WC_ADMIN_URL_IN_CONTENT_AREA'; url: string }
 	| { type: 'LAUNCH_STORE' }
 	| { type: 'LAUNCH_STORE_SUCCESS' };
+
+const sidebarQueryParamListener = fromCallback( ( { sendBack } ) => {
+	return createQueryParamsListener( 'sidebar' )( sendBack );
+} );
+
 export const sidebarMachine = setup( {
 	types: {} as {
 		context: SidebarMachineContext;
@@ -47,19 +55,57 @@ export const sidebarMachine = setup( {
 			( { context } ) => context.mainContentMachineRef,
 			{ type: 'SHOW_LOADING' }
 		),
+		updateQueryParams: (
+			_,
+			{ sidebar, content }: { sidebar?: string; content?: string }
+		) => {
+			updateQueryParams( { sidebar, content } );
+		},
+	},
+	guards: {
+		hasSidebarLocation: (
+			_,
+			{ sidebarLocation }: { sidebarLocation: string }
+		) => {
+			const { sidebar } = getQuery() as { sidebar?: string };
+			return !! sidebar && sidebar === sidebarLocation;
+		},
+	},
+	actors: {
+		sidebarQueryParamListener,
 	},
 } ).createMachine( {
 	id: 'sidebar',
-	initial: 'init',
+	initial: 'navigate',
 	context: ( { input } ) => ( {
 		externalUrl: null,
 		mainContentMachineRef: input.mainContentMachineRef,
 	} ),
+	invoke: {
+		id: 'sidebarQueryParamListener',
+		src: 'sidebarQueryParamListener',
+	},
 	states: {
-		init: {
-			always: {
-				target: 'launchYourStoreHub',
-			},
+		navigate: {
+			always: [
+				{
+					guard: {
+						type: 'hasSidebarLocation',
+						params: { sidebarLocation: 'hub' },
+					},
+					target: 'launchYourStoreHub',
+				},
+				{
+					guard: {
+						type: 'hasSidebarLocation',
+						params: { sidebarLocation: 'launch-success' },
+					},
+					target: 'storeLaunchSuccessful',
+				},
+				{
+					target: 'launchYourStoreHub',
+				},
+			],
 		},
 		launchYourStoreHub: {
 			initial: 'preLaunchYourStoreHub',
@@ -70,6 +116,12 @@ export const sidebarMachine = setup( {
 				},
 				launchYourStoreHub: {
 					tags: 'sidebar-visible',
+					entry: [
+						{
+							type: 'updateQueryParams',
+							params: { sidebar: 'hub' },
+						},
+					],
 					meta: {
 						component: LaunchYourStoreHubSidebar,
 					},
@@ -91,7 +143,6 @@ export const sidebarMachine = setup( {
 					on: {
 						LAUNCH_STORE_SUCCESS: {
 							target: '#storeLaunchSuccessful',
-							actions: { type: 'showLaunchStoreSuccessPage' },
 						},
 					},
 				},
@@ -100,6 +151,16 @@ export const sidebarMachine = setup( {
 		storeLaunchSuccessful: {
 			id: 'storeLaunchSuccessful',
 			tags: 'fullscreen',
+			entry: [
+				{
+					type: 'updateQueryParams',
+					params: {
+						sidebar: 'launch-success',
+						content: 'launch-store-success',
+					},
+				},
+				{ type: 'showLaunchStoreSuccessPage' },
+			],
 		},
 		openExternalUrl: {
 			id: 'openExternalUrl',
@@ -108,6 +169,9 @@ export const sidebarMachine = setup( {
 		},
 	},
 	on: {
+		EXTERNAL_URL_UPDATE: {
+			target: '.navigate',
+		},
 		OPEN_EXTERNAL_URL: {
 			target: '#openExternalUrl',
 		},

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -30,7 +30,7 @@ export type SidebarMachineEvents =
 	| { type: 'LAUNCH_STORE_SUCCESS' };
 
 const sidebarQueryParamListener = fromCallback( ( { sendBack } ) => {
-	return createQueryParamsListener( 'sidebar' )( sendBack );
+	return createQueryParamsListener( 'sidebar', sendBack );
 } );
 
 export const sidebarMachine = setup( {
@@ -57,9 +57,9 @@ export const sidebarMachine = setup( {
 		),
 		updateQueryParams: (
 			_,
-			{ sidebar, content }: { sidebar?: string; content?: string }
+			params: { sidebar?: string; content?: string }
 		) => {
-			updateQueryParams( { sidebar, content } );
+			updateQueryParams( params );
 		},
 	},
 	guards: {
@@ -116,12 +116,6 @@ export const sidebarMachine = setup( {
 				},
 				launchYourStoreHub: {
 					tags: 'sidebar-visible',
-					entry: [
-						{
-							type: 'updateQueryParams',
-							params: { sidebar: 'hub' },
-						},
-					],
 					meta: {
 						component: LaunchYourStoreHubSidebar,
 					},

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/test/common.test.ts
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/test/common.test.ts
@@ -1,0 +1,164 @@
+/**
+ * External dependencies
+ */
+import * as navigation from '@woocommerce/navigation';
+/**
+ * Internal dependencies
+ */
+import { updateQueryParams, createQueryParamsListener } from '../common';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	getHistory: jest.fn(),
+	getQuery: jest.fn(),
+	updateQueryString: jest.fn(),
+} ) );
+
+const mockedGetQuery = navigation.getQuery as jest.Mock;
+const mockedUpdateQueryString = navigation.updateQueryString as jest.Mock;
+const mockedGetHistory = navigation.getHistory as jest.Mock;
+
+describe( 'updateQueryParams', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'calls updateQueryString with correct changes', () => {
+		mockedGetQuery.mockReturnValue( {
+			sidebar: 'oldSidebar',
+			content: 'oldContent',
+		} );
+		const changes = { sidebar: 'newSidebar', content: 'newContent' };
+		updateQueryParams( changes );
+		expect( mockedUpdateQueryString ).toHaveBeenCalledWith( changes );
+	} );
+
+	it( 'does not call updateQueryString when new values match current ones', () => {
+		mockedGetQuery.mockReturnValue( {
+			sidebar: 'sameSidebar',
+			content: 'sameContent',
+		} );
+		updateQueryParams( { sidebar: 'sameSidebar', content: 'sameContent' } );
+		expect( mockedUpdateQueryString ).not.toHaveBeenCalled();
+	} );
+
+	// note that in this test and the below tests, we use .mock.lastCall and .toStrictEqual so that
+	// we can distinguish the difference between { content: 'bar', sidebar: undefined } and { content: 'bar }
+	// this is important because calling it with sidebar: undefined will unset the sidebar query parameter,
+	// while calling it without the sidebar key will leave the existing sidebar query parameter if any
+	it( 'calls updateQueryString with both parameters as undefined if passed in', () => {
+		mockedGetQuery.mockReturnValue( {
+			sidebar: 'existingSidebar',
+			content: 'existingContent',
+		} );
+		const changes = { sidebar: undefined, content: undefined };
+		updateQueryParams( changes );
+		expect( mockedUpdateQueryString.mock.lastCall[ 0 ] ).toStrictEqual(
+			changes
+		);
+	} );
+
+	it( 'correctly updates with undefined if one parameter is undefined', () => {
+		mockedGetQuery.mockReturnValue( {
+			sidebar: 'existingSidebar',
+			content: 'existingContent',
+		} );
+		const changes = { sidebar: 'newSidebar', content: undefined };
+		updateQueryParams( changes );
+		expect( mockedUpdateQueryString.mock.lastCall[ 0 ] ).toStrictEqual(
+			changes
+		);
+	} );
+
+	it( 'only updates changes that are different', () => {
+		mockedGetQuery.mockReturnValue( {
+			sidebar: 'existingSidebar',
+			content: 'existingContent',
+		} );
+		const changes = { sidebar: 'newSidebar', content: 'existingContent' };
+		updateQueryParams( changes );
+		expect( mockedUpdateQueryString.mock.lastCall[ 0 ] ).toStrictEqual( {
+			sidebar: 'newSidebar',
+		} );
+	} );
+
+	it( 'only updates changes that are passed in', () => {
+		mockedGetQuery.mockReturnValue( {
+			sidebar: 'existingSidebar',
+		} );
+		const changes = { sidebar: 'newSidebar' };
+		updateQueryParams( changes );
+		expect( mockedUpdateQueryString.mock.lastCall[ 0 ] ).toStrictEqual(
+			changes
+		);
+	} );
+} );
+
+describe( 'createQueryParamsListener', () => {
+	let unlistenMock: jest.Mock;
+	let sendBackMock: jest.Mock;
+	let historyMock: { listen: jest.Mock; location: { search: string } };
+
+	beforeEach( () => {
+		sendBackMock = jest.fn();
+		unlistenMock = jest.fn();
+		historyMock = {
+			listen: jest.fn().mockImplementation( () => {
+				return unlistenMock;
+			} ),
+			location: { search: '?test=sameValue' },
+		};
+		mockedGetHistory.mockReturnValue( historyMock );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'registers and unregisters the listener', () => {
+		const unlisten = createQueryParamsListener( 'test', sendBackMock );
+		expect( historyMock.listen ).toHaveBeenCalled();
+		unlisten();
+		expect( unlistenMock ).toHaveBeenCalled();
+	} );
+
+	it( 'calls sendBack when the specified query parameter changes', () => {
+		const paramName = 'test';
+		createQueryParamsListener( paramName, sendBackMock );
+
+		// Simulate a query param change
+		historyMock.listen.mock.calls[ 0 ][ 0 ]( {
+			action: 'POP',
+			location: { search: `?${ paramName }=newValue` },
+		} );
+
+		expect( sendBackMock ).toHaveBeenCalledWith( {
+			type: 'EXTERNAL_URL_UPDATE',
+		} );
+	} );
+
+	it( "does not call sendBack when the query parameter that changes isn't what we are listening to", () => {
+		const paramName = 'test';
+		createQueryParamsListener( paramName, sendBackMock );
+
+		// Simulate a navigation that does not change the specific query param
+		historyMock.listen.mock.calls[ 0 ][ 0 ]( {
+			action: 'POP',
+			location: { search: '?test=sameValue&anotherParam=different' },
+		} );
+
+		expect( sendBackMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not call sendBack when action is not POP', () => {
+		const paramName = 'test';
+		createQueryParamsListener( paramName, sendBackMock );
+
+		// Simulate a PUSH action
+		historyMock.listen.mock.calls[ 0 ][ 0 ]( {
+			action: 'PUSH',
+			location: { search: `?${ paramName }=newValue` },
+		} );
+
+		expect( sendBackMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/woocommerce/changelog/add-lys-xstate-url-handling
+++ b/plugins/woocommerce/changelog/add-lys-xstate-url-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added URL handling for LYS XState pages


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45582

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Please exclude from Solaris and GlobalStep testing as this is gated behind a feature flag and is part of the Launch Your Store feature which will be tested as a complete feature when the call for testing is released.

1. Ensure that the "launch-your-store" feature flag is enabled using WC Beta Tester plugin
2. Go to http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Flaunch-your-store and test around
3. Observe that the below works as expected:
    - There should be query parameters introduced to handle the state
    - Browser back button should work as expected
    - Should be able to link to a state by copying and pasting the URL
 4. There haven't been enough states implemented to fully test the extent of the edge cases, but analysis of the test cases should be insightful. There is a significant amount of additional complexity compared to the previous XState URL handling due to the separate state handling on the sidebar and content. Some of the additional complexity also stems from making the code easily generalisable so that we can add more parameters and also handle URL changes from external sources if necessary.
    - In general, we want the history stack to only reflect atomic and idempotent states that the user can end up in. 
    - The loading screen does not see a URL update as it does not make sense to link back to it, as it's not possible to populate the configuration with the user landing on it. 
    - It also doesn't make sense to 'go back' to it from the success page, and if the user goes back from there, they should end up at the state prior to that. 
    - We also don't want to pollute the history stack if nothing changes on screen, as it is un-intuitive for the user to hit back and nothing changes on the screen.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
