### PR TITLE
performance: checks fo $this->data_synchronizer->data_sync_is_enabled…

### DIFF
--- a/plugins/woocommerce/changelog/46616-fix-46556
+++ b/plugins/woocommerce/changelog/46616-fix-46556
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Avoid unnecessary query when HPOS compatibility mode is disabled.

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -74,8 +74,11 @@ class COTMigrationUtil {
 	 * @return bool
 	 */
 	public function is_custom_order_tables_in_sync() : bool {
+		if(!$this->data_synchronizer->data_sync_is_enabled()) {
+			return false;
+		}
 		$sync_status = $this->data_synchronizer->get_sync_status();
-		return 0 === $sync_status['current_pending_count'] && $this->data_synchronizer->data_sync_is_enabled();
+		return 0 === $sync_status['current_pending_count'];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -74,9 +74,10 @@ class COTMigrationUtil {
 	 * @return bool
 	 */
 	public function is_custom_order_tables_in_sync() : bool {
-		if(!$this->data_synchronizer->data_sync_is_enabled()) {
+		if ( ! $this->data_synchronizer->data_sync_is_enabled() ) {
 			return false;
 		}
+
 		$sync_status = $this->data_synchronizer->get_sync_status();
 		return 0 === $sync_status['current_pending_count'];
 	}


### PR DESCRIPTION
…() before executing $this->data_synchronizer->get_sync_status()

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46556 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Before checking out this branch, install the Query Monitor plugin on your test site.
2. Navigate to the WooCommerce > Settings > Advanced > Features screen in WP Admin. Ensure that High-performance order storage is enabled, and compatibility mode is disabled.
3. Open the Query Monitor console, click on "Database Queries", and then "Queries by Caller". Find the caller with the name that's something like `Automattic\W\I\D\O\DataSynchronizer->get_current_orders_pending_sync_count()`. Note the number of queries being run by this caller.
4. Add this snippet to your site (in an mu-plugin file for example):
    ```php
	use Automattic\WooCommerce\Utilities\OrderUtil;
	add_action(
		'admin_init',
		function() {
			OrderUtil::is_custom_order_tables_in_sync();
		}
	);
    ```
5. Refresh the screen and check the QM console again. The number of queries for our caller should be higher now.
6. Now check out this branch (or apply this PR's changeset as a patch) and refresh the screen again. The number of queries should be back at its original number, indicating that `OrderUtil::is_custom_order_tables_in_sync()` is no longer causing extra queries to run when compatibility mode is disabled.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Avoid unnecessary query when HPOS compatibility mode is disabled.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
