### PR TITLE
Validate missing fields in Store API

### DIFF
--- a/plugins/woocommerce/changelog/fix-additional-fields-validation
+++ b/plugins/woocommerce/changelog/fix-additional-fields-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Always validate missing additional fields

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -129,7 +129,7 @@
 	</rule>
 
 	<!-- Temporary -->
-	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+	<rule ref="Universal.Arrays.DisallowShortArraySyntax.Found">
 		<exclude-pattern>src/Blocks/</exclude-pattern>
 		<exclude-pattern>src/StoreApi/</exclude-pattern>
 	</rule>

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -38,7 +38,7 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $supported_field_types = [ 'text', 'select', 'checkbox' ];
+	private $supported_field_types = array( 'text', 'select', 'checkbox' );
 
 	/**
 	 * Instance of the asset data registry.
@@ -532,13 +532,13 @@ class CheckoutFields {
 		// We check if attributes are valid. This is done to prevent too much nesting and also to allow field registration
 		// even if the attributes property is invalid. We can just skip it and register the field without attributes.
 		if ( empty( $attributes ) ) {
-			return [];
+			return array();
 		}
 
 		if ( ! is_array( $attributes ) || 0 === count( $attributes ) ) {
 			$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
 			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
-			return [];
+			return array();
 		}
 
 		// These are formatted in camelCase because React components expect them that way.
@@ -553,7 +553,7 @@ class CheckoutFields {
 
 		$valid_attributes = array_filter(
 			$attributes,
-			function( $_, $key ) use ( $allowed_attributes ) {
+			function ( $_, $key ) use ( $allowed_attributes ) {
 				return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0 || strpos( $key, 'data-' ) === 0;
 			},
 			ARRAY_FILTER_USE_BOTH
@@ -568,7 +568,7 @@ class CheckoutFields {
 
 		// Escape attributes to remove any malicious code and return them.
 		return array_map(
-			function( $value ) {
+			function ( $value ) {
 				return esc_attr( $value );
 			},
 			$valid_attributes
@@ -756,13 +756,13 @@ class CheckoutFields {
 
 			return array_filter(
 				$this->get_additional_fields(),
-				function( $key ) use ( $order_fields_keys ) {
+				function ( $key ) use ( $order_fields_keys ) {
 					return in_array( $key, $order_fields_keys, true );
 				},
 				ARRAY_FILTER_USE_KEY
 			);
 		}
-		return [];
+		return array();
 	}
 
 	/**
@@ -1095,7 +1095,7 @@ class CheckoutFields {
 		);
 		return array_filter(
 			$fields,
-			function( $key ) use ( $customer_fields_keys ) {
+			function ( $key ) use ( $customer_fields_keys ) {
 				if ( 0 === strpos( $key, '/billing/' ) ) {
 					$key = str_replace( '/billing/', '', $key );
 				} elseif ( 0 === strpos( $key, '/shipping/' ) ) {
@@ -1117,7 +1117,7 @@ class CheckoutFields {
 	public function filter_fields_for_location( $fields, $location ) {
 		return array_filter(
 			$fields,
-			function( $key ) use ( $location ) {
+			function ( $key ) use ( $location ) {
 				if ( 0 === strpos( $key, '/billing/' ) ) {
 					$key = str_replace( '/billing/', '', $key );
 				} elseif ( 0 === strpos( $key, '/shipping/' ) ) {
@@ -1138,7 +1138,7 @@ class CheckoutFields {
 	public function filter_fields_for_order_confirmation( $fields ) {
 		return array_filter(
 			$fields,
-			function( $field ) {
+			function ( $field ) {
 				return ! empty( $field['show_in_order_confirmation'] );
 			}
 		);

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -24,7 +24,7 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $additional_fields = array();
+	private $additional_fields = [];
 
 	/**
 	 * Fields locations.
@@ -38,7 +38,7 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $supported_field_types = array( 'text', 'select', 'checkbox' );
+	private $supported_field_types = [ 'text', 'select', 'checkbox' ];
 
 	/**
 	 * Instance of the asset data registry.
@@ -75,8 +75,8 @@ class CheckoutFields {
 	 */
 	public function __construct( AssetDataRegistry $asset_data_registry ) {
 		$this->asset_data_registry = $asset_data_registry;
-		$this->core_fields         = array(
-			'email'      => array(
+		$this->core_fields         = [
+			'email'      => [
 				'label'          => __( 'Email address', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Email address (optional)',
@@ -87,8 +87,8 @@ class CheckoutFields {
 				'autocomplete'   => 'email',
 				'autocapitalize' => 'none',
 				'index'          => 0,
-			),
-			'first_name' => array(
+			],
+			'first_name' => [
 				'label'          => __( 'First name', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'First name (optional)',
@@ -99,8 +99,8 @@ class CheckoutFields {
 				'autocomplete'   => 'given-name',
 				'autocapitalize' => 'sentences',
 				'index'          => 10,
-			),
-			'last_name'  => array(
+			],
+			'last_name'  => [
 				'label'          => __( 'Last name', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Last name (optional)',
@@ -111,8 +111,8 @@ class CheckoutFields {
 				'autocomplete'   => 'family-name',
 				'autocapitalize' => 'sentences',
 				'index'          => 20,
-			),
-			'company'    => array(
+			],
+			'company'    => [
 				'label'          => __( 'Company', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Company (optional)',
@@ -123,8 +123,8 @@ class CheckoutFields {
 				'autocomplete'   => 'organization',
 				'autocapitalize' => 'sentences',
 				'index'          => 30,
-			),
-			'address_1'  => array(
+			],
+			'address_1'  => [
 				'label'          => __( 'Address', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Address (optional)',
@@ -135,8 +135,8 @@ class CheckoutFields {
 				'autocomplete'   => 'address-line1',
 				'autocapitalize' => 'sentences',
 				'index'          => 40,
-			),
-			'address_2'  => array(
+			],
+			'address_2'  => [
 				'label'          => __( 'Apartment, suite, etc.', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Apartment, suite, etc. (optional)',
@@ -147,8 +147,8 @@ class CheckoutFields {
 				'autocomplete'   => 'address-line2',
 				'autocapitalize' => 'sentences',
 				'index'          => 50,
-			),
-			'country'    => array(
+			],
+			'country'    => [
 				'label'         => __( 'Country/Region', 'woocommerce' ),
 				'optionalLabel' => __(
 					'Country/Region (optional)',
@@ -158,8 +158,8 @@ class CheckoutFields {
 				'hidden'        => false,
 				'autocomplete'  => 'country',
 				'index'         => 50,
-			),
-			'city'       => array(
+			],
+			'city'       => [
 				'label'          => __( 'City', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'City (optional)',
@@ -170,8 +170,8 @@ class CheckoutFields {
 				'autocomplete'   => 'address-level2',
 				'autocapitalize' => 'sentences',
 				'index'          => 70,
-			),
-			'state'      => array(
+			],
+			'state'      => [
 				'label'          => __( 'State/County', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'State/County (optional)',
@@ -182,8 +182,8 @@ class CheckoutFields {
 				'autocomplete'   => 'address-level1',
 				'autocapitalize' => 'sentences',
 				'index'          => 80,
-			),
-			'postcode'   => array(
+			],
+			'postcode'   => [
 				'label'          => __( 'Postal code', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Postal code (optional)',
@@ -194,8 +194,8 @@ class CheckoutFields {
 				'autocomplete'   => 'postal-code',
 				'autocapitalize' => 'characters',
 				'index'          => 90,
-			),
-			'phone'      => array(
+			],
+			'phone'      => [
 				'label'          => __( 'Phone', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Phone (optional)',
@@ -207,15 +207,15 @@ class CheckoutFields {
 				'autocomplete'   => 'tel',
 				'autocapitalize' => 'characters',
 				'index'          => 100,
-			),
-		);
+			],
+		];
 
-		$this->fields_locations = array(
+		$this->fields_locations = [
 			// omit email from shipping and billing fields.
 			'address'    => array_merge( \array_diff_key( array_keys( $this->core_fields ), array( 'email' ) ) ),
 			'contact'    => array( 'email' ),
-			'additional' => array(),
-		);
+			'additional' => [],
+		];
 
 		add_filter( 'woocommerce_get_country_locale_default', array( $this, 'update_default_locale_with_fields' ) );
 	}
@@ -296,7 +296,7 @@ class CheckoutFields {
 		// The above validate_options function ensures these options are valid. Type might not be supplied but then it defaults to text.
 		$field_data = wp_parse_args(
 			$options,
-			array(
+			[
 				'id'                         => '',
 				'label'                      => '',
 				'optionalLabel'              => sprintf(
@@ -308,11 +308,11 @@ class CheckoutFields {
 				'type'                       => 'text',
 				'hidden'                     => false,
 				'required'                   => false,
-				'attributes'                 => array(),
+				'attributes'                 => [],
 				'show_in_order_confirmation' => true,
 				'sanitize_callback'          => array( $this, 'default_sanitize_callback' ),
 				'validate_callback'          => array( $this, 'default_validate_callback' ),
-			)
+			]
 		);
 
 		$field_data['attributes'] = $this->register_field_attributes( $field_data['id'], $field_data['attributes'] );
@@ -452,8 +452,8 @@ class CheckoutFields {
 			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
-		$cleaned_options = array();
-		$added_values    = array();
+		$cleaned_options = [];
+		$added_values    = [];
 
 		// Check all entries in $options['options'] has a key and value member.
 		foreach ( $options['options'] as $option ) {
@@ -474,10 +474,10 @@ class CheckoutFields {
 
 			$added_values[] = $sanitized_value;
 
-			$cleaned_options[] = array(
+			$cleaned_options[] = [
 				'value' => $sanitized_value,
 				'label' => $sanitized_label,
-			);
+			];
 		}
 
 		$field_data['options'] = $cleaned_options;
@@ -485,12 +485,12 @@ class CheckoutFields {
 		// If the field is not required, inject an empty option at the start.
 		if ( isset( $field_data['required'] ) && false === $field_data['required'] && ! in_array( '', $added_values, true ) ) {
 			$field_data['options'] = array_merge(
-				array(
-					array(
+				[
+					[
 						'value' => '',
 						'label' => '',
-					),
-				),
+					],
+				],
 				$field_data['options']
 			);
 		}
@@ -532,24 +532,24 @@ class CheckoutFields {
 		// We check if attributes are valid. This is done to prevent too much nesting and also to allow field registration
 		// even if the attributes property is invalid. We can just skip it and register the field without attributes.
 		if ( empty( $attributes ) ) {
-			return array();
+			return [];
 		}
 
 		if ( ! is_array( $attributes ) || 0 === count( $attributes ) ) {
 			$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
 			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
-			return array();
+			return [];
 		}
 
 		// These are formatted in camelCase because React components expect them that way.
-		$allowed_attributes = array(
+		$allowed_attributes = [
 			'maxLength',
 			'readOnly',
 			'pattern',
 			'autocomplete',
 			'autocapitalize',
 			'title',
-		);
+		];
 
 		$valid_attributes = array_filter(
 			$attributes,
@@ -762,7 +762,7 @@ class CheckoutFields {
 				ARRAY_FILTER_USE_KEY
 			);
 		}
-		return array();
+		return [];
 	}
 
 	/**
@@ -923,7 +923,7 @@ class CheckoutFields {
 		$meta_data = $object->get_meta( $meta_key, true );
 
 		if ( ! is_array( $meta_data ) ) {
-			$meta_data = array();
+			$meta_data = [];
 		}
 
 		$meta_data[ $key ] = $value;
@@ -1001,11 +1001,12 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	public function get_all_fields_from_customer( $customer, $all = false ) {
-		$meta_data = array(
-			'billing'    => array(),
-			'shipping'   => array(),
-			'additional' => array(),
-		);
+		$meta_data = [
+			'billing'    => [],
+			'shipping'   => [],
+			'additional' => [],
+		];
+
 		if ( $customer instanceof WC_Customer ) {
 			$meta_data['billing']    = $customer->get_meta( self::BILLING_FIELDS_KEY, true );
 			$meta_data['shipping']   = $customer->get_meta( self::SHIPPING_FIELDS_KEY, true );
@@ -1023,11 +1024,12 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	public function get_all_fields_from_order( $order, $all = false ) {
-		$meta_data = array(
-			'billing'    => array(),
-			'shipping'   => array(),
-			'additional' => array(),
-		);
+		$meta_data = [
+			'billing'    => [],
+			'shipping'   => [],
+			'additional' => [],
+		];
+
 		if ( $order instanceof WC_Order ) {
 			$meta_data['billing']    = $order->get_meta( self::BILLING_FIELDS_KEY, true );
 			$meta_data['shipping']   = $order->get_meta( self::SHIPPING_FIELDS_KEY, true );
@@ -1045,11 +1047,11 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	private function format_meta_data( $meta, $all = false ) {
-		$billing_fields    = $meta['billing'] ?? array();
-		$shipping_fields   = $meta['shipping'] ?? array();
-		$additional_fields = $meta['additional'] ?? array();
+		$billing_fields    = $meta['billing'] ?? [];
+		$shipping_fields   = $meta['shipping'] ?? [];
+		$additional_fields = $meta['additional'] ?? [];
 
-		$fields = array();
+		$fields = [];
 
 		if ( is_array( $billing_fields ) ) {
 			foreach ( $billing_fields as $key => $value ) {
@@ -1155,7 +1157,7 @@ class CheckoutFields {
 	 */
 	public function get_order_additional_fields_with_values( $order, $location, $group = '', $context = 'edit' ) {
 		$fields             = $this->get_fields_for_location( $location );
-		$fields_with_values = array();
+		$fields_with_values = [];
 
 		foreach ( $fields as $field_key => $field ) {
 			$value = $this->get_field_from_order( $field_key, $order, $group );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -75,123 +75,123 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		$additional_field_schema = $this->get_additional_fields_schema();
-		return [
-			'order_id'          => [
+		return array(
+			'order_id'          => array(
 				'description' => __( 'The order ID to process during checkout.', 'woocommerce' ),
 				'type'        => 'integer',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-			],
-			'status'            => [
+			),
+			'status'            => array(
 				'description' => __( 'Order status. Payment providers will update this value after payment.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-			],
-			'order_key'         => [
+			),
+			'order_key'         => array(
 				'description' => __( 'Order key used to check validity or protect access to certain order data.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-			],
-			'order_number'      => [
+			),
+			'order_number'      => array(
 				'description' => __( 'Order number used for display.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-			],
-			'customer_note'     => [
+			),
+			'customer_note'     => array(
 				'description' => __( 'Note added to the order by the customer during checkout.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
-			],
-			'customer_id'       => [
+				'context'     => array( 'view', 'edit' ),
+			),
+			'customer_id'       => array(
 				'description' => __( 'Customer ID if registered. Will return 0 for guests.', 'woocommerce' ),
 				'type'        => 'integer',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-			],
-			'billing_address'   => [
+			),
+			'billing_address'   => array(
 				'description' => __( 'Billing address.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'properties'  => $this->billing_address_schema->get_properties(),
-				'arg_options' => [
-					'sanitize_callback' => [ $this->billing_address_schema, 'sanitize_callback' ],
-					'validate_callback' => [ $this->billing_address_schema, 'validate_callback' ],
-				],
+				'arg_options' => array(
+					'sanitize_callback' => array( $this->billing_address_schema, 'sanitize_callback' ),
+					'validate_callback' => array( $this->billing_address_schema, 'validate_callback' ),
+				),
 				'required'    => true,
-			],
-			'shipping_address'  => [
+			),
+			'shipping_address'  => array(
 				'description' => __( 'Shipping address.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'properties'  => $this->shipping_address_schema->get_properties(),
-				'arg_options' => [
-					'sanitize_callback' => [ $this->shipping_address_schema, 'sanitize_callback' ],
-					'validate_callback' => [ $this->shipping_address_schema, 'validate_callback' ],
-				],
-			],
-			'payment_method'    => [
+				'arg_options' => array(
+					'sanitize_callback' => array( $this->shipping_address_schema, 'sanitize_callback' ),
+					'validate_callback' => array( $this->shipping_address_schema, 'validate_callback' ),
+				),
+			),
+			'payment_method'    => array(
 				'description' => __( 'The ID of the payment method being used to process the payment.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				// Validation may be based on cart contents which is not available here; this returns all enabled
 				// gateways. Further validation occurs during the request.
 				'enum'        => array_values( WC()->payment_gateways->get_payment_gateway_ids() ),
-			],
-			'create_account'    => [
+			),
+			'create_account'    => array(
 				'description' => __( 'Whether to create a new user account as part of order processing.', 'woocommerce' ),
 				'type'        => 'boolean',
-				'context'     => [ 'view', 'edit' ],
-			],
-			'payment_result'    => [
+				'context'     => array( 'view', 'edit' ),
+			),
+			'payment_result'    => array(
 				'description' => __( 'Result of payment processing, or false if not yet processed.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-				'properties'  => [
-					'payment_status'  => [
+				'properties'  => array(
+					'payment_status'  => array(
 						'description' => __( 'Status of the payment returned by the gateway. One of success, pending, failure, error.', 'woocommerce' ),
 						'readonly'    => true,
 						'type'        => 'string',
-					],
-					'payment_details' => [
+					),
+					'payment_details' => array(
 						'description' => __( 'An array of data being returned from the payment gateway.', 'woocommerce' ),
 						'readonly'    => true,
 						'type'        => 'array',
-						'items'       => [
+						'items'       => array(
 							'type'       => 'object',
-							'properties' => [
-								'key'   => [
+							'properties' => array(
+								'key'   => array(
 									'type' => 'string',
-								],
-								'value' => [
+								),
+								'value' => array(
 									'type' => 'string',
-								],
-							],
-						],
-					],
-					'redirect_url'    => [
+								),
+							),
+						),
+					),
+					'redirect_url'    => array(
 						'description' => __( 'A URL to redirect the customer after checkout. This could be, for example, a link to the payment processors website.', 'woocommerce' ),
 						'readonly'    => true,
 						'type'        => 'string',
-					],
-				],
-			],
-			'additional_fields' => [
+					),
+				),
+			),
+			'additional_fields' => array(
 				'description' => __( 'Additional fields to be persisted on the order.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'properties'  => $additional_field_schema,
-				'arg_options' => [
-					'sanitize_callback' => [ $this, 'sanitize_additional_fields' ],
-					'validate_callback' => [ $this, 'validate_additional_fields' ],
-				],
+				'arg_options' => array(
+					'sanitize_callback' => array( $this, 'sanitize_additional_fields' ),
+					'validate_callback' => array( $this, 'validate_additional_fields' ),
+				),
 				'required'    => $this->schema_has_required_property( $additional_field_schema ),
-			],
+			),
 			self::EXTENDING_KEY => $this->get_extended_schema( self::IDENTIFIER ),
-		];
+		);
 	}
 
 	/**
@@ -212,7 +212,7 @@ class CheckoutSchema extends AbstractSchema {
 	 * @return array
 	 */
 	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null ) {
-		return [
+		return array(
 			'order_id'          => $order->get_id(),
 			'status'            => $order->get_status(),
 			'order_key'         => $order->get_order_key(),
@@ -222,14 +222,14 @@ class CheckoutSchema extends AbstractSchema {
 			'billing_address'   => (object) $this->billing_address_schema->get_item_response( $order ),
 			'shipping_address'  => (object) $this->shipping_address_schema->get_item_response( $order ),
 			'payment_method'    => $order->get_payment_method(),
-			'payment_result'    => [
+			'payment_result'    => array(
 				'payment_status'  => $payment_result->status,
 				'payment_details' => $this->prepare_payment_details_for_response( $payment_result->payment_details ),
 				'redirect_url'    => $payment_result->redirect_url,
-			],
+			),
 			'additional_fields' => $this->get_additional_fields_response( $order ),
 			self::EXTENDING_KEY => $this->get_extended_data( self::IDENTIFIER ),
-		];
+		);
 	}
 
 	/**
@@ -243,11 +243,11 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	protected function prepare_payment_details_for_response( array $payment_details ) {
 		return array_map(
-			function( $key, $value ) {
-				return (object) [
+			function ( $key, $value ) {
+				return (object) array(
 					'key'   => $key,
 					'value' => $value,
-				];
+				);
 			},
 			array_keys( $payment_details ),
 			$payment_details
@@ -265,7 +265,7 @@ class CheckoutSchema extends AbstractSchema {
 			$this->additional_fields_controller->get_all_fields_from_order( $order ),
 			$this->additional_fields_controller->get_all_fields_from_customer( wc()->customer )
 		);
-		$response = [];
+		$response = array();
 
 		foreach ( $fields as $key => $value ) {
 			if ( 0 === strpos( $key, '/billing/' ) || 0 === strpos( $key, '/shipping/' ) ) {
@@ -297,18 +297,18 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	protected function generate_additional_fields_schema( ...$args ) {
 		$additional_fields = array_merge( ...$args );
-		$schema            = [];
+		$schema            = array();
 		foreach ( $additional_fields as $key => $field ) {
-			$field_schema = [
+			$field_schema = array(
 				'description' => $field['label'],
 				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
+				'context'     => array( 'view', 'edit' ),
 				'required'    => $field['required'],
-			];
+			);
 
 			if ( 'select' === $field['type'] ) {
 				$field_schema['enum'] = array_map(
-					function( $option ) {
+					function ( $option ) {
 						return $option['value'];
 					},
 					$field['options']
@@ -333,7 +333,7 @@ class CheckoutSchema extends AbstractSchema {
 	protected function schema_has_required_property( $additional_fields_schema ) {
 		return array_reduce(
 			array_keys( $additional_fields_schema ),
-			function( $carry, $key ) use ( $additional_fields_schema ) {
+			function ( $carry, $key ) use ( $additional_fields_schema ) {
 				return $carry || $additional_fields_schema[ $key ]['required'];
 			},
 			false
@@ -352,7 +352,7 @@ class CheckoutSchema extends AbstractSchema {
 		$fields             = $sanitization_utils->wp_kses_array(
 			array_reduce(
 				array_keys( $fields ),
-				function( $carry, $key ) use ( $fields, $properties ) {
+				function ( $carry, $key ) use ( $fields, $properties ) {
 					if ( ! isset( $properties[ $key ] ) ) {
 						return $carry;
 					}
@@ -362,7 +362,7 @@ class CheckoutSchema extends AbstractSchema {
 					$carry[ $key ]  = $rest_sanitized;
 					return $carry;
 				},
-				[]
+				array()
 			)
 		);
 
@@ -389,7 +389,7 @@ class CheckoutSchema extends AbstractSchema {
 				// Optional fields can go missing.
 				continue;
 			}
-			$field_value = $fields[ $key ];
+			$field_value = isset( $fields[ $key ] ) ? $fields[ $key ] : null;
 			$result      = rest_validate_value_from_schema( $field_value, $schema, $key );
 
 			// Only allow custom validation on fields that pass the schema validation.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -383,12 +383,14 @@ class CheckoutSchema extends AbstractSchema {
 		$fields                  = $this->sanitize_additional_fields( $fields );
 		$additional_field_schema = $this->get_additional_fields_schema();
 
-		// Validate individual properties first.
-		foreach ( $fields as $key => $field_value ) {
-			if ( ! isset( $additional_field_schema[ $key ] ) ) {
+		// Loop over the schema instead of the fields. This is to ensure missing fields are validated.
+		foreach ( $additional_field_schema as $key => $schema ) {
+			if ( ! isset( $fields[ $key ] ) && ! $schema['required'] ) {
+				// Optional fields can go missing.
 				continue;
 			}
-			$result = rest_validate_value_from_schema( $field_value, $additional_field_schema[ $key ], $key );
+			$field_value = $fields[ $key ];
+			$result      = rest_validate_value_from_schema( $field_value, $schema, $key );
 
 			// Only allow custom validation on fields that pass the schema validation.
 			if ( true === $result ) {
@@ -422,6 +424,6 @@ class CheckoutSchema extends AbstractSchema {
 			}
 		}
 
-		return $errors->has_errors( $errors ) ? $errors : true;
+		return $errors->has_errors() ? $errors : true;
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -75,123 +75,123 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		$additional_field_schema = $this->get_additional_fields_schema();
-		return array(
-			'order_id'          => array(
+		return [
+			'order_id'          => [
 				'description' => __( 'The order ID to process during checkout.', 'woocommerce' ),
 				'type'        => 'integer',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'status'            => array(
+			],
+			'status'            => [
 				'description' => __( 'Order status. Payment providers will update this value after payment.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'order_key'         => array(
+			],
+			'order_key'         => [
 				'description' => __( 'Order key used to check validity or protect access to certain order data.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'order_number'      => array(
+			],
+			'order_number'      => [
 				'description' => __( 'Order number used for display.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'customer_note'     => array(
+			],
+			'customer_note'     => [
 				'description' => __( 'Note added to the order by the customer during checkout.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
-			),
-			'customer_id'       => array(
+				'context'     => [ 'view', 'edit' ],
+			],
+			'customer_id'       => [
 				'description' => __( 'Customer ID if registered. Will return 0 for guests.', 'woocommerce' ),
 				'type'        => 'integer',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'billing_address'   => array(
+			],
+			'billing_address'   => [
 				'description' => __( 'Billing address.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'properties'  => $this->billing_address_schema->get_properties(),
-				'arg_options' => array(
-					'sanitize_callback' => array( $this->billing_address_schema, 'sanitize_callback' ),
-					'validate_callback' => array( $this->billing_address_schema, 'validate_callback' ),
-				),
+				'arg_options' => [
+					'sanitize_callback' => [ $this->billing_address_schema, 'sanitize_callback' ],
+					'validate_callback' => [ $this->billing_address_schema, 'validate_callback' ],
+				],
 				'required'    => true,
-			),
-			'shipping_address'  => array(
+			],
+			'shipping_address'  => [
 				'description' => __( 'Shipping address.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'properties'  => $this->shipping_address_schema->get_properties(),
-				'arg_options' => array(
-					'sanitize_callback' => array( $this->shipping_address_schema, 'sanitize_callback' ),
-					'validate_callback' => array( $this->shipping_address_schema, 'validate_callback' ),
-				),
-			),
-			'payment_method'    => array(
+				'arg_options' => [
+					'sanitize_callback' => [ $this->shipping_address_schema, 'sanitize_callback' ],
+					'validate_callback' => [ $this->shipping_address_schema, 'validate_callback' ],
+				],
+			],
+			'payment_method'    => [
 				'description' => __( 'The ID of the payment method being used to process the payment.', 'woocommerce' ),
 				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				// Validation may be based on cart contents which is not available here; this returns all enabled
 				// gateways. Further validation occurs during the request.
 				'enum'        => array_values( WC()->payment_gateways->get_payment_gateway_ids() ),
-			),
-			'create_account'    => array(
+			],
+			'create_account'    => [
 				'description' => __( 'Whether to create a new user account as part of order processing.', 'woocommerce' ),
 				'type'        => 'boolean',
-				'context'     => array( 'view', 'edit' ),
-			),
-			'payment_result'    => array(
+				'context'     => [ 'view', 'edit' ],
+			],
+			'payment_result'    => [
 				'description' => __( 'Result of payment processing, or false if not yet processed.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-				'properties'  => array(
-					'payment_status'  => array(
+				'properties'  => [
+					'payment_status'  => [
 						'description' => __( 'Status of the payment returned by the gateway. One of success, pending, failure, error.', 'woocommerce' ),
 						'readonly'    => true,
 						'type'        => 'string',
-					),
-					'payment_details' => array(
+					],
+					'payment_details' => [
 						'description' => __( 'An array of data being returned from the payment gateway.', 'woocommerce' ),
 						'readonly'    => true,
 						'type'        => 'array',
-						'items'       => array(
+						'items'       => [
 							'type'       => 'object',
-							'properties' => array(
-								'key'   => array(
+							'properties' => [
+								'key'   => [
 									'type' => 'string',
-								),
-								'value' => array(
+								],
+								'value' => [
 									'type' => 'string',
-								),
-							),
-						),
-					),
-					'redirect_url'    => array(
+								],
+							],
+						],
+					],
+					'redirect_url'    => [
 						'description' => __( 'A URL to redirect the customer after checkout. This could be, for example, a link to the payment processors website.', 'woocommerce' ),
 						'readonly'    => true,
 						'type'        => 'string',
-					),
-				),
-			),
-			'additional_fields' => array(
+					],
+				],
+			],
+			'additional_fields' => [
 				'description' => __( 'Additional fields to be persisted on the order.', 'woocommerce' ),
 				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'properties'  => $additional_field_schema,
-				'arg_options' => array(
-					'sanitize_callback' => array( $this, 'sanitize_additional_fields' ),
-					'validate_callback' => array( $this, 'validate_additional_fields' ),
-				),
+				'arg_options' => [
+					'sanitize_callback' => [ $this, 'sanitize_additional_fields' ],
+					'validate_callback' => [ $this, 'validate_additional_fields' ],
+				],
 				'required'    => $this->schema_has_required_property( $additional_field_schema ),
-			),
+			],
 			self::EXTENDING_KEY => $this->get_extended_schema( self::IDENTIFIER ),
-		);
+		];
 	}
 
 	/**
@@ -212,7 +212,7 @@ class CheckoutSchema extends AbstractSchema {
 	 * @return array
 	 */
 	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null ) {
-		return array(
+		return [
 			'order_id'          => $order->get_id(),
 			'status'            => $order->get_status(),
 			'order_key'         => $order->get_order_key(),
@@ -222,14 +222,14 @@ class CheckoutSchema extends AbstractSchema {
 			'billing_address'   => (object) $this->billing_address_schema->get_item_response( $order ),
 			'shipping_address'  => (object) $this->shipping_address_schema->get_item_response( $order ),
 			'payment_method'    => $order->get_payment_method(),
-			'payment_result'    => array(
+			'payment_result'    => [
 				'payment_status'  => $payment_result->status,
 				'payment_details' => $this->prepare_payment_details_for_response( $payment_result->payment_details ),
 				'redirect_url'    => $payment_result->redirect_url,
-			),
+			],
 			'additional_fields' => $this->get_additional_fields_response( $order ),
 			self::EXTENDING_KEY => $this->get_extended_data( self::IDENTIFIER ),
-		);
+		];
 	}
 
 	/**
@@ -244,10 +244,10 @@ class CheckoutSchema extends AbstractSchema {
 	protected function prepare_payment_details_for_response( array $payment_details ) {
 		return array_map(
 			function ( $key, $value ) {
-				return (object) array(
+				return (object) [
 					'key'   => $key,
 					'value' => $value,
-				);
+				];
 			},
 			array_keys( $payment_details ),
 			$payment_details
@@ -265,7 +265,7 @@ class CheckoutSchema extends AbstractSchema {
 			$this->additional_fields_controller->get_all_fields_from_order( $order ),
 			$this->additional_fields_controller->get_all_fields_from_customer( wc()->customer )
 		);
-		$response = array();
+		$response = [];
 
 		foreach ( $fields as $key => $value ) {
 			if ( 0 === strpos( $key, '/billing/' ) || 0 === strpos( $key, '/shipping/' ) ) {
@@ -297,14 +297,14 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	protected function generate_additional_fields_schema( ...$args ) {
 		$additional_fields = array_merge( ...$args );
-		$schema            = array();
+		$schema            = [];
 		foreach ( $additional_fields as $key => $field ) {
-			$field_schema = array(
+			$field_schema = [
 				'description' => $field['label'],
 				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'required'    => $field['required'],
-			);
+			];
 
 			if ( 'select' === $field['type'] ) {
 				$field_schema['enum'] = array_map(
@@ -362,7 +362,7 @@ class CheckoutSchema extends AbstractSchema {
 					$carry[ $key ]  = $rest_sanitized;
 					return $carry;
 				},
-				array()
+				[]
 			)
 		);
 
@@ -389,6 +389,7 @@ class CheckoutSchema extends AbstractSchema {
 				// Optional fields can go missing.
 				continue;
 			}
+
 			$field_value = isset( $fields[ $key ] ) ? $fields[ $key ] : null;
 			$result      = rest_validate_value_from_schema( $field_value, $schema, $key );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1315,7 +1315,8 @@ class AdditionalFields extends MockeryTestCase {
 				),
 				'payment_method'    => 'bacs',
 				'additional_fields' => array(
-					$id => 'value',
+					'plugin-namespace/job-function' => 'engineering',
+					$id                             => 'value',
 				),
 			)
 		);
@@ -1383,7 +1384,8 @@ class AdditionalFields extends MockeryTestCase {
 				),
 				'payment_method'    => 'bacs',
 				'additional_fields' => array(
-					$id => 'invalid',
+					'plugin-namespace/job-function' => 'engineering',
+					$id                             => 'invalid',
 				),
 			)
 		);
@@ -1458,7 +1460,8 @@ class AdditionalFields extends MockeryTestCase {
 				),
 				'payment_method'    => 'bacs',
 				'additional_fields' => array(
-					$id => 'value',
+					'plugin-namespace/job-function' => 'engineering',
+					$id                             => 'value',
 				),
 			)
 		);
@@ -1533,7 +1536,8 @@ class AdditionalFields extends MockeryTestCase {
 				),
 				'payment_method'    => 'bacs',
 				'additional_fields' => array(
-					$id => 'invalid',
+					'plugin-namespace/job-function' => 'engineering',
+					$id                             => 'invalid',
 				),
 			)
 		);
@@ -1597,7 +1601,9 @@ class AdditionalFields extends MockeryTestCase {
 					'plugin-namespace/gov-id' => 'gov id',
 				),
 				'payment_method'    => 'bacs',
-				'additional_fields' => array(),
+				'additional_fields' => array(
+					'plugin-namespace/job-function' => 'engineering',
+				),
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -1659,7 +1665,9 @@ class AdditionalFields extends MockeryTestCase {
 					'plugin-namespace/gov-id' => 'gov id',
 				),
 				'payment_method'    => 'bacs',
-				'additional_fields' => array(),
+				'additional_fields' => array(
+					'plugin-namespace/job-function' => 'engineering',
+				),
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -141,7 +141,8 @@ class AdditionalFields extends MockeryTestCase {
 	 * Unregister fields after testing.
 	 */
 	private function unregister_fields() {
-		array_map( '__internal_woocommerce_blocks_deregister_checkout_field', array_column( $this->fields, 'id' ) );
+		$fields = $this->controller->get_additional_fields();
+		array_map( '__internal_woocommerce_blocks_deregister_checkout_field', array_keys( $fields ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1616,13 +1616,11 @@ class AdditionalFields extends MockeryTestCase {
 	 * Ensures an error is returned when required fields in Contact are missing.
 	 */
 	public function test_place_order_required_contact_field() {
-		$this->markTestSkipped( 'Additional fields aren\'t validated due to a bug #45496.' );
-		$id    = 'plugin-namespace/my-required-contact-field';
-		$label = 'My Required Field';
+		$id = 'plugin-namespace/my-required-contact-field';
 		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
-				'label'    => $label,
+				'label'    => 'My Required Field',
 				'location' => 'contact',
 				'type'     => 'text',
 				'required' => true,
@@ -1668,8 +1666,7 @@ class AdditionalFields extends MockeryTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status(), print_r( $data, true ) );
-		// Error should be updated once we got this working.
-		$this->assertEquals( \sprintf( 'There was a problem with the provided shipping address: %s is required', $label ), $data['message'], print_r( $data, true ) );
+		$this->assertEquals( \sprintf( '%s is not of type string.', $id ), $data['data']['params']['additional_fields'], print_r( $data, true ) );
 
 		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In additional fields, we would only validate passed fields, this means required missing fields would not get validated, this fixes it and enable the test for it.

Closes https://github.com/woocommerce/woocommerce/issues/45496

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Tests should pass.
2. Add the following snippet to your store
```php
add_action(
	'woocommerce_loaded',
	function () {
		__experimental_woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'plugin-namespace/job-function',
				'label'    => 'What is your main role at your company?',
				'location' => 'additional',
				'required' => true,
				'type'     => 'text',
			)
		);
	}
);
```
3. Send this request to Store API after adding to cart:
```json
{
	"billing_address": {
		"first_name": "test",
		"last_name": "test",
		"company": "",
		"address_1": "test",
		"address_2": "",
		"city": "test",
		"state": "",
		"postcode": "cb241ab",
		"country": "GB",
		"phone": "",
		"email": "testaccount@test.com"
	},
	"shipping_address": {
		"first_name": "test",
		"last_name": "test",
		"company": "",
		"address_1": "test",
		"address_2": "",
		"city": "test",
		"state": "",
		"postcode": "cb241ab",
		"country": "GB",
		"phone": ""
	},
	"payment_method": "bacs",
	"additional_fields": {}
}
```
4. You should get an error saying the field is missing or not the correct type.
