### PR TITLE
[CFT Custom fields]: Show error message after pressing Add or Add another

### DIFF
--- a/packages/js/product-editor/changelog/fix-46610
+++ b/packages/js/product-editor/changelog/fix-46610
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix validation for the custom fields

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -29,6 +29,7 @@ const DEFAULT_CUSTOM_FIELD = {
 } satisfies Metadata< string >;
 
 export function CreateModal( {
+	values,
 	onCreate,
 	onCancel,
 	...props
@@ -90,9 +91,13 @@ export function CreateModal( {
 		prop: keyof Metadata< string >
 	) {
 		return function handleBlur( event: FocusEvent< HTMLInputElement > ) {
-			const error = validate( {
-				[ prop ]: event.target.value,
-			} );
+			const error = validate(
+				{
+					...customField,
+					[ prop ]: event.target.value,
+				},
+				[ ...customFields, ...values ]
+			);
 			const id = String( customField.id );
 			setValidationError( ( current ) => ( {
 				...current,
@@ -139,7 +144,10 @@ export function CreateModal( {
 	function handleAddButtonClick() {
 		const { errors, hasErrors } = customFields.reduce(
 			( prev, customField ) => {
-				const _errors = validate( customField );
+				const _errors = validate( customField, [
+					...customFields,
+					...values,
+				] );
 				prev.errors[ String( customField.id ) ] = _errors;
 
 				if ( _errors.key ) {
@@ -171,7 +179,10 @@ export function CreateModal( {
 		}
 
 		onCreate(
-			customFields.map( ( { id, ...customField } ) => customField )
+			customFields.map( ( { id, ...customField } ) => ( {
+				key: customField.key.trim(),
+				value: customField.value?.trim(),
+			} ) )
 		);
 
 		recordEvent( 'product_custom_fields_add_new_button_click', {

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -14,7 +14,11 @@ import type { FocusEvent } from 'react';
  */
 import { TRACKS_SOURCE } from '../../../constants';
 import { TextControl } from '../../text-control';
-import { validate, type ValidationErrors } from '../utils/validations';
+import {
+	ValidationError,
+	validate,
+	type ValidationErrors,
+} from '../utils/validations';
 import type { Metadata } from '../../../types';
 import type { CreateModalProps } from './types';
 
@@ -87,13 +91,15 @@ export function CreateModal( {
 	) {
 		return function handleBlur( event: FocusEvent< HTMLInputElement > ) {
 			const error = validate( {
-				...customField,
 				[ prop ]: event.target.value,
 			} );
 			const id = String( customField.id );
 			setValidationError( ( current ) => ( {
 				...current,
-				[ id ]: error,
+				[ id ]: {
+					...( current[ id ] as ValidationError ),
+					[ prop ]: error[ prop ],
+				},
 			} ) );
 		};
 	}

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/types.ts
@@ -12,6 +12,7 @@ export type CreateModalProps = Omit<
 	Modal.Props,
 	'title' | 'onRequestClose' | 'children'
 > & {
+	values: Metadata< string >[];
 	onCreate( value: Metadata< string >[] ): void;
 	onCancel(): void;
 };

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -163,6 +163,7 @@ export function CustomFields( {
 
 			{ showCreateModal && (
 				<CreateModal
+					values={ customFields }
 					onCreate={ handleCreateModalCreate }
 					onCancel={ handleCreateModalCancel }
 				/>
@@ -171,6 +172,7 @@ export function CustomFields( {
 			{ selectedCustomField && (
 				<EditModal
 					initialValue={ selectedCustomField }
+					values={ customFields }
 					onUpdate={ handleEditModalUpdate }
 					onCancel={ handleEditModalCancel }
 				/>

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -169,7 +169,7 @@ export function CustomFields( {
 				/>
 			) }
 
-			{ selectedCustomFieldIndex != undefined && (
+			{ selectedCustomFieldIndex !== undefined && (
 				<EditModal
 					initialValue={ customFields[ selectedCustomFieldIndex ] }
 					values={ customFields }

--- a/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-fields.tsx
@@ -32,8 +32,8 @@ export function CustomFields( {
 	} = useCustomFields();
 
 	const [ showCreateModal, setShowCreateModal ] = useState( false );
-	const [ selectedCustomField, setSelectedCustomField ] =
-		useState< Metadata< string > >();
+	const [ selectedCustomFieldIndex, setSelectedCustomFieldIndex ] =
+		useState< number >();
 
 	function handleAddNewButtonClick() {
 		setShowCreateModal( true );
@@ -43,11 +43,11 @@ export function CustomFields( {
 		} );
 	}
 
-	function customFieldEditButtonClickHandler(
-		customField: Metadata< string >
-	) {
+	function customFieldEditButtonClickHandler( customFieldIndex: number ) {
 		return function handleCustomFieldEditButtonClick() {
-			setSelectedCustomField( customField );
+			setSelectedCustomFieldIndex( customFieldIndex );
+
+			const customField = customFields[ customFieldIndex ];
 
 			recordEvent( 'product_custom_fields_show_edit_modal', {
 				source: TRACKS_SOURCE,
@@ -85,12 +85,12 @@ export function CustomFields( {
 	}
 
 	function handleEditModalUpdate( customField: Metadata< string > ) {
-		updateCustomField( customField );
-		setSelectedCustomField( undefined );
+		updateCustomField( customField, selectedCustomFieldIndex );
+		setSelectedCustomFieldIndex( undefined );
 	}
 
 	function handleEditModalCancel() {
-		setSelectedCustomField( undefined );
+		setSelectedCustomFieldIndex( undefined );
 
 		recordEvent( 'product_custom_fields_cancel_edit_modal', {
 			source: TRACKS_SOURCE,
@@ -123,7 +123,7 @@ export function CustomFields( {
 						</tr>
 					</thead>
 					<tbody>
-						{ customFields.map( ( customField ) => (
+						{ customFields.map( ( customField, index ) => (
 							<tr
 								className="woocommerce-product-custom-fields__table-row"
 								key={ customField.id ?? customField.key }
@@ -138,7 +138,7 @@ export function CustomFields( {
 									<Button
 										variant="tertiary"
 										onClick={ customFieldEditButtonClickHandler(
-											customField
+											index
 										) }
 									>
 										{ __( 'Edit', 'woocommerce' ) }
@@ -169,9 +169,9 @@ export function CustomFields( {
 				/>
 			) }
 
-			{ selectedCustomField && (
+			{ selectedCustomFieldIndex != undefined && (
 				<EditModal
-					initialValue={ selectedCustomField }
+					initialValue={ customFields[ selectedCustomFieldIndex ] }
 					values={ customFields }
 					onUpdate={ handleEditModalUpdate }
 					onCancel={ handleEditModalCancel }

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -19,6 +19,7 @@ import type { EditModalProps } from './types';
 
 export function EditModal( {
 	initialValue,
+	values,
 	onUpdate,
 	onCancel,
 	...props
@@ -49,16 +50,19 @@ export function EditModal( {
 
 	function blurHandler( prop: keyof Metadata< string > ) {
 		return function handleBlur( event: FocusEvent< HTMLInputElement > ) {
-			const error = validate( {
-				...customField,
-				[ prop ]: event.target.value,
-			} );
+			const error = validate(
+				{
+					...customField,
+					[ prop ]: event.target.value,
+				},
+				values
+			);
 			setValidationError( error );
 		};
 	}
 
 	function handleUpdateButtonClick() {
-		const errors = validate( customField );
+		const errors = validate( customField, values );
 
 		if ( errors.key || errors.value ) {
 			setValidationError( errors );
@@ -72,7 +76,11 @@ export function EditModal( {
 			return;
 		}
 
-		onUpdate( customField );
+		onUpdate( {
+			...customField,
+			key: customField.key.trim(),
+			value: customField.value?.trim(),
+		} );
 
 		recordEvent( 'product_custom_fields_update_button_click', {
 			source: TRACKS_SOURCE,

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/types.ts
@@ -13,6 +13,7 @@ export type EditModalProps = Omit<
 	'title' | 'onRequestClose' | 'children'
 > & {
 	initialValue: Metadata< string >;
+	values: Metadata< string >[];
 	onUpdate( value: Metadata< string > ): void;
 	onCancel(): void;
 };

--- a/packages/js/product-editor/src/components/custom-fields/utils/validations/validate.ts
+++ b/packages/js/product-editor/src/components/custom-fields/utils/validations/validate.ts
@@ -10,7 +10,8 @@ import type { Metadata } from '../../../../types';
 import type { ValidationError } from './types';
 
 export function validate(
-	customField: Partial< Metadata< string > >
+	customField: Partial< Metadata< string > >,
+	customFields: Metadata< string >[]
 ): ValidationError {
 	const errors = {} as ValidationError;
 
@@ -21,6 +22,13 @@ export function validate(
 			'The name cannot begin with the underscore (_) character.',
 			'woocommerce'
 		);
+	} else if (
+		customFields.some(
+			( field ) =>
+				field.id !== customField.id && field.key === customField.key
+		)
+	) {
+		errors.key = __( 'The name must be unique.', 'woocommerce' );
 	}
 
 	if ( ! customField.value ) {

--- a/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
@@ -47,6 +47,9 @@ export function useCustomFields<
 				if ( customField.id && field.id === customField.id ) {
 					return customField;
 				}
+				if ( field.key === customField.key ) {
+					return customField;
+				}
 				return field;
 			} )
 		);

--- a/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
+++ b/packages/js/product-editor/src/hooks/use-custom-fields/use-custom-fields.ts
@@ -41,13 +41,13 @@ export function useCustomFields<
 		setCustomFields( ( current ) => [ ...current, ...value ] );
 	}
 
-	function updateCustomField( customField: T ) {
+	function updateCustomField( customField: T, index?: number ) {
 		setCustomFields( ( current ) =>
-			current.map( ( field ) => {
+			current.map( ( field, fieldIndex ) => {
 				if ( customField.id && field.id === customField.id ) {
 					return customField;
 				}
-				if ( field.key === customField.key ) {
+				if ( index === fieldIndex ) {
 					return customField;
 				}
 				return field;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46610
Closes #46611
Closes #46613

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-custom-fields` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `Products` -> `Add new` from the left menu to create a new product
4. Then go to the `Organization` tab
5. At the end of the page a new `Show custom fields` toggle should be shown
6. The following should be fixed.
   - [x] When adding a new custom field and tabbing to the value field, the “The value is required” validation error immediately appears. The expected behavior is: when we tab to the field for the first time, we shouldn't show any error ![image](https://github.com/woocommerce/woocommerce/assets/13334210/9f029d7a-d239-4af2-9bb5-dad47ef56fb8)
   - [x] On an unsaved new product, values cannot be edited. The expected behavior is: to be able to edit the value in anytime ![Screen Recording on 2024-04-15 at 05-45-46](https://github.com/woocommerce/woocommerce/assets/1314156/bb9f1285-cdf4-4c31-8567-8bc3b4cb8cb0)
   - [x] In the classic editor, whitespace at the beginning and end of custom field names and values are trimmed.
In the new editor, the whitespace is kept, which is error-prone. The expected behavior is: to trim the values introduced in the field ![image](https://github.com/woocommerce/woocommerce/assets/13334210/8561871d-4273-41da-a76e-4a2878d2bf8e)
 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
