### PR TITLE
Set access modifier for $error_message to public and added a setter method

### DIFF
--- a/plugins/woocommerce/changelog/46642-fix-set_property_access_modifier_to_public
+++ b/plugins/woocommerce/changelog/46642-fix-set_property_access_modifier_to_public
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed a bug causing incompatibility with 3rd-party coupon extensions when certain conditions were met.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -84,9 +84,14 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	/**
 	 * Error message.
 	 *
+	 * This property should not be considered public API, and should not be accessed directly.
+	 * It is being added to supress PHP > 8.0 warnings against dynamic property creation, and all access
+	 * should be through the getter and setter methods, namely `get_error_message()` and `set_error_message()`.
+	 * In the future, the access modifier may be changed back to protected.
+	 *
 	 * @var string
 	 */
-	protected $error_message;
+	public $error_message;
 
 	/**
 	 * Sorting.
@@ -869,6 +874,17 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 */
 	public function get_error_message() {
 		return $this->error_message;
+	}
+
+	/**
+	 * Sets the error_message string.
+	 *
+	 * @param string $message Message string.
+	 *
+	 * @return void
+	 */
+	public function set_error_message( string $message ) {
+		$this->error_message = $message;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the access modifier for the `WC_Coupon::error_message` property from `protected` to `public`. This property was previously created dynamically, and in PHP the default access modifier for dynamic properties is `public`. Due to third-party extensions accessing it directly after it was explicitly declared as `protected`, a fatal error is produced, breaking third-party compatibility with WooCommerce 8.8.0.
A public setter method `WC_Coupon::set_error_message()` was also added, providing the recommended way to have write access to this property, which in the future might be changed back to `protected`.

Closes #46645

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WC 8.8.0 and [WooCommerce Smart Coupons](https://woocommerce.com/products/smart-coupons/)
2. Create a coupon with auto-apply to cart, and exclude a product from it
3. Add that very same product to the cart, and observe no critical error is displayed

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixed a bug causing incompatibility with 3rd-party coupon extensions when certain conditions were met.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
