### PR TITLE
Adjust shipping calculations copy

### DIFF
--- a/plugins/woocommerce/changelog/46022-update-41534-adjust-shipping-calculation-text
+++ b/plugins/woocommerce/changelog/46022-update-41534-adjust-shipping-calculation-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: This PR contains a minor textual update.
+

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -147,7 +147,7 @@ class ShippingController {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
 					$settings[ $index ]['desc'] = sprintf(
 						/* translators: %s: URL to the documentation. */
-						__( 'Not available when using the <a href="%s">Local pickup options powered by the Checkout block</a>.', 'woocommerce' ),
+						__( 'Hide shipping costs until an address is entered (Not available when using the <a href="%s">Local pickup options powered by the Checkout block</a>)', 'woocommerce' ),
 						'https://woo.com/document/woocommerce-blocks-local-pickup/'
 					);
 					$settings[ $index ]['disabled'] = true;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41534.

In #45614, we've changed _"Not available when using WooCommerce Blocks Local Pickup"_ to _"Not available when using the <a href="%s">Local pickup options powered by the Checkout block</a>"_. It turned out that the copy should have been changed to _"Hide shipping costs until an address is entered (Not available when using the <a href="%s">Local pickup options powered by the Checkout block</a>)"_ instead. This PR adjusts the text accordingly.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location`.
2. Enable local pickup.
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=options`.
4. Verify that the second text in the shipping calculations shows _"Hide shipping costs until an address is entered (Not available when using the [Local pickup options powered by the Checkout block](https://woo.com/document/woocommerce-blocks-local-pickup/))"_.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

This PR contains a minor textual update.

</details>
