### PR TITLE
Default to `live` when woocommerce_coming_soon option is not available

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -28,6 +28,7 @@ const SiteVisibility = () => {
 		privateLink: initialPrivateLink = false,
 	} = useLaunchYourStore();
 	const [ comingSoon, setComingSoon ] = useState( initialComingSoon );
+
 	const [ storePagesOnly, setStorePagesOnly ] = useState(
 		initialStorePagesOnly
 	);
@@ -35,7 +36,7 @@ const SiteVisibility = () => {
 
 	useEffect( () => {
 		if ( ! isLoading ) {
-			setComingSoon( initialComingSoon );
+			setComingSoon( initialComingSoon ? initialComingSoon : 'no' );
 			setStorePagesOnly( initialStorePagesOnly );
 			setPrivateLink( initialPrivateLink );
 		}

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -28,7 +28,6 @@ const SiteVisibility = () => {
 		privateLink: initialPrivateLink = false,
 	} = useLaunchYourStore();
 	const [ comingSoon, setComingSoon ] = useState( initialComingSoon );
-
 	const [ storePagesOnly, setStorePagesOnly ] = useState(
 		initialStorePagesOnly
 	);

--- a/plugins/woocommerce/changelog/45913-update-45901-lys-setting-default-to-live
+++ b/plugins/woocommerce/changelog/45913-update-45901-lys-setting-default-to-live
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Set 'live' as default when woocommerce_coming_soon is not available


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45901 

This PR defaults to `live` option when `woocommerce_coming_soon` is not available.

![Screen Shot 2024-03-25 at 4 45 30 PM](https://github.com/woocommerce/woocommerce/assets/4723145/ea7881e5-da2c-4f1e-8b3e-a6595bd2d58f)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a new JN site with this branch and enable `launch-your-store` feature flag.
2. Finish the onboarding.
3. Make sure to delete `woocommerce_coming_soon` option.
4. Go to `WooCommerce -> Settings`
5. Confirm `live` is selected.
6. Change to `Coming soon` and click the save changes button.
7. Reload the page and confirm `Coming soon` is selected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Set 'live' as default when woocommerce_coming_soon is not available

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
