### PR TITLE
Product Editor: Show correct Publish/Schedule button label when timezone is behind UTC (UTC-1, UTC-4, UTC-9, etc.)

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-publish-schedule-button-label
+++ b/packages/js/product-editor/changelog/fix-product-editor-publish-schedule-button-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: Show correct Publish/Schedule button label.

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -4,7 +4,6 @@
 import { MouseEvent } from 'react';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { isInTheFuture } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import type { Product } from '@woocommerce/data';
 
@@ -12,6 +11,7 @@ import type { Product } from '@woocommerce/data';
  * Internal dependencies
  */
 import { useProductManager } from '../../../../hooks/use-product-manager';
+import { useProductScheduled } from '../../../../hooks/use-product-scheduled';
 import type { WPError } from '../../../../utils/get-product-error-message';
 import type { PublishButtonProps } from '../../publish-button';
 
@@ -35,11 +35,7 @@ export function usePublish< T = Product >( {
 		'status'
 	);
 
-	const [ editedDate ] = useEntityProp< string >(
-		'postType',
-		productType,
-		'date_created_gmt'
-	);
+	const { isScheduled } = useProductScheduled( productType );
 
 	const isBusy = isPublishing || isValidating;
 	const isDisabled =
@@ -61,7 +57,7 @@ export function usePublish< T = Product >( {
 	function getButtonText() {
 		if (
 			window.wcAdminFeatures[ 'product-pre-publish-modal' ] &&
-			isInTheFuture( editedDate )
+			isScheduled
 		) {
 			return __( 'Schedule', 'woocommerce' );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a problem that has been observed on some installations where the WordPress timezone (**Settings** > **General** > **Timezone**) is set to a UTC minus anything value (UTC-1, UTC-4, UTC-9, etc.)...

1. Go to **Products** > **Add New**
2. Enter a product name
3. Click **Schedule** (this is the bug... it should be **Publish**)
4. Verify that there is a mis-match between the button in the header and the pre-publish sidebar...

<img width="1125" alt="Screenshot 2024-03-22 at 12 11 54" src="https://github.com/woocommerce/woocommerce/assets/2098816/bace1fd7-5374-444c-8fd7-4e213f18bb48">



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Make sure the WordPress timezone is set to a UTC minus anything value (UTC-1, UTC-4, UTC-9, etc.) in **Settings** > **General** > **Timezone**
2. Go to to **Products** > **Add New**
3. Enter a product name
4. Click **Publish** (if the button is labeled **Schedule**, then this bug is *not* fixed)
5. Verify that the button in the header and the pre-publish sidebar are in-sync and correct for various values of the scheduled date
    - Selecting **Now** should reset things to **Publish** and **Publish: [DATE/TIME]**
    - Selecting a date/time in the past should set things to **Publish** and **Publish: Immediately**
    - Select a date/time in the future should set things to **Schedule** and **Publish: [DATE/TIME]**

<img width="1125" alt="Screenshot 2024-03-22 at 12 13 59" src="https://github.com/woocommerce/woocommerce/assets/2098816/ab2feeb8-518e-4db6-800f-67c962f7a346">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
