### PR TITLE
fix: lys hub show only incompleted and recent tasks

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
@@ -25,8 +25,9 @@ import {
  */
 import type { SidebarComponentProps } from '../xstate';
 import { SidebarContainer } from './sidebar-container';
-import { taskCompleteIcon, taskIcons } from './icons';
+import { taskCompleteIcon } from './icons';
 import { SiteHub } from '~/customize-store/assembler-hub/site-hub';
+import { CompletedTaskItem, IncompleteTaskItem } from '../tasklist';
 export const LaunchYourStoreHubSidebar: React.FC< SidebarComponentProps > = (
 	props
 ) => {
@@ -109,28 +110,25 @@ export const LaunchYourStoreHubSidebar: React.FC< SidebarComponentProps > = (
 				<ItemGroup className="edit-site-sidebar-navigation-screen-essential-tasks__group">
 					{ tasklist &&
 						hasIncompleteTasks &&
-						tasklist.tasks.map( ( task ) => (
-							<SidebarNavigationItem
-								className={ classnames( task.id, {
-									'is-complete': task.isComplete,
-								} ) }
-								icon={
-									task.isComplete
-										? taskCompleteIcon
-										: taskIcons[ task.id ]
-								}
-								withChevron
-								key={ task.id }
-								onClick={ () => {
-									props.sendEventToSidebar( {
-										type: 'TASK_CLICKED',
-										task,
-									} );
-								} }
-							>
-								{ task.title }
-							</SidebarNavigationItem>
-						) ) }
+						tasklist.tasks.map( ( task ) =>
+							task.isComplete ? (
+								<CompletedTaskItem
+									task={ task }
+									key={ task.id }
+								/>
+							) : (
+								<IncompleteTaskItem
+									task={ task }
+									key={ task.id }
+									onClick={ () => {
+										props.sendEventToSidebar( {
+											type: 'TASK_CLICKED',
+											task,
+										} );
+									} }
+								/>
+							)
+						) }
 					{ tasklist && ! hasIncompleteTasks && (
 						<SidebarNavigationItem
 							className="all-tasks-complete"

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.ts
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.ts
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { ONBOARDING_STORE_NAME, TaskType } from '@woocommerce/data';
+import { navigateTo, getNewPath } from '@woocommerce/navigation';
+import { resolveSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { createStorageUtils } from '~/utils/localStorage';
+
+const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
+export const LYS_RECENTLY_ACTIONED_TASKS_KEY = 'lys_recently_actioned_tasks';
+
+export const {
+	getWithExpiry: getRecentlyActionedTasks,
+	setWithExpiry: saveRecentlyActionedTask,
+} = createStorageUtils< string[] >(
+	LYS_RECENTLY_ACTIONED_TASKS_KEY,
+	SEVEN_DAYS_IN_SECONDS
+);
+
+export const getLysTasklist = async () => {
+	const LYS_TASKS_WHITELIST = [
+		'products',
+		'customize-store',
+		'woocommerce-payments',
+		'payments',
+		'shipping',
+		'tax',
+	];
+
+	/**
+	 * This filter allows customizing the list of tasks to show in WooCommerce Launch Your Store feature.
+	 *
+	 * @filter woocommerce_launch_your_store_tasklist_whitelist
+	 * @param {string[]} LYS_TASKS_WHITELIST Default list of task IDs to show in LYS.
+	 *
+	 */
+	const filteredTasks = applyFilters(
+		'woocommerce_launch_your_store_tasklist_whitelist',
+		[ ...LYS_TASKS_WHITELIST ]
+	) as string[];
+
+	const tasklist = await resolveSelect(
+		ONBOARDING_STORE_NAME
+	).getTaskListsByIds( [ 'setup' ] );
+
+	const recentlyActionedTasks = getRecentlyActionedTasks() ?? [];
+
+	/**
+	 * show tasks that fulfill all the following conditions:
+	 * 1. part of the whitelist of tasks to show in LYS
+	 * 2. either not completed or recently actioned
+	 */
+	const visibleTasks = tasklist[ 0 ].tasks.filter(
+		( task ) =>
+			filteredTasks.includes( task.id ) &&
+			( ! task.isComplete || recentlyActionedTasks.includes( task.id ) )
+	);
+
+	return {
+		...tasklist[ 0 ],
+		tasks: visibleTasks,
+	};
+};
+
+export function taskClickedAction( event: {
+	type: 'TASK_CLICKED';
+	task: TaskType;
+} ) {
+	const recentlyActionedTasks = getRecentlyActionedTasks() ?? [];
+	saveRecentlyActionedTask( [ ...recentlyActionedTasks, event.task.id ] );
+	if ( event.task.actionUrl ) {
+		navigateTo( { url: event.task.actionUrl } );
+	} else {
+		navigateTo( {
+			url: getNewPath( { task: event.task.id }, '/', {} ),
+		} );
+	}
+}

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.tsx
@@ -57,7 +57,7 @@ export const getLysTasklist = async () => {
 	const recentlyActionedTasks = getRecentlyActionedTasks() ?? [];
 
 	/**
-	 * show tasks that fulfill all the following conditions:
+	 * Show tasks that fulfill all the following conditions:
 	 * 1. part of the whitelist of tasks to show in LYS
 	 * 2. either not completed or recently actioned
 	 */

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @woocommerce/dependency-group */
 /**
  * External dependencies
  */
@@ -5,11 +7,15 @@ import { ONBOARDING_STORE_NAME, TaskType } from '@woocommerce/data';
 import { navigateTo, getNewPath } from '@woocommerce/navigation';
 import { resolveSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
+import classnames from 'classnames';
+// @ts-ignore No types for this exist yet.
+import SidebarNavigationItem from '@wordpress/edit-site/build-module/components/sidebar-navigation-item';
 
 /**
  * Internal dependencies
  */
 import { createStorageUtils } from '~/utils/localStorage';
+import { taskCompleteIcon, taskIcons } from './components/icons';
 
 const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
 export const LYS_RECENTLY_ACTIONED_TASKS_KEY = 'lys_recently_actioned_tasks';
@@ -81,3 +87,31 @@ export function taskClickedAction( event: {
 		} );
 	}
 }
+
+export const CompletedTaskItem: React.FC< {
+	task: TaskType;
+	classNames?: string;
+} > = ( { task, classNames } ) => (
+	<SidebarNavigationItem
+		className={ classnames( task.id, 'is-complete', classNames ) }
+		icon={ taskCompleteIcon }
+		disabled={ true }
+	>
+		{ task.title }
+	</SidebarNavigationItem>
+);
+
+export const IncompleteTaskItem: React.FC< {
+	task: TaskType;
+	classNames?: string;
+	onClick: () => void;
+} > = ( { task, classNames, onClick } ) => (
+	<SidebarNavigationItem
+		className={ classnames( task.id, classNames ) }
+		icon={ taskIcons[ task.id ] }
+		withChevron
+		onClick={ onClick }
+	>
+		{ task.title }
+	</SidebarNavigationItem>
+);

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -11,14 +11,8 @@ import {
 } from 'xstate5';
 import React from 'react';
 import classnames from 'classnames';
-import { getNewPath, getQuery, navigateTo } from '@woocommerce/navigation';
-import { resolveSelect } from '@wordpress/data';
-import {
-	ONBOARDING_STORE_NAME,
-	TaskListType,
-	TaskType,
-} from '@woocommerce/data';
-import { applyFilters } from '@wordpress/hooks';
+import { getQuery, navigateTo } from '@woocommerce/navigation';
+import { TaskListType, TaskType } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -27,6 +21,7 @@ import { LaunchYourStoreHubSidebar } from './components/launch-store-hub';
 import type { LaunchYourStoreComponentProps } from '..';
 import type { mainContentMachine } from '../main-content/xstate';
 import { updateQueryParams, createQueryParamsListener } from '../common';
+import { taskClickedAction, getLysTasklist } from './tasklist';
 
 export type SidebarMachineContext = {
 	externalUrl: string | null;
@@ -51,31 +46,6 @@ export type SidebarMachineEvents =
 const sidebarQueryParamListener = fromCallback( ( { sendBack } ) => {
 	return createQueryParamsListener( 'sidebar', sendBack );
 } );
-
-const getLysTasklist = async () => {
-	const LYS_TASKS = [
-		'products',
-		'customize-store',
-		'woocommerce-payments',
-		'payments',
-		'shipping',
-		'tax',
-	];
-
-	const tasklist = await resolveSelect(
-		ONBOARDING_STORE_NAME
-	).getTaskListsByIds( [ 'setup' ] );
-	const visibleTasks: string[] = applyFilters(
-		'woocommerce_launch_your_store_tasklist_visible',
-		[ ...LYS_TASKS ]
-	) as string[];
-	return {
-		...tasklist[ 0 ],
-		tasks: tasklist[ 0 ].tasks.filter( ( task ) =>
-			visibleTasks.includes( task.id )
-		),
-	};
-};
 
 export const sidebarMachine = setup( {
 	types: {} as {
@@ -107,13 +77,7 @@ export const sidebarMachine = setup( {
 		},
 		taskClicked: ( { event } ) => {
 			if ( event.type === 'TASK_CLICKED' ) {
-				if ( event.task.actionUrl ) {
-					navigateTo( { url: event.task.actionUrl } );
-				} else {
-					navigateTo( {
-						url: getNewPath( { task: event.task.id }, '/', {} ),
-					} );
-				}
+				taskClickedAction( event );
 			}
 		},
 		openWcAdminUrl: ( { event } ) => {

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
@@ -247,6 +247,10 @@
 									background: transparent;
 									color: $gray-700;
 								}
+
+								.components-flex-block {
+									color: $gray-700;
+								}
 							}
 						}
 					}

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
@@ -242,6 +242,11 @@
 							.edit-site-sidebar-navigation-item.is-complete {
 								text-decoration: line-through;
 								color: $gray-700;
+
+								&:hover {
+									background: transparent;
+									color: $gray-700;
+								}
 							}
 						}
 					}

--- a/plugins/woocommerce-admin/client/utils/localStorage.ts
+++ b/plugins/woocommerce-admin/client/utils/localStorage.ts
@@ -1,0 +1,41 @@
+type StoredItem< T > = {
+	data: T;
+	expiry: string;
+};
+
+/**
+ * This constructor function exists for type safety purposes, so when you create a pair of set/get functions they have the
+ *  same type for the value they store/retrieve.
+ */
+export function createStorageUtils< T >(
+	key: string,
+	durationInSeconds: number
+) {
+	return {
+		setWithExpiry: ( value: T ): void => {
+			const now = new Date();
+			const expiry = new Date( now.getTime() + durationInSeconds * 1000 );
+
+			const item: StoredItem< T > = {
+				data: value,
+				expiry: expiry.toISOString(),
+			};
+
+			localStorage.setItem( key, JSON.stringify( item ) );
+		},
+		getWithExpiry: (): T | null => {
+			const itemStr = localStorage.getItem( key );
+			if ( ! itemStr ) {
+				return null;
+			}
+
+			const item: StoredItem< T > = JSON.parse( itemStr );
+			const now = new Date();
+			if ( now > new Date( item.expiry ) ) {
+				localStorage.removeItem( key );
+				return null;
+			}
+			return item.data;
+		},
+	};
+}

--- a/plugins/woocommerce/changelog/fix-lys-incomplete-tasks
+++ b/plugins/woocommerce/changelog/fix-lys-incomplete-tasks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the LYS Hub tasklist so that it only shows incomplete tasks and tasks that were recently actioned


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Modifies the LYS Tasklist display such that only tasks that are either incomplete or recently actioned from within LYS are shown

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `launch-your-store` feature flag
2. Prior to entering LYS, complete at least one task from within Add Products, Customize your store, Payments, Shipping, or Taxes
3. Enter LYS
4. Observe that the task you completed previously will not show up on the LYS task list
5. Click on one of the LYS task list tasks and complete it
6. Return to LYS
7. Observe that the task shows as strikethrough and becomes non-interactive
8. This feature has a 7 day validity period so the recently actioned tasks will not show up if it has been more than 7 days.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
