### PR TITLE
Add filters for HPOS order search to support custom filters

### DIFF
--- a/plugins/woocommerce/changelog/perf-hpos-search
+++ b/plugins/woocommerce/changelog/perf-hpos-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add filters to support adding custom search methods in HPOS admin

--- a/plugins/woocommerce/changelog/perf-hpos-search
+++ b/plugins/woocommerce/changelog/perf-hpos-search
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Add filters to support adding custom search methods in HPOS admin
+Add filters to support adding custom search methods in HPOS admin and remember the last used search option

--- a/plugins/woocommerce/changelog/perf-hpos-search2
+++ b/plugins/woocommerce/changelog/perf-hpos-search2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Remember last used search option in HPOS admin

--- a/plugins/woocommerce/changelog/perf-hpos-search2
+++ b/plugins/woocommerce/changelog/perf-hpos-search2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Remember last used search option in HPOS admin

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1643,10 +1643,11 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @param $options array List of available filters.
 		 */
-		$options  = apply_filters( 'woocommerce_hpos_admin_search_filters', $options );
-		$selected = sanitize_text_field( wp_unslash( $_REQUEST['search-filter'] ?? $_COOKIE['wc-search-filter-hpos-admin'] ?? 'all' ) );
-		if ( $_COOKIE['wc-search-filter-hpos-admin'] !== $selected ) {
-			wc_setcookie( 'wc-search-filter-hpos-admin', $selected );
+		$options       = apply_filters( 'woocommerce_hpos_admin_search_filters', $options );
+		$saved_setting = get_user_setting( 'wc-search-filter-hpos-admin', 'all' );
+		$selected      = sanitize_text_field( wp_unslash( $_REQUEST['search-filter'] ?? $saved_setting ) );
+		if ( $saved_setting !== $selected ) {
+			set_user_setting( 'wc-search-filter-hpos-admin', $selected );
 		}
 		?>
 		<select name="search-filter" id="order-search-filter">

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1352,7 +1352,7 @@ class ListTable extends WP_List_Table {
 			}
 
 			do_action( 'woocommerce_remove_order_personal_data', $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-			$changed++;
+			++$changed;
 		}
 
 		return $changed;
@@ -1380,7 +1380,7 @@ class ListTable extends WP_List_Table {
 
 			$order->update_status( $new_status, __( 'Order status changed by bulk edit.', 'woocommerce' ), true );
 			do_action( 'woocommerce_order_edit_status', $id, $new_status ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-			$changed++;
+			++$changed;
 		}
 
 		return $changed;
@@ -1403,7 +1403,7 @@ class ListTable extends WP_List_Table {
 			$updated_order = wc_get_order( $id );
 
 			if ( ( $force_delete && false === $updated_order ) || ( ! $force_delete && $updated_order->get_status() === 'trash' ) ) {
-				$changed++;
+				++$changed;
 			}
 		}
 
@@ -1423,7 +1423,7 @@ class ListTable extends WP_List_Table {
 
 		foreach ( $ids as $id ) {
 			if ( $orders_store->untrash_order( wc_get_order( $id ) ) ) {
-				$changed++;
+				++$changed;
 			}
 		}
 
@@ -1635,9 +1635,17 @@ class ListTable extends WP_List_Table {
 			'all'            => __( 'All', 'woocommerce' ),
 		);
 
-		$options = apply_filters( 'woocommerce_hpos_admin_search_filters', $options );
-		$selected = $_REQUEST['search-filter'] ?? $_COOKIE['wc-search-filter-hpos-admin'] ?? 'all';
-		if( $_COOKIE['wc-search-filter-hpos-admin'] !== $selected ) {
+		/**
+		 * Filters the search filters available in the admin order search. Can be used to add new or remove existing filters.
+		 * When adding new filters, `woocommerce_hpos_generate_where_for_search_filter` should also be used to generate the WHERE clause for the new filter
+		 *
+		 * @since 8.9.0.
+		 *
+		 * @param $options array List of available filters.
+		 */
+		$options  = apply_filters( 'woocommerce_hpos_admin_search_filters', $options );
+		$selected = sanitize_text_field( wp_unslash( $_REQUEST['search-filter'] ?? $_COOKIE['wc-search-filter-hpos-admin'] ?? 'all' ) );
+		if ( $_COOKIE['wc-search-filter-hpos-admin'] !== $selected ) {
 			wc_setcookie( 'wc-search-filter-hpos-admin', $selected );
 		}
 		?>

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1634,10 +1634,16 @@ class ListTable extends WP_List_Table {
 			'products'       => __( 'Products', 'woocommerce' ),
 			'all'            => __( 'All', 'woocommerce' ),
 		);
+
+		$options = apply_filters( 'woocommerce_hpos_admin_search_filters', $options );
+		$selected = $_REQUEST['search-filter'] ?? $_COOKIE['wc-search-filter-hpos-admin'] ?? 'all';
+		if( $_COOKIE['wc-search-filter-hpos-admin'] !== $selected ) {
+			wc_setcookie( 'wc-search-filter-hpos-admin', $selected );
+		}
 		?>
 		<select name="search-filter" id="order-search-filter">
 			<?php foreach ( $options as $value => $label ) { ?>
-				<option value="<?php echo esc_attr( wp_unslash( sanitize_text_field( $value ) ) ); ?>" <?php selected( $value, sanitize_text_field( wp_unslash( $_REQUEST['search-filter'] ?? 'all' ) ) ); ?>><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( wp_unslash( sanitize_text_field( $value ) ) ); ?>" <?php selected( $value, sanitize_text_field( wp_unslash( $selected ) ) ); ?>><?php echo esc_html( $label ); ?></option>
 				<?php
 			}
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -121,7 +121,7 @@ class OrdersTableSearchQuery {
 		}
 
 		/**
-		 * Filter to support adding a new search filter.
+		 * Filter to support adding a custom order search filter.
 		 * Provide a JOIN clause for a new search filter. This should be used along with `woocommerce_hpos_admin_search_filters`
 		 * to declare a new custom filter, and `woocommerce_hpos_generate_where_for_search_filter` to generate the WHERE
 		 * clause.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -52,7 +52,7 @@ class OrdersTableSearchQuery {
 	 * @return array Array of search filters.
 	 */
 	private function sanitize_search_filters( string $search_filter ) : array {
-		$available_filters = array(
+		$core_filters = array(
 			'order_id',
 			'customer_email',
 			'customers', // customers also searches in meta.
@@ -60,9 +60,9 @@ class OrdersTableSearchQuery {
 		);
 
 		if ( 'all' === $search_filter || '' === $search_filter ) {
-			return $available_filters;
+			return $core_filters;
 		} else {
-			return array_intersect( $available_filters, array( $search_filter ) );
+			return array( $search_filter );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -212,7 +212,7 @@ class OrdersTableSearchQuery {
 		}
 
 		/**
-		 * Filter to support adding a new search filter.
+		 * Filter to support adding a custom order search filter.
 		 * Provide a WHERE clause for a custom search filter via this filter. This should be used with the
 		 * `woocommerce_hpos_admin_search_filters` to declare a new custom filter, and optionally also with the
 		 * `woocommerce_hpos_generate_join_for_search_filter` filter if a join is also needed.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -119,7 +119,29 @@ class OrdersTableSearchQuery {
 				LEFT JOIN $items_table AS search_query_items ON search_query_items.order_id = $orders_table.id
 			";
 		}
-		return '';
+
+		/**
+		 * Filter to support adding a new search filter.
+		 * Provide a JOIN clause for a new search filter. This should be used along with `woocommerce_hpos_admin_search_filters`
+		 * to declare a new custom filter, and `woocommerce_hpos_generate_where_for_search_filter` to generate the WHERE
+		 * clause.
+		 *
+		 * Hardcoded JOINS (products) cannot be modified using this filter for consistency.
+		 *
+		 * @since 8.9.0
+		 *
+		 * @param string $join The JOIN clause.
+		 * @param string $search_term The search term.
+		 * @param string $search_filter The search filter. Use this to bail early if this is not filter you are interested in.
+		 * @param OrdersTableQuery $query The order query object.
+		 */
+		return apply_filters(
+			'woocommerce_hpos_generate_join_for_search_filter',
+			'',
+			$this->search_term,
+			$search_filter,
+			$this->query
+		);
 	}
 
 	/**
@@ -189,7 +211,28 @@ class OrdersTableSearchQuery {
 			return "`$order_table`.id IN ( $meta_sub_query ) ";
 		}
 
-		return '';
+		/**
+		 * Filter to support adding a new search filter.
+		 * Provide a WHERE clause for a custom search filter via this filter. This should be used with the
+		 * `woocommerce_hpos_admin_search_filters` to declare a new custom filter, and optionally also with the
+		 * `woocommerce_hpos_generate_join_for_search_filter` filter if a join is also needed.
+		 *
+		 * Hardcoded filters (products, customers, ID and email) cannot be modified using this filter for consistency.
+		 *
+		 * @since 8.9.0
+		 *
+		 * @param string $where WHERE clause to add to the search query.
+		 * @param string $search_term The search term.
+		 * @param string $search_filter Name of the search filter. Use this to bail early if this is not the filter you are looking for.
+		 * @param OrdersTableQuery $query The order query object.
+		 */
+		return apply_filters(
+			'woocommerce_hpos_generate_where_for_search_filter',
+			'',
+			$this->search_term,
+			$search_filter,
+			$this->query
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Additionally, also remembers the last used filter for a session by saving it in a cookie.

Note that initially, I was also planning to modify the search method that we use to make it similar to posts, however, that will be added via a different PR after more testing.

This PR allows adding new search methods, or remove existing ones via filter.

Towards #45721 #41317

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

We will test both changes, i.e. ability to add new search methods, as well as functionality to remember last searched method.

1. With HPOS authoritative, add the following as a custom code snippet to enable a new search method. This method searches similar to post inside HPOS, and we will be called `Products (In query)`
```php

add_filter( 'woocommerce_hpos_admin_search_filters', function ( $options ) {
	$options['product-filter-faster'] = __( 'Products (In query)', 'woocommerce' );
	return $options;
}, 10, 1 );

add_filter( 'woocommerce_hpos_generate_where_for_search_filter', function ( $where, $search_term, $search_filter, $query ) {
	global $wpdb;
	if( 'product-filter-faster' !== $search_filter ) {
		return $where;
	}
	$items_table = $query->get_table_name( 'items' );
	$order_table = $query->get_table_name( 'orders' );
	$query = $wpdb->prepare( "
		$order_table.id IN (
		SELECT search_query_items.order_id from $items_table as search_query_items WHERE search_query_items.order_item_name LIKE %s )",
		'%' . $wpdb->esc_like( $search_term ) . '%'
	);
	return $query;
}, 10, 4 );
```
2. Go to the WooCommerce -> Orders, and in the right dropdown, make sure that the option `Products (In query)` is available like so:
<img width="1502" alt="Screenshot 2024-03-28 at 1 49 38 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/7630f5cf-c436-475a-94e0-0b252e430d75">


4.  Search for a product that is purchased in an order. If you are testing with a fresh site, complete an order first with any product, and then search for that product in the order list screen.
5. Test that the order shows up.

Now let's test that setting is remembered.
6. Go to any other page, such as WooCommerce -> Settings and come back to the order listing page WooCommerce -> Orders
7. Check that the filter last used is automatically selected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
