### PR TITLE
add: lys hub tracks

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/Congrats.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/Congrats.tsx
@@ -93,6 +93,9 @@ export const Congrats = ( {
 				</span>
 				<Button
 					onClick={ () => {
+						recordEvent(
+							'launch_your_store_congrats_back_to_home_click'
+						);
 						navigateTo( { url: '/' } );
 					} }
 					className="back-to-home-button"
@@ -125,7 +128,7 @@ export const Congrats = ( {
 								ref={ copyClipboardRef }
 								onClick={ () => {
 									recordEvent(
-										'launch_you_store_congrats_copy_store_link_click'
+										'launch_your_store_congrats_copy_store_link_click'
 									);
 								} }
 							>
@@ -136,7 +139,7 @@ export const Congrats = ( {
 								variant="primary"
 								onClick={ () => {
 									recordEvent(
-										'launch_you_store_congrats_preview_store_click'
+										'launch_your_store_congrats_preview_store_click'
 									);
 									window.open( homeUrl, '_blank' );
 								} }
@@ -256,8 +259,8 @@ export const Congrats = ( {
 											onClick={ () => {
 												recordEvent(
 													isWooExpress
-														? 'launch_you_store_congrats_survey_click'
-														: 'launch_you_store_on_core_congrats_survey_click'
+														? 'launch_your_store_congrats_survey_click'
+														: 'launch_your_store_on_core_congrats_survey_click'
 												);
 												sendData();
 											} }

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/tasklist.tsx
@@ -16,6 +16,7 @@ import SidebarNavigationItem from '@wordpress/edit-site/build-module/components/
  */
 import { createStorageUtils } from '~/utils/localStorage';
 import { taskCompleteIcon, taskIcons } from './components/icons';
+import { recordEvent } from '@woocommerce/tracks';
 
 const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
 export const LYS_RECENTLY_ACTIONED_TASKS_KEY = 'lys_recently_actioned_tasks';
@@ -70,6 +71,10 @@ export const getLysTasklist = async () => {
 	return {
 		...tasklist[ 0 ],
 		tasks: visibleTasks,
+		recentlyActionedTasks,
+		fullLysTaskList: tasklist[ 0 ].tasks.filter( ( task ) =>
+			filteredTasks.includes( task.id )
+		),
 	};
 };
 
@@ -79,6 +84,9 @@ export function taskClickedAction( event: {
 } ) {
 	const recentlyActionedTasks = getRecentlyActionedTasks() ?? [];
 	saveRecentlyActionedTask( [ ...recentlyActionedTasks, event.task.id ] );
+	recordEvent( 'launch_your_store_hub_task_clicked', {
+		task: event.task.id,
+	} );
 	if ( event.task.actionUrl ) {
 		navigateTo( { url: event.task.actionUrl } );
 	} else {

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -71,12 +71,12 @@ const launchStoreAction = async () => {
 	throw new Error( JSON.stringify( results ) );
 };
 
-const recordLaunchStoreAttempt = ( {
+const recordStoreLaunchAttempt = ( {
 	context,
 }: {
 	context: SidebarMachineContext;
 } ) => {
-	const total = context.tasklist?.fullLysTaskList.length || 0;
+	const total_count = context.tasklist?.fullLysTaskList.length || 0;
 	const incomplete_tasks =
 		context.tasklist?.tasks
 			.filter( ( task ) => ! task.isComplete )
@@ -87,26 +87,24 @@ const recordLaunchStoreAttempt = ( {
 			.filter( ( task ) => task.isComplete )
 			.map( ( task ) => task.id ) || [];
 
-	const completed_in_lys = completed.filter( ( task ) =>
+	const tasks_completed_in_lys = completed.filter( ( task ) =>
 		context.tasklist?.recentlyActionedTasks.includes( task )
 	); // recently actioned tasks can include incomplete tasks
 
 	recordEvent( 'launch_your_store_hub_store_launch_attempted', {
-		tasks: {
-			total, // all lys eligible tasks
-			completed, // all lys eligible tasks that are completed
-			completed_count: completed.length,
-			completed_in_lys,
-			completed_in_lys_count: completed_in_lys.length,
-			incomplete_tasks,
-			incomplete_tasks_count: incomplete_tasks.length,
-		},
+		tasks_total_count: total_count, // all lys eligible tasks
+		tasks_completed: completed, // all lys eligible tasks that are completed
+		tasks_completed_count: completed.length,
+		tasks_completed_in_lys,
+		tasks_completed_in_lys_count: tasks_completed_in_lys.length,
+		incomplete_tasks,
+		incomplete_tasks_count: incomplete_tasks.length,
 		delete_test_orders: context.removeTestOrders || false,
 	} );
 	return performance.now();
 };
 
-const recordLaunchStoreResults = ( timestamp: number, success: boolean ) => {
+const recordStoreLaunchResults = ( timestamp: number, success: boolean ) => {
 	recordEvent( 'launch_your_store_hub_store_launch_results', {
 		success,
 		duration: getTimeFrame( performance.now() - timestamp ),
@@ -154,13 +152,13 @@ export const sidebarMachine = setup( {
 			window.history.back();
 		},
 		recordStoreLaunchAttempt: assign( {
-			launchStoreAttemptTimestamp: recordLaunchStoreAttempt,
+			launchStoreAttemptTimestamp: recordStoreLaunchAttempt,
 		} ),
 		recordStoreLaunchResults: (
 			{ context },
 			{ success }: { success: boolean }
 		) => {
-			recordLaunchStoreResults(
+			recordStoreLaunchResults(
 				context.launchStoreAttemptTimestamp || 0,
 				success
 			);

--- a/plugins/woocommerce/changelog/add-lys-hub-tracks
+++ b/plugins/woocommerce/changelog/add-lys-hub-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added tracks events for LYS hub


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is part of https://github.com/woocommerce/team-ghidorah/issues/301 but does not fully complete it.
It introduces changes to record tracks events for LYS Hub, and also some minor changes to the tracks on the post-launch Congrats page

It fulfils the following requests:

```
% of users that complete at least one pending task from the LYS hub. [LYS hub]
What tasks have been performed from the LYS hub? [LYS hub]
How many users remove vs. keep test orders? [LYS hub]
Frequency of errors — How often do we fail in launching a store? [LYS hub]

What the users do once on the Congrats page — Preview their store, copy link ans so forth. [Congrats page]
How many users engage with the feedback request and what their answers are. [Congrats page] -> Where do we see user feedback?

Measure time to launch (?)
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the LYS feature flag
2. Explore the LYS Hub functionality and observe that the following tracks events are fired as appropriate

### LYS Hub
- `launch_your_store_hub_task_clicked` with `task: task.id` when a task is clicked in LYS Hub
-  `launch_your_store_hub_store_launch_results` with `{ success: bool, duration: timeframe }` where timeframe is one of [these](https://github.com/woocommerce/woocommerce/blob/d7631ff422eb88b599e5c9fcc30156a8dee13998/plugins/woocommerce-admin/client/utils/index.js#L71) when the launch either succeeds or fails
- `launch_your_store_hub_store_launch_attempted` when the launch store button is clicked

```
{ 		
	tasks_total_count, // all lys eligible tasks
	tasks_completed, // all lys eligible tasks that are completed
	tasks_completed_count: completed.length,
	tasks_completed_in_lys,
	tasks_completed_in_lys_count: completed_in_lys.length,
	incomplete_tasks,
	incomplete_tasks_count: incomplete_tasks.length,
	delete_test_orders: bool
 }
```


### Congrats Page

- `launch_your_store_congrats_survey_complete` with the survey results when the survey is submitted
- `launch_your_store_on_core_congrats_survey_click` when the survey send button is clicked on woocommerce core
- `launch_your_store_congrats_survey_click` when the survey send button is clicked on woo express
- `launch_your_store_congrats_preview_store_click` when the preview store button is clicked
- `launch_your_store_congrats_copy_store_link_click` when the copy store link button is clicked
- `launch_your_store_congrats_back_to_home_click` when the back to home button on the top left is clicked


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
