### PR TITLE
Remove accidental count call within an is_array check

### DIFF
--- a/plugins/woocommerce/changelog/fix-analytics_comparison_by_product
+++ b/plugins/woocommerce/changelog/fix-analytics_comparison_by_product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Removed count from is_array check to fix Analytics comparison filter.

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Segmenter.php
@@ -165,7 +165,7 @@ class Segmenter extends ReportsSegmenter {
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
-			if ( ! isset( $this->query_args['product_includes'] ) || ! is_array( count( $this->query_args['product_includes'] ) ) || count( $this->query_args['product_includes'] ) !== 1 ) {
+			if ( ! isset( $this->query_args['product_includes'] ) || ! is_array( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
 				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce' ) );
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes: #45911

This is a fix that was introduced by this PR https://github.com/woocommerce/woocommerce/pull/43233, where a count call was accidentally added within an `is_array` call. Meaning that it would always render false. 

This fixes an issue in the Analytics products page when filtering by a selected product, in which case the graph doesn't show up and it shows an error ( see issue ).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with a couple variable products
2. Create an order with one of the variable products and complete it.
3. Make sure order actions finished under **WooCommerce > Status > Scheduled Actions**
4. Go to **Analytics > Products**
5. Select one of the variable products that you had an order with within the **Show** dropdown
6. There should be no errors and the graph should render correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
