### PR TITLE
Change Tracks event name for Quick variations menu action

### DIFF
--- a/packages/js/product-editor/changelog/fix-41761_tracks_event_name_for_downloads
+++ b/packages/js/product-editor/changelog/fix-41761_tracks_event_name_for_downloads
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Change Tracks event name for Quick variations menu action #45889

--- a/packages/js/product-editor/src/components/variations-table/downloads-menu-item/downloads-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/downloads-menu-item/downloads-menu-item.tsx
@@ -136,10 +136,13 @@ export function DownloadsMenuItem( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<MenuItem
 					onClick={ () => {
-						recordEvent( 'product_variations_menu_shipping_click', {
-							source: TRACKS_SOURCE,
-							variation_id: ids,
-						} );
+						recordEvent(
+							'product_variations_menu_downloads_click',
+							{
+								source: TRACKS_SOURCE,
+								variation_id: ids,
+							}
+						);
 						onToggle();
 					} }
 					aria-expanded={ isOpen }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR renames a Tracks event triggered after clicking a Quick action menu for variations.

![Image](https://github.com/woocommerce/woocommerce/assets/13561163/eb7764b4-b8ae-4c04-83cb-b745c6f2b2af)

Closes #41761.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Create a new product with the new editor, incl. variations.
3. Go to the _Variations_ tab. 
4. Select all variations and _Quick update._
5. Select _Downloads_.
6. Verify that the name of the fired event is: `wcadmin_product_variations_menu_downloads_click `

![Screenshot 2024-03-25 at 10 53 36 AM](https://github.com/woocommerce/woocommerce/assets/1314156/bc31d816-642b-48f4-a38d-da7be6a31c6b)


* _To test this PR you should enable the wc-admin Tracking under `Tools > WCA Test Helper > Tools`. Then open the browser's dev tools and go to the `Console` tab. Click on the `All levels` selector and choose `Verbose`.
After that, you will see the `Tracks` events fired from the React side in the `Console` tab._

![image](https://github.com/woocommerce/woocommerce/assets/1314156/1155bbaa-dd03-4ca5-b443-02fec73b6b52)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
