### PR TITLE
Highlighting text in the product's description of the new product editor is not visible inside editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-gutenberg-global-presets
+++ b/plugins/woocommerce/changelog/fix-gutenberg-global-presets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Highlighting text in the product's description of the new product editor is not visible inside editor

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -115,9 +115,9 @@ class Init {
 		);
 		wp_tinymce_inline_scripts();
 		wp_enqueue_media();
-		wp_register_style( 'wc-gutenberg-global-presets', false ); // phpcs:ignore
-		wp_add_inline_style( 'wc-gutenberg-global-presets', gutenberg_get_global_stylesheet( array( 'presets' ) ) );
-		wp_enqueue_style( 'wc-gutenberg-global-presets' );
+		wp_register_style( 'wc-global-presets', false ); // phpcs:ignore
+		wp_add_inline_style( 'wc-global-presets', wp_get_global_stylesheet( array( 'presets' ) ) );
+		wp_enqueue_style( 'wc-global-presets' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -115,6 +115,9 @@ class Init {
 		);
 		wp_tinymce_inline_scripts();
 		wp_enqueue_media();
+		wp_register_style( 'wc-gutenberg-global-presets', false ); // phpcs:ignore
+		wp_add_inline_style( 'wc-gutenberg-global-presets', gutenberg_get_global_stylesheet( array( 'presets' ) ) );
+		wp_enqueue_style( 'wc-gutenberg-global-presets' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Highlighting text in the product's description of the new product editor is not visible inside editor

I found out that this is happening because there were some styles that were required that were not being enqueued. The classes follow the format `.has-{color}-color`. Theses classes exist in the editor configuration but were not applied.

Closes #45662 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Go to the Description field
4. Type something and highlight it, both the text and the background
5. It should work as expected

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
