### PR TITLE
Increase shipping/payment borders to prevent half pixel issues on high-resolution screens

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/style.scss
@@ -1,7 +1,7 @@
 .wc-block-checkout__shipping-option {
 	.wc-block-components-radio-control__option {
 		margin: 0;
-		padding: em($gap-small) em($gap-small) em($gap-small) em($gap-huge);
+		padding: 0.875em 0.875em 0.875em em($gap-huge);
 	}
 
 	.wc-block-components-shipping-rates-control__no-results-notice {

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -35,7 +35,7 @@
 	// and right of the selected element, and top and bottom of the first/last elements.
 	label.wc-block-components-radio-control__option--checked-option-highlighted,
 	.wc-block-components-radio-control-accordion-option--checked-option-highlighted {
-		box-shadow: 0 0 0 0.1em currentColor inset;
+		box-shadow: 0 0 0 2px currentColor inset;
 		border-radius: 4px;
 	}
 

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -35,7 +35,7 @@
 	// and right of the selected element, and top and bottom of the first/last elements.
 	label.wc-block-components-radio-control__option--checked-option-highlighted,
 	.wc-block-components-radio-control-accordion-option--checked-option-highlighted {
-		box-shadow: 0 0 0 1.5px currentColor inset;
+		box-shadow: 0 0 0 0.1em currentColor inset;
 		border-radius: 4px;
 	}
 

--- a/plugins/woocommerce/changelog/fix-half-pixel-borders
+++ b/plugins/woocommerce/changelog/fix-half-pixel-borders
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes an issue on high-res screens. The bug was not present in any released version
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In #46150 we added a border to shipping and payment methods. On some screen sizes this did now show up correctly.

Changing to 2px rather than 1.5px prevents this.

In this PR it also adds additional padding to the shipping method radio buttons.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add multiple shipping methods to your store.
2. Add an item to your Cart and go to the Checkout block.
3. Test the shipping method selector on different browsers and screen resolutions (You can zoom out using `cmd + -` to also reproduce the issue).
4. You should see even borders around the shipping and payment methods.

Notice in the before picture, the borders are uneven (it is hard to see, though).

| Before | After |
| ------ | ----- |
| <img width="969" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/c05e3aca-a675-4b65-818e-4c85bc1a080a"> | <img width="948" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/b3472194-35dd-45f8-8880-a4697a735340"> |

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
