### PR TITLE
[e2e test] Fix locator for customer combobox in create order test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-create-order-test-fix
+++ b/plugins/woocommerce/changelog/e2e-fix-create-order-test-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix locator in create order tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
@@ -361,7 +361,9 @@ test.describe( 'WooCommerce Orders > Add new order', () => {
 
 		// Select customer
 		await page.getByText( 'Guest' ).click();
-		await page.getByRole( 'combobox' ).nth( 4 ).fill( 'sideshowbob@' );
+		await page
+			.locator( 'input[aria-owns="select2-customer_user-results"]' )
+			.fill( 'sideshowbob@' );
 		await page.getByRole( 'option', { name: 'Sideshow Bob' } ).click();
 
 		// Add a product


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/45850

One locator in create-order spec was using indexes and that index was getting shifted in some cases when other tests (e.g. `create-checkout-block.spec.js`) were changing the site config and other comboboxes were introduced in the screen.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Locally: 
`pnpm env:restart && pnpm test:e2e-pw create-checkout-block.spec.js create-order.spec.js`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>