### PR TITLE
Fix bug parsing memory_limit in product importer

### DIFF
--- a/plugins/woocommerce/changelog/do-not-assume-megabytes
+++ b/plugins/woocommerce/changelog/do-not-assume-megabytes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug parsing memory_limit in product importer

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -747,7 +747,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			// Unlimited, set to 32GB.
 			$memory_limit = '32000M';
 		}
-		return intval( $memory_limit ) * 1024 * 1024;
+		return wp_convert_hr_to_bytes( $memory_limit );
 	}
 
 	/**


### PR DESCRIPTION
Previously, the code assumed that all memory_limit values used the "M" suffix (for megabytes); values using "G" (for gigabytes), "K" (for kilobytes), or no suffix (for bytes) were all parsed incorrectly.  Now, all possible values should be handled correctly.

This bug has actually been fixed twice before in other locations:

Commit 538403306c5dfa44ee072dcf5a5c9887f1dd8d21 (#30908)

Commit 4557108805ca2140ebdf86f91eddc4858c4ff2f5 (#21557)

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In the admin section, run the product importer.  (Click "Products", then click the "Import" button.)
2. Any CSV file you upload should exercise the code modified in this pull request.  (The code will run once for every product in the CSV file.)

<!-- End testing instructions -->