### PR TITLE
[CYS] Redirect to transitional page to the intro page if the CYS task was not completed

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -61,6 +61,7 @@
 }
 
 .woocommerce-customize-store__step-assemblerHub,
+.woocommerce-customize-store__step-transitionalScreen,
 .woocommerce-customize-store__step-intro {
 	a {
 		text-decoration: none;

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -489,22 +489,22 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			},
 		},
 		transitionalScreen: {
-			initial: 'fetchActiveThemeHasMods',
+			initial: 'fetchCustomizeStoreCompleted',
 			states: {
-				fetchActiveThemeHasMods: {
+				fetchCustomizeStoreCompleted: {
 					invoke: {
-						src: 'fetchActiveThemeHasMods',
+						src: 'fetchCustomizeStoreCompleted',
 						onDone: {
-							actions: 'assignActiveThemeHasMods',
-							target: 'checkActiveThemeHasMods',
+							actions: 'assignCustomizeStoreCompleted',
+							target: 'checkCustomizeStoreCompleted',
 						},
 					},
 				},
-				checkActiveThemeHasMods: {
+				checkCustomizeStoreCompleted: {
 					always: [
 						{
 							// Redirect to the "intro step" if the active theme has no modifications.
-							cond: 'activeThemeHasNoMods',
+							cond: 'customizeTaskIsNotCompleted',
 							actions: [
 								{ type: 'updateQueryStep', step: 'intro' },
 							],
@@ -512,7 +512,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 						},
 						{
 							// Otherwise, proceed to the next step.
-							cond: 'activeThemeHasMods',
+							cond: 'customizeTaskIsCompleted',
 							target: 'preTransitional',
 						},
 					],
@@ -629,6 +629,12 @@ export const CustomizeStoreController = ( {
 				},
 				activeThemeHasNoMods: ( _ctx ) => {
 					return ! _ctx.activeThemeHasMods;
+				},
+				customizeTaskIsCompleted: ( _ctx ) => {
+					return _ctx.intro.customizeStoreTaskCompleted;
+				},
+				customizeTaskIsNotCompleted: ( _ctx ) => {
+					return ! _ctx.intro.customizeStoreTaskCompleted;
 				},
 			},
 		} );

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -489,8 +489,34 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			},
 		},
 		transitionalScreen: {
-			initial: 'preTransitional',
+			initial: 'fetchActiveThemeHasMods',
 			states: {
+				fetchActiveThemeHasMods: {
+					invoke: {
+						src: 'fetchActiveThemeHasMods',
+						onDone: {
+							actions: 'assignActiveThemeHasMods',
+							target: 'checkActiveThemeHasMods',
+						},
+					},
+				},
+				checkActiveThemeHasMods: {
+					always: [
+						{
+							// Redirect to the "intro step" if the active theme has no modifications.
+							cond: 'activeThemeHasNoMods',
+							actions: [
+								{ type: 'updateQueryStep', step: 'intro' },
+							],
+							target: '#customizeStore.intro',
+						},
+						{
+							// Otherwise, proceed to the next step.
+							cond: 'activeThemeHasMods',
+							target: 'preTransitional',
+						},
+					],
+				},
 				preTransitional: {
 					meta: {
 						component: CYSSpinner,

--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -72,6 +72,16 @@ export const fetchActiveThemeHasMods = async () => {
 	return { activeThemeHasMods };
 };
 
+export const fetchCustomizeStoreCompleted = async () => {
+	const task = await resolveSelect( ONBOARDING_STORE_NAME ).getTask(
+		'customize-store'
+	);
+
+	return {
+		customizeStoreTaskCompleted: task?.isComplete,
+	};
+};
+
 export const fetchIntroData = async () => {
 	const currentTemplatePromise =
 		// @ts-expect-error No types for this exist yet.

--- a/plugins/woocommerce/changelog/45933-redirect-to-intro-when-going-to-transitional-but-no-theme-mods
+++ b/plugins/woocommerce/changelog/45933-redirect-to-intro-when-going-to-transitional-but-no-theme-mods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Redirect to the CYS intro screen when accessing the transitional page without going through the customizing process.

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
@@ -2,10 +2,12 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { setOption } = require( '../../utils/options' );
 const { activateTheme } = require( '../../utils/themes' );
 const { AssemblerPage } = require( './assembler/assembler.page' );
+const { features } = require( '../../utils' );
 
 const CUSTOMIZE_STORE_URL =
 	'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store';
 const TRANSITIONAL_URL = `${ CUSTOMIZE_STORE_URL }%2Ftransitional`;
+const INTRO_URL = `${ CUSTOMIZE_STORE_URL }%2Fintro`;
 
 const test = base.extend( {
 	pageObject: async ( { page }, use ) => {
@@ -54,6 +56,18 @@ test.describe( 'Store owner can view the Transitional page', () => {
 			'woocommerce_customize_store_onboarding_tour_hidden',
 			'no'
 		);
+	} );
+
+	test.only( 'Accessing the transitional page when the CYS flow is not completed should redirect to the Intro page', async ( {
+		page,
+		baseURL,
+	} ) => {
+		await page.goto( TRANSITIONAL_URL );
+
+		const locator = page.locator( 'h1:visible' );
+		await expect( locator ).not.toHaveText( 'Your store looks great!' );
+
+		await expect( page.url() ).toBe( `${ baseURL }${ INTRO_URL }` );
 	} );
 
 	test( 'Clicking on "Done" in the assembler should go to the transitional page', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
@@ -58,7 +58,7 @@ test.describe( 'Store owner can view the Transitional page', () => {
 		);
 	} );
 
-	test.only( 'Accessing the transitional page when the CYS flow is not completed should redirect to the Intro page', async ( {
+	test( 'Accessing the transitional page when the CYS flow is not completed should redirect to the Intro page', async ( {
 		page,
 		baseURL,
 	} ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
@@ -2,7 +2,6 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { setOption } = require( '../../utils/options' );
 const { activateTheme } = require( '../../utils/themes' );
 const { AssemblerPage } = require( './assembler/assembler.page' );
-const { features } = require( '../../utils' );
 
 const CUSTOMIZE_STORE_URL =
 	'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces a check before the transitional step to redirect to the intro screen if the customize your store task has not been completed (has not gone through the cys flow).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure to `Reset Customize Your Store` on `wp-admin/tools.php?page=woocommerce-admin-test-helper` if the store is now newly created.
2. Go to `wp-admin/admin.php?page=wc-admin&path=/customize-store/transitional`.
3. Check it redirects to the intro screen (should not show the transitional page).
4. Go to `WooCommerce > Home`, click on the `Start Customizing` button, click on `Start designing` and click on `Done` in the assembler.
5. Go to `wp-admin/admin.php?page=wc-admin&path=/customize-store/transitional`.
6. Check this time it does not redirect (should show the transitional page).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Redirect to the CYS intro screen when accessing the transitional page without going through the customizing process.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
