### PR TITLE
Use delete query format suppored by wpdb::get_table_from_query() in Abstract_WC_Order_Data_Store_CPT::delete_items()

### DIFF
--- a/plugins/woocommerce/changelog/46692-fix-86639-delete-order-item-meta-query-hyperdb
+++ b/plugins/woocommerce/changelog/46692-fix-86639-delete-order-item-meta-query-hyperdb
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update delete item meta query to format supported by wpdb::get_table_from_query()

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -636,13 +636,15 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	public function delete_items( $order, $type = null ) {
 		global $wpdb;
+
 		if ( ! empty( $type ) ) {
-			$wpdb->query( $wpdb->prepare( "DELETE FROM itemmeta USING {$wpdb->prefix}woocommerce_order_itemmeta itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order->get_id(), $type ) );
+			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order->get_id(), $type ) );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = %s", $order->get_id(), $type ) );
 		} else {
-			$wpdb->query( $wpdb->prepare( "DELETE FROM itemmeta USING {$wpdb->prefix}woocommerce_order_itemmeta itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $order->get_id() ) );
+			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $order->get_id() ) );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order->get_id() ) );
 		}
+
 		$this->clear_caches( $order );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -355,4 +355,87 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			$this->assertSame( $order, $order_from_before_delete );
 		}
 	}
+
+	/**
+	 * @testDox Deleting order items should only delete items of the specified type.
+	 */
+	public function test_delete_items() {
+		$order        = WC_Helper_Order::create_order();
+		$product      = WC_Helper_Product::create_simple_product();
+		$product_item = new WC_Order_Item_Product();
+		$product_item->set_product( $product );
+		$product_item->set_quantity( 1 );
+		$product_item->save();
+
+		$fee_item_1 = new WC_Order_Item_Fee();
+		$fee_item_1->set_amount( 20 );
+		$fee_item_1->save();
+
+		$fee_item_2 = new WC_Order_Item_Fee();
+		$fee_item_2->set_amount( 30 );
+		$fee_item_2->save();
+
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_name( 'dummy shipping' );
+		$shipping_item->set_total( 20 );
+		$shipping_item->save();
+
+		$order->add_item( $product_item );
+		$order->add_item( $fee_item_1 );
+		$order->add_item( $fee_item_2 );
+		$order->add_item( $shipping_item );
+
+		$order->save();
+
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertTrue( $r_order->get_item( $fee_item_1->get_id() )->get_id() === $fee_item_1->get_id() );
+		$this->assertTrue( $r_order->get_item( $fee_item_2->get_id() )->get_id() === $fee_item_2->get_id() );
+		$this->assertTrue( $r_order->get_item( $product_item->get_id() )->get_id() === $product_item->get_id() );
+		$this->assertTrue( $r_order->get_item( $shipping_item->get_id() )->get_id() === $shipping_item->get_id() );
+
+		// Deleting single item type should only delete that item type.
+		$r_order->get_data_store()->delete_items( $r_order, $fee_item_1->get_type() );
+		$this->assertFalse( $r_order->get_item( $fee_item_1->get_id() ) );
+		$this->assertFalse( $r_order->get_item( $fee_item_2->get_id() ) );
+		$this->assertTrue( $r_order->get_item( $product_item->get_id() )->get_id() === $product_item->get_id() );
+		$this->assertTrue( $r_order->get_item( $shipping_item->get_id() )->get_id() === $shipping_item->get_id() );
+
+		// Deleting all items should all items.
+		$r_order->get_data_store()->delete_items( $r_order );
+		$this->assertFalse( $r_order->get_item( $fee_item_1->get_id() ) );
+		$this->assertFalse( $r_order->get_item( $fee_item_2->get_id() ) );
+		$this->assertFalse( $r_order->get_item( $product_item->get_id() ) );
+		$this->assertFalse( $r_order->get_item( $shipping_item->get_id() ) );
+	}
+
+	/**
+	 * @testDox Deleting order item should delete items from only that order.
+	 */
+	public function test_delete_items_multi_order() {
+		$order_1        = WC_Helper_Order::create_order();
+		$product        = WC_Helper_Product::create_simple_product();
+		$product_item_1 = new WC_Order_Item_Product();
+		$product_item_1->set_product( $product );
+		$product_item_1->set_quantity( 1 );
+		$product_item_1->save();
+
+		$order_2        = WC_Helper_Order::create_order();
+		$product_item_2 = new WC_Order_Item_Product();
+		$product_item_2->set_product( $product );
+		$product_item_2->set_quantity( 1 );
+		$product_item_2->save();
+
+		$order_1->add_item( $product_item_1 );
+		$order_1->save();
+		$order_2->add_item( $product_item_2 );
+		$order_2->save();
+
+		$this->assertTrue( $order_1->get_item( $product_item_1->get_id() )->get_id() === $product_item_1->get_id() );
+		$this->assertTrue( $order_2->get_item( $product_item_2->get_id() )->get_id() === $product_item_2->get_id() );
+
+		$order_1->get_data_store()->delete_items( $order_1 );
+
+		$this->assertFalse( $order_1->get_item( $product_item_1->get_id() ) );
+		$this->assertTrue( $order_2->get_item( $product_item_2->get_id() )->get_id() === $product_item_2->get_id() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #46639.

This change updates the delete queries for order item meta in  `Abstract_WC_Order_Data_Store_CPT::delete_items()` from the format of `DELETE FROM {alias} USING {table} {alias}` to a format of `DELETE {alias} FROM {table} as {alias}`.  The former is not a format supported by `wpdb::get_table_from_query()` in WordPress core, so `::get_table_from_query()` instead returns the alias as the table name.  This breaks DB extensions like HyperDB that rely on the table name to determine what dataset to query from.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This is difficult to isolate this specific code for testing.  One option is to setup a site using HyperDB to route queries in a way that configured to only recognize tables starting with the default `wp_` table prefix and attempt to remove order items from an order.

Alternatively, we can validate the queries specifically by duplicating them in a custom unit test that uses the `WpdbExposedMethodsForTesting` to expose the `::get_table_from_query()` method. E.g:

```
public function test_delete_item_meta_queries() {
	global $wpdb;

	$test_wpdb = new WpdbExposedMethodsForTesting();
	$query = $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", 1, 'foo' );
	$actual_table = $test_wpdb->get_table_from_query($query);
	$expected_table = "{$wpdb->prefix}woocommerce_order_itemmeta";
	$this->assertEquals($expected_table, $actual_table);

}
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Update delete item meta query to format supported by wpdb::get_table_from_query()

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
