### PR TITLE
CYS - color picker: fix CSS

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/style.scss
@@ -74,16 +74,3 @@
 		}
 	}
 }
-
-// Hide "theme" and "default" sections
-.block-editor-color-gradient-control__panel {
-	// Text or Background tab
-	> .components-flex > .components-h-stack.components-v-stack {
-		display: none;
-	}
-
-	// Gradient tab
-	> .components-spacer > .components-flex > .components-h-stack.components-v-stack:not(.components-custom-gradient-picker) {
-		display: none;
-	}
-}

--- a/plugins/woocommerce/changelog/46227-46193-cys-color-picker-no-gradient-to-choose-when-gutenberg-latest-is-active
+++ b/plugins/woocommerce/changelog/46227-46193-cys-color-picker-no-gradient-to-choose-when-gutenberg-latest-is-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: CYS - color picker: fix CSS
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes some CSS that was added to hide some functionalities of Gutenberg: https://github.com/woocommerce/woocommerce/pull/40326. Also, we have another CSS rule that does the same thing: https://github.com/woocommerce/woocommerce/pull/41103.

After some refactoring in Gutenberg components, the rules added with #40326, causing the `display: none' rule to be applied to the entire container.

Regarding this section, we have to add some E2E tests. For more details check: https://github.com/woocommerce/woocommerce/issues/45344


Closes #46193.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Please check this testing instruction with:

- WordPress 6.4
- WordPress 6.5 
- WordPress 6.5 + last version of Gutenberg

1. Head over to WooCommerce > Home > Customize your store.
2. Click on "Start designing" and proceed to the Pattern Assembler.
3. Click on "Choose your color palette".
4. Check the "or create your own" section.
5. Click on background > gradient
6. Ensure that box looks like this image:

![image](https://github.com/woocommerce/woocommerce/assets/4463174/d53b08a7-bfc9-4099-9efe-c0f866b592f6)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

CYS - color picker: fix CSS

</details>
