### PR TITLE
CYS - E2E tests: fix flaky assembler-hub test

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -156,7 +156,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 							// @todo: Move the current component in a common folder or create a new one dedicated to this flow.
 							component: ApiCallLoader,
 						},
-						initial: 'installAndActivateTheme',
+						type: 'parallel',
 						states: {
 							installAndActivateTheme: {
 								initial: 'pending',
@@ -165,7 +165,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 										invoke: {
 											src: 'installAndActivateTheme',
 											onDone: {
-												target: 'setupStore',
+												target: 'success',
 											},
 											onError: {
 												actions:
@@ -173,72 +173,67 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 											},
 										},
 									},
-									setupStore: {
-										type: 'parallel',
-										states: {
-											assembleSite: {
-												initial: 'pending',
-												states: {
-													pending: {
-														invoke: {
-															src: 'assembleSite',
-															onDone: {
-																target: 'success',
-															},
-															onError: {
-																actions:
-																	'redirectToIntroWithError',
-															},
-														},
-													},
-													success: {
-														type: 'final',
-													},
-												},
+									success: { type: 'final' },
+								},
+							},
+							createProducts: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'createProducts',
+											onDone: {
+												target: 'success',
 											},
-											createProducts: {
-												initial: 'pending',
-												states: {
-													pending: {
-														invoke: {
-															src: 'createProducts',
-															onDone: {
-																target: 'success',
-															},
-															onError: {
-																actions:
-																	'redirectToIntroWithError',
-															},
-														},
-													},
-													success: {
-														type: 'final',
-													},
-												},
-											},
-											installFontFamilies: {
-												initial:
-													installFontFamiliesState.initial,
-												states: {
-													checkFontLibrary:
-														installFontFamiliesState
-															.states
-															.checkFontLibrary,
-													pending:
-														installFontFamiliesState
-															.states.pending,
-													success: {
-														type: 'final',
-													},
-												},
+											onError: {
+												actions:
+													'redirectToIntroWithError',
 											},
 										},
-										onDone: {
-											target: '#designWithoutAI.showAssembleHub',
-										},
+									},
+									success: {
+										type: 'final',
 									},
 								},
 							},
+							installFontFamilies: {
+								initial: installFontFamiliesState.initial,
+								states: {
+									checkFontLibrary:
+										installFontFamiliesState.states
+											.checkFontLibrary,
+									pending:
+										installFontFamiliesState.states.pending,
+									success: {
+										type: 'final',
+									},
+								},
+							},
+						},
+						onDone: {
+							target: 'assembleSite',
+						},
+					},
+					assembleSite: {
+						initial: 'pending',
+						states: {
+							pending: {
+								invoke: {
+									src: 'assembleSite',
+									onDone: {
+										target: 'success',
+									},
+									onError: {
+										actions: 'redirectToIntroWithError',
+									},
+								},
+							},
+							success: {
+								type: 'final',
+							},
+						},
+						onDone: {
+							target: '#designWithoutAI.showAssembleHub',
 						},
 					},
 				},

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -59,7 +59,12 @@ const installFontFamiliesState = {
 					target: 'success',
 				},
 				onError: {
-					actions: 'redirectToIntroWithError',
+					actions: [
+						'redirectToIntroWithError',
+						( context, event ) => {
+							console.log( event );
+						},
+					],
 				},
 			},
 		},
@@ -156,7 +161,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 							// @todo: Move the current component in a common folder or create a new one dedicated to this flow.
 							component: ApiCallLoader,
 						},
-						type: 'parallel',
+						initial: 'installAndActivateTheme',
 						states: {
 							installAndActivateTheme: {
 								initial: 'pending',
@@ -173,65 +178,72 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 											},
 										},
 									},
-									success: { type: 'final' },
-								},
-							},
-							assembleSite: {
-								initial: 'pending',
-								states: {
-									pending: {
-										invoke: {
-											src: 'assembleSite',
-											onDone: {
-												target: 'success',
+									success: {
+										type: 'parallel',
+										states: {
+											assembleSite: {
+												initial: 'pending',
+												states: {
+													pending: {
+														invoke: {
+															src: 'assembleSite',
+															onDone: {
+																target: 'success',
+															},
+															onError: {
+																actions:
+																	'redirectToIntroWithError',
+															},
+														},
+													},
+													success: {
+														type: 'final',
+													},
+												},
 											},
-											onError: {
-												actions:
-													'redirectToIntroWithError',
+											createProducts: {
+												initial: 'pending',
+												states: {
+													pending: {
+														invoke: {
+															src: 'createProducts',
+															onDone: {
+																target: 'success',
+															},
+															onError: {
+																actions:
+																	'redirectToIntroWithError',
+															},
+														},
+													},
+													success: {
+														type: 'final',
+													},
+												},
+											},
+											installFontFamilies: {
+												initial:
+													installFontFamiliesState.initial,
+												states: {
+													checkFontLibrary:
+														installFontFamiliesState
+															.states
+															.checkFontLibrary,
+													pending:
+														installFontFamiliesState
+															.states.pending,
+													success: {
+														type: 'final',
+													},
+												},
 											},
 										},
-									},
-									success: {
-										type: 'final',
-									},
-								},
-							},
-							createProducts: {
-								initial: 'pending',
-								states: {
-									pending: {
-										invoke: {
-											src: 'createProducts',
-											onDone: {
-												target: 'success',
-											},
-											onError: {
-												actions:
-													'redirectToIntroWithError',
-											},
+										onDone: {
+											target: '#designWithoutAI.showAssembleHub',
 										},
 									},
-									success: {
-										type: 'final',
-									},
 								},
 							},
-							installFontFamilies: {
-								initial: installFontFamiliesState.initial,
-								states: {
-									checkFontLibrary:
-										installFontFamiliesState.states
-											.checkFontLibrary,
-									pending:
-										installFontFamiliesState.states.pending,
-									success: {
-										type: 'final',
-									},
-								},
-							},
-						},
-						onDone: {
-							target: '#designWithoutAI.showAssembleHub',
 						},
 					},
 				},

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -59,12 +59,7 @@ const installFontFamiliesState = {
 					target: 'success',
 				},
 				onError: {
-					actions: [
-						'redirectToIntroWithError',
-						( context, event ) => {
-							console.log( event );
-						},
-					],
+					actions: 'redirectToIntroWithError',
 				},
 			},
 		},

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -165,7 +165,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 										invoke: {
 											src: 'installAndActivateTheme',
 											onDone: {
-												target: 'success',
+												target: 'setupStore',
 											},
 											onError: {
 												actions:
@@ -173,7 +173,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 											},
 										},
 									},
-									success: {
+									setupStore: {
 										type: 'parallel',
 										states: {
 											assembleSite: {

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/tests/state-machine.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/tests/state-machine.test.ts
@@ -152,6 +152,9 @@ describe( 'Design Without AI state machine', () => {
 					assembleSite: assembleSiteMock,
 					createProducts: createProductsMock,
 				},
+				actions: {
+					redirectToAssemblerHub: jest.fn(),
+				},
 			} );
 
 			const state = machine.getInitialState( initialState );
@@ -160,28 +163,18 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.pending'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore'
 				);
 			} );
+
+			await actor.stop();
 
 			expect( installAndActivateThemeMock ).toHaveBeenCalled();
-
-			const finalState = await waitFor( actor, ( currentState ) => {
-				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.success'
-				);
-			} );
-
-			expect(
-				finalState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.success'
-				)
-			).toBeTruthy();
 		} );
 
 		it( 'should invoke `redirectToIntroWithError` when `assembleSite` service fails', async () => {
 			const initialState =
-				'preAssembleSite.preApiCallLoader.assembleSite';
+				'preAssembleSite.preApiCallLoader.installAndActivateTheme';
 
 			const assembleSiteMock = jest.fn( () => Promise.reject() );
 			const createProductsMock = jest.fn( () => {
@@ -212,7 +205,7 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.assembleSite.pending'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore'
 				);
 			} );
 
@@ -222,7 +215,7 @@ describe( 'Design Without AI state machine', () => {
 
 		it( 'should invoke `assembleSite` service', async () => {
 			const initialState =
-				'preAssembleSite.preApiCallLoader.assembleSite';
+				'preAssembleSite.preApiCallLoader.installAndActivateTheme';
 
 			const assembleSiteMock = jest.fn( () => Promise.resolve() );
 			const installAndActivateThemeMock = jest.fn( () =>
@@ -240,6 +233,9 @@ describe( 'Design Without AI state machine', () => {
 					createProducts: createProductsMock,
 					installAndActivateTheme: installAndActivateThemeMock,
 				},
+				actions: {
+					redirectToAssemblerHub: jest.fn(),
+				},
 			} );
 
 			const state = machine.getInitialState( initialState );
@@ -248,28 +244,22 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.assembleSite.pending'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.assembleSite.success'
 				);
 			} );
 
 			expect( assembleSiteMock ).toHaveBeenCalled();
 
 			const finalState = await waitFor( actor, ( currentState ) => {
-				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.assembleSite.success'
-				);
+				return currentState.matches( 'showAssembleHub' );
 			} );
 
-			expect(
-				finalState.matches(
-					'preAssembleSite.preApiCallLoader.assembleSite.success'
-				)
-			).toBeTruthy();
+			expect( finalState.matches( 'showAssembleHub' ) ).toBeTruthy();
 		} );
 
 		it( 'should invoke `redirectToIntroWithError` when `createProducts` service fails', async () => {
 			const initialState =
-				'preAssembleSite.preApiCallLoader.createProducts';
+				'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts';
 
 			const createProductsMock = jest.fn( () => Promise.reject() );
 			const assembleSiteMock = jest.fn( () => Promise.resolve() );
@@ -296,7 +286,7 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.pending'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.pending'
 				);
 			} );
 
@@ -306,7 +296,7 @@ describe( 'Design Without AI state machine', () => {
 
 		it( 'should invoke `createProducts` service', async () => {
 			const initialState =
-				'preAssembleSite.preApiCallLoader.createProducts';
+				'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts';
 
 			const createProductsMock = jest.fn( () =>
 				Promise.resolve( {
@@ -326,7 +316,7 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.pending'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.pending'
 				);
 			} );
 
@@ -334,13 +324,13 @@ describe( 'Design Without AI state machine', () => {
 
 			const finalState = await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.success'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.success'
 				);
 			} );
 
 			expect(
 				finalState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.success'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.success'
 				)
 			).toBeTruthy();
 		} );

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/tests/state-machine.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/tests/state-machine.test.ts
@@ -152,9 +152,6 @@ describe( 'Design Without AI state machine', () => {
 					assembleSite: assembleSiteMock,
 					createProducts: createProductsMock,
 				},
-				actions: {
-					redirectToAssemblerHub: jest.fn(),
-				},
 			} );
 
 			const state = machine.getInitialState( initialState );
@@ -163,18 +160,27 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore'
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.pending'
 				);
 			} );
 
-			await actor.stop();
-
 			expect( installAndActivateThemeMock ).toHaveBeenCalled();
+
+			const finalState = await waitFor( actor, ( currentState ) => {
+				return currentState.matches(
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.success'
+				);
+			} );
+
+			expect(
+				finalState.matches(
+					'preAssembleSite.preApiCallLoader.installAndActivateTheme.success'
+				)
+			).toBeTruthy();
 		} );
 
 		it( 'should invoke `redirectToIntroWithError` when `assembleSite` service fails', async () => {
-			const initialState =
-				'preAssembleSite.preApiCallLoader.installAndActivateTheme';
+			const initialState = 'preAssembleSite.assembleSite';
 
 			const assembleSiteMock = jest.fn( () => Promise.reject() );
 			const createProductsMock = jest.fn( () => {
@@ -205,7 +211,7 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore'
+					'preAssembleSite.assembleSite.pending'
 				);
 			} );
 
@@ -214,8 +220,7 @@ describe( 'Design Without AI state machine', () => {
 		} );
 
 		it( 'should invoke `assembleSite` service', async () => {
-			const initialState =
-				'preAssembleSite.preApiCallLoader.installAndActivateTheme';
+			const initialState = 'preAssembleSite.assembleSite';
 
 			const assembleSiteMock = jest.fn( () => Promise.resolve() );
 			const installAndActivateThemeMock = jest.fn( () =>
@@ -242,24 +247,18 @@ describe( 'Design Without AI state machine', () => {
 
 			const actor = interpret( machine ).start( state );
 
-			await waitFor( actor, ( currentState ) => {
-				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.assembleSite.success'
-				);
-			} );
-
-			expect( assembleSiteMock ).toHaveBeenCalled();
-
 			const finalState = await waitFor( actor, ( currentState ) => {
 				return currentState.matches( 'showAssembleHub' );
 			} );
+
+			expect( assembleSiteMock ).toHaveBeenCalled();
 
 			expect( finalState.matches( 'showAssembleHub' ) ).toBeTruthy();
 		} );
 
 		it( 'should invoke `redirectToIntroWithError` when `createProducts` service fails', async () => {
 			const initialState =
-				'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts';
+				'preAssembleSite.preApiCallLoader.createProducts';
 
 			const createProductsMock = jest.fn( () => Promise.reject() );
 			const assembleSiteMock = jest.fn( () => Promise.resolve() );
@@ -286,7 +285,7 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.pending'
+					'preAssembleSite.preApiCallLoader.createProducts.pending'
 				);
 			} );
 
@@ -296,7 +295,7 @@ describe( 'Design Without AI state machine', () => {
 
 		it( 'should invoke `createProducts` service', async () => {
 			const initialState =
-				'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts';
+				'preAssembleSite.preApiCallLoader.createProducts';
 
 			const createProductsMock = jest.fn( () =>
 				Promise.resolve( {
@@ -316,7 +315,7 @@ describe( 'Design Without AI state machine', () => {
 
 			await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.pending'
+					'preAssembleSite.preApiCallLoader.createProducts.pending'
 				);
 			} );
 
@@ -324,13 +323,13 @@ describe( 'Design Without AI state machine', () => {
 
 			const finalState = await waitFor( actor, ( currentState ) => {
 				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.success'
+					'preAssembleSite.preApiCallLoader.createProducts.success'
 				);
 			} );
 
 			expect(
 				finalState.matches(
-					'preAssembleSite.preApiCallLoader.installAndActivateTheme.setupStore.createProducts.success'
+					'preAssembleSite.preApiCallLoader.createProducts.success'
 				)
 			).toBeTruthy();
 		} );

--- a/plugins/woocommerce/changelog/46030-44514-flaky-customize-storeassembler-hubspecjs
+++ b/plugins/woocommerce/changelog/46030-44514-flaky-customize-storeassembler-hubspecjs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: CYS - E2E tests: fix flaky assembler-hub test
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
@@ -1,5 +1,5 @@
-const { test, expect, request } = require( '@playwright/test' );
-const { BASE_URL } = process.env;
+const { test: base, expect, request } = require( '@playwright/test' );
+const { AssemblerPage } = require( './assembler/assembler.page' );
 const { activateTheme } = require( '../../utils/themes' );
 const { setOption } = require( '../../utils/options' );
 
@@ -8,21 +8,12 @@ const ASSEMBLER_HUB_URL =
 const CUSTOMIZE_STORE_URL =
 	'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store';
 
-const skipTestIfUndefined = () => {
-	const skipMessage = `Skipping this test on daily run. Environment not compatible.`;
-
-	test.skip( () => {
-		const shouldSkip = BASE_URL !== undefined;
-
-		if ( shouldSkip ) {
-			console.log( skipMessage );
-		}
-
-		return shouldSkip;
-	}, skipMessage );
-};
-
-skipTestIfUndefined();
+const test = base.extend( {
+	assemblerPageObject: async ( { page }, use ) => {
+		const pageObject = new AssemblerPage( { page } );
+		await use( pageObject );
+	},
+} );
 
 test.describe( 'Store owner can view Assembler Hub for store customization', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
@@ -79,17 +70,18 @@ test.describe( 'Store owner can view Assembler Hub for store customization', () 
 
 	test( 'Can view the Assembler Hub page when the theme is already customized', async ( {
 		page,
+		assemblerPageObject,
 	} ) => {
 		await page.goto( CUSTOMIZE_STORE_URL );
 		await page.click( 'text=Start designing' );
 		await page
 			.getByRole( 'button', { name: 'Design a new theme' } )
 			.click();
-
-		await page.waitForURL( ASSEMBLER_HUB_URL );
-
-		await page.goto( ASSEMBLER_HUB_URL );
-		await expect( page.locator( "text=Let's get creative" ) ).toBeVisible();
+		await assemblerPageObject.waitForLoadingScreenFinish();
+		const assembler = await assemblerPageObject.getAssembler();
+		await expect(
+			assembler.locator( "text=Let's get creative" )
+		).toBeVisible();
 	} );
 
 	test( 'Visiting change header should show a list of block patterns to choose from', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
@@ -7,25 +7,8 @@ export class AssemblerPage {
 	async setupSite( baseUrl ) {
 		const DESIGN_URL =
 			baseUrl +
-			'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fintro';
-
-		const waitForThemeResponse = this.page.waitForResponse( ( response ) =>
-			response.url().includes( 'wp-json/wp/v2/themes' )
-		);
-
-		const waitForTemplateResponse = this.page.waitForResponse(
-			( response ) => response.url().includes( '?_wp-find-template=true' )
-		);
-
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign';
 		await this.page.goto( DESIGN_URL );
-
-		await Promise.all( [ waitForThemeResponse, waitForTemplateResponse ] );
-
-		await this.page.getByText( 'Start designing' ).click();
-
-		await this.page
-			.getByRole( 'button', { name: 'Design a new theme' } )
-			.click();
 	}
 
 	async waitForLoadingScreenFinish() {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
@@ -7,8 +7,17 @@ export class AssemblerPage {
 	async setupSite( baseUrl ) {
 		const DESIGN_URL =
 			baseUrl +
-			'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign';
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fintro';
+
 		await this.page.goto( DESIGN_URL );
+		await this.page.waitForResponse( ( res ) =>
+			res.url().includes( '?_wp-find-template' )
+		);
+		await this.page.getByText( 'Start designing' ).click();
+
+		await this.page
+			.getByRole( 'button', { name: 'Design a new theme' } )
+			.click();
 	}
 
 	async waitForLoadingScreenFinish() {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
@@ -9,10 +9,18 @@ export class AssemblerPage {
 			baseUrl +
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fintro';
 
-		await this.page.goto( DESIGN_URL );
-		await this.page.waitForResponse( ( res ) =>
-			res.url().includes( '?_wp-find-template' )
+		const waitForThemeResponse = this.page.waitForResponse( ( response ) =>
+			response.url().includes( 'wp-json/wp/v2/themes' )
 		);
+
+		const waitForTemplateResponse = this.page.waitForResponse(
+			( response ) => response.url().includes( '?_wp-find-template=true' )
+		);
+
+		await this.page.goto( DESIGN_URL );
+
+		await Promise.all( [ waitForThemeResponse, waitForTemplateResponse ] );
+
 		await this.page.getByText( 'Start designing' ).click();
 
 		await this.page

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -1,5 +1,8 @@
-const { test: base, expect } = require( '@playwright/test' );
+const { test: base, expect, request } = require( '@playwright/test' );
 const { AssemblerPage } = require( '../assembler/assembler.page' );
+const { setOption } = require( '../../../utils/options' );
+const { activateTheme } = require( '../../../utils/themes' );
+
 const {
 	createRequestsToSetupStoreDictionary,
 	setupRequestInterceptor,
@@ -20,6 +23,42 @@ const steps = [
 
 test.describe( 'Assembler - Loading Page', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
+
+	test.beforeAll( async ( { baseURL } ) => {
+		try {
+			// In some environments the tour blocks clicking other elements.
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_customize_store_onboarding_tour_hidden',
+				'yes'
+			);
+		} catch ( error ) {
+			console.log( 'Store completed option not updated' );
+		}
+	} );
+
+	test.afterAll( async ( { baseURL } ) => {
+		try {
+			// In some environments the tour blocks clicking other elements.
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_customize_store_onboarding_tour_hidden',
+				'no'
+			);
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_admin_customize_store_completed',
+				'no'
+			);
+
+			await activateTheme( 'twentynineteen' );
+		} catch ( error ) {
+			console.log( 'Store completed option not updated' );
+		}
+	} );
 
 	test( 'should display loading screen and steps on first run', async ( {
 		pageObject,
@@ -84,7 +123,6 @@ test.describe( 'Assembler - Loading Page', () => {
 		await pageObject.waitForLoadingScreenFinish();
 
 		const assembler = await pageObject.getAssembler();
-		await assembler.getByRole( 'button', { name: 'Skip' } ).click();
 		await assembler.getByRole( 'button', { name: 'Done' } ).click();
 		await pageObject.setupSite( baseURL );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue in the current setup store flow. Currently, we:
- setup the theme.
- configure the template.
- install fonts.
- create products.

at the same time. 

This could be an issue for a slow client and/or slow server (like CI env). In the specific, the `__experimentalGetTemplateForLink` ([CYS codebase](https://github.com/woocommerce/woocommerce/blob/8500140dc07ba7ed08b2fd42f5eb021e1a6739e9/plugins/woocommerce-admin/client/customize-store/data/actions.ts/#L84-L87)) always returns a value only in case of block theme. ([__experimentalGetTemplateForLink implementation source code](https://github.com/WordPress/gutenberg/blob/ab708fd203f1196ca65d31735e23f173df33899f/packages/core-data/src/resolvers.js/#L484-L502)).


For this reason, in some cases - including the CI, the server is too slow to switch the theme, and the `__experimentalGetTemplateForLink` returns null, and this causes an error in the CYS flow.

To fix this issue, this PR changes the setup of the store flow. First:
- install and active the theme
- install fonts
- create products

And after that, the template configuration.

Closes #44514  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Head over to WooCommerce > Home > Customize your store
2. Click on "Start designing" and proceed to the Pattern Assembler.
3. Do a smoke test.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
CYS - E2E tests: fix flaky assembler-hub test 

</details>
