### PR TITLE
Create a beforeStep handler for product tour

### DIFF
--- a/packages/js/components/changelog/45845-dakota-product-tour-add-before-handler
+++ b/packages/js/components/changelog/45845-dakota-product-tour-add-before-handler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Adds a `onBeforeStep` callback to the product tour

--- a/packages/js/components/src/tour-kit/types.ts
+++ b/packages/js/components/src/tour-kit/types.ts
@@ -33,6 +33,7 @@ export interface WooStep extends Step {
 			text?: string;
 			isVisible?: boolean;
 		};
+		onBeforeStep?: () => void;
 	};
 	/** Auto apply the focus state for the element. Default to null */
 	focusElement?: {

--- a/plugins/woocommerce-admin/client/guided-tours/add-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-tour/index.tsx
@@ -289,6 +289,7 @@ export const ProductTour = () => {
 		},
 		onNextStepHandler: ( stepIndex ) => {
 			const stepName = tourConfig.steps[ stepIndex ].meta.name;
+			tourConfig.steps?.[ stepIndex + 1 ].meta.onBeforeStep?.();
 
 			// This records all "next" steps and ignores the final "publish" step.
 			recordEvent( 'walkthrough_product_step_completed', {

--- a/plugins/woocommerce/changelog/45845-dakota-product-tour-add-before-handler
+++ b/plugins/woocommerce/changelog/45845-dakota-product-tour-add-before-handler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Adds a `onBeforeStep` callback to the product tour


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Building on from the work done in https://github.com/woocommerce/woocommerce/pull/45617, the ability to add a before step callback was needed for certain product tours. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout and build this PR
2. Checkout and build https://github.com/woocommerce/woocommerce-product-bundles/pull/1339 of WooCommerce Product Bundles (You can ask @jimjasson for a pre-release zip if needed)
3. Using the onboarding task list (`/wp-admin/admin.php?page=wc-admin&task=products`), create a new product bundle
4. You should be taken to a new product page with a type of `product bundle` and the tour should be displayed
5. Follow the tour to see that the product data tabs are activated as needed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds a `onBeforeStep` callback to the product tour

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
