### PR TITLE
Rename the "other" location from `generic` to `site`

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/utils.tsx
@@ -6,7 +6,13 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-type LocationType = 'product' | 'archive' | 'cart' | 'order' | 'generic';
+export const enum LocationType {
+	Product = 'product',
+	Archive = 'archive',
+	Cart = 'cart',
+	Order = 'order',
+	Site = 'site',
+}
 type Context< T > = T & {
 	templateSlug?: string;
 	postId?: number;
@@ -143,7 +149,9 @@ export const useGetLocation = < T, >(
 	 */
 
 	if ( isInSingleProductBlock ) {
-		return createLocationObject( 'product', { productId: postId } );
+		return createLocationObject( LocationType.Product, {
+			productId: postId,
+		} );
 	}
 
 	/**
@@ -152,7 +160,7 @@ export const useGetLocation = < T, >(
 	 */
 
 	if ( isInSomeCartCheckoutBlock ) {
-		return createLocationObject( 'cart' );
+		return createLocationObject( LocationType.Cart );
 	}
 
 	/**
@@ -161,7 +169,7 @@ export const useGetLocation = < T, >(
 	 */
 
 	if ( isInSpecificProductTemplate ) {
-		return createLocationObject( 'product', { productId } );
+		return createLocationObject( LocationType.Product, { productId } );
 	}
 
 	const isInGenericTemplate = prepareIsInGenericTemplate( templateSlug );
@@ -176,7 +184,9 @@ export const useGetLocation = < T, >(
 	);
 
 	if ( isInSingleProductTemplate ) {
-		return createLocationObject( 'product', { productId: null } );
+		return createLocationObject( LocationType.Product, {
+			productId: null,
+		} );
 	}
 
 	/**
@@ -185,7 +195,7 @@ export const useGetLocation = < T, >(
 	 */
 
 	if ( isInSpecificCategoryTemplate ) {
-		return createLocationObject( 'archive', {
+		return createLocationObject( LocationType.Archive, {
 			taxonomy: 'product_cat',
 			termId: categoryId,
 		} );
@@ -197,7 +207,7 @@ export const useGetLocation = < T, >(
 	 */
 
 	if ( isInSpecificTagTemplate ) {
-		return createLocationObject( 'archive', {
+		return createLocationObject( LocationType.Archive, {
 			taxonomy: 'product_tag',
 			termId: tagId,
 		} );
@@ -213,7 +223,7 @@ export const useGetLocation = < T, >(
 	);
 
 	if ( isInProductsByCategoryTemplate ) {
-		return createLocationObject( 'archive', {
+		return createLocationObject( LocationType.Archive, {
 			taxonomy: 'product_cat',
 			termId: null,
 		} );
@@ -224,7 +234,7 @@ export const useGetLocation = < T, >(
 	);
 
 	if ( isInProductsByTagTemplate ) {
-		return createLocationObject( 'archive', {
+		return createLocationObject( LocationType.Archive, {
 			taxonomy: 'product_tag',
 			termId: null,
 		} );
@@ -235,7 +245,7 @@ export const useGetLocation = < T, >(
 	);
 
 	if ( isInProductsByAttributeTemplate ) {
-		return createLocationObject( 'archive', {
+		return createLocationObject( LocationType.Archive, {
 			taxonomy: null,
 			termId: null,
 		} );
@@ -251,7 +261,7 @@ export const useGetLocation = < T, >(
 		templateSlug === templateSlugs.checkout;
 
 	if ( isInCartCheckoutTemplate ) {
-		return createLocationObject( 'cart' );
+		return createLocationObject( LocationType.Cart );
 	}
 
 	/**
@@ -264,7 +274,7 @@ export const useGetLocation = < T, >(
 	);
 
 	if ( isInOrderTemplate ) {
-		return createLocationObject( 'order' );
+		return createLocationObject( LocationType.Order );
 	}
 
 	/**
@@ -272,7 +282,7 @@ export const useGetLocation = < T, >(
 	 * All other cases
 	 */
 
-	return createLocationObject( 'generic' );
+	return createLocationObject( LocationType.Site );
 };
 
 /**

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.side_effects.spec.ts
@@ -1002,7 +1002,7 @@ test.describe( 'Product Collection', () => {
 			expect( termId ).toBe( '' );
 		} );
 
-		test( 'as generic in post', async ( {
+		test( 'as site in post', async ( {
 			admin,
 			editorUtils,
 			pageObject,
@@ -1019,7 +1019,7 @@ test.describe( 'Product Collection', () => {
 			const { type, sourceData } =
 				getLocationDetailsFromRequest( locationRequest );
 
-			expect( type ).toBe( 'generic' );
+			expect( type ).toBe( 'site' );
 			// Field is not sent at all. URLSearchParams get method returns a null
 			// if field is not available.
 			expect( sourceData ).toBe( null );

--- a/plugins/woocommerce/changelog/update-rename-generic-product-collection-location-to-site
+++ b/plugins/woocommerce/changelog/update-rename-generic-product-collection-location-to-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Collection: Rename "other" location from `generic` to `site`


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During the general review we realized that the "other" location of Product Collection block has name `generic` while we agreed it should be `site`.

This PR fixes that and in addition introduces enums instead of plain strings.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Prerequisites to testing:
1. To verify the location, go to Developer Tools -> Network tab
2. Search for: `product isproductcollection`

### Testing steps:
1. Create new post
2. Insert Product Collection block
4. Choose some collection, for example, Featured
5. **Expecxted:** Verify the proper payload is sent with the request by checking Payload tab.
  - `location[type]: site`
 
<img width="922" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/2e3275c4-11b7-454f-973b-62db8fe578cb">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
