### PR TITLE
[Product Block Editor]: introduce core/bindings store

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-introduce-bindings-custom-store
+++ b/packages/js/product-editor/changelog/update-product-editor-introduce-bindings-custom-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: introduce core/bindings store

--- a/packages/js/product-editor/src/bindings/store/Readme.md
+++ b/packages/js/product-editor/src/bindings/store/Readme.md
@@ -1,0 +1,1 @@
+# WooCommerce Product Editor Bingings Store

--- a/packages/js/product-editor/src/bindings/store/actions.ts
+++ b/packages/js/product-editor/src/bindings/store/actions.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { ACTION_REGISTER_BINDINGS_SOURCE } from './constants';
+import type { RegisterSourceAction } from './types';
+
+/**
+ * Register an external source
+ *
+ * @param {RegisterSourceAction} action Name of the source to register.
+ */
+export function registerSourceHandler( action: RegisterSourceAction ) {
+	const { type, ...settings } = action;
+	return {
+		type: ACTION_REGISTER_BINDINGS_SOURCE,
+		...settings,
+	};
+}

--- a/packages/js/product-editor/src/bindings/store/constants.ts
+++ b/packages/js/product-editor/src/bindings/store/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Full editor actions
+ */
+export const ACTION_REGISTER_BINDINGS_SOURCE =
+	'ACTION_REGISTER_BINDINGS_SOURCE';

--- a/packages/js/product-editor/src/bindings/store/index.ts
+++ b/packages/js/product-editor/src/bindings/store/index.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+export const store = 'woocommerce/bindings';
+
+const bindingsStore = createReduxStore( store, {
+	actions,
+	selectors,
+	reducer,
+} );
+
+export default function registerBindingsStore() {
+	register( bindingsStore );
+}

--- a/packages/js/product-editor/src/bindings/store/reducer.ts
+++ b/packages/js/product-editor/src/bindings/store/reducer.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { ACTION_REGISTER_BINDINGS_SOURCE } from './constants';
+import type { BindingsAction, BindingsStateProps } from './types';
+
+/**
+ * Types & Constants
+ */
+const INITIAL_STATE: BindingsStateProps = {
+	sources: {},
+};
+
+export default function reducer(
+	state: BindingsStateProps | undefined = INITIAL_STATE,
+	action: BindingsAction
+): BindingsStateProps {
+	switch ( action.type ) {
+		case ACTION_REGISTER_BINDINGS_SOURCE:
+			const { type, name, ...source } = action;
+
+			return {
+				...state,
+				sources: {
+					...state.sources,
+					[ name ]: source,
+				},
+			};
+	}
+
+	return state;
+}

--- a/packages/js/product-editor/src/bindings/store/selectors.ts
+++ b/packages/js/product-editor/src/bindings/store/selectors.ts
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import type { BindingsSourcesProps, BindingsStateProps } from './types';
+
+/**
+ * Returns all the bindings sources registered.
+ *
+ * @param {Object} state - Data state.
+ * @return {Object}        All registered sources handlers.
+ */
+export function getAllBindingsSources(
+	state: BindingsStateProps
+): BindingsSourcesProps {
+	return state.sources;
+}
+
+/**
+ * Returns a specific bindings source.
+ *
+ * @param {Object} state      - Data state.
+ * @param {string} sourceName - Source handler name.
+ * @return {Object}             The specific binding source.
+ */
+export function getBindingsSource(
+	state: BindingsStateProps,
+	sourceName: string
+): BindingsSourcesProps[ string ] {
+	return state.sources[ sourceName ];
+}

--- a/packages/js/product-editor/src/bindings/store/test/actions.js
+++ b/packages/js/product-editor/src/bindings/store/test/actions.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ACTION_REGISTER_BINDINGS_SOURCE } from '../constants';
+import { registerSourceHandler } from '../actions';
+
+describe( 'actions', () => {
+	describe( 'registerSourceHandler', () => {
+		it( 'should return the ACTION_REGISTER_BINDINGS_SOURCE action', () => {
+			const source = {
+				name: 'namespace/source-name',
+				label: 'The name source handler of the namespace',
+				anotherAttribute: 'anotherValue',
+			};
+
+			deepFreeze( source );
+
+			const result = registerSourceHandler( source );
+			expect( result ).toEqual( {
+				type: ACTION_REGISTER_BINDINGS_SOURCE,
+				...source,
+			} );
+		} );
+	} );
+} );

--- a/packages/js/product-editor/src/bindings/store/test/reducer.js
+++ b/packages/js/product-editor/src/bindings/store/test/reducer.js
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import { ACTION_REGISTER_BINDINGS_SOURCE } from '../constants';
+
+describe( 'reducer', () => {
+	describe( 'ACTION_REGISTER_BINDINGS_SOURCE', () => {
+		it( 'should handle the action and update the state accordingly', () => {
+			const initialState = {
+				sources: {},
+			};
+			deepFreeze( initialState );
+
+			const source = {
+				name: 'namespace/source-name',
+				label: 'Source handler of the namespace',
+				anotherAttribute: 'anotherValue',
+			};
+
+			const action = {
+				type: ACTION_REGISTER_BINDINGS_SOURCE,
+				...source,
+			};
+
+			deepFreeze( action );
+
+			const expectedState = {
+				sources: {
+					'namespace/source-name': {
+						label: 'Source handler of the namespace',
+						anotherAttribute: 'anotherValue',
+					},
+				},
+			};
+
+			const resultState = reducer( initialState, action );
+			expect( resultState ).toEqual( expectedState );
+		} );
+
+		it( 'should add new sources without overwriting existing ones', () => {
+			const initialState = {
+				sources: {
+					'namespace/old-source-name': {
+						label: 'An old source',
+						anotherAttribute: 'someValue',
+					},
+				},
+			};
+			deepFreeze( initialState );
+
+			const newSource = {
+				name: 'namespace/new-source-name',
+				label: 'A new source',
+				newAttribute: 'newValue',
+			};
+
+			const action = {
+				type: ACTION_REGISTER_BINDINGS_SOURCE,
+				...newSource,
+			};
+
+			deepFreeze( action );
+
+			const expectedState = {
+				...initialState,
+				sources: {
+					...initialState.sources,
+					'namespace/new-source-name': {
+						label: 'A new source',
+						newAttribute: 'newValue',
+					},
+				},
+			};
+
+			const resultState = reducer( initialState, action );
+			expect( resultState ).toEqual( expectedState );
+		} );
+
+		it( 'should not modify state if action type does not match', () => {
+			const initialState = {
+				sources: {
+					'namespace/old-source-name': {
+						label: 'An old source',
+						anotherAttribute: 'someValue',
+					},
+				},
+			};
+			deepFreeze( initialState );
+
+			const action = {
+				type: 'UNKNOWN_ACTION',
+				name: 'namespace/new-source',
+			};
+			deepFreeze( action );
+
+			const resultState = reducer( initialState, action );
+			expect( resultState ).toEqual( initialState );
+		} );
+	} );
+} );

--- a/packages/js/product-editor/src/bindings/store/test/selectors.js
+++ b/packages/js/product-editor/src/bindings/store/test/selectors.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { getAllBindingsSources, getBindingsSource } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getAllBindingsSources', () => {
+		it( 'should return all registered bindings sources', () => {
+			const state = {
+				sources: {
+					'namespace/source-name_1': {
+						name: 'namespace/source-name_1',
+						label: 'The first source handler of the namespace',
+						anotherAttribute: 'anotherValue',
+					},
+					'namespace/source-name_2': {
+						name: 'namespace/source-name_2',
+						label: 'The second source handler of the namespace',
+						anotherAttribute: 'anotherValue',
+					},
+				},
+			};
+			deepFreeze( state );
+
+			const result = getAllBindingsSources( state );
+			expect( result ).toEqual( state.sources );
+		} );
+	} );
+
+	describe( 'getBindingsSource', () => {
+		it( 'should return a specific bindings source given its name', () => {
+			const state = {
+				sources: {
+					'namespace/source-name_1': {
+						name: 'namespace/source-name_1',
+						label: 'The first source handler of the namespace',
+						anotherAttribute: 'anotherValue',
+					},
+					'namespace/source-name_2': {
+						name: 'namespace/source-name_2',
+						label: 'The second source handler of the namespace',
+						anotherAttribute: 'anotherValue',
+					},
+				},
+			};
+			deepFreeze( state );
+
+			const result = getBindingsSource(
+				state,
+				'namespace/source-name_2'
+			);
+			expect( result ).toEqual(
+				state.sources[ 'namespace/source-name_2' ]
+			);
+		} );
+
+		it( 'should return undefined if the bindings source does not exist', () => {
+			const state = {
+				sources: {
+					sources: {
+						'namespace/source-name_1': {
+							name: 'namespace/source-name_1',
+							label: 'The first source handler of the namespace',
+							anotherAttribute: 'anotherValue',
+						},
+						'namespace/source-name_2': {
+							name: 'namespace/source-name_2',
+							label: 'The second source handler of the namespace',
+							anotherAttribute: 'anotherValue',
+						},
+					},
+				},
+			};
+			deepFreeze( state );
+
+			const result = getBindingsSource(
+				state,
+				'namespace/source-name_3'
+			);
+			expect( result ).toBeUndefined();
+		} );
+	} );
+} );

--- a/packages/js/product-editor/src/bindings/store/types.ts
+++ b/packages/js/product-editor/src/bindings/store/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { BindingSourceHandlerProps } from '../types';
+import { ACTION_REGISTER_BINDINGS_SOURCE } from './constants';
+
+/*
+ * Actions types
+ */
+export type RegisterSourceAction = {
+	type: typeof ACTION_REGISTER_BINDINGS_SOURCE;
+} & BindingSourceHandlerProps;
+
+export type BindingsAction = RegisterSourceAction | { type: 'UNKNOWN' };
+
+export type BindingsSourcesProps = Record<
+	string,
+	Omit< BindingSourceHandlerProps, 'name' >
+>;
+
+export type BindingsStateProps = {
+	sources: BindingsSourcesProps;
+};

--- a/packages/js/product-editor/src/bindings/types.ts
+++ b/packages/js/product-editor/src/bindings/types.ts
@@ -2,26 +2,14 @@
  * External dependencies
  */
 import type { BlockEditProps, BlockAttributes } from '@wordpress/blocks';
-import {
-	// @ts-expect-error no exported member.
-	type ComponentType,
-} from '@wordpress/element';
 
-export type AttributeBindingProps = {
+/**
+ * Internal dependencies
+ */
+export type ExternalSourceProps = {
 	source: string;
-	args: { prop: string };
+	args: Record< string, string | object | number | null | undefined >;
 };
-
-export type MetadataBindingsProps = Record< string, AttributeBindingProps >;
-
-export type BoundBlockAttributes = BlockAttributes & {
-	metadata?: {
-		bindings: MetadataBindingsProps;
-	};
-};
-
-export type BoundBlockEditInstance = CoreBlockEditProps< BoundBlockAttributes >;
-export type BoundBlockEditComponent = ComponentType< BoundBlockEditInstance >;
 
 /*
  * Block Binding API
@@ -40,8 +28,9 @@ export type BindingUseSourceProps = {
 	 */
 	updateValue: ( newValue: any ) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
-
-export interface BindingSourceHandlerProps< T > {
+export interface BindingSourceHandlerProps<
+	T = ExternalSourceProps[ 'args' ]
+> {
 	/*
 	 * The name of the binding source handler.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the custom `core/bindings` store in the Product Editor app. It will register data in the Bindings Integration, like the external source.
This is a fallback registry handler for the core. Although the core already has a registry system, it's private, making accessing the data from an external plugin impossible. [getAllBlockBindingsSources()](https://github.com/WordPress/gutenberg/blob/ed1dafa961198d77bb6d0851494ce800954c1f42/packages/blocks/src/store/private-selectors.js#L197) and [getBlockBindingsSource()](https://github.com/WordPress/gutenberg/blob/ed1dafa961198d77bb6d0851494ce800954c1f42/packages/blocks/src/store/private-selectors.js#L209C17-L209C39) are private selectors.
We can switch to core resources once they are made public.


Closes https://github.com/woocommerce/woocommerce/issues/45422

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The store implementation is not used and has not even been exposed, either. The testing process ends up a matter of running the tests:

```cli
pnpm --filter=./packages/js/product-editor run test:js packages/js/product-editor/src/bindings
```

<img width="634" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/c0148c61-251f-46fc-bb11-6dbf64024527">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
