### PR TITLE
add: lys prefetch congrats data

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -8,6 +8,7 @@ import {
 	fromCallback,
 	fromPromise,
 	assign,
+	spawnChild,
 } from 'xstate5';
 import React from 'react';
 import classnames from 'classnames';
@@ -23,6 +24,7 @@ import type { LaunchYourStoreComponentProps } from '..';
 import type { mainContentMachine } from '../main-content/xstate';
 import { updateQueryParams, createQueryParamsListener } from '../common';
 import { taskClickedAction, getLysTasklist } from './tasklist';
+import { fetchCongratsData } from '../main-content/pages/launch-store-success/services';
 
 export type SidebarMachineContext = {
 	externalUrl: string | null;
@@ -116,6 +118,7 @@ export const sidebarMachine = setup( {
 		sidebarQueryParamListener,
 		getTasklist: fromPromise( getLysTasklist ),
 		updateLaunchStoreOptions: fromPromise( launchStoreAction ),
+		fetchCongratsData,
 	},
 } ).createMachine( {
 	id: 'sidebar',
@@ -155,6 +158,11 @@ export const sidebarMachine = setup( {
 			initial: 'preLaunchYourStoreHub',
 			states: {
 				preLaunchYourStoreHub: {
+					entry: [
+						spawnChild( 'fetchCongratsData', {
+							id: 'prefetch-congrats-data ',
+						} ),
+					],
 					invoke: {
 						src: 'getTasklist',
 						onDone: {

--- a/plugins/woocommerce/changelog/add-lys-prefetch-congrats-data
+++ b/plugins/woocommerce/changelog/add-lys-prefetch-congrats-data
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+
+Adds a prefetch for the LYS congrats data
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46305.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `launch-your-store` feature flag
2. Open devtools and keep an eye on the network panel
3. Go to WC home and click on the "Launch your store" task
4. Observe that the option for the congrats screen are pre-loaded upon entry to LYS (`woocommerce_admin_launch_your_store_survey_completed`)
5. Observe that when the launch your store button is clicked, there is no loading spinner
6. Also observe that when the page is loaded directly (hard refresh on the congrats page), the spinner should still show up

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
