### PR TITLE
In-app marketplace: remove extension update count bubble from menu item if we're showing a promotional bubble

### DIFF
--- a/plugins/woocommerce/changelog/fix-wccom-19988-double-bubble
+++ b/plugins/woocommerce/changelog/fix-wccom-19988-double-bubble
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixing minor bug with display of menu item bubble in marketplace.
+
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -262,7 +262,7 @@ class WC_Admin_Marketplace_Promotions {
 				&& $promotion['menu_item_id'] === $menu_item['id']
 			) {
 				$bubble_text                   = $promotion['content'][ self::$locale ] ?? ( $promotion['content']['en_US'] ?? __( 'Sale', 'woocommerce' ) );
-				$menu_items[ $index ]['title'] = $menu_item['title'] . self::append_bubble( $bubble_text );
+				$menu_items[ $index ]['title'] = self::append_bubble( $menu_item['title'], $bubble_text );
 
 				break;
 			}
@@ -272,26 +272,21 @@ class WC_Admin_Marketplace_Promotions {
 	}
 
 	/**
-	 * Return the markup for a menu item bubble with a given text and optional additional attributes.
+	 * Return the markup for a menu item bubble with a given text.
 	 *
-	 * @param string $bubble_text Text of bubble.
-	 * @param array  $attributes Optional. Additional attributes for the bubble, such as class or style.
+	 * @param string $menu_item_text Text of menu item we want to change.
+	 * @param string $bubble_text    Text of bubble.
 	 *
 	 * @return string
 	 */
-	private static function append_bubble( $bubble_text, $attributes = array() ) {
-		$default_attributes = array(
-			'class' => 'awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge',
-			'style' => '',
-		);
+	private static function append_bubble( string $menu_item_text, string $bubble_text ): string {
+		// Strip out update count bubble added by Marketplace::get_marketplace_update_count_html.
+		$menu_item_text = preg_replace( '|<span class="update-plugins count-[\d]+">[A-z0-9 <>="-]+</span>|', '', $menu_item_text );
 
-		$attributes = wp_parse_args( $attributes, $default_attributes );
-		$class_attr = ! empty( $attributes['class'] ) ? sprintf( 'class="%s"', esc_attr( $attributes['class'] ) ) : '';
-		$style_attr = ! empty( $attributes['style'] ) ? sprintf( 'style="%s"', esc_attr( $attributes['style'] ) ) : '';
-
-		$bubble_html = sprintf( ' <span %s %s>%s</span>', $class_attr, $style_attr, esc_html( $bubble_text ) );
-
-		return $bubble_html;
+		return $menu_item_text
+			. '<span class="awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge">'
+			. esc_html( $bubble_text )
+			. '</span>';
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In testing https://github.com/woocommerce/woocommerce/pull/45786#pullrequestreview-1952173894, we found that if one or more Woo extensions has an available update, [Marketplace::get_marketplace_update_count_html](https://github.com/woocommerce/woocommerce/blob/b357bdc593103845600eede5589ebbbfec44a22d/plugins/woocommerce/src/Internal/Admin/Marketplace.php#L83) adds a bubble with a count of the extensions next to the Extensions menu item. If we are showing a promotional menu item bubble at the same time, the two bubbles will display together.

This PR strips out the update count bubble if we're showing a promotional bubble. It also simplifies the arguments of the `append_bubble` function slightly.

Closes 19988-gh-Automattic/woocommerce.com

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Don't check out this branch yet, we want to reproduce the problem.
2. Open WooCommerce, for example by going to `wp-admin/admin.php?page=wc-admin&path=%2Fextensions`. If you have some Woo extensions already installed, you may see the update count bubble on the "Extensions" menu item.

<p>
<img width="1350" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/765664e6-68bd-4803-8a53-ea486c5d0987">
</p>

3. If you don't see the update count bubble, put this filter in your `mu-plugins` to add one. (See "Adding a `mu-plugins` folder to `wp-env`" below for further details.)

```php
add_filter(
	'woocommerce_marketplace_menu_items',
	function ( $menu_items ) {
		foreach ( $menu_items as $index => $menu_item ) {
			if (
				'woocommerce' === $menu_item['parent']
			) {
				$bubble = ' <span class="update-plugins count-1"><span class="update-count">1</span></span>';
				$menu_items[ $index ]['title'] = $menu_item['title'] . $bubble;

				break;
			}
		}

		return $menu_items;
	}
);
```

4. Now we want to replicate a promotion in the marketplace. Edit `plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php` and replace the `PROMOTIONS_API_URL` value `https://woo.com/wp-json/wccom-extensions/3.0/promotions` with `https://gist.githubusercontent.com/andfinally/acd8646151c0108f92979c985c20a0d8/raw/`. This is a gist with dummy data that is valid until 1 May.
5. Go to Tools > Scheduled Actions (for example http://localhost:8888/wp-admin/tools.php?page=action-scheduler&s=woocommerce_marketplace_fetch_promotions&action=-1&action2=-1&orderby=schedule&order=desc), and find the pending action `woocommerce_marketplace_fetch_promotions`. However over the action and click the `Run` link to run it.
6. Go back to WooCommerce, or refresh your view of the marketplace. You should see both the update count bubble and the `Sale` menu item bubble next to the Extensions menu item.

<img width="150" src="https://github.com/woocommerce/woocommerce/assets/1647564/163b319c-3379-4050-9256-b7e2149a06c5">

7. Now check out this branch and refresh the in-app marketplace in your browser. You should only see the `Sale` bubble.

### Adding a `mu-plugins` folder to `wp-env`.

- Create a folder ~/.wp-env/mu-plugins and save your plugin file in it.
- Add a file `.wp-env.override.json` in the `plugins/woocommerce` folder of your project with a mapping to the new folder. For example:

```json
{
  "mappings": {
    "wp-content/mu-plugins": "/Users/administrator/.wp-env/mu-plugins"
  }
}
```

- Restart the wp-env environment: `pnpm env:restart`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>