### PR TITLE
[CYS on Core] Update the copy for the fonts opt-in modal

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
@@ -164,7 +164,7 @@ export const SidebarNavigationScreenTypography = () => {
 										'woocommerce-customize-store__opt-in-usage-tracking-modal'
 									}
 									title={ __(
-										'Opt in to usage tracking',
+										'Get more fonts',
 										'woocommerce'
 									) }
 									onRequestClose={ closeModal }
@@ -174,7 +174,7 @@ export const SidebarNavigationScreenTypography = () => {
 										className="core-profiler__checkbox"
 										label={ interpolateComponents( {
 											mixedString: __(
-												'I agree to share my data to tailor my store setup experience, get more relevant content, and help make WooCommerce better for everyone. You can opt out at any time in WooCommerce settings. {{link}}Learn more about usage tracking{{/link}}.',
+												'I would like to get store updates, including new fonts, on an ongoing basis. In doing so, I agree to share my data to tailor my store setup experience, get more relevant content, and help make WooCommerce better for everyone. You can opt out at any time in WooCommerce settings. {{link}}Learn more about usage tracking{{/link}}.',
 												'woocommerce'
 											),
 											components: {

--- a/plugins/woocommerce/changelog/45805-update-copy-cys-opt-in-modal
+++ b/plugins/woocommerce/changelog/45805-update-copy-cys-opt-in-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS Update the copy for the fonts opt-in modal in the pattern assembler.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Update the copy for the fonts opt-in modal.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have the WooCommerce Beta Tester plugin installed and activated
2. Under Tools > WCA Test Helper > Features, make sure customize-store is enabled
3. Under Tools > WCA Test Helper > Tools, click on Reset Customize Your Store
4. Access `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and make sure the usage tracking is disabled:

<img width="1868" alt="Screenshot 2024-03-21 at 18 12 47" src="https://github.com/woocommerce/woocommerce/assets/15730971/1238e0d5-a84e-4c76-a15a-c2f74c39ef7a">

6. Access WooCommerce > Home > Customize Your Store
7. On the intro screen, click on "Start designing"
8. In the Pattern Assembler, click on "Choose Fonts"
9. Click on: Opt in to usage tracking to get access to more fonts.

<img width="841" alt="Screenshot 2024-03-21 at 18 16 18" src="https://github.com/woocommerce/woocommerce/assets/15730971/bb2def1a-b701-4c57-9140-78b73ba659ec">

10. Make sure the following modal is displayed with the following copy:

<img width="1870" alt="Screenshot 2024-03-21 at 18 08 36" src="https://github.com/woocommerce/woocommerce/assets/15730971/d6ac7aa1-279c-45d2-8e5e-5e00dbf6b45a">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS Update the copy for the fonts opt-in modal in the pattern assembler.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
