### PR TITLE
Add a test for the `woocommerce_specific_allowed_countries` option

### DIFF
--- a/plugins/woocommerce/changelog/add-test-for-woocommerce_specific_allowed_countries
+++ b/plugins/woocommerce/changelog/add-test-for-woocommerce_specific_allowed_countries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a test for the `woocommerce_specific_allowed_countries` option.

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
@@ -400,15 +400,53 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test getting the default location with no default address set but specific countries allowed.
+	 * Test getting the customer default location with different configurations of options set or unset.
 	 */
-	public function test_default_location_with_specific_allowed_countries() {
+	public function test_wc_get_customer_default_location() {
+		// Test with none of the options set.
 		delete_option( 'woocommerce_default_customer_address' );
+		delete_option( 'woocommerce_default_country' );
+		delete_option( 'woocommerce_allowed_countries' );
+		delete_option( 'woocommerce_specific_allowed_countries' );
+		$customer_default_location = wc_get_customer_default_location();
+		$this->assertEquals( 'US', $customer_default_location['country'] );
+		$this->assertEquals( 'CA', $customer_default_location['state'] );
+
+		// Test with default address set.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'DE:LS' );
+		delete_option( 'woocommerce_allowed_countries' );
+		delete_option( 'woocommerce_specific_allowed_countries' );
+		$customer_default_location = wc_get_customer_default_location();
+		$this->assertEquals( 'DE', $customer_default_location['country'] );
+		$this->assertEquals( 'LS', $customer_default_location['state'] );
+
+		// Test with default address, but specific countries set.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'DE:LS' );
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
+		$customer_default_location = wc_get_customer_default_location();
+		$this->assertEquals( 'DE', $customer_default_location['country'] );
+		$this->assertEquals( 'LS', $customer_default_location['state'] );
+
+		// Test with no default address, but specific countries set.
+		delete_option( 'woocommerce_default_customer_address' );
+		delete_option( 'woocommerce_default_country' );
 		update_option( 'woocommerce_allowed_countries', 'specific' );
 		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
 		$customer_default_location = wc_get_customer_default_location();
 		$this->assertEquals( 'DE', $customer_default_location['country'] );
 		$this->assertEquals( '', $customer_default_location['state'] );
+
+		// Test forgetting to set the allowed countries to specific.
+		delete_option( 'woocommerce_default_customer_address' );
+		delete_option( 'woocommerce_default_country' );
+		delete_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
+		$customer_default_location = wc_get_customer_default_location();
+		$this->assertEquals( 'US', $customer_default_location['country'] );
+		$this->assertEquals( 'CA', $customer_default_location['state'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
@@ -400,6 +400,18 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting the default location with no default address set but specific countries allowed.
+	 */
+	public function test_default_location_with_specific_allowed_countries() {
+		delete_option( 'woocommerce_default_customer_address' );
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
+		$customer_default_location = wc_get_customer_default_location();
+		$this->assertEquals( 'DE', $customer_default_location['country'] );
+		$this->assertEquals( '', $customer_default_location['state'] );
+	}
+
+	/**
 	 * Test setting a customer's location (multiple address fields at once)
 	 * @since 3.0.0
 	 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/tax/tax.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/tax/tax.php
@@ -269,7 +269,6 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	 */
 	public function test_calc_compound_tax() {
 		update_option( 'woocommerce_default_country', 'CA' );
-		update_option( 'woocommerce_default_state', 'QC' );
 
 		$tax_rate_1 = array(
 			'tax_rate_country'  => 'CA',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Reading through #45648 I wasn't sure what exactly the correct behavior was here, so I wrote a test to illustrate that it is indeed correct as it is, but that in addition to the `woocommerce_specific_allowed_countries` option set to an array of allowed countries, we also need to set the `woocommerce_allowed_countries` option to the string `specific`. 

Closes #45648.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. ensure the logic looks correct
2. ensure the CI checks pass

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
