### PR TITLE
Fix "add_action" accepted args

### DIFF
--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -402,7 +402,7 @@ add_action(
 		}
 	},
 	10,
-	4
+	3
 );
 ```
 
@@ -524,11 +524,9 @@ add_action(
 				return $error;
 			},
 			10,
-			4
+			3
 		);
-	},
-	10,
-	4
+	}
 );
 
 add_action(

--- a/plugins/woocommerce/changelog/45862-patch-4
+++ b/plugins/woocommerce/changelog/45862-patch-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: No changelog needed, this is just a docs update
+


### PR DESCRIPTION
Fixing the "add_action" accepted args on the "Additional Checkout Fields" examples

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Just fixing examples
### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment
No changelog needed, this is just a docs update

</details>

