### PR TITLE
[Product Block Editor]: remove unused markedAttributes object

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-remoce-unused-memo-in-attributes-field
+++ b/packages/js/product-editor/changelog/update-product-editor-remoce-unused-memo-in-attributes-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: remove unused markedAttributes object

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Spinner } from '@wordpress/components';
-import { createElement, useMemo } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTES_STORE_NAME,
 	WCDataSelector,
@@ -37,7 +37,6 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 	placeholder,
 	label,
 	disabled,
-	disabledAttributeIds = [],
 	disabledAttributeMessage,
 	ignoredAttributeIds = [],
 	createNewAttributesAsGlobal = false,
@@ -57,18 +56,6 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 			attributes: getProductAttributes(),
 		};
 	} );
-
-	const markedAttributes = useMemo(
-		function setDisabledAttribute() {
-			return (
-				attributes?.map( ( attribute: NarrowedQueryAttribute ) => ( {
-					...attribute,
-					isDisabled: disabledAttributeIds.includes( attribute.id ),
-				} ) ) ?? []
-			);
-		},
-		[ attributes, disabledAttributeIds ]
-	);
 
 	function isNewAttributeListItem(
 		attribute: NarrowedQueryAttribute
@@ -148,7 +135,7 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 	return (
 		<SelectControl< NarrowedQueryAttribute >
 			className="woocommerce-attribute-input-field"
-			items={ markedAttributes || [] }
+			items={ attributes || [] }
 			label={ label || '' }
 			disabled={ disabled }
 			getFilteredItems={ getFilteredItems }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a janitorial PR that removes an unneeded `markedAttributes` object.

`markedAttributes` is a copy of `attributes` but populates every with the `isDisabled` property. `markedAttributes` defines the `items` property of the SelectControl component. However, after researching the code, afaics,`isDisabled` is not used for any component.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46636

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The `markedAttributes` defines the `isDisabled` property for every item. Inspect the code and confirm this property is not consumed by any component:


1. Here the [isDisabled](https://github.com/woocommerce/woocommerce/blob/7d414722069f6db1cb1313ff8db9f3b5a693c910/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx#L66) is set
2. it defines the [items](https://github.com/woocommerce/woocommerce/blob/b73de2ae4abf2b0b80e72afbfa0b5d65610f9885/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx#L151) SelectControl property
3. In the SelectControl component, it defines the [filteredItems](https://github.com/woocommerce/woocommerce/blob/b73de2ae4abf2b0b80e72afbfa0b5d65610f9885/packages/js/components/src/experimental-select-control/select-control.tsx#L155) constant...
4. ...which is passed down to the useComboboxComponent hook, [here](https://github.com/woocommerce/woocommerce/blob/b73de2ae4abf2b0b80e72afbfa0b5d65610f9885/packages/js/components/src/experimental-select-control/select-control.tsx#L195).
5. Finally, confirm the `isDisable` isn't expected for the hook. [This is the core file](https://github.com/downshift-js/downshift/blob/master/src/hooks/useCombobox/index.js).

Also, confirm the app works as expected: create new attributes, add options, etc.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
