### PR TITLE
Make sure admin features hooks are added as soon as possible in WC Beta Tester

### DIFF
--- a/plugins/woocommerce-beta-tester/api/features/features.php
+++ b/plugins/woocommerce-beta-tester/api/features/features.php
@@ -42,11 +42,7 @@ function toggle_feature( $request ) {
 		return new WP_REST_Response( $features, 204 );
 	}
 
-	if ( isset( $custom_feature_values[ $feature_name ] ) ) {
-		unset( $custom_feature_values[ $feature_name ] );
-	} else {
-		$custom_feature_values[ $feature_name ] = ! $features[ $feature_name ];
-	}
+	$custom_feature_values[ $feature_name ] = ! $features[ $feature_name ];
 
 	update_option( OPTION_NAME_PREFIX, $custom_feature_values );
 	return new WP_REST_Response( get_features(), 200 );

--- a/plugins/woocommerce-beta-tester/changelog/update-beta-tester-admin-feature-flags
+++ b/plugins/woocommerce-beta-tester/changelog/update-beta-tester-admin-feature-flags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make sure the admin features filters are added as early as possible

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-admin-features.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-admin-features.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Beta Tester Plugin Admin Features class.
+ *
+ * @package WC_Beta_Tester
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Beta_Tester Admin Features Class.
+ */
+class WC_Beta_Tester_Admin_Features {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		/**
+		 * We need to hook into both filters to ensure that the feature flags are correctly set.
+		 *
+		 * The `woocommerce_admin_get_feature_config` filter is used to modify the feature config which holds the default values for the feature flags. We need this to ensure beta tester can fetch the available feature flags. See get_features() in ../api/features/features.php and replace_supported_features() in Automattic\WooCommerce\Internal\Admin\FeaturePlugin.
+		 *
+		 * The `woocommerce_admin_features` filter is used to modify the features directly. This allows us to test code behind feature flags even if they are run before the plugins_loaded hook is fired. For example, test code behind a feature flag in WooCommerce's install routines.
+		 */
+		add_filter( 'woocommerce_admin_get_feature_config', array( $this, 'modify_feature_config' ) );
+		add_filter( 'woocommerce_admin_features', array( $this, 'modify_features' ) );
+	}
+
+	/**
+	 * Modify the features.
+	 *
+	 * @param array $features Features.
+	 * @return array
+	 */
+	public function modify_features( $features ) {
+		$custom_feature_values = get_option( 'wc_admin_helper_feature_values', array() );
+
+		$disabled_features = array_keys( array_diff( $custom_feature_values, array( true ) ) );
+		$enabled_features  = array_keys( array_filter( $custom_feature_values ) );
+
+		$features = array_merge( $features, $enabled_features );
+		$features = array_diff( $features, $disabled_features );
+
+		return $features;
+	}
+
+	/**
+	 * Modify the feature config.
+	 *
+	 * @param array $feature_config Feature config.
+	 * @return array
+	 */
+	public function modify_feature_config( $feature_config ) {
+		$custom_feature_values = get_option( 'wc_admin_helper_feature_values', array() );
+		foreach ( $custom_feature_values as $feature => $value ) {
+			if ( isset( $feature_config[ $feature ] ) ) {
+				$feature_config[ $feature ] = $value;
+			}
+		}
+		return $feature_config;
+	}
+}
+
+return new WC_Beta_Tester_Admin_Features();

--- a/plugins/woocommerce-beta-tester/plugin.php
+++ b/plugins/woocommerce-beta-tester/plugin.php
@@ -1,28 +1,25 @@
 <?php
-add_action( 'admin_menu', function() {
-	add_management_page(
-		'WooCommerce Admin Test Helper',
-		'WCA Test Helper',
-		'install_plugins',
-		'woocommerce-admin-test-helper',
-		function() {
-			?><div id="woocommerce-admin-test-helper-app-root"></div><?php
-		}
-	);
-} );
+add_action(
+	'admin_menu',
+	function() {
+		add_management_page(
+			'WooCommerce Admin Test Helper',
+			'WCA Test Helper',
+			'install_plugins',
+			'woocommerce-admin-test-helper',
+			function() {
+				?><div id="woocommerce-admin-test-helper-app-root"></div>
+				<?php
+			}
+		);
+	}
+);
 
-add_action( 'wp_loaded', function() {
-	require_once __DIR__ . '/vendor/autoload.php';
-	require( 'api/api.php' );
-} );
+add_action(
+	'wp_loaded',
+	function() {
+		require_once __DIR__ . '/vendor/autoload.php';
+		require 'api/api.php';
+	}
+);
 
-add_filter( 'woocommerce_admin_get_feature_config', function( $feature_config ) {
-	$feature_config['beta-tester-slotfill-examples'] = false;
-    $custom_feature_values = get_option( 'wc_admin_helper_feature_values', array() );
-    foreach ( $custom_feature_values as $feature => $value ) {
-        if ( isset(  $feature_config[$feature] ) ) {
-            $feature_config[$feature] = $value;
-        }
-    }
-	return $feature_config;
-} );

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -139,3 +139,5 @@ add_action(
 
 // Initialize the live branches feature.
 require_once dirname( __FILE__ ) . '/includes/class-wc-beta-tester-live-branches.php';
+// Initialize the admin features as early as possible.
+require_once dirname( __FILE__ ) . '/includes/class-wc-beta-tester-admin-features.php';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related: https://github.com/Automattic/jurassic.ninja/issues/289

Currently, beta testers are not able to test the new features behind the feature flags in WooCommerce's install. This is because the feature flag filters are added in the `plugins_loaded` hook and FeaturePlugin is also loaded in the `plugins_loaded` hook. This means that the feature flags are not available before the FeaturePlugin is loaded.

This PR adds the feature flag filters when the beta tester plugin is loaded and add a hook to `woocommerce_admin_features` filter directly to modify the features.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper > Features
2. Toggle the feature flag for the feature you want to test
3. Confirm that the feature is enabled/disabled as expected
4. Enable the feature flag for `launch-your-store`
5. Add `error_log( 'launch-your-store is enabled' );` inside the feature flag [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-woocommerce.php#L258) 
6. Confirm that the message is logged

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
