### PR TITLE
Remove side effect entry that is causing module collision in mini cart

### DIFF
--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -17,7 +17,6 @@
 		"./assets/js/atomic/blocks/**",
 		"./assets/js/filters/**",
 		"./assets/js/middleware/**",
-		"./assets/js/types/**",
 		"./assets/js/blocks/checkout/inner-blocks/**/index.tsx",
 		"./assets/js/blocks/checkout/inner-blocks/register-components.ts",
 		"./assets/js/blocks/cart/inner-blocks/**/index.tsx",

--- a/plugins/woocommerce/changelog/46714-dev-fix-minicart-exception
+++ b/plugins/woocommerce/changelog/46714-dev-fix-minicart-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix a bug in blocks where mini-cart would load a tree-shaken module and throw an exception.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This will close https://github.com/woocommerce/woocommerce/issues/46542 and if you're testing this also confirm it does not reintroduce: https://github.com/woocommerce/woocommerce-blocks/issues/12032

I understand *what* is happening that causes this bug, but I do not understand *why*. 

What happens is, when you include a block on the page like price filters, it will load and cache the @woocommerce/types module first. 

If it has tree-shaken differently based on used or unused code the import will be broken for other modules.

All of this stems from the fact that many entrypoints have been created in the front-end bundle and if some are loaded together but tree shake a module differently they could conflict with each other in this way, essentially creating pollution of the module import.

All that said, I remain perplexed because I think I would consider this a bug in Webpack. Is it related to the deferred loading of mini cart or something else?

If this bug surfaces again with some other block, I would encourage us to simply split out one more bundle for mini cart itself to avoid this unexplained conflict.

Thanks @gigitux for spotting that removing the side effect entry fixes the problem

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Please refer to https://github.com/woocommerce/woocommerce/issues/46542 and https://github.com/woocommerce/woocommerce-blocks/issues/12032 for testing instructions.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Fix a bug in blocks where mini-cart would load a tree-shaken module and throw an exception.

</details>
