### PR TITLE
Avoid JS errors if Sourcebuster library isn't loaded

### DIFF
--- a/plugins/woocommerce/changelog/fix-handle-missing-sourcebuster
+++ b/plugins/woocommerce/changelog/fix-handle-missing-sourcebuster
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a bailout to prevent JavaScript errors if Sourcebuster isn't loaded

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -65,6 +65,8 @@
 		if ( ! allow ) {
 			// Reset cookies, and clear form data.
 			removeTrackingCookies();
+		} else if ( typeof sbjs === 'undefined' ) {
+			return; // Do nothing, as sourcebuster.js is not loaded.
 		} else {
 			// If not done yet, initialize sourcebuster.js which populates `sbjs.get` object.
 			sbjs.init( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This just adds a bailout in the Order Attribution initialization process that catches a missing Sourcebuster-JS library (not loaded or blocked by a consent management plugin) and skips any `sbjs` object operations, preventing a JavaScript error.

Closes #45569.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
**Quick local test**
1. Install this branch. 
2. Make the Sourcebuster.js library unavailable:
   - Rename the files `woocommerce/assets/js/frontend/order-attribution.js` and `woocommerce/assets/js/frontend/order-attribution.min.js` so they aren't loaded
   - Or, change the name in `woocommerce/src/Internal/Orders/OrderAttributionController.php::227` so that WooCommerce tries to load the wrong file.
4. In the current implementation, this will throw an error:
`Uncaught ReferenceError: sbjs is not defined`
5. With this bailout, the error will be that the Sourcebuster library can't be loaded `GET … sourcebuster.min.js 404 (Not Found)` but no JavaScript error.
6. Make a purchase at the store and confirm that there are no errors, and the Order origin is "Unknown"
![image](https://github.com/woocommerce/woocommerce/assets/228780/e62fb6dc-9880-469f-ba0c-6376e7c863d0)

7. Make the Sourcebuster library available again (undoing step 2). Visit the store with some UTM params, like `?utm_source=TEST_SOURCE`
8. After a checkout, confirm that the source is assigned correctly to the order:
![image](https://github.com/woocommerce/woocommerce/assets/228780/994fc124-c811-46a1-b3b1-6f94be4c1ea8)


**CookieYes**
There's also JN site with CookieYes installed and actively blocking the Sourcebuster library.
1. Visit `https://fixed-pine.jurassic.ninja/shop/` (valid through 24 April)
2. Confirm that the CookieYes consent popup displays:
![image](https://github.com/woocommerce/woocommerce/assets/228780/69d7cb9d-37d0-4190-8aad-cca11be06d56)
3. Check there are no JS errors in the console.
4. Check that no cookies are created besides `cookieyes-consent`:
![image](https://github.com/woocommerce/woocommerce/assets/228780/1e222ea0-92ca-466d-902a-f64b6d258756)
5. Complete a checkout to confirm no errors. Check the order has no origin info.
6. Load the shop again, accept the cookies, and RELOAD with the UTM params (CookieYes doesn't currently load origin info on consent events, so there needs to be a reload after accepting the cookies).
7. Confirm the `sbjs` cookies are created, complete checkout, and confirm that the origin is added correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
