### PR TITLE
Remove unneeded empty "Unknown" code handling in Order Attribution

### DIFF
--- a/plugins/woocommerce/changelog/remove-order-attribution-empty-unknown-handling
+++ b/plugins/woocommerce/changelog/remove-order-attribution-empty-unknown-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Remove unneeded empty "Unknown" code handling in Order Attribution.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -335,9 +335,6 @@ class OrderAttributionController implements RegisterHooksInterface {
 		$source_type = $order->get_meta( $this->get_meta_prefixed_field_name( 'source_type' ) );
 		$source      = $order->get_meta( $this->get_meta_prefixed_field_name( 'utm_source' ) );
 		$origin      = $this->get_origin_label( $source_type, $source );
-		if ( empty( $origin ) ) {
-			$origin = __( 'Unknown', 'woocommerce' );
-		}
 		echo esc_html( $origin );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In this PR, we remove an unneeded code block in Order Attribution feature.

The following is the code block being removed in `OrderAttributionController.php`:

```php
		if ( empty( $origin ) ) {
			$origin = __( 'Unknown', 'woocommerce' );
		}
```

`$origin` comes from `get_origin_label`, and `get_origin_label` would return "Unknown" by default, and therefore `empty($origin)` would not be true.

If someone uses a `wc_order_attribution_origin_formatted_source` filter (used inside `get_origin_label`) to return `''` as the formatted source, we should respect it anyway and we should not override it with "Unknown".

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This is a code tidying PR. It should not change any WooCommerce default behavior.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
