### PR TITLE
Add safety check for rare fatal case with subscription note

### DIFF
--- a/plugins/woocommerce/changelog/fix-32216
+++ b/plugins/woocommerce/changelog/fix-32216
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add safety check to prevent rare occurences of a fatal in WooSubscriptionsNotes

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
@@ -221,6 +221,9 @@ class WooSubscriptionsNotes {
 	 * @return int|false
 	 */
 	public function get_product_id_from_subscription_note( &$note ) {
+		if ( false === $note ) {
+			return false;
+		}
 		$content_data = $note->get_content_data();
 
 		if ( property_exists( $content_data, 'product_id' ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
@@ -221,7 +221,7 @@ class WooSubscriptionsNotes {
 	 * @return int|false
 	 */
 	public function get_product_id_from_subscription_note( &$note ) {
-		if ( false === $note ) {
+		if ( ! is_object( $note ) ) {
 			return false;
 		}
 		$content_data = $note->get_content_data();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds a simple check to make sure the passed in `$note` object isn't `false`, as there may be an edge case where this happens.

Closes #32216 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Simple Connection Test

1. Generate a zip from this branch: `pnpm --filter='@woocommerce/plugin-woocommerce' build:zip`
2. Create a JN/live site and install the WooCommerce zip
3. Finish the onboarding
4. On **WooCommerce > Home** the 'connect to woocommerce.com' should be present ( under **Inbox** )
5. Connect your site to WooCommerce.com 
6. Verify the Connect to WooCommerce.com note is no longer in your inbox.

More complicated test ( to make sure things still work as normal, may not be necessary ):

1. At WooCommerce.com, buy a single site subscription for Product Add-Ons ( DO NOT ENABLE AUTORENEW FOR PRODUCT ADD ONS )
2. Modify the order on woocommerce.com so that Product Add-Ons expires about 30 days from today.
3. Download, install, and activate Product-Add Ons
4. Set the Product-Add Ons subscription to active on **wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions**
5. Go to **WooCommerce > Home > Inbox** and make sure you have a note that the Product Add Ons subscription is expiring in 30 days.
6. Set the Product-Add Ons subscription to inactive on **WooCommerce > Extensions > WooCommerce.com Subscriptions**
7. Go to **WooCommerce > Dashboard > Inbox** and make sure you DO NOT have a note about the Product Add Ons subscription.

IMPORTANT: Set the Product-Add Ons subscription to active on **wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions** (or you will not be able to do so once it has expired)
8. Modify the order on woocommerce.com so that Product Add-Ons expired last week.
9. Go to **WooCommerce > Home > Inbox** and make sure you have a note that the Product Add Ons subscription expired.
10. Set the Product-Add Ons subscription to inactive on **WooCommerce > Extensions > WooCommerce.com Subscriptions**
11. Go to **WooCommerce > Home > Inbox** and make sure you DO NOT have a note about the Product Add Ons subscription.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
