### PR TITLE
Fix deprecated error message for LYS in PHP 8.1 environment

### DIFF
--- a/plugins/woocommerce/changelog/fix-deprecated-error-lys-strlen
+++ b/plugins/woocommerce/changelog/fix-deprecated-error-lys-strlen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix deprecated error message with strlen usage in PHP 8.1

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -235,7 +235,7 @@ class WCAdminHelper {
 	private static function get_normalized_url_path( $url ) {
 		$query           = wp_parse_url( $url, PHP_URL_QUERY );
 		$path            = wp_parse_url( $url, PHP_URL_PATH ) . ( $query ? '?' . $query : '' );
-		$home_path       = wp_parse_url( site_url(), PHP_URL_PATH );
+		$home_path       = wp_parse_url( site_url(), PHP_URL_PATH ) ?? '';
 		$normalized_path = trim( substr( $path, strlen( $home_path ) ), '/' );
 		return $normalized_path;
 	}


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Fixes deprecated error message in PHP 8.1:

<img width="1387" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/3748730d-cc24-49dc-b04a-c06d44be81c4">


### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a new environment using PHP >= 8.1
2. Go to WooCommerce > Settings > Site visibility
3. Select `Coming soon` and `Restrict to store pages` and save
4. In an incognito window, go to the `/shop` page of your site
5. Observe no deprecated error message

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
