### PR TITLE
Product Collection: fetch all products for hand-picked products control

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
@@ -35,7 +35,13 @@ function useProducts() {
 	);
 
 	useEffect( () => {
-		getProducts( { selected: [] } ).then( ( results ) => {
+		getProducts( {
+			selected: [],
+			queryArgs: {
+				// Fetch all products.
+				per_page: 0,
+			},
+		} ).then( ( results ) => {
 			const newProductsMap = new Map();
 			( results as ProductResponseItem[] ).forEach( ( product ) => {
 				newProductsMap.set( product.id, product );

--- a/plugins/woocommerce/changelog/45931-fix-45842-product-collection-block-hand-picked-items-limited-to-first-100-in-catalog
+++ b/plugins/woocommerce/changelog/45931-fix-45842-product-collection-block-hand-picked-items-limited-to-first-100-in-catalog
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Hand-picked control only allow selection from first 100 products


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates how we use the `getProducts` function in the Hand-Picked Products control to ensure we fetch all products, no matter the catalog size. To achieve this, we're tweaking to set `queryArgs` explicitly, including `per_page: 0` in the function call. By default, `getProducts` caps at [returning 100 products](https://github.com/woocommerce/woocommerce/blob/2ee1cc08d246c935627597456d7d5dc5f51dcf63/plugins/woocommerce-blocks/assets/js/editor-components/utils/index.js#L24), but we're going beyond that limit with this change!

Closes #45842 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Prerequisite**

- Ensure your store contains over 100 products.

**Steps**

1. Add the Product Collection block to a post/page.
2. In the Filters section of the block controls, click the three dots and choose Hand-Picked Products
3. A box will appear to select products to feature. Verify that you are able to search for something that’s not in the first 100 products alphabetically.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Hand-picked control only allow selection from first 100 products

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
