### PR TITLE
Add WordPress.WP.Capabilities config to phpcs.xml

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpcs-add-WordPress.WP.Capabilities
+++ b/plugins/woocommerce/changelog/fix-phpcs-add-WordPress.WP.Capabilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add WordPress.WP.Capabilities config to phpcs.xml

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -54,6 +54,31 @@
 		<exclude-pattern>tests/src</exclude-pattern>
 	</rule>
 
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element key="0" value="download_file"/>
+				<element key="1" value="read_product"/>
+				<element key="2" value="edit_products"/>
+				<element key="3" value="edit_private_products"/>
+				<element key="4" value="edit_others_products"/>
+				<element key="5" value="edit_product"/>
+				<element key="6" value="publish_shop_orders"/>
+				<element key="7" value="edit_shop_orders"/>
+				<element key="8" value="edit_others_shop_orders"/>
+				<element key="9" value="view_order"/>
+				<element key="10" value="pay_for_order"/>
+				<element key="11" value="order_again"/>
+				<element key="12" value="cancel_order"/>
+				<element key="13" value="read_private_shop_orders"/>
+				<element key="14" value="customer"/>
+				<element key="15" value="manage_woocommerce"/>
+				<element key="16" value="manage_product_terms"/>
+				<element key="17" value="view_woocommerce_reports"/>
+			</property>
+		</properties>
+	</rule>
+
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
 		<exclude-pattern>tests/</exclude-pattern>


### PR DESCRIPTION
Blocks https://github.com/woocommerce/woocommerce/pull/45763.

### Changes proposed in this Pull Request:

It turns out we have some PHPCS warnings when using `current_user_can( ... )`, that's because some capabilities appear as unknown. This PR updates `phpcs.xml` to add all capabilities which are currently causing warnings.

Thanks @samueljseay for helping me with PHPCS. :slightly_smiling_face: 

### How to test the changes in this Pull Request:

Testing steps for developers only:

1. Make this [change in `composer.json`](https://github.com/woocommerce/woocommerce/blob/217a70a31a2f8b1fc6fbc487771ae50fb56c12a1/plugins/woocommerce/composer.json#L101) so only `WordPress.WP.Capabilities` warnings are displayed:

```diff
                "phpcs": [
-                       "phpcs -s -p"
+                       "phpcs -s -p --sniffs=WordPress.WP.Capabilities"
                ],
```

2. Go to the WooCommerce directory: `cd plugin/woocommerce`.
3. Run linting in several directories and verify there are no warnings related to `WordPress.WP.Capabilities`:

```
pnpm --filter="@woocommerce/plugin-woocommerce" lint:php i18n/
pnpm --filter="@woocommerce/plugin-woocommerce" lint:php includes/
pnpm --filter="@woocommerce/plugin-woocommerce" lint:php templates/
pnpm --filter="@woocommerce/plugin-woocommerce" lint:php src/
```