### PR TITLE
Exclude coming soon page from navigation

### DIFF
--- a/plugins/woocommerce/changelog/update-exclude-coming-soon-page-from-nav
+++ b/plugins/woocommerce/changelog/update-exclude-coming-soon-page-from-nav
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Exclude coming soon page from navigation


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46230.


This PR excludes the coming soon page from the navigation. As Moon mentioned in the issue, the `wp_get_nav_menu_items` hook no longer works for block themes, I did some research and found that
`block_core_navigation_render_inner_blocks` is a bit complex to work with. So, I decided to use the `get_pages` filter to exclude the coming soon page from the navigation for the front end ([render_block_core_page_list](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/page-list/index.php#L266-L271)). 

I also use the `rest_page_query` filter to exclude the coming soon page from API because the site editor uses the API to fetch the pages and renders navigation based on that using JS. However, this also removes it from `Site editor > Pages` (/wp-admin/site-editor.php?path=%2Fpage). I think that should be fine since the user can directly edit it by clicking the `Customize "Coming soon" page` menu item from the status dropdown or by going to `Pages > All Pages.` If we want to keep it in the site editor, we can possibly check the [query args](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js#L24-L36) and exclude it only when the request is coming from the site editor (But it might break in the future if the site editor changes the way it fetches the pages).



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a JN site with `launch-your-store` feature flag enabled
2. Go to frontend
3. Confirm coming soon page is not in the navigation
4. Go to Site editor
5. Confirm coming soon page is not in the navigation

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
