### PR TITLE
POC: Create client-side notices from notices added with `wc_add_notice` in Checkout block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -13,6 +13,11 @@ import {
 } from '@woocommerce/types';
 import { noticeContexts } from '@woocommerce/base-context/event-emit/utils';
 
+/**
+ * Internal dependencies
+ */
+import { processNotices } from './process-notices';
+
 type ApiParamError = {
 	param: string;
 	id: string;
@@ -193,6 +198,10 @@ export const processErrorResponse = (
 ) => {
 	if ( ! isApiErrorResponse( response ) ) {
 		return;
+	}
+
+	if ( response.data?.notices ) {
+		processNotices( response.data?.notices );
 	}
 
 	if ( response.code === 'rest_invalid_param' ) {

--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-notices.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-notices.ts
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import {
+	WCNotice,
+	WCNoticeList,
+} from '@woocommerce/type-defs/api-error-response';
+import { isObject, isString } from '@woocommerce/types';
+import { createNotice } from '@woocommerce/base-utils';
+import { select } from '@wordpress/data';
+
+export const processNotices = ( notices: WCNoticeList ) => {
+	if ( ! isObject( notices ) ) {
+		return;
+	}
+
+	const validContexts = select(
+		'wc/store/store-notices'
+	).getRegisteredContainers();
+
+	// Map server-side notices to client-side equivalents.
+	const noticeTypeMap: [
+		keyof WCNoticeList,
+		'info' | 'error' | 'success'
+	][] = [
+		[ 'notice', 'info' ],
+		[ 'success', 'success' ],
+		[ 'error', 'error' ],
+	];
+
+	// Loop through each type of notice (notice, success, and error) and create client-side notices.
+	noticeTypeMap.forEach( ( [ serverSideType, clientSideType ] ) => {
+		if ( ! Array.isArray( notices[ serverSideType ] ) ) {
+			return;
+		}
+
+		const noticesOfType = notices[ serverSideType ] as WCNotice[];
+
+		noticesOfType.forEach( ( notice: WCNotice ) => {
+			if ( ! isString( notice?.notice ) ) {
+				return;
+			}
+
+			if (
+				! isString( notice?.data?.context ) ||
+				! validContexts.includes( notice?.data?.context )
+			) {
+				return;
+			}
+
+			createNotice( clientSideType, notice.notice, {
+				context: notice?.data?.context || 'wc/checkout',
+			} );
+		} );
+	} );
+};

--- a/plugins/woocommerce-blocks/assets/js/types/type-defs/api-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/types/type-defs/api-error-response.ts
@@ -3,6 +3,19 @@
  */
 import type { CartResponse } from './cart-response';
 
+// The notice added from wc_get_notices contains only the notice text an any additional data.
+export interface WCNotice {
+	data?: Record< string, string >;
+	notice?: string;
+}
+
+// The array of notices returned from wc_get_notices contains three members, one for each type of notice.
+export interface WCNoticeList {
+	notice?: WCNotice[];
+	error?: WCNotice[];
+	success?: WCNotice[];
+}
+
 // This is the standard API response data when an error is returned.
 export type ApiErrorResponse = {
 	code: string;
@@ -17,6 +30,7 @@ export type ApiErrorResponseData = {
 	details: Record< string, ApiErrorResponseDataDetails >;
 	// Some endpoints return cart data to update the client.
 	cart?: CartResponse | undefined;
+	notices?: WCNoticeList;
 } | null;
 
 // The details object lists individual errors for each field.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -290,6 +290,9 @@ class Checkout extends AbstractCartRoute {
 		if ( 409 === $http_status_code ) {
 			return $this->add_data_to_error_object( $error_from_message, $additional_data, $http_status_code, true );
 		}
+
+		$additional_data['notices'] = wc_get_notices();
+		wc_clear_notices();
 		return $this->add_data_to_error_object( $error_from_message, $additional_data, $http_status_code );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Create a `processNotices` function - this takes a list of notices in the format returned by `wc_get_notices` and uses the `core/notices` data store to add them on the client.
- On error responses in checkout, process the notices.

Note, I have not done this for successful checkouts or other store API actions yet such as changing shipping method, this is only for showing notices added during payment failure.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add [woocommerce-failed-gateway.zip](https://github.com/woocommerce/woocommerce/files/14945043/woocommerce-failed-gateway.zip) to your site
2. Try to check out using the failed gateway method
3. See the `wc_add_notices` notices added when payment fails.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
