### PR TITLE
Update background color and padding in WooCommerce LYS status popover

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/style.scss
@@ -10,7 +10,7 @@
 .woocommerce-lys-status-pill {
 	display: flex;
 	align-items: center;
-	background-color: var(--gray-gray-5, #dcdcde);
+	background-color: #eaeaeb;
 	color: #2c3338;
 	padding: 0 3px 0 10px;
 	font-size: 12px;
@@ -34,6 +34,10 @@
 	}
 }
 .woocommerce-lys-status-popover {
+	a.components-button.components-menu-item__button {
+		padding: 6px 8px;
+	}
+
 	.components-menu-item__item {
 		svg {
 			margin-right: 8px;

--- a/plugins/woocommerce/changelog/46322-fix-lys-badge-dropdown
+++ b/plugins/woocommerce/changelog/46322-fix-lys-badge-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update background color and padding in WooCommerce LYS status popover


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46237, #46236.

- Update badge color to `#EAEAEB` when status is coming soon
- Adjust the padding on the site visibility dropdown. 0BWMerqRR1f468EwC7g5tg-fi-2410_193967

![image](https://github.com/woocommerce/woocommerce/assets/4344253/c67d8e20-dc80-4641-9659-445787622986)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Please exclude from Solaris and GlobalStep testing as this is gated behind a feature flag and is part of the Launch Your Store feature which will be tested as a complete feature when the call for testing is released.



1. Create a new JN site with `launch-your-store feature` flag enabled.
2. Go to `WooCommerce > Home`
3. Confirm that the status badge color is `#EAEAEB` when the status is `Coming soon`
4. Click on `Site coming soon` dropdown
5. Confirm that the padding is adjusted (6px top-bottom, 8px left-right)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update background color and padding in WooCommerce LYS status popover

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>