### PR TITLE
Fix back from CYS via LYS goes to Home, not LYS

### DIFF
--- a/packages/js/navigation/changelog/update-coming-soon-page-style
+++ b/packages/js/navigation/changelog/update-coming-soon-page-style
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-Add __experimentLocationStack prop to history
+Add __experimentalLocationStack prop to history

--- a/packages/js/navigation/changelog/update-coming-soon-page-style
+++ b/packages/js/navigation/changelog/update-coming-soon-page-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add __experimentLocationStack prop to history

--- a/packages/js/navigation/src/history.ts
+++ b/packages/js/navigation/src/history.ts
@@ -16,7 +16,7 @@ interface WooLocation extends Location {
  */
 export interface WooBrowserHistory extends BrowserHistory {
 	location: WooLocation;
-	readonly __experimentLocationStack: WooLocation[];
+	readonly __experimentalLocationStack: WooLocation[];
 }
 
 let _history: WooBrowserHistory;
@@ -93,7 +93,7 @@ function getHistory(): WooBrowserHistory {
 					pathname,
 				};
 			},
-			get __experimentLocationStack() {
+			get __experimentalLocationStack() {
 				return [ ...locationStack ];
 			},
 			createHref: browserHistory.createHref,

--- a/packages/js/navigation/src/history.ts
+++ b/packages/js/navigation/src/history.ts
@@ -7,13 +7,16 @@ import { parse } from 'qs';
 // See https://github.com/ReactTraining/react-router/blob/master/FAQ.md#how-do-i-access-the-history-object-outside-of-components
 // ^ This is a bit outdated but there's no newer documentation - the replacement for this is to use <unstable_HistoryRouter /> https://reactrouter.com/docs/en/v6/routers/history-router
 
+interface WooLocation extends Location {
+	pathname: string;
+}
+
 /**
  * Extension of history.BrowserHistory but also adds { pathname: string } to the location object.
  */
 export interface WooBrowserHistory extends BrowserHistory {
-	location: Location & {
-		pathname: string;
-	};
+	location: WooLocation;
+	readonly __experimentLocationStack: WooLocation[];
 }
 
 let _history: WooBrowserHistory;
@@ -35,6 +38,31 @@ let _history: WooBrowserHistory;
 function getHistory(): WooBrowserHistory {
 	if ( ! _history ) {
 		const browserHistory = createBrowserHistory();
+		let locationStack: WooLocation[] = [ browserHistory.location ];
+
+		const updateNextLocationStack = (
+			action: WooBrowserHistory[ 'action' ],
+			location: WooBrowserHistory[ 'location' ]
+		) => {
+			switch ( action ) {
+				case 'POP':
+					locationStack = locationStack.slice(
+						0,
+						locationStack.length - 1
+					);
+					break;
+				case 'PUSH':
+					locationStack = [ ...locationStack, location ];
+					break;
+				case 'REPLACE':
+					locationStack = [
+						...locationStack.slice( 0, locationStack.length - 1 ),
+						location,
+					];
+					break;
+			}
+		};
+
 		_history = {
 			get action() {
 				return browserHistory.action;
@@ -65,6 +93,9 @@ function getHistory(): WooBrowserHistory {
 					pathname,
 				};
 			},
+			get __experimentLocationStack() {
+				return [ ...locationStack ];
+			},
 			createHref: browserHistory.createHref,
 			push: browserHistory.push,
 			replace: browserHistory.replace,
@@ -81,6 +112,10 @@ function getHistory(): WooBrowserHistory {
 				} );
 			},
 		};
+
+		browserHistory.listen( () =>
+			updateNextLocationStack( _history.action, _history.location )
+		);
 	}
 	return _history;
 }

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -86,10 +86,14 @@ const redirectToWooHome = () => {
 };
 
 const goBack = () => {
-	// If the user navigated to the customize store from a WC admin page, we want to go back to that page.
-	// Otherwise, we go back to the home page.
 	const history = getHistory();
-	if ( history.action === 'PUSH' ) {
+	if (
+		history.__experimentLocationStack.length >= 2 &&
+		! history.__experimentLocationStack[
+			history.__experimentLocationStack.length - 2
+		].search.includes( 'customize-store' )
+	) {
+		// If the previous location is not a customize-store step, go back in history.
 		history.back();
 		return;
 	}

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -88,9 +88,9 @@ const redirectToWooHome = () => {
 const goBack = () => {
 	const history = getHistory();
 	if (
-		history.__experimentLocationStack.length >= 2 &&
-		! history.__experimentLocationStack[
-			history.__experimentLocationStack.length - 2
+		history.__experimentalLocationStack.length >= 2 &&
+		! history.__experimentalLocationStack[
+			history.__experimentalLocationStack.length - 2
 		].search.includes( 'customize-store' )
 	) {
 		// If the previous location is not a customize-store step, go back in history.

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -11,6 +11,7 @@ import {
 	getNewPath,
 	getQuery,
 	updateQueryString,
+	getHistory,
 } from '@woocommerce/navigation';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { dispatch, resolveSelect } from '@wordpress/data';
@@ -84,6 +85,18 @@ const redirectToWooHome = () => {
 	navigateOrParent( window, url );
 };
 
+const goBack = () => {
+	// If the user navigated to the customize store from a WC admin page, we want to go back to that page.
+	// Otherwise, we go back to the home page.
+	const history = getHistory();
+	if ( history.action === 'PUSH' ) {
+		history.back();
+		return;
+	}
+
+	redirectToWooHome();
+};
+
 const redirectToThemes = ( _context: customizeStoreStateMachineContext ) => {
 	if ( isWooExpress() ) {
 		window.location.href =
@@ -130,6 +143,7 @@ export const machineActions = {
 	updateQueryStep,
 	redirectToWooHome,
 	redirectToThemes,
+	goBack,
 };
 
 export const customizeStoreStateMachineActions = {
@@ -330,7 +344,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			},
 			on: {
 				CLICKED_ON_BREADCRUMB: {
-					actions: 'redirectToWooHome',
+					actions: 'goBack',
 				},
 				DESIGN_WITH_AI: {
 					actions: [ 'recordTracksDesignWithAIClicked' ],

--- a/plugins/woocommerce/changelog/fix-back-from-cys-via-lys
+++ b/plugins/woocommerce/changelog/fix-back-from-cys-via-lys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix back from CYS via LYS goes to Home, not LYS


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/307.

When a user go to CYS via LYS task and click on back button, it should go back to LYS task, not to Home.

This PR fixes the issue by adding a `goBack` action and check if the user is coming from a WC admin page, if so, it will go back to the previous page, otherwise, it will go back to Home page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a fresh install with `launch-your-store` feature flag enabled
2. Go to `WooCommerce Home > Launch Your Store`
3. Click on `Customize Your Store Task List` Item
4. Now click the "back" button.
5. Verify that you are taken back to the `Launch Your Store` page.
6. Go to `WooCommerce Home > Customize Your Store`
7. Click the "back" button.
8. Confirm you are taken back to the WC Home page.
9. Go to Customize Your Store via URL in a new tab.
10. Click the "back" button.
11. Confirm you are taken back to the WC Home page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
