### PR TITLE
[Enhancement]: Block-based checkout - Update address fields display logic

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -15,7 +15,13 @@ import {
 	BillingStateInput,
 	ShippingStateInput,
 } from '@woocommerce/base-components/state-input';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { useShallowEqual } from '@woocommerce/base-hooks';
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -26,6 +32,7 @@ import {
 	FormFieldsConfig,
 } from '@woocommerce/settings';
 import { objectHasProp } from '@woocommerce/types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -71,6 +78,18 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 			hidden: preparedFields.filter( ( field ) => field.hidden ),
 		};
 	}, [ currentFields, currentFieldConfig, currentCountry, addressType ] );
+
+	const [ isAddress2Visible, setIsAddress2Visible ] = useState(
+		objectHasProp( values, 'address_2' ) && values.address_2 !== ''
+	);
+
+	const toggleAddress2Visibility = useCallback(
+		( event: React.MouseEvent< HTMLElement > ) => {
+			event.preventDefault();
+			setIsAddress2Visible( ( prevVisibility ) => ! prevVisibility );
+		},
+		[]
+	);
 
 	// Stores refs for rendered fields so we can access them later.
 	const fieldsRef = useRef<
@@ -147,6 +166,54 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 							} }
 							{ ...fieldProps }
 						/>
+					);
+				}
+
+				if ( field.key === 'address_2' ) {
+					return (
+						<>
+							{ isAddress2Visible ? (
+								<ValidatedTextInput
+									key={ field.key }
+									ref={ ( el ) =>
+										( fieldsRef.current[ field.key ] = el )
+									}
+									{ ...fieldProps }
+									type={ field.type }
+									value={ values[ field.key ] }
+									onChange={ ( newValue: string ) =>
+										onChange( {
+											...values,
+											[ field.key ]: newValue,
+										} )
+									}
+									customValidation={ (
+										inputObject: HTMLInputElement
+									) =>
+										customValidationHandler(
+											inputObject,
+											field.key,
+											objectHasProp( values, 'country' )
+												? values.country
+												: ''
+										)
+									}
+								/>
+							) : (
+								<button
+									key={ `${ field.key }-toggle` }
+									className={
+										'wc-block-components-address-form__address_2-toggle'
+									}
+									onClick={ toggleAddress2Visibility }
+								>
+									{ __(
+										'+ Add apartment, suite, etc.',
+										'woocommerce'
+									) }
+								</button>
+							) }
+						</>
 					);
 				}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -39,6 +39,16 @@
 			.wc-block-components-checkbox {
 				flex: 0 0 100%;
 			}
+
+			.wc-block-components-address-form__address_2-toggle {
+				background: none;
+				border: none;
+				cursor: pointer;
+				font-size: inherit;
+				margin-top: $gap;
+				text-align: left;
+				width: 100%;
+			}
 		}
 	}
 	.wc-block-components-address-form {


### PR DESCRIPTION
> [!CAUTION]
> This PR is blocked until we've clarified the display logic when the `Address ine 2` field is marked as optional, but contains texts, see https://github.com/woocommerce/woocommerce/issues/46512#issuecomment-2051192171.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46512.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
