### PR TITLE
assign blocks PHP PR reviews to blocks teams

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -85,9 +85,17 @@
   - team: mothra
   - team: ghidorah
 
+"plugins/woocommerce/src/Blocks/**/*":
+  - team: rubik
+  - team: woo-fse
+
 "plugins/woocommerce/src/Internal/Admin/**/*":
   - team: mothra
   - team: ghidorah
+
+"plugins/woocommerce/src/StoreApi/**/*":
+  - team: rubik
+  - team: woo-fse
 
 "plugins/woocommerce-admin/**/*":
   - team: mothra


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds entries to the community PR assignment configuration to assign PRs changing `src/StoreApi` or `src/Blocks` to both Rubik & Woo FSE. This is consistent with the PR assignment for the `plugins/woocommerce-blocks` folder. Currently all PRs making changes to the `src` folder are assigned to Proton.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. YAML review.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
