### PR TITLE
Fix DataSourcePoller footer error on upgrade downgrade

### DIFF
--- a/plugins/woocommerce/changelog/fix-wcpaypromotion-footer-error-on-upgrade-downgrade
+++ b/plugins/woocommerce/changelog/fix-wcpaypromotion-footer-error-on-upgrade-downgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatals from DataSourcePoller call when downgrade or upgrade WC

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -111,6 +111,11 @@ class Init extends RemoteSpecsEngine {
 	 * Go through the specs and run them.
 	 */
 	public static function get_promotions() {
+		// Hacky fix for footer error on upgrade/downgrade WC.
+		if ( ! class_exists( '\Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller' ) ) {
+			return array();
+		}
+
 		$locale = get_user_locale();
 
 		$specs   = self::get_specs();

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -111,11 +111,6 @@ class Init extends RemoteSpecsEngine {
 	 * Go through the specs and run them.
 	 */
 	public static function get_promotions() {
-		// Hacky fix for footer error on upgrade/downgrade WC.
-		if ( ! class_exists( '\Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller' ) ) {
-			return array();
-		}
-
 		$locale = get_user_locale();
 
 		$specs   = self::get_specs();

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPayPromotionDataSourcePoller.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPayPromotionDataSourcePoller.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Automattic\WooCommerce\Internal\Admin\WCPayPromotion;
 
-use Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller;
+use Automattic\WooCommerce\Admin\DataSourcePoller;
 
 /**
  * Specs data source poller class for WooCommerce Payment Promotion.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes fatal error caused by DataSourcePoller class refactor p1711334228664619/1711312760.121469-slack-C05JQBR78RW

The issue originates from an existing version of WooCommerce is run while it is being upgraded/downgraded.

In this instance, my observation is the `WCPayPromotionDataSourcePoller` file is the new version while being called from a previous version WC (currently 8.7.0 in a standard Woo Express site). As a result, `Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller` doesn't exists since it's introduced in 8.8.0.

My fix will simply use the old `DataSourcePoller` path which is handled properly in previous versions since the file's inception and 8.8.0.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Upgrade test
1. Follow the instructions in p1711313371293309/1711312760.121469-slack-C05JQBR78RW to create Woo Express site
2. Go to `/wp-admin/plugin-install.php`
2. Upload WooCommerce with the zipfile in this PR ([artifact](https://github.com/woocommerce/woocommerce/actions/runs/8430109561), or [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/14752051/woocommerce.zip))
3. Go to `WooCommerce > Status > Logs` and look for `fatal-errors-*` log
4. Observe no fatal error `CRITICAL Uncaught Error: Class "Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller" not found in /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPayPromotionDataSourcePoller.php:9`

#### Downgrade test
1. Go back to `/wp-admin/plugin-install.php`
6. Upload [WooCommerce 8.7.0](https://github.com/woocommerce/woocommerce/releases/tag/8.7.0)
3. Go to `WooCommerce > Status > Logs` and look for `fatal-errors-*` log
7. Observe no similar fatal error 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>