### PR TITLE
Fix PaymentGatewaySuggestionsDataSourcePoller and disable deprecation logging

### DIFF
--- a/plugins/woocommerce/changelog/fix-datasourcepoller-upgrade-issues
+++ b/plugins/woocommerce/changelog/fix-datasourcepoller-upgrade-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Temporary disable DataSourcePoller class deprecation message

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -16,8 +16,8 @@ abstract class DataSourcePoller extends RemoteSpecsDataSourcePoller {
 	 * Log a deprecation to the error log.
 	 */
 	private static function log_deprecation() {
-		// Temporarily disable deprecation message in logs due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
-		return;
+		/*
+		// Temporarily disable deprecation message in logs since due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
 		error_log( // phpcs:ignore
 			sprintf(
 				'%1$s is deprecated since version %2$s! Use %3$s instead.',
@@ -26,6 +26,7 @@ abstract class DataSourcePoller extends RemoteSpecsDataSourcePoller {
 				'Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller'
 			)
 		);
+		*/
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -16,6 +16,8 @@ abstract class DataSourcePoller extends RemoteSpecsDataSourcePoller {
 	 * Log a deprecation to the error log.
 	 */
 	private static function log_deprecation() {
+		// Temporarily disable deprecation message in logs since due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
+		return;
 		error_log( // phpcs:ignore
 			sprintf(
 				'%1$s is deprecated since version %2$s! Use %3$s instead.',

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -16,17 +16,7 @@ abstract class DataSourcePoller extends RemoteSpecsDataSourcePoller {
 	 * Log a deprecation to the error log.
 	 */
 	private static function log_deprecation() {
-		/*
 		// Temporarily disable deprecation message in logs due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
-		error_log( // phpcs:ignore
-			sprintf(
-				'%1$s is deprecated since version %2$s! Use %3$s instead.',
-				self::class,
-				'8.8.0',
-				'Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller'
-			)
-		);
-		*/
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -16,7 +16,7 @@ abstract class DataSourcePoller extends RemoteSpecsDataSourcePoller {
 	 * Log a deprecation to the error log.
 	 */
 	private static function log_deprecation() {
-		// Temporarily disable deprecation message in logs since due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
+		// Temporarily disable deprecation message in logs due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
 		return;
 		error_log( // phpcs:ignore
 			sprintf(

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -16,7 +16,11 @@ abstract class DataSourcePoller extends RemoteSpecsDataSourcePoller {
 	 * Log a deprecation to the error log.
 	 */
 	private static function log_deprecation() {
-		// Temporarily disable deprecation message in logs due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
+		/**
+		 * Note: Deprecation messages have been temporarily disabled due to upgrade issues.
+		 * For more details, see the discussion in the WooCommerce GitHub repository:
+		 * https://github.com/woocommerce/woocommerce/pull/45892.
+		 */
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -17,7 +17,7 @@ abstract class DataSourcePoller extends RemoteSpecsDataSourcePoller {
 	 */
 	private static function log_deprecation() {
 		/*
-		// Temporarily disable deprecation message in logs since due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
+		// Temporarily disable deprecation message in logs due to upgrade issues https://github.com/woocommerce/woocommerce/pull/45892.
 		error_log( // phpcs:ignore
 			sprintf(
 				'%1$s is deprecated since version %2$s! Use %3$s instead.',

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaySuggestionsDataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaySuggestionsDataSourcePoller.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions;
 
-use Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller;
+use Automattic\WooCommerce\Admin\DataSourcePoller;
 
 /**
  * Specs data source poller class for payment gateway suggestions.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses the following issues:

- Similar fatal occurring from `PaymentGatewaySuggestionsDataSourcePoller` (pb22l9-2AS-p2#comment-2838)
- Deprecation message flooding debug.log (p1712065654429989-slack-C01SFMVEYAK)

Follow-up to https://github.com/woocommerce/woocommerce/pull/45892

- Apply the same "fix" for `PaymentGatewaySuggestionsDataSourcePoller`
- Disable logging since it's flooding WC 8.8.0 users

### How to test the changes in this Pull Request:


#### Upgrade test
1. Follow the instructions in p1711313371293309/1711312760.121469-slack-C05JQBR78RW to create Woo Express site
2. Go to `/wp-admin/plugin-install.php`
2. Upload WooCommerce with the zipfile in this PR ([artifact](https://github.com/woocommerce/woocommerce/actions/runs/8537114233?pr=46163), or [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/14850772/woocommerce.zip))
3. Go to `WooCommerce > Status > Logs` and look for `fatal-errors-*` log
4. Observe no fatal error of the following: 
 
```
CRITICAL Uncaught Error: Class "Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller" not found in /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPayPromotionDataSourcePoller.php:9
``` 
or
```
Critical Uncaught Error: Class "Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller" not found in /srv/htdocs/wp-content/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaySuggestionsDataSourcePoller.php:10
```

#### Downgrade test
1. Go back to `/wp-admin/plugin-install.php`
7. Upload [WooCommerce 8.7.0](https://github.com/woocommerce/woocommerce/releases/tag/8.7.0)
3. Go to `WooCommerce > Status > Logs` and look for `fatal-errors-*` log
8. Observe no similar fatal error 

#### Error log test
1. SSH to your site
7. Run `tail -f /tmp/php-errors`
8. Go to WooCommerce > Home
3. Observe no message `Automattic\WooCommerce\Admin\DataSourcePoller is deprecated since version 8.8.0! Use Automattic\WooCommerce\Admin\RemoteSpecs\DataSourcePoller instead.`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>