### PR TITLE
Only select all terms of an attribute if there are less than 10 entries

### DIFF
--- a/packages/js/product-editor/changelog/enhancement-max-n-terms-selection
+++ b/packages/js/product-editor/changelog/enhancement-max-n-terms-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Only select all terms of an attribute if there are less than 10 entries

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -58,6 +58,8 @@ type AttributeForm = {
 	attributes: Array< EnhancedProductAttribute | null >;
 };
 
+const MAX_N_TERMS_AUTO_SELECTION = 10;
+
 export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	title = __( 'Add attributes', 'woocommerce' ),
 	description = '',
@@ -254,7 +256,11 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 											getProductAttributeObject(
 												value
 											) as EnhancedProductAttribute;
-										if ( termsAutoSelection === 'all' ) {
+										if (
+											termsAutoSelection === 'all' &&
+											terms.length <=
+												MAX_N_TERMS_AUTO_SELECTION
+										) {
 											selectedAttribute.terms = terms;
 										} else if ( terms.length > 0 ) {
 											selectedAttribute.terms = [


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PS: the acceptance criteria of the issue mentions:

> If the attribute has more values, we don't add any values automatically and let the user select them manually.

I thought it would be confusing NOT to add the first term in that case, since the current behavior for attributes is to always add the first term. If we want to change this, I think we need to rethink the behavior in the attributes as well.

Closes #40747

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Products > Attributes
2. Create an attribute with more than 10 terms
3. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
4. Go to Products > Add
5. Go to the Variations tab
6. Add a new variation option
7. Add the attribute you just added before
8. Only the first term should be selected, and not all of them

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
