### PR TITLE
Add Business Services tab to in-app marketplace

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
@@ -19,6 +19,7 @@ import { ProductType } from '../product-list/types';
 const ALL_CATEGORIES_SLUGS = {
 	[ ProductType.extension ]: '_all',
 	[ ProductType.theme ]: 'themes',
+	[ ProductType.businessService ]: 'business-services',
 };
 
 interface CategorySelectorProps {

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -56,6 +56,8 @@ export default function Content(): JSX.Element {
 			params.append( 'category', 'themes' );
 		} else if ( query?.tab === 'search' ) {
 			params.append( 'category', 'extensions-themes' );
+		} else if ( query?.tab === 'business-services' ) {
+			params.append( 'category', 'business-services' );
 		}
 
 		const wccomSettings = getAdminSetting( 'wccomHelper', false );
@@ -111,6 +113,14 @@ export default function Content(): JSX.Element {
 						products={ products }
 						categorySelector={ true }
 						type={ ProductType.theme }
+					/>
+				);
+			case 'business-services':
+				return (
+					<Products
+						products={ products }
+						categorySelector={ true }
+						type={ ProductType.businessService }
 					/>
 				);
 			case 'search':

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list/types.ts
@@ -57,6 +57,7 @@ export interface ProductTracksData {
 export enum ProductType {
 	theme = 'theme',
 	extension = 'extension',
+	businessService = 'businessService',
 }
 
 export enum SearchResultType {

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.scss
@@ -1,6 +1,7 @@
 .woocommerce-marketplace {
 	&__search-extensions,
-	&__search-themes {
+	&__search-themes,
+	&__search-business-services {
 		margin-bottom: 48px;
 	}
 	&__view-all-button {

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -47,6 +47,10 @@ const LABELS = {
 		label: __( 'themes', 'woocommerce' ),
 		singularLabel: __( 'theme', 'woocommerce' ),
 	},
+	[ ProductType.businessService ]: {
+		label: __( 'business services', 'woocommerce' ),
+		singularLabel: __( 'business service', 'woocommerce' ),
+	},
 };
 
 export default function Products( props: ProductsProps ) {
@@ -108,18 +112,23 @@ export default function Products( props: ProductsProps ) {
 		);
 	}
 
+	const labelForClassName =
+		label === 'business services' ? 'business-services' : label;
+
 	const baseContainerClass = 'woocommerce-marketplace__search-';
 	const baseProductListTitleClass = 'product-list-title--';
 
-	const containerClassName = classnames( baseContainerClass + label );
+	const containerClassName = classnames(
+		baseContainerClass + labelForClassName
+	);
 	const productListTitleClassName = classnames(
 		'woocommerce-marketplace__product-list-title',
-		baseContainerClass + baseProductListTitleClass + label,
+		baseContainerClass + baseProductListTitleClass + labelForClassName,
 		{ 'is-loading': isLoading }
 	);
 	const viewAllButonClassName = classnames(
 		'woocommerce-marketplace__view-all-button',
-		baseContainerClass + 'button-' + label
+		baseContainerClass + 'button-' + labelForClassName
 	);
 
 	if ( products.length === 0 ) {

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -60,6 +60,12 @@ const tabs: Tabs = {
 		showUpdateCount: false,
 		updateCount: 0,
 	},
+	'business-services': {
+		name: 'business-services',
+		title: __( 'Business services', 'woocommerce' ),
+		showUpdateCount: false,
+		updateCount: 0,
+	},
 	'my-subscriptions': {
 		name: 'my-subscriptions',
 		title: __( 'My subscriptions', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We're introducing a new Business Services product type in the WooCommerce.com marketplace. These products will be listed on their own tab in the marketplace, and this needs to be reflected on the in-app marketplace as well.

Closes https://github.com/Automattic/woocommerce.com/issues/19973

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch
2. Go to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
3. Visit the [in-app marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions)
4. Confirm you see a Business Services tab listed after Themes
5. Confirm you can switch between the new tab and the other existing tabs
6. You won't results for the tab since we haven't implemented the search API for the new product type yet
7. Open `plugins/woocommerce-admin/client/marketplace/components/content/content.tsx` and comment out lines 59 and 60
8. Rebuild the project and refresh the in-app marketplace
9. Now the Business Services tab will show regular extension product cards, but it should show the count at the top with the Business Services label
10. Test around this issue

<!-- End testing instructions -->
![Cursor_and_Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/5297a276-d269-4eea-abf5-ccfadf0d7714)

![Cursor_and_Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/dd3979f6-d718-40e5-add4-ec5f5f045e27)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
