### PR TITLE
Check shop page after page deletion

### DIFF
--- a/plugins/woocommerce/changelog/e2e-new-e2e-page-titles-assertions
+++ b/plugins/woocommerce/changelog/e2e-new-e2e-page-titles-assertions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Adds some end to end tests to verify page titles of key WC pages

--- a/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
@@ -9,6 +9,13 @@ test( 'Load the home page', async ( { page } ) => {
 			.getByRole( 'link', { name: 'WooCommerce Core E2E Test' } )
 			.count()
 	).toBeGreaterThan( 0 );
+	await expect(
+		page.getByText( 'Proudly powered by WordPress' )
+	).toBeVisible();
+	expect( await page.title() ).toBe( 'WooCommerce Core E2E Test Suite' );
+	await expect(
+		page.getByRole( 'link', { name: 'WordPress' } )
+	).toBeVisible();
 } );
 
 test( 'Load wp-admin as admin', async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
@@ -131,7 +131,7 @@ test.describe.serial( 'Tax rates in the cart and checkout', () => {
 				value: 'incl',
 			} );
 
-			await test.step( 'Load shop page and confirm price display', async () => {
+			await test.step( 'Load shop page, confirm title and confirm price display', async () => {
 				await page.goto( '/shop/' );
 				await expect(
 					page.getByRole( 'heading', { name: 'Shop' } )
@@ -140,6 +140,9 @@ test.describe.serial( 'Tax rates in the cart and checkout', () => {
 				await expect(
 					page.getByText( '$250.00', { exact: true } )
 				).toBeVisible();
+				expect( await page.title() ).toBe(
+					'Shop – WooCommerce Core E2E Test Suite'
+				);
 			} );
 
 			await test.step( 'Load cart page and confirm price display', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
@@ -122,6 +122,11 @@ test.describe( 'Single Product Page', () => {
 
 	test( 'should be able to see product description', async ( { page } ) => {
 		await page.goto( `product/${ simpleProductSlug }` );
+
+		expect( await page.title() ).toBe(
+			simpleProductName + ' – WooCommerce Core E2E Test Suite'
+		);
+
 		await page.getByRole( 'tab', { name: 'Description' } ).click();
 
 		await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
@@ -1,0 +1,38 @@
+const { test, expect } = require( '@playwright/test' );
+
+// test case for bug https://github.com/woocommerce/woocommerce/pull/46429
+test.describe( 'Check the title of the shop page after the page has been deleted', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+	test.beforeEach( async ( { page } ) => {
+		await page.goto( 'wp-admin/edit.php?post_type=page' );
+		await page.getByRole( 'cell', { name: '“Shop” (Edit)' } ).hover();
+		await page
+			.getByLabel( 'Move “Shop” to the Trash' )
+			.click( { force: true } );
+		await expect(
+			page.getByText( 'page moved to the Trash. Undo' )
+		).toBeVisible();
+	} );
+
+	test.afterEach( async ( { page } ) => {
+		await page.goto( 'wp-admin/edit.php?post_status=trash&post_type=page' );
+		await page
+			.getByRole( 'cell', { name: 'Shop — Shop Page Restore “' } )
+			.hover();
+		await page
+			.getByLabel( 'Restore “Shop” from the Trash' )
+			.click( { force: true } );
+		await expect(
+			page.getByText( '1 page restored from the Trash.' )
+		).toBeVisible();
+	} );
+
+	test( 'Check the title of the shop page after the page has been deleted', async ( {
+		page,
+	} ) => {
+		await page.goto( '/shop/' );
+		expect( await page.title() ).toBe(
+			'Shop – WooCommerce Core E2E Test Suite'
+		);
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46431
Closes https://github.com/woocommerce/woocommerce/issues/46433
Closes https://github.com/woocommerce/woocommerce/issues/46435

Adds an end to end test to check the title of the shop page, after that page has been moved to the trash.

Tweaks the basic e2e test to assert that the links in the footer are loaded and that the page title is correct on the home page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure CI passes
2. `pnpm env:restart && pnpm test:e2e-pw shopper/shop-title-after-deletion`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
