### PR TITLE
add comment blocks around each enqueued JS chunk

### DIFF
--- a/plugins/woocommerce/changelog/46518-add-queued-js-comments
+++ b/plugins/woocommerce/changelog/46518-add-queued-js-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add handles to enqueued JS, making it easier to filter.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1006,17 +1006,13 @@ function wc_enqueue_js( $code, $handle = '' ) {
 
 	$handle = esc_js( $handle ?: wp_generate_uuid4() );
 
-	$block = implode('', [
-		"\n",
+	$code = implode( "\n", [
 		"/** wc_enqueued_js_start:$handle */",
-		"\n",
 		$code,
-		"\n",
 		"/** wc_enqueued_js_end:$handle */",
-		"\n",
-	]);
+	] );
 
-	$wc_queued_js .= $block;
+	$wc_queued_js .= "\n" . $code . "\n";
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1004,7 +1004,7 @@ function wc_enqueue_js( $code, $handle = '' ) {
 		$wc_queued_js = '';
 	}
 
-	$handle = $handle ?: wp_generate_uuid4();
+	$handle = esc_js( $handle ?: wp_generate_uuid4() );
 
 	$block = implode('', [
 		"\n",

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -995,15 +995,28 @@ function wc_get_image_size( $image_size ) {
  * Queue some JavaScript code to be output in the footer.
  *
  * @param string $code Code.
+ * @param string $handle Handle (optional). Will be generated automatically if not given.
  */
-function wc_enqueue_js( $code ) {
+function wc_enqueue_js( $code, $handle = '' ) {
 	global $wc_queued_js;
 
 	if ( empty( $wc_queued_js ) ) {
 		$wc_queued_js = '';
 	}
 
-	$wc_queued_js .= "\n" . $code . "\n";
+	$handle = $handle ?: wp_generate_uuid4();
+
+	$block = implode('', [
+		"\n",
+		"/** wc_enqueued_js_start:$handle */",
+		"\n",
+		$code,
+		"\n",
+		"/** wc_enqueued_js_end:$handle */",
+		"\n",
+	]);
+
+	$wc_queued_js .= $block;
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a follow-up to #46104 - an alternative approach suggested in [this comment](https://github.com/woocommerce/woocommerce/pull/46104#issuecomment-2038169079).

This PR proposes a 2nd, optional `$handle` parameter for the `wc_enqueue_js` helper. 

The rationale is that filtering enqueued JS usin the existing `woocommerce_queued_js` filter is currently complicated, because all code is instantly concatenated into a single, long string. There is no reliable way to identify code blocks within this string. 

Introducing a handle will solve this issue:
* when a code chunk is enqueued, the handle is used to add comment blocks before and after the enqueued JS
* when no handle is provided, a unique handle is automatically generated

A sample use case for this change is a privacy plugin that tries to remove enqueued analytics or tracking JS based on visitor location.

Note: open to any ideas on what these comment blocks should look like.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enqueue 2 chunks of JS:
```php
wc_enqueue_js( "console.log('Hello, World!')", "hello-handle" ); // here we are providing the handle
wc_enqueue_js( "console.log('Hello, Again!')" ); // notice no handle
```
2. Load any frontend page
   - [ ] Both messages are logged to browser console
3. Inspect the page source
   - [ ] Both JS blocks have start and end comments (like below):
   
```js
/** wc_enqueued_js_start:hello-handle */
console.log('Hello, World!')
/** wc_enqueued_js_end:hello-handle */
/** wc_enqueued_js_start:9ab1f74f-0bae-4a98-ae90-795f2872e072 */
console.log('Hello, Again!')
/** wc_enqueued_js_end:9ab1f74f-0bae-4a98-ae90-795f2872e072 */
```
<!-- End testing instructions -->

Note: the only breaking change here is that the global `$wc_queued_js` is no longer a string, but an array. Given that WC codebase only accesses this global object using the 2 updated functions, I don't see this as a problem. However, there may be 3rd parties that access this variable directly, which may break their implementations.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add handles to enqueued JS, making it easier to filter.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
