### PR TITLE
[Linked products] - Change number of 'choose products for me' to 4

### DIFF
--- a/packages/js/product-editor/changelog/dev-44239_change_number_of_choose_products_for_me
+++ b/packages/js/product-editor/changelog/dev-44239_change_number_of_choose_products_for_me
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+[Linked products] - Change number of 'choose products for me' to 4 #46094

--- a/packages/js/product-editor/src/utils/get-related-products/index.ts
+++ b/packages/js/product-editor/src/utils/get-related-products/index.ts
@@ -12,6 +12,7 @@ type getRelatedProductsOptions = {
 
 const POSTS_NUMBER_TO_RANDOMIZE = 30;
 const POSTS_NUMBER_TO_PICK = 3;
+const POSTS_NUMBER_TO_DISPLAY = 4;
 
 /**
  * Return related products for a given product ID.
@@ -99,6 +100,7 @@ export async function getSuggestedProductsFor( {
 			: [],
 		tags: data?.tags ? data.tags.map( ( tag ) => tag.id ) : [],
 		exclude: exclude?.length ? exclude : [ postId ],
+		limit: POSTS_NUMBER_TO_DISPLAY,
 	};
 
 	if ( forceRequest ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We used to add 5 products by default for up-sells and cross-sells, which doesn't work well with most themes. This PR changes the default to 4.

Before

![QWs8Jv.png](https://github.com/woocommerce/woocommerce/assets/2240960/412cae8a-26e0-4c64-a2e3-833a996e9a35)

After

![Screenshot 2024-04-02 at 12 00 48 PM](https://github.com/woocommerce/woocommerce/assets/1314156/afc2afad-30ba-4237-9b87-aab13558c26b)

Closes #44239.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the New product editor and the Linked products (`product-linked`) are enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Product > Add New.
3. Add a product name.
4. Go `Linked products` and press `Choose products for me` under Upsells and Cross-sells.
5. Verify that 4 products have been chosen in both sections.
6. Publish the product and press `View product` in the pre-publish panel.
7. Verify that we show 4 upsells and cross-sells products instead of 5.

![Screen Recording on 2024-04-02 at 12-10-01](https://github.com/woocommerce/woocommerce/assets/1314156/eed09028-75e8-494d-b9f7-f583b6c3485e)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
