### PR TITLE
Product Editor: Only send edited properties when saving

### DIFF
--- a/packages/js/product-editor/changelog/fix-45957-product-editor-unable-to-save
+++ b/packages/js/product-editor/changelog/fix-45957-product-editor-unable-to-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: Fixes issue where saves would fail when certain extensions were installed.

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -72,7 +72,7 @@ export function useProductManager< T = Product >( postType: string ) {
 			await validate( extraProps );
 			const { saveEntityRecord } = dispatch( 'core' );
 
-			const { blocks, content, selection, ...edits } =
+			const { blocks, content, selection, ...editedProduct } =
 				// @ts-expect-error There are no types for this.
 				wpSelect( 'core' ).getEntityRecordEdits(
 					'postType',
@@ -101,7 +101,7 @@ export function useProductManager< T = Product >( postType: string ) {
 				'postType',
 				postType,
 				{
-					...edits,
+					...editedProduct,
 					[ entityIdKey ]: id,
 					...extraProps,
 				},

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -80,30 +80,13 @@ export function useProductManager< T = Product >( postType: string ) {
 					id
 				);
 
-			const entityConfigs =
-				// @ts-expect-error There are no types for this.
-				wpSelect( 'core' ).getEntitiesConfig( 'postType' );
-			const entityConfig = entityConfigs?.find(
-				// @ts-expect-error There are no types for this.
-				( config ) =>
-					config.kind === 'postType' && config.name === postType
-			);
-
-			if ( ! entityConfig ) {
-				throw new Error( 'Entity config not found' );
-			}
-
-			// DEFAULT_ENTITY_KEY is not exported from `@wordpress/core-data` so we
-			// hardcode 'id' as the fallback
-			const entityIdKey = entityConfig.key || 'id';
-
 			const savedProduct = await saveEntityRecord(
 				'postType',
 				postType,
 				{
 					...editedProduct,
-					[ entityIdKey ]: id,
 					...extraProps,
+					id,
 				},
 				// @ts-expect-error There are no types for this.
 				{

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -72,16 +72,37 @@ export function useProductManager< T = Product >( postType: string ) {
 			await validate( extraProps );
 			const { saveEntityRecord } = dispatch( 'core' );
 
-			const { blocks, content, selection, ...editedProduct } = wpSelect(
-				'core'
+			const { blocks, content, selection, ...edits } =
 				// @ts-expect-error There are no types for this.
-			).getEditedEntityRecord( 'postType', postType, id );
+				wpSelect( 'core' ).getEntityRecordEdits(
+					'postType',
+					postType,
+					id
+				);
+
+			const entityConfigs =
+				// @ts-expect-error There are no types for this.
+				wpSelect( 'core' ).getEntitiesConfig( 'postType' );
+			const entityConfig = entityConfigs?.find(
+				// @ts-expect-error There are no types for this.
+				( config ) =>
+					config.kind === 'postType' && config.name === postType
+			);
+
+			if ( ! entityConfig ) {
+				throw new Error( 'Entity config not found' );
+			}
+
+			// DEFAULT_ENTITY_KEY is not exported from `@wordpress/core-data` so we
+			// hardcode 'id' as the fallback
+			const entityIdKey = entityConfig.key || 'id';
 
 			const savedProduct = await saveEntityRecord(
 				'postType',
 				postType,
 				{
-					...editedProduct,
+					...edits,
+					[ entityIdKey ]: id,
 					...extraProps,
 				},
 				// @ts-expect-error There are no types for this.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the saving in the new product editor to only send edited properties. This fixes the issue #45957 where product saves fail when some extensions are installed.

Closes #45957.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**) and the **WooCommerce Product Bundles** plugin activated...

1. Go to **Products** > **Add New**
2. Enter a name
3. Click **Publish** > **Publish**
4. Verify product is saved correctly.

Regression testing to verify that the desired changes from #45436 are still in place (original testing instructions from that PR):

1. Make sure the New product editor and the Prepublish sidebar (product-pre-publish-modal) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Create a new product with SKU `product`.
3. Now, create another product with the same SKU and press Publish.
4. After seeing the prepublish panel press `Publish` again.
5. Verify that a validation error will be visible and the success message is not shown in the prepublish panel.
6. Now add a valid SKU and press Publish.
7. The product should be published correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
