### PR TITLE
Avoid reading items from DB of a order whose ID is zero

### DIFF
--- a/plugins/woocommerce/changelog/fix-25623
+++ b/plugins/woocommerce/changelog/fix-25623
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent reading items with zero order ID to avoid mixups.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
  * Abstract Order Data Store: Stored in CPT.
  *
@@ -80,6 +81,13 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		}
 
 		$id = wp_insert_post(
+			/**
+			 * Filters the data for a new order before it is inserted into the database.
+			 *
+			 * @param array $data Array of data for the new order.
+			 *
+			 * @since 3.3.0
+			 */
 			apply_filters(
 				'woocommerce_new_order_data',
 				array(
@@ -115,7 +123,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @param int $order_id The order id to check.
 	 * @return bool True if an order exists with the given name.
 	 */
-	public function order_exists( $order_id ) : bool {
+	public function order_exists( $order_id ): bool {
 		if ( ! $order_id ) {
 			return false;
 		}
@@ -135,7 +143,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$order->set_defaults();
 		$post_object = get_post( $order->get_id() );
 		if ( ! $order->get_id() || ! $post_object || ! in_array( $post_object->post_type, wc_get_order_types(), true ) ) {
-			throw new Exception( __( 'Invalid order.', 'woocommerce' ) );
+			throw new Exception( esc_html( __( 'Invalid order.', 'woocommerce' ) ) );
 		}
 
 		$this->set_order_props(
@@ -291,7 +299,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				/**
 				 * Fires immediately after an order is deleted.
 				 *
-				 * @since
+				 * @since 2.7.0
 				 *
 				 * @param int $order_id ID of the order that has been deleted.
 				 */
@@ -345,6 +353,13 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$order_status = $order->get_status( 'edit' );
 
 		if ( ! $order_status ) {
+			/**
+			 * Filters the default order status to use when creating a new order.
+			 *
+			 * @param string $order_status Default order status.
+			 *
+			 * @since 3.7.0
+			 */
 			$order_status = apply_filters( 'woocommerce_default_order_status', 'pending' );
 		}
 
@@ -352,7 +367,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$valid_statuses = get_post_stati();
 
 		// Add a wc- prefix to the status, but exclude some core statuses which should not be prefixed.
-		// @todo In the future this should only happen based on `wc_is_order_status`, but in order to
+		// In the future this should only happen based on `wc_is_order_status`, but in order to
 		// preserve back-compatibility this happens to all statuses except a select few. A doing_it_wrong
 		// Notice will be needed here, followed by future removal.
 		if ( ! in_array( $post_status, array( 'auto-draft', 'draft', 'trash' ), true ) && in_array( 'wc-' . $post_status, $valid_statuses, true ) ) {
@@ -380,7 +395,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	protected function get_post_title() {
 		// @codingStandardsIgnoreStart
 		/* translators: %s: Order date */
-		return sprintf( __( 'Order &ndash; %s', 'woocommerce' ), (new DateTime('now'))->format( _x( 'M d, Y @ h:i A', 'Order date parsed by DateTime::format', 'woocommerce' ) ) );
+		return sprintf( __( 'Order &ndash; %s', 'woocommerce' ), ( new DateTime( 'now' ) )->format( _x( 'M d, Y @ h:i A', 'Order date parsed by DateTime::format', 'woocommerce' ) ) );
 		// @codingStandardsIgnoreEnd
 	}
 
@@ -466,6 +481,14 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			}
 		}
 
+		/**
+		 * Action fired after updating order properties.
+		 *
+		 * @param WC_Abstract_Order $order Order object.
+		 * @param string[]          $updated_props Array of updated properties.
+		 *
+		 * @since 2.7.0
+		 */
 		do_action( 'woocommerce_order_object_updated_props', $order, $updated_props );
 	}
 

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -143,7 +143,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$order->set_defaults();
 		$post_object = get_post( $order->get_id() );
 		if ( ! $order->get_id() || ! $post_object || ! in_array( $post_object->post_type, wc_get_order_types(), true ) ) {
-			throw new Exception( esc_html( __( 'Invalid order.', 'woocommerce' ) ) );
+			throw new Exception( esc_html__( 'Invalid order.', 'woocommerce' ) );
 		}
 
 		$this->set_order_props(

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -491,6 +491,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function read_items( $order, $type ) {
 		global $wpdb;
 
+		// When the order is not yet saved, we cannot get the items from DB. Trying to do so will risk reading items of different orders that were saved incorrectly.
+		if ( 0 === $order->get_id() ) {
+			return array();
+		}
+
 		// Get from cache if available.
 		$items = 0 < $order->get_id() ? wp_cache_get( 'order-items-' . $order->get_id(), 'orders' ) : false;
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -7,6 +7,7 @@
 
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
  * Class WC_Abstract_Order.
  */
@@ -148,7 +149,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'wc_get_price_excluding_tax' => function( $product, $args = array() ) use ( &$product_passed_to_get_price, &$args_passed_to_get_price ) {
+				'wc_get_price_excluding_tax' => function ( $product, $args = array() ) use ( &$product_passed_to_get_price, &$args_passed_to_get_price ) {
 						$product_passed_to_get_price = $product;
 						$args_passed_to_get_price    = $args;
 
@@ -311,7 +312,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	public function test_cache_does_not_interferes_with_order_object() {
 		add_action(
 			'woocommerce_new_order',
-			function( $order_id ) {
+			function ( $order_id ) {
 				// this makes the cache store a specific order class instance, but it's quickly replaced by a generic one
 				// as we're in the middle of a save and this gets executed before the logic in WC_Abstract_Order.
 				$order = wc_get_order( $order_id );
@@ -358,7 +359,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 
 		$product1_for_order1 = WC_Helper_Product::create_simple_product();
 		$product2_for_order1 = WC_Helper_Product::create_simple_product();
-		$product_for_order2 = WC_Helper_Product::create_simple_product();
+		$product_for_order2  = WC_Helper_Product::create_simple_product();
 
 		$item1_1 = new WC_Order_Item_Product();
 		$item1_1->set_product( $product1_for_order1 );
@@ -387,6 +388,6 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$this->assertContains( $item1_1->get_id(), $order1_items );
 		$this->assertContains( $item1_1->get_id(), $order1_items );
 
-		$this->assertEquals( $item2->get_id(), array_keys ( $order2->get_items( 'line_item' ) )[0] );
+		$this->assertEquals( $item2->get_id(), array_keys( $order2->get_items( 'line_item' ) )[0] );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -348,4 +348,43 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$order_terms = wp_list_pluck( wp_get_object_terms( $order->get_id(), $custom_taxonomy->name ), 'name' );
 		$this->assertContains( 'new_term', $order_terms );
 	}
+
+	/**
+	 * @testDox Test that order items are not mixed when order_id is zero.
+	 */
+	public function test_order_items_shouldnot_mix_with_zero_id() {
+		$order1 = new WC_Order();
+		$order2 = new WC_Order();
+
+		$product1_for_order1 = WC_Helper_Product::create_simple_product();
+		$product2_for_order1 = WC_Helper_Product::create_simple_product();
+		$product_for_order2 = WC_Helper_Product::create_simple_product();
+
+		$item1_1 = new WC_Order_Item_Product();
+		$item1_1->set_product( $product1_for_order1 );
+		$item1_1->set_quantity( 1 );
+		$item1_1->save();
+
+		$item1_2 = new WC_Order_Item_Product();
+		$item1_2->set_product( $product2_for_order1 );
+		$item1_2->set_quantity( 1 );
+		$item1_2->save();
+
+		$item2 = new WC_Order_Item_Product();
+		$item2->set_product( $product_for_order2 );
+		$item2->set_quantity( 1 );
+		$item2->save();
+
+		$order1->add_item( $item1_1 );
+		$order2->add_item( $item2 );
+		$order1->add_item( $item1_2 );
+
+		$this->assertCount( 1, $order2->get_items( 'line_item' ) );
+		$this->assertCount( 2, $order1->get_items( 'line_item' ) );
+
+		$this->assertEquals( $item1_2->get_id(), $order1->get_items( 'line_item' )[1]->get_id() );
+		$this->assertEquals( $item1_1->get_id(), $order1->get_items( 'line_item' )[0]->get_id() );
+
+		$this->assertEquals( $item2->get_id(), $order2->get_items( 'line_item' )[0]->get_id() );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -382,9 +382,11 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$this->assertCount( 1, $order2->get_items( 'line_item' ) );
 		$this->assertCount( 2, $order1->get_items( 'line_item' ) );
 
-		$this->assertEquals( $item1_2->get_id(), $order1->get_items( 'line_item' )[1]->get_id() );
-		$this->assertEquals( $item1_1->get_id(), $order1->get_items( 'line_item' )[0]->get_id() );
+		$order1_items = array_keys( $order1->get_items( 'line_item' ) );
 
-		$this->assertEquals( $item2->get_id(), $order2->get_items( 'line_item' )[0]->get_id() );
+		$this->assertContains( $item1_1->get_id(), $order1_items );
+		$this->assertContains( $item1_1->get_id(), $order1_items );
+
+		$this->assertEquals( $item2->get_id(), array_keys ( $order2->get_items( 'line_item' ) )[0] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the order ID is zero, we should avoid reading its items altogether. Usually, we expect that items are not saved to DB till the order itself is saved first, however, via custom code, we can end up in a scenario where order items are indeed saved before the order is. In this case, items are saved with order id of `0`, and such there is not way to differentiate between items of different orders that are saved with ID 0.

We prevent this by not reading items from DB at all when ID is zero.

Closes #25623 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that it's really hard to test via testing instructions due to the nature of bug (race condition). So exploratory testing around creating orders via blocks checkout and traditional checkout should be enough. I have added a unit test simulating the race condition.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
