### PR TITLE
[LYS] Regenerate share key on the fly

### DIFF
--- a/plugins/woocommerce/changelog/enhance-regenerate-share-key-on-the-fly
+++ b/plugins/woocommerce/changelog/enhance-regenerate-share-key-on-the-fly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Regenerate share key on the fly

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -69,6 +69,11 @@ class LaunchYourStore {
 		$is_setting_page = $current_screen && 'woocommerce_page_wc-settings' === $current_screen->id;
 
 		if ( $is_setting_page ) {
+			// Regnerate the share key if it's not set.
+			if ( false === get_option( 'woocommerce_share_key', false ) ) {
+				update_option( 'woocommerce_share_key', wp_generate_password( 32, false ) );
+			}
+
 			$settings['siteVisibilitySettings'] = array(
 				'shop_permalink'               => get_permalink( wc_get_page_id( 'shop' ) ),
 				'woocommerce_coming_soon'      => get_option( 'woocommerce_coming_soon' ),

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -70,9 +70,7 @@ class LaunchYourStore {
 
 		if ( $is_setting_page ) {
 			// Regnerate the share key if it's not set.
-			if ( false === get_option( 'woocommerce_share_key', false ) ) {
-				update_option( 'woocommerce_share_key', wp_generate_password( 32, false ) );
-			}
+			add_option( 'woocommerce_share_key', wp_generate_password( 32, false ) );
 
 			$settings['siteVisibilitySettings'] = array(
 				'shop_permalink'               => get_permalink( wc_get_page_id( 'shop' ) ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46624.

Regenerate share key on the fly when the share key is not set

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a JN site but do not pre-enable `launch-your-store` feature flag
2. Go to /tools.php?page=woocommerce-admin-test-helper > Features
3. Enable `launch-your-store` feature flag
4. Go to /wp-admin/admin.php?page=wc-settings&tab=site-visibility
5. Select `Coming soon` and turn on `Share your site with a private link`
6. Observe that the share key is set as a 32 character string
7. Delete `woocommerce_share_key` option if you want to test the regeneration of the share ke again

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
