### PR TITLE
Use default state ordering in the Checkout block instead of sorting alphabetically

### DIFF
--- a/plugins/woocommerce/changelog/fix-state-order
+++ b/plugins/woocommerce/changelog/fix-state-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the default ordering of states in the Checkout block

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -62,7 +62,7 @@ class CartCheckoutUtils {
 			$country_data[ $country_code ] = [
 				'allowBilling'  => isset( $billing_countries[ $country_code ] ),
 				'allowShipping' => isset( $shipping_countries[ $country_code ] ),
-				'states'        => self::deep_sort_with_accents( $country_states[ $country_code ] ?? [] ),
+				'states'        => $country_states[ $country_code ] ?? [],
 				'locale'        => $country_locales[ $country_code ] ?? [],
 			];
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the wrapping `deep_sort_with_accents` function when adding the states to `countryData` in the asset data registry.

The states come from `wc()->countries->get_states()` which returns them in the "default" order. Applying alphabetical sorting to this means we are ignoring the result of the `woocommerce_states` filter.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45280 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an item to your cart and load the Checkout block.
2. In the shipping address form, choose United States as the country.
3. In the state input, check the states are in alphabetical order.
4. Scroll down to the bottom of this list and ensure the "Armed forces (xx)" options come last.
5. Change country to Algeria
6. Go to states and ensure the list starts with: Adrar, Chlef, Laghouat. Note that they are not sorted alphabetically, but rather by "state code" (not visible to the merchant)
7. Repeat these steps for the billing address too.
8. Check out and ensure the checkout works OK and the selected state shows up on the order confirmation screen correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
