### PR TITLE
[e2e tests] Fix command palette tests failing with Gutenberg installed

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-command-pallete-locator-gb-nightly
+++ b/plugins/woocommerce/changelog/e2e-fix-command-pallete-locator-gb-nightly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix command palette tests failing with Gutenberg installed

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -9,7 +9,10 @@ const clickOnCommandPaletteOption = async ( { page, optionName } ) => {
 	// Press `Ctrl` + `K` to open the command palette.
 	await page.keyboard.press( cmdKeyCombo );
 
-	await page.getByPlaceholder( 'Search for commands' ).fill( optionName );
+	await page
+		.getByLabel( 'Command palette' )
+		.locator( 'input' )
+		.fill( optionName );
 
 	// Click on the relevant option.
 	const option = page.getByRole( 'option', {


### PR DESCRIPTION


### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`command-palette.spec.js` has been failing for with Gutenberg installed. This PR updates a locator that should make it work both with and without Gutenberg.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Run `pnpm test:e2e-pw command-palette.spec.js` with Gutenberg plugin installed and without it.

<!-- End testing instructions -->
