### PR TITLE
Product Collection: fix "Reset All" button in Editor filters

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/constants.ts
@@ -94,15 +94,25 @@ export const getDefaultSettings = (
 	query: getDefaultQuery( currentAttributes.query ),
 } );
 
-export const DEFAULT_FILTERS: Partial< ProductCollectionQuery > = {
+export const DEFAULT_FILTERS: Pick<
+	ProductCollectionQuery,
+	| 'woocommerceOnSale'
+	| 'woocommerceStockStatus'
+	| 'woocommerceAttributes'
+	| 'woocommerceHandPickedProducts'
+	| 'taxQuery'
+	| 'featured'
+	| 'timeFrame'
+	| 'priceRange'
+> = {
 	woocommerceOnSale: DEFAULT_QUERY.woocommerceOnSale,
-	woocommerceStockStatus: getDefaultStockStatuses(),
-	woocommerceAttributes: [],
+	woocommerceStockStatus: DEFAULT_QUERY.woocommerceStockStatus,
+	woocommerceAttributes: DEFAULT_QUERY.woocommerceAttributes,
+	woocommerceHandPickedProducts: DEFAULT_QUERY.woocommerceHandPickedProducts,
 	taxQuery: DEFAULT_QUERY.taxQuery,
-	woocommerceHandPickedProducts: [],
 	featured: DEFAULT_QUERY.featured,
-	timeFrame: undefined,
-	priceRange: undefined,
+	timeFrame: DEFAULT_QUERY.timeFrame,
+	priceRange: DEFAULT_QUERY.priceRange,
 };
 
 /**

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/attributes-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/attributes-control.tsx
@@ -16,6 +16,7 @@ import {
  * Internal dependencies
  */
 import { QueryControlProps } from '../../types';
+import { DEFAULT_FILTERS } from '../../constants';
 
 const EDIT_ATTRIBUTES_URL = `${ ADMIN_URL }edit.php?post_type=product&page=product_attributes`;
 
@@ -31,7 +32,9 @@ const AttributesControl = ( {
 	);
 
 	const deselectCallback = () => {
-		setQueryAttribute( { woocommerceAttributes: [] } );
+		setQueryAttribute( {
+			woocommerceAttributes: DEFAULT_FILTERS.woocommerceAttributes,
+		} );
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/attributes-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/attributes-control.tsx
@@ -30,10 +30,16 @@ const AttributesControl = ( {
 		} )
 	);
 
+	const deselectCallback = () => {
+		setQueryAttribute( { woocommerceAttributes: [] } );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Product Attributes', 'woocommerce' ) }
 			hasValue={ () => !! woocommerceAttributes?.length }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			<ProductAttributeTermControl
 				messages={ {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/created-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/created-control.tsx
@@ -28,15 +28,18 @@ const CreatedControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
 	const { timeFrame } = query;
 
+	const deselectCallback = () => {
+		setQueryAttribute( {
+			timeFrame: undefined,
+		} );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Created', 'woocommerce' ) }
 			hasValue={ () => timeFrame?.operator && timeFrame?.value }
-			onDeselect={ () => {
-				setQueryAttribute( {
-					timeFrame: undefined,
-				} );
-			} }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			<Flex direction="column" gap={ 3 }>
 				<FlexItem>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/created-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/created-control.tsx
@@ -23,6 +23,7 @@ import {
  * Internal dependencies
  */
 import { ETimeFrameOperator, QueryControlProps } from '../../types';
+import { DEFAULT_FILTERS } from '../../constants';
 
 const CreatedControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
@@ -30,7 +31,7 @@ const CreatedControl = ( props: QueryControlProps ) => {
 
 	const deselectCallback = () => {
 		setQueryAttribute( {
-			timeFrame: undefined,
+			timeFrame: DEFAULT_FILTERS.timeFrame,
 		} );
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/featured-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/featured-products-control.tsx
@@ -18,15 +18,18 @@ import { QueryControlProps } from '../../types';
 const FeaturedProductsControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
 
+	const deselectCallback = () => {
+		setQueryAttribute( {
+			featured: false,
+		} );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Featured', 'woocommerce' ) }
 			hasValue={ () => query.featured === true }
-			onDeselect={ () => {
-				setQueryAttribute( {
-					featured: false,
-				} );
-			} }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			<BaseControl
 				id="product-collection-featured-products-control"

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/featured-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/featured-products-control.tsx
@@ -14,13 +14,14 @@ import {
  * Internal dependencies
  */
 import { QueryControlProps } from '../../types';
+import { DEFAULT_FILTERS } from '../../constants';
 
 const FeaturedProductsControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
 
 	const deselectCallback = () => {
 		setQueryAttribute( {
-			featured: false,
+			featured: DEFAULT_FILTERS.featured,
 		} );
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import { QueryControlProps } from '../../types';
+import { DEFAULT_FILTERS } from '../../constants';
 
 /**
  * Returns:
@@ -117,7 +118,8 @@ const HandPickedProductsControl = ( {
 
 	const deselectCallback = () => {
 		setQueryAttribute( {
-			woocommerceHandPickedProducts: [],
+			woocommerceHandPickedProducts:
+				DEFAULT_FILTERS.woocommerceHandPickedProducts,
 		} );
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
@@ -115,15 +115,18 @@ const HandPickedProductsControl = ( {
 		return decodeEntities( product?.name ) || '';
 	};
 
+	const deselectCallback = () => {
+		setQueryAttribute( {
+			woocommerceHandPickedProducts: [],
+		} );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Hand-picked Products', 'woocommerce' ) }
 			hasValue={ () => !! selectedProductIds?.length }
-			onDeselect={ () => {
-				setQueryAttribute( {
-					woocommerceHandPickedProducts: [],
-				} );
-			} }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			<FormTokenField
 				disabled={ ! productsMap.size }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -31,7 +31,7 @@ import {
 	FilterName,
 } from '../../types';
 import { setQueryAttribute } from '../../utils';
-import { DEFAULT_FILTERS, getDefaultSettings } from '../../constants';
+import { getDefaultSettings } from '../../constants';
 import UpgradeNotice from './upgrade-notice';
 import ColumnsControl from './columns-control';
 import InheritQueryControl from './inherit-query-control';

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -107,10 +107,9 @@ const ProductCollectionInspectorControls = (
 				<ToolsPanel
 					label={ __( 'Filters', 'woocommerce' ) }
 					resetAll={ ( resetAllFilters: ( () => void )[] ) => {
-						setQueryAttribute( props, DEFAULT_FILTERS );
-						resetAllFilters.forEach( ( resetFilter ) =>
-							resetFilter()
-						);
+						resetAllFilters.forEach( ( resetFilter ) => {
+							resetFilter();
+						} );
 					} }
 					className="wc-block-editor-product-collection-inspector-toolspanel__filters"
 				>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/keyword-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/keyword-control.tsx
@@ -33,12 +33,16 @@ const KeywordControl = ( props: QueryControlProps ) => {
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
 
+	const deselectCallback = () => {
+		setQuerySearch( '' );
+	};
+
 	return (
 		<ToolsPanelItem
 			hasValue={ () => !! querySearch }
 			label={ __( 'Keyword', 'woocommerce' ) }
-			onDeselect={ () => setQuerySearch( '' ) }
-			resetAllFilter={ () => setQuerySearch( '' ) }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			<TextControl
 				label={ __( 'Keyword', 'woocommerce' ) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/on-sale-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/on-sale-control.tsx
@@ -13,12 +13,15 @@ import {
  * Internal dependencies
  */
 import { QueryControlProps } from '../../types';
+import { DEFAULT_FILTERS } from '../../constants';
 
 const OnSaleControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
 
 	const deselectCallback = () => {
-		setQueryAttribute( { woocommerceOnSale: false } );
+		setQueryAttribute( {
+			woocommerceOnSale: DEFAULT_FILTERS.woocommerceOnSale,
+		} );
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/on-sale-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/on-sale-control.tsx
@@ -17,16 +17,17 @@ import { QueryControlProps } from '../../types';
 const OnSaleControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
 
+	const deselectCallback = () => {
+		setQueryAttribute( { woocommerceOnSale: false } );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'On Sale', 'woocommerce' ) }
 			hasValue={ () => query.woocommerceOnSale === true }
 			isShownByDefault
-			onDeselect={ () => {
-				setQueryAttribute( {
-					woocommerceOnSale: false,
-				} );
-			} }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			<ToggleControl
 				label={ __( 'Show only products on sale', 'woocommerce' ) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
@@ -51,6 +51,10 @@ const OrderByControl = ( props: QueryControlProps ) => {
 	const { order, orderBy } = query;
 	const defaultQuery = getDefaultQuery( query );
 
+	const deselectCallback = () => {
+		setQueryAttribute( { orderBy: defaultQuery.orderBy } );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Order by', 'woocommerce' ) }
@@ -59,9 +63,8 @@ const OrderByControl = ( props: QueryControlProps ) => {
 				orderBy !== defaultQuery?.orderBy
 			}
 			isShownByDefault
-			onDeselect={ () => {
-				setQueryAttribute( defaultQuery );
-			} }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			<SelectControl
 				value={ `${ orderBy }/${ order }` }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/price-range-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/price-range-control/index.tsx
@@ -22,15 +22,18 @@ const PriceRangeControl = ( props: QueryControlProps ) => {
 
 	const value = query.priceRange;
 
+	const deselectCallback = () => {
+		setQueryAttribute( { priceRange: undefined } );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Price Range', 'woocommerce' ) }
 			hasValue={ () => {
 				return value?.min !== undefined || value?.max !== undefined;
 			} }
-			onDeselect={ () => {
-				setQueryAttribute( { priceRange: undefined } );
-			} }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 			className="wc-block-product-price-range-control"
 		>
 			<BaseControl.VisualLabel>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/price-range-control/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/price-range-control/index.tsx
@@ -15,6 +15,7 @@ import {
  * Internal dependencies
  */
 import { QueryControlProps } from '../../../types';
+import { DEFAULT_FILTERS } from '../../../constants';
 import PriceTextField from './PriceTextField';
 
 const PriceRangeControl = ( props: QueryControlProps ) => {
@@ -23,7 +24,7 @@ const PriceRangeControl = ( props: QueryControlProps ) => {
 	const value = query.priceRange;
 
 	const deselectCallback = () => {
-		setQueryAttribute( { priceRange: undefined } );
+		setQueryAttribute( { priceRange: DEFAULT_FILTERS.priceRange } );
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
@@ -14,7 +14,11 @@ import {
  * Internal dependencies
  */
 import { QueryControlProps } from '../../types';
-import { STOCK_STATUS_OPTIONS, getDefaultStockStatuses } from '../../constants';
+import {
+	STOCK_STATUS_OPTIONS,
+	DEFAULT_FILTERS,
+	getDefaultStockStatuses,
+} from '../../constants';
 
 /**
  * Gets the id of a specific stock status from its text label
@@ -38,7 +42,7 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 
 	const deselectCallback = () => {
 		setQueryAttribute( {
-			woocommerceStockStatus: getDefaultStockStatuses(),
+			woocommerceStockStatus: DEFAULT_FILTERS.woocommerceStockStatus,
 		} );
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
@@ -36,6 +36,12 @@ function getStockStatusIdByLabel( statusLabel: FormTokenField.Value ) {
 const StockStatusControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
 
+	const deselectCallback = () => {
+		setQueryAttribute( {
+			woocommerceStockStatus: getDefaultStockStatuses(),
+		} );
+	};
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Stock status', 'woocommerce' ) }
@@ -45,11 +51,8 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 					getDefaultStockStatuses()
 				)
 			}
-			onDeselect={ () => {
-				setQueryAttribute( {
-					woocommerceStockStatus: getDefaultStockStatuses(),
-				} );
-			} }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 			isShownByDefault
 		>
 			<FormTokenField

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
@@ -17,6 +17,7 @@ import {
  */
 import TaxonomyItem from './taxonomy-item';
 import { ProductCollectionQuery } from '../../../types';
+import { DEFAULT_FILTERS } from '../../../constants';
 
 interface TaxonomyControlProps {
 	query: ProductCollectionQuery;
@@ -53,7 +54,8 @@ function TaxonomyControls( {
 		return null;
 	}
 
-	const deselectCallback = () => setQueryAttribute( { taxQuery: {} } );
+	const deselectCallback = () =>
+		setQueryAttribute( { taxQuery: DEFAULT_FILTERS.taxQuery } );
 
 	return (
 		<ToolsPanelItem

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
@@ -53,6 +53,8 @@ function TaxonomyControls( {
 		return null;
 	}
 
+	const deselectCallback = () => setQueryAttribute( { taxQuery: {} } );
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Taxonomies', 'woocommerce' ) }
@@ -61,7 +63,8 @@ function TaxonomyControls( {
 					( terms ) => !! terms.length
 				)
 			}
-			onDeselect={ () => setQueryAttribute( { taxQuery: {} } ) }
+			onDeselect={ deselectCallback }
+			resetAllFilter={ deselectCallback }
 		>
 			{ taxonomies.map( ( taxonomy: Taxonomy ) => {
 				const termIds = taxQuery?.[ taxonomy.slug ] || [];

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
@@ -81,11 +81,11 @@ export interface ProductCollectionQuery {
 	 * ),
 	 * ```
 	 */
-	woocommerceStockStatus?: string[];
-	woocommerceAttributes?: AttributeMetadata[];
-	isProductCollectionBlock?: boolean;
-	woocommerceHandPickedProducts?: string[];
-	priceRange?: undefined | PriceRange;
+	woocommerceStockStatus: string[];
+	woocommerceAttributes: AttributeMetadata[];
+	isProductCollectionBlock: boolean;
+	woocommerceHandPickedProducts: string[];
+	priceRange: undefined | PriceRange;
 }
 
 export type ProductCollectionEditComponentProps =

--- a/plugins/woocommerce/changelog/46156-product-collection-reset-all-resets-also-the-collection-filters
+++ b/plugins/woocommerce/changelog/46156-product-collection-reset-all-resets-also-the-collection-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: Fix the "Reset All" funtionality in Editor filters


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The "Reset All" button in Product Collection Editor filters worked incorrectly: it reset the filters which should not change for specific collections. For example, On Sale collection has an `onSale` filter enabled all the time (it's unchangeable by the merchant). However, using "Reset All" resets an unchangeable filter, in this case, `onSale`.

After checking it occurred to me we were doing a reset incorrectly by principle. This PR:
- removes the original reset by directly editing the query.
- adds `deselectCallback` to each filter which is then passed to both:
    - `onDeselect` - fired on deselecting specific filter,
    - `resetAllFilter` - fired when clicking "Reset All".
That leverages the native Gutenberg feature and also if the specific filter is out of control by the merchant, this won't be reset on clicking "Reset All".

Closes https://github.com/woocommerce/woocommerce/issues/46156

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Add Product Collection block
3. Choose On Sale collection - please note only on sale products are displayed
4. Apply two additional filters that would limit the number of displayed products, for example:
  - Price Range: max price (value depends on your local setup, choose a value that would filter some of the products out)
  - Taxonomies - Product category: (value depends on your local setup, choose a value that would filter some of the products out)
5. Click three-dot Filter menu and click "Reset All"

<img width="288" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/aff6abcf-7a75-44e1-9be3-6a8b836b7ecb">

7. **Expected:** collection is back at the state from step 3: all the applied filters are reset and the collection still displays on sale products.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
