### PR TITLE
Fix coming soon page fatal error with non-FSE theme

### DIFF
--- a/plugins/woocommerce/changelog/46570-fix-coming-soon-page-fatal-error
+++ b/plugins/woocommerce/changelog/46570-fix-coming-soon-page-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coming soon page fatal error with non-FSE theme

--- a/plugins/woocommerce/patterns/coming-soon-store-only.php
+++ b/plugins/woocommerce/patterns/coming-soon-store-only.php
@@ -9,7 +9,12 @@
 
 ?>
 
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<?php
+if ( wc_current_theme_is_fse_theme() ) {
+	echo '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->';
+}
+?>
+
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -31,5 +36,10 @@
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
 
+
+<?php
+if ( wc_current_theme_is_fse_theme() ) {
+	echo '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->';
+}
+?>

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\Templates\ProductCatalogTemplate;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
+use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
 
 /**
  * BlockTypesController class.
@@ -331,12 +332,13 @@ class BlockTemplatesController {
 	 * @return array
 	 */
 	public function add_block_templates( $query_result, $query, $template_type ) {
-		if ( ! BlockTemplateUtils::supports_block_templates( $template_type ) ) {
+		$slugs = isset( $query['slug__in'] ) ? $query['slug__in'] : array();
+
+		if ( ! BlockTemplateUtils::supports_block_templates( $template_type ) && ! in_array( ComingSoonTemplate::SLUG, $slugs, true ) ) {
 			return $query_result;
 		}
 
 		$post_type      = isset( $query['post_type'] ) ? $query['post_type'] : '';
-		$slugs          = isset( $query['slug__in'] ) ? $query['slug__in'] : array();
 		$template_files = $this->get_block_templates( $slugs, $template_type );
 		$theme_slug     = wp_get_theme()->get_stylesheet();
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
@@ -53,7 +53,9 @@ class BlockTemplatesRegistry {
 				SingleProductTemplate::SLUG        => new SingleProductTemplate(),
 			);
 		} else {
-			$templates = array();
+			$templates = array(
+				ComingSoonTemplate::SLUG => new ComingSoonTemplate(),
+			);
 		}
 		if ( BlockTemplateUtils::supports_block_templates( 'wp_template_part' ) ) {
 			$template_parts = array(

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -70,7 +70,16 @@ class ComingSoonRequestHandler {
 		add_theme_support( 'block-template-parts' );
 
 		$template = get_query_template( 'coming-soon' );
+
+		if ( ! wc_current_theme_is_fse_theme() && $this->coming_soon_helper->is_store_coming_soon() ) {
+			get_header();
+		}
+
 		include $template;
+
+		if ( ! wc_current_theme_is_fse_theme() && $this->coming_soon_helper->is_store_coming_soon() ) {
+			get_footer();
+		}
 
 		die();
 	}

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -67,7 +67,6 @@ class ComingSoonRequestHandler {
 		// A coming soon page needs to be displayed. Don't cache this response.
 		nocache_headers();
 		add_theme_support( 'block-templates' );
-		add_theme_support( 'block-template-parts' );
 
 		$template = get_query_template( 'coming-soon' );
 

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -66,6 +66,8 @@ class ComingSoonRequestHandler {
 
 		// A coming soon page needs to be displayed. Don't cache this response.
 		nocache_headers();
+		add_theme_support( 'block-templates' );
+		add_theme_support( 'block-template-parts' );
 
 		$template = get_query_template( 'coming-soon' );
 		include $template;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/304.

Fix coming soon page fatal error with non-FSE themes

<img width="1137" alt="Screenshot 2024-04-15 at 15 15 48" src="https://github.com/woocommerce/woocommerce/assets/4344253/75d937fe-dc66-4b03-9f1d-0ff767879cdd">


This PR only fixes the fatal error.

we still need to

1. fix font and styles issues with classic themes when the coming soon page is enabled for all site pages.

2. Woocommerce Breadcrumb (Additional `Home` text` in screenshot above) is rendered in the coming soon page with StoreFront I think we should remove it as well. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create JN site with `launch-your-store` feature flag enabled.
2. After the profiler, set `Restrict to store pages only` toggled on
3. Change your theme to Storefront or any other non-FSE theme
4. Visit a store page in incognito mode, you should see the coming soon page without any fatal error

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix coming soon page fatal error with non-FSE theme

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
