### PR TITLE
Adding $item in the filter woocommerce_hidden_order_itemmeta

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -25,7 +25,8 @@ $hidden_order_itemmeta = apply_filters(
 		'cost',
 		'_reduced_stock',
 		'_restock_refunded_items',
-	)
+	),
+	$item
 );
 ?><div class="view">
 	<?php


### PR DESCRIPTION
Adding $item in the woocommerce_hidden_order_itemmeta filter.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding $item in the filter for woocommerce_hidden_order_itemmeta.

Closes #26342

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

</details>
