### PR TITLE
Fix homepage link in create-woo-extension package.json

### DIFF
--- a/packages/js/create-woo-extension/changelog/45811-patch-3
+++ b/packages/js/create-woo-extension/changelog/45811-patch-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix a small typo in package.json homepage url.

--- a/packages/js/create-woo-extension/package.json
+++ b/packages/js/create-woo-extension/package.json
@@ -20,7 +20,7 @@
 	"scripts": {
 		"changelog": "composer install && composer exec -- changelogger"
 	},
-	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/create-woo-extensionv#readme",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/create-woo-extension#readme",
 	"devDependencies": {
 		"wireit": "0.14.3"
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Hey 👋  This fixes a small typo in package.json `homepage` url, otherwise it leads to a 404

I noticed it because `homepage` url is used on [npmjs.com](https://www.npmjs.com/package/@woocommerce/create-woo-extension):

![Image 2024-03-21 at 8 23 36 PM](https://github.com/woocommerce/woocommerce/assets/1530318/f529819c-f50c-49d5-a116-3fd7c135732b)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.


#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix a small typo in package.json homepage url.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->