### PR TITLE
Product Editor: Accessible label for text area block

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-text-area-field-label-a11y
+++ b/packages/js/product-editor/changelog/fix-product-text-area-field-label-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: Fix accessibility of woocommerce/product-text-area-field label.

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -24,6 +24,9 @@
 		"required": {
 			"type": "string"
 		},
+		"tooltip": {
+			"type": "string"
+		},
 		"disabled": {
 			"type": "boolean"
 		},

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
+import { LegacyRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { createElement } from '@wordpress/element';
+import { createElement, useRef } from '@wordpress/element';
 import { BaseControl, TextareaControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { BlockControls, RichText } from '@wordpress/block-editor';
@@ -51,7 +52,8 @@ export function TextAreaBlockEdit( {
 		'wp-block-woocommerce-product-content-field__content'
 	);
 
-	const labelId = contentId.toString() + '__label';
+	const labelWrapperId = contentId.toString() + '__label-wrapper';
+	const labelId = labelWrapperId + '__label';
 
 	// `property` attribute is required.
 	if ( ! property ) {
@@ -79,6 +81,12 @@ export function TextAreaBlockEdit( {
 		setAttributes( { direction: value } );
 	}
 
+	const richTextRef = useRef< HTMLParagraphElement >( null );
+
+	function focusRichText() {
+		richTextRef.current?.focus();
+	}
+
 	const blockControlsBlockProps = { group: 'block' };
 
 	const isRichTextMode = mode === 'rich-text';
@@ -104,17 +112,21 @@ export function TextAreaBlockEdit( {
 				id={ contentId.toString() }
 				label={
 					<Label
-						id={ labelId }
+						id={ labelWrapperId }
 						label={ label || '' }
 						required={ required }
 						note={ note }
 						tooltip={ tooltip }
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore onClick exists on Label
+						onClick={ isRichTextMode ? focusRichText : undefined }
 					/>
 				}
 				help={ help }
 			>
 				{ isRichTextMode && (
 					<RichText
+						ref={ richTextRef as unknown as LegacyRef< 'p' > }
 						id={ contentId.toString() }
 						aria-labelledby={ labelId }
 						identifier="content"

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -153,6 +153,7 @@ export function TextAreaBlockEdit( {
 				{ isPlainTextMode && (
 					<TextareaControl
 						ref={ textAreaRef }
+						aria-labelledby={ labelId }
 						value={ content || '' }
 						onChange={ setContent }
 						placeholder={ placeholder }

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -114,6 +114,7 @@ export function TextAreaBlockEdit( {
 					<Label
 						id={ labelWrapperId }
 						label={ label || '' }
+						labelId={ labelId }
 						required={ required }
 						note={ note }
 						tooltip={ tooltip }

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -52,8 +52,7 @@ export function TextAreaBlockEdit( {
 		'wp-block-woocommerce-product-content-field__content'
 	);
 
-	const labelWrapperId = contentId.toString() + '__label-wrapper';
-	const labelId = labelWrapperId + '__label';
+	const labelId = contentId.toString() + '__label';
 
 	// `property` attribute is required.
 	if ( ! property ) {
@@ -117,7 +116,6 @@ export function TextAreaBlockEdit( {
 				id={ contentId.toString() }
 				label={
 					<Label
-						id={ labelWrapperId }
 						label={ label || '' }
 						labelId={ labelId }
 						required={ required }

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -117,8 +117,6 @@ export function TextAreaBlockEdit( {
 						required={ required }
 						note={ note }
 						tooltip={ tooltip }
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore onClick exists on Label
 						onClick={ isRichTextMode ? focusRichText : undefined }
 					/>
 				}

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -145,6 +145,7 @@ export function TextAreaBlockEdit( {
 						allowedFormats={ allowedFormats }
 						placeholder={ placeholder }
 						required={ required }
+						aria-required={ required }
 						disabled={ disabled }
 						onBlur={ hideToolbar }
 					/>

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -82,9 +82,14 @@ export function TextAreaBlockEdit( {
 	}
 
 	const richTextRef = useRef< HTMLParagraphElement >( null );
+	const textAreaRef = useRef< HTMLTextAreaElement >( null );
 
 	function focusRichText() {
 		richTextRef.current?.focus();
+	}
+
+	function focusTextArea() {
+		textAreaRef.current?.focus();
 	}
 
 	const blockControlsBlockProps = { group: 'block' };
@@ -118,7 +123,9 @@ export function TextAreaBlockEdit( {
 						required={ required }
 						note={ note }
 						tooltip={ tooltip }
-						onClick={ isRichTextMode ? focusRichText : undefined }
+						onClick={
+							isRichTextMode ? focusRichText : focusTextArea
+						}
 					/>
 				}
 				help={ help }
@@ -147,6 +154,7 @@ export function TextAreaBlockEdit( {
 
 				{ isPlainTextMode && (
 					<TextareaControl
+						ref={ textAreaRef }
 						value={ content || '' }
 						onChange={ setContent }
 						placeholder={ placeholder }

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -51,6 +51,8 @@ export function TextAreaBlockEdit( {
 		'wp-block-woocommerce-product-content-field__content'
 	);
 
+	const labelId = contentId.toString() + '__label';
+
 	// `property` attribute is required.
 	if ( ! property ) {
 		throw new Error(
@@ -102,6 +104,7 @@ export function TextAreaBlockEdit( {
 				id={ contentId.toString() }
 				label={
 					<Label
+						id={ labelId }
 						label={ label || '' }
 						required={ required }
 						note={ note }
@@ -113,6 +116,7 @@ export function TextAreaBlockEdit( {
 				{ isRichTextMode && (
 					<RichText
 						id={ contentId.toString() }
+						aria-labelledby={ labelId }
 						identifier="content"
 						tagName="p"
 						value={ content || '' }

--- a/packages/js/product-editor/src/components/label/label.tsx
+++ b/packages/js/product-editor/src/components/label/label.tsx
@@ -12,7 +12,6 @@ import { __experimentalTooltip as Tooltip } from '@woocommerce/components';
 import { sanitizeHTML } from '../../utils/sanitize-html';
 
 export interface LabelProps {
-	id?: string;
 	label: string;
 	labelId?: string;
 	required?: boolean;
@@ -22,7 +21,6 @@ export interface LabelProps {
 }
 
 export const Label: React.FC< LabelProps > = ( {
-	id,
 	label,
 	labelId,
 	required,
@@ -80,7 +78,7 @@ export const Label: React.FC< LabelProps > = ( {
 	}
 
 	return (
-		<div id={ id } className="woocommerce-product-form-label__label">
+		<div className="woocommerce-product-form-label__label">
 			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */ }
 			<span id={ labelId } onClick={ onClick }>
 				{ labelElement }

--- a/packages/js/product-editor/src/components/label/label.tsx
+++ b/packages/js/product-editor/src/components/label/label.tsx
@@ -12,6 +12,7 @@ import { __experimentalTooltip as Tooltip } from '@woocommerce/components';
 import { sanitizeHTML } from '../../utils/sanitize-html';
 
 export interface LabelProps {
+	id?: string;
 	label: string;
 	required?: boolean;
 	note?: string;
@@ -19,6 +20,7 @@ export interface LabelProps {
 }
 
 export const Label: React.FC< LabelProps > = ( {
+	id,
 	label,
 	required,
 	tooltip,
@@ -74,7 +76,7 @@ export const Label: React.FC< LabelProps > = ( {
 	}
 
 	return (
-		<div className="woocommerce-product-form-label__label">
+		<div id={ id } className="woocommerce-product-form-label__label">
 			{ labelElement }
 
 			{ tooltip && (

--- a/packages/js/product-editor/src/components/label/label.tsx
+++ b/packages/js/product-editor/src/components/label/label.tsx
@@ -42,7 +42,10 @@ export const Label: React.FC< LabelProps > = ( {
 						</span>
 					),
 					required: (
-						<span className="woocommerce-product-form-label__required">
+						<span
+							aria-hidden="true"
+							className="woocommerce-product-form-label__required"
+						>
 							{ /* translators: field 'required' indicator */ }
 							{ __( '*', 'woocommerce' ) }
 						</span>
@@ -55,7 +58,10 @@ export const Label: React.FC< LabelProps > = ( {
 				{
 					label: <span>{ label }</span>,
 					required: (
-						<span className="woocommerce-product-form-label__required">
+						<span
+							aria-hidden="true"
+							className="woocommerce-product-form-label__required"
+						>
 							{ /* translators: field 'required' indicator */ }
 							{ __( '*', 'woocommerce' ) }
 						</span>

--- a/packages/js/product-editor/src/components/label/label.tsx
+++ b/packages/js/product-editor/src/components/label/label.tsx
@@ -17,6 +17,7 @@ export interface LabelProps {
 	required?: boolean;
 	note?: string;
 	tooltip?: string;
+	onClick?: ( event: React.MouseEvent ) => void;
 }
 
 export const Label: React.FC< LabelProps > = ( {
@@ -25,8 +26,11 @@ export const Label: React.FC< LabelProps > = ( {
 	required,
 	tooltip,
 	note,
+	onClick,
 } ) => {
 	let labelElement: JSX.Element | string = label;
+
+	const labelId = id ? `${ id }__label` : undefined;
 
 	if ( required ) {
 		if ( note?.length ) {
@@ -77,7 +81,10 @@ export const Label: React.FC< LabelProps > = ( {
 
 	return (
 		<div id={ id } className="woocommerce-product-form-label__label">
-			{ labelElement }
+			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */ }
+			<span id={ labelId } onClick={ onClick }>
+				{ labelElement }
+			</span>
 
 			{ tooltip && (
 				<Tooltip

--- a/packages/js/product-editor/src/components/label/label.tsx
+++ b/packages/js/product-editor/src/components/label/label.tsx
@@ -14,6 +14,7 @@ import { sanitizeHTML } from '../../utils/sanitize-html';
 export interface LabelProps {
 	id?: string;
 	label: string;
+	labelId?: string;
 	required?: boolean;
 	note?: string;
 	tooltip?: string;
@@ -23,14 +24,13 @@ export interface LabelProps {
 export const Label: React.FC< LabelProps > = ( {
 	id,
 	label,
+	labelId,
 	required,
 	tooltip,
 	note,
 	onClick,
 } ) => {
 	let labelElement: JSX.Element | string = label;
-
-	const labelId = id ? `${ id }__label` : undefined;
 
 	if ( required ) {
 		if ( note?.length ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the following accessibility features to the `woocommerce/product-text-area-field` block that is used in the new product editor:

* Click on label to focus associated input
    * For `plain-text` mode, only works with Gutenberg 16.8 or above installed, or WordPress 6.5 or above installed (depends on https://github.com/WordPress/gutenberg/pull/54975); on sites without those, clicking on the label does nothing for `plain-text` mode
* Label input with associated label text
    * Use a screenreader such as VoiceOver to confirm this

Closes #45555.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Test plugin: [test-45968-text-area-label.zip](https://github.com/woocommerce/woocommerce/files/14780384/test-45968-text-area-label.zip)

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**) and the test plugin above installed...

1. Go to **Products** > **Add New**
2. Go to the **Test 45968 Text Area Label** section
3. Interact with the various text area fields and verify that their labels work properly
    - Clicking on label should focus associated input
    - Focusing on input should read associated label when using a screen reader such as VoiceOver

<img width="1110" alt="Screenshot 2024-03-27 at 15 30 00" src="https://github.com/woocommerce/woocommerce/assets/2098816/6027a9d5-35ad-40ed-817a-4cb39c730014">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
