### PR TITLE
Fix/46128 check cached order id before get order return

### DIFF
--- a/plugins/woocommerce/changelog/46393-fix-46128-check-cached-order-id-before-get_order-return
+++ b/plugins/woocommerce/changelog/46393-fix-46128-check-cached-order-id-before-get_order-return
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Update `WC_Order_Factory::get_order()` to return false when failing to load cached order.

--- a/plugins/woocommerce/changelog/fix-46128-check-cached-order-id-before-get_order-return
+++ b/plugins/woocommerce/changelog/fix-46128-check-cached-order-id-before-get_order-return
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Verify cached order is valid before returning from OrderFactory

--- a/plugins/woocommerce/changelog/fix-46128-check-cached-order-id-before-get_order-return
+++ b/plugins/woocommerce/changelog/fix-46128-check-cached-order-id-before-get_order-return
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Verify cached order is valid before returning from OrderFactory

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -36,7 +36,7 @@ class WC_Order_Factory {
 			$order_cache = wc_get_container()->get( OrderCache::class );
 			$order       = $order_cache->get( $order_id );
 			if ( ! is_null( $order ) ) {
-				return $order;
+				return 0 === $order->get_id() ? false : $order;
 			}
 		}
 

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -283,6 +283,7 @@ class WC_Unit_Tests_Bootstrap {
 		// Traits.
 		require_once $this->tests_dir . '/framework/traits/trait-wc-rest-api-complex-meta.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/HPOSToggleTrait.php';
+		require_once dirname( $this->tests_dir ) . '/php/helpers/SerializingCacheTrait.php';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/helpers/SerializingCacheProxy.php
+++ b/plugins/woocommerce/tests/php/helpers/SerializingCacheProxy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Automattic\WooCommerce\RestApi\UnitTests;
+
+/**
+ * Proxy class used to mimic object cache instances that serialize/deserialized stored data.
+ */
+class Serializing_Cache_Proxy {
+	public $original_cache_instance;
+
+	/**
+	 * @param \WP_Object_Cache $original_cache_instance
+	 */
+	public function __construct( $original_cache_instance ) {
+		$this->original_cache_instance = $original_cache_instance;
+	}
+
+	/**
+	 * Proxy method to route all method calls to the underlying cache object.
+	 *
+	 * @param string $func The function name being called.
+	 * @param array $args The arguments to pass to the underlying class.
+	 *
+	 * @return mixed
+	 */
+	public function __call( $func, $args ) {
+		return $this->original_cache_instance->$func( ...$args );
+	}
+
+	/**
+	 * Retrieves the cache contents, if it exists. This is a wrapper to the underlying WP_Object_Cache
+	 * instance and will serialize and deserialize any arrays or objects prior to returning in order to
+	 * mimic behaviour of caching where data is stored serialized.
+	 *
+	 * @param int|string $key The key under which the cache contents are stored.
+	 * @param string $group Optional. Where the cache contents are grouped. Default 'default'.
+	 * @param bool $force Optional. Unused. Whether to force an update of the local cache
+	 *                          from the persistent cache. Default false.
+	 * @param bool $found Optional. Whether the key was found in the cache (passed by reference).
+	 *                          Disambiguates a return of false, a storable value. Default null.
+	 *
+	 * @return mixed|false The cache contents on success, false on failure to retrieve contents.
+	 */
+	public function get( $key, $group = 'default', $force = false, &$found = null ) {
+		$data = $this->original_cache_instance->get( $key, $group, $found, $found );
+		if ( is_object( $data ) || is_array( $data ) ) {
+			return unserialize( serialize( $data ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize,WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		}
+
+		return $data;
+	}
+}

--- a/plugins/woocommerce/tests/php/helpers/SerializingCacheProxy.php
+++ b/plugins/woocommerce/tests/php/helpers/SerializingCacheProxy.php
@@ -15,7 +15,7 @@ class Serializing_Cache_Proxy {
 	public $original_cache_instance;
 
 	/**
-	 * @param \WP_Object_Cache $original_cache_instance
+	 * @param \WP_Object_Cache $original_cache_instance The original global $wp_object_cache instance.
 	 */
 	public function __construct( $original_cache_instance ) {
 		$this->original_cache_instance = $original_cache_instance;
@@ -25,7 +25,7 @@ class Serializing_Cache_Proxy {
 	 * Proxy method to route all method calls to the underlying cache object.
 	 *
 	 * @param string $func The function name being called.
-	 * @param array $args The arguments to pass to the underlying class.
+	 * @param array  $args The arguments to pass to the underlying class.
 	 *
 	 * @return mixed
 	 */

--- a/plugins/woocommerce/tests/php/helpers/SerializingCacheProxy.php
+++ b/plugins/woocommerce/tests/php/helpers/SerializingCacheProxy.php
@@ -6,6 +6,12 @@ namespace Automattic\WooCommerce\RestApi\UnitTests;
  * Proxy class used to mimic object cache instances that serialize/deserialized stored data.
  */
 class Serializing_Cache_Proxy {
+
+	/**
+	 * A reference to the original global object cache instance.
+	 *
+	 * @var \WP_Object_Cache
+	 */
 	public $original_cache_instance;
 
 	/**
@@ -33,11 +39,11 @@ class Serializing_Cache_Proxy {
 	 * mimic behaviour of caching where data is stored serialized.
 	 *
 	 * @param int|string $key The key under which the cache contents are stored.
-	 * @param string $group Optional. Where the cache contents are grouped. Default 'default'.
-	 * @param bool $force Optional. Unused. Whether to force an update of the local cache
-	 *                          from the persistent cache. Default false.
-	 * @param bool $found Optional. Whether the key was found in the cache (passed by reference).
-	 *                          Disambiguates a return of false, a storable value. Default null.
+	 * @param string     $group Optional. Where the cache contents are grouped. Default 'default'.
+	 * @param bool       $force Optional. Unused. Whether to force an update of the local cache
+	 *                    from the persistent cache. Default false.
+	 * @param bool       $found Optional. Whether the key was found in the cache (passed by reference).
+	 *                    Disambiguates a return of false, a storable value. Default null.
 	 *
 	 * @return mixed|false The cache contents on success, false on failure to retrieve contents.
 	 */

--- a/plugins/woocommerce/tests/php/helpers/SerializingCacheTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/SerializingCacheTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Automattic\WooCommerce\RestApi\UnitTests;
+
+use PHPUnit\Framework\MockObject\MockBuilder;
+
+/**
+ * TestCase trait that allows the replacement of the default WP_Object_Cache with an instance that will
+ * serialize and deserialize objects stored in cache instead of just keeping in memory to better mimic
+ * most real world caching implementations.
+ */
+trait SerializingCacheTrait {
+
+	private $wp_object_cache_instance;
+
+	abstract public function getMockBuilder( string $className ): MockBuilder;
+
+
+	public function setup_mock_cache() {
+		if ( is_null( $this->wp_object_cache_instance ) ) {
+			$this->wp_object_cache_instance = $GLOBALS['wp_object_cache'];
+
+			$GLOBALS['wp_object_cache'] = new Serializing_Cache_Proxy( $this->wp_object_cache_instance );
+		}
+	}
+
+	/**
+	 *
+	 * @return void
+	 *
+	 * @after Force cleanup of serializing cache instance if being used.
+	 */
+	public function cleanup_mock_cache() {
+		if ( ! is_null( $this->wp_object_cache_instance ) ) {
+			$GLOBALS['wp_object_cache'] = $this->wp_object_cache_instance;
+			unset( $this->wp_object_cache_instance );
+		}
+	}
+
+}
+
+/**
+ * Proxy class used to mimic object cache instances that serialize/deserialized stored data.
+ */
+class Serializing_Cache_Proxy {
+	public $original_cache_instance;
+
+	public function __construct( $original_cache_instance ) {
+		$this->original_cache_instance = $original_cache_instance;
+	}
+
+	public function __call( $function, $args ) {
+		return $this->original_cache_instance->$function( ...$args );
+	}
+
+	public function get( $key, $group = 'default', $force = false, &$found = null ) {
+		$data = $this->original_cache_instance->get( $key, $group, $found, $found );
+		if ( is_object( $data ) || is_array( $data ) ) {
+			return unserialize( serialize( $data ) );
+		}
+
+		return $data;
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
@@ -108,7 +108,7 @@ class WC_Order_Factory_Test extends WC_Unit_Test_Case {
 		global $wpdb;
 
 		OrderHelper::toggle_cot_feature_and_usage( true );
-		$this->setup_mock_cache();
+		$this->setup_serializing_cache();
 
 		$order = OrderHelper::create_order();
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
@@ -119,8 +119,8 @@ class WC_Order_Factory_Test extends WC_Unit_Test_Case {
 		// Delete the order from the DB to mimic situations like SQL replication lag where the cache has propagated,
 		// but SQL data hasn't yet caught up.
 		$wpdb->delete( OrdersTableDataStore::get_orders_table_name(), array( 'ID' => $retrieved_order->get_id() ) );
-		foreach ( OrdersTableDataStore::get_all_table_names_with_id() as $id => $table ) {
-			if ( 'orders' != $id ) {
+		foreach ( OrdersTableDataStore::get_all_table_names_with_id() as $table_id => $table ) {
+			if ( 'orders' !== $table_id ) {
 				$wpdb->delete( $table, array( 'order_id' => $retrieved_order->get_id() ) );
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
@@ -118,7 +118,7 @@ class WC_Order_Factory_Test extends WC_Unit_Test_Case {
 
 		// Delete the order from the DB to mimic situations like SQL replication lag where the cache has propagated,
 		// but SQL data hasn't yet caught up.
-		$wpdb->delete( OrdersTableDataStore::get_orders_table_name(), [ 'ID' => $retrieved_order->get_id() ] );
+		$wpdb->delete( OrdersTableDataStore::get_orders_table_name(), array( 'ID' => $retrieved_order->get_id() ) );
 
 		/**
 		 * Retrieving the order again should either:

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
@@ -125,18 +125,9 @@ class WC_Order_Factory_Test extends WC_Unit_Test_Case {
 			}
 		}
 
-		/**
-		 * Retrieving the order again should either:
-		 * - return false because the order was not able to fully load.
-		 * - return a fully loaded order. Our direct DB write purposefully does not trigger a cache refresh so a fully
-		 *      loaded order should also be an expected result with cache enabled.
-		 */
+		// Retrieving the order again should either return false because the order was not able to fully load.
 		$retrieved_order = WC_Order_Factory::get_order( $order->get_id() );
-		if ( is_object( $retrieved_order ) ) {
-			$this->assertEquals( $order->get_id(), $retrieved_order->get_id() );
-		} else {
-			$this->assertFalse( $retrieved_order );
-		}
+		$this->assertFalse( $retrieved_order );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
@@ -1,12 +1,15 @@
 <?php
 
 use Automattic\WooCommerce\Caches\OrderCache;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 
 /**
  * WC_Order_Factory_Test Class.
  */
 class WC_Order_Factory_Test extends WC_Unit_Test_Case {
+
+	use \Automattic\WooCommerce\RestApi\UnitTests\SerializingCacheTrait;
 
 	/**
 	 * Store COT state at the start of the test so we can restore it later.
@@ -96,6 +99,39 @@ class WC_Order_Factory_Test extends WC_Unit_Test_Case {
 		$this->assertEquals( $order1->get_id(), $orders[0]->get_id() );
 		$this->assertEquals( $order2->get_id(), $orders[1]->get_id() );
 		OrderHelper::toggle_cot_feature_and_usage( false );
+	}
+
+	/**
+	 * @testDox Test that an WC_Order_Factory::get_order() does not return an order that did not properly load, $id = 0.
+	 */
+	public function test_get_order_doesnt_return_invalid_cached_order() {
+		global $wpdb;
+
+		OrderHelper::toggle_cot_feature_and_usage( true );
+		$this->setup_mock_cache();
+
+		$order = OrderHelper::create_order();
+
+		// Retrieve the order to prime the cache.
+		$retrieved_order = WC_Order_Factory::get_order( $order->get_id() );
+		$this->assertEquals( $order->get_id(), $retrieved_order->get_id() );
+
+		// Delete the order from the DB to mimic situations like SQL replication lag where the cache has propagated,
+		// but SQL data hasn't yet caught up.
+		$wpdb->delete( OrdersTableDataStore::get_orders_table_name(), [ 'ID' => $retrieved_order->get_id() ] );
+
+		/**
+		 * Retrieving the order again should either:
+		 * - return false because the order was not able to fully load.
+		 * - return a fully loaded order. Our direct DB write purposefully does not trigger a cache refresh so a fully
+		 *      loaded order should also be an expected result with cache enabled.
+		 */
+		$retrieved_order = WC_Order_Factory::get_order( $order->get_id() );
+		if ( is_object( $retrieved_order ) ) {
+			$this->assertEquals( $order->get_id(), $retrieved_order->get_id() );
+		} else {
+			$this->assertFalse( $retrieved_order );
+		}
 	}
 
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
@@ -119,6 +119,11 @@ class WC_Order_Factory_Test extends WC_Unit_Test_Case {
 		// Delete the order from the DB to mimic situations like SQL replication lag where the cache has propagated,
 		// but SQL data hasn't yet caught up.
 		$wpdb->delete( OrdersTableDataStore::get_orders_table_name(), array( 'ID' => $retrieved_order->get_id() ) );
+		foreach ( OrdersTableDataStore::get_all_table_names_with_id() as $id => $table ) {
+			if ( 'orders' != $id ) {
+				$wpdb->delete( $table, array( 'order_id' => $retrieved_order->get_id() ) );
+			}
+		}
 
 		/**
 		 * Retrieving the order again should either:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46128.

This change corrects the behavior within `WC_Order_Factory::get_order()` to return false for an order that was not able to load from the database when the order was saved to the `OrderCache`.

It multi-datacenter environments where data has to be replicated from one datacenter to another, cache can propagate faster than SQL data. When this happens, the `OrderCache` may contain a cached Order that does not yet exist in the database.  Since the `WC_Data` `__sleep()/__wakeup()` methods only cache the ID of the order, the rest of the data is read from the DB during construction as the order is deserialized.

Without this change, the order instance that is returned from `::get_order()` was unable to load any data and has an ID set to `0` when it was present in the `OrderCache`.

With this change, `::get_order()` will now return `false` for the order when it is in the `OrderCache` just like it would if it weren't previously cached.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The test `WC_Order_Factory_Test::test_get_order_doesnt_return_invalid_cached_order()` has been added to the to cover this.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Update `WC_Order_Factory::get_order()` to return false when failing to load cached order.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
