### PR TITLE
Add clause to `CustomMetaDataStore::get_meta_keys` query to exclude empty order meta keys

### DIFF
--- a/plugins/woocommerce/changelog/update-custom-meta-data-store-get-meta-keys
+++ b/plugins/woocommerce/changelog/update-custom-meta-data-store-get-meta-keys
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Added clause to query in CustomMetaDataStore::get_meta_keys to exclude metas where the key is ''.
+
+

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -250,7 +250,9 @@ abstract class CustomMetaDataStore {
 		$query = "SELECT DISTINCT meta_key FROM {$db_info['table']} ";
 
 		if ( ! $include_private ) {
-			$query .= $wpdb->prepare( 'WHERE meta_key NOT LIKE %s ', $wpdb->esc_like( '_' ) . '%' );
+			$query .= $wpdb->prepare( 'WHERE meta_key != \'\' AND meta_key NOT LIKE %s ', $wpdb->esc_like( '_' ) . '%' );
+		} else {
+			$query .= $wpdb->prepare( 'WHERE meta_key != \'\' ');
 		}
 
 		$order  = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -252,7 +252,7 @@ abstract class CustomMetaDataStore {
 		if ( ! $include_private ) {
 			$query .= $wpdb->prepare( 'WHERE meta_key != \'\' AND meta_key NOT LIKE %s ', $wpdb->esc_like( '_' ) . '%' );
 		} else {
-			$query .= $wpdb->prepare( 'WHERE meta_key != \'\' ');
+			$query .= "WHERE meta_key != '' ";
 		}
 
 		$order  = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Notes

- It's possible for an order meta to be accidentally created with an empty key and value. 
- In this situation, a null value for the key can be passed to an `is_protected_meta` filter. (This is applied in the function of the same name.) 
- If the filter isn't expecting this, it can throw a fatal error, which can mean that custom metaboxes don't appear on the order page. 
- This was the case in WCCOM, where we had such a filter in our WooCommerce Subscriptions implementation. 
- This change heads this off at the pass by excluding empty metas from the records fetched in  `CustomMetaDataStore::get_meta_keys`.

### Changes proposed in this Pull Request:

- Adds clause to query in `CustomMetaDataStore::get_meta_keys` to exclude metas where the key is ''.

Related: 20194-gh-Automattic/woocommerce.com

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. First, reproduce the issue. 
2. You need an order on your test WooCommerce site.

- If you're starting with a fresh wp-env environment, you can import sample products by going to http://localhost:8888/wp-admin/edit.php?post_type=product and importing the file `plugins/woocommerce/sample_data/sample_products.csv`. 
- Then make sure your store has a location
- Select a payment method like Cash on Delivery in http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=checkout.
- Then make the order on the front end.

3. Start a bash session on your environment. On wp-env, it's `wp-env run cli bash`.
4. Find the order in your [orders list](http://localhost:8888/wp-admin/admin.php?page=wc-orders) and note the ID.
5. Create a dodgy order meta:

```bash
$order = wc_get_order( ID );
$order->update_meta_data( '', '' );
$order->save();
```

6. View the order. Find the Custom Fields metabox at the bottom, and click in the dropdown under Add New Custom Field. Note that the first item in the dropdown is empty.

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/97cfc56a-bbb4-4aaa-8987-ec838dfa9627">

7. Now check out this branch. Note that the dropdown no longer has an empty item.

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/1b6ce43f-4e7a-481b-bac0-9694c434d022">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>