### PR TITLE
[CFT Custom fields]: Remove horizontal separator that initially appears

### DIFF
--- a/packages/js/product-editor/changelog/fix-46615
+++ b/packages/js/product-editor/changelog/fix-46615
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove block appender below the custom fields block

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/edit.tsx
@@ -30,7 +30,10 @@ export function Edit( {
 			className:
 				'wp-block-woocommerce-product-custom-fields-toggle-field__inner-blocks',
 		},
-		{ templateLock: 'all' }
+		{
+			templateLock: 'all',
+			renderAppender: false,
+		}
 	);
 
 	const { isLoading, metaboxhiddenProduct, saveMetaboxhiddenProduct } =


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46615

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` -> `Add new` from the left menu to create a new product
4. Then go to the `Organization` tab
5. At the end of the page a new `Show custom fields` toggle should be shown
6. When toggle it the appender at the bottom of the block should not longer be visible 
![image](https://github.com/woocommerce/woocommerce/assets/13334210/6cb126b4-f42c-41ea-8a59-64971062cb05)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
