### PR TITLE
Fix blocks e2e test for `additional-fields.merchant.block_theme.side_effects.spec.ts`

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
@@ -297,10 +297,16 @@ test.describe( 'Merchant → Additional Checkout Fields', () => {
 			.getByLabel( 'Is this a personal purchase or a business purchase?' )
 			.selectOption( 'personal' );
 
-		await admin.page
+		const clickPromise = admin.page
 			.getByRole( 'button', { name: 'Update' } )
 			.first()
 			.click();
+
+		const navigationPromise = admin.page.waitForEvent( 'domcontentloaded' );
+
+		// When update is clicked without waiting for DOMContentLoaded the page becomes
+		// available before click handlers are attached to the shipping edit link.
+		await Promise.all( [ clickPromise, navigationPromise ] );
 
 		await admin.page
 			.getByRole( 'heading', { name: 'Shipping Edit' } )

--- a/plugins/woocommerce/changelog/46258-dev-fix-e2e-additional-fields
+++ b/plugins/woocommerce/changelog/46258-dev-fix-e2e-additional-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix blocks e2e test for additional-fields.merchant.block_theme.side_effects.spec.ts
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Debugging the traces from past runs, this e2e test has been broken or flaky a while. Basically when you click "Update", the page reloads and is available before click handlers are attached to the shipping edit "link". Which causes it to navigate instead of showing the form.

While this isn't a perfect fix to wait for DOMContentLoaded, I'm hoping it will be enough. I considered modifying the meta-boxes JS code to add a class or data attribute, but I'd rather not do anything to that legacy JS code if possible.
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You'll need to check the CI output for the PlayWright tests CI (actually navigate into the shard's log output in GH CI, because shards have a test failure threshold, you'll need to see output to confirm this indeed passed. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fix blocks e2e test for additional-fields.merchant.block_theme.side_effects.spec.ts

</details>
