### PR TITLE
[CFT Custom fields]: Fix modal separator at the bottom

### DIFF
--- a/packages/js/product-editor/changelog/fix-46608
+++ b/packages/js/product-editor/changelog/fix-46608
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove table separator, move field names to table columns and fix the modal growing when there are validation errors

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -188,44 +188,78 @@ export function CreateModal( {
 				props.className
 			) }
 		>
-			<ul className="woocommerce-product-custom-fields__create-modal-list">
-				{ customFields.map( ( customField ) => (
-					<li
-						key={ customField.id }
-						className="woocommerce-product-custom-fields__create-modal-list-item"
-					>
-						<TextControl
-							ref={ getRef( customField, 'key' ) }
-							label={ __( 'Name', 'woocommerce' ) }
-							error={ getValidationError( customField, 'key' ) }
-							value={ customField.key }
-							onChange={ changeHandler( customField, 'key' ) }
-							onBlur={ blurHandler( customField, 'key' ) }
+			<div role="table">
+				<div role="rowgroup">
+					<div role="rowheader">
+						<div role="columnheader">
+							{ __( 'Name', 'woocommerce' ) }
+						</div>
+						<div role="columnheader">
+							{ __( 'Value', 'woocommerce' ) }
+						</div>
+						<div
+							role="columnheader"
+							aria-label={ __( 'Actions', 'woocommerce' ) }
 						/>
-
-						<TextControl
-							ref={ getRef( customField, 'value' ) }
-							label={ __( 'Value', 'woocommerce' ) }
-							error={ getValidationError( customField, 'value' ) }
-							value={ customField.value }
-							onChange={ changeHandler( customField, 'value' ) }
-							onBlur={ blurHandler( customField, 'value' ) }
-						/>
-
-						<Button
-							icon={ closeSmall }
-							disabled={ customFields.length <= 1 }
-							aria-label={ __(
-								'Remove custom field',
-								'woocommerce'
-							) }
-							onClick={ removeCustomFieldButtonClickHandler(
-								customField
-							) }
-						/>
-					</li>
-				) ) }
-			</ul>
+					</div>
+				</div>
+				<div role="rowgroup">
+					{ customFields.map( ( customField ) => (
+						<div key={ customField.id } role="row">
+							<div role="cell">
+								<TextControl
+									ref={ getRef( customField, 'key' ) }
+									label={ '' }
+									aria-label={ __( 'Name', 'woocommerce' ) }
+									error={ getValidationError(
+										customField,
+										'key'
+									) }
+									value={ customField.key }
+									onChange={ changeHandler(
+										customField,
+										'key'
+									) }
+									onBlur={ blurHandler( customField, 'key' ) }
+								/>
+							</div>
+							<div role="cell">
+								<TextControl
+									ref={ getRef( customField, 'value' ) }
+									label={ '' }
+									aria-label={ __( 'Value', 'woocommerce' ) }
+									error={ getValidationError(
+										customField,
+										'value'
+									) }
+									value={ customField.value }
+									onChange={ changeHandler(
+										customField,
+										'value'
+									) }
+									onBlur={ blurHandler(
+										customField,
+										'value'
+									) }
+								/>
+							</div>
+							<div role="cell">
+								<Button
+									icon={ closeSmall }
+									disabled={ customFields.length <= 1 }
+									aria-label={ __(
+										'Remove custom field',
+										'woocommerce'
+									) }
+									onClick={ removeCustomFieldButtonClickHandler(
+										customField
+									) }
+								/>
+							</div>
+						</div>
+					) ) }
+				</div>
+			</div>
 
 			<div className="woocommerce-product-custom-fields__create-modal-add-another">
 				<Button

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
@@ -1,27 +1,51 @@
 .woocommerce-product-custom-fields__create-modal {
 	min-width: 75%;
 
-	&-list {
-		&-item {
-			display: flex;
-			gap: $grid-unit-20;
-			border-bottom: 1px solid $gray-200;
-			padding-top: $grid-unit-30;
-			padding-bottom: $grid-unit;
-			margin-bottom: 0;
+	[role="table"] {
+		width: 100%;
 
-			&:first-child {
-				padding-top: 0;
-			}
+		[role="rowheader"],
+		[role="row"] {
+			display: grid;
+			grid-template-columns: 1fr 1fr 36px;
+			gap: $grid-unit-20;
+		}
+
+		[role="row"] {
+			border-top: 1px solid $gray-200;
+			border-bottom: 1px solid transparent;
+			padding-top: $grid-unit-40;
+		}
+
+		[role="columnheader"] {
+			text-transform: uppercase;
+			color: $gray-700;
+			padding-top: $grid-unit-30;
+			padding-bottom: $grid-unit-20;
+		}
+
+		[role="cell"] {
+			height: $grid-unit-80;
 
 			.components-base-control {
 				width: 100%;
+				margin-bottom: 0;
+
+				.components-input-base {
+					gap: 0;
+				}
 			}
 
-			.components-button {
-				margin-top: 20px;
+			.components-button.has-icon {
+				min-width: $grid-unit-40;
+				width: $grid-unit-40;
+				height: $grid-unit-40;
 			}
 		}
+	}
+
+	&-add-another {
+		margin-top: $grid-unit-40;
 	}
 
 	&-actions {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46608
Closes #46609
Closes #46607

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` -> `Add new` from the left menu to create a new product
4. Then go to the `Organization` tab
5. At the end of the page a new `Show custom fields` toggle should be shown
6. The following should be done.
   - [x] Remove the separator at the bottom of the list 
![image](https://github.com/woocommerce/woocommerce/assets/13334210/c3a21442-59af-48dd-a16f-655f9d892a7e)
   - [x] The labeling of the name and value inputs on this modal differs from how it is done on the attributes modal, even though they are extremely similar interaction-wise. Before: ![image](https://github.com/woocommerce/woocommerce/assets/13334210/5dbd80fa-6382-4296-ba4c-38a846be74dc) After:
![image](https://github.com/woocommerce/woocommerce/assets/13334210/07f01099-549f-4a2b-adc7-773bb6d2512f)
   - [x] The modal height jumps when validation errors are shown ![image](https://github.com/woocommerce/woocommerce/assets/13334210/df433c94-0662-405c-93cf-d1437c7e2ab1)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
