### PR TITLE
Show notice to connect to woocommerce.com in plugin update message for unconnected stores

### DIFF
--- a/plugins/woocommerce/changelog/46082-add-plugin-message-connect-woocom
+++ b/plugins/woocommerce/changelog/46082-add-plugin-message-connect-woocom
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Use a public helper API endpoint update-check-public to check latest versions of Woo extensions and show a plugin update message in the plugin table list to connect to Woo.com.
+Use a public helper API endpoint update-check-public to check latest versions of WooCommerce extensions and show a plugin update message in the plugin table list to connect to woocommerce.com.

--- a/plugins/woocommerce/changelog/46082-add-plugin-message-connect-woocom
+++ b/plugins/woocommerce/changelog/46082-add-plugin-message-connect-woocom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Use a public helper API endpoint update-check-public to check latest versions of Woo extensions and show a plugin update message in the plugin table list to connect to Woo.com.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -159,8 +159,7 @@ class WC_Helper_Updater {
 			$filename = $plugin['_filename'];
 			if ( WC_Helper::is_site_connected() ) {
 				add_action( 'in_plugin_update_message-' . $filename, array( __CLASS__, 'add_install_marketplace_plugin_message' ), 10, 2 );
-			}
-			else {
+			} else {
 				add_action( 'in_plugin_update_message-' . $filename, array( __CLASS__, 'add_connect_woocom_plugin_message' ), 10, 2 );
 			}
 		}
@@ -467,8 +466,7 @@ class WC_Helper_Updater {
 					'authenticated' => true,
 				)
 			);
-		}
-		else {
+		} else {
 			$request = WC_Helper_API::post(
 				'update-check-public',
 				array(

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -155,9 +155,10 @@ class WC_Helper_Updater {
 	 * @return void.
 	 */
 	public static function setup_update_plugins_messages() {
+		$is_site_connected = WC_Helper::is_site_connected();
 		foreach ( WC_Helper::get_local_woo_plugins() as $plugin ) {
 			$filename = $plugin['_filename'];
-			if ( WC_Helper::is_site_connected() ) {
+			if ( $is_site_connected ) {
 				add_action( 'in_plugin_update_message-' . $filename, array( __CLASS__, 'add_install_marketplace_plugin_message' ), 10, 2 );
 			} else {
 				add_action( 'in_plugin_update_message-' . $filename, array( __CLASS__, 'add_connect_woocom_plugin_message' ) );

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -167,7 +167,7 @@ class WC_Helper_Updater {
 	}
 
 	/**
-	 * Runs on in_plugin_update_message-{file-name}, show a message to connect to Woo.com for unconnected stores
+	 * Runs on in_plugin_update_message-{file-name}, show a message to connect to woocommerce.com for unconnected stores
 	 *
 	 * @return void.
 	 */
@@ -184,7 +184,7 @@ class WC_Helper_Updater {
 		printf(
 			wp_kses(
 			/* translators: 1: Woo Update Manager plugin install URL */
-				__( ' <a href="%1$s">Connect your store</a> to Woo.com to update.', 'woocommerce' ),
+				__( ' <a href="%1$s">Connect your store</a> to woocommerce.com to update.', 'woocommerce' ),
 				array(
 					'a' => array(
 						'href' => array(),

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -160,7 +160,7 @@ class WC_Helper_Updater {
 			if ( WC_Helper::is_site_connected() ) {
 				add_action( 'in_plugin_update_message-' . $filename, array( __CLASS__, 'add_install_marketplace_plugin_message' ), 10, 2 );
 			} else {
-				add_action( 'in_plugin_update_message-' . $filename, array( __CLASS__, 'add_connect_woocom_plugin_message' ), 10, 2 );
+				add_action( 'in_plugin_update_message-' . $filename, array( __CLASS__, 'add_connect_woocom_plugin_message' ) );
 			}
 		}
 	}
@@ -173,7 +173,7 @@ class WC_Helper_Updater {
 	 *
 	 * @return void.
 	 */
-	public static function add_connect_woocom_plugin_message( $plugin_data, $response ) {
+	public static function add_connect_woocom_plugin_message() {
 		$connect_page_url = add_query_arg(
 			array(
 				'page' => 'wc-admin',

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -33,7 +33,7 @@ class WC_Helper_Updater {
 	 * Add the hook for modifying default WPCore update notices on the plugins management page.
 	 */
 	public static function add_hook_for_modifying_update_notices() {
-		if ( ! WC_Woo_Update_Manager_Plugin::is_plugin_active() ) {
+		if ( ! WC_Woo_Update_Manager_Plugin::is_plugin_active() || ! WC_Helper::is_site_connected() ) {
 			add_action( 'load-plugins.php', array( __CLASS__, 'setup_update_plugins_messages' ), 11 );
 		}
 	}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -470,7 +470,7 @@ class WC_Helper_Updater {
 			$request = WC_Helper_API::post(
 				'update-check-public',
 				array(
-					'body'          => wp_json_encode( array( 'products' => $payload ) ),
+					'body' => wp_json_encode( array( 'products' => $payload ) ),
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -168,9 +168,6 @@ class WC_Helper_Updater {
 	/**
 	 * Runs on in_plugin_update_message-{file-name}, show a message to connect to Woo.com for unconnected stores
 	 *
-	 * @param object $plugin_data An array of plugin metadata.
-	 * @param object $response  An object of metadata about the available plugin update.
-	 *
 	 * @return void.
 	 */
 	public static function add_connect_woocom_plugin_message() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds these following behaviour:
- When a store is unconnected to woo.com, use a public helper API endpoint `update-check-public` to check latest versions of woo extensions
- Show a plugin update message in the plugin table list to connect to Woo.com

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Download an old version of a Woo Plugins (for example: Checkout Field Editor version 1.7.10, I already updated this product version data to public API response). You can find it in the github/woocommerce account.
2. Run the woocommerce `pnpm -- wp-env start`. Make sure the store is not connected to woo.com
3. Upload and install the old plugin
4. Open the Plugins->Installed Plugins page in wp-admin. Verify that there is now a in-message-plugin upgrade with additional notice to connect to woo.com
<img width="1265" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1663428/22b4e123-7d02-4263-b0dc-49740fa04d5a">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
