### PR TITLE
Fix LYS success page shown but Task not crossed off

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/Congrats.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/Congrats.tsx
@@ -14,6 +14,8 @@ import { closeSmall } from '@wordpress/icons';
 import { CustomerFeedbackSimple } from '@woocommerce/customer-effort-score';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { Button, TextareaControl, Icon, Dashicon } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -64,6 +66,10 @@ export const Congrats = ( {
 		}
 	);
 
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		ONBOARDING_STORE_NAME
+	);
+
 	const sendData = () => {
 		const emojis = {
 			1: 'very_difficult',
@@ -96,6 +102,7 @@ export const Congrats = ( {
 						recordEvent(
 							'launch_your_store_congrats_back_to_home_click'
 						);
+						invalidateResolutionForStoreSelector( 'getTaskLists' );
 						navigateTo( { url: '/' } );
 					} }
 					className="back-to-home-button"

--- a/plugins/woocommerce/changelog/fix-lys-task-not-crossed-off
+++ b/plugins/woocommerce/changelog/fix-lys-task-not-crossed-off
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix LYS success page shown but Task not crossed off


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/309.

Invalidate `getTaskLists` selector before navigating back to home page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a JN site with `launch-your-store` feature flag enabled.
2. Go to WooCommerce > Home.
3. Click on "Launch your store" task
4. Click on "Launch your store" button.
5. Click on "Back to home" button.
6. Confirm that the "Launch your store" task is marked as incomplete.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
