### PR TITLE
Fix: Remove Unused Variable 'discount_amount_html'

### DIFF
--- a/plugins/woocommerce/changelog/46437-hotfix-remove-unused-var
+++ b/plugins/woocommerce/changelog/46437-hotfix-remove-unused-var
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Removed unused local variable 'discount_amount_html' to improve code clarity and efficiency.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -283,8 +283,6 @@ function wc_cart_totals_coupon_html( $coupon ) {
 		$coupon = new WC_Coupon( $coupon );
 	}
 
-	$discount_amount_html = '';
-
 	$amount               = WC()->cart->get_coupon_discount_amount( $coupon->get_code(), WC()->cart->display_cart_ex_tax );
 	$discount_amount_html = '-' . wc_price( $amount );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In this Pull Request, I have addressed the issue of an unused local variable 'discount_amount_html' in the codebase. The variable was identified as being declared but not utilized for any subsequent operations, as its value was overwritten immediately after declaration.

### Changes Made:

- Removed the declaration of the unused variable 'discount_amount_html'.
- Updated the relevant code section for clarity and efficiency.

### Changelog Entry:

- [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

- [x] Minor

#### Type

- [x] Tweak - A minor adjustment to the codebase

#### Message

Removed unused local variable 'discount_amount_html' to improve code clarity and efficiency.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

### Additional Notes:

- This PR aims to enhance the maintainability and readability of the codebase by removing unnecessary declarations.
- Please review the modifications and provide feedback as needed.

### Closing Note:

Kindly review and merge this Pull Request at your earliest convenience. Thank you!
