### PR TITLE
Add translation context to ambiguous words

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sort } from 'fast-sort';
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __, sprintf, _n, _x } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import {
 	InspectorControls,
@@ -201,11 +201,19 @@ const Edit = ( {
 					>
 						<ToggleGroupControlOption
 							value="multiple"
-							label={ __( 'Multiple', 'woocommerce' ) }
+							label={ _x(
+								'Multiple',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 						<ToggleGroupControlOption
 							value="single"
-							label={ __( 'Single', 'woocommerce' ) }
+							label={ _x(
+								'Single',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 					</ToggleGroupControl>
 					{ selectType === 'multiple' && (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/components/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/components/inspector-controls.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -51,11 +51,19 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				>
 					<ToggleGroupControlOption
 						value="multiple"
-						label={ __( 'Multiple', 'woocommerce' ) }
+						label={ _x(
+							'Multiple',
+							'Number of filters',
+							'woocommerce'
+						) }
 					/>
 					<ToggleGroupControlOption
 						value="single"
-						label={ __( 'Single', 'woocommerce' ) }
+						label={ _x(
+							'Single',
+							'Number of filters',
+							'woocommerce'
+						) }
 					/>
 				</ToggleGroupControl>
 				{ selectType === 'multiple' && (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/rating-filter/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/rating-filter/components/inspector.tsx
@@ -3,7 +3,7 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	PanelBody,
 	ToggleControl,
@@ -53,11 +53,19 @@ export const Inspector = ( {
 					>
 						<ToggleGroupControlOption
 							value="multiple"
-							label={ __( 'Multiple', 'woocommerce' ) }
+							label={ _x(
+								'Multiple',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 						<ToggleGroupControlOption
 							value="single"
-							label={ __( 'Single', 'woocommerce' ) }
+							label={ _x(
+								'Single',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 					</ToggleGroupControl>
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/stock-filter/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/stock-filter/components/inspector.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	PanelBody,
 	ToggleControl,
@@ -47,11 +47,19 @@ export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
 				>
 					<ToggleGroupControlOption
 						value="multiple"
-						label={ __( 'Multiple', 'woocommerce' ) }
+						label={ _x(
+							'Multiple',
+							'Number of filters',
+							'woocommerce'
+						) }
 					/>
 					<ToggleGroupControlOption
 						value="single"
-						label={ __( 'Single', 'woocommerce' ) }
+						label={ _x(
+							'Single',
+							'Number of filters',
+							'woocommerce'
+						) }
 					/>
 				</ToggleGroupControl>
 				<ToggleGroupControl

--- a/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import type { BlockEditProps } from '@wordpress/blocks';
@@ -79,11 +79,19 @@ const Edit = ( {
 					>
 						<ToggleGroupControlOption
 							value="multiple"
-							label={ __( 'Multiple', 'woocommerce' ) }
+							label={ _x(
+								'Multiple',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 						<ToggleGroupControlOption
 							value="single"
-							label={ __( 'Single', 'woocommerce' ) }
+							label={ _x(
+								'Single',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 					</ToggleGroupControl>
 					<ToggleGroupControl

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import BlockTitle from '@woocommerce/editor-components/block-title';
@@ -72,11 +72,19 @@ const Edit = ( {
 					>
 						<ToggleGroupControlOption
 							value="multiple"
-							label={ __( 'Multiple', 'woocommerce' ) }
+							label={ _x(
+								'Multiple',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 						<ToggleGroupControlOption
 							value="single"
-							label={ __( 'Single', 'woocommerce' ) }
+							label={ _x(
+								'Single',
+								'Number of filters',
+								'woocommerce'
+							) }
 						/>
 					</ToggleGroupControl>
 					<ToggleGroupControl

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { ADMIN_URL, getSetting } from '@woocommerce/settings';
 import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
@@ -22,7 +22,7 @@ import { useSettingsContext } from './settings-context';
 
 const GeneralSettingsDescription = () => (
 	<>
-		<h2>{ __( 'General', 'woocommerce' ) }</h2>
+		<h2>{ _x( 'General', 'Admin settings', 'woocommerce' ) }</h2>
 		<p>
 			{ __(
 				'Enable or disable local pickup on your store, and define costs. Local pickup is only available from the block checkout.',

--- a/plugins/woocommerce/changelog/46382-blocks-translations
+++ b/plugins/woocommerce/changelog/46382-blocks-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add more translator context to ambiguous words


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/42610

This PR adds the `_x()` gettext function with context. I believe this PR is quite subjective in the sense that the words can be interpreted differently to different people. I've only picked the words that are super ambiguous giving the context.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a post.
2. From the block inserter, add the following product filters:
    - `Filter by Attribute`,
    - `Filter by Stock`,
    - `Product Filter: Attribute (beta)` (experimental block - only to be tested by developers),
    - `Product Filter: Stock Status (beta)` (experimental block - only to be tested by developers).
4. Add the `Product Collection (beta): Product Catalog` block.
5. Ensure the blocks are working as expected admin and frontend.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add more translator context to ambiguous words

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
