### PR TITLE
add: lys launch store action

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
@@ -227,7 +227,7 @@ export const LaunchYourStoreHubSidebar: React.FC< SidebarComponentProps > = (
 						{ hasSubmitted ? (
 							<Spinner />
 						) : (
-							__( 'Launch Store', 'woocommerce' )
+							__( 'Launch your store', 'woocommerce' )
 						) }
 					</Button>
 				</ItemGroup>

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
@@ -4,7 +4,11 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { createInterpolateElement, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 // @ts-ignore No types for this exist yet.
@@ -18,6 +22,8 @@ import {
 	// @ts-ignore No types for this exist yet.
 	__experimentalHeading as Heading,
 	ToggleControl,
+	Notice,
+	Spinner,
 } from '@wordpress/components';
 
 /**
@@ -36,6 +42,7 @@ export const LaunchYourStoreHubSidebar: React.FC< SidebarComponentProps > = (
 			tasklist,
 			removeTestOrders: removeTestOrdersContext,
 			testOrderCount,
+			launchStoreError,
 		},
 	} = props;
 
@@ -77,6 +84,23 @@ export const LaunchYourStoreHubSidebar: React.FC< SidebarComponentProps > = (
 	const [ removeTestOrders, setRemoveTestOrder ] = useState(
 		removeTestOrdersContext ?? true
 	);
+
+	const [ errorNoticeDismissed, setErrorNoticeDismissed ] = useState( false );
+	const [ hasSubmitted, setHasSubmitted ] = useState( false );
+
+	const launchStoreAction = () => {
+		setHasSubmitted( true );
+		props.sendEventToSidebar( {
+			type: 'LAUNCH_STORE',
+			removeTestOrders,
+		} );
+	};
+
+	useEffect( () => {
+		if ( launchStoreError?.message ) {
+			setHasSubmitted( false );
+		}
+	}, [ launchStoreError?.message ] );
 
 	return (
 		<div
@@ -171,16 +195,40 @@ export const LaunchYourStoreHubSidebar: React.FC< SidebarComponentProps > = (
 					</>
 				) }
 				<ItemGroup className="edit-site-sidebar-navigation-screen-launch-store-button__group">
-					<Button
-						variant="primary"
-						onClick={ () => {
-							props.sendEventToSidebar( {
-								type: 'LAUNCH_STORE',
-								removeTestOrders,
-							} );
-						} }
-					>
-						{ __( 'Launch Store', 'woocommerce' ) }
+					{ launchStoreError?.message && ! errorNoticeDismissed && (
+						<Notice
+							className="launch-store-error-notice"
+							isDismissible={ true }
+							onRemove={ () => setErrorNoticeDismissed( true ) }
+							status="error"
+						>
+							{ createInterpolateElement(
+								__(
+									'Oops! We encountered a problem while launching your store. <retryButton/>',
+									'woocommerce'
+								),
+								{
+									retryButton: (
+										<Button
+											onClick={ launchStoreAction }
+											variant="tertiary"
+										>
+											{ __(
+												'Please try again',
+												'woocommerce'
+											) }
+										</Button>
+									),
+								}
+							) }
+						</Notice>
+					) }
+					<Button variant="primary" onClick={ launchStoreAction }>
+						{ hasSubmitted ? (
+							<Spinner />
+						) : (
+							__( 'Launch Store', 'woocommerce' )
+						) }
 					</Button>
 				</ItemGroup>
 			</SidebarContainer>

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -167,6 +167,7 @@ export const sidebarMachine = setup( {
 					},
 				},
 				launchYourStoreHub: {
+					id: 'launchYourStoreHub',
 					tags: 'sidebar-visible',
 					meta: {
 						component: LaunchYourStoreHubSidebar,
@@ -184,6 +185,7 @@ export const sidebarMachine = setup( {
 			initial: 'launching',
 			states: {
 				launching: {
+					entry: assign( { launchStoreError: undefined } ), // clear the errors if any from previously
 					invoke: {
 						src: 'updateLaunchStoreOptions',
 						onDone: {
@@ -197,7 +199,7 @@ export const sidebarMachine = setup( {
 									};
 								},
 							} ),
-							target: '..launchYourStoreHub',
+							target: '#launchYourStoreHub',
 						},
 					},
 				},

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
@@ -228,6 +228,38 @@
 								button {
 									justify-content: center;
 								}
+
+								.components-spinner {
+									margin-bottom: 6px;
+								}
+
+								.launch-store-error-notice {
+									background: #fce2e4;
+									padding: $gap-small;
+									font-size: 13px;
+									font-style: normal;
+									font-weight: 400;
+									line-height: 24px;
+									color: $gray-900;
+									margin: 0;
+									margin-bottom: 16px;
+								
+									.components-notice__content {
+										margin: 0;
+									}
+								
+									.components-button {
+										padding: 0;
+										height: initial;
+										min-width: 24px;
+										min-height: 24px;
+
+										svg {
+											width: 16px;
+											fill: $gray-900;
+										}
+									}
+								}
 							}
 
 							.components-heading {

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/styles.scss
@@ -243,11 +243,11 @@
 									color: $gray-900;
 									margin: 0;
 									margin-bottom: 16px;
-								
+
 									.components-notice__content {
 										margin: 0;
 									}
-								
+
 									.components-button {
 										padding: 0;
 										height: initial;

--- a/plugins/woocommerce/changelog/add-lys-launch-store-action
+++ b/plugins/woocommerce/changelog/add-lys-launch-store-action
@@ -1,0 +1,5 @@
+Significance: minor
+Type: add
+
+Added the action to set the appropriate options when launch store button is clicked in LYS
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/300 .

Reviewer please note that the commits from https://github.com/woocommerce/woocommerce/pull/46190 are included as there would be a merge conflict otherwise. This PR can go in after the former, after a rebase.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `launch-your-store` feature flag
2. Go to WC home and click on the "Launch your store" task
3. Do anything you wish but you can just click on the launch store task immediately as well
4. Use WC Test helper to check that the options `woocommerce_coming_soon` and `launch-status` are set to 'no' and 'launched' respectively
5. To test the error flow, you can use the devtools to set your network status to offline. This will trigger the error notice.

![image](https://github.com/woocommerce/woocommerce/assets/27843274/a6f8af3d-33a8-4a02-a693-2acbbb5768b9)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
