### PR TITLE
Blocks E2E: Fix template revert tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Page } from '@playwright/test';
-import { Editor } from '@wordpress/e2e-test-utils-playwright';
+import { Editor, expect } from '@wordpress/e2e-test-utils-playwright';
 import { BlockRepresentation } from '@wordpress/e2e-test-utils-playwright/build-types/editor/insert-block';
 
 /**
@@ -425,27 +425,24 @@ export class EditorUtils {
 	}
 
 	async revertTemplateCustomizations( templateName: string ) {
+		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
+
 		const templateRow = this.page.getByRole( 'row' ).filter( {
 			has: this.page.getByRole( 'link', {
 				name: templateName,
 				exact: true,
 			} ),
 		} );
-		const resetButton = templateRow.getByRole( 'button', {
-			name: 'Reset',
-		} );
-		const waitForReset = this.page
+		const resetButton = templateRow.getByLabel( 'Reset', { exact: true } );
+		const revertedNotice = this.page
 			.getByLabel( 'Dismiss this notice' )
-			.getByText( `"${ templateName }" reverted.` )
-			.waitFor();
-
-		const waitForSavedLabel = this.page
-			.getByRole( 'button', { name: 'Saved' } )
-			.waitFor();
+			.getByText( `"${ templateName }" reverted.` );
+		const savedButton = this.page.getByRole( 'button', { name: 'Saved' } );
 
 		await resetButton.click();
-		await waitForSavedLabel;
-		await waitForReset;
+
+		await expect( revertedNotice ).toBeVisible();
+		await expect( savedButton ).toBeVisible();
 	}
 
 	async updatePost() {

--- a/plugins/woocommerce/changelog/fix-e2e-template-modification-tests
+++ b/plugins/woocommerce/changelog/fix-e2e-template-modification-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix template revert tests where the template is unreachable due to pagination.


### PR DESCRIPTION
### What's up

Our template modification tests started failing because some templates could not be reached due to the newly added pagination to the All Templates view. This fix addresses that.

### Example failure

[Link to CI job](https://github.com/woocommerce/woocommerce/actions/runs/8614797318/job/23608969805?pr=46269)
```
  ✘  17 [blockTheme] › templates/template-customization.block_theme.spec.ts:22:7 › Single Product template › can be modified and reverted (20.3s)
```

![test-failed-1](https://github.com/woocommerce/woocommerce/assets/1451471/74051d0b-b97a-49e8-b9d1-2a851ee1176b)



### Testing instructions
CI tests should pass. To test locally run:
```
pnpm test:e2e template-customization
```