### PR TITLE
Make LYS preview frame resizable

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
@@ -60,7 +60,7 @@
 	height: 100vh;
 	width: 100%;
 	position: relative;
-	z-index: 2;
+	z-index: 3;
 
 	.launch-store-site__preview-site-iframe {
 		display: block;
@@ -92,8 +92,8 @@
 		justify-content: center;
 		position: absolute;
 		top: 0;
-		left: 0;
-		width: calc(100% - 16px);
-		padding: 16px 16px 16px 0;
+		left: -32px; // Make room for the handle on the left side for maximum width
+		width: calc(100% + 32px);
+		padding: 16px 16px 16px 32px;
 	}
 }

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
@@ -60,6 +60,7 @@
 	height: 100vh;
 	width: 100%;
 	position: relative;
+	z-index: 2;
 
 	.launch-store-site__preview-site-iframe {
 		display: block;
@@ -80,8 +81,8 @@
 		z-index: 1;
 		background-color: #fff;
 		opacity: 0.9;
-		height: calc(100% - 32px);
-		width: calc(100% - 16px);
+		height: 100%;
+		width: 100%;
 	}
 
 	.launch-store-preview-layout__canvas {

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
@@ -95,9 +95,4 @@
 		width: calc(100% - 16px);
 		padding: 16px 16px 16px 0;
 	}
-
-	.components-resizable-box__container {
-		border-radius: 20px;
-		box-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.25), 0 6px 10px 0 rgba(0, 0, 0, 0.02), 0 13px 15px 0 rgba(0, 0, 0, 0.03), 0 15px 20px 0 rgba(0, 0, 0, 0.04);
-	}
 }

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/site-preview.scss
@@ -1,7 +1,64 @@
+// Resizable frame styles
+.edit-site-resizable-frame__inner.is-resizing::before {
+	content: "";
+	inset: 0;
+	position: absolute;
+	z-index: 1;
+}
+
+.edit-site-resizable-frame__inner-content {
+	inset: 0;
+	position: absolute;
+	z-index: 0;
+	height: 100%;
+	width: 100%;
+}
+
+.edit-site-resizable-frame__handle {
+	align-items: center;
+	border: 0;
+	border-radius: 4px;
+	background: var(--wp-admin-theme-color);
+	cursor: ew-resize;
+	display: flex;
+	height: 64px;
+	justify-content: flex-end;
+	padding: 0;
+	position: absolute;
+	top: calc(50% - 32px);
+	width: 4px;
+	z-index: 100;
+}
+
+.edit-site-resizable-frame__handle::before {
+	content: "";
+	height: 100%;
+	left: 100%;
+	position: absolute;
+	width: 32px;
+}
+
+.edit-site-resizable-frame__handle::after {
+	content: "";
+	height: 100%;
+	position: absolute;
+	right: 100%;
+	width: 32px;
+}
+
+.edit-site-resizable-frame__handle:focus-visible {
+	outline: 2px solid #0000;
+}
+
+.edit-site-resizable-frame__handle.is-resizing,
+.edit-site-resizable-frame__handle:focus,
+.edit-site-resizable-frame__handle:hover {
+	background-color: var(--wp-admin-theme-color);
+}
+
 .launch-store-site-preview-page__container {
 	height: 100vh;
 	width: 100%;
-	padding: 16px 16px 16px 0;
 	position: relative;
 
 	.launch-store-site__preview-site-iframe {
@@ -25,5 +82,22 @@
 		opacity: 0.9;
 		height: calc(100% - 32px);
 		width: calc(100% - 16px);
+	}
+
+	.launch-store-preview-layout__canvas {
+		align-items: center;
+		bottom: 0;
+		display: flex;
+		justify-content: center;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: calc(100% - 16px);
+		padding: 16px 16px 16px 0;
+	}
+
+	.components-resizable-box__container {
+		border-radius: 20px;
+		box-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.25), 0 6px 10px 0 rgba(0, 0, 0, 0.02), 0 13px 15px 0 rgba(0, 0, 0, 0.03), 0 15px 20px 0 rgba(0, 0, 0, 0.04);
 	}
 }

--- a/plugins/woocommerce/changelog/update-make-lys-preview-frame-resizable
+++ b/plugins/woocommerce/changelog/update-make-lys-preview-frame-resizable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make LYS preview frame resizable


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46184

This PR adds a resize handle (from CYS) to the LYS preview frame so that users can resize the frame to their liking.


https://github.com/woocommerce/woocommerce/assets/4344253/6e9eff9b-23d0-466c-beec-250185d47ace


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Please exclude from Solaris and GlobalStep testing as this is gated behind a feature flag and is part of the Launch Your Store feature which will be tested as a complete feature when the call for testing is released.


1. Enable `launch-your-store` feature flag.
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Flaunch-your-store`
3. Resize the preview frame by dragging the resize handle.
4. Verify that the preview frame can be resized.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
