### PR TITLE
Allow loading of layout template directly through metadata

### DIFF
--- a/packages/js/product-editor/changelog/add-layout-template-id
+++ b/packages/js/product-editor/changelog/add-layout-template-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow loading of layout template directly through metadata

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -160,7 +160,7 @@ export function BlockEditor( {
 	);
 
 	const [ layoutTemplateId ] = useProductEntityProp< string >(
-		'meta_data.layout_template_id',
+		'meta_data._layout_template_id',
 		{ postType }
 	);
 

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -52,9 +52,14 @@ import { ProductTemplate } from '../../types';
 import { LoadingState } from './loading-state';
 
 function getLayoutTemplateId(
+	layoutTemplateId: string | undefined,
 	productTemplate: ProductTemplate | undefined,
 	postType: string
 ) {
+	if ( layoutTemplateId ) {
+		return layoutTemplateId;
+	}
+
 	if ( productTemplate?.layoutTemplateId ) {
 		return productTemplate.layoutTemplateId;
 	}
@@ -154,6 +159,11 @@ export function BlockEditor( {
 		{ postType }
 	);
 
+	const [ layoutTemplateId ] = useProductEntityProp< string >(
+		'meta_data.layout_template_id',
+		{ postType }
+	);
+
 	const { record: product } = useEntityRecord(
 		'postType',
 		postType,
@@ -166,7 +176,7 @@ export function BlockEditor( {
 	);
 
 	const { layoutTemplate } = useLayoutTemplate(
-		getLayoutTemplateId( productTemplate, postType )
+		getLayoutTemplateId( layoutTemplateId, productTemplate, postType )
 	);
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(

--- a/plugins/woocommerce/changelog/change-variation-template
+++ b/plugins/woocommerce/changelog/change-variation-template
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Change ProductVariationTemplate methods to protected
+
+

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -64,7 +64,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	/**
 	 * Adds the group blocks to the template.
 	 */
-	private function add_group_blocks() {
+	protected function add_group_blocks() {
 		$this->add_group(
 			array(
 				'id'         => $this::GROUP_IDS['GENERAL'],
@@ -106,7 +106,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	/**
 	 * Adds the general group blocks to the template.
 	 */
-	private function add_general_group_blocks() {
+	protected function add_general_group_blocks() {
 		$general_group = $this->get_group_by_id( $this::GROUP_IDS['GENERAL'] );
 		$general_group->add_block(
 			array(
@@ -193,7 +193,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	/**
 	 * Adds the pricing group blocks to the template.
 	 */
-	private function add_pricing_group_blocks() {
+	protected function add_pricing_group_blocks() {
 		$is_calc_taxes_enabled = wc_tax_enabled();
 
 		$pricing_group = $this->get_group_by_id( $this::GROUP_IDS['PRICING'] );
@@ -315,7 +315,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	/**
 	 * Adds the inventory group blocks to the template.
 	 */
-	private function add_inventory_group_blocks() {
+	protected function add_inventory_group_blocks() {
 		$inventory_group = $this->get_group_by_id( $this::GROUP_IDS['INVENTORY'] );
 		$inventory_group->add_block(
 			array(
@@ -425,7 +425,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	/**
 	 * Adds the shipping group blocks to the template.
 	 */
-	private function add_shipping_group_blocks() {
+	protected function add_shipping_group_blocks() {
 		$shipping_group = $this->get_group_by_id( $this::GROUP_IDS['SHIPPING'] );
 		$shipping_group->add_block(
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds the possibility of choosing the layout template ID directly when it is persisted in the `layout_template_id` meta attribute. This is a way for extensions to control what layout template the generated variations should use, as an example, as we don't want to create a product template, since we don't allow creating a variation directly. 

Needed by https://github.com/woocommerce/woocommerce-gift-cards/issues/784
Related to https://github.com/woocommerce/woocommerce/pull/45953


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the following plugin:
[test-layout-template.zip](https://github.com/woocommerce/woocommerce/files/14773902/test-layout-template.zip)
2. Install the plugin https://wordpress.org/plugins/pexlechris-adminer/
3. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
4. Go to Products > Add
5. Fill in the name, go to the Variations tab, add a variation option and generate variations
6. Save the product
7. Copy the id of one of the generated variations
8. Go to Tools > WP Adminer
9. Go to wp_postmeta and "New Item"
10. Fill the following data:
post_id : the variation id you just copied
meta_key: _layout_template_id
meta_value: test-my-product
11. Save it
12. Open the variation in the new product editor
13. It should load with a custom layout template that only shows the general tab (the 'test-my-product' layout template)  
<img width="1221" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13437655/afbd37b7-9ed8-4d58-a48d-81dd161414d3">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
