### PR TITLE
Blocks E2E: Fix basic role-based tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/basic.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/basic.block_theme.spec.ts
@@ -2,30 +2,25 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-import { customerFile } from '@woocommerce/e2e-utils';
+import { customerFile, guestFile } from '@woocommerce/e2e-utils';
 
-test.describe( 'A basic set of tests to ensure WP, wp-admin and my-account load', async () => {
-	test( 'Load the home page', async ( { page } ) => {
-		await page.goto( '/' );
-		const title = page
-			.locator( 'header' )
-			.locator( '.wp-block-site-title' );
-		await expect( title ).toHaveText( 'WooCommerce Blocks E2E Test Suite' );
-	} );
-
-	test.describe( 'Sign in as admin', () => {
-		test( 'Load wp-admin', async ( { page } ) => {
+test.describe( 'Basic role-based functionality tests', async () => {
+	test.describe( 'As admin', () => {
+		// Admin is the default user, so no need to set storage state.
+		test( 'Load Dashboard page', async ( { page } ) => {
 			await page.goto( '/wp-admin' );
-			const title = page.locator( 'div.wrap > h1' );
-			await expect( title ).toHaveText( 'Dashboard' );
+
+			await expect(
+				page.getByRole( 'heading', { name: 'Dashboard' } )
+			).toHaveText( 'Dashboard' );
 		} );
 	} );
 
-	test.describe( 'Sign in as customer', () => {
+	test.describe( 'As customer', () => {
 		test.use( {
 			storageState: customerFile,
 		} );
-		test.only( 'Load customer my account page', async ( { page } ) => {
+		test( 'Load My Account page', async ( { page } ) => {
 			await page.goto( '/my-account' );
 
 			await expect(
@@ -33,6 +28,22 @@ test.describe( 'A basic set of tests to ensure WP, wp-admin and my-account load'
 			).toBeVisible();
 			await expect(
 				page.getByText( 'Hello Jane Smith (not Jane Smith? Log out)' )
+			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'As guest', () => {
+		test.use( {
+			storageState: guestFile,
+		} );
+
+		test( 'Load home page', async ( { page } ) => {
+			await page.goto( '/' );
+
+			await expect(
+				page.getByRole( 'banner' ).getByRole( 'link', {
+					name: 'WooCommerce Blocks E2E Test',
+				} )
 			).toBeVisible();
 		} );
 	} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/basic.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/basic.block_theme.spec.ts
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-
-/**
- * Internal dependencies
- */
+import { customerFile } from '@woocommerce/e2e-utils';
 
 test.describe( 'A basic set of tests to ensure WP, wp-admin and my-account load', async () => {
 	test( 'Load the home page', async ( { page } ) => {
@@ -26,12 +23,17 @@ test.describe( 'A basic set of tests to ensure WP, wp-admin and my-account load'
 
 	test.describe( 'Sign in as customer', () => {
 		test.use( {
-			storageState: process.env.CUSTOMERSTATE,
+			storageState: customerFile,
 		} );
-		test( 'Load customer my account page', async ( { page } ) => {
+		test.only( 'Load customer my account page', async ( { page } ) => {
 			await page.goto( '/my-account' );
-			const title = page.locator( 'h1.wp-block-post-title' );
-			await expect( title ).toHaveText( 'My Account' );
+
+			await expect(
+				page.getByRole( 'heading', { name: 'My Account' } )
+			).toBeVisible();
+			await expect(
+				page.getByText( 'Hello Jane Smith (not Jane Smith? Log out)' )
+			).toBeVisible();
 		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/fix-e2e-basic-customer-test
+++ b/plugins/woocommerce/changelog/fix-e2e-basic-customer-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Fix basic role-based functionality tests


### PR DESCRIPTION
### Proposed changes

This PR fixes 2 broken tests from the "basic" suite:
- Verify if My Account page loads for the customer, 
- Verify if the home page loads for the guest user.

Both of the above checked those pages against the Admin account, which makes them false positives. They were passing because the assertions weren't strict enough.

### Testing instructions

Run the suite locally via `pnpm test:e2e tests/basic.block_theme.spec.ts --headed` and ensure the correct roles are used. 