### PR TITLE
Add E2E tests to cover Publish dropdown options

### DIFF
--- a/plugins/woocommerce/changelog/dev-46593_e2e_test_publish_dropdown
+++ b/plugins/woocommerce/changelog/dev-46593_e2e_test_publish_dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add E2E tests to cover Publish dropdown options #46658

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
@@ -80,3 +80,70 @@ test( 'can update the general information of a product', async ( {
 			.toHaveText( updatedProduct.description );
 	} );
 } );
+
+test( 'can schedule a product publication', async ( { page, product } ) => {
+	await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
+
+	await page
+		.locator( '.woocommerce-product-header__actions' )
+		.first()
+		.locator( 'button[aria-label="More options"]' )
+		.click();
+
+	await page.getByText( 'Schedule publish' ).click();
+
+	await expect(
+		page.getByRole( 'heading', { name: 'Schedule product' } )
+	).toBeVisible();
+
+	await page
+		.locator( '.woocommerce-schedule-publish-modal' )
+		.locator( 'button[aria-label="View next month"]' )
+		.click();
+
+	await page
+		.locator( '.woocommerce-schedule-publish-modal' )
+		.getByText( '14' )
+		.click();
+
+	await page.getByRole( 'button', { name: 'Schedule' } ).click();
+
+	await expect(
+		page.getByLabel( 'Dismiss this notice' ).first()
+	).toContainText( 'Product scheduled for' );
+
+	await page
+		.locator( '.woocommerce-product-header__actions' )
+		.first()
+		.locator( 'button[aria-label="More options"]' )
+		.click();
+
+	await page.getByText( 'Copy to a new draft' ).click();
+
+	await expect(
+		page.getByLabel( 'Dismiss this notice' ).first()
+	).toContainText( 'Product successfully duplicated' );
+
+	await expect(
+		page.getByRole( 'heading', { name: `${ product.name } (Copy)` } )
+	).toBeVisible();
+
+	await expect(
+		page
+			.locator( '.woocommerce-product-header__visibility-tags' )
+			.getByText( 'Draft' )
+			.first()
+	).toBeVisible();
+
+	await page
+		.locator( '.woocommerce-product-header__actions' )
+		.first()
+		.locator( 'button[aria-label="More options"]' )
+		.click();
+
+	await page.getByText( 'Move to trash' ).click();
+
+	await expect(
+		page.getByRole( 'heading', { name: 'Products' } ).first()
+	).toBeVisible();
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
@@ -81,69 +81,83 @@ test( 'can update the general information of a product', async ( {
 	} );
 } );
 
-test( 'can schedule a product publication', async ( { page, product } ) => {
-	await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
+test.describe( 'Publish dropdown options', () => {
+	test( 'can schedule a product publication', async ( { page, product } ) => {
+		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
 
-	await page
-		.locator( '.woocommerce-product-header__actions' )
-		.first()
-		.locator( 'button[aria-label="More options"]' )
-		.click();
-
-	await page.getByText( 'Schedule publish' ).click();
-
-	await expect(
-		page.getByRole( 'heading', { name: 'Schedule product' } )
-	).toBeVisible();
-
-	await page
-		.locator( '.woocommerce-schedule-publish-modal' )
-		.locator( 'button[aria-label="View next month"]' )
-		.click();
-
-	await page
-		.locator( '.woocommerce-schedule-publish-modal' )
-		.getByText( '14' )
-		.click();
-
-	await page.getByRole( 'button', { name: 'Schedule' } ).click();
-
-	await expect(
-		page.getByLabel( 'Dismiss this notice' ).first()
-	).toContainText( 'Product scheduled for' );
-
-	await page
-		.locator( '.woocommerce-product-header__actions' )
-		.first()
-		.locator( 'button[aria-label="More options"]' )
-		.click();
-
-	await page.getByText( 'Copy to a new draft' ).click();
-
-	await expect(
-		page.getByLabel( 'Dismiss this notice' ).first()
-	).toContainText( 'Product successfully duplicated' );
-
-	await expect(
-		page.getByRole( 'heading', { name: `${ product.name } (Copy)` } )
-	).toBeVisible();
-
-	await expect(
-		page
-			.locator( '.woocommerce-product-header__visibility-tags' )
-			.getByText( 'Draft' )
+		await page
+			.locator( '.woocommerce-product-header__actions' )
 			.first()
-	).toBeVisible();
+			.locator( 'button[aria-label="More options"]' )
+			.click();
 
-	await page
-		.locator( '.woocommerce-product-header__actions' )
-		.first()
-		.locator( 'button[aria-label="More options"]' )
-		.click();
+		await page.getByText( 'Schedule publish' ).click();
 
-	await page.getByText( 'Move to trash' ).click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Schedule product' } )
+		).toBeVisible();
 
-	await expect(
-		page.getByRole( 'heading', { name: 'Products' } ).first()
-	).toBeVisible();
+		await page
+			.locator( '.woocommerce-schedule-publish-modal' )
+			.locator( 'button[aria-label="View next month"]' )
+			.click();
+
+		await page
+			.locator( '.woocommerce-schedule-publish-modal' )
+			.getByText( '14' )
+			.click();
+
+		await page.getByRole( 'button', { name: 'Schedule' } ).click();
+
+		await expect(
+			page.getByLabel( 'Dismiss this notice' ).first()
+		).toContainText( 'Product scheduled for' );
+	} );
+	test( 'can dupicate a product', async ( { page, product } ) => {
+		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
+		await page
+			.locator( '.woocommerce-product-header__actions' )
+			.first()
+			.locator( 'button[aria-label="More options"]' )
+			.click();
+
+		await page.getByText( 'Copy to a new draft' ).click();
+
+		await expect(
+			page.getByLabel( 'Dismiss this notice' ).first()
+		).toContainText( 'Product successfully duplicated' );
+
+		await expect(
+			page.getByRole( 'heading', { name: `${ product.name } (Copy)` } )
+		).toBeVisible();
+
+		await expect(
+			page
+				.locator( '.woocommerce-product-header__visibility-tags' )
+				.getByText( 'Draft' )
+				.first()
+		).toBeVisible();
+
+		await page
+			.locator( '.woocommerce-product-header__actions' )
+			.first()
+			.locator( 'button[aria-label="More options"]' )
+			.click();
+
+		await page.getByText( 'Move to trash' ).click();
+	} );
+	test( 'can delete a product', async ( { page, product } ) => {
+		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
+		await page
+			.locator( '.woocommerce-product-header__actions' )
+			.first()
+			.locator( 'button[aria-label="More options"]' )
+			.click();
+
+		await page.getByText( 'Move to trash' ).click();
+
+		await expect(
+			page.getByRole( 'heading', { name: 'Products' } ).first()
+		).toBeVisible();
+	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
@@ -113,7 +113,7 @@ test.describe( 'Publish dropdown options', () => {
 			page.getByLabel( 'Dismiss this notice' ).first()
 		).toContainText( 'Product scheduled for' );
 	} );
-	test( 'can dupicate a product', async ( { page, product } ) => {
+	test( 'can duplicate a product', async ( { page, product } ) => {
 		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
 		await page
 			.locator( '.woocommerce-product-header__actions' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds tests to cover the Publish dropdown options. It will test the `Schedule` a product publication, the `Copy to new draft` option and the `Move to trash` functionallity.   

![Screenshot 2024-04-17 at 1 07 56 PM](https://github.com/woocommerce/woocommerce/assets/1314156/4b488a32-1c37-4997-8829-f843223d895a)

Closes #46593.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Run `cd plugins/woocommerce && pnpm env:start`
3. Then run `USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js` if you add the relative path behind it will run the file you want. I would also add `--headed` to see visually what's going on. In this case, the command should look like `USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js ./tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js --headed`
4. All the tests should pass.

More details [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e-pw/README.md).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
