### PR TITLE
Fix linked product e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-test-linked-product-count
+++ b/plugins/woocommerce/changelog/fix-e2e-test-linked-product-count
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix linked product e2e tests #46286

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -94,7 +94,7 @@ test.describe( 'General tab', () => {
 				( [ selector, expectedCount ] ) =>
 					document.querySelectorAll( selector ).length ===
 					expectedCount,
-				[ '.woocommerce-product-list div[role="row"]', 5 ]
+				[ '.woocommerce-product-list div[role="row"]', 4 ]
 			);
 
 			const upsellsRows = page.locator(
@@ -103,7 +103,7 @@ test.describe( 'General tab', () => {
 
 			const upsellsRowsCount = await upsellsRows.count();
 
-			await expect( upsellsRowsCount ).toBe( 5 );
+			await expect( upsellsRowsCount ).toBe( 4 );
 
 			await page
 				.locator(
@@ -159,7 +159,7 @@ test.describe( 'General tab', () => {
 
 			const productsCount = await productsList.count();
 
-			await expect( productsCount ).toBe( 5 );
+			await expect( productsCount ).toBe( 4 );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We used to add 5 products by default for up-sells and cross-sells (after pressing 'choose products for me'), but the default number [was changed to 4](https://github.com/woocommerce/woocommerce/pull/46094). That PR was included at the same time as the E2E tests for linked products, creating an error in our E2E tests.

This PR modifies the E2E tests to make them match the current number.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run our E2E tests. All the tests should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
