### PR TITLE
dev: disable xstate inspector in prod build

### DIFF
--- a/plugins/woocommerce-admin/client/xstate.js
+++ b/plugins/woocommerce-admin/client/xstate.js
@@ -27,7 +27,7 @@ async function enableXStateV4Inspect() {
  */
 let XStateV5Inspect;
 async function enableXStateV5Inspect() {
-	const { createBrowserInspector } = await import( '@statelyai/inspect' );
+	const { createBrowserInspector } = require( '@statelyai/inspect' );
 	XStateV5Inspect = createBrowserInspector;
 	// eslint-disable-next-line no-console
 	console.log(
@@ -55,7 +55,11 @@ if ( isDevelopmentEnvironment && isXStateInspectEnabled ) {
 
 export const useXStateInspect = ( machineVersion ) => {
 	let xstateV5Inspector;
-	if ( isXStateV5InspectEnabled && machineVersion === 'V5' ) {
+	if (
+		isDevelopmentEnvironment &&
+		isXStateV5InspectEnabled &&
+		machineVersion === 'V5'
+	) {
 		xstateV5Inspector = XStateV5Inspect().inspect;
 	}
 

--- a/plugins/woocommerce-admin/client/xstate.js
+++ b/plugins/woocommerce-admin/client/xstate.js
@@ -27,7 +27,7 @@ async function enableXStateV4Inspect() {
  */
 let XStateV5Inspect;
 async function enableXStateV5Inspect() {
-	const { createBrowserInspector } = require( '@statelyai/inspect' );
+	const { createBrowserInspector } = await import( '@statelyai/inspect' );
 	XStateV5Inspect = createBrowserInspector;
 	// eslint-disable-next-line no-console
 	console.log(

--- a/plugins/woocommerce/changelog/46109-dev-disable-xstate-in-prod-builds
+++ b/plugins/woocommerce/changelog/46109-dev-disable-xstate-in-prod-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fixes a bug introduced previously where enabling localStorage.xstateV5_inspect would cause the page to crash because it's not supposed to be used in prod builds.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previous PR https://github.com/woocommerce/woocommerce/pull/45879 introduced a bug where the env isn't being checked before attempting to access statelyai inspector. 

This PR now adds the check back.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `localStorage.xstateV5_inspect=true' in jurassic ninja
1. Enable 'launch-your-store' feature flag and go to the LYS hub
2. It should load and not crash, and there should be no xstate inspector window popping up

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixes a bug introduced previously where enabling localStorage.xstateV5_inspect would cause the page to crash because it's not supposed to be used in prod builds.


#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
