### PR TITLE
k6 perf tests: Add assertions for the "Shop" page title and product headers.

### DIFF
--- a/plugins/woocommerce/changelog/add-k6-shop-page-title-product-titles
+++ b/plugins/woocommerce/changelog/add-k6-shop-page-title-product-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+In k6 perf tests, add checks for the Shop page title and presence of product headers.

--- a/plugins/woocommerce/tests/performance/requests/shopper/shop-page.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/shop-page.js
@@ -45,6 +45,11 @@ export function shopPage() {
 				response.body.includes(
 					'<header class="woocommerce-products-header">'
 				),
+			'body contains: woocommerce-loop-product__title': ( response ) =>
+				response
+					.html()
+					.find( '.woocommerce-loop-product__title' )
+					.toArray().length > 0,
 		} );
 	} );
 

--- a/plugins/woocommerce/tests/performance/requests/shopper/shop-page.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/shop-page.js
@@ -36,6 +36,11 @@ export function shopPage() {
 		} );
 		check( response, {
 			'is status 200': ( r ) => r.status === 200,
+			'title equals: Shop – WooCommerce Core E2E Test Suite': (
+				response
+			) =>
+				response.html().find( 'head title' ).text() ===
+				'Shop – WooCommerce Core E2E Test Suite',
 			'body contains: woocommerce-products-header': ( response ) =>
 				response.body.includes(
 					'<header class="woocommerce-products-header">'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Closes #46438.

This PR adds two assertions to `plugins/woocommerce/tests/performance/requests/shopper/shop-page.js`:
- An assertion to check if the page title of the shop page was "Shop – WooCommerce Core E2E Test Suite"
- An assertion to check if the elements with class `woocommerce-loop-product__title` are present in the page. They are the individual product titles in the Shop page as shown below:
    <img width="600" alt="BZa3JTOOtE" src="https://github.com/woocommerce/woocommerce/assets/4509348/41a84c51-dab1-4eca-b2ba-8a26ef693d0a">
    
Note that the 2nd assertion corresponds to Atomic's `<h2\s+[^>]*class="woocommerce-loop-category__title"[^>]*>\s*Clothing/i'` assertion. Our wp-env localhost does not have a `.woocommerce-loop-category__title` HTML element. For some reason, Atomic's `/shop` page shows category titles instead of product titles as shown below.

<img width="600" alt="zDv1PrvJej" src="https://github.com/woocommerce/woocommerce/assets/4509348/8ea4c71b-532b-437d-b86a-27bb030a06b5">

 So the next closest thing is to assert for the presence of `.woocommerce-loop-product__title` elements.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the k6 perf tests in this PR passes.
2. Test locally. Assuming you had already installed k6 globally on your machine:
    ```bash
    # Run setup scripts for launching the k6 local test environment
    pnpm install
    pnpm --filter=@woocommerce/plugin-woocommerce build
    pnpm --filter=@woocommerce/plugin-woocommerce env:dev
    pnpm --filter=@woocommerce/plugin-woocommerce env:performance-init

    # Run the shop-page.js test
    k6 run plugins/woocommerce/tests/performance/requests/shopper/shop-page.js
    ```
    Make sure that the two new assertions pass.
    <img width="405" alt="FCcVovi9dB" src="https://github.com/woocommerce/woocommerce/assets/4509348/72f45216-23fb-4f09-89c2-b708dd6ac21e">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
