### PR TITLE
Can only be inserted once test excludes the mini-cart template button

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
@@ -9,8 +9,11 @@ const blockData: BlockData = {
 	slug: 'woocommerce/mini-cart',
 	mainClass: '.wc-block-minicart',
 	selectors: {
+		editor: {
+			block: '.wp-block-woocommerce-mini-cart',
+			insertButton: "//button//span[text()='Mini-Cart']",
+		},
 		frontend: {},
-		editor: {},
 	},
 };
 
@@ -54,10 +57,18 @@ test.describe( 'Merchant → Mini Cart', () => {
 				.getByLabel( 'Search for blocks and patterns' )
 				.fill( blockData.slug );
 
-			const miniCartButton = editorUtils.page
-				.getByLabel( 'WooCommerce', { exact: true } )
-				.getByRole( 'option', { name: blockData.name } );
+			// Await for blocks commercial to be loaded in the Blocks inserter.
+			await expect(
+				editorUtils.page.locator(
+					'.block-directory-downloadable-block-list-item__details'
+				)
+			).toBeVisible();
 
+			const miniCartButton = editorUtils.page.getByRole( 'option', {
+				name: blockData.name,
+			} );
+
+			await expect( miniCartButton ).toBeVisible();
 			await expect( miniCartButton ).toBeDisabled();
 		} );
 	} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
@@ -54,10 +54,9 @@ test.describe( 'Merchant → Mini Cart', () => {
 				.getByLabel( 'Search for blocks and patterns' )
 				.fill( blockData.slug );
 
-			const miniCartButton = editorUtils.page.getByRole( 'option', {
-				name: blockData.name,
-				exact: true,
-			} );
+			const miniCartButton = editorUtils.page
+				.getByLabel( 'WooCommerce', { exact: true } )
+				.getByRole( 'option', { name: blockData.name } );
 
 			await expect( miniCartButton ).toHaveAttribute(
 				'aria-disabled',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
@@ -58,10 +58,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 				.getByLabel( 'WooCommerce', { exact: true } )
 				.getByRole( 'option', { name: blockData.name } );
 
-			await expect( miniCartButton ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
+			await expect( miniCartButton ).toBeDisabled();
 		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/fix-mini-cart-test
+++ b/plugins/woocommerce/changelog/fix-mini-cart-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+can only be inserted once excludes the mini-cart template button


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


`tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts > Can only be inserted once test` excludes the mini-cart template button.
This test was failing for me locally because there is also a Mini-cart template button under Theme. 

### How to test the changes in this Pull Request:
1. Make sure this test passes locally
2. All E2E tests should pass on the CI

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
