### PR TITLE
Allow to disable shipping independent of Local Pickup settings

### DIFF
--- a/plugins/woocommerce/changelog/45828-fix-44405-disable-shipping-logic
+++ b/plugins/woocommerce/changelog/45828-fix-44405-disable-shipping-logic
@@ -1,0 +1,4 @@
+Significance: major
+Type: fix
+
+Fix a bug that prevented placing an order when shipping is disabled, but Local Pickup is still enabled.

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -75,7 +75,6 @@ class ShippingController {
 		add_filter( 'pre_update_option_woocommerce_pickup_location_settings', array( $this, 'flush_cache' ) );
 		add_filter( 'pre_update_option_pickup_location_pickup_locations', array( $this, 'flush_cache' ) );
 		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
-		add_filter( 'wc_shipping_enabled', array( $this, 'force_shipping_enabled' ), 100, 1 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
 
 		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
@@ -97,19 +96,6 @@ class ShippingController {
 			return 'no';
 		}
 		return $value;
-	}
-
-	/**
-	 * Force shipping to be enabled if the Checkout block is in use on the Checkout page.
-	 *
-	 * @param boolean $enabled Whether shipping is currently enabled.
-	 * @return boolean Whether shipping should continue to be enabled/disabled.
-	 */
-	public function force_shipping_enabled( $enabled ) {
-		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
-			return true;
-		}
-		return $enabled;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -55,7 +55,7 @@ class ShippingController {
 		if ( is_admin() ) {
 			$this->asset_data_registry->add(
 				'countryStates',
-				function() {
+				function () {
 					return WC()->countries->get_states();
 				},
 				true
@@ -64,9 +64,9 @@ class ShippingController {
 
 		$this->asset_data_registry->add( 'collectableMethodIds', array( 'Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils', 'get_local_pickup_method_ids' ), true );
 		$this->asset_data_registry->add( 'shippingCostRequiresAddress', get_option( 'woocommerce_shipping_cost_requires_address', false ) === 'yes' );
-		add_action( 'rest_api_init', [ $this, 'register_settings' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'hydrate_client_settings' ] );
+		add_action( 'rest_api_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'hydrate_client_settings' ) );
 		add_action( 'woocommerce_load_shipping_methods', array( $this, 'register_local_pickup' ) );
 		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
 		add_filter( 'woocommerce_order_hide_shipping_address', array( $this, 'hide_shipping_address_for_local_pickup' ), 10 );
@@ -101,14 +101,14 @@ class ShippingController {
 	/**
 	 * Inject collection details onto the order received page.
 	 *
-	 * @param string    $return Return value.
+	 * @param string    $return_value Return value.
 	 * @param \WC_Order $order Order object.
 	 * @return string
 	 */
-	public function show_local_pickup_details( $return, $order ) {
+	public function show_local_pickup_details( $return_value, $order ) {
 		// Confirm order is valid before proceeding further.
 		if ( ! $order instanceof \WC_Order ) {
-			return $return;
+			return $return_value;
 		}
 
 		$shipping_method_ids = ArrayUtil::select( $order->get_shipping_methods(), 'get_method_id', ArrayUtil::SELECT_BY_OBJECT_METHOD );
@@ -116,7 +116,7 @@ class ShippingController {
 
 		// Ensure order used pickup location method, otherwise bail.
 		if ( 'pickup_location' !== $shipping_method_id ) {
-			return $return;
+			return $return_value;
 		}
 
 		$shipping_method = current( $order->get_shipping_methods() );
@@ -125,7 +125,7 @@ class ShippingController {
 		$address         = $shipping_method->get_meta( 'pickup_address' );
 
 		if ( ! $address ) {
-			return $return;
+			return $return_value;
 		}
 
 		return sprintf(
@@ -167,86 +167,86 @@ class ShippingController {
 		register_setting(
 			'options',
 			'woocommerce_pickup_location_settings',
-			[
+			array(
 				'type'         => 'object',
 				'description'  => 'WooCommerce Local Pickup Method Settings',
-				'default'      => [],
-				'show_in_rest' => [
+				'default'      => array(),
+				'show_in_rest' => array(
 					'name'   => 'pickup_location_settings',
-					'schema' => [
+					'schema' => array(
 						'type'       => 'object',
 						'properties' => array(
-							'enabled'    => [
+							'enabled'    => array(
 								'description' => __( 'If enabled, this method will appear on the block based checkout.', 'woocommerce' ),
 								'type'        => 'string',
-								'enum'        => [ 'yes', 'no' ],
-							],
-							'title'      => [
+								'enum'        => array( 'yes', 'no' ),
+							),
+							'title'      => array(
 								'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
 								'type'        => 'string',
-							],
-							'tax_status' => [
+							),
+							'tax_status' => array(
 								'description' => __( 'If a cost is defined, this controls if taxes are applied to that cost.', 'woocommerce' ),
 								'type'        => 'string',
-								'enum'        => [ 'taxable', 'none' ],
-							],
-							'cost'       => [
+								'enum'        => array( 'taxable', 'none' ),
+							),
+							'cost'       => array(
 								'description' => __( 'Optional cost to charge for local pickup.', 'woocommerce' ),
 								'type'        => 'string',
-							],
+							),
 						),
-					],
-				],
-			]
+					),
+				),
+			)
 		);
 		register_setting(
 			'options',
 			'pickup_location_pickup_locations',
-			[
+			array(
 				'type'         => 'array',
 				'description'  => 'WooCommerce Local Pickup Locations',
-				'default'      => [],
-				'show_in_rest' => [
+				'default'      => array(),
+				'show_in_rest' => array(
 					'name'   => 'pickup_locations',
-					'schema' => [
+					'schema' => array(
 						'type'  => 'array',
-						'items' => [
+						'items' => array(
 							'type'       => 'object',
 							'properties' => array(
-								'name'    => [
+								'name'    => array(
 									'type' => 'string',
-								],
-								'address' => [
+								),
+								'address' => array(
 									'type'       => 'object',
 									'properties' => array(
-										'address_1' => [
+										'address_1' => array(
 											'type' => 'string',
-										],
-										'city'      => [
+										),
+										'city'      => array(
 											'type' => 'string',
-										],
-										'state'     => [
+										),
+										'state'     => array(
 											'type' => 'string',
-										],
-										'postcode'  => [
+										),
+										'postcode'  => array(
 											'type' => 'string',
-										],
-										'country'   => [
+										),
+										'country'   => array(
 											'type' => 'string',
-										],
+										),
 									),
-								],
-								'details' => [
+								),
+								'details' => array(
 									'type' => 'string',
-								],
-								'enabled' => [
+								),
+								'enabled' => array(
 									'type' => 'boolean',
-								],
+								),
 							),
-						],
-					],
-				],
-			]
+						),
+					),
+				),
+			)
 		);
 	}
 
@@ -254,16 +254,16 @@ class ShippingController {
 	 * Hydrate client settings
 	 */
 	public function hydrate_client_settings() {
-		$locations = get_option( 'pickup_location_pickup_locations', [] );
+		$locations = get_option( 'pickup_location_pickup_locations', array() );
 
-		$formatted_pickup_locations = [];
+		$formatted_pickup_locations = array();
 		foreach ( $locations as $location ) {
-			$formatted_pickup_locations[] = [
+			$formatted_pickup_locations[] = array(
 				'name'    => $location['name'],
 				'address' => $location['address'],
 				'details' => $location['details'],
 				'enabled' => wc_string_to_bool( $location['enabled'] ),
-			];
+			);
 		}
 
 		$has_legacy_pickup = false;
@@ -293,7 +293,7 @@ class ShippingController {
 		}
 
 		$settings = array(
-			'pickupLocationSettings' => get_option( 'woocommerce_pickup_location_settings', [] ),
+			'pickupLocationSettings' => get_option( 'woocommerce_pickup_location_settings', array() ),
 			'pickupLocations'        => $formatted_pickup_locations,
 			'readonlySettings'       => array(
 				'hasLegacyPickup' => $has_legacy_pickup,
@@ -315,7 +315,7 @@ class ShippingController {
 	 * Load admin scripts.
 	 */
 	public function admin_scripts() {
-		$this->asset_api->register_script( 'wc-shipping-method-pickup-location', 'assets/client/blocks/wc-shipping-method-pickup-location.js', [], true );
+		$this->asset_api->register_script( 'wc-shipping-method-pickup-location', 'assets/client/blocks/wc-shipping-method-pickup-location.js', array(), true );
 	}
 
 	/**
@@ -377,8 +377,8 @@ class ShippingController {
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		if ( $chosen_method_id && true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && in_array( $chosen_method_id, LocalPickupUtils::get_local_pickup_method_ids(), true ) ) {
-			$pickup_locations = get_option( 'pickup_location_pickup_locations', [] );
-			$pickup_location  = $pickup_locations[ $chosen_method_instance ] ?? [];
+			$pickup_locations = get_option( 'pickup_location_pickup_locations', array() );
+			$pickup_location  = $pickup_locations[ $chosen_method_instance ] ?? array();
 
 			if ( isset( $pickup_location['address'], $pickup_location['address']['country'] ) && ! empty( $pickup_location['address']['country'] ) ) {
 				$address = array(
@@ -407,8 +407,8 @@ class ShippingController {
 		// Check all packages for an instance of a collectable shipping method.
 		$valid_packages = array_filter(
 			$packages,
-			function( $package ) {
-				$shipping_method_ids = ArrayUtil::select( $package['rates'] ?? [], 'get_method_id', ArrayUtil::SELECT_BY_OBJECT_METHOD );
+			function ( $package ) {
+				$shipping_method_ids = ArrayUtil::select( $package['rates'] ?? array(), 'get_method_id', ArrayUtil::SELECT_BY_OBJECT_METHOD );
 				return ! empty( array_intersect( LocalPickupUtils::get_local_pickup_method_ids(), $shipping_method_ids ) );
 			}
 		);
@@ -416,14 +416,14 @@ class ShippingController {
 		// Remove pickup location from rates arrays.
 		if ( count( $valid_packages ) !== count( $packages ) ) {
 			$packages = array_map(
-				function( $package ) {
+				function ( $package ) {
 					if ( ! is_array( $package['rates'] ) ) {
-						$package['rates'] = [];
+						$package['rates'] = array();
 						return $package;
 					}
 					$package['rates'] = array_filter(
 						$package['rates'],
-						function( $rate ) {
+						function ( $rate ) {
 							return ! in_array( $rate->get_method_id(), LocalPickupUtils::get_local_pickup_method_ids(), true );
 						}
 					);
@@ -468,7 +468,7 @@ class ShippingController {
 			'pickup_locations_enabled' => count(
 				array_filter(
 					$locations,
-					function( $location ) {
+					function ( $location ) {
 						return $location['enabled']; }
 				)
 			),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44405.

This PR introduces the following changes:

For WooCommerce Blocks, we've introduced a new Local Pickup option. We identified an issue where it was impossible to place orders with shipping disabled while Local Pickup remained active. This update allows shipping to be disabled independently of Local Pickup settings, aligning with standard shipping methods.

Additionally, this PR addresses numerous PHPCS errors and warnings within `plugins/woocommerce/src/Blocks/Shipping/ShippingController.php`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings`.
2. For `Shipping location(s)` select `Ship to all countries` and save the changes.
3. Verify that the shipping tab is visible.
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping`.
5. Ensure that there's at least one active shipping method (either in a shipping zone or in the Rest of the world zone).
6. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location`.
7. Ensure that Local pickup is enabled.
8. Go to `/wp-admin/admin.php?page=wc-settings` again.
9. For `Shipping location(s)` select `Disable shipping & shipping calculations` and save the changes.
10. Verify that the shipping tab is no longer visible.
11. Go to the frontend and add a product to the cart.
12. Go to the cart page and verify that no shipping section is visible.
13. Go to the checkout page and verify that no shipping sections are visible.
14. Place the order.
15. Verify that the order can be placed.

### Screenshots

#### Shipping tab

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="883" alt="Screenshot 2024-03-22 at 17 31 50" src="https://github.com/woocommerce/woocommerce/assets/3323310/e78bbd9b-d317-42d7-a46f-a69f1e326771">
</td>
<td valign="top">After:
<br><br>
<img width="797" alt="Screenshot 2024-03-22 at 17 33 09" src="https://github.com/woocommerce/woocommerce/assets/3323310/5b8a58d7-cc38-4e36-a189-9be0f620dace">
</td>
</tr>
</table>

#### Cart page

<table>
<tr>
<td valign="top">Before:
<br><br>

![store test_cart_](https://github.com/woocommerce/woocommerce/assets/3323310/840227b0-f083-4368-a14e-c43512d3ac9d)

</td>
<td valign="top">After:
<br><br>

![store test_cart_ (1)](https://github.com/woocommerce/woocommerce/assets/3323310/f245d928-2fe3-4c2b-9ea6-54b773fd9191)

</td>
</tr>
</table>

#### Checkout page

<table>
<tr>
<td valign="top">Before:
<br><br>

![store test_checkout_](https://github.com/woocommerce/woocommerce/assets/3323310/f71bd2c3-2b01-4121-b615-5c34c070072a)

</td>
<td valign="top">After:
<br><br>

![store test_checkout_ (1)](https://github.com/woocommerce/woocommerce/assets/3323310/6bd0bf2e-2e95-4168-abaa-4cd94b8e2727)

</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a bug that prevented placing an order when shipping is disabled, but Local Pickup is still enabled.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
