### PR TITLE
[Product Block Editor]: when adding a new attribute, show selected item right after user clicks on it

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-render-new-attribute-right-after-selected
+++ b/packages/js/product-editor/changelog/update-product-editor-render-new-attribute-right-after-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+[Product Block Editor]: when adding a new attribute, show selected item right after user clicks on it

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -237,6 +237,15 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 								value &&
 								! ( typeof value === 'string' )
 							) {
+								const selectedAttribute =
+									getProductAttributeObject(
+										value
+									) as EnhancedProductAttribute;
+
+								setValue( 'attributes[' + index + ']', {
+									...selectedAttribute,
+								} );
+
 								resolveSelect(
 									EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME
 								)
@@ -250,10 +259,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 										attribute_id: value.id,
 									} )
 									.then( ( terms ) => {
-										const selectedAttribute =
-											getProductAttributeObject(
-												value
-											) as EnhancedProductAttribute;
 										if ( termsAutoSelection === 'all' ) {
 											selectedAttribute.terms = terms;
 										} else if ( terms.length > 0 ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The changes made in this PR allow for the selection of the new attribute immediately upon user click, without waiting for the response when pulling the attribute terms.

Closes https://github.com/woocommerce/woocommerce/issues/46586

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Product Editor
2. Edit/create a new product 
3. Go to the `Variations` section
4. Confirm when selecting an attribute from the select it shows it right after clicking on the item
5. Confirm when creating a new item, it doesn't show the select input blank for a minor while


https://github.com/woocommerce/woocommerce/assets/77539/4ddcb133-bf48-4a5d-adde-b43f4adb0018


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
