### PR TITLE
Unify Product Elements inserter category to "WooCommerce Product Elements"

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"title": "Add to Cart with Options",
 	"description": "Display a button so the customer can add a product to their cart. Options will also be displayed depending on product type. e.g. quantity, variation.",
+	"category": "woocommerce-product-elements",
 	"attributes": {
 		"isDescendentOfSingleProductBlock": {
 			"type": "boolean",

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
@@ -9,9 +9,8 @@
 			"default": false
 		}
 	},
-	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
-	"usesContext": ["postId"],
+	"usesContext": [ "postId" ],
 	"textdomain": "woocommerce",
 	"apiVersion": 2,
 	"$schema": "https://schemas.wp.org/trunk/block.json"

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/block.json
@@ -8,7 +8,6 @@
 			"type": "string"
 		}
 	},
-	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"ancestor": [ "woocommerce/single-product" ],
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/block.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"title": "Product Average Rating (Beta)",
 	"description": "Display the average rating of a product",
+	"category": "woocommerce-product-elements",
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/block.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"title": "Add to Cart Button",
 	"description": "Display a call to action button which either adds the product to the cart, or links to the product page.",
-	"category": "woocommerce",
+	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"usesContext": [ "query", "queryId", "postId" ],
 	"textdomain": "woocommerce",
@@ -58,9 +58,7 @@
 			"label": "Outline"
 		}
 	],
-	"viewScript": [
-		"wc-product-button-interactivity-frontend"
-	],
+	"viewScript": [ "wc-product-button-interactivity-frontend" ],
 	"apiVersion": 2,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.json
@@ -4,6 +4,7 @@
 	"icon": "info",
 	"title": "Product Details",
 	"description": "Display a product's description, attributes, and reviews.",
+	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"align": true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.json
@@ -4,7 +4,6 @@
 	"icon": "info",
 	"title": "Product Details",
 	"description": "Display a product's description, attributes, and reviews.",
-	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"align": true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/block.json
@@ -4,7 +4,6 @@
 	"title": "Product Image Gallery",
 	"icon": "gallery",
 	"description": "Display a product's images.",
-	"category": "woocommerce",
 	"supports": {
 		"align": true,
 		"multiple": false

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/block.json
@@ -4,6 +4,7 @@
 	"title": "Product Image Gallery",
 	"icon": "gallery",
 	"description": "Display a product's images.",
+	"category": "woocommerce-product-elements",
 	"supports": {
 		"align": true,
 		"multiple": false

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-meta/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-meta/block.json
@@ -4,6 +4,7 @@
 	"title": "Product Meta",
 	"icon": "product",
 	"description": "Display a product’s SKU, categories, tags, and more.",
+	"category": "woocommerce-product-elements",
 	"supports": {
 		"align": true,
 		"reusable": false

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-meta/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-meta/block.json
@@ -4,7 +4,6 @@
 	"title": "Product Meta",
 	"icon": "product",
 	"description": "Display a product’s SKU, categories, tags, and more.",
-	"category": "woocommerce",
 	"supports": {
 		"align": true,
 		"reusable": false

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-reviews/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-reviews/block.json
@@ -4,6 +4,7 @@
 	"icon": "admin-comments",
 	"title": "Product Reviews",
 	"description": "A block that shows the reviews for a product.",
+	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"supports": {},
 	"attributes": {},

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-reviews/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-reviews/block.json
@@ -4,7 +4,6 @@
 	"icon": "admin-comments",
 	"title": "Product Reviews",
 	"description": "A block that shows the reviews for a product.",
-	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {},
 	"attributes": {},

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/block.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"title": "Product Rating Counter",
 	"description": "Display the review count of a product",
+	"category": "woocommerce-product-elements",
 	"attributes": {
 		"productId": {
 			"type": "number",

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/block.json
@@ -26,7 +26,6 @@
 		}
 	},
 	"usesContext": [ "query", "queryId", "postId" ],
-	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"align": true

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/block.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"title": "Product Rating Stars",
 	"description": "Display the average rating of a product with stars",
+	"category": "woocommerce-product-elements",
 	"attributes": {
 		"productId": {
 			"type": "number",

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/block.json
@@ -26,7 +26,6 @@
 		}
 	},
 	"usesContext": [ "query", "queryId", "postId" ],
-	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"align": true

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/block.json
@@ -27,7 +27,6 @@
 		}
 	},
 	"usesContext": [ "query", "queryId", "postId" ],
-	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"align": true

--- a/plugins/woocommerce/changelog/add-change-product-elements-category-to-product-elements
+++ b/plugins/woocommerce/changelog/add-change-product-elements-category-to-product-elements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Elements: unify the Product Elements inserter category


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During some work I realized only some of the Product Elements are placed in the "WooCommerce Product Elements" category while there's a group of blocks to which we refer as Product Elements and that may be confusing to users.

This PR unifies the inserter category for all Product Elements. You can see two types of changes:
- `category: 'woocommerce'` is removed - it's the case for blocks that use [shared config](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/shared/config.tsx#L18) which defines category,
- `category: 'woocommerce'` is replaced with `category: 'woocommerce-product-elements'` - it's the case for blocks that use shared config. I didn't want to spend time making them rely on shared config hence just a replacement.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


#### Product Collection

1. Create a new post
2. Insert Product Collection block and choose some collection (e.g. Featured)
3. Open inserter inside Product Collection block and click "Browse All"

<img width="654" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/079dea52-f90a-4991-9696-0c446c8e2cf1">

4. Scroll to the bottom
5. Expected: There's 7 Product Elements available in "WooCommerce Product Elements" category

Before | After
-- | -- 
<img width="339" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/6cef2942-358b-45fb-9820-2c4e75550488"> | <img width="339" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/8e978670-f1b3-4b74-bab9-230e1ae01d29">

#### Single Product block

1. Create a new post
2. Insert Single Product block and choose some product
3. Open inserter inside Single Product block and click "Browse All"

<img width="699" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/bb4d3cc0-430b-4395-a6d6-bc46ca8600b3">

4. Scroll to the bottom
5. Expected: There's 14 Product Elements available in "WooCommerce Product Elements" category. (Note: Image below shows 15, but "Add to Cart" block is experimental and won't display in production build!!!)

Before | After
-- | -- 
<img width="337" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/70eb7057-98c6-42f0-9415-4f23e4a95357"> | <img width="343" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/875a6c6e-ec37-4dde-a762-eb18f981a74f">

#### Single Product template

1. Go to Editor -> Templates -> Single Product template
2. Open the nserter somewhere on a template and click "Browse All"
3. Scroll to the bottom
4. Expected: There's 7 Product Elements available in "WooCommerce Product Elements" category

Before | After
-- | -- 
<img width="338" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/9feac93e-8cd9-4261-b606-668fb115d648"> | <img width="339" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/d7b593c4-5643-47f9-af83-611a3b26f24b">




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
