### PR TITLE
Make templates fallback methods template-agnostic

### DIFF
--- a/plugins/woocommerce/changelog/fix-agnostic-fallback-methods
+++ b/plugins/woocommerce/changelog/fix-agnostic-fallback-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Refactor block templates fallback methods so they are template-agnostic
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -53,6 +53,10 @@ class BlockTemplatesController {
 	 * This function is used on the `pre_get_block_template` hook to return the fallback template from the db in case
 	 * the template is eligible for it.
 	 *
+	 * Currently, the Products by Category, Products by Tag and Products by Attribute templates fall back to the
+	 * Product Catalog template. That means that if there are customizations in the Product Catalog template,
+	 * they are also reflected in the other templates as long as they haven't been customized as well.
+	 *
 	 * @param \WP_Block_Template|null $template Block template object to short-circuit the default query,
 	 *                                          or null to allow WP to run its normal queries.
 	 * @param string                  $id Template unique identifier (example: theme_slug//template_slug).

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -77,7 +77,7 @@ class BlockTemplatesController {
 		$theme               = $template_name_parts[0] ?? '';
 		$slug                = $template_name_parts[1] ?? '';
 
-		if ( empty( $theme ) || empty( $slug ) || ! BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $slug ) ) {
+		if ( empty( $theme ) || empty( $slug ) || ! BlockTemplateUtils::template_is_eligible_for_fallback( $slug ) ) {
 			return null;
 		}
 
@@ -135,7 +135,7 @@ class BlockTemplatesController {
 		$templates_eligible_for_fallback = array_filter(
 			$template_slugs,
 			function ( $template_slug ) {
-				return BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $template_slug );
+				return BlockTemplateUtils::template_is_eligible_for_fallback( $template_slug );
 			}
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -234,9 +234,10 @@ class BlockTemplatesController {
 		list( $template_id, $template_slug ) = $template_name_parts;
 
 		// If the theme has an archive-product.html template, but not a taxonomy-product_cat/tag/attribute.html template let's use the themes archive-product.html template.
-		if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_theme( $template_slug ) ) {
-			$template_path   = BlockTemplateUtils::get_theme_template_path( ProductCatalogTemplate::SLUG );
-			$template_object = BlockTemplateUtils::create_new_block_template_object( $template_path, $template_type, $template_slug, true );
+		if ( BlockTemplateUtils::template_is_eligible_for_fallback_from_theme( $template_slug ) ) {
+			$registered_template = BlockTemplateUtils::get_template( $template_slug );
+			$template_path       = BlockTemplateUtils::get_theme_template_path( $registered_template->fallback_template );
+			$template_object     = BlockTemplateUtils::create_new_block_template_object( $template_path, $template_type, $template_slug, true );
 			return BlockTemplateUtils::build_template_result_from_file( $template_object, $template_type );
 		}
 
@@ -441,7 +442,7 @@ class BlockTemplatesController {
 				continue;
 			}
 
-			if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_db( $template_slug, $already_found_templates ) ) {
+			if ( BlockTemplateUtils::template_is_eligible_for_fallback_from_db( $template_slug, $already_found_templates ) ) {
 				$template              = clone BlockTemplateUtils::get_fallback_template_from_db( $template_slug, $already_found_templates );
 				$template_id           = explode( '//', $template->id );
 				$template->id          = $template_id[0] . '//' . $template_slug;
@@ -453,9 +454,10 @@ class BlockTemplatesController {
 			}
 
 			// If the theme has an archive-product.html template, but not a taxonomy-product_cat/tag/attribute.html template let's use the themes archive-product.html template.
-			if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_theme( $template_slug ) ) {
-				$template_file = BlockTemplateUtils::get_theme_template_path( ProductCatalogTemplate::SLUG );
-				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug, true );
+			if ( BlockTemplateUtils::template_is_eligible_for_fallback_from_theme( $template_slug ) ) {
+				$registered_template = BlockTemplateUtils::get_template( $template_slug );
+				$template_file       = BlockTemplateUtils::get_theme_template_path( $registered_template->fallback_template );
+				$templates[]         = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug, true );
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -76,13 +76,14 @@ class BlockTemplatesController {
 		$template_name_parts = explode( '//', $id );
 		$theme               = $template_name_parts[0] ?? '';
 		$slug                = $template_name_parts[1] ?? '';
+		$registered_template = BlockTemplateUtils::get_template( $slug );
 
-		if ( empty( $theme ) || empty( $slug ) || ! BlockTemplateUtils::template_is_eligible_for_fallback( $slug ) ) {
+		if ( empty( $theme ) || empty( $slug ) || ! $registered_template || ! isset( $registered_template->fallback_template ) ) {
 			return null;
 		}
 
 		$wp_query_args  = array(
-			'post_name__in' => array( ProductCatalogTemplate::SLUG, $slug ),
+			'post_name__in' => array( $registered_template->fallback_template, $slug ),
 			'post_type'     => $template_type,
 			'post_status'   => array( 'auto-draft', 'draft', 'publish', 'trash' ),
 			'no_found_rows' => true,
@@ -103,7 +104,7 @@ class BlockTemplatesController {
 			return null;
 		}
 
-		if ( count( $posts ) > 0 && ProductCatalogTemplate::SLUG === $posts[0]->post_name ) {
+		if ( count( $posts ) > 0 && $registered_template->fallback_template === $posts[0]->post_name ) {
 			$template = _build_block_template_result_from_post( $posts[0] );
 
 			if ( ! is_wp_error( $template ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -98,7 +98,7 @@ class BlockTemplatesController {
 		$posts          = $template_query->posts;
 
 		// If we have more than one result from the query, it means that the current template is present in the db (has
-		// been customized by the user) and we should not return the `archive-product` template.
+		// been customized by the user) and we should not return the fallback template.
 		if ( count( $posts ) > 1 ) {
 			return null;
 		}
@@ -121,8 +121,7 @@ class BlockTemplatesController {
 	}
 
 	/**
-	 * Adds the `archive-product` template to the `taxonomy-product_cat`, `taxonomy-product_tag`, `taxonomy-attribute`
-	 * templates to be able to fall back to it.
+	 * Adds the fallback template to the template hierarchy.
 	 *
 	 * @param array $template_hierarchy A list of template candidates, in descending order of priority.
 	 */
@@ -229,7 +228,8 @@ class BlockTemplatesController {
 
 		list( $template_id, $template_slug ) = $template_name_parts;
 
-		// If the theme has an archive-product.html template, but not a taxonomy-product_cat/tag/attribute.html template let's use the themes archive-product.html template.
+		// If the template is not present in the theme but its fallback template is,
+		// let's use the theme's fallback template.
 		if ( BlockTemplateUtils::template_is_eligible_for_fallback_from_theme( $template_slug ) ) {
 			$registered_template = BlockTemplateUtils::get_template( $template_slug );
 			$template_path       = BlockTemplateUtils::get_theme_template_path( $registered_template->fallback_template );
@@ -449,7 +449,8 @@ class BlockTemplatesController {
 				continue;
 			}
 
-			// If the theme has an archive-product.html template, but not a taxonomy-product_cat/tag/attribute.html template let's use the themes archive-product.html template.
+			// If the template is not present in the theme but its fallback template is,
+			// let's use the theme's fallback template.
 			if ( BlockTemplateUtils::template_is_eligible_for_fallback_from_theme( $template_slug ) ) {
 				$registered_template = BlockTemplateUtils::get_template( $template_slug );
 				$template_file       = BlockTemplateUtils::get_theme_template_path( $registered_template->fallback_template );

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -510,6 +510,23 @@ class BlockTemplateUtils {
 	}
 
 	/**
+	 * Checks if we can fall back to a different template for a given slug.
+	 *
+	 * `taxonomy-product_cat`, `taxonomy-product_tag`, `taxonomy-product_attribute` templates can
+	 *  generally use the `archive-product` as a fallback if there are no specific overrides.
+	 *
+	 * @param string $template_slug Slug to check for fallbacks.
+	 * @return boolean
+	 */
+	public static function template_is_eligible_for_fallback( $template_slug ) {
+		$registered_template = self::get_template( $template_slug );
+		if ( $registered_template && isset( $registered_template->fallback_template ) ) {
+			return ProductCatalogTemplate::SLUG === $registered_template->fallback_template;
+		}
+		return false;
+	}
+
+	/**
 	 * Checks if we can fall back to an `archive-product` template stored on the db for a given slug.
 	 *
 	 * @param string $template_slug Slug to check for fallbacks.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -510,23 +510,6 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Checks if we can fall back to the `archive-product` template for a given slug.
-	 *
-	 * `taxonomy-product_cat`, `taxonomy-product_tag`, `taxonomy-product_attribute` templates can
-	 *  generally use the `archive-product` as a fallback if there are no specific overrides.
-	 *
-	 * @param string $template_slug Slug to check for fallbacks.
-	 * @return boolean
-	 */
-	public static function template_is_eligible_for_fallback( $template_slug ) {
-		$registered_template = self::get_template( $template_slug );
-		if ( $registered_template && isset( $registered_template->fallback_template ) ) {
-			return isset( $registered_template->fallback_template );
-		}
-		return false;
-	}
-
-	/**
 	 * Checks if we can fall back to an `archive-product` template stored on the db for a given slug.
 	 *
 	 * @param string $template_slug Slug to check for fallbacks.
@@ -534,21 +517,20 @@ class BlockTemplateUtils {
 	 * @return boolean
 	 */
 	public static function template_is_eligible_for_fallback_from_db( $template_slug, $db_templates ) {
-		$eligible_for_fallback = self::template_is_eligible_for_fallback( $template_slug );
-		if ( ! $eligible_for_fallback ) {
-			return false;
-		}
-
 		$registered_template = self::get_template( $template_slug );
 
-		$array_filter = array_filter(
-			$db_templates,
-			function ( $template ) use ( $registered_template ) {
-				return isset( $registered_template->fallback_template ) && $registered_template->fallback_template === $template->slug;
-			}
-		);
+		if ( $registered_template && isset( $registered_template->fallback_template ) ) {
+			$array_filter = array_filter(
+				$db_templates,
+				function ( $template ) use ( $registered_template ) {
+					return isset( $registered_template->fallback_template ) && $registered_template->fallback_template === $template->slug;
+				}
+			);
 
-		return count( $array_filter ) > 0;
+			return count( $array_filter ) > 0;
+		}
+
+		return false;
 	}
 
 	/**
@@ -559,16 +541,13 @@ class BlockTemplateUtils {
 	 * @return boolean|object
 	 */
 	public static function get_fallback_template_from_db( $template_slug, $db_templates ) {
-		$eligible_for_fallback = self::template_is_eligible_for_fallback( $template_slug );
-		if ( ! $eligible_for_fallback ) {
-			return false;
-		}
-
 		$registered_template = self::get_template( $template_slug );
 
-		foreach ( $db_templates as $template ) {
-			if ( $registered_template->fallback_template === $template->slug ) {
-				return $template;
+		if ( $registered_template && isset( $registered_template->fallback_template ) ) {
+			foreach ( $db_templates as $template ) {
+				if ( $registered_template->fallback_template === $template->slug ) {
+					return $template;
+				}
 			}
 		}
 
@@ -587,7 +566,7 @@ class BlockTemplateUtils {
 	public static function template_is_eligible_for_fallback_from_theme( $template_slug ) {
 		$registered_template = self::get_template( $template_slug );
 
-		return self::template_is_eligible_for_fallback( $template_slug )
+		return $registered_template && isset( $registered_template->fallback_template )
 			&& ! self::theme_has_template( $template_slug )
 			&& self::theme_has_template( $registered_template->fallback_template );
 	}

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -510,23 +510,6 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Checks if we can fall back to a different template for a given slug.
-	 *
-	 * `taxonomy-product_cat`, `taxonomy-product_tag`, `taxonomy-product_attribute` templates can
-	 *  generally use the `archive-product` as a fallback if there are no specific overrides.
-	 *
-	 * @param string $template_slug Slug to check for fallbacks.
-	 * @return boolean
-	 */
-	public static function template_is_eligible_for_fallback( $template_slug ) {
-		$registered_template = self::get_template( $template_slug );
-		if ( $registered_template && isset( $registered_template->fallback_template ) ) {
-			return ProductCatalogTemplate::SLUG === $registered_template->fallback_template;
-		}
-		return false;
-	}
-
-	/**
 	 * Checks if we can fall back to an `archive-product` template stored on the db for a given slug.
 	 *
 	 * @param string $template_slug Slug to check for fallbacks.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -611,7 +611,7 @@ class BlockTemplateUtils {
 				$query_result_template->slug === $template->slug
 				&& $query_result_template->theme === $template->theme
 			) {
-				if ( self::template_is_eligible_for_product_archive_fallback_from_theme( $template->slug ) ) {
+				if ( self::template_is_eligible_for_fallback_from_theme( $template->slug ) ) {
 					$query_result_template->has_theme_file = true;
 				}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -44,7 +44,7 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Provides data for testing template_is_eligible_for_product_archive_fallback.
+	 * Provides data for testing template_is_eligible_for_fallback functions.
 	 */
 	public function provideFallbackData() {
 		return array(
@@ -56,39 +56,27 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test template_is_eligible_for_product_archive_fallback.
-	 *
-	 * @param string $input    The template slug.
-	 * @param bool   $expected The expected result.
-	 *
-	 * @dataProvider provideFallbackData
+	 * Test template_is_eligible_for_fallback_from_db when the template is not eligible.
 	 */
-	public function test_template_is_eligible_for_product_archive_fallback( $input, $expected ) {
-		$this->assertEquals( $expected, BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $input ) );
+	public function test_template_is_eligible_for_fallback_from_db_no_eligible_template() {
+		$this->assertEquals( false, BlockTemplateUtils::template_is_eligible_for_fallback_from_db( 'single-product', array() ) );
 	}
 
 	/**
-	 * Test template_is_eligible_for_product_archive_fallback_from_db when the template is not eligible.
+	 * Test template_is_eligible_for_fallback_from_db when the template is eligible but not in the db.
 	 */
-	public function test_template_is_eligible_for_product_archive_fallback_from_db_no_eligible_template() {
-		$this->assertEquals( false, BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_db( 'single-product', array() ) );
+	public function test_template_is_eligible_for_fallback_from_db_eligible_template_empty_db() {
+		$this->assertEquals( false, BlockTemplateUtils::template_is_eligible_for_fallback_from_db( 'taxonomy-product_cat', array() ) );
 	}
 
 	/**
-	 * Test template_is_eligible_for_product_archive_fallback_from_db when the template is eligible but not in the db.
+	 * Test template_is_eligible_for_fallback_from_db when the template is eligible and in the db.
 	 */
-	public function test_template_is_eligible_for_product_archive_fallback_from_db_eligible_template_empty_db() {
-		$this->assertEquals( false, BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_db( 'taxonomy-product_cat', array() ) );
-	}
-
-	/**
-	 * Test template_is_eligible_for_product_archive_fallback_from_db when the template is eligible and in the db.
-	 */
-	public function test_template_is_eligible_for_product_archive_fallback_from_db_eligible_template_custom_in_the_db() {
+	public function test_template_is_eligible_for_fallback_from_db_eligible_template_custom_in_the_db() {
 		$db_templates = array(
 			(object) array( 'slug' => 'archive-product' ),
 		);
-		$this->assertEquals( true, BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_db( 'taxonomy-product_cat', $db_templates ) );
+		$this->assertEquals( true, BlockTemplateUtils::template_is_eligible_for_fallback_from_db( 'taxonomy-product_cat', $db_templates ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -56,18 +56,6 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test template_is_eligible_for_fallback.
-	 *
-	 * @param string $input    The template slug.
-	 * @param bool   $expected The expected result.
-	 *
-	 * @dataProvider provideFallbackData
-	 */
-	public function test_template_is_eligible_for_fallback( $input, $expected ) {
-		$this->assertEquals( $expected, BlockTemplateUtils::template_is_eligible_for_fallback( $input ) );
-	}
-
-	/**
 	 * Test template_is_eligible_for_fallback_from_db when the template is not eligible.
 	 */
 	public function test_template_is_eligible_for_fallback_from_db_no_eligible_template() {

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -56,6 +56,18 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test template_is_eligible_for_fallback.
+	 *
+	 * @param string $input    The template slug.
+	 * @param bool   $expected The expected result.
+	 *
+	 * @dataProvider provideFallbackData
+	 */
+	public function test_template_is_eligible_for_fallback( $input, $expected ) {
+		$this->assertEquals( $expected, BlockTemplateUtils::template_is_eligible_for_fallback( $input ) );
+	}
+
+	/**
 	 * Test template_is_eligible_for_fallback_from_db when the template is not eligible.
 	 */
 	public function test_template_is_eligible_for_fallback_from_db_no_eligible_template() {


### PR DESCRIPTION
This PR:

* Gets rid of the `template_is_eligible_for_product_archive_fallback()` method, as knowing if a template is elligible for fallback is as easy as checking if `$template->template_fallback` exists.
* Refactors all `templates_is_eligible_for_product_archive_fallback...` methods to be template-agnostic, that means removing `product_archive` from the method name and checking for the `template_fallback` property, instead of only checking for the Product Catalog slug.

Sidenote: in the future we should be able to simplify this logic once we fix https://github.com/woocommerce/woocommerce/issues/42531, but there were some upstream blockers that didn't allow us to fix it yet (see https://github.com/woocommerce/woocommerce/pull/44778).

### How to test the changes in this Pull Request:

This PR doesn't change the behavior of how WooCommerce templates currently work in the Site Editor. Hopefully any issues would be evident (ie: a PHP fatal) or would be caught by e2e tests. In any case, to do some smoke testing, related to the templates fallback logic:

Context: the Products by Category, Products by Tag and Products by Attribute templates fall back to the Product Catalog template. That means that if there are customizations in the Product Catalog template, they are also reflected in the other templates as long as they haven't been customized as well.

1. Go to Appearance > Editor and make some edits to the Product Catalog and Products by Category template.
2. Go to the Shop page in the frontend (`/shop`) and verify the edits you did in the Product Catalog template are visible.
3. Go to a category page in the frontend (ie: `/product-category/clothing`) and verify the edits you did in the Products by Category template are visible.
4. Go to a tag page in the frontend (ie: `/product-tag/recommended`, note: you might need to create the tag first from Products > Tags) and verify the edits you did in the Product Catalog template are visible.
5. Revert the editions.
6. Visit the frontend pages again and verify there are no edits.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
