### PR TITLE
Change copy on the "coming soon" restricted pages

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -118,7 +118,7 @@ const SiteVisibility = () => {
 						label={
 							<>
 								{ __(
-									'Hide store pages only',
+									'Enable for store pages only',
 									'woocommerce'
 								) }
 								<p>

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -118,7 +118,7 @@ const SiteVisibility = () => {
 						label={
 							<>
 								{ __(
-									'Restrict to store pages only',
+									'Hide store pages only',
 									'woocommerce'
 								) }
 								<p>


### PR DESCRIPTION
Avoid confusing text, the tooltip seems to have clear wording. Kudos to suggestion: Katie Keith on X: https://twitter.com/KatieKeithBarn2/status/1775255118960550019

Instead of: "Restrict to store pages only"

Go with: "Hide store pages only"