### PR TITLE
Logging: Add more robust method of filesystem initialization to handle configuration edge cases

### DIFF
--- a/plugins/woocommerce/changelog/try-logging-filesystem-checks
+++ b/plugins/woocommerce/changelog/try-logging-filesystem-checks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add more robust method of filesystem initialization

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -4,7 +4,8 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
 
 use Automattic\Jetpack\Constants;
-use WP_Filesystem_Direct;
+use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
+use Exception;
 
 /**
  * File class.
@@ -60,14 +61,6 @@ class File {
 	 * @param string $path The absolute path of the file.
 	 */
 	public function __construct( $path ) {
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-
-		global $wp_filesystem;
-
-		if ( ! $wp_filesystem instanceof WP_Filesystem_Direct ) {
-			WP_Filesystem();
-		}
-
 		$this->path = $path;
 		$this->ingest_path();
 	}
@@ -237,27 +230,33 @@ class File {
 	/**
 	 * Check if the file represented by the class instance is a file and is readable.
 	 *
-	 * @global WP_Filesystem_Direct $wp_filesystem
-	 *
 	 * @return bool
 	 */
 	public function is_readable(): bool {
-		global $wp_filesystem;
+		try {
+			$filesystem  = FilesystemUtil::get_wp_filesystem();
+			$is_readable = $filesystem->is_file( $this->path ) && $filesystem->is_readable( $this->path );
+		} catch ( Exception $exception ) {
+			return false;
+		}
 
-		return $wp_filesystem->is_file( $this->path ) && $wp_filesystem->is_readable( $this->path );
+		return $is_readable;
 	}
 
 	/**
 	 * Check if the file represented by the class instance is a file and is writable.
 	 *
-	 * @global WP_Filesystem_Direct $wp_filesystem
-	 *
 	 * @return bool
 	 */
 	public function is_writable(): bool {
-		global $wp_filesystem;
+		try {
+			$filesystem  = FilesystemUtil::get_wp_filesystem();
+			$is_writable = $filesystem->is_file( $this->path ) && $filesystem->is_writable( $this->path );
+		} catch ( Exception $exception ) {
+			return false;
+		}
 
-		return $wp_filesystem->is_file( $this->path ) && $wp_filesystem->is_writable( $this->path );
+		return $is_writable;
 	}
 
 	/**
@@ -372,31 +371,38 @@ class File {
 	/**
 	 * Get the time of the last modification of the file, as a Unix timestamp. Or false if the file isn't readable.
 	 *
-	 * @global WP_Filesystem_Direct $wp_filesystem
-	 *
 	 * @return int|false
 	 */
 	public function get_modified_timestamp() {
-		global $wp_filesystem;
+		try {
+			$filesystem = FilesystemUtil::get_wp_filesystem();
+			$timestamp  = $filesystem->mtime( $this->path );
+		} catch ( Exception $exception ) {
+			return false;
+		}
 
-		return $wp_filesystem->mtime( $this->path );
+		return $timestamp;
 	}
 
 	/**
 	 * Get the size of the file in bytes. Or false if the file isn't readable.
 	 *
-	 * @global WP_Filesystem_Direct $wp_filesystem
-	 *
 	 * @return int|false
 	 */
 	public function get_file_size() {
-		global $wp_filesystem;
+		try {
+			$filesystem = FilesystemUtil::get_wp_filesystem();
 
-		if ( ! $wp_filesystem->is_readable( $this->path ) ) {
+			if ( ! $filesystem->is_readable( $this->path ) ) {
+				return false;
+			}
+
+			$size = $filesystem->size( $this->path );
+		} catch ( Exception $exception ) {
 			return false;
 		}
 
-		return $wp_filesystem->size( $this->path );
+		return $size;
 	}
 
 	/**
@@ -405,10 +411,13 @@ class File {
 	 * @return bool
 	 */
 	protected function create(): bool {
-		global $wp_filesystem;
-
-		$created = $wp_filesystem->touch( $this->path );
-		$modded  = $wp_filesystem->chmod( $this->path );
+		try {
+			$filesystem = FilesystemUtil::get_wp_filesystem();
+			$created    = $filesystem->touch( $this->path );
+			$modded     = $filesystem->chmod( $this->path );
+		} catch ( Exception $exception ) {
+			return false;
+		}
 
 		return $created && $modded;
 	}
@@ -463,8 +472,6 @@ class File {
 			return false;
 		}
 
-		global $wp_filesystem;
-
 		$created = 0;
 		if ( $this->has_standard_filename() ) {
 			$created = $this->get_created_timestamp();
@@ -489,7 +496,13 @@ class File {
 		$new_filename = str_replace( $search, $replace, $old_filename );
 		$new_path     = str_replace( $old_filename, $new_filename, $this->path );
 
-		$moved = $wp_filesystem->move( $this->path, $new_path, true );
+		try {
+			$filesystem = FilesystemUtil::get_wp_filesystem();
+			$moved      = $filesystem->move( $this->path, $new_path, true );
+		} catch ( Exception $exception ) {
+			return false;
+		}
+
 		if ( ! $moved ) {
 			return false;
 		}
@@ -503,13 +516,16 @@ class File {
 	/**
 	 * Delete the file from the filesystem.
 	 *
-	 * @global WP_Filesystem_Direct $wp_filesystem
-	 *
 	 * @return bool True on success, false on failure.
 	 */
 	public function delete(): bool {
-		global $wp_filesystem;
+		try {
+			$filesystem = FilesystemUtil::get_wp_filesystem();
+			$deleted    = $filesystem->delete( $this->path, false, 'f' );
+		} catch ( Exception $exception ) {
+			return false;
+		}
 
-		return $wp_filesystem->delete( $this->path, false, 'f' );
+		return $deleted;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -481,10 +481,7 @@ class FileController {
 
 		$files = $this->get_files_by_id( $file_ids );
 		foreach ( $files as $file ) {
-			$result = false;
-			if ( $file->is_writable() ) {
-				$result = $file->delete();
-			}
+			$result = $file->delete();
 
 			if ( true === $result ) {
 				$deleted ++;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -292,6 +292,12 @@ class Settings {
 		$location_info = array();
 		$directory     = self::get_log_directory();
 
+		try {
+			FilesystemUtil::get_wp_filesystem();
+		} catch ( Exception $exception ) {
+			$location_info[] = __( '⚠️ The file system connection could not be initialized. You may want to switch to the database for log storage.', 'woocommerce' );
+		}
+
 		$location_info[] = sprintf(
 			// translators: %s is a location in the filesystem.
 			__( 'Log files are stored in this directory: %s', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Exception;
 use WC_Admin_Settings;
 use WC_Log_Handler_DB, WC_Log_Handler_File, WC_Log_Levels;
+use WP_Filesystem_Direct;
 
 /**
  * Settings class.
@@ -292,10 +293,18 @@ class Settings {
 		$location_info = array();
 		$directory     = self::get_log_directory();
 
+		$status_info = array();
 		try {
-			FilesystemUtil::get_wp_filesystem();
+			$filesystem = FilesystemUtil::get_wp_filesystem();
+			if ( $filesystem instanceof WP_Filesystem_Direct ) {
+				$status_info[] = __( '✅ Ready', 'woocommerce' );
+			} else {
+				$status_info[] = __( '⚠️ The file system is not configured for direct writes. This could cause problems for the logger.', 'woocommerce' );
+				$status_info[] = __( 'You may want to switch to the database for log storage.', 'woocommerce' );
+			}
 		} catch ( Exception $exception ) {
-			$location_info[] = __( '⚠️ The file system connection could not be initialized. You may want to switch to the database for log storage.', 'woocommerce' );
+			$status_info[] = __( '⚠️ The file system connection could not be initialized.', 'woocommerce' );
+			$status_info[] = __( 'You may want to switch to the database for log storage.', 'woocommerce' );
 		}
 
 		$location_info[] = sprintf(
@@ -322,6 +331,11 @@ class Settings {
 				'title' => __( 'File system settings', 'woocommerce' ),
 				'id'    => self::PREFIX . 'settings',
 				'type'  => 'title',
+			),
+			'file_status'   => array(
+				'title' => __( 'Status', 'woocommerce' ),
+				'type'  => 'info',
+				'text'  => implode( "\n\n", $status_info ),
 			),
 			'log_directory' => array(
 				'title' => __( 'Location', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -83,7 +83,7 @@ class Settings {
 					$filesystem = FilesystemUtil::get_wp_filesystem();
 					$filesystem->put_contents( $dir . '.htaccess', 'deny from all' );
 					$filesystem->put_contents( $dir . 'index.html', '' );
-				} catch ( Exception $exception ) {
+				} catch ( Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// Creation failed.
 				}
 			}

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -15,7 +15,7 @@ class FilesystemUtil {
 	 * Wrapper to retrieve the class instance contained in the $wp_filesystem global, after initializing if necessary.
 	 *
 	 * @return WP_Filesystem_Base
-	 * @throws Exception
+	 * @throws Exception Thrown when the filesystem fails to initialize.
 	 */
 	public static function get_wp_filesystem(): WP_Filesystem_Base {
 		global $wp_filesystem;

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -51,33 +51,62 @@ class FilesystemUtil {
 		if ( 'direct' === $method ) {
 			$initialized = WP_Filesystem();
 		} elseif ( false !== $method ) {
-			$credentials = get_option(
-				'ftp_credentials',
-				array(
-					'hostname' => '',
-					'username' => '',
-				)
-			);
-
-			$ftp_constants = array(
-				'hostname'    => 'FTP_HOST',
-				'username'    => 'FTP_USER',
-				'password'    => 'FTP_PASS',
-				'public_key'  => 'FTP_PUBKEY',
-				'private_key' => 'FTP_PRIKEY',
-			);
-
-			foreach ( $ftp_constants as $key => $constant ) {
-				if ( Constants::is_defined( $constant ) ) {
-					$credentials[ $key ] = Constants::get_constant( $constant );
-				} elseif ( ! isset( $credentials[ $key ] ) ) {
-					$credentials[ $key ] = '';
-				}
-			}
-
-			$initialized = WP_Filesystem( $credentials );
+			$initialized = WP_Filesystem( self::get_credentials( $method ) );
 		}
 
 		return is_null( $initialized ) ? false : $initialized;
+	}
+
+	/**
+	 * Attempt to get credentials for accessing the filesystem when using a non-direct method (FTP, SSH, etc.).
+	 *
+	 * This is largely copied from the `request_filesystem_credentials()` method in WordPress core.
+	 *
+	 * @param string $method The method to use for accessing the filesystem.
+	 *
+	 * @return array
+	 */
+	protected static function get_credentials( string $method ): array {
+		$credentials = get_option(
+			'ftp_credentials',
+			array(
+				'hostname' => '',
+				'username' => '',
+			)
+		);
+
+		$ftp_constants = array(
+			'hostname'    => 'FTP_HOST',
+			'username'    => 'FTP_USER',
+			'password'    => 'FTP_PASS',
+			'public_key'  => 'FTP_PUBKEY',
+			'private_key' => 'FTP_PRIKEY',
+		);
+
+		foreach ( $ftp_constants as $key => $constant ) {
+			if ( Constants::is_defined( $constant ) ) {
+				$credentials[ $key ] = Constants::get_constant( $constant );
+			} elseif ( ! isset( $credentials[ $key ] ) ) {
+				$credentials[ $key ] = '';
+			}
+		}
+
+		// Sanitize the hostname, some people might pass in odd data.
+		$credentials['hostname'] = preg_replace( '|\w+://|', '', $credentials['hostname'] ); // Strip any schemes off.
+
+		if ( strpos( $credentials['hostname'], ':' ) ) {
+			list( $credentials['hostname'], $credentials['port'] ) = explode( ':', $credentials['hostname'], 2 );
+			if ( ! is_numeric( $credentials['port'] ) ) {
+				unset( $credentials['port'] );
+			}
+		} else {
+			unset( $credentials['port'] );
+		}
+
+		if ( Constants::get_constant( 'FTP_SSL' ) && 'ftpext' === $method ) { // Only the FTP Extension understands SSL.
+			$credentials['connection_type'] = 'ftps';
+		}
+
+		return $credentials;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -1,0 +1,81 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+use Automattic\Jetpack\Constants;
+use Exception;
+use WP_Filesystem_Base;
+
+/**
+ * FilesystemUtil class.
+ */
+class FilesystemUtil {
+	/**
+	 * Wrapper to retrieve the class instance contained in the $wp_filesystem global, after initializing if necessary.
+	 *
+	 * @return WP_Filesystem_Base
+	 * @throws Exception
+	 */
+	public static function get_wp_filesystem(): WP_Filesystem_Base {
+		global $wp_filesystem;
+
+		if ( ! $wp_filesystem instanceof WP_Filesystem_Base ) {
+			$initialized = self::initialize_wp_filesystem();
+
+			if ( false === $initialized ) {
+				throw new Exception( 'The WordPress filesystem could not be initialized.' );
+			}
+		}
+
+		return $wp_filesystem;
+	}
+
+	/**
+	 * Wrapper to initialize the WP filesystem with defined credentials if they are available.
+	 *
+	 * @return bool True if the $wp_filesystem global was successfully initialized.
+	 */
+	protected static function initialize_wp_filesystem(): bool {
+		global $wp_filesystem;
+
+		if ( $wp_filesystem instanceof WP_Filesystem_Base ) {
+			return true;
+		}
+
+		$method      = get_filesystem_method();
+		$initialized = false;
+
+		if ( 'direct' === $method ) {
+			$initialized = WP_Filesystem();
+		} elseif ( false !== $method ) {
+			$credentials = get_option(
+				'ftp_credentials',
+				array(
+					'hostname' => '',
+					'username' => '',
+				)
+			);
+
+			$ftp_constants = array(
+				'hostname'    => 'FTP_HOST',
+				'username'    => 'FTP_USER',
+				'password'    => 'FTP_PASS',
+				'public_key'  => 'FTP_PUBKEY',
+				'private_key' => 'FTP_PRIKEY',
+			);
+
+			foreach ( $ftp_constants as $key => $constant ) {
+				if ( Constants::is_defined( $constant ) ) {
+					$credentials[ $key ] = Constants::get_constant( $constant );
+				} elseif ( ! isset( $credentials[ $key ] ) ) {
+					$credentials[ $key ] = '';
+				}
+			}
+
+			$initialized = WP_Filesystem( $credentials );
+		}
+
+		return is_null( $initialized ) ? false : $initialized;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -43,6 +43,8 @@ class FilesystemUtil {
 			return true;
 		}
 
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
 		$method      = get_filesystem_method();
 		$initialized = false;
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/integrations/maxmind-geolocation/class-wc-tests-maxmind-integration.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/integrations/maxmind-geolocation/class-wc-tests-maxmind-integration.php
@@ -34,6 +34,18 @@ class WC_Tests_MaxMind_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		unset( $GLOBALS['wp_filesystem'] );
+
+		remove_filter( 'filesystem_method', array( $this, 'override_filesystem_method' ) );
+		remove_filter( 'woocommerce_maxmind_geolocation_database_service', array( $this, 'override_integration_service' ) );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Make sure that the database is not updated if no target database path is given.
 	 */
 	public function test_update_database_does_nothing_without_database_path() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/log/logger.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/log/logger.php
@@ -82,23 +82,13 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 * @since 2.4
 	 */
 	public function test_clear() {
-		$logger = new WC_Logger();
-		$source = 'clear-test';
-		$logger->log( 'debug', 'Clear test', array( 'source' => $source ) );
-		$logger->log( 'debug', 'Other log', array( 'source' => 'other-source' ) );
-
-		$files = glob( Settings::get_log_directory() . '*.log' );
-		$this->assertCount( 2, $files );
-		$files = glob( Settings::get_log_directory() . $source . '*.log' );
-		$this->assertCount( 1, $files );
-
-		$logger->clear( $source );
-
-		// The clear method creates a log entry upon completion, so there are still 2 log files.
-		$files = glob( Settings::get_log_directory() . '*.log' );
-		$this->assertCount( 2, $files );
-		$files = glob( Settings::get_log_directory() . $source . '*.log' );
-		$this->assertCount( 0, $files );
+		$path = Settings::get_log_directory() . 'unit-tests.log';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+		file_put_contents( $path, 'Test file content.' );
+		$this->assertFileExists( $path );
+		$log = new WC_Logger();
+		$log->clear( 'unit-tests' );
+		$this->assertFileDoesNotExist( $path );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/log/logger.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/log/logger.php
@@ -82,13 +82,23 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 * @since 2.4
 	 */
 	public function test_clear() {
-		$path = Settings::get_log_directory() . 'unit-tests.log';
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
-		file_put_contents( $path, 'Test file content.' );
-		$this->assertFileExists( $path );
-		$log = new WC_Logger();
-		$log->clear( 'unit-tests' );
-		$this->assertFileDoesNotExist( $path );
+		$logger = new WC_Logger();
+		$source = 'clear-test';
+		$logger->log( 'debug', 'Clear test', array( 'source' => $source ) );
+		$logger->log( 'debug', 'Other log', array( 'source' => 'other-source' ) );
+
+		$files = glob( Settings::get_log_directory() . '*.log' );
+		$this->assertCount( 2, $files );
+		$files = glob( Settings::get_log_directory() . $source . '*.log' );
+		$this->assertCount( 1, $files );
+
+		$logger->clear( $source );
+
+		// The clear method creates a log entry upon completion, so there are still 2 log files.
+		$files = glob( Settings::get_log_directory() . '*.log' );
+		$this->assertCount( 2, $files );
+		$files = glob( Settings::get_log_directory() . $source . '*.log' );
+		$this->assertCount( 0, $files );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/SettingsTest.php
@@ -117,8 +117,6 @@ class SettingsTest extends WC_Unit_Test_Case {
 		$upload_dir = wp_upload_dir();
 		$path       = $upload_dir['basedir'] . '/wc-logs-test/';
 
-		$this->assertFalse( wp_is_writable( $path ) );
-
 		$callback = fn() => $path;
 		add_filter( 'woocommerce_log_directory', $callback );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -7,7 +7,9 @@ use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
 use WC_Unit_Test_Case;
 use WP_Filesystem_Base;
 
-
+/**
+ * FilesystemUtilTest class.
+ */
 class FilesystemUtilTest extends WC_Unit_Test_Case {
 	/**
 	 * Set up before running any tests.

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -1,0 +1,59 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
+use WC_Unit_Test_Case;
+use WP_Filesystem_Base;
+
+
+class FilesystemUtilTest extends WC_Unit_Test_Case {
+	/**
+	 * Set up before running any tests.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		unset( $GLOBALS['wp_filesystem'] );
+	}
+
+	/**
+	 * Tear down between each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		unset( $GLOBALS['wp_filesystem'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Check that the get_wp_filesystem method returns an appropriate class instance.
+	 */
+	public function test_get_wp_filesystem_success(): void {
+		$callback = fn() => 'direct';
+		add_filter( 'filesystem_method', $callback );
+
+		$this->assertInstanceOf( WP_Filesystem_Base::class, FilesystemUtil::get_wp_filesystem() );
+
+		remove_filter( 'filesystem_method', $callback );
+	}
+
+	/**
+	 * @testdox Check that the get_wp_filesystem method throws an exception when the filesystem cannot be initialized.
+	 */
+	public function test_get_wp_filesystem_failure(): void {
+		$this->expectException( 'Exception' );
+
+		$callback = fn() => 'asdf';
+		add_filter( 'filesystem_method', $callback );
+
+		FilesystemUtil::get_wp_filesystem();
+
+		remove_filter( 'filesystem_method', $callback );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is inspired by the problem described in #44827. On some hosts WordPress is configured to use an alternate method of working with the filesystem, such as FTP or SSH, generally because of file ownership quirks on shared hosting (see [this](https://developer.wordpress.org/apis/filesystem/#purpose) for more context). WordPress itself has some functions to detect and manage this situation, but they are kind of unwieldy and we aren't using them quite right in the logging system (and maybe a few other places). So in this PR we're introducing a utility method for ensuring the filesystem is actually initialized correctly before we try to use it, and then updating all the usages of `$wp_filesystem` in the logger to use this utility method instead. We're also adding some warnings on the Logs Settings screen when the filesystem method is not set to "direct" recommending that the user switch to database logging.

### How to test the changes in this Pull Request:

It's challenging and impractical to set up an environment that successfully uses one of the alternative file system methods supported by WordPress (PHP's FTP extension, SSH). Instead, I propose to just test that file logging still works normally with this changeset, and that it fails gracefully if the file system method is not set to direct.

1. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) to generate test log files.
2. Navigate to WooCommerce > Status > Logs, and in a separate tab, navigate to WooCommerce > Status > Tools.
3. On the Tools tab, click the button to generate some log entries. On the Logs tab, check that the entries were generated successfully.
4. Now add this code snippet to simulate the file system method being configured to `ftpext`:
    ```php
	add_filter(
		'filesystem_method',
		function() {
			return 'ftpext';
		}
	);
    ```
5. On the Logs tab, it should now show that there are no log files (because the file system is not successfully reading the log directory). Click the Settings link to go to the Settings screen. There, you should see a warning that the file system could not be initialized, and a recommendation to switch to the database logger (but don't do that).
6. Back on the Tools tab, click the button to generate some more log entries. It should still say that the tool ran successfully.
7. On the Logs tab, it should still show that there are no log files.
8. Now remove the code snippet added earlier. On the Logs tab, you should see the log files that were generated before adding the code snippet. If you view the files, though, you should see that no additional entries were added while the code snippet was in place.