### PR TITLE
[e2e tests] Update customer-payment-page spec to be theme agnostic

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-customer-payment-page-fix
+++ b/plugins/woocommerce/changelog/e2e-fix-customer-payment-page-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: make payment page tests more resilient to theme changes

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
@@ -79,9 +79,9 @@ test.describe( 'WooCommerce Merchant Flow: Orders > Customer Payment Page', () =
 		await page.locator( 'label[for=order_status] > a' ).click();
 
 		// verify we landed on the customer payment page
-		await expect( page.locator( 'h1.entry-title' ) ).toContainText(
-			'Pay for order'
-		);
+		await expect(
+			page.getByText( 'You are paying for a guest order.' )
+		).toBeVisible();
 		await expect( page.locator( 'td.product-name' ) ).toContainText(
 			productName
 		);
@@ -101,14 +101,14 @@ test.describe( 'WooCommerce Merchant Flow: Orders > Customer Payment Page', () =
 		await page.locator( 'button#place_order' ).click();
 
 		// Verify we landed on the order received page
-		await expect( page.locator( 'h1.entry-title' ) ).toContainText(
-			'Order received'
-		);
 		await expect(
-			page.locator( 'li.woocommerce-order-overview__order.order' )
-		).toContainText( orderId.toString() );
+			page.getByText( 'Your order has been received' )
+		).toBeVisible();
 		await expect(
-			page.locator( 'span.woocommerce-Price-amount.amount >> nth=0' )
-		).toContainText( productPrice );
+			page.getByText( `Order number: ${ orderId }` )
+		).toBeVisible();
+		await expect(
+			await page.getByText( `Total: $${ productPrice }` ).count()
+		).toBeGreaterThan( 0 );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45885

`customer-payment-page.spec.js` fails when checking the order in frontend with themes other than twentynineteen. There are tests that change the active theme, and the possibility that the theme is not properly (or in time) set back to the expected one adds a chance that these tests will fail. This is most probably the reason they started failing recently, after https://github.com/woocommerce/woocommerce/pull/45356 was merged, which activates different themes during testing.

This PR updates some of the checks in these test to make them more theme agnostic.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Locally: 

Start the env: `pnpm env:start`
Run the tests with `pnpm test:e2e-pw customer-payment-page.spec.js`
Activate different themes and run the tests again. They should pass with each theme.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
