### PR TITLE
Allow enbling HPOS when the only incompatible plugin is the Legacy REST API one

### DIFF
--- a/plugins/woocommerce/changelog/pr-46634
+++ b/plugins/woocommerce/changelog/pr-46634
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow enbling HPOS when the only incompatible plugin is the Legacy REST API one

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -457,7 +457,9 @@ class CustomOrdersTableController {
 			$sync_complete        = 0 === $this->get_orders_pending_sync_count();
 			$disabled             = array();
 			// Changing something here? might also want to look at `enable|disable` functions in CLIRunner.
-			if ( count( array_merge( $plugin_compatibility['uncertain'], $plugin_compatibility['incompatible'] ) ) > 0 ) {
+			$incompatible_plugins = array_merge( $plugin_compatibility['uncertain'], $plugin_compatibility['incompatible'] );
+			$incompatible_plugins = array_diff( $incompatible_plugins, $this->plugin_util->get_plugins_excluded_from_compatibility_ui() );
+			if ( count( $incompatible_plugins ) > 0 ) {
 				$disabled = array( 'yes' );
 			}
 			if ( ! $sync_complete && ! $this->changing_data_source_with_sync_pending_is_allowed() ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -437,7 +437,7 @@ class CustomOrdersTableController {
 			return array();
 		}
 
-		$get_value = function() {
+		$get_value = function () {
 			return $this->custom_orders_table_usage_is_enabled() ? 'yes' : 'no';
 		};
 
@@ -446,13 +446,13 @@ class CustomOrdersTableController {
 		 * gets called while it's still being instantiated and creates and endless loop.
 		 */
 
-		$get_desc = function() {
+		$get_desc = function () {
 			$plugin_compatibility = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
 
 			return $this->plugin_util->generate_incompatible_plugin_feature_warning( 'custom_order_tables', $plugin_compatibility );
 		};
 
-		$get_disabled = function() {
+		$get_disabled = function () {
 			$plugin_compatibility = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
 			$sync_complete        = 0 === $this->get_orders_pending_sync_count();
 			$disabled             = array();
@@ -495,11 +495,11 @@ class CustomOrdersTableController {
 			return array();
 		}
 
-		$get_value = function() {
+		$get_value = function () {
 			return get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION );
 		};
 
-		$get_sync_message = function() {
+		$get_sync_message = function () {
 			$orders_pending_sync_count = $this->get_orders_pending_sync_count();
 			$sync_in_progress          = $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) );
 			$sync_enabled              = $this->data_synchronizer->data_sync_is_enabled();
@@ -578,7 +578,7 @@ class CustomOrdersTableController {
 			return implode( '<br />', $sync_message );
 		};
 
-		$get_description_is_error = function() {
+		$get_description_is_error = function () {
 			$sync_is_pending = $this->get_orders_pending_sync_count() > 0;
 
 			return $sync_is_pending && $this->changing_data_source_with_sync_pending_is_allowed();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/45610 we excluded the Legacy REST API plugin from the feature compatibility UI, but there was an oversight: the UI for changing the orders data storage between posts and the orders table (in WooCommerce - Settings - Features) was still disabled if the Legacy REST API plugin was active. This pull request fixes that.

### How to test the changes in this Pull Request:

1. Install WooCommerce with this fix in a new site.
2. Install and activate [the dedicated Legacy REST API extension](https://wordpress.org/plugins/woocommerce-legacy-rest-api/).
4. Go to the features settings page (WooCommerce - Settings - Advanced - Features).
5. Verify that the radio buttons for "Order data storage" are enabled and you are able to switch between data storages.
9. Now install another HPOS-incompatible plugin, for example [WooCommerce Square](https://wordpress.org/plugins/woocommerce-square/advanced/). Make sure to download the ZIP file for a version before 3.3.0, as that version started declaring HPOS compatibility. 
10. Reload the features page, this time the radio buttons for "Order data storage" are disabled as expected.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
