### PR TITLE
Data: introduce optimisticQueryUpdate item option

### DIFF
--- a/packages/js/data/changelog/update-introduce-optimistc-query-update
+++ b/packages/js/data/changelog/update-introduce-optimistc-query-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Data: introduce optimisticQueryUpdate create item option

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -9,7 +9,7 @@ import { apiFetch } from '@wordpress/data-controls';
 import { cleanQuery, getUrlParameters, getRestPath, parseId } from './utils';
 import CRUD_ACTIONS from './crud-actions';
 import TYPES from './action-types';
-import { IdType, IdQuery, Item, ItemQuery } from './types';
+import { IdType, IdQuery, Item, ItemQuery, CrudActionOptions } from './types';
 
 type ResolverOptions = {
 	resourceName: string;
@@ -36,9 +36,7 @@ export function createItemSuccess(
 	key: IdType,
 	item: Item,
 	query: Partial< ItemQuery >,
-	options: {
-		optimisticQueryUpdate: Partial< ItemQuery > | boolean;
-	}
+	options: CrudActionOptions
 ) {
 	return {
 		type: TYPES.CREATE_ITEM_SUCCESS as const,
@@ -182,9 +180,7 @@ export const createDispatchActions = ( {
 }: ResolverOptions ) => {
 	const createItem = function* (
 		query: Partial< ItemQuery >,
-		options: {
-			optimisticQueryUpdate: Partial< ItemQuery > | boolean;
-		}
+		options: CrudActionOptions
 	) {
 		yield createItemRequest( query );
 		const urlParameters = getUrlParameters( namespace, query );

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -35,13 +35,17 @@ export function createItemRequest( query: Partial< ItemQuery > ) {
 export function createItemSuccess(
 	key: IdType,
 	item: Item,
-	query: Partial< ItemQuery >
+	query: Partial< ItemQuery >,
+	options: {
+		optimisticQueryUpdate: Partial< ItemQuery > | boolean;
+	}
 ) {
 	return {
 		type: TYPES.CREATE_ITEM_SUCCESS as const,
 		key,
 		item,
 		query,
+		options,
 	};
 }
 
@@ -176,7 +180,12 @@ export const createDispatchActions = ( {
 	namespace,
 	resourceName,
 }: ResolverOptions ) => {
-	const createItem = function* ( query: Partial< ItemQuery > ) {
+	const createItem = function* (
+		query: Partial< ItemQuery >,
+		options: {
+			optimisticQueryUpdate: Partial< ItemQuery > | boolean;
+		}
+	) {
 		yield createItemRequest( query );
 		const urlParameters = getUrlParameters( namespace, query );
 
@@ -191,7 +200,7 @@ export const createDispatchActions = ( {
 			} );
 			const { key } = parseId( item.id, urlParameters );
 
-			yield createItemSuccess( key, item, query );
+			yield createItemSuccess( key, item, query, options );
 			return item;
 		} catch ( error ) {
 			yield createItemError( query, error );

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -277,18 +277,12 @@ export const createReducer = (
 						( payload.query || {} ) as ItemQuery
 					);
 
-					// console.log( '(reducer) Item Query: ', itemQuery );
-
-					const nextItemsDos = {
-						...state.items,
-						[ itemQuery ]: { data: ids },
-					};
-
-					// console.log( '(reducer) Next Items: ', nextItemsDos );
-
 					return {
 						...state,
-						items: nextItemsDos,
+						items: {
+							...state.items,
+							[ itemQuery ]: { data: ids },
+						},
 						data: {
 							...state.data,
 							...nextResources,

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -95,15 +95,15 @@ export const createReducer = (
 					let items = state.items;
 					let itemsCount = state.itemsCount;
 
-					if ( options.optimisticQueryUpdate ) {
+					if ( typeof options.optimisticQueryUpdate === 'object' ) {
 						const getItemQuery = getRequestIdentifier(
 							CRUD_ACTIONS.GET_ITEMS,
-							options.optimisticQueryUpdate as ItemQuery
+							options.optimisticQueryUpdate
 						);
 
 						const getItemCountQuery = getTotalCountResourceName(
 							CRUD_ACTIONS.GET_ITEMS,
-							options.optimisticQueryUpdate as ItemQuery
+							options.optimisticQueryUpdate
 						);
 
 						items = {

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -126,7 +126,7 @@ export const createReducer = (
 						};
 					}
 
-					const newState = {
+					return {
 						...state,
 						items,
 						itemsCount,
@@ -142,7 +142,6 @@ export const createReducer = (
 							[ createItemSuccessRequestId ]: false,
 						},
 					};
-					return newState;
 				}
 
 				case TYPES.GET_ITEM_SUCCESS:

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -95,7 +95,7 @@ export const createReducer = (
 					let items = state.items;
 					let itemsCount = state.itemsCount;
 
-					if ( typeof options.optimisticQueryUpdate === 'object' ) {
+					if ( typeof options?.optimisticQueryUpdate === 'object' ) {
 						const getItemQuery = getRequestIdentifier(
 							CRUD_ACTIONS.GET_ITEMS,
 							options.optimisticQueryUpdate

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -93,8 +93,15 @@ export const createReducer = (
 
 					const { options } = payload;
 					let items = state.items;
+					let itemsCount = state.itemsCount;
+
 					if ( options.optimisticQueryUpdate ) {
 						const getItemQuery = getRequestIdentifier(
+							CRUD_ACTIONS.GET_ITEMS,
+							options.optimisticQueryUpdate as ItemQuery
+						);
+
+						const getItemCountQuery = getTotalCountResourceName(
 							CRUD_ACTIONS.GET_ITEMS,
 							options.optimisticQueryUpdate as ItemQuery
 						);
@@ -110,11 +117,19 @@ export const createReducer = (
 								],
 							},
 						};
+
+						itemsCount = {
+							...state.itemsCount,
+							[ getItemCountQuery ]:
+								( state.itemsCount[ getItemCountQuery ] || 0 ) +
+								1,
+						};
 					}
 
 					const newState = {
 						...state,
 						items,
+						itemsCount,
 						data: {
 							...itemData,
 							[ payload.key ]: {

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -92,6 +92,14 @@ export const createReducer = (
 					);
 
 					const { options } = payload;
+					const data = {
+						...itemData,
+						[ payload.key ]: {
+							...( itemData[ payload.key ] || {} ),
+							...payload.item,
+						},
+					};
+
 					let items = state.items;
 					let itemsCount = state.itemsCount;
 
@@ -110,19 +118,15 @@ export const createReducer = (
 							...state.items,
 							[ getItemQuery ]: {
 								...state.items[ getItemQuery ],
-								data: [
-									...( state.items[ getItemQuery ]?.data ||
-										[] ),
-									payload.key,
-								],
+								data: Object.keys( data ).map(
+									( key ) => +key
+								),
 							},
 						};
 
 						itemsCount = {
 							...state.itemsCount,
-							[ getItemCountQuery ]:
-								( state.itemsCount[ getItemCountQuery ] || 0 ) +
-								1,
+							[ getItemCountQuery ]: Object.keys( data ).length,
 						};
 					}
 
@@ -130,13 +134,7 @@ export const createReducer = (
 						...state,
 						items,
 						itemsCount,
-						data: {
-							...itemData,
-							[ payload.key ]: {
-								...( itemData[ payload.key ] || {} ),
-								...payload.item,
-							},
-						},
+						data,
 						requesting: {
 							...state.requesting,
 							[ createItemSuccessRequestId ]: false,

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -313,38 +313,91 @@ describe( 'crud reducer', () => {
 		expect( state.requesting[ requestId ] ).toEqual( false );
 	} );
 
-	it( 'should handle CREATE_ITEM_SUCCESS', () => {
-		const item: Item = {
-			id: 2,
-			name: 'Off the hook!',
-			status: 'draft',
-		};
-		const query = {
-			name: 'Off the hook!',
-			status: 'draft',
-		};
+	describe( 'should handle CREATE_ITEM_SUCCESS', () => {
+		it( 'when no options are passed', () => {
+			const item: Item = {
+				id: 2,
+				name: 'Off the hook!',
+				status: 'draft',
+			};
+			const query = {
+				name: 'Off the hook!',
+				status: 'draft',
+			};
 
-		const options = {
-			optimisticQueryUpdate: false,
-		};
+			const options = {
+				optimisticQueryUpdate: false,
+			};
 
-		const resourceName = getRequestIdentifier(
-			CRUD_ACTIONS.CREATE_ITEM,
-			item.id,
-			query
-		);
+			const resourceName = getRequestIdentifier(
+				CRUD_ACTIONS.CREATE_ITEM,
+				item.id,
+				query
+			);
 
-		const state = reducer( defaultState, {
-			type: TYPES.CREATE_ITEM_SUCCESS,
-			key: item.id,
-			item,
-			query,
-			options,
+			const state = reducer( defaultState, {
+				type: TYPES.CREATE_ITEM_SUCCESS,
+				key: item.id,
+				item,
+				query,
+				options,
+			} );
+
+			expect( state.data[ 2 ].name ).toEqual( item.name );
+			expect( state.data[ 2 ].status ).toEqual( item.status );
+			expect( state.requesting[ resourceName ] ).toEqual( false );
 		} );
 
-		expect( state.data[ 2 ].name ).toEqual( item.name );
-		expect( state.data[ 2 ].status ).toEqual( item.status );
-		expect( state.requesting[ resourceName ] ).toEqual( false );
+		it( 'when optimisticQueryUpdate is {}', () => {
+			const item: Item = {
+				id: 7,
+				name: 'Off the hook!',
+				status: 'draft',
+			};
+			const query = {
+				name: 'Off the hook!',
+				status: 'draft',
+			};
+
+			const options = {
+				optimisticQueryUpdate: {},
+			};
+
+			const state = reducer( defaultState, {
+				type: TYPES.CREATE_ITEM_SUCCESS,
+				key: item.id,
+				item,
+				query,
+				options,
+			} );
+
+			const itemQuery = getRequestIdentifier(
+				CRUD_ACTIONS.GET_ITEMS,
+				options.optimisticQueryUpdate
+			);
+
+			const itemsCountQuery = getRequestIdentifier(
+				CRUD_ACTIONS.GET_ITEMS,
+				options.optimisticQueryUpdate
+			);
+
+			expect( state.data[ 7 ].name ).toEqual( item.name );
+			expect( state.data[ 7 ].status ).toEqual( item.status );
+
+			const resourceName = getRequestIdentifier(
+				CRUD_ACTIONS.CREATE_ITEM,
+				item.id,
+				query
+			);
+			expect( state.requesting[ resourceName ] ).toEqual( false );
+
+			// Items
+			expect( state.items[ itemQuery ].data ).toHaveLength( 1 );
+			expect( state.items[ itemQuery ].data[ 0 ] ).toEqual( item.id );
+
+			// Items Count
+			expect( state.itemsCount[ itemsCountQuery ] ).toEqual( 1 );
+		} );
 	} );
 
 	it( 'should handle DELETE_ITEM_SUCCESS', () => {

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -323,6 +323,11 @@ describe( 'crud reducer', () => {
 			name: 'Off the hook!',
 			status: 'draft',
 		};
+
+		const options = {
+			optimisticQueryUpdate: false,
+		};
+
 		const resourceName = getRequestIdentifier(
 			CRUD_ACTIONS.CREATE_ITEM,
 			item.id,
@@ -334,6 +339,7 @@ describe( 'crud reducer', () => {
 			key: item.id,
 			item,
 			query,
+			options,
 		} );
 
 		expect( state.data[ 2 ].name ).toEqual( item.name );

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -40,6 +40,10 @@ type WithRequiredProperty< Type, Key extends keyof Type > = Type & {
 	[ Property in Key ]-?: Type[ Property ];
 };
 
+export type CrudActionOptions = {
+	optimisticQueryUpdate?: boolean | Partial< Item >;
+};
+
 export type CrudActions<
 	ResourceName,
 	ItemType,
@@ -47,7 +51,10 @@ export type CrudActions<
 	RequiredFields extends keyof MutableProperties | undefined = undefined
 > = MapActions<
 	{
-		create: ( query: Partial< ItemType > ) => Item;
+		create: (
+			query: Partial< ItemType >,
+			options?: CrudActionOptions
+		) => ItemType;
 		update: ( query: Partial< ItemType > ) => Item;
 	},
 	ResourceName,

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -245,7 +245,7 @@ export interface WCDataSelector {
 
 // Other exports
 export { ActionDispatchers as PluginsStoreActions } from './plugins/actions';
-export { ActionDispatchers as ProductAttributesActions } from './product-attributes/types';
+export { CustomActionDispatchers as ProductAttributesActions } from './product-attributes/types';
 export { ActionDispatchers as ProductTagsActions } from './product-tags/types';
 export { ActionDispatchers as ProductCategoryActions } from './product-categories/types';
 export { ActionDispatchers as ProductAttributeTermsActions } from './product-attribute-terms/types';

--- a/packages/js/data/src/product-attributes/types.ts
+++ b/packages/js/data/src/product-attributes/types.ts
@@ -18,10 +18,6 @@ export type QueryProductAttribute = {
 	generate_slug: boolean;
 };
 
-export type QueryProductOptionProps = {
-	optimisticQueryUpdate: boolean;
-};
-
 type Query = {
 	context?: string;
 };

--- a/packages/js/data/src/product-attributes/types.ts
+++ b/packages/js/data/src/product-attributes/types.ts
@@ -18,6 +18,10 @@ export type QueryProductAttribute = {
 	generate_slug: boolean;
 };
 
+export type QueryProductOptionProps = {
+	optimisticQueryUpdate: boolean;
+};
+
 type Query = {
 	context?: string;
 };
@@ -43,3 +47,16 @@ export type ProductAttributeSelectors = CrudSelectors<
 >;
 
 export type ActionDispatchers = DispatchFromMap< ProductAttributeActions >;
+
+/*
+ * Add a the second `options` parameter to the `createProductAttribute` action dispatcher
+ * todo: do this in a more generic way
+ */
+export interface CustomActionDispatchers extends ActionDispatchers {
+	createProductAttribute: (
+		x: Partial< Omit< QueryProductAttribute, 'id' > >,
+		options?: {
+			optimisticQueryUpdate: Partial< QueryProductAttribute > | boolean;
+		}
+	) => Promise< QueryProductAttribute >;
+}

--- a/packages/js/product-editor/changelog/update-introduce-optimistc-query-update
+++ b/packages/js/product-editor/changelog/update-introduce-optimistc-query-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Data: introduce optimisticQueryUpdate create item option

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
@@ -45,7 +45,7 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 	const { createErrorNotice } = useDispatch( 'core/notices' );
 	const { createProductAttribute, invalidateResolution } = useDispatch(
 		EXPERIMENTAL_PRODUCT_ATTRIBUTES_STORE_NAME
-	) as ProductAttributesActions & WPDataActions;
+	) as unknown as ProductAttributesActions & WPDataActions;
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	const { attributes, isLoading } = useSelect( ( select: WCDataSelector ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces an `options` object as a secondary argument to the `createItem` action, which accepts the `optimisticQueryUpdate` property. This property populates the store when a new item is created.
The idea behind this suggestion is to improve the data flow, avoiding hitting/waiting, sometimes, and depending on the case, for an async request to get fresh data.

Following-ups:

* Improve how it defines the TS types. Currently, it only covers the createProductAttribute action.
* Improve the doc
* Implement similar data handling but when deleting an item

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The PR updates and adds a few tests to check the implementation. So you can run the tests locally:

```cli
pnpm --filter=./packages/js/data run test:js packages/js/data/src/crud
```

<img width="718" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/9d5edb02-fa0e-41bd-bd2a-b40edc1a65bb">


Additionally, it's possible to test by using the Product Editor app:

1. Ensure you have the Redux dev tool installed in your browser
2. Create a new product by using the new Product Editor
3. Ensure to select the proper store by using the Redux tool. Check the initial state:

<img width="857" alt="Screenshot 2024-04-08 at 17 36 53" src="https://github.com/woocommerce/woocommerce/assets/77539/646c2ef1-21e4-48d0-8aaa-0276912ad0a3">

4. Dispatch an action to pull and initially populates the redux store with the product variations:

```js
wp.data.select( 'wc/admin/products/attributes' ).getProductAttributes()
```

<img width="815" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/c201e3a9-6920-4fc9-b455-7bc53d07b30d">

Above, I have one `Sizes` global attribute in my testing site. 

5. Dispatch an action to create a new attribute, **without using the optimistic feature**:

```js
wp.data.dispatch( 'wc/admin/products/attributes' ).createProductAttribute( {
    name: 'My new attribute',
    generate_slug: true,
} )
```

6. Confirm it populates the `data` object of the store (pink)
7.  ...but also confirm it does not update the `items` and `countItems` ones (green)

<img width="489" alt="Screenshot 2024-04-08 at 17 47 06" src="https://github.com/woocommerce/woocommerce/assets/77539/61119942-8edf-48d2-a6fc-5988e7b935d2">

8. Create a new attribute, but now being optimistic:
```js
wp.data.dispatch( 'wc/admin/products/attributes' ).createProductAttribute( {
    name: 'My another new attribute',
    generate_slug: true,
},
{
        optimisticQueryUpdate: {},
} )
```
9. Confirm now the app populates not only the `data` property but also the `items` and `itemsCount` ones:
<img width="552" alt="Screenshot 2024-04-08 at 18 02 17" src="https://github.com/woocommerce/woocommerce/assets/77539/aa6eab03-0ada-4bea-b528-732f780d9e6e">
10. Invalidate the select resolution and dispatch an action to hit and get a fresh response:

```js
wp.data.dispatch( 'wc/admin/products/attributes' ).invalidateResolution( 'getProductAttributes' )
```

```js
wp.data.select( 'wc/admin/products/attributes' ).getProductAttributes()
```

11. Confirm that, in this case, the items array changes its order (expected) but keeps the same number and values.

<img width="558" alt="Screenshot 2024-04-08 at 18 04 28" src="https://github.com/woocommerce/woocommerce/assets/77539/8e39287f-e2ff-44a1-84f9-b3ffaf1e892a">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
