### PR TITLE
Add red bubble with update count  on in-app My Subscriptions tab

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -28,6 +28,23 @@
 			border-color: var(--wp-admin-theme-color);
 		}
 	}
+
+	&__update-count {
+		display: inline-block;
+		vertical-align: top;
+		box-sizing: border-box;
+		margin: 1px 0 -1px 4px;
+		padding: 0 5px;
+		min-width: 16px;
+		height: 16px;
+		border-radius: 9px;
+		background-color: #d63638;
+		color: #fff;
+		font-size: 10px;
+		line-height: 1.6;
+		text-align: center;
+		z-index: 26;
+	}
 }
 
 @media (width <= $breakpoint-medium) {

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -123,12 +123,9 @@ const renderTabs = (
 				>
 					{ tabs[ tabKey ]?.title }
 					{ tabs[ tabKey ]?.showUpdateCount && updateCount > 0 && (
-						<span
-							className="woocommerce-marketplace__update-count"
-							dangerouslySetInnerHTML={ sanitizeHTML(
-								'<span>' + updateCount + '</span>'
-							) }
-						></span>
+						<span className="woocommerce-marketplace__update-count">
+							<span> { updateCount } </span>
+						</span>
 					) }
 				</Button>
 			)

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -14,6 +14,8 @@ import './tabs.scss';
 import { DEFAULT_TAB_KEY, MARKETPLACE_PATH } from '../constants';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 import { MarketplaceContextType } from '../../contexts/types';
+import sanitizeHTML from '../../../lib/sanitize-html';
+import { getAdminSetting } from '../../../utils/admin-settings';
 
 export interface TabsProps {
 	additionalClassNames?: Array< string > | undefined;
@@ -23,6 +25,7 @@ interface Tab {
 	name: string;
 	title: string;
 	href?: string;
+	showUpdateCount?: boolean;
 }
 
 interface Tabs {
@@ -49,6 +52,7 @@ const tabs: Tabs = {
 	'my-subscriptions': {
 		name: 'my-subscriptions',
 		title: __( 'My subscriptions', 'woocommerce' ),
+		showUpdateCount: true,
 	},
 };
 
@@ -73,11 +77,14 @@ const getVisibleTabs = ( selectedTab: string ) => {
 
 	return currentVisibleTabs;
 };
+
 const renderTabs = (
 	marketplaceContextValue: MarketplaceContextType,
 	visibleTabs: Tabs
 ) => {
 	const { selectedTab, setSelectedTab } = marketplaceContextValue;
+	const wccomSettings = getAdminSetting( 'wccomHelper', {} );
+	const updateCount = wccomSettings?.wooUpdateCount ?? 0;
 
 	const onTabClick = ( tabKey: string ) => {
 		if ( tabKey === selectedTab ) {
@@ -115,6 +122,14 @@ const renderTabs = (
 					key={ tabKey }
 				>
 					{ tabs[ tabKey ]?.title }
+					{ tabs[ tabKey ]?.showUpdateCount && updateCount > 0 && (
+						<span
+							className="woocommerce-marketplace__update-count"
+							dangerouslySetInnerHTML={ sanitizeHTML(
+								'<span>' + updateCount + '</span>'
+							) }
+						></span>
+					) }
 				</Button>
 			)
 		);

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -14,7 +14,6 @@ import './tabs.scss';
 import { DEFAULT_TAB_KEY, MARKETPLACE_PATH } from '../constants';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 import { MarketplaceContextType } from '../../contexts/types';
-import sanitizeHTML from '../../../lib/sanitize-html';
 import { getAdminSetting } from '../../../utils/admin-settings';
 
 export interface TabsProps {

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -24,34 +24,47 @@ interface Tab {
 	name: string;
 	title: string;
 	href?: string;
-	showUpdateCount?: boolean;
+	showUpdateCount: boolean;
+	updateCount: number;
 }
 
 interface Tabs {
 	[ key: string ]: Tab;
 }
 
+const wccomSettings = getAdminSetting( 'wccomHelper', {} );
+const wooUpdateCount = wccomSettings?.wooUpdateCount ?? 0;
+
 const tabs: Tabs = {
 	search: {
 		name: 'search',
 		title: __( 'Search results', 'woocommerce' ),
+		showUpdateCount: false,
+		updateCount: 0,
 	},
 	discover: {
 		name: 'discover',
 		title: __( 'Discover', 'woocommerce' ),
+		showUpdateCount: false,
+		updateCount: 0,
 	},
 	extensions: {
 		name: 'extensions',
 		title: __( 'Browse', 'woocommerce' ),
+		showUpdateCount: false,
+		updateCount: 0,
 	},
 	themes: {
 		name: 'themes',
 		title: __( 'Themes', 'woocommerce' ),
+		showUpdateCount: false,
+		updateCount: 0,
 	},
 	'my-subscriptions': {
 		name: 'my-subscriptions',
 		title: __( 'My subscriptions', 'woocommerce' ),
 		showUpdateCount: true,
+		updateCount: wooUpdateCount,
 	},
 };
 
@@ -82,8 +95,6 @@ const renderTabs = (
 	visibleTabs: Tabs
 ) => {
 	const { selectedTab, setSelectedTab } = marketplaceContextValue;
-	const wccomSettings = getAdminSetting( 'wccomHelper', {} );
-	const updateCount = wccomSettings?.wooUpdateCount ?? 0;
 
 	const onTabClick = ( tabKey: string ) => {
 		if ( tabKey === selectedTab ) {
@@ -121,11 +132,12 @@ const renderTabs = (
 					key={ tabKey }
 				>
 					{ tabs[ tabKey ]?.title }
-					{ tabs[ tabKey ]?.showUpdateCount && updateCount > 0 && (
-						<span className="woocommerce-marketplace__update-count">
-							<span> { updateCount } </span>
-						</span>
-					) }
+					{ tabs[ tabKey ]?.showUpdateCount &&
+						tabs[ tabKey ]?.updateCount > 0 && (
+							<span className="woocommerce-marketplace__update-count">
+								<span> { tabs[ tabKey ]?.updateCount } </span>
+							</span>
+						) }
 				</Button>
 			)
 		);

--- a/plugins/woocommerce/changelog/46088-update-red-bubble-on-my-subs-tab
+++ b/plugins/woocommerce/changelog/46088-update-red-bubble-on-my-subs-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Displays a red badge on in-app My Subscriptions tab if Woo.com Update Manager is not installed or activated

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -62,7 +62,7 @@ class WC_Helper_Admin {
 			'wooUpdateManagerActive'     => WC_Woo_Update_Manager_Plugin::is_plugin_active(),
 			'wooUpdateManagerInstallUrl' => WC_Woo_Update_Manager_Plugin::generate_install_url(),
 			'wooUpdateManagerPluginSlug' => WC_Woo_Update_Manager_Plugin::WOO_UPDATE_MANAGER_SLUG,
-			'wooUpdateCount'             => WC_Woo_Update_Manager_Plugin::increment_update_count_for_woo_update_manager( WC_Helper_Updater::get_updates_count() ?? 0 ),
+			'wooUpdateCount'             => WC_Helper_Updater::get_updates_count_based_on_site_status(),
 		);
 
 		return $settings;

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -62,7 +62,7 @@ class WC_Helper_Admin {
 			'wooUpdateManagerActive'     => WC_Woo_Update_Manager_Plugin::is_plugin_active(),
 			'wooUpdateManagerInstallUrl' => WC_Woo_Update_Manager_Plugin::generate_install_url(),
 			'wooUpdateManagerPluginSlug' => WC_Woo_Update_Manager_Plugin::WOO_UPDATE_MANAGER_SLUG,
-			'wooUpdateCount'             => WC_Woo_Update_Manager_Plugin::increment_update_count_for_woo_update_manager( WC_Helper_Updater::get_updates_count() ),
+			'wooUpdateCount'             => WC_Woo_Update_Manager_Plugin::increment_update_count_for_woo_update_manager( WC_Helper_Updater::get_updates_count() ?? 0 ),
 		);
 
 		return $settings;

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -62,7 +62,7 @@ class WC_Helper_Admin {
 			'wooUpdateManagerActive'     => WC_Woo_Update_Manager_Plugin::is_plugin_active(),
 			'wooUpdateManagerInstallUrl' => WC_Woo_Update_Manager_Plugin::generate_install_url(),
 			'wooUpdateManagerPluginSlug' => WC_Woo_Update_Manager_Plugin::WOO_UPDATE_MANAGER_SLUG,
-			'wooUpdateCount'             => Marketplace::get_marketplace_update_count(),
+			'wooUpdateCount'             => WC_Woo_Update_Manager_Plugin::increment_update_count_for_woo_update_manager( WC_Helper_Updater::get_updates_count() ),
 		);
 
 		return $settings;

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Admin\Helper
  */
 
+use Automattic\WooCommerce\Internal\Admin\Marketplace;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -60,6 +62,7 @@ class WC_Helper_Admin {
 			'wooUpdateManagerActive'     => WC_Woo_Update_Manager_Plugin::is_plugin_active(),
 			'wooUpdateManagerInstallUrl' => WC_Woo_Update_Manager_Plugin::generate_install_url(),
 			'wooUpdateManagerPluginSlug' => WC_Woo_Update_Manager_Plugin::WOO_UPDATE_MANAGER_SLUG,
+			'wooUpdateCount'             => Marketplace::get_marketplace_update_count(),
 		);
 
 		return $settings;

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -312,7 +312,7 @@ class WC_Helper_Updater {
 		*/
 		$active_for_translations = array_filter(
 			$active_woo_plugins,
-			function( $plugin ) use ( $plugins ) {
+			function ( $plugin ) use ( $plugins ) {
 				/**
 				 * Filters the plugins that are subscribed to the automatic translations updates.
 				 *
@@ -476,7 +476,7 @@ class WC_Helper_Updater {
 			}
 
 			if ( version_compare( $plugin['Version'], $update_data[ $plugin['_product_id'] ]['version'], '<' ) ) {
-				$count++;
+				++$count;
 			}
 		}
 
@@ -487,7 +487,7 @@ class WC_Helper_Updater {
 			}
 
 			if ( version_compare( $theme['Version'], $update_data[ $theme['_product_id'] ]['version'], '<' ) ) {
-				$count++;
+				++$count;
 			}
 		}
 
@@ -501,12 +501,10 @@ class WC_Helper_Updater {
 	 * @return string Updates count markup, empty string if no updates avairable.
 	 */
 	public static function get_updates_count_html() {
-		$count = self::get_updates_count();
-		if ( ! $count ) {
-			return '';
-		}
-
+		$count      = self::get_updates_count() ?? 0;
+		$count      = WC_Woo_Update_Manager_Plugin::increment_update_count_for_woo_update_manager( $count );
 		$count_html = sprintf( '<span class="update-plugins count-%d"><span class="update-count">%d</span></span>', $count, number_format_i18n( $count ) );
+
 		return $count_html;
 	}
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -492,6 +492,25 @@ class WC_Helper_Updater {
 		}
 
 		set_transient( $cache_key, $count, 12 * HOUR_IN_SECONDS );
+
+		return $count;
+	}
+
+	/**
+	 * Get the update count to based on the status of the site.
+	 *
+	 * @return int
+	 */
+	public static function get_updates_count_based_on_site_status() {
+		if ( ! WC_Helper::is_site_connected() ) {
+			return 1;
+		}
+
+		$count = self::get_updates_count() ?? 0;
+		if ( ! WC_Woo_Update_Manager_Plugin::is_plugin_installed() || ! WC_Woo_Update_Manager_Plugin::is_plugin_active() ) {
+			++$count;
+		}
+
 		return $count;
 	}
 
@@ -501,8 +520,7 @@ class WC_Helper_Updater {
 	 * @return string Updates count markup, empty string if no updates avairable.
 	 */
 	public static function get_updates_count_html() {
-		$count      = self::get_updates_count() ?? 0;
-		$count      = WC_Woo_Update_Manager_Plugin::increment_update_count_for_woo_update_manager( $count );
+		$count      = self::get_updates_count_based_on_site_status();
 		$count_html = sprintf( '<span class="update-plugins count-%d"><span class="update-count">%d</span></span>', $count, number_format_i18n( $count ) );
 
 		return $count_html;

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1201,7 +1201,7 @@ class WC_Helper {
 	public static function get_subscription_install_url( $product_key, $product_slug ) {
 		$install_url = add_query_arg(
 			array(
-				'product-key' => $product_key,
+				'product-key' => rawurlencode( $product_key ),
 			),
 			self::get_install_base_url() . "{$product_slug}/"
 		);

--- a/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
@@ -109,6 +109,20 @@ class WC_Woo_Update_Manager_Plugin {
 	}
 
 	/**
+	 * Adjust update counter if Woo.com Update Manager is not installed.
+	 *
+	 * @param int $count number of updates available excluding Woo.com Update Manager
+	 * @return int
+	 */
+	public static function increment_update_count_for_woo_update_manager( int $count ): int {
+		if ( ! self::is_plugin_installed() || ! self::is_plugin_active() ) {
+			++$count;
+		}
+
+		return $count;
+	}
+
+	/**
 	 * Check if the installation notice has been dismissed.
 	 *
 	 * @return bool

--- a/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
@@ -115,7 +115,12 @@ class WC_Woo_Update_Manager_Plugin {
 	 * @return int
 	 */
 	public static function increment_update_count_for_woo_update_manager( int $count ): int {
-		if ( ! self::is_plugin_installed() || ! self::is_plugin_active() || ! WC_Helper::is_site_connected() ) {
+
+		if ( ! WC_Helper::is_site_connected() ) {
+			return 1;
+		}
+
+		if ( ! self::is_plugin_installed() || ! self::is_plugin_active() ) {
 			++$count;
 		}
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
@@ -111,11 +111,11 @@ class WC_Woo_Update_Manager_Plugin {
 	/**
 	 * Adjust update counter if Woo.com Update Manager is not installed.
 	 *
-	 * @param int $count number of updates available excluding Woo.com Update Manager
+	 * @param int $count number of updates available excluding Woo.com Update Manager.
 	 * @return int
 	 */
 	public static function increment_update_count_for_woo_update_manager( int $count ): int {
-		if ( ! self::is_plugin_installed() || ! self::is_plugin_active() ) {
+		if ( ! self::is_plugin_installed() || ! self::is_plugin_active() || ! WC_Helper::is_site_connected() ) {
 			++$count;
 		}
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
@@ -109,25 +109,6 @@ class WC_Woo_Update_Manager_Plugin {
 	}
 
 	/**
-	 * Adjust update counter if Woo.com Update Manager is not installed.
-	 *
-	 * @param int $count number of updates available excluding Woo.com Update Manager.
-	 * @return int
-	 */
-	public static function increment_update_count_for_woo_update_manager( int $count ): int {
-
-		if ( ! WC_Helper::is_site_connected() ) {
-			return 1;
-		}
-
-		if ( ! self::is_plugin_installed() || ! self::is_plugin_active() ) {
-			++$count;
-		}
-
-		return $count;
-	}
-
-	/**
 	 * Check if the installation notice has been dismissed.
 	 *
 	 * @return bool

--- a/plugins/woocommerce/src/Internal/Admin/Marketplace.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketplace.php
@@ -76,11 +76,11 @@ class Marketplace {
 	}
 
 	/**
-	 * Create the menu bubble for extensions menu based on number of updates available.
+	 * Get marketplace update count considering the status of Woo Update Manager.
 	 *
-	 * @return string
+	 * @return int
 	 */
-	private static function get_marketplace_update_count_html() {
+	public static function get_marketplace_update_count() {
 		$count = WC_Helper_Updater::get_updates_count();
 		if ( empty( $count ) ) {
 			$count = 0;
@@ -90,6 +90,17 @@ class Marketplace {
 		if ( ! WC_Woo_Update_Manager_Plugin::is_plugin_installed() || ! WC_Woo_Update_Manager_Plugin::is_plugin_active() ) {
 			++$count;
 		}
+
+		return $count;
+	}
+
+	/**
+	 * Create the menu bubble for extensions menu based on number of updates available.
+	 *
+	 * @return string
+	 */
+	private static function get_marketplace_update_count_html() {
+		$count = self::get_marketplace_update_count();
 
 		if ( 0 === $count ) {
 			return '';
@@ -107,7 +118,7 @@ class Marketplace {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( 'woocommerce_page_wc-admin' !== $hook_suffix ) {
 			return;
-		};
+		}
 
 		if ( ! isset( $_GET['path'] ) || '/extensions' !== $_GET['path'] ) {
 			return;

--- a/plugins/woocommerce/src/Internal/Admin/Marketplace.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketplace.php
@@ -61,7 +61,7 @@ class Marketplace {
 			array(
 				'id'         => 'woocommerce-marketplace',
 				'parent'     => 'woocommerce',
-				'title'      => __( 'Extensions', 'woocommerce' ) . self::get_marketplace_update_count_html(),
+				'title'      => __( 'Extensions', 'woocommerce' ) . WC_Helper_Updater::get_updates_count_html(),
 				'page_title' => __( 'Extensions', 'woocommerce' ),
 				'path'       => '/extensions',
 			),
@@ -73,40 +73,6 @@ class Marketplace {
 		 * @since 8.0
 		 */
 		return apply_filters( 'woocommerce_marketplace_menu_items', $marketplace_pages );
-	}
-
-	/**
-	 * Get marketplace update count considering the status of Woo Update Manager.
-	 *
-	 * @return int
-	 */
-	public static function get_marketplace_update_count() {
-		$count = WC_Helper_Updater::get_updates_count();
-		if ( empty( $count ) ) {
-			$count = 0;
-		}
-
-		$count = intval( $count );
-		if ( ! WC_Woo_Update_Manager_Plugin::is_plugin_installed() || ! WC_Woo_Update_Manager_Plugin::is_plugin_active() ) {
-			++$count;
-		}
-
-		return $count;
-	}
-
-	/**
-	 * Create the menu bubble for extensions menu based on number of updates available.
-	 *
-	 * @return string
-	 */
-	private static function get_marketplace_update_count_html() {
-		$count = self::get_marketplace_update_count();
-
-		if ( 0 === $count ) {
-			return '';
-		}
-
-		return sprintf( ' <span class="update-plugins count-%d"><span class="update-count">%d</span></span>', $count, number_format_i18n( $count ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

- This PR adds a red badge on My Subscription tab of the store if it isn't connected.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start the development environment ```pnpm -- wp-env start```
2. Build assets using `pnpm --filter='@woocommerce/plugin-woocommerce' build`
3. Your store shouldn't be connected to Woo.com and the Woo Update Manager plugin shouldn't be installed.
4. Visit [WCCore My Subscriptions page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions), credentials can be found under [wp-env documentation](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-env/)
5. Notice the red bubble on in-app, My Subscriptions tab showing `1`
<img width="1638" alt="Screenshot 2024-04-01 at 13 47 36" src="https://github.com/woocommerce/woocommerce/assets/1531403/8ea7e28c-c599-4cca-8844-0c572b3e20eb">

6. Connect your site. After the site is connected, if the Woo.com Update Manager isn't installed the red bubble on Extensions menu and the My Subscriptions tab should show `number of updates Available for Woo.com extensions` + 1.
7. For an example in the screenshot AW has an update available, so the update count is one, since Woo.com update manager isn't installed it should display `2`.
<img width="1943" alt="Screenshot 2024-04-01 at 13 52 06" src="https://github.com/woocommerce/woocommerce/assets/1531403/b416a49e-609e-459d-b4d5-1bd2bdc812de">

8. If AutomateWoo is updated to the latest version, update count should only show `1` as Woo.com Update Manager isn't installed.
<img width="1919" alt="Screenshot 2024-04-01 at 15 29 31" src="https://github.com/woocommerce/woocommerce/assets/1531403/5ee10eda-df89-4238-9401-e854e6d22c67">

9. Install WUM by downloading it via : https://woo.com/product-download/woo-update-manager

10. If WUM is installed but not activated, still the red bubble should be displayed.
<img width="1360" alt="Screenshot 2024-04-01 at 15 33 47" src="https://github.com/woocommerce/woocommerce/assets/1531403/b514313f-2b07-4a49-8f0b-cbead5f008aa">

11. When the WUM is activated and no other Woo.com extension are needed to be updated, the red bubble should not be displayed.

<img width="1311" alt="Screenshot 2024-04-01 at 15 35 42" src="https://github.com/woocommerce/woocommerce/assets/1531403/96298296-b3aa-4d20-be85-1e872f3a69d7">


12. When the site is disconnected, the red badge should be shown regardless of WUM installtion status. 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Displays a red badge on in-app My Subscriptions tab if Woo.com Update Manager is not installed or activated

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
