### PR TITLE
Fix marketplace promotions action scheduler

### DIFF
--- a/plugins/woocommerce/changelog/fix-marketplace-promotions-action-scheduler
+++ b/plugins/woocommerce/changelog/fix-marketplace-promotions-action-scheduler
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Defensive coding for when Action Scheduler function as_has_scheduled_action is not defined.
+
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -38,18 +38,16 @@ class WC_Admin_Marketplace_Promotions {
 	 * @return void
 	 */
 	public static function init() {
-		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
-
 		/**
 		 * Filter to suppress the requests for and showing of marketplace promotions.
 		 *
 		 * @since 8.8
 		 */
 		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
-			add_action( 'init', array( __CLASS__, 'clear_scheduled_event' ), 13 );
-
 			return;
 		}
+
+		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
 
 		// Add the callback for our scheduled action.
 		if ( ! has_action( self::SCHEDULED_ACTION_HOOK, array( __CLASS__, 'fetch_marketplace_promotions' ) ) ) {
@@ -77,7 +75,11 @@ class WC_Admin_Marketplace_Promotions {
 	 */
 	public static function schedule_promotion_fetch() {
 		// Schedule the action twice a day using Action Scheduler.
-		if ( false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK ) ) {
+		if (
+			function_exists( 'as_has_scheduled_action' )
+			&& function_exists( 'as_schedule_recurring_action' )
+			&& false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK )
+		) {
 			as_schedule_recurring_action( time(), self::SCHEDULED_ACTION_INTERVAL, self::SCHEDULED_ACTION_HOOK );
 		}
 	}
@@ -295,7 +297,9 @@ class WC_Admin_Marketplace_Promotions {
 	 * @return void
 	 */
 	public static function clear_scheduled_event() {
-		as_unschedule_all_actions( self::SCHEDULED_ACTION_HOOK );
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( self::SCHEDULED_ACTION_HOOK );
+		}
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce 8.8.1 introduced some code dependent on Action Scheduler 3.3+. Under normal circumstances that'd be ok, as this WooCommerce version comes bundled with A-S 3.7.0. But other plugins that also bundle A-S might be loading their version of A-S unusually early, preventing the one in WC from loading. In this situation, activating WooCommerce would give rise to this fatal error.

```
PHP Fatal error:  Uncaught Error: Call to undefined function as_has_scheduled_action() in /wordpress/plugins/woocommerce/8.8.1/includes/admin/class-wc-admin-marketplace-promotions.php:80
Stack trace:
#0 /wordpress/core/6.5.2/wp-includes/class-wp-hook.php(324): WC_Admin_Marketplace_Promotions::schedule_promotion_fetch('')
#1 /wordpress/core/6.5.2/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#2 /wordpress/core/6.5.2/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /wordpress/core/6.5.2/wp-settings.php(695): do_action('init')
#4 /srv/htdocs/wp-config.php(81): require_once('/wordpress/core...')
#5 /wordpress/core/6.5.2/wp-load.php(55): require_once('/srv/htdocs/wp-...')
#6 /wordpress/core/6.5.2/wp-admin/admin-ajax.php(22): require_once('/wordpress/core...')
#7 {main}
  thrown in /wordpress/plugins/woocommerce/8.8.1/includes/admin/class-wc-admin-marketplace-promotions.php on line 80
```

This PR adds defensive checks to `WC_Admin_Marketplace_Promotions` to ensure A-S functions are available before it calls them.

### Notes

- Other parts of WooCommerce also call `as_has_scheduled_action`: [BatchProcessingController](https://github.com/woocommerce/woocommerce/blob/c752c60fd40fdc976381fcf9c8b248f2e3666999/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php#L114) and [TransientFilesEngine](https://github.com/woocommerce/woocommerce/blob/eb9723e5e0b3b1b2000f21ec335823e87ee31ed1/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php#L317). However, these other calls do not cause errors which totally break wp-admin. This critical error seems more urgent, so I haven't touched those other areas in this PR. I've created a separate issue for them: https://github.com/woocommerce/woocommerce/issues/46632.
- I'm currently seeing an issue on my local wp-env environment on the marketplace Discover tab http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=extensions&path=%2Fextensions. The page's request to https://woocommerce.test/wp-json/wccom-extensions/2.0/featured is returning `cURL error 35: OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to [woocommerce.com:443](http://woocommerce.com:443/)`. So the content isn't rendered. This is not related to the current change: it happens in trunk too. It's probably due to local configuration on wp-env.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Disable WooCommerce in your local testing environment.
2. Check out this branch. Build WooCommerce:

```bash
nvm use
pnpm install
pnpm build
```

3. Install and activate WP Mail SMTP 2.8.0. You can use this file: [wp-mail-smtp.2.8.0.zip](https://github.com/woocommerce/woocommerce/files/14994676/wp-mail-smtp.2.8.0.zip). 
4. Activate WooCommerce. You should be able to view wp-admin without getting the fatal error.

#### Testing the marketplace promotions still work

5. Deactivate WP Mail SMTP.
6. Edit `plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php` and replace line 97 with this. This makes a request to a gist with dummy data that is valid until 1 May.

```php
$raw_promotions = wp_safe_remote_get( 'https://gist.githubusercontent.com/andfinally/acd8646151c0108f92979c985c20a0d8/raw/promotions.json' );
```
7. On line 21, change the frequency of the scheduled action to five minutes:

```php
const SCHEDULED_ACTION_INTERVAL = 5 * MINUTE_IN_SECONDS;
```

8. Visit the [pending scheduled actions page](http://localhost:8888/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending) and search for `woocommerce_marketplace_fetch_promotions`. If there's a pending action, cancel it using the "cancel" hover link under it in the list. A new action should be scheduled.
9. After 5 minutes or so, the action should run. (You may need to jog it by viewing a page on your test site.)
10. The menu bubble should appear on the `WooCommerce > Extensions` menu item, and the notice should appear on Marketplace pages like `http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions`.

<p>
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/218533c2-3ba4-4506-b3f7-c48d2cbde244">
</p>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>