### PR TITLE
Add optional handle to wc_enqueue_js

### DIFF
--- a/plugins/woocommerce/changelog/46104-add-queued-js-handles
+++ b/plugins/woocommerce/changelog/46104-add-queued-js-handles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add handles to enqueued JS, introduce the `woocommerce_queued_js_chunks` filter


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR proposes a 2nd, optional `$handle` parameter for the `wc_enqueue_js` helper. 

The rationale is that filtering enqueued JS usin the existing `woocommerce_queued_js` filter is currently complicated, because all code is instantly concatenated into a single, long string. There is no reliable way to identify code blocks within this string. 

Introducing a handle will solve this issue:
* when a code chunk is enqueued, the handle is used to uniquely identify the code chunk, just like in `wp_enqueue_script`
* when no handle is provided, a unique handle is automatically generated
* instead of immediately concatenating to `$wc_enqueued_js`, the chunk is pushed to the array using the handle as the key
* finally, just before the JS is concatenated and printed, the chunks are passed to the `woocommerce_queued_js_chunks` filter, which makes it very simply to identify code chunks and filter them as needed.

A sample use case for this change is a privacy plugin that tries to remove enqueued analytics or tracking JS based on visitor location.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enqueue 2 chunks of JS:
```php
wc_enqueue_js( "console.log('Hello, World!')", "hello-handle" ); // here we are providing the handle
wc_enqueue_js( "console.log('Hello, Again!')" ); // notice no handle
```
2. Load any frontend page
   - [ ] Both messages are logged to browser console
3. Add a filter:
```php
add_filter( 'woocommerce_queued_js_chunks', function( $chunks ) {
   unset( $chunks['hello-handle'] );
   
   return $chunks;
} );
```
4. Reload the frontend page
   - [ ] Only "Hello, Again" is logged to the browser console
<!-- End testing instructions -->

Note: the only breaking change here is that the global `$wc_queued_js` is no longer a string, but an array. Given that WC codebase only accesses this global object using the 2 updated functions, I don't see this as a problem. However, there may be 3rd parties that access this variable directly, which may break their implementations.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add handles to enqueued JS, introduce the `woocommerce_queued_js_chunks` filter

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
