### PR TITLE
Fix E2E search string for Cart block shipping tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-tests-for-shipping
+++ b/plugins/woocommerce/changelog/fix-e2e-tests-for-shipping
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix e2e tests
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -187,9 +187,9 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 		).toBeVisible();
 		await expect(
 			page.locator(
-				'.wc-block-components-radio-control__description > .wc-block-components-formatted-money-amount'
+				'.wc-block-components-radio-control__description > .wc-block-components-shipping-rates-control__package__description--free'
 			)
-		).toContainText( 'FREE' );
+		).toContainText( 'Free' );
 		await expect(
 			page.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -242,7 +242,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-totals-shipping > .wc-block-components-totals-item'
 			)
-		).toContainText( 'FREE' );
+		).toContainText( '$0.00' );
 		let totalPrice = await page
 			.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
@@ -356,7 +356,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-totals-shipping > .wc-block-components-totals-item'
 			)
-		).toContainText( 'FREE' );
+		).toContainText( '$0.00' );
 		totalPrice = await page
 			.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -189,7 +189,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-radio-control__description > .wc-block-components-formatted-money-amount'
 			)
-		).toContainText( '$0.00' );
+		).toContainText( 'Free' );
 		await expect(
 			page.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
@@ -242,7 +242,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-totals-shipping > .wc-block-components-totals-item'
 			)
-		).toContainText( '$0.00' );
+		).toContainText( 'Free' );
 		let totalPrice = await page
 			.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
@@ -356,7 +356,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-totals-shipping > .wc-block-components-totals-item'
 			)
-		).toContainText( '$0.00' );
+		).toContainText( 'Free' );
 		totalPrice = await page
 			.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -1,5 +1,4 @@
 const { test, expect } = require( '@playwright/test' );
-const { admin } = require( '../../test-data/data' );
 const { disableWelcomeModal } = require( '../../utils/editor' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -166,6 +165,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 		await context.clearCookies();
 
 		await page.goto( `/shop/?add-to-cart=${ product1Id }` );
+		// eslint-disable-next-line playwright/no-networkidle
 		await page.waitForLoadState( 'networkidle' );
 
 		await page.goto( cartBlockPageSlug );
@@ -204,6 +204,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 		await context.clearCookies();
 
 		await page.goto( `/shop/?add-to-cart=${ product1Id }` );
+		// eslint-disable-next-line playwright/no-networkidle
 		await page.waitForLoadState( 'networkidle' );
 
 		await page.goto( cartBlockPageSlug );
@@ -265,6 +266,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 		await context.clearCookies();
 
 		await page.goto( `/shop/?add-to-cart=${ product1Id }` );
+		// eslint-disable-next-line playwright/no-networkidle
 		await page.waitForLoadState( 'networkidle' );
 
 		await page.goto( cartBlockPageSlug );
@@ -307,9 +309,11 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 		await context.clearCookies();
 
 		await page.goto( `/shop/?add-to-cart=${ product1Id }` );
+		// eslint-disable-next-line playwright/no-networkidle
 		await page.waitForLoadState( 'networkidle' );
 
 		await page.goto( `/shop/?add-to-cart=${ product2Id }` );
+		// eslint-disable-next-line playwright/no-networkidle
 		await page.waitForLoadState( 'networkidle' );
 
 		await page.goto( cartBlockPageSlug );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -189,7 +189,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-radio-control__description > .wc-block-components-formatted-money-amount'
 			)
-		).toContainText( 'Free' );
+		).toContainText( 'FREE' );
 		await expect(
 			page.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
@@ -242,7 +242,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-totals-shipping > .wc-block-components-totals-item'
 			)
-		).toContainText( 'Free' );
+		).toContainText( 'FREE' );
 		let totalPrice = await page
 			.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
@@ -356,7 +356,7 @@ test.describe( 'Cart Block Calculate Shipping', () => {
 			page.locator(
 				'.wc-block-components-totals-shipping > .wc-block-components-totals-item'
 			)
-		).toContainText( 'Free' );
+		).toContainText( 'FREE' );
 		totalPrice = await page
 			.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce/pull/46345 we changed how free shipping is shown so instead of `$0.00` we show `Free`, this broke some E2E tests that were checking for that string. This PR fixes it.