### PR TITLE
Add a red alert badge in my-subscription tab for disconnected stores

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -27,6 +27,21 @@
 		&.is-active {
 			border-color: var(--wp-admin-theme-color);
 		}
+		.awaiting-mod {
+			display: inline-block;
+			vertical-align: top;
+			box-sizing: border-box;
+			margin: 1px 0 -1px 8px;
+			padding: 0 5px;
+			min-width: 18px;
+			height: 18px;
+			border-radius: 9px;
+			background-color: #d63638;
+			color: #fff;
+			font-size: 11px;
+			line-height: 1.6;
+			text-align: center;
+		}
 	}
 }
 

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -27,11 +27,11 @@
 		&.is-active {
 			border-color: var(--wp-admin-theme-color);
 		}
-		.awaiting-mod {
+		.woocommerce-badge-color-red {
 			display: inline-block;
 			vertical-align: top;
 			box-sizing: border-box;
-			margin: 1px 0 -1px 8px;
+			margin: 1px 0 -1px 10px;
 			padding: 0 5px;
 			min-width: 18px;
 			height: 18px;

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -6,7 +6,6 @@ import { useContext, useEffect, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';
-import { getAdminSetting } from '../../../utils/admin-settings';
 
 /**
  * Internal dependencies
@@ -15,6 +14,7 @@ import './tabs.scss';
 import { DEFAULT_TAB_KEY, MARKETPLACE_PATH } from '../constants';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 import { MarketplaceContextType } from '../../contexts/types';
+import { getAdminSetting } from '~/utils/admin-settings';
 
 export interface TabsProps {
 	additionalClassNames?: Array< string > | undefined;

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useContext, useEffect, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
+import { Badge } from '@woocommerce/components';
 import classNames from 'classnames';
 import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';
 
@@ -25,7 +26,7 @@ interface Tab {
 	title: string;
 	href?: string;
 	show_badge?: boolean;
-	badge_text_to_render?: string;
+	badge_text_to_render?: number;
 }
 
 interface Tabs {
@@ -54,7 +55,7 @@ const tabs: Tabs = {
 		name: 'my-subscriptions',
 		title: __( 'My subscriptions', 'woocommerce' ),
 		show_badge: ! wccomSettings?.isConnected,
-		badge_text_to_render: '1',
+		badge_text_to_render: 1,
 	},
 };
 
@@ -122,9 +123,11 @@ const renderTabs = (
 				>
 					{ tabs[ tabKey ]?.title }
 					{ tabs[ tabKey ]?.show_badge && (
-						<span className="awaiting-mod">
-							{ tabs[ tabKey ]?.badge_text_to_render }
-						</span>
+						<Badge
+							key={ `${ tabKey }-badge` }
+							className={ 'woocommerce-badge-color-red' }
+							count={  Number(tabs[ tabKey ]?.badge_text_to_render) }
+						/>
 					) }
 				</Button>
 			)

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -6,6 +6,7 @@ import { useContext, useEffect, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';
+import { getAdminSetting } from '../../../utils/admin-settings';
 
 /**
  * Internal dependencies
@@ -23,11 +24,14 @@ interface Tab {
 	name: string;
 	title: string;
 	href?: string;
+	show_badge?: boolean;
+	badge_text_to_render?: string;
 }
 
 interface Tabs {
 	[ key: string ]: Tab;
 }
+const wccomSettings = getAdminSetting( 'wccomHelper', {} );
 
 const tabs: Tabs = {
 	search: {
@@ -49,6 +53,8 @@ const tabs: Tabs = {
 	'my-subscriptions': {
 		name: 'my-subscriptions',
 		title: __( 'My subscriptions', 'woocommerce' ),
+		show_badge: ! wccomSettings?.isConnected,
+		badge_text_to_render: '1',
 	},
 };
 
@@ -115,6 +121,7 @@ const renderTabs = (
 					key={ tabKey }
 				>
 					{ tabs[ tabKey ]?.title }
+					{ tabs[ tabKey ]?.show_badge && (<span className="awaiting-mod"> {tabs[ tabKey ]?.badge_text_to_render} </span>)}
 				</Button>
 			)
 		);

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -121,7 +121,11 @@ const renderTabs = (
 					key={ tabKey }
 				>
 					{ tabs[ tabKey ]?.title }
-					{ tabs[ tabKey ]?.show_badge && (<span className="awaiting-mod"> {tabs[ tabKey ]?.badge_text_to_render} </span>)}
+					{ tabs[ tabKey ]?.show_badge && (
+						<span className="awaiting-mod">
+							{ tabs[ tabKey ]?.badge_text_to_render }
+						</span>
+					) }
 				</Button>
 			)
 		);

--- a/plugins/woocommerce/changelog/add-red-alert-badge-for-disconnected-stores
+++ b/plugins/woocommerce/changelog/add-red-alert-badge-for-disconnected-stores
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Red alert badge for disconnected stores


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added a red alert badge in the My Subscriptions tab when the store is not connected with woo.com

![Screenshot 2024-03-28 at 11 48 19 AM](https://github.com/woocommerce/woocommerce/assets/10769293/2bbefa67-0c19-44b6-9ffb-6522826ab3c6)


<!-- Begin testing instructions -->

### If you haven't configured your development environment for WooCommerce development, please refer to this documentation.
- https://github.com/woocommerce/woocommerce/blob/trunk/README.md#getting-started
- https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md#plugin-development-environments

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build WooCommerce on your local environment, e.g.: `cd plugins/woocommerce` then `nvm use && pnpm run build --filter=woocommerce`.
2. Refresh WP Admin and go to WooCommerce > Extensions
3. Make sure the store is not connected with woo.com
4. You should see the red alert badge near the My Subscriptions tab 

![Screenshot 2024-03-28 at 11 48 19 AM](https://github.com/woocommerce/woocommerce/assets/10769293/2bbefa67-0c19-44b6-9ffb-6522826ab3c6)
5. Try to connect store with woo.com and then follow step 2 
6. The red alert badge should not be with the My Subscription tab

![Screenshot 2024-03-28 at 4 43 23 PM](https://github.com/woocommerce/woocommerce/assets/10769293/745b3492-ce87-4094-9383-70ff4f759522)
