### PR TITLE
Remove Launch Your Store Feature Flag

### DIFF
--- a/plugins/woocommerce/changelog/update-lys-feature-flag
+++ b/plugins/woocommerce/changelog/update-lys-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Coming soon mode and the Launch Your Store task.

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -38,6 +38,6 @@
 		"wc-pay-promotion": true,
 		"wc-pay-welcome-page": true,
 		"async-product-editor-category-field": false,
-		"launch-your-store": false
+		"launch-your-store": true
 	}
 }

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -1,9 +1,10 @@
-const { chromium, expect } = require( '@playwright/test' );
+const { chromium, expect, request } = require( '@playwright/test' );
 const { admin, customer } = require( './test-data/data' );
 const fs = require( 'fs' );
 const { site } = require( './utils' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { ENABLE_HPOS } = process.env;
+const { setOption } = require( '.utils/options' );
 
 /**
  * @param {import('@playwright/test').FullConfig} config
@@ -55,6 +56,9 @@ module.exports = async ( config ) => {
 	const customerContext = await browser.newContext( contextOptions );
 	const adminPage = await adminContext.newPage();
 	const customerPage = await customerContext.newPage();
+
+	// Ensure live mode state (coming soon = no)
+	await setOption( request, baseURL, 'woocommerce_coming_soon', 'no' );
 
 	// Sign in as admin user and save state
 	const adminRetries = 5;

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -4,7 +4,7 @@ const fs = require( 'fs' );
 const { site } = require( './utils' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { ENABLE_HPOS } = process.env;
-const { setOption } = require( '.utils/options' );
+const { setOption } = require( './utils/options' );
 
 /**
  * @param {import('@playwright/test').FullConfig} config


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

To prepare the Launch Your Store feature for testing ahead of the 8.9 code freeze, this PR enables the feature flag by default.

<img width="1792" alt="Screen Shot 2024-04-12 at 2 28 40 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/212e361f-054b-4946-bd24-ad047b23da3a">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. On a fresh site.
2. Go to WooCommerce Home.
3. See that the Launch Your Store task is present in the task list.
<img width="1792" alt="Screen Shot 2024-04-12 at 2 28 33 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/6f3ae897-ad13-4446-9e9a-57ecd0ea94bf">

4. Test around this feature (complete the task, and change visibility settings)
<img width="1792" alt="Screen Shot 2024-04-12 at 2 29 11 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/c9bf928a-c910-415a-9f81-2e140223b617">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
