### PR TITLE
Prevent fatal error on the Status page when the log directory contains an unreadable directory

### DIFF
--- a/plugins/woocommerce/changelog/pr-46709
+++ b/plugins/woocommerce/changelog/pr-46709
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error on the Status page when the log directory contains an unreadable directory

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -662,7 +662,7 @@ class FileController {
 		$path  = realpath( Settings::get_log_directory() );
 
 		if ( wp_is_writable( $path ) ) {
-			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ) );
+			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ), \RecursiveIteratorIterator::CATCH_GET_CHILD );
 
 			foreach ( $iterator as $file ) {
 				$bytes += $file->getSize();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standx-bbedit-document:///untitled%20text%202?49ards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This change fixes a undocumented bug on the WooCommerce Status page when the log directory contains an unreadable directory.

Steps to reproduce this bug:
1. Create a directory in the Woocommerce log directory, for example:  mkdir [PATH TO WORDPRESS]/wp-content/uploads/wc-logs/no_permissions_test
2. Make the test folder unreadable, for example: sudo chmod 022 [PATH TO WORDPRESS]/wp-content/uploads/wc-logs/no_permissions_test
3. Go to WooCommerce Status page running on same above system: /wp-admin/admin.php?page=wc-status
4. BUG: The status page will throw the following fatal error:

Fatal error: Uncaught Exception: RecursiveDirectoryIterator::__construct([PATH TO WORDPRESS]/wp-content/uploads/wc-logs/no_permissions_test): Failed to open directory: Permission denied
in [PATH TO WORDPRESS]/wp-content/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php on line 679

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds the CATCH_GET_CHILD flag to RecursiveDirectoryIterator (see https://www.php.net/manual/en/recursiveiteratoriterator.construct.php) to ignore exceptions thrown in calls to RecursiveIteratorIterator::getChildren(). This resolves the unreadable directory bug above.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a directory in the Woocommerce log directory:  mkdir [PATH TO WORDPRESS]/wp-content/uploads/wc-logs/no_permissions_test
2. Make the test folder unreadable: sudo chmod 022 [PATH TO WORDPRESS]/wp-content/uploads/wc-logs/no_permissions_test
3. Go to WooCommerce Status page running on same above system: /wp-admin/admin.php?page=wc-status
4. The status page should show as normal, not throwing a fatal error

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Adds CATCH_GET_CHILD flag to RecursiveDirectoryIterator constructor in woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php on line 665 to prevent fatal error when log directory contains an unreadable directory
</details>
