### PR TITLE
[CFT Custom fields] Fix copy and link

### DIFF
--- a/packages/js/product-editor/changelog/fix-46540
+++ b/packages/js/product-editor/changelog/fix-46540
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add custom fields tracking events

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -5,12 +5,14 @@ import { Button, Modal } from '@wordpress/components';
 import { createElement, useState, useRef, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
+import { recordEvent } from '@woocommerce/tracks';
 import classNames from 'classnames';
 import type { FocusEvent } from 'react';
 
 /**
  * Internal dependencies
  */
+import { TRACKS_SOURCE } from '../../../constants';
 import { TextControl } from '../../text-control';
 import { validate, type ValidationErrors } from '../utils/validations';
 import type { Metadata } from '../../../types';
@@ -122,6 +124,10 @@ export function CreateModal( {
 				{ ...DEFAULT_CUSTOM_FIELD, id: ( lastField.id ?? 0 ) + 1 },
 			];
 		} );
+
+		recordEvent( 'product_custom_fields_add_another_button_click', {
+			source: TRACKS_SOURCE,
+		} );
 	}
 
 	function handleAddButtonClick() {
@@ -161,6 +167,14 @@ export function CreateModal( {
 		onCreate(
 			customFields.map( ( { id, ...customField } ) => customField )
 		);
+
+		recordEvent( 'product_custom_fields_add_new_button_click', {
+			source: TRACKS_SOURCE,
+			custom_field_names: customFields.map(
+				( customField ) => customField.key
+			),
+			total: customFields.length,
+		} );
 	}
 
 	return (

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -5,11 +5,13 @@ import { Button } from '@wordpress/components';
 import { createElement, Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
+import { recordEvent } from '@woocommerce/tracks';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import { TRACKS_SOURCE } from '../../constants';
 import { useCustomFields } from '../../hooks/use-custom-fields';
 import { CreateModal } from './create-modal';
 import { EditModal } from './edit-modal';
@@ -35,6 +37,10 @@ export function CustomFields( {
 
 	function handleAddNewButtonClick() {
 		setShowCreateModal( true );
+
+		recordEvent( 'product_custom_fields_show_add_modal', {
+			source: TRACKS_SOURCE,
+		} );
 	}
 
 	function customFieldEditButtonClickHandler(
@@ -42,6 +48,12 @@ export function CustomFields( {
 	) {
 		return function handleCustomFieldEditButtonClick() {
 			setSelectedCustomField( customField );
+
+			recordEvent( 'product_custom_fields_show_edit_modal', {
+				source: TRACKS_SOURCE,
+				custom_field_id: customField.id,
+				custom_field_name: customField.key,
+			} );
 		};
 	}
 
@@ -50,6 +62,12 @@ export function CustomFields( {
 	) {
 		return function handleCustomFieldRemoveButtonClick() {
 			removeCustomField( customField );
+
+			recordEvent( 'product_custom_fields_remove_button_click', {
+				source: TRACKS_SOURCE,
+				custom_field_id: customField.id,
+				custom_field_name: customField.key,
+			} );
 		};
 	}
 
@@ -60,6 +78,10 @@ export function CustomFields( {
 
 	function handleCreateModalCancel() {
 		setShowCreateModal( false );
+
+		recordEvent( 'product_custom_fields_cancel_add_modal', {
+			source: TRACKS_SOURCE,
+		} );
 	}
 
 	function handleEditModalUpdate( customField: Metadata< string > ) {
@@ -69,6 +91,10 @@ export function CustomFields( {
 
 	function handleEditModalCancel() {
 		setSelectedCustomField( undefined );
+
+		recordEvent( 'product_custom_fields_cancel_edit_modal', {
+			source: TRACKS_SOURCE,
+		} );
 	}
 
 	return (

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -4,12 +4,14 @@
 import { Button, Modal } from '@wordpress/components';
 import { createElement, useState, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 import classNames from 'classnames';
 import type { FocusEvent } from 'react';
 
 /**
  * Internal dependencies
  */
+import { TRACKS_SOURCE } from '../../../constants';
 import { TextControl } from '../../text-control';
 import type { Metadata } from '../../../types';
 import { type ValidationError, validate } from '../utils/validations';
@@ -71,6 +73,13 @@ export function EditModal( {
 		}
 
 		onUpdate( customField );
+
+		recordEvent( 'product_custom_fields_update_button_click', {
+			source: TRACKS_SOURCE,
+			custom_field_id: customField.id,
+			custom_field_name: customField.key,
+			prev_custom_field_name: initialValue.key,
+		} );
 	}
 
 	return (

--- a/plugins/woocommerce/changelog/fix-46540
+++ b/plugins/woocommerce/changelog/fix-46540
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the link in the custom field helper test

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -539,7 +539,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'title'       => __( 'Custom fields', 'woocommerce' ),
 						'description' => sprintf(
 							/* translators: %1$s: Custom fields guide link opening tag. %2$s: Custom fields guide link closing tag. */
-							__( 'Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or internal inventory organization. %1$sRead more about custom fields%2$s', 'woocommerce' ),
+							__( 'Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. %1$sRead more about custom fields%2$s', 'woocommerce' ),
 							'<a href="https://woocommerce.com/document/custom-product-fields/" target="_blank" rel="noreferrer">',
 							'</a>'
 						),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -540,7 +540,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'description' => sprintf(
 							/* translators: %1$s: Custom fields guide link opening tag. %2$s: Custom fields guide link closing tag. */
 							__( 'Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or internal inventory organization. %1$sRead more about custom fields%2$s', 'woocommerce' ),
-							'<a href="https://wordpress.org/documentation/article/assign-custom-fields/" target="_blank" rel="noreferrer">',
+							'<a href="https://woocommerce.com/document/custom-product-fields/" target="_blank" rel="noreferrer">',
 							'</a>'
 						),
 					),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46540
Related to #44169

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` -> `Add new` from the left menu to create a new product
4. Then go to the `Organization` tab
5. At the end of the page a new `Show custom fields` toggle should be shown
6. The link in the helper text should be replaced with this one: [https://woocommerce.com/document/custom-product-fields/](https://href.li/?https://woocommerce.com/document/custom-product-fields/) <img width="355" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/10e22c76-4a43-44fd-b100-aa9461933d16">
7. The tooltip wording should be changed from "or internal inventory organization" to “or for internal inventory organization”.
8. When `Enable WooCommerce Analytics` is enabled from `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` in the browser DevTools the following events should be sown.
  - When toggle the `Show custom fields` <img width="838" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/66e9f6b9-fa43-4a2e-9799-528368906810">
  - When clicking the `Add new` button <img width="840" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/cae3ddd5-8c81-4161-95e7-ff029f36f42e">
  - When clicking `+ Add another` button from the `Add custom field` modal <img width="839" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/ad154cd7-f436-4bfb-9140-146ab454a4b5">
  - When clicking `Add` button from the `Add custom field` modal <img width="819" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/128b5097-0811-49dc-9525-25fda78f8406">
  - When clicking `Cancel` button from the `Add custom field` modal <img width="840" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/02cfc6df-edc6-4509-8a9d-a57944a3d092">
  - When clicking `Edit` button from the table <img width="825" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/64938ea2-55bc-4bb1-a3fc-e004067607f7">
  - When clicking `Update` button from the `Edit ...` modal <img width="847" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/9402c9e3-9e28-4b13-9f0e-4076bbcfe42a">
  - When clicking `Cancel` button from the `Edit ...` modal <img width="839" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/5fa1c5fb-1627-4bb7-9883-2d6734dcdc68">
  - When clicking `X` button from the table <img width="839" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c1dd9717-c3f8-4a81-ae90-d7332ed2b7d6">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
