### PR TITLE
Track site visibility setting actions

### DIFF
--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -93,7 +93,13 @@ if ( appRoot ) {
 		window.wcAdminFeatures &&
 		window.wcAdminFeatures[ 'launch-your-store' ] === true
 	) {
-		registerSiteVisibilitySlotFill();
+		const urlParams = new URLSearchParams( window.location.search );
+		if (
+			urlParams.get( 'tab' ) === 'general' ||
+			! urlParams.get( 'tab' )
+		) {
+			registerSiteVisibilitySlotFill();
+		}
 	}
 }
 

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -93,13 +93,7 @@ if ( appRoot ) {
 		window.wcAdminFeatures &&
 		window.wcAdminFeatures[ 'launch-your-store' ] === true
 	) {
-		const urlParams = new URLSearchParams( window.location.search );
-		if (
-			urlParams.get( 'tab' ) === 'general' ||
-			! urlParams.get( 'tab' )
-		) {
-			registerSiteVisibilitySlotFill();
-		}
+		registerSiteVisibilitySlotFill();
 	}
 }
 

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -159,22 +159,6 @@ const SiteVisibility = () => {
 										'woocommerce'
 									) }
 								</p>
-								{ privateLink === 'yes' && (
-									<div className="site-visibility-settings-slotfill-private-link">
-										{ getPrivateLink() }
-										<Button
-											ref={ copyClipboardRef }
-											variant="link"
-											onClick={ () => {
-												recordEvent(
-													'site_visibility_private_link_copy'
-												);
-											} }
-										>
-											{ copyLinkText }
-										</Button>
-									</div>
-								) }
 							</>
 						}
 						checked={ privateLink === 'yes' }
@@ -191,6 +175,22 @@ const SiteVisibility = () => {
 						} }
 					/>
 				</div>
+				{ privateLink === 'yes' && (
+					<div className="site-visibility-settings-slotfill-private-link">
+						{ getPrivateLink() }
+						<Button
+							ref={ copyClipboardRef }
+							variant="link"
+							onClick={ () => {
+								recordEvent(
+									'site_visibility_private_link_copy'
+								);
+							} }
+						>
+							{ copyLinkText }
+						</Button>
+					</div>
+				) }
 			</div>
 			<div className="site-visibility-settings-slotfill-section">
 				<RadioControl

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -18,6 +18,7 @@ import { useCopyToClipboard } from '@wordpress/compose';
  */
 import { SETTINGS_SLOT_FILL_CONSTANT } from '../../settings/settings-slots';
 import './style.scss';
+import { recordEvent } from '@woocommerce/tracks';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
@@ -91,6 +92,9 @@ const SiteVisibility = () => {
 				<RadioControl
 					onChange={ () => {
 						setComingSoon( 'yes' );
+						recordEvent( 'site_visibility_toggle', {
+							status: 'coming_soon',
+						} );
 					} }
 					options={ [
 						{
@@ -130,9 +134,15 @@ const SiteVisibility = () => {
 							</>
 						}
 						checked={ storePagesOnly === 'yes' }
-						onChange={ () => {
+						onChange={ ( enabled ) => {
 							setStorePagesOnly(
 								storePagesOnly === 'yes' ? 'no' : 'yes'
+							);
+							recordEvent(
+								'site_visibility_restrict_store_pages_only_toggle',
+								{
+									enabled,
+								}
 							);
 						} }
 					/>
@@ -155,6 +165,11 @@ const SiteVisibility = () => {
 										<Button
 											ref={ copyClipboardRef }
 											variant="link"
+											onClick={ () => {
+												recordEvent(
+													'site_visibility_private_link_copy'
+												);
+											} }
 										>
 											{ copyLinkText }
 										</Button>
@@ -163,9 +178,15 @@ const SiteVisibility = () => {
 							</>
 						}
 						checked={ privateLink === 'yes' }
-						onChange={ () => {
+						onChange={ ( enabled ) => {
 							setPrivateLink(
 								privateLink === 'yes' ? 'no' : 'yes'
+							);
+							recordEvent(
+								'site_visibility_share_private_link_toggle',
+								{
+									enabled,
+								}
 							);
 						} }
 					/>
@@ -175,6 +196,9 @@ const SiteVisibility = () => {
 				<RadioControl
 					onChange={ () => {
 						setComingSoon( 'no' );
+						recordEvent( 'site_visibility_toggle', {
+							status: 'live',
+						} );
 					} }
 					options={ [
 						{

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -12,13 +12,13 @@ import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { useCopyToClipboard } from '@wordpress/compose';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
 import { SETTINGS_SLOT_FILL_CONSTANT } from '../../settings/settings-slots';
 import './style.scss';
-import { recordEvent } from '@woocommerce/tracks';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
@@ -9,6 +9,7 @@
 	}
 
 	.site-visibility-settings-slotfill-private-link {
+		margin-left: 73px;
 		padding: 8px 16px;
 		border-radius: 4px;
 		border: 1px solid #dcdcde;

--- a/plugins/woocommerce/changelog/46078-add-45873-track-site-visibility-action
+++ b/plugins/woocommerce/changelog/46078-add-45873-track-site-visibility-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add tracks for site visibility settings

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -37,12 +37,19 @@ class LaunchYourStore {
 			'woocommerce_private_link'     => array( 'yes', 'no' ),
 		);
 
+		$at_least_one_saved = false;
+
 		foreach ( $options as $name => $option ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			if ( isset( $_POST[ $name ] ) && in_array( $_POST[ $name ], $option, true ) ) {
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				update_option( $name, wp_unslash( $_POST[ $name ] ) );
+				$at_least_one_saved = true;
 			}
+		}
+
+		if ( $at_least_one_saved ) {
+			wc_admin_record_tracks_event( 'site_visibility_saved' );
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45873 .

This PR adds tracks for the following actions on the site visibility setting. 

- Change between `Coming soon` and `Live`
- Toggle `Restrict to store pages only` and `Share your site with a private link`
- Copy link click
- Save changes button click (only fires when there is at least one change)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch and enable `launch-your-store` feature flag.
2. Go to `WooCommerce -> Settings`
3. Open your browser inspector and paste `localStorage.setItem( 'debug', 'wc-admin:*' );`
4. Enable `Verbose` log level for your inspector.
5. Click Coming soon, Restrict to store pages only, share your site with a private link, and Live options.
6. Confirm each click fires a track event.
7. Change one of the options and click on `Save changes`
8. Click `Network` tab and search for `wcadmin_site_visibility_saved` track.

Tracks:

- wcadmin_site_visibility_share_private_link_toggle
- wcadmin_site_visibility_toggle
- wcadmin_site_visibility_restrict_store_pages_only_toggle
- wcadmin_site_visibility_private_link_copy
- wcadmin_site_visibility_saved


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add tracks for site visibility settings

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
