### PR TITLE
[Product Block Editor]: disable TextArea RichText instance according to `disabled` attribute value

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-text-area-read-only-attr
+++ b/packages/js/product-editor/changelog/update-product-editor-text-area-read-only-attr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+[Product Block Editor]: disable TextArea RichText instance according to `disabled` attribute value

--- a/packages/js/product-editor/src/blocks/generic/text-area/README.md
+++ b/packages/js/product-editor/src/blocks/generic/text-area/README.md
@@ -32,6 +32,13 @@ Help text that appears below the field, providing additional guidance to the use
 
 Indicates that the field is required.
 
+### readOnly
+
+-   **Type:** `Boolean`
+-   **Required:** `No`
+
+Indicates that the field is not editable.
+
 ### tooltip
 
 -   **Type:** `String`

--- a/packages/js/product-editor/src/blocks/generic/text-area/README.md
+++ b/packages/js/product-editor/src/blocks/generic/text-area/README.md
@@ -32,7 +32,7 @@ Help text that appears below the field, providing additional guidance to the use
 
 Indicates that the field is required.
 
-### readOnly
+### disabled
 
 -   **Type:** `Boolean`
 -   **Required:** `No`

--- a/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text-area/edit.tsx
@@ -36,7 +36,7 @@ export function TextAreaBlockEdit( {
 		required,
 		note,
 		tooltip,
-		disabled,
+		disabled = false,
 		align,
 		allowedFormats,
 		direction,
@@ -146,7 +146,7 @@ export function TextAreaBlockEdit( {
 						placeholder={ placeholder }
 						required={ required }
 						aria-required={ required }
-						disabled={ disabled }
+						readOnly={ disabled }
 						onBlur={ hideToolbar }
 					/>
 				) }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR disables the RichText component instance of the TextArea block field when the `disabled` attribute value is True.

e.g:

```php
array(
  'id'         => 'product-summary',
  'blockName'  => 'woocommerce/product-text-area-field',
  'attributes' => array(
    'label'    => __( 'Summary', 'woocommerce' ),
    'disabled' => true,
	// ...
  ),
)
```

Under the hood, it sets the `readOnly` property. Although [it isn't public yet](https://github.com/WordPress/gutenberg/pull/60327), it's a matter of time. Let's put everything in place to make it work once it is.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/42736

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

A visual review is more than enough for now.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
