### PR TITLE
Fix: update REST API v3 reports/orders/totals endpoint to be compatible with HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-update-rest-api-order-totals-hpos
+++ b/plugins/woocommerce/changelog/fix-update-rest-api-order-totals-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the wc/v3/reports/orders/totals endpoint is compatible with HPOS.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-report-orders-totals-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-report-orders-totals-controller.php
@@ -8,6 +8,8 @@
  * @since   3.5.0
  */
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -39,18 +41,18 @@ class WC_REST_Report_Orders_Totals_Controller extends WC_REST_Reports_Controller
 	 * @return array
 	 */
 	protected function get_reports() {
-		$totals = wp_count_posts( 'shop_order' );
+		$totals = OrderUtil::get_count_for_type( 'shop_order' );
 		$data   = array();
 
 		foreach ( wc_get_order_statuses() as $slug => $name ) {
-			if ( ! isset( $totals->$slug ) ) {
+			if ( ! array_key_exists( $slug, $totals ) ) {
 				continue;
 			}
 
 			$data[] = array(
 				'slug'  => str_replace( 'wc-', '', $slug ),
 				'name'  => $name,
-				'total' => (int) $totals->$slug,
+				'total' => (int) $totals[ $slug ],
 			);
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/reports-orders-totals.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/reports-orders-totals.php
@@ -6,9 +6,12 @@
  * @since 3.5.0
  */
 
- use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
- use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 
+/**
+ * WC_Tests_API_Reports_Orders_Totals.
+ */
 class WC_Tests_API_Reports_Orders_Totals extends WC_REST_Unit_Test_Case {
 
 	use HPOSToggleTrait;
@@ -77,7 +80,11 @@ class WC_Tests_API_Reports_Orders_Totals extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		// Create some orders with HPOS enabled.
-		$order_counts = array( 'wc-pending' => 3, 'wc-processing' => 2, 'wc-on-hold' => 1 );
+		$order_counts = array(
+			'wc-pending'    => 3,
+			'wc-processing' => 2,
+			'wc-on-hold'    => 1,
+		);
 		foreach ( $order_counts as $status => $count ) {
 			for ( $i = 0; $i < $count; $i++ ) {
 				$order = OrderHelper::create_order();

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/reports-orders-totals.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/reports-orders-totals.php
@@ -36,7 +36,7 @@ class WC_Tests_API_Reports_Orders_Totals extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test getting all product reviews.
+	 * Test getting order totals.
 	 *
 	 * @since 3.5.0
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the REST API v3 reports/orders/totals endpoint to be compatible with HPOS. 

Closes https://github.com/woocommerce/woocommerce-ios/issues/12468.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. checkout the branch locally and then move HEAD to the first commit that adds the failing test
2. run the test, observe that it fails: `pnpm test:php:env --filter=WC_Tests_API_Reports_Orders_Totals`
3. move HEAD to the tip of this branch again
4. run the test, observe that it passes: `pnpm test:php:env --filter=WC_Tests_API_Reports_Orders_Totals`
5. ensure CI checks pass

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
