### PR TITLE
[LYS] Tweak site visibility settings page

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -188,9 +188,9 @@ const SiteVisibility = () => {
 						} }
 					/>
 				</div>
-				{ privateLink === 'yes' && (
+				{ comingSoon === 'yes' && privateLink === 'yes' && (
 					<div className="site-visibility-settings-slotfill-private-link">
-						{ getPrivateLink() }
+						<input value={ getPrivateLink() } readOnly />
 						<Button
 							ref={ copyClipboardRef }
 							variant="link"

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
@@ -13,6 +13,7 @@
 	}
 
 	.site-visibility-settings-slotfill-private-link {
+		margin-top: 12px;
 		margin-left: 73px;
 		padding: 8px 16px;
 		border-radius: 4px;
@@ -20,8 +21,29 @@
 		background: #fff;
 		display: flex;
 		justify-content: space-between;
+		height: 40px;
+		box-sizing: border-box;
+
+		input {
+			width: 100%;
+			outline: none;
+			border: 0;
+			background: #fff;
+			font-size: 13px;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 20px;
+			color: $gray-900;
+		}
+
 		button {
 			text-decoration: none;
+			white-space: nowrap;
+			font-size: 13px;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 20px;
+
 			&:focus {
 				outline: none !important;
 				box-shadow: none;
@@ -74,17 +96,25 @@
 	}
 
 	.site-visibility-settings-slotfill-section {
-		max-width: 620px;
+		max-width: 650px;
+
 		&:last-child {
 			margin-top: 16px;
 		}
 
 		.site-visibility-settings-slotfill-section-content {
+			gap: 16px;
+			display: flex;
+			flex-direction: column;
+			margin: 16px 0 0 30px;
+
 			&.is-hidden {
 				display: none;
 			}
-			margin: 16px 0 0 30px;
+
 			.components-toggle-control {
+				margin: 0;
+
 				.components-h-stack {
 					align-items: baseline;
 				}
@@ -93,6 +123,7 @@
 			.components-base-control__field {
 				p {
 					margin-top: 6px;
+					margin-bottom: 0;
 				}
 			}
 		}

--- a/plugins/woocommerce/changelog/tweak-lys-settings-page
+++ b/plugins/woocommerce/changelog/tweak-lys-settings-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweaks Site visibility settings page'

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -323,7 +323,7 @@ final class WooCommerce {
 
 		$coming_soon      = $is_new_install ? 'yes' : 'no';
 		$store_pages_only = WCAdminHelper::is_site_fresh() ? 'no' : 'yes';
-		$private_link     = 'yes';
+		$private_link     = 'no';
 		$share_key        = wp_generate_password( 32, false );
 
 		if ( false === get_option( 'woocommerce_coming_soon', false ) ) {

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -51,7 +51,7 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( 'yes', get_option( 'woocommerce_coming_soon' ) );
 		$this->assertEquals( 'no', get_option( 'woocommerce_store_pages_only' ) );
-		$this->assertEquals( 'yes', get_option( 'woocommerce_private_link' ) );
+		$this->assertEquals( 'no', get_option( 'woocommerce_private_link' ) );
 		$this->assertNotEmpty( get_option( 'woocommerce_share_key' ) );
 		$this->assertMatchesRegularExpression( '/^[a-zA-Z0-9]{32}$/', get_option( 'woocommerce_share_key' ) );
 	}
@@ -67,7 +67,7 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( 'no', get_option( 'woocommerce_coming_soon' ) );
 		$this->assertEquals( 'yes', get_option( 'woocommerce_store_pages_only' ) );
-		$this->assertEquals( 'yes', get_option( 'woocommerce_private_link' ) );
+		$this->assertEquals( 'no', get_option( 'woocommerce_private_link' ) );
 		$this->assertNotEmpty( get_option( 'woocommerce_share_key' ) );
 		$this->assertMatchesRegularExpression( '/^[a-zA-Z0-9]{32}$/', get_option( 'woocommerce_share_key' ) );
 	}
@@ -88,7 +88,7 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( 'yes', get_option( 'woocommerce_coming_soon' ) );
 		$this->assertEquals( 'no', get_option( 'woocommerce_store_pages_only' ) );
-		$this->assertEquals( 'yes', get_option( 'woocommerce_private_link' ) );
+		$this->assertEquals( 'no', get_option( 'woocommerce_private_link' ) );
 		$this->assertEquals( 'test', get_option( 'woocommerce_share_key' ) );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -88,7 +88,7 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( 'yes', get_option( 'woocommerce_coming_soon' ) );
 		$this->assertEquals( 'no', get_option( 'woocommerce_store_pages_only' ) );
-		$this->assertEquals( 'no', get_option( 'woocommerce_private_link' ) );
+		$this->assertEquals( 'yes', get_option( 'woocommerce_private_link' ) );
 		$this->assertEquals( 'test', get_option( 'woocommerce_share_key' ) );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46356.

This PR makes the following changes to the site visibility settings:

- Set the `woocommerce_private_link` option to `no` by default.
- "Copy link" text should be on one line. Use the read-only input field to make the text on one line.
- Tweak CSS to match the design.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh JN site with `launch-your-store` feature flag enabled.
2. Go to `WooCommerce > Settings > Site Visibility`.
3. Confirm that `Share your site with a private link` option is disabled by default.

<img width="720" alt="Screenshot 2024-04-09 at 17 00 15" src="https://github.com/woocommerce/woocommerce/assets/4344253/dac20f43-f7bd-419b-ba96-b67268e0fd7b">


4. Turn on the `Share your site with a private link` option.
5. Confirm that the `Copy link` text is on one line.

<img width="742" alt="Screenshot 2024-04-09 at 17 00 10" src="https://github.com/woocommerce/woocommerce/assets/4344253/8e87f68e-8b81-400c-8fc8-1a4cfb8b3b78">

6. Change `Site visibility` to `Live`
7. Observe that the `Copy link` is not visible.

<img width="712" alt="Screenshot 2024-04-09 at 17 00 20" src="https://github.com/woocommerce/woocommerce/assets/4344253/287c205e-55d2-42b2-a3a6-6a238d573748">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
