### PR TITLE
Sync LYS task completion with `woocommerce_coming_soon` option

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hooks/use-launch-your-store.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/hooks/use-launch-your-store.js
@@ -7,7 +7,6 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 export const useLaunchYourStore = () => {
 	const {
 		isLoading,
-		launchStatus,
 		launchYourStoreEnabled,
 		comingSoon,
 		storePagesOnly,
@@ -18,7 +17,6 @@ export const useLaunchYourStore = () => {
 			select( OPTIONS_STORE_NAME );
 
 		const allOptionResolutionsFinished =
-			! hasFinishedResolution( 'getOption', [ 'launch-status' ] ) &&
 			! hasFinishedResolution( 'getOption', [
 				'woocommerce_coming_soon',
 			] ) &&
@@ -32,7 +30,6 @@ export const useLaunchYourStore = () => {
 
 		return {
 			isLoading: allOptionResolutionsFinished,
-			launchStatus: getOption( 'launch-status' ),
 			comingSoon: getOption( 'woocommerce_coming_soon' ),
 			storePagesOnly: getOption( 'woocommerce_store_pages_only' ),
 			privateLink: getOption( 'woocommerce_private_link' ),
@@ -48,7 +45,6 @@ export const useLaunchYourStore = () => {
 		storePagesOnly,
 		privateLink,
 		shareKey,
-		launchStatus,
 		launchYourStoreEnabled,
 	};
 };

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -54,7 +54,6 @@ const sidebarQueryParamListener = fromCallback( ( { sendBack } ) => {
 const launchStoreAction = async () => {
 	const results = await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_coming_soon: 'no',
-		'launch-status': 'launched',
 	} );
 	if ( results.success ) {
 		return results;

--- a/plugins/woocommerce/changelog/update-lys-completion-logic
+++ b/plugins/woocommerce/changelog/update-lys-completion-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Sync LYS task completion with woocommerce_coming_soon optionSync LYS task completion with woocommerce_coming_soon option

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -322,7 +322,6 @@ final class WooCommerce {
 		$is_new_install = current_action() === 'woocommerce_newly_installed';
 
 		$coming_soon      = $is_new_install ? 'yes' : 'no';
-		$launch_status    = $is_new_install ? 'unlaunched' : 'launched';
 		$store_pages_only = WCAdminHelper::is_site_fresh() ? 'no' : 'yes';
 		$private_link     = 'yes';
 		$share_key        = wp_generate_password( 32, false );
@@ -338,9 +337,6 @@ final class WooCommerce {
 		}
 		if ( false === get_option( 'woocommerce_share_key', false ) ) {
 			update_option( 'woocommerce_share_key', $share_key );
-		}
-		if ( false === get_option( 'launch-status', false ) ) {
-			update_option( 'launch-status', $launch_status );
 		}
 	}
 
@@ -1023,7 +1019,7 @@ final class WooCommerce {
 	 * @param string $filename The filename of the activated plugin.
 	 */
 	public function activated_plugin( $filename ) {
-		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
+		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
 
 		if ( '/woocommerce.php' === substr( $filename, -16 ) ) {
 			set_transient( 'woocommerce_activated_plugin', $filename );
@@ -1039,7 +1035,7 @@ final class WooCommerce {
 	 * @param string $filename The filename of the deactivated plugin.
 	 */
 	public function deactivated_plugin( $filename ) {
-		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
+		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
 
 		WC_Helper::deactivated_plugin( $filename );
 	}

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -225,7 +225,6 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_store_pages_only',
 			'woocommerce_private_link',
 			'woocommerce_share_key',
-			'launch-status',
 			'woocommerce_show_lys_tour',
 			'woocommerce_coming_soon_page_id',
 			// WC Test helper options.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/LaunchYourStore.php
@@ -74,15 +74,7 @@ class LaunchYourStore extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		$launch_status = get_option( 'launch-status' );
-
-		// The site is launched when the launch status is 'launched' or missing.
-		$launched_values = array(
-			'launched',
-			'',
-			false,
-		);
-		return in_array( $launch_status, $launched_values, true );
+		return 'no' !== get_option( 'woocommerce_coming_soon' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/LaunchYourStore.php
@@ -74,7 +74,7 @@ class LaunchYourStore extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return 'no' !== get_option( 'woocommerce_coming_soon' );
+		return 'yes' !== get_option( 'woocommerce_coming_soon' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -38,7 +38,6 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		delete_option( 'woocommerce_store_pages_only' );
 		delete_option( 'woocommerce_private_link' );
 		delete_option( 'woocommerce_share_key' );
-		delete_option( 'launch-status' );
 	}
 
 	/**
@@ -55,7 +54,6 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'yes', get_option( 'woocommerce_private_link' ) );
 		$this->assertNotEmpty( get_option( 'woocommerce_share_key' ) );
 		$this->assertMatchesRegularExpression( '/^[a-zA-Z0-9]{32}$/', get_option( 'woocommerce_share_key' ) );
-		$this->assertEquals( 'unlaunched', get_option( 'launch-status' ) );
 	}
 
 	/**
@@ -72,7 +70,6 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'yes', get_option( 'woocommerce_private_link' ) );
 		$this->assertNotEmpty( get_option( 'woocommerce_share_key' ) );
 		$this->assertMatchesRegularExpression( '/^[a-zA-Z0-9]{32}$/', get_option( 'woocommerce_share_key' ) );
-		$this->assertEquals( 'launched', get_option( 'launch-status' ) );
 	}
 
 	/**
@@ -85,7 +82,6 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		update_option( 'woocommerce_store_pages_only', 'no' );
 		update_option( 'woocommerce_private_link', 'yes' );
 		update_option( 'woocommerce_share_key', 'test' );
-		update_option( 'launch-status', 'unlaunched' );
 
 		$this->set_current_action( 'woocommerce_updated' );
 		( WooCommerce::instance() )->add_lys_default_values();
@@ -94,7 +90,6 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'no', get_option( 'woocommerce_store_pages_only' ) );
 		$this->assertEquals( 'yes', get_option( 'woocommerce_private_link' ) );
 		$this->assertEquals( 'test', get_option( 'woocommerce_share_key' ) );
-		$this->assertEquals( 'unlaunched', get_option( 'launch-status' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46341.

- Mark the task as complete when `woocommerce_coming_soon` **is not equal to** `yes`.
- Clean up / remove code references of the previous `launch-status` option

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `launch-your-store` feature flag.
2. Set `woocommerce_coming_soon` option to `yes`. 
3. Go to `WooCommerce > Home`
4. Observe that the LYS task is not marked as complete.
5. Set `woocommerce_coming_soon` option to `no` or delete the  `woocommerce_coming_soon` option.
6. Refresh the page.
7. Observe that the LYS task is marked as complete.


![Screenshot 2024-04-09 at 14 00 04](https://github.com/woocommerce/woocommerce/assets/4344253/cb2cc55a-3eb8-48bd-9387-81a014e4bdcb)
![Screenshot 2024-04-09 at 14 00 18](https://github.com/woocommerce/woocommerce/assets/4344253/a8a8144a-4b67-4667-8016-c5e569fe0533)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
