### PR TITLE
Try: Product form CPT translation

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
@@ -45,12 +45,12 @@ class BlockTemplateUtils {
     /**
      * Get all the block templates from the directory by type.
      *
-	 * @param string $template_type wp_template or wp_template_part.
+	 * @param string $slug Template slug.
      */
-    public static function get_block_template( $file ) {
+    public static function get_block_template( $slug ) {
         $directory = self::get_templates_directory();
 
-		return trailingslashit( $directory ) . $file;
+		return trailingslashit( $directory ) . $slug . '.php';
     }
 
     /**
@@ -73,6 +73,20 @@ class BlockTemplateUtils {
         $file_data['product_types'] = explode( ',', trim( $file_data['product_types'] ) );
 
         return $file_data;
+    }
+
+    /**
+     * Get the template content
+     *
+     * @param $file_path File path.
+     * @return string Content.
+     */
+    public static function get_template_content( $file_path ) {
+        ob_start();
+        include( $file_path );
+        $content = ob_get_contents(); 
+        ob_end_clean();
+        return $content;
     }
 
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
+
+class BlockTemplateUtils {
+
+    /**
+	 * Directory which contains all templates
+	 *
+	 * @var string
+	 */
+	const TEMPLATES_ROOT_DIR = 'templates';
+
+    /**
+     * Directory names.
+     *
+     * @var array
+     */
+    const DIRECTORY_NAMES = [
+        'TEMPLATES' => 'product-form',
+        'TEMPLATE_PARTS' => 'product-form/parts'
+    ];
+
+    /**
+	 * Gets the directory where templates of a specific template type can be found.
+	 *
+	 * @param string $template_type wp_template or wp_template_part.
+	 * @return string
+	 */
+    private static function get_templates_directory( $template_type = 'wp_template' ) {
+        $root_path                = dirname( __DIR__, 4 ) . '/' . self::TEMPLATES_ROOT_DIR . DIRECTORY_SEPARATOR;
+        $templates_directory      = $root_path . self::DIRECTORY_NAMES['TEMPLATES'];
+        $template_parts_directory = $root_path . self::DIRECTORY_NAMES['TEMPLATE_PARTS'];
+
+        if ( 'wp_template_part' === $template_type ) {
+            return $template_parts_directory;
+        }
+
+        return $templates_directory;
+    }
+
+
+    /**
+     * Get all the block templates from the directory by type.
+     *
+	 * @param string $template_type wp_template or wp_template_part.
+     */
+    public static function get_block_template( $file ) {
+        $directory = self::get_templates_directory();
+
+		return trailingslashit( $directory ) . $file;
+    }
+
+    /**
+     * Get the template data from the headers.
+     *
+     * @param string $file_path File path.
+     * @return array Template data.
+     */
+    public static function get_template_data( $file_path ) {
+        $file_data = get_file_data(
+            $file_path,
+            array(
+                'title'         => 'Title',
+                'slug'          => 'Slug',
+                'description'   => 'Description',
+                'product_types' => 'Product Types'
+            )
+        );
+
+        $file_data['product_types'] = explode( ',', trim( $file_data['product_types'] ) );
+
+        return $file_data;
+    }
+
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * WooCommerce Product Forms Controller
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+/**
+ * Handle retrieval of product forms.
+ */
+class ProductFormsController {
+
+    /**
+	 * Set up the product forms controller.
+	 */
+	public function init() {
+		add_action( 'admin_init', array( $this, 'maybe_create_product_forms' ) );
+	}
+
+	/**
+	 * Create the product forms if they don't yet exist.
+	 */
+	public function maybe_create_product_forms() {
+        $templates = apply_filters(
+            'woocommerce_product_form_templates',
+            array(
+                'simple.php'
+            )
+        );
+        foreach ( $templates as $template ) {
+            $file_path = BlockTemplateUtils::get_block_template( $template );
+            $file_data = BlockTemplateUtils::get_template_data( $file_path );
+            $posts     = get_posts(
+                array(
+                    'name'           => $file_data['slug'],
+                    'post_type'      => 'product_form',
+                    'post_status'    => 'any',
+                    'posts_per_page' => 1
+                )
+            );
+
+            if ( ! empty( $posts ) ) {
+                continue;
+            }
+            
+            $post = wp_insert_post(
+                array(
+                    'post_title'  => $file_data['title'],
+                    'post_name'   => $file_data['slug'],
+                    'post_status' =>	'publish',
+                    'post_type'   => 'product_form'
+                )
+            );
+        }
+	}
+
+}

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -12,6 +12,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<!-- wp:woocommerce/product-section {"id":"basic-details","title":"<?php echo __( 'Basic details', 'woocommerce' ); ?>"} -->
-    <!-- wp:woocommerce/product-regular-price-field /-->
+<!-- wp:woocommerce/product-section {"title":"<?php _e( 'Basic details', 'woocommerce' ); ?>"} -->
+<div data-block-name="woocommerce/product-section" class="wp-block-woocommerce-product-section" data-title="<?php _e( 'Basic details', 'woocommerce' ); ?>">
+    <div>
+        <!-- wp:woocommerce/product-regular-price-field -->
+        <div data-block-name="woocommerce/product-regular-price-field" class="wp-block-woocommerce-product-regular-price-field"></div>
+        <!-- /wp:woocommerce/product-regular-price-field -->
+        <!-- wp:woocommerce/product-checkbox-field {"label":"<?php _e( 'Translatable Label', 'woocommerce' ); ?>","property":"testproperty"} -->
+        <div data-block-name="woocommerce/product-checkbox-field" class="wp-block-woocommerce-product-checkbox-field" data-label="<?php _e( 'Translatable Label', 'woocommerce' ); ?>"></div>
+        <!-- /wp:woocommerce/product-checkbox-field -->
+    </div>
+</div>
 <!-- /wp:woocommerce/product-section -->

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Simple Product Form
+ *
+ * Title: Simple
+ * Slug: simple
+ * Description: This is the template description.
+ * Product Types: simple, variable
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<!-- wp:woocommerce/product-section {"id":"basic-details","title":"<?php echo __( 'Basic details', 'woocommerce' ); ?>"} -->
+    <!-- wp:woocommerce/product-regular-price-field /-->
+<!-- /wp:woocommerce/product-section -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR shows how we can allow translation of CPTs.  It follows the Gutenberg pattern where once a template or block is saved, that block's translation is up to the user to determine.

Prior to that point, the block content bypasses what's in the database if it has not yet been modified and instead uses template content directly from the PHP file which can be translated.
<img width="866" alt="Screenshot 2024-04-08 at 2 39 47 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/7f81d7a3-dd08-461c-a208-70137060e0b9">
<img width="881" alt="Screenshot 2024-04-08 at 2 39 15 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/bac2051f-db31-4271-aff6-aba21dc50fad">


**Why persist any posts at all if we're just retrieving the template content?**

Persisting these posts allows them to be edited, but more importantly allows them to be queried and used by the other built-in WP endpoints and tools.

**What about persisted posts, how do those get translated?**

Once a product form has been persisted, the user is responsible for translation and this gets translated much like any other post.  Gutenberg phase 4 will likely bring benefits to translation with the primary focus on Multilingual sites.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Optionally, install a plugin like Loco Translate and translate the "Translatable label" text to a language of your choice
2. Visit the Products -> Add new page
3. Select the "Simple" product template
4. See your default language in the product form
5. Change your site's language settings under Settings->General
6. Visit the add new product page again and see the translated form
7. Update the "Simple" form by visiting Product Forms
8. Visit the add product page a third time and note that text is no longer translated

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
