### PR TITLE
Move logic to hide Template selector in Shop page into Product Catalog class and add e2e test

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
@@ -18,6 +18,6 @@ test.describe( 'Shop page', async () => {
 		
 		await admin.editPost( numberMatch[0] );
 
-		await expect( page.getByText( 'Template' ) ).toHaveCount( 0 );
+		await expect( page.getByText( 'Template' ) ).toBeHidden();
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
@@ -15,8 +15,8 @@ test.describe( 'Shop page', async () => {
 		);
 		const numberMatch = cliOutput.stdout.match( /\d+/ );
 		expect( numberMatch ).not.toBeNull();
-		
-		await admin.editPost( numberMatch[0] );
+
+		await admin.editPost( numberMatch[ 0 ] );
 
 		await expect( page.getByText( 'Template' ) ).toBeHidden();
 	} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { cli } from '@woocommerce/e2e-utils';
+
+test.describe( 'Shop page', async () => {
+	test( 'template selector is not visible in the Page editor', async ( {
+		admin,
+		page,
+	} ) => {
+		// Get Shop page ID.
+		const cliOutput = await cli(
+			`npm run wp-env run tests-cli -- wp option get woocommerce_shop_page_id`
+		);
+		const lines = cliOutput.stdout.split( '\n' );
+		const shopPageId = lines.reverse().find( ( line ) => line !== '' );
+
+		// eslint-disable-next-line playwright/no-conditional-in-test
+		if ( ! shopPageId ) {
+			throw new Error( 'Shop page ID not found' );
+		}
+
+		await admin.editPost( shopPageId );
+
+		await expect( page.getByText( 'Template' ) ).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/shop-page.block_theme.spec.ts
@@ -13,15 +13,10 @@ test.describe( 'Shop page', async () => {
 		const cliOutput = await cli(
 			`npm run wp-env run tests-cli -- wp option get woocommerce_shop_page_id`
 		);
-		const lines = cliOutput.stdout.split( '\n' );
-		const shopPageId = lines.reverse().find( ( line ) => line !== '' );
-
-		// eslint-disable-next-line playwright/no-conditional-in-test
-		if ( ! shopPageId ) {
-			throw new Error( 'Shop page ID not found' );
-		}
-
-		await admin.editPost( shopPageId );
+		const numberMatch = cliOutput.stdout.match( /\d+/ );
+		expect( numberMatch ).not.toBeNull();
+		
+		await admin.editPost( numberMatch[0] );
 
 		await expect( page.getByText( 'Template' ) ).toHaveCount( 0 );
 	} );

--- a/plugins/woocommerce/changelog/fix-46376-hide-template-selector-shop-page-in-product-catalog
+++ b/plugins/woocommerce/changelog/fix-46376-hide-template-selector-shop-page-in-product-catalog
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Move logic to hide Template selector in Shop page into Product Catalog class and add e2e test
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -26,7 +26,6 @@ class BlockTemplatesController {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
-		add_filter( 'current_theme_supports-block-templates', array( $this, 'remove_block_template_support_for_shop_page' ) );
 		add_filter( 'taxonomy_template_hierarchy', array( $this, 'add_archive_product_to_eligible_for_fallback_templates' ), 10, 1 );
 		add_action( 'after_switch_theme', array( $this, 'check_should_use_blockified_product_grid_templates' ), 10, 2 );
 		add_filter( 'post_type_archive_title', array( $this, 'update_product_archive_title' ), 10, 2 );
@@ -575,31 +574,5 @@ class BlockTemplatesController {
 		}
 
 		return $post_type_name;
-	}
-
-	/**
-	 * Remove the template panel from the Sidebar of the Shop page because
-	 * the Site Editor handles it.
-	 *
-	 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6278
-	 *
-	 * @param bool $is_support Whether the active theme supports block templates.
-	 *
-	 * @return bool
-	 */
-	public function remove_block_template_support_for_shop_page( $is_support ) {
-		global $pagenow, $post;
-
-		if (
-			is_admin() &&
-			'post.php' === $pagenow &&
-			function_exists( 'wc_get_page_id' ) &&
-			is_a( $post, 'WP_Post' ) &&
-			wc_get_page_id( 'shop' ) === $post->ID
-		) {
-			return false;
-		}
-
-		return $is_support;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -23,6 +23,7 @@ class ProductCatalogTemplate extends AbstractTemplate {
 	 */
 	public function init() {
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
+		add_filter( 'current_theme_supports-block-templates', array( $this, 'remove_block_template_support_for_shop_page' ) );
 	}
 
 	/**
@@ -56,5 +57,31 @@ class ProductCatalogTemplate extends AbstractTemplate {
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
+	}
+
+	/**
+	 * Remove the template panel from the Sidebar of the Shop page because
+	 * the Site Editor handles it.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6278
+	 *
+	 * @param bool $is_support Whether the active theme supports block templates.
+	 *
+	 * @return bool
+	 */
+	public function remove_block_template_support_for_shop_page( $is_support ) {
+		global $pagenow, $post;
+
+		if (
+			is_admin() &&
+			'post.php' === $pagenow &&
+			function_exists( 'wc_get_page_id' ) &&
+			is_a( $post, 'WP_Post' ) &&
+			wc_get_page_id( 'shop' ) === $post->ID
+		) {
+			return false;
+		}
+
+		return $is_support;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR moves the logic to hide the _Template_ selector when editing the _Shop_ page from the `BlockTemplatesController` classic into the `ProductCatalogTemplate` class. Additionally, it adds an e2e test to make sure there are no regressions in the future.

Closes https://github.com/woocommerce/woocommerce/issues/46376.

### How to test the changes in this Pull Request:

This PR doesn't introduce any functionality changes, so test is simply making sure there are no regressions.

1. Go to Pages > Shop.
2. Verify there is no _Template_ selector in the sidebar.
3. Edit any other page.
4. Verify there is the _Template_ selector in the sidebar.

Shop page | Any other page
--- | ---
![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/edc90273-d026-4264-af66-ce0852d511ca) | ![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/96b79ad1-71f5-4fcb-9314-b78516253e1c)

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
