### PR TITLE
add: lys badge tracks

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
@@ -69,7 +69,12 @@ export const LaunchYourStoreStatus = ( {
 								<MenuItem
 									onClick={ () => {
 										recordEvent(
-											'launch_your_store_badge_menu_manage_site_visibility_click'
+											'launch_your_store_badge_menu_manage_site_visibility_click',
+											{
+												site_visibility: isComingSoon
+													? 'coming_soon'
+													: 'live',
+											}
 										);
 									} }
 									// @ts-expect-error Prop gets passed down to underlying button https://developer.wordpress.org/block-editor/reference-guides/components/menu-item/#props

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
@@ -108,7 +108,6 @@ export const LaunchYourStoreStatus = ( {
 											) }
 										</MenuItem>
 									) }
-
 							</MenuGroup>
 						</>
 					) }

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
@@ -91,11 +91,11 @@ export const LaunchYourStoreStatus = ( {
 								{ isComingSoon &&
 									getSetting( 'currentThemeIsFSETheme' ) && (
 										<MenuItem
-                                        	onClick={ () => {
-											    recordEvent(
-												    'launch_your_store_badge_menu_customize_coming_soon_click'
-											    );
-									    	} }
+											onClick={ () => {
+												recordEvent(
+													'launch_your_store_badge_menu_customize_coming_soon_click'
+												);
+											} }
 											// @ts-expect-error Prop gets passed down to underlying button https://developer.wordpress.org/block-editor/reference-guides/components/menu-item/#props
 											href={
 												COMING_SOON_PAGE_EDITOR_LINK

--- a/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/status/index.tsx
@@ -6,6 +6,7 @@ import { Icon, moreVertical, edit, cog } from '@wordpress/icons';
 import { Dropdown, Button, MenuGroup, MenuItem } from '@wordpress/components';
 import { getAdminLink, getSetting } from '@woocommerce/settings';
 import classnames from 'classnames';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -66,6 +67,11 @@ export const LaunchYourStoreStatus = ( {
 						<>
 							<MenuGroup className="woocommerce-lys-status-popover">
 								<MenuItem
+									onClick={ () => {
+										recordEvent(
+											'launch_your_store_badge_menu_manage_site_visibility_click'
+										);
+									} }
 									// @ts-expect-error Prop gets passed down to underlying button https://developer.wordpress.org/block-editor/reference-guides/components/menu-item/#props
 									href={ getAdminLink(
 										'admin.php?page=wc-settings&tab=site-visibility'
@@ -80,6 +86,11 @@ export const LaunchYourStoreStatus = ( {
 								{ isComingSoon &&
 									getSetting( 'currentThemeIsFSETheme' ) && (
 										<MenuItem
+                                        	onClick={ () => {
+											    recordEvent(
+												    'launch_your_store_badge_menu_customize_coming_soon_click'
+											    );
+									    	} }
 											// @ts-expect-error Prop gets passed down to underlying button https://developer.wordpress.org/block-editor/reference-guides/components/menu-item/#props
 											href={
 												COMING_SOON_PAGE_EDITOR_LINK
@@ -92,6 +103,7 @@ export const LaunchYourStoreStatus = ( {
 											) }
 										</MenuItem>
 									) }
+
 							</MenuGroup>
 						</>
 					) }

--- a/plugins/woocommerce/changelog/add-lys-badge-tracks
+++ b/plugins/woocommerce/changelog/add-lys-badge-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add tracks events for the LYS badge

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -56,7 +56,7 @@ class LaunchYourStore {
 
 					// log the transition if there is one.
 					if ( $current_value !== $new_value ) {
-						$enabled_or_disabled              = yes === $new_value ? 'enabled' : 'disabled';
+						$enabled_or_disabled              = 'yes' === $new_value ? 'enabled' : 'disabled';
 						$event_data[ $name . '_toggled' ] = $enabled_or_disabled;
 					}
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is part of https://github.com/woocommerce/team-ghidorah/issues/301 but does not fully complete it.

It introduces changes to record tracks events for LYS Badge. It was planned to complete the settings page tracks events on this PR too but it seems like they already exist! I will include testing instructions for them just to ensure coverage.

It fulfils the following requests:

```
How many users interact with “Manage site visibility”? [WooCommerce Home - Badge]
How many users interact with “Customize ‘Coming soon’ page”? [WooCommerce Home - Badge]

How many users switch from “Live” to “Coming soon” mode? [WooCommerce Settings]
How many users enable “Store pages only” vs. “Entire site” when in “Coming soon”? [WooCommerce Settings]
How many users enable the “Share private link” functionality? [WooCommerce Settings]
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the LYS feature flag
2. Explore the LYS Badge functionality and observe that the following tracks events are fired as appropriate

### LYS Badge (JS Tracks)

- Find this on the WC Home screen
- There are two states, "Site coming soon" and "Live"
- In "Live" you should be able to only click on "Manage site visibility", and it should fire: `launch_your_store_badge_menu_manage_site_visibility_click` with `site_visibility: live`
- In "Site coming soon" there will be two entries, "Manage site visibility" and "Customize coming soon page". They should fire:
    - `launch_your_store_badge_menu_manage_site_visibility_click` with `site_visibility: coming_soon`
    - `launch_your_store_badge_menu_customize_coming_soon_click`


### LYS Settings (PHP Tracks)
To view PHP tracks, go to Woocommerce -> Status, under the Logs tab. Look for the "Tracks" entry with the expected date. If you don't see that, you may have to enable tracking under Woocommerce settings -> Advanced -> WooCommerce.com - Enable tracking

Whenever the site visibility settings are saved, there should be this tracks event:

```
wcadmin_site_visibility_saved: {
    woocommerce_coming_soon: 'yes' | 'no'
    woocommerce_store_pages_only: 'yes' | 'no'
    woocommerce_private_link: 'yes' | 'no'
    woocommerce_coming_soon_toggled?: 'enabled' | 'disabled'
    woocommerce_store_pages_toggled?: 'enabled' | 'disabled'
    woocommerce_private_link_toggled?: 'enabled' | 'disabled'
}
```

Note that the respective 'toggled' properties are optional and only show up if they were changed.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
