### PR TITLE
Add e2e for analytics product segmentation

### DIFF
--- a/plugins/woocommerce/changelog/add-46107_e2e_for_analytics_product_segmentation
+++ b/plugins/woocommerce/changelog/add-46107_e2e_for_analytics_product_segmentation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add E2E test for Analytics products segmentation filter.

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -585,6 +585,103 @@ test.describe( 'Analytics-related tests', () => {
 		).toBeVisible();
 	} );
 
+	test( 'use filter by single product on products report', async ( {
+		page,
+	} ) => {
+		await page.goto(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts'
+		);
+
+		// FTUX tour on first run through
+		try {
+			await page.getByLabel( 'Close Tour' ).click( { timeout: 5000 } );
+		} catch ( e ) {
+			console.log( 'Tour was not visible, skipping.' );
+		}
+
+		// no filters applied
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Orders 10 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Net sales $1,229.30 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Average order value $122.93 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Average items per order 11 No change from Previous year:',
+			} )
+		).toBeVisible();
+
+		// apply some filters
+		await page.getByRole( 'button', { name: 'All orders' } ).click();
+		await page.getByText( 'Advanced filters' ).click();
+
+		await page.getByRole( 'button', { name: 'Add a Filter' } ).click();
+		await page.getByRole( 'button', { name: 'Order Status' } ).click();
+		await page
+			.getByLabel( 'Select an order status filter match' )
+			.selectOption( 'Is' );
+		await page
+			.getByLabel( 'Select an order status', { exact: true } )
+			.selectOption( 'Failed' );
+		await page.getByRole( 'link', { name: 'Filter', exact: true } ).click();
+
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Orders 0 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Net sales $0.00 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Average order value $0.00 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Average items per order 0 No change from Previous year:',
+			} )
+		).toBeVisible();
+
+		await page
+			.getByLabel( 'Select an order status', { exact: true } )
+			.selectOption( 'Completed' );
+		await page.getByRole( 'link', { name: 'Filter', exact: true } ).click();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Orders 10 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Net sales $1,229.30 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Average order value $122.93 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Average items per order 11 No change from Previous year:',
+			} )
+		).toBeVisible();
+	} );
+
 	test( 'analytics settings', async ( { page } ) => {
 		await page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fsettings'

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -607,77 +607,77 @@ test.describe( 'Analytics-related tests', () => {
 		).toBeVisible();
 		await expect(
 			page.getByRole( 'menuitem', {
+				name: 'Items sold 110 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
 				name: 'Net sales $1,229.30 No change from Previous year:',
 			} )
 		).toBeVisible();
-		await expect(
-			page.getByRole( 'menuitem', {
-				name: 'Average order value $122.93 No change from Previous year:',
-			} )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'menuitem', {
-				name: 'Average items per order 11 No change from Previous year:',
-			} )
-		).toBeVisible();
-
-		// apply some filters
-		await page.getByRole( 'button', { name: 'All orders' } ).click();
-		await page.getByText( 'Advanced filters' ).click();
-
-		await page.getByRole( 'button', { name: 'Add a Filter' } ).click();
-		await page.getByRole( 'button', { name: 'Order Status' } ).click();
-		await page
-			.getByLabel( 'Select an order status filter match' )
-			.selectOption( 'Is' );
-		await page
-			.getByLabel( 'Select an order status', { exact: true } )
-			.selectOption( 'Failed' );
-		await page.getByRole( 'link', { name: 'Filter', exact: true } ).click();
-
-		await expect(
-			page.getByRole( 'menuitem', {
-				name: 'Orders 0 No change from Previous year:',
-			} )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'menuitem', {
-				name: 'Net sales $0.00 No change from Previous year:',
-			} )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'menuitem', {
-				name: 'Average order value $0.00 No change from Previous year:',
-			} )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'menuitem', {
-				name: 'Average items per order 0 No change from Previous year:',
-			} )
-		).toBeVisible();
-
-		await page
-			.getByLabel( 'Select an order status', { exact: true } )
-			.selectOption( 'Completed' );
-		await page.getByRole( 'link', { name: 'Filter', exact: true } ).click();
 		await expect(
 			page.getByRole( 'menuitem', {
 				name: 'Orders 10 No change from Previous year:',
 			} )
 		).toBeVisible();
+
+		// apply some filters
+		await page.getByRole( 'button', { name: 'All products' } ).click();
+		await page.getByText( 'Single product' ).click();
+
+		// Search for single product
+		await page
+			.getByPlaceholder( 'Type to search for a product' )
+			.last()
+			.fill( 'Variable Product' );
+
+		await page.getByRole( 'option', { name: 'Variable Product' } ).click();
+
 		await expect(
 			page.getByRole( 'menuitem', {
-				name: 'Net sales $1,229.30 No change from Previous year:',
+				name: 'Items sold 40 No change from Previous year:',
 			} )
 		).toBeVisible();
 		await expect(
 			page.getByRole( 'menuitem', {
-				name: 'Average order value $122.93 No change from Previous year:',
+				name: 'Net sales $260.00 No change from Previous year:',
 			} )
 		).toBeVisible();
 		await expect(
 			page.getByRole( 'menuitem', {
-				name: 'Average items per order 11 No change from Previous year:',
+				name: 'Orders 10 No change from Previous year:',
+			} )
+		).toBeVisible();
+
+		await page.getByText( 'All variations' ).click();
+
+		// Search for single product
+		await expect(
+			page.getByRole( 'button', { name: 'Single variation' } )
+		).toBeVisible();
+		await page.getByRole( 'button', { name: 'Single variation' } ).click();
+		await page
+			.getByPlaceholder( 'Type to search for a variation' )
+			.last()
+			.fill( 'Blue' );
+
+		await page
+			.getByRole( 'option', { name: 'Variable Product - Blue' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Items sold 30 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Net sales $180.00 No change from Previous year:',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', {
+				name: 'Orders 10 No change from Previous year:',
 			} )
 		).toBeVisible();
 	} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46107  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure e2e tests pass on CI
2. Pull branch, `pnpm env:restart`
3. `pnpm test:e2e-pw admin-analytics/analytics-data.spec.js`
4. Checkout `add/46107_e2e_for_analytics_product_segmentation_with_bug` and run `pnpm test:e2e-pw admin-analytics/analytics-data.spec.js` again
5. This time the new test "use filter by single product on products report" should fail ( this branch includes the bug that made it through last time ).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
