### PR TITLE
Fix styling bug with saved payment methods in Checkout block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -189,6 +189,8 @@
 	.wc-block-components-radio-control__option:first-child,
 	.wc-block-components-radio-control__option:last-child {
 		margin: 0;
+		padding-bottom: em($gap);
+		padding-top: em($gap);
 	}
 
 	.wc-block-components-radio-control__option-checked {
@@ -209,10 +211,6 @@
 	.wc-block-components-radio-control-accordion-option
 	.wc-block-components-radio-control__option {
 		border-width: 0;
-	}
-	.wc-block-components-radio-control-accordion-option {
-		padding-bottom: $gap;
-		padding-top: $gap;
 	}
 
 	.wc-block-components-radio-control-accordion-option:first-child::after {

--- a/plugins/woocommerce/changelog/fix-saved-payment-method-styling
+++ b/plugins/woocommerce/changelog/fix-saved-payment-method-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug where saved payment methods were not rendered correctly in the heckout block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45955 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Stripe, or some other method that uses saved payment methods.
2. As a logged-in user, add an item to your cart and check out using this payment method. Save the payment method to your account.
3. Re-add an item and return to the checkout block.
4. Ensure the saved payment method is rendering correctly when there is only one method.
<img width="712" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/b435aaa0-c75e-4a8f-834f-cd2e4ff73964">

6. Repeat this again and check out with a different card (so that you can save it and have two saved methods).
7. Re-add an item to the cart and return to the checkout.
8. Ensure the saved payment methods display OK when there are more than one.

<img width="704" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/8f530093-887a-4192-8836-e62e5064eb0a">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
