### PR TITLE
Fix a bug in the e2e test where the wrong button was clicked for edit

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
@@ -303,11 +303,11 @@ test.describe( 'Merchant → Additional Checkout Fields', () => {
 			.click();
 
 		await admin.page
-			.getByRole( 'heading', { name: 'Shipping Edit' } )
+			.getByRole( 'heading', { name: 'Billing Edit' } )
 			.getByRole( 'link' )
 			.click();
 
-		// Change all the shipping details
+		// Change all the billing details
 		await admin.page
 			.getByRole( 'textbox', {
 				name: 'Government ID',

--- a/plugins/woocommerce/changelog/46256-dev-fix-additional-checkout-fields-e2e
+++ b/plugins/woocommerce/changelog/46256-dev-fix-additional-checkout-fields-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix broken blocks e2e test
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I believe this e2e test has been failing since introduction, but not noticed due to error thresholds on our PlayWright tests. This fixes a simple logic bug in that test. It was clicking the wrong edit button to edit the Government ID field which is under billing not shipping.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

See CI pass but also you're going to need to check the individual playwright shards to see this e2e test has passed (`checkout/additional-fields.shopper.block_theme.side_effects.spec.ts`)
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fix broken blocks e2e test

</details>
