### PR TITLE
Update shipping and payment radio controls to use borders on selected items

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -6,6 +6,8 @@ import {
 	RadioControlOptionType,
 } from '@woocommerce/blocks-components';
 import { CartShippingPackageShippingRate } from '@woocommerce/types';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
+import { useSelect } from '@wordpress/data';
 
 interface LocalPickupSelectProps {
 	title?: string | undefined;
@@ -31,9 +33,14 @@ export const LocalPickupSelect = ( {
 	renderPickupLocation,
 	packageCount,
 }: LocalPickupSelectProps ) => {
+	const internalPackageCount = useSelect(
+		( select ) =>
+			select( CART_STORE_KEY )?.getCartData()?.shippingRates?.length
+	);
 	// Hacky way to check if there are multiple packages, this way is borrowed from  `assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx`
 	// We have no built-in way of checking if other extensions have added packages.
 	const multiplePackages =
+		internalPackageCount > 1 ||
 		document.querySelectorAll(
 			'.wc-block-components-local-pickup-select .wc-block-components-radio-control'
 		).length > 1;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -45,6 +45,7 @@ export const LocalPickupSelect = ( {
 					setSelectedOption( value );
 					onSelectRate( value );
 				} }
+				highlightChecked={ true }
 				selected={ selectedOption }
 				options={ pickupLocations.map( ( location ) =>
 					renderPickupLocation( location, packageCount )

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -27,6 +27,8 @@ export const ShippingRatesControlPackage = ( {
 	showItems,
 }: PackageProps ): ReactElement => {
 	const { selectShippingRate, isSelectingRate } = useShippingData();
+
+	// We have no built-in way of checking if other extensions have added packages e.g. if subscriptions has added them.
 	const multiplePackages =
 		document.querySelectorAll(
 			'.wc-block-components-shipping-rates-control__package'

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -9,6 +9,8 @@ import { useCallback, useMemo } from '@wordpress/element';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { sanitizeHTML } from '@woocommerce/utils';
 import type { ReactElement } from 'react';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -27,10 +29,10 @@ export const ShippingRatesControlPackage = ( {
 	showItems,
 }: PackageProps ): ReactElement => {
 	const { selectShippingRate, isSelectingRate } = useShippingData();
-	const multiplePackages =
-		document.querySelectorAll(
-			'.wc-block-components-shipping-rates-control__package'
-		).length > 1;
+	const multiplePackages = useSelect(
+		( select ) =>
+			select( CART_STORE_KEY )?.getCartData()?.shippingRates?.length > 1
+	);
 
 	// If showItems is not set, we check if we have multiple packages.
 	// We sometimes don't want to show items even if we have multiple packages.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -9,8 +9,6 @@ import { useCallback, useMemo } from '@wordpress/element';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { sanitizeHTML } from '@woocommerce/utils';
 import type { ReactElement } from 'react';
-import { CART_STORE_KEY } from '@woocommerce/block-data';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -29,10 +27,10 @@ export const ShippingRatesControlPackage = ( {
 	showItems,
 }: PackageProps ): ReactElement => {
 	const { selectShippingRate, isSelectingRate } = useShippingData();
-	const multiplePackages = useSelect(
-		( select ) =>
-			select( CART_STORE_KEY )?.getCartData()?.shippingRates?.length > 1
-	);
+	const multiplePackages =
+		document.querySelectorAll(
+			'.wc-block-components-shipping-rates-control__package'
+		).length > 1;
 
 	// If showItems is not set, we check if we have multiple packages.
 	// We sometimes don't want to show items even if we have multiple packages.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -9,6 +9,8 @@ import { useCallback, useMemo } from '@wordpress/element';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { sanitizeHTML } from '@woocommerce/utils';
 import type { ReactElement } from 'react';
+import { useSelect } from '@wordpress/data';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -29,8 +31,14 @@ export const ShippingRatesControlPackage = ( {
 }: PackageProps ): ReactElement => {
 	const { selectShippingRate, isSelectingRate } = useShippingData();
 
+	const internalPackageCount = useSelect(
+		( select ) =>
+			select( CART_STORE_KEY )?.getCartData()?.shippingRates?.length
+	);
+
 	// We have no built-in way of checking if other extensions have added packages e.g. if subscriptions has added them.
 	const multiplePackages =
+		internalPackageCount > 1 ||
 		document.querySelectorAll(
 			'.wc-block-components-shipping-rates-control__package'
 		).length > 1;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { _n, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Label, Panel } from '@woocommerce/blocks-components';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { sanitizeHTML } from '@woocommerce/utils';
 import type { ReactElement } from 'react';
@@ -104,6 +104,12 @@ export const ShippingRatesControlPackage = ( {
 		disabled: isSelectingRate,
 	};
 
+	const selectedOptionNumber = useMemo( () => {
+		return packageData?.shipping_rates?.findIndex(
+			( rate ) => rate?.selected
+		);
+	}, [ packageData?.shipping_rates ] );
+
 	if ( shouldBeCollapsible ) {
 		return (
 			<Panel
@@ -135,6 +141,16 @@ export const ShippingRatesControlPackage = ( {
 				{
 					'wc-block-components-shipping-rates-control__package--disabled':
 						isSelectingRate,
+				},
+				{
+					'wc-block-components-shipping-rates-control__package--first-selected':
+						! isSelectingRate && selectedOptionNumber === 0,
+				},
+				{
+					'wc-block-components-shipping-rates-control__package--last-selected':
+						! isSelectingRate &&
+						selectedOptionNumber ===
+							packageData?.shipping_rates?.length - 1,
 				}
 			) }
 		>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -143,12 +143,8 @@ export const ShippingRatesControlPackage = ( {
 				{
 					'wc-block-components-shipping-rates-control__package--disabled':
 						isSelectingRate,
-				},
-				{
 					'wc-block-components-shipping-rates-control__package--first-selected':
 						! isSelectingRate && selectedOptionNumber === 0,
-				},
-				{
 					'wc-block-components-shipping-rates-control__package--last-selected':
 						! isSelectingRate &&
 						selectedOptionNumber ===

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -25,6 +25,7 @@ export const ShippingRatesControlPackage = ( {
 	packageData,
 	collapsible,
 	showItems,
+	highlightChecked = false,
 }: PackageProps ): ReactElement => {
 	const { selectShippingRate, isSelectingRate } = useShippingData();
 
@@ -104,6 +105,7 @@ export const ShippingRatesControlPackage = ( {
 		),
 		renderOption,
 		disabled: isSelectingRate,
+		highlightChecked,
 	};
 
 	const selectedOptionNumber = useMemo( () => {

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -13,7 +13,7 @@ import { usePrevious } from '@woocommerce/base-hooks';
  * Internal dependencies
  */
 import { renderPackageRateOption } from './render-package-rate-option';
-import type { PackageRateRenderOption } from '../shipping-rates-control-package';
+import type { PackageRateRenderOption } from '../shipping-rates-control-package/types';
 
 interface PackageRates {
 	onSelectRate: ( selectedRateId: string ) => void;
@@ -23,6 +23,8 @@ interface PackageRates {
 	noResultsMessage: JSX.Element;
 	selectedRate: CartShippingPackageShippingRate | undefined;
 	disabled?: boolean;
+	// Should the selected rate be highlighted.
+	highlightChecked?: boolean;
 }
 
 const PackageRates = ( {
@@ -33,6 +35,7 @@ const PackageRates = ( {
 	renderOption = renderPackageRateOption,
 	selectedRate,
 	disabled = false,
+	highlightChecked = false,
 }: PackageRates ): JSX.Element => {
 	const selectedRateId = selectedRate?.rate_id || '';
 	const previousSelectedRateId = usePrevious( selectedRateId );
@@ -76,7 +79,7 @@ const PackageRates = ( {
 					setSelectedOption( value );
 					onSelectRate( value );
 				} }
-				highlightChecked={ true }
+				highlightChecked={ highlightChecked }
 				disabled={ disabled }
 				selected={ selectedOption }
 				options={ rates.map( renderOption ) }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -76,6 +76,7 @@ const PackageRates = ( {
 					setSelectedOption( value );
 					onSelectRate( value );
 				} }
+				highlightChecked={ true }
 				disabled={ disabled }
 				selected={ selectedOption }
 				options={ rates.map( renderOption ) }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -93,7 +93,7 @@
 	@include font-size(small);
 	display: block;
 	list-style: none;
-	margin: 0;
+	margin: 0 0 $gap-small 0;
 	padding: 0;
 }
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -1,6 +1,20 @@
 .wc-block-components-shipping-rates-control__package {
 	margin: 0;
-	border-bottom: 1px solid $universal-border-light;
+	position: relative;
+
+	&:after {
+		content: "";
+		top: 0;
+		right: 0;
+		pointer-events: none;
+		bottom: 0;
+		position: absolute;
+		border: 1px solid rgba(17, 17, 17, 0.11);
+		width: 100%;
+		box-sizing: border-box;
+		border-bottom: 0;
+	}
+
 
 	&.wc-block-components-panel {
 		margin-bottom: 0;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -15,6 +15,36 @@
 		border-bottom: 0;
 	}
 
+	&.wc-block-components-shipping-rates-control__package--first-selected {
+		&:after {
+			border-top: 0;
+			margin-top: 2px;
+		}
+	}
+
+	&.wc-block-components-shipping-rates-control__package--last-selected {
+		&:after {
+			border-bottom: 0;
+			margin-bottom: 2px;
+		}
+	}
+
+	.wc-block-components-radio-control__option-checked-option-highlighted + .wc-block-components-radio-control__option:not(.wc-block-components-radio-control__option-checked-option-highlighted) {
+		border-top: 0;
+	}
+
+	.wc-block-components-radio-control__option:not(.wc-block-components-radio-control__option-checked-option-highlighted) {
+		border-bottom: 0;
+		border-top: 1px solid $universal-border-light;
+
+		&:first-child {
+			border-top: 1px solid transparent;
+		}
+
+		&:last-child {
+			border-bottom: 1px solid $universal-border-light;;
+		}
+	}
 
 	&.wc-block-components-panel {
 		margin-bottom: 0;
@@ -28,8 +58,6 @@
 	}
 
 	&:last-child {
-		border-bottom: 0;
-
 		.wc-block-components-panel__button {
 			padding-bottom: 0;
 		}

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -1,33 +1,5 @@
 .wc-block-components-shipping-rates-control__package {
 	margin: 0;
-	position: relative;
-
-	&:after {
-		content: "";
-		top: 0;
-		right: 0;
-		pointer-events: none;
-		bottom: 0;
-		position: absolute;
-		border: 1px solid rgba(17, 17, 17, 0.11);
-		width: 100%;
-		box-sizing: border-box;
-		border-bottom: 0;
-	}
-
-	&.wc-block-components-shipping-rates-control__package--first-selected {
-		&:after {
-			border-top: 0;
-			margin-top: 2px;
-		}
-	}
-
-	&.wc-block-components-shipping-rates-control__package--last-selected {
-		&:after {
-			border-bottom: 0;
-			margin-bottom: 2px;
-		}
-	}
 
 	.wc-block-components-radio-control__option-checked-option-highlighted + .wc-block-components-radio-control__option:not(.wc-block-components-radio-control__option-checked-option-highlighted) {
 		border-top: 0;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -1,23 +1,6 @@
 .wc-block-components-shipping-rates-control__package {
 	margin: 0;
 
-	.wc-block-components-radio-control__option-checked-option-highlighted + .wc-block-components-radio-control__option:not(.wc-block-components-radio-control__option-checked-option-highlighted) {
-		border-top: 0;
-	}
-
-	.wc-block-components-radio-control__option:not(.wc-block-components-radio-control__option-checked-option-highlighted) {
-		border-bottom: 0;
-		border-top: 1px solid $universal-border-light;
-
-		&:first-child {
-			border-top: 1px solid transparent;
-		}
-
-		&:last-child {
-			border-bottom: 1px solid $universal-border-light;;
-		}
-	}
-
 	&.wc-block-components-panel {
 		margin-bottom: 0;
 	}

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/types.ts
@@ -46,4 +46,6 @@ export interface PackageProps {
 	collapsible?: TernaryFlag;
 	noResultsMessage: ReactElement;
 	showItems?: TernaryFlag;
+	// Should the selected rate be highlighted.
+	highlightChecked?: boolean;
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -33,6 +33,7 @@ const Packages = ( {
 	collapsible,
 	noResultsMessage,
 	renderOption,
+	context = '',
 }: PackagesProps ): JSX.Element | null => {
 	// If there are no packages, return nothing.
 	if ( ! packages.length ) {
@@ -42,6 +43,7 @@ const Packages = ( {
 		<>
 			{ packages.map( ( { package_id: packageId, ...packageData } ) => (
 				<ShippingRatesControlPackage
+					highlightChecked={ context !== 'woocommerce/cart' }
 					key={ packageId }
 					packageId={ packageId }
 					packageData={ packageData }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control/types.ts
@@ -27,6 +27,9 @@ export interface PackagesProps {
 
 	// Function to render a shipping rate
 	renderOption: PackageRateRenderOption;
+
+	// The context that this component is rendered in (Cart/Checkout)
+	context?: 'woocommerce/cart' | 'woocommerce/checkout' | '';
 }
 
 export interface ShippingRatesControlProps {

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -96,6 +96,7 @@ const PaymentMethodOptions = () => {
 	} );
 	return isExpressPaymentMethodActive ? null : (
 		<RadioControlAccordion
+			highlightChecked={ true }
 			id={ 'wc-payment-method-options' }
 			className={ singleOptionClass }
 			selected={ activeSavedToken ? null : activePaymentMethod }

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.tsx
@@ -170,6 +170,7 @@ const SavedPaymentMethodOptions = () => {
 	return options.length > 0 ? (
 		<>
 			<RadioControl
+				highlightChecked={ true }
 				id={ 'wc-payment-method-saved-tokens' }
 				selected={ activeSavedToken }
 				options={ options }

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -198,17 +198,6 @@
 		font-weight: bold;
 	}
 
-	.wc-block-components-radio-control {
-		border: 1px solid $universal-border-light;
-		border-radius: $universal-border-radius;
-	}
-	.wc-block-components-radio-control-accordion-option,
-	.wc-block-components-radio-control__option {
-		border-top: 1px solid $universal-border-light;
-		&:first-child {
-			border-top: 0;
-		}
-	}
 	.wc-block-components-radio-control-accordion-option
 	.wc-block-components-radio-control__option {
 		border-width: 0;

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -174,6 +174,7 @@
 .wc-block-checkout__payment-method {
 	.wc-block-components-radio-control__option {
 		padding-left: em($gap-huge);
+		padding-right: em($gap-small);
 
 		&::after {
 			content: none;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -4,7 +4,7 @@
 		.wc-block-components-radio-control__option {
 			border-bottom: 1px solid $universal-border-light;
 			margin: 0;
-			padding: em($gap-small) 0 em($gap-small) em($gap-huge);
+			padding: em($gap-small) em($gap-small) em($gap-small) em($gap-huge);
 		}
 		.wc-block-components-shipping-rates-control__no-results-notice {
 			margin: em($gap-small) 0;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -2,7 +2,6 @@
 .wp-block-woocommerce-checkout-pickup-options-block {
 	.wc-block-components-local-pickup-rates-control {
 		.wc-block-components-radio-control__option {
-			border-bottom: 1px solid $universal-border-light;
 			margin: 0;
 			padding: em($gap-small) em($gap-small) em($gap-small) em($gap-huge);
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/style.scss
@@ -1,8 +1,7 @@
 .wc-block-checkout__shipping-option {
 	.wc-block-components-radio-control__option {
-		border-bottom: 1px solid $universal-border-light;
 		margin: 0;
-		padding: em($gap-small) 0 em($gap-small) em($gap-huge);
+		padding: em($gap-small) em($gap-small) em($gap-small) em($gap-huge);
 	}
 
 	.wc-block-components-shipping-rates-control__no-results-notice {

--- a/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
@@ -53,7 +53,13 @@ const RadioControlAccordion = ( {
 				const checked = option.value === selected;
 				return (
 					<div
-						className="wc-block-components-radio-control-accordion-option"
+						className={ classnames(
+							'wc-block-components-radio-control-accordion-option',
+							{
+								'wc-block-components-radio-control-accordion-option__checked-option-highlighted':
+									checked && highlightChecked,
+							}
+						) }
 						key={ option.value }
 					>
 						<RadioControlOption

--- a/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
@@ -67,14 +67,13 @@ const RadioControlAccordion = ( {
 						className={ classnames(
 							'wc-block-components-radio-control-accordion-option',
 							{
-								'wc-block-components-radio-control-accordion-option__checked-option-highlighted':
+								'wc-block-components-radio-control-accordion-option--checked-option-highlighted':
 									checked && highlightChecked,
 							}
 						) }
 						key={ option.value }
 					>
 						<RadioControlOption
-							highlightChecked={ highlightChecked }
 							name={ `radio-control-${ radioControlId }` }
 							checked={ checked }
 							option={ option }

--- a/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
@@ -57,6 +57,7 @@ const RadioControlAccordion = ( {
 						key={ option.value }
 					>
 						<RadioControlOption
+							highlightChecked={ highlightChecked }
 							name={ `radio-control-${ radioControlId }` }
 							checked={ checked }
 							option={ option }

--- a/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
@@ -3,12 +3,12 @@
  */
 import classnames from 'classnames';
 import { withInstanceId } from '@wordpress/compose';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { RadioControlOption } from '../radio-control';
-import { useMemo } from '@wordpress/element';
 
 export interface RadioControlAccordionProps {
 	className?: string;

--- a/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
@@ -8,6 +8,7 @@ import { withInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import { RadioControlOption } from '../radio-control';
+import { useMemo } from '@wordpress/element';
 
 export interface RadioControlAccordionProps {
 	className?: string;
@@ -37,6 +38,10 @@ const RadioControlAccordion = ( {
 }: RadioControlAccordionProps ): JSX.Element | null => {
 	const radioControlId = id || instanceId;
 
+	const selectedOptionNumber = useMemo( () => {
+		return options.findIndex( ( option ) => option.value === selected );
+	}, [ options, selected ] );
+
 	if ( ! options.length ) {
 		return null;
 	}
@@ -44,6 +49,12 @@ const RadioControlAccordion = ( {
 		<div
 			className={ classnames(
 				'wc-block-components-radio-control',
+				{
+					'wc-block-components-radio-control--highlight-checked':
+						highlightChecked,
+					'wc-block-components-radio-control--highlight-checked--first-selected':
+						highlightChecked && selectedOptionNumber === 0,
+				},
 				className
 			) }
 		>

--- a/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
@@ -22,6 +22,8 @@ export interface RadioControlAccordionProps {
 		content: JSX.Element;
 	} >;
 	selected: string | null;
+	// Should the selected option be highlighted with a border?
+	highlightChecked?: boolean;
 }
 
 const RadioControlAccordion = ( {
@@ -31,6 +33,7 @@ const RadioControlAccordion = ( {
 	selected,
 	onChange,
 	options = [],
+	highlightChecked = false,
 }: RadioControlAccordionProps ): JSX.Element | null => {
 	const radioControlId = id || instanceId;
 

--- a/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control-accordion/index.tsx
@@ -54,6 +54,9 @@ const RadioControlAccordion = ( {
 						highlightChecked,
 					'wc-block-components-radio-control--highlight-checked--first-selected':
 						highlightChecked && selectedOptionNumber === 0,
+					'wc-block-components-radio-control--highlight-checked--last-selected':
+						highlightChecked &&
+						selectedOptionNumber === options.length - 1,
 				},
 				className
 			) }

--- a/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
@@ -36,17 +36,13 @@ const RadioControl = ( {
 			className={ classnames(
 				'wc-block-components-radio-control',
 				{
-					'wc-block-components-radio-control--highlight-checked':
-						highlightChecked,
-				},
-				{
 					'wc-block-components-radio-control--highlight-checked--first-selected':
 						highlightChecked && selectedOptionNumber === 0,
-				},
-				{
 					'wc-block-components-radio-control--highlight-checked--last-selected':
 						highlightChecked &&
 						selectedOptionNumber === options.length - 1,
+					'wc-block-components-radio-control--highlight-checked':
+						highlightChecked,
 				},
 				className
 			) }

--- a/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
@@ -17,6 +17,7 @@ const RadioControl = ( {
 	onChange,
 	options = [],
 	disabled = false,
+	highlightChecked = false,
 }: RadioControlProps ): JSX.Element | null => {
 	const instanceId = useInstanceId( RadioControl );
 	const radioControlId = id || instanceId;
@@ -34,6 +35,7 @@ const RadioControl = ( {
 		>
 			{ options.map( ( option ) => (
 				<RadioControlOption
+					highlightChecked={ highlightChecked }
 					key={ `${ radioControlId }-${ option.value }` }
 					name={ `radio-control-${ radioControlId }` }
 					checked={ option.value === selected }

--- a/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
@@ -3,13 +3,14 @@
  */
 import classnames from 'classnames';
 import { useInstanceId } from '@wordpress/compose';
+import { useMemo } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */
 import RadioControlOption from './option';
 import type { RadioControlProps } from './types';
 import './style.scss';
-import { useMemo } from '@wordpress/element';
 
 const RadioControl = ( {
 	className = '',

--- a/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/index.tsx
@@ -9,6 +9,7 @@ import { useInstanceId } from '@wordpress/compose';
 import RadioControlOption from './option';
 import type { RadioControlProps } from './types';
 import './style.scss';
+import { useMemo } from '@wordpress/element';
 
 const RadioControl = ( {
 	className = '',
@@ -22,6 +23,10 @@ const RadioControl = ( {
 	const instanceId = useInstanceId( RadioControl );
 	const radioControlId = id || instanceId;
 
+	const selectedOptionNumber = useMemo( () => {
+		return options.findIndex( ( option ) => option.value === selected );
+	}, [ options, selected ] );
+
 	if ( ! options.length ) {
 		return null;
 	}
@@ -30,6 +35,19 @@ const RadioControl = ( {
 		<div
 			className={ classnames(
 				'wc-block-components-radio-control',
+				{
+					'wc-block-components-radio-control--highlight-checked':
+						highlightChecked,
+				},
+				{
+					'wc-block-components-radio-control--highlight-checked--first-selected':
+						highlightChecked && selectedOptionNumber === 0,
+				},
+				{
+					'wc-block-components-radio-control--highlight-checked--last-selected':
+						highlightChecked &&
+						selectedOptionNumber === options.length - 1,
+				},
 				className
 			) }
 		>

--- a/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
@@ -15,6 +15,7 @@ const Option = ( {
 	onChange,
 	option,
 	disabled = false,
+	highlightChecked = false,
 }: RadioControlOptionProps ): JSX.Element => {
 	const { value, label, description, secondaryLabel, secondaryDescription } =
 		option;

--- a/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
@@ -32,7 +32,7 @@ const Option = ( {
 						checked,
 				},
 				{
-					'wc-block-components-radio-control__option-checked-option-highlighted':
+					'wc-block-components-radio-control__option--checked-option-highlighted':
 						checked && highlightChecked,
 				}
 			) }

--- a/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
@@ -30,8 +30,6 @@ const Option = ( {
 				{
 					'wc-block-components-radio-control__option-checked':
 						checked,
-				},
-				{
 					'wc-block-components-radio-control__option--checked-option-highlighted':
 						checked && highlightChecked,
 				}

--- a/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
@@ -30,6 +30,10 @@ const Option = ( {
 				{
 					'wc-block-components-radio-control__option-checked':
 						checked,
+				},
+				{
+					'wc-block-components-radio-control__option-checked-option-highlighted':
+						checked && highlightChecked,
 				}
 			) }
 			htmlFor={ `${ name }-${ value }` }

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -41,45 +41,45 @@
 	&:after {
 		content: "";
 		top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			pointer-events: none;
-			position: absolute;
-			border: 1px solid rgba(17, 17, 17, 0.11);
-			width: 100%;
-			box-sizing: border-box;
-			border-bottom: 0;
-		}
-
-	&.wc-block-components-radio-control--highlight-checked--first-selected {
-		&:after {
-			border-top: 0;
-			margin-top: 2px;
-		}
+		right: 0;
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+		position: absolute;
+		border: 1px solid $universal-border-light;
+		width: 100%;
+		box-sizing: border-box;
 	}
 
-	&.wc-block-components-radio-control--highlight-checked--last-selected {
-		&:after {
-			border-bottom: 0;
-			margin-bottom: 2px;
-		}
-	}
-
-	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option {
+	&.wc-block-components-radio-control--highlight-checked--first-selected:after {
 		border-top: 0;
 	}
 
-	.wc-block-components-radio-control__option {
+	&.wc-block-components-radio-control--highlight-checked--last-selected:after {
 		border-bottom: 0;
-		border-top: 1px solid $universal-border-light;
+	}
 
-		&:first-child {
-			border-top: 1px solid transparent;
+	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option:after {
+		display: none;
+	}
+
+	.wc-block-components-radio-control__option {
+		border: 1px solid transparent;
+		border-left: 0;
+		border-right: 0;
+
+		&:after {
+			content: '';
+			background: $universal-border-light;
+			height: 1px;
+			right: 1px;
+			left: 1px;
+			top: 0;
+			position: absolute;
 		}
 
-		&:last-child {
-			border-bottom: 1px solid $universal-border-light;;
+		&:first-child:after {
+			display: none;
 		}
 	}
 }

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -1,3 +1,43 @@
+.wc-block-components-radio-control--highlight-checked {
+	position: relative;
+
+	label.wc-block-components-radio-control__option-checked-option-highlighted {
+		box-shadow: 0 0 0 1.5px currentColor inset;
+		border-radius: 4px;
+		border: 1px solid transparent;
+		border-left: 0;
+		border-right: 0;
+	}
+
+		&:after {
+			content: "";
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			pointer-events: none;
+			position: absolute;
+			border: 1px solid rgba(17, 17, 17, 0.11);
+			width: 100%;
+			box-sizing: border-box;
+			border-bottom: 0;
+		}
+
+	&.wc-block-components-radio-control--highlight-checked--first-selected {
+		&:after {
+			border-top: 0;
+			margin-top: 2px;
+		}
+	}
+
+	&.wc-block-components-radio-control--highlight-checked--last-selected {
+		&:after {
+			border-bottom: 0;
+			margin-bottom: 2px;
+		}
+	}
+}
+
 .wc-block-components-radio-control__option {
 	@include reset-color();
 	@include reset-typography();
@@ -11,13 +51,6 @@
 	&:last-child {
 		margin-bottom: 0;
 	}
-}
-label.wc-block-components-radio-control__option-checked-option-highlighted {
-	box-shadow: 0 0 0 1.5px currentColor inset;
-	border-radius: 4px;
-	border: 1px solid transparent;
-	border-left: 0;
-	border-right: 0;
 }
 
 .wc-block-components-radio-control__option-layout {

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -31,6 +31,8 @@
 		}
 	}
 
+	// Adds a "border" around the selected option. This is done with a box-shadow to prevent a double border on the left
+	// and right of the selected element, and top and bottom of the first/last elements.
 	label.wc-block-components-radio-control__option--checked-option-highlighted,
 	.wc-block-components-radio-control-accordion-option--checked-option-highlighted {
 		box-shadow: 0 0 0 1.5px currentColor inset;
@@ -75,10 +77,10 @@
 	}
 
 	.wc-block-components-radio-control__option {
-		border: 1px solid transparent;
-		border-left: 0;
-		border-right: 0;
 
+		// Add a fake border to the top of each radio option. This is because using CSS borders would result in an
+		// overlap and two transparent borders combining to make a darker pixel. This fake border allows us to bring the
+		// border in by one pixel on each side to avoid the overlap.
 		&::after {
 			content: "";
 			background: $universal-border-light;
@@ -89,6 +91,7 @@
 			position: absolute;
 		}
 
+		// The first child doesn't need a fake border-top because it's handled by its parent's border-top.
 		&:first-child::after {
 			display: none;
 		}

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -19,11 +19,8 @@
 			position: absolute;
 		}
 
-		&:last-child::after {
-			bottom: 0;
-			position: absolute;
-		}
-
+		// The first child doesn't need a fake border-top because it's handled by its parent's border-top. This stops
+		// a double border.
 		&:first-child::after {
 			display: none;
 		}

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -4,8 +4,8 @@
 	div.wc-block-components-radio-control-accordion-option {
 		position: relative;
 
-		&:after {
-			content: '';
+		&::after {
+			content: "";
 			background: $universal-border-light;
 			height: 1px;
 			right: 1px;
@@ -14,17 +14,16 @@
 			position: absolute;
 		}
 
-		&:last-child:after {
-			content: '';
-			background: $universal-border-light;
-			height: 1px;
-			right: 1px;
-			left: 1px;
+		&:last-child::after {
 			bottom: 0;
 			position: absolute;
 		}
 
-		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted + div.wc-block-components-radio-control-accordion-option:after {
+		&:first-child::after {
+			display: none;
+		}
+
+		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted + div.wc-block-components-radio-control-accordion-option::after {
 			display: none;
 		}
 	}
@@ -38,7 +37,7 @@
 	// Defines a border around the radio control. Cannot be done with normal CSS borders because when selecting an item
 	// the selected item needs its own borders with a radius, so we get a double border, or incorrect looking styling with
 	// overlaps under the selected item's border (due to its border-radius).
-	&:after {
+	&::after {
 		content: "";
 		top: 0;
 		right: 0;
@@ -51,15 +50,17 @@
 		box-sizing: border-box;
 	}
 
-	&.wc-block-components-radio-control--highlight-checked--first-selected:after {
+	&.wc-block-components-radio-control--highlight-checked--first-selected::after {
 		border-top: 0;
+		margin-top: 2px;
 	}
 
-	&.wc-block-components-radio-control--highlight-checked--last-selected:after {
+	&.wc-block-components-radio-control--highlight-checked--last-selected::after {
+		margin-bottom: 2px;
 		border-bottom: 0;
 	}
 
-	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option:after {
+	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option::after {
 		display: none;
 	}
 
@@ -68,8 +69,8 @@
 		border-left: 0;
 		border-right: 0;
 
-		&:after {
-			content: '';
+		&::after {
+			content: "";
 			background: $universal-border-light;
 			height: 1px;
 			right: 1px;
@@ -78,7 +79,7 @@
 			position: absolute;
 		}
 
-		&:first-child:after {
+		&:first-child::after {
 			display: none;
 		}
 	}

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -36,6 +36,23 @@
 			margin-bottom: 2px;
 		}
 	}
+
+	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option {
+		border-top: 0;
+	}
+
+	.wc-block-components-radio-control__option {
+		border-bottom: 0;
+		border-top: 1px solid $universal-border-light;
+
+		&:first-child {
+			border-top: 1px solid transparent;
+		}
+
+		&:last-child {
+			border-bottom: 1px solid $universal-border-light;;
+		}
+	}
 }
 
 .wc-block-components-radio-control__option {

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -5,13 +5,19 @@
 	margin: em($gap) 0;
 	margin-top: 0;
 	padding: 0 0 0 em($gap-larger);
-
 	position: relative;
 	cursor: pointer;
 
 	&:last-child {
 		margin-bottom: 0;
 	}
+}
+label.wc-block-components-radio-control__option-checked-option-highlighted {
+	box-shadow: 0 0 0 1.5px currentColor inset;
+	border-radius: 4px;
+	border: 1px solid transparent;
+	border-left: 0;
+	border-right: 0;
 }
 
 .wc-block-components-radio-control__option-layout {

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -1,17 +1,46 @@
 .wc-block-components-radio-control--highlight-checked {
 	position: relative;
 
-	label.wc-block-components-radio-control__option--checked-option-highlighted {
-		box-shadow: 0 0 0 1.5px currentColor inset;
-		border-radius: 4px;
-		border: 1px solid transparent;
-		border-left: 0;
-		border-right: 0;
-	}
+	div.wc-block-components-radio-control-accordion-option {
+		position: relative;
 
 		&:after {
-			content: "";
+			content: '';
+			background: $universal-border-light;
+			height: 1px;
+			right: 1px;
+			left: 1px;
 			top: 0;
+			position: absolute;
+		}
+
+		&:last-child:after {
+			content: '';
+			background: $universal-border-light;
+			height: 1px;
+			right: 1px;
+			left: 1px;
+			bottom: 0;
+			position: absolute;
+		}
+
+		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted + div.wc-block-components-radio-control-accordion-option:after {
+			display: none;
+		}
+	}
+
+	label.wc-block-components-radio-control__option--checked-option-highlighted,
+	.wc-block-components-radio-control-accordion-option--checked-option-highlighted {
+		box-shadow: 0 0 0 1.5px currentColor inset;
+		border-radius: 4px;
+	}
+
+	// Defines a border around the radio control. Cannot be done with normal CSS borders because when selecting an item
+	// the selected item needs its own borders with a radius, so we get a double border, or incorrect looking styling with
+	// overlaps under the selected item's border (due to its border-radius).
+	&:after {
+		content: "";
+		top: 0;
 			right: 0;
 			bottom: 0;
 			left: 0;

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -1,7 +1,7 @@
 .wc-block-components-radio-control--highlight-checked {
 	position: relative;
 
-	label.wc-block-components-radio-control__option-checked-option-highlighted {
+	label.wc-block-components-radio-control__option--checked-option-highlighted {
 		box-shadow: 0 0 0 1.5px currentColor inset;
 		border-radius: 4px;
 		border: 1px solid transparent;

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -4,6 +4,11 @@
 	div.wc-block-components-radio-control-accordion-option {
 		position: relative;
 
+		// This ::after element is to fake a transparent border-top on each option.
+		// We can't just use border-top on the option itself because of the border around the entire accordion.
+		// Both borders have transparency so there's an overlap where the border is darker (due to adding two
+		// transparent colours together). Doing it with an ::after lets us bring the "border" in by one pixel on each
+		// side to avoid the overlap.
 		&::after {
 			content: "";
 			background: $universal-border-light;
@@ -23,6 +28,7 @@
 			display: none;
 		}
 
+		// This rule removes the fake border-top from the selected element to prevent a double border.
 		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted + div.wc-block-components-radio-control-accordion-option::after {
 			display: none;
 		}
@@ -34,9 +40,9 @@
 		border-radius: 4px;
 	}
 
-	// Defines a border around the radio control. Cannot be done with normal CSS borders because when selecting an item
-	// the selected item needs its own borders with a radius, so we get a double border, or incorrect looking styling with
-	// overlaps under the selected item's border (due to its border-radius).
+	// Defines a border around the radio control. Cannot be done with normal CSS borders or outlines because when
+	// selecting an item we get a double border on the left and right. It's not possible to remove the outer border just
+	// for the selected element, but using a pseudo element gives us more control.
 	&::after {
 		content: "";
 		top: 0;
@@ -46,20 +52,27 @@
 		pointer-events: none;
 		position: absolute;
 		border: 1px solid $universal-border-light;
+		border-radius: 4px;
 		width: 100%;
 		box-sizing: border-box;
 	}
 
+	// Remove the top border when the first element is selected, this is so we don't get a double border with the
+	// box-shadow.
 	&.wc-block-components-radio-control--highlight-checked--first-selected::after {
 		border-top: 0;
 		margin-top: 2px;
 	}
 
+	// Remove the bottom border when the last element is selected, this is so we don't get a double border with the
+	// box-shadow.
 	&.wc-block-components-radio-control--highlight-checked--last-selected::after {
 		margin-bottom: 2px;
 		border-bottom: 0;
 	}
 
+	// Remove the fake border-top from the item after the selected element, this is to prevent a double border with the
+	// selected element's box-shadow.
 	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option::after {
 		display: none;
 	}

--- a/plugins/woocommerce-blocks/packages/components/radio-control/types.ts
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/types.ts
@@ -16,6 +16,8 @@ export interface RadioControlProps {
 	options: RadioControlOption[];
 	// Is the control disabled.
 	disabled?: boolean;
+	// Should the selected option be highlighted with a border?
+	highlightChecked?: boolean;
 }
 
 export interface RadioControlOptionProps {
@@ -24,6 +26,8 @@ export interface RadioControlOptionProps {
 	onChange: ( value: string ) => void;
 	option: RadioControlOption;
 	disabled?: boolean;
+	// Should the selected option be highlighted with a border?
+	highlightChecked?: boolean;
 }
 
 interface RadioControlOptionContent {

--- a/plugins/woocommerce/changelog/update-shipping-borders
+++ b/plugins/woocommerce/changelog/update-shipping-borders
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change styling for shipping, payment, and local pickup radio buttons in the Checkout block


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In this PR I propose some changes to the radio control and radio accordion (CC @samueljseay as you may be looking at these as part of the `@wordpress/components` project)

The main changes are:
- Add a new prop `RadioControl` and `RadioControlAccordion` called `highlightChecked` which defaults to false.
  - This is to ensure we can explicitly enable this setting on components we choose, rather than blanket applying it to all instances.
- Update components that use these and want to highlight the selected elements to pass this prop

The rest of the changes apply only when `highlightChecked` is true:

- Enclose the entire radio group in a fake border implemented with the `::after` pseudo element. 
  - This is because using regular CSS borders or the `outline` property resulted in double borders on the selected element. Using a pseudo element allows us finer control over the border compared to what we'd get with the border property.
- Add an `::after` element to each item in the group to replace the `border-top` property. This is to add a separator between each item. Using the border property resulted in a small area where two transparent colours would combine to make a darker colour. The pseudo element gives us better control and allows us to bring the "border" in by 2px to prevent this.
- Add new class names to the radio control group to signal when the first or last element is selected. This is so we can remove the top or bottom border to prevent double borders.
- Use box-shadow to add a highlight to the selected element. This uses `currentColor` so it follows the theme.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46009.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure you have multiple shipping methods set up. (Go to WooCommerce -> Settings -> Shipping and add several methods to a zone, you can create several flat rates. Give them different names and prices).
2. Enable Local pickup (Go to WooCommerce -> Settings -> Shipping -> Local Pickup). Add 3 or more locations. Enable them all.
3. Ensure you have several payment methods set up (e.g. Stripe, Bank Transfer, COD etc.) Ensure one of them supports saved payment methods (e.g. Stripe)
4. Check out three times using the payment method that supports saved options. Each time, use a different carf so it can save three different cards. [For reference, here are some cards you can use with Stripe](https://docs.stripe.com/testing#cards).
5. Add an item to your cart and go to the Cart block.
6. Ensure the shipping rates on the sidebar show correctly. They should not have borders and should look like the bottom right of the image.

<img width="885" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/9badba85-c8d7-456a-98e4-0f1e646c6537">


7. Try changing the shipping methods in the cart. It should work without any errors. If you see a notice about local pickup, that's OK.
8. Proceed to the Checkout block.
9. Select "Shipping" for your shipping method.
10. Scroll down to the shipping methods and change it a few times. Ensure they display like the screenshot below. There should be no border overlaps or double borders. 

<img width="559" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/e778da39-3295-4186-a377-6e537b318c8d">

11. Change your shipping method to "Local pickup" and repeat the test with the pickup locations. They should look like this:

<img width="557" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/80651993-d873-4c3a-8e7e-012c9f807342">

12. Change between them and ensure there are no overlapping borders, jumping text etc.
13. Scroll down to the payment method section. Ensure it looks like the screenshots below:

<img width="585" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/8aa3add1-43d0-4036-9d23-f843f79d6530">
and 
<img width="578" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/99efc3e5-bc8b-4de2-8c6a-7e4f5e1b0533">

14. Change the methods a few times, between saved methods and "other" methods. Ensure there are no overlapping borders. The text becoming bold when the option is selected is expected.
15. Install [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/). 
16. Go to WooCommerce -> Settings -> Multiple Packages and enable it. Set "Group by" to "Product (Individual).
17. Add 3 items to your cart and repeat the steps relating to checking shipping methods. Each item should be in its own package and each package should have the correct styling.

#### Testing with WC Subscriptions (Don't do this until https://github.com/Automattic/woocommerce-subscriptions-core/pull/593 is merged

0. Install WC Subscriptions
1. Create 3 subscription items with different lengths, (weekly, yearly, monthly)
2. Add them to your cart and go to the Cart block.
3. Ensure the shipping options in the sidebar show correctly, i.e. without borders around each rate.

<img width="300" alt="image" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/5656702/114f92c1-e584-4b1a-b409-442f59986b5e">

4. Go to the Checkout block. Ensure you can see the additional packages, and that they _do_ have borders around each rate

<img width="517" alt="image" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/5656702/8c8a0aab-c4df-4f7f-890b-9d666f54eda4">

5. Switch back to WC Core trunk and run the tests again, the borders won't show but please ensure the shipping selectors for recurring packages still work and can change the method.

#### Developer only steps for when WC Subscriptions 593 is not merged

19. Check out https://github.com/Automattic/woocommerce-subscriptions-core/pull/593 in WooCommerce Subscriptions Core.
20. Follow the testing steps from that PR.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>