### PR TITLE
Solve error when coupons are applied to orders that reference deleted products

### DIFF
--- a/plugins/woocommerce/changelog/fix-27077-order-editor-coupons-deleted-products
+++ b/plugins/woocommerce/changelog/fix-27077-order-editor-coupons-deleted-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Addresses a fatal error that can occur when applying a coupon within the order editor (where one of the products has been deleted).

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -906,7 +906,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return bool
 	 */
 	public function is_valid_for_product( $product, $values = array() ) {
-		if ( ! $this->is_type( wc_get_product_coupon_types() ) ) {
+		if ( ! $this->is_type( wc_get_product_coupon_types() ) || ! is_a( $product, WC_Product::class ) ) {
 			return apply_filters( 'woocommerce_coupon_is_valid_for_product', false, $product, $this, $values );
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Tests for WC_Coupon.
+ *
+ * See also ../../legacy/unit-tests/coupon/coupon.php for other related tests.
+ */
+class WC_Coupon_Tests extends WC_Unit_Test_Case {
+	/**
+	 * If a coupon is applied to an order where one or more products have been deleted, the operation should still
+	 * succeed.
+	 *
+	 * However, the coupon will have no impact on any line items referencing the deleted product(s), since in most cases
+	 * the product's eligibility can no longer be assessed (therefore, it is up to the merchant to manually adjust if
+	 * this is problematic).
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/27077
+	 *
+	 * @return void
+	 */
+	public function test_deleted_products_do_not_prevent_application_of_coupons(): void {
+		// Test order will have one product added already (price: 10, quantity: 4).
+		$order         = WC_Helper_Order::create_order();
+		$extra_product = WC_Helper_Product::create_simple_product();
+		$coupon        = WC_Helper_Coupon::create_coupon(
+			'look_after_the_pennies',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => 10,
+			)
+		);
+
+		// Add our further product to the order, but then delete the product itself.
+		$order->add_product( $extra_product );
+		$order->save();
+		wp_delete_post( $extra_product->get_id(), true );
+
+		$this->assertTrue(
+			$order->apply_coupon( $coupon ),
+			'The coupon was successfully applied to an order containing a deleted product, without triggering an error.'
+		);
+
+		// Both products have a cost of $10. The first item has a quantity of 4 units ($40). So, the 10% discount
+		// should give an actual discount total of $4 (the second line item is excluded from the calculation, because
+		// its product was deleted).
+		$this->assertEquals(
+			4,
+			$order->get_discount_total(),
+			'Line items associated with deleted products are not included in the discount calculation.'
+		);
+	}
+}


### PR DESCRIPTION
When a coupon is applied to an order, we check if the coupon is valid for each product. However, in some cases, such as if one of the products has been deleted, the relevant method may receive `(bool) false` instead of a valid product object. 

This can lead to fatal errors that 'crash' the order editor, which is what this change seeks to solve.

Closes #27077.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. As an admin user, use the order editor to create an order (or edit a suitable existing one). Add two products, save.
2. Fully delete one of the products used in that order.
3. Reload the editor, try to apply a coupon.
4. Without this change, the editor will 'hang' (you will see a spinner that will not go away). With this change, the editor should no longer hang and the coupon will successfully be applied (assuming, of course, its constraints allow it to be applied).

Additional testing:

1. As a customer, visit the storefront and add a product to the cart.
2. Add a coupon.
3. Ensure the coupon is successfully applied (and that the handling is generally unaffected by this change).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

### Notes

With this change, if a product has been deleted, the discount will not be applied to the corresponding line item. Where appropriate, it should still be applied to all other line items.

That seems reasonable since, for many coupons, particularly those with restrictions, we can't realistically verify the validity of the coupon under these conditions. On the other hand, I think a case could be made that some very simple coupons without constraints should *still* be capable of being applied, but a) engineering that would be a larger effort b) custom logic hooked into `woocommerce_coupon_is_valid_for_product` may be confused by this, and c) expecting the merchant to make a manual adjustment if needed seems reasonable.