### PR TITLE
Reference to wc-completed status should be renamed to completed

### DIFF
--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -270,7 +270,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 
 			do_action( 'woocommerce_update_new_customer_past_order', $order_id, $customer );
 
-			if ( $order->get_status() === 'wc-completed' ) {
+			if ( $order->get_status() === 'completed' ) {
 				$complete++;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR is a minor change.

The user function `wc_update_new_customer_past_orders` is using order status with `wc-` name (`wc-completed`).
This function currently doesn't find any "completed" orders.

The status should be compared to `complete`.

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality