### PR TITLE
Return with home URL when permalink structure is empty

### DIFF
--- a/plugins/woocommerce/changelog/46664-fix-46623-restrict-only-does-not-work-on-a-sub-dir-site
+++ b/plugins/woocommerce/changelog/46664-fix-46623-restrict-only-does-not-work-on-a-sub-dir-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+FIxed a bug where shop page isn't recognized as a WooCommerce page when WordPress is installed in a subdirectory with permalink set to plain.

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonHelper.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonHelper.php
@@ -61,11 +61,6 @@ class ComingSoonHelper {
 	 * @param \WP $wp WordPress environment instance.
 	 */
 	public function get_url_from_wp( \WP $wp ) {
-		// Special case for plain permalinks.
-		if ( empty( get_option( 'permalink_structure' ) ) ) {
-			return home_url( add_query_arg( $wp->query_vars, $wp->request ) );
-		}
-
-		return trailingslashit( '/' . $wp->request );
+		return home_url( add_query_arg( $wp->query_vars, $wp->request ) );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonHelper.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonHelper.php
@@ -63,7 +63,7 @@ class ComingSoonHelper {
 	public function get_url_from_wp( \WP $wp ) {
 		// Special case for plain permalinks.
 		if ( empty( get_option( 'permalink_structure' ) ) ) {
-			return '/' . add_query_arg( $wp->query_vars, $wp->request );
+			return home_url( add_query_arg( $wp->query_vars, $wp->request ) );
 		}
 
 		return trailingslashit( '/' . $wp->request );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46623 .

This PR fixes a bug where shop page isn't recognized as a WooCommerce page when WordPress is installed in a subdirectory with permalink set to plain.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new site in a subdirectory by following Pb22l9-2CU-p2
2. Upload and activate https://betadownload.jetpack.me/data/woocommerce/trunk/woocommerce-dev.zip 
3. Open an incognito session and visit your site.
4. Click on `shop` 
5. Confir the coming soon page renders as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

FIxed a bug where shop page isn't recognized as a WooCommerce page when WordPress is installed in a subdirectory with permalink set to plain.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>