### PR TITLE
Be less aggressive on selected shipping rate logic for Checkout block

### DIFF
--- a/plugins/woocommerce/changelog/46719-fix-less-restricive-shipping-validation
+++ b/plugins/woocommerce/changelog/46719-fix-less-restricive-shipping-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Be less aggressive when checking for selected shipping rates in Store API. Reminder that shipping rate id should be on the shape of `method_id:instance_id`.

--- a/plugins/woocommerce/src/StoreApi/Utilities/ArrayUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ArrayUtils.php
@@ -16,7 +16,7 @@ class ArrayUtils {
 	public static function natural_language_join( $array, $enclose_items_with_quotes = false ) {
 		if ( true === $enclose_items_with_quotes ) {
 			$array = array_map(
-				function( $item ) {
+				function ( $item ) {
 					return '"' . $item . '"';
 				},
 				$array
@@ -32,5 +32,22 @@ class ArrayUtils {
 			);
 		}
 		return $last;
+	}
+
+	/**
+	 * Check if a string contains any of the items in an array.
+	 *
+	 * @param string $needle The string to check.
+	 * @param array  $haystack  The array of items to check for.
+	 *
+	 * @return bool true if the string contains any of the items in the array, false otherwise.
+	 */
+	public static function string_contains_array( $needle, $haystack ) {
+		foreach ( $haystack as $item ) {
+			if ( false !== strpos( $needle, $item ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -562,7 +562,7 @@ class OrderController {
 			if (
 				false === $chosen_shipping_method ||
 				! is_string( $chosen_shipping_method ) ||
-				! in_array( current( explode( ':', $chosen_shipping_method ) ), $valid_methods, true )
+				! ArrayUtils::string_contains_array( $chosen_shipping_method, $valid_methods )
 			) {
 				throw $exception;
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
WooCommerce expects shipping rates id to be on the shape of `{method_id}:{instance_id}`, yet this is not enforced anywhere, this means that certain shipping methods can have a different id and it would work fine. This however, worked fine and didn't break.

In Store API we added a check to prevent placing an order if no valid shipping method is selected, and how we check for that is by using the assumption of it starting with a method id, then a `:` separator. This broke certain shipping methods. This PR makes the check less aggressive and only checks if the rate ID contains the method id.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46705 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install this plugin https://gist.github.com/senadir/e2a4541f793e6946cd629547e71254b9/archive/f560dbdfa3ca05b411763ff25acfbefee75d0425.zip
2. In Checkout block, select "Shipping Method 1" or "Shipping Method 2"
3. Make sure you can place the order.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Be less aggressive when checking for selected shipping rates in Store API. Reminder that shipping rate id should be on the shape of `method_id:instance_id`.


#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
