### PR TITLE
Fix Launch Your Store task item should not be clickable once completed

### DIFF
--- a/packages/js/experimental/changelog/46361-fix-lys-task-not-clickable-once-completed
+++ b/packages/js/experimental/changelog/46361-fix-lys-task-not-clickable-once-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Launch Your Store task item should not be clickable once completed

--- a/packages/js/experimental/src/experimental-list/task-item/index.tsx
+++ b/packages/js/experimental/src/experimental-list/task-item/index.tsx
@@ -39,7 +39,7 @@ type ActionArgs = {
 type TaskItemProps = {
 	title: string;
 	completed: boolean;
-	onClick: React.MouseEventHandler< HTMLElement >;
+	onClick?: React.MouseEventHandler< HTMLElement >;
 	onCollapse?: () => void;
 	onDelete?: () => void;
 	onDismiss?: () => void;

--- a/plugins/woocommerce-admin/client/task-lists/fills/index.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/index.ts
@@ -9,6 +9,7 @@ import './appearance';
 import './tax';
 import './woocommerce-payments';
 import './deprecated-tasks';
+import './launch-your-store';
 
 const possiblyImportProductTask = async () => {
 	if ( isImportProduct() ) {

--- a/plugins/woocommerce-admin/client/task-lists/fills/launch-your-store.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/launch-your-store.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
+
+const LaunchYourStoreTaskItem = () => {
+	return (
+		<WooOnboardingTaskListItem id="launch-your-store">
+			{ ( {
+				defaultTaskItem: DefaultTaskItem,
+				isComplete,
+			}: {
+				defaultTaskItem: ( props: {
+					isClickable: boolean;
+				} ) => JSX.Element;
+				onClick: () => void;
+				isComplete: boolean;
+			} ) => {
+				return <DefaultTaskItem isClickable={ ! isComplete } />;
+			} }
+		</WooOnboardingTaskListItem>
+	);
+};
+
+registerPlugin( 'woocommerce-admin-task-launch-your-store', {
+	// @ts-expect-error scope is not defined in the type definition but it is a valid property
+	scope: 'woocommerce-tasks',
+	render: LaunchYourStoreTaskItem,
+} );

--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-list-item.tsx
@@ -62,7 +62,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	};
 
 	const DefaultTaskItem = useCallback(
-		( props ) => {
+		( props: { onClick?: () => void; isClickable?: boolean } ) => {
 			const className = classnames(
 				'woocommerce-task-list__item index-' + taskIndex,
 				{
@@ -71,13 +71,17 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 				}
 			);
 
-			const onClickActions = () => {
+			const onClick = ( e: React.MouseEvent< HTMLButtonElement > ) => {
+				if ( ( e.target as HTMLElement ).tagName === 'A' ) {
+					return;
+				}
 				if ( props.onClick ) {
 					trackClick();
 					return props.onClick();
 				}
 				goToTask();
 			};
+
 			return (
 				<TaskItem
 					key={ taskId }
@@ -87,12 +91,9 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 					completed={ isComplete }
 					additionalInfo={ additionalInfo }
 					content={ content }
-					onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
-						if ( ( e.target as HTMLElement ).tagName === 'A' ) {
-							return;
-						}
-						onClickActions();
-					} }
+					onClick={
+						props.isClickable === false ? undefined : onClick
+					}
 					onDismiss={
 						isDismissable ? () => onDismissTask() : undefined
 					}

--- a/plugins/woocommerce/changelog/46361-fix-lys-task-not-clickable-once-completed
+++ b/plugins/woocommerce/changelog/46361-fix-lys-task-not-clickable-once-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Launch Your Store task item should not be clickable once completed


### PR DESCRIPTION
Fix Launch Your Store task item should not be clickable once completed

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46352.

This PR adds launch your store task item fill to make it non-clickable once completed.

To make the task clickable again,  set `woocommerce_coming_soon` option to `yes` to reset the task completion status.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `launch-your-store` feature flag.
2. Set `woocommerce_coming_soon` option to `yes` if it's `no`.
3. Go to `WooCommerce > Home`
4. Confirm that the `Launch Your Store` task item is clickable.
5. Set `woocommerce_coming_soon` option to `no`
6. Go to WooCommerce > Home.
7. Confirm that the `Launch Your Store` task item is complete and not clickable.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Launch Your Store task item should not be clickable once completed

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
