### PR TITLE
Move the LYS feature flag check inside add_lys_default_values()

### DIFF
--- a/plugins/woocommerce/changelog/fix-lys-default-values-actions
+++ b/plugins/woocommerce/changelog/fix-lys-default-values-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move the feature flag check to add_lys_default_values method

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -254,11 +254,8 @@ final class WooCommerce {
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_inbox_variant' ) );
 		add_action( 'woocommerce_installed', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
-
-		if ( Features::is_enabled( 'launch-your-store' ) ) {
-			add_action( 'woocommerce_newly_installed', array( $this, 'add_lys_default_values' ) );
-			add_action( 'woocommerce_updated', array( $this, 'add_lys_default_values' ) );
-		}
+		add_action( 'woocommerce_newly_installed', array( $this, 'add_lys_default_values' ) );
+		add_action( 'woocommerce_updated', array( $this, 'add_lys_default_values' ) );
 
 		// These classes set up hooks on instantiation.
 		$container = wc_get_container();
@@ -318,6 +315,10 @@ final class WooCommerce {
 	 * Set default option values for launch your store task.
 	 */
 	public function add_lys_default_values() {
+		if ( ! Feature::is_enabled( 'launch-your-store' ) ) {
+			return;
+		}
+
 		$is_new_install = current_action() === 'woocommerce_newly_installed';
 
 		$coming_soon      = $is_new_install ? 'yes' : 'no';
@@ -431,7 +432,6 @@ final class WooCommerce {
 		 * The SSR in the name is preserved for bw compatibility, as this was initially used in System Status Report.
 		 */
 		$this->define( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE', 'none' );
-
 	}
 
 	/**
@@ -1023,7 +1023,7 @@ final class WooCommerce {
 	 * @param string $filename The filename of the activated plugin.
 	 */
 	public function activated_plugin( $filename ) {
-		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
+		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
 
 		if ( '/woocommerce.php' === substr( $filename, -16 ) ) {
 			set_transient( 'woocommerce_activated_plugin', $filename );
@@ -1039,7 +1039,7 @@ final class WooCommerce {
 	 * @param string $filename The filename of the deactivated plugin.
 	 */
 	public function deactivated_plugin( $filename ) {
-		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
+		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
 
 		WC_Helper::deactivated_plugin( $filename );
 	}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -315,7 +315,7 @@ final class WooCommerce {
 	 * Set default option values for launch your store task.
 	 */
 	public function add_lys_default_values() {
-		if ( ! Feature::is_enabled( 'launch-your-store' ) ) {
+		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1023,7 +1023,7 @@ final class WooCommerce {
 	 * @param string $filename The filename of the activated plugin.
 	 */
 	public function activated_plugin( $filename ) {
-		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
+		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
 
 		if ( '/woocommerce.php' === substr( $filename, -16 ) ) {
 			set_transient( 'woocommerce_activated_plugin', $filename );
@@ -1039,7 +1039,7 @@ final class WooCommerce {
 	 * @param string $filename The filename of the deactivated plugin.
 	 */
 	public function deactivated_plugin( $filename ) {
-		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
+		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
 
 		WC_Helper::deactivated_plugin( $filename );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


This PR moves the LYS feature flag check inside `add_lys_default_values()` function. I just realized feature flags are not available before the `add_action` calls because they are set during the `plugins_loaded` hook. Even if we enable the feature flag by default, it won't work because the feature flag config is not loaded yet.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Please exclude from Solaris and GlobalStep testing as this is gated behind a feature flag and is part of the Launch Your Store feature which will be tested as a complete feature when the call for testing is released.


1. Create a new JN site via [this link](https://jurassic.ninja/create?woocommerce-beta-tester&woocommerce-beta-tester-live-branch=fix/lys-default-values-actions&wp-debug-log&nojetpack&woocommerce-beta-tester-feature-flags=launch-your-store)
2. Skip core profiler
3. Go to `WooCommerce > Home`
4. Confirm `Launch Your Store` task is shown and is incomplete
5. Confirm status badge displays `Site coming soon`
6. Go to `WooCommerce > Settings` > `Site visibility`
7. Confirm private link is shown with `?share=<random_32_chars_string>`

<img width="1327" alt="Screenshot 2024-04-03 at 15 32 03" src="https://github.com/woocommerce/woocommerce/assets/4344253/6b450c9c-68df-4696-a71c-b1ef97679e0e">


<img width="765" alt="Screenshot 2024-04-03 at 15 31 16" src="https://github.com/woocommerce/woocommerce/assets/4344253/7f911e64-209f-46a7-aa0d-1309b586857e">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
