### PR TITLE
Product Editor: Add ability to check if product editor made REST request

### DIFF
--- a/packages/js/product-editor/changelog/try-detect-save-via-product-editor
+++ b/packages/js/product-editor/changelog/try-detect-save-via-product-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add X-Wc-From-Product-Editor HTTP header for REST requests made by the product editor.

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -30,6 +30,7 @@ export * from './sort-fills-by-order';
 export * from './register-product-editor-block-type';
 export * from './init-block';
 export * from './product-apifetch-middleware';
+export * from './product-editor-header-apifetch-middleware';
 export * from './sift';
 export * from './truncate';
 

--- a/packages/js/product-editor/src/utils/is-product-editor.ts
+++ b/packages/js/product-editor/src/utils/is-product-editor.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { getQuery } from '@woocommerce/navigation';
+
+export const isProductEditor = () => {
+	const query: { page?: string; path?: string } = getQuery();
+	return (
+		query?.page === 'wc-admin' &&
+		[ '/add-product', '/product/' ].some( ( path ) =>
+			query?.path?.startsWith( path )
+		)
+	);
+};

--- a/packages/js/product-editor/src/utils/product-apifetch-middleware.ts
+++ b/packages/js/product-editor/src/utils/product-apifetch-middleware.ts
@@ -4,6 +4,11 @@
 import apiFetch from '@wordpress/api-fetch';
 import { getQuery } from '@woocommerce/navigation';
 
+/**
+ * Internal dependencies
+ */
+import { isProductEditor } from './is-product-editor';
+
 const routeMatchers = [
 	{
 		matcher: new RegExp( '^/wp/v2/product(?!_)' ),
@@ -25,16 +30,6 @@ const routeMatchers = [
 		},
 	},
 ];
-
-const isProductEditor = () => {
-	const query: { page?: string; path?: string } = getQuery();
-	return (
-		query?.page === 'wc-admin' &&
-		[ '/add-product', '/product/' ].some( ( path ) =>
-			query?.path?.startsWith( path )
-		)
-	);
-};
 
 export const productApiFetchMiddleware = () => {
 	// This is needed to ensure that we use the correct namespace for the entity data store

--- a/packages/js/product-editor/src/utils/product-editor-header-apifetch-middleware.ts
+++ b/packages/js/product-editor/src/utils/product-editor-header-apifetch-middleware.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { isProductEditor } from './is-product-editor';
+
+export const productEditorHeaderApiFetchMiddleware = () => {
+	// This is needed to ensure that we use the correct namespace for the entity data store
+	// without disturbing the rest_namespace outside of the product block editor.
+	apiFetch.use( ( options, next ) => {
+		if ( isProductEditor() ) {
+			options.headers = options.headers || {};
+			options.headers[ 'X-Wc-Product-Editor' ] = '1';
+		}
+		return next( options );
+	} );
+};

--- a/packages/js/product-editor/src/utils/product-editor-header-apifetch-middleware.ts
+++ b/packages/js/product-editor/src/utils/product-editor-header-apifetch-middleware.ts
@@ -14,7 +14,7 @@ export const productEditorHeaderApiFetchMiddleware = () => {
 	apiFetch.use( ( options, next ) => {
 		if ( isProductEditor() ) {
 			options.headers = options.headers || {};
-			options.headers[ 'X-Wc-Product-Editor' ] = '1';
+			options.headers[ 'X-Wc-From-Product-Editor' ] = '1';
 		}
 		return next( options );
 	} );

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalInitBlocks as initBlocks,
 	__experimentalWooProductMoreMenuItem as WooProductMoreMenuItem,
 	productApiFetchMiddleware,
+	productEditorHeaderApiFetchMiddleware,
 	TRACKS_SOURCE,
 	__experimentalProductMVPCESFooter as FeedbackBar,
 	__experimentalEditorLoadingContext as EditorLoadingContext,
@@ -24,6 +25,7 @@ import { useProductEntityRecord } from './hooks/use-product-entity-record';
 import { MoreMenuFill } from './fills/product-block-editor-fills';
 import './product-page.scss';
 
+productEditorHeaderApiFetchMiddleware();
 productApiFetchMiddleware();
 
 // Lazy load components

--- a/plugins/woocommerce-admin/client/products/product-variation-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-page.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalInitBlocks as initBlocks,
 	__experimentalWooProductMoreMenuItem as WooProductMoreMenuItem,
 	productApiFetchMiddleware,
+	productEditorHeaderApiFetchMiddleware,
 	TRACKS_SOURCE,
 	__experimentalVariationSwitcherFooter as VariationSwitcherFooter,
 	__experimentalProductMVPFeedbackModalContainer as ProductMVPFeedbackModalContainer,
@@ -24,6 +25,7 @@ import { useProductVariationEntityRecord } from './hooks/use-product-variation-e
 import { DeleteVariationMenuItem } from './fills/more-menu-items';
 import './product-page.scss';
 
+productEditorHeaderApiFetchMiddleware();
 productApiFetchMiddleware();
 
 export default function ProductPage() {

--- a/plugins/woocommerce/changelog/try-detect-save-via-product-editor
+++ b/plugins/woocommerce/changelog/try-detect-save-via-product-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add wc_rest_is_from_product_editor() function to check if REST request was made by product editor.

--- a/plugins/woocommerce/includes/wc-rest-functions.php
+++ b/plugins/woocommerce/includes/wc-rest-functions.php
@@ -363,3 +363,13 @@ function wc_rest_check_product_reviews_permissions( $context = 'read', $object_i
 
 	return apply_filters( 'woocommerce_rest_check_permissions', $permission, $context, $object_id, 'product_review' );
 }
+
+/**
+ * Returns true if the current REST request is from the product editor.
+ *
+ * @since 8.9.0
+ * @return bool
+ */
+function wc_rest_is_from_product_editor() {
+	return isset( $_SERVER['HTTP_X_WC_FROM_PRODUCT_EDITOR'] ) && '1' === $_SERVER['HTTP_X_WC_FROM_PRODUCT_EDITOR'];
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds an HTTP header to all requests sent from the product editor so that PHP code can detect if a REST API request came from the product editor and perform conditional logic.

- HTTP Header: `X-Wc-From-Product-Editor` (this is considered an implementation detail, use the PHP function below)
- PHP convenience function: `wc_rest_is_from_product_editor()`

Example how to use:

```php
<?php
/*
 * Plugin Name: Test 46741 Product Editor Check
 */

 add_action(
	'woocommerce_before_product_object_save',
	function( $product ) {
		wc_get_logger()->info(
			'***TEST 46741*** woocommerce_before_product_object_save from Product Editor: ' .
			( wc_rest_is_from_product_editor() ? 'yes' : 'no' )
		);
	},
	10,
	1
);
```

Closes #45143.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Test plugin: [test-46741-product-editor-check.zip](https://github.com/woocommerce/woocommerce/files/15030674/test-46741-product-editor-check.zip)

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**) and the test plugin above installed...

1. Go to **Products** > **Add New**
2. Save a new product (or update an existing product).
3. Verify that an info message is logged to the `plugin-test-46741-product-editor-check-{DATE}` log file showing that the save came from the product editor:

```
***TEST 46741*** woocommerce_before_product_object_save from Product Editor: yes
``` 
4. Disable the new product editor (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)
5. Go to **Products** > **Add New**
6. Save a new product (or update an existing product).
7. Verify that an info message is logged to the `plugin-test-46741-product-editor-check-{DATE}` log file showing that the save did not come from the product editor:

```
***TEST 46741*** woocommerce_before_product_object_save from Product Editor: no
``` 

Bonus testing if you want to go above and beyond:
- Make direct API calls (https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-product) using a tool like Postman and verify that the save did not come from the product editor
- Use other hooks that you know will be called when a REST API endpoint is called from the product editor and verify that `wc_rest_is_from_product_editor()` returns `true`.
   - One such hook is `woocommerce_after_product_object_save`. Here's a snippet:

```php
<?php
add_action(
	'woocommerce_after_product_object_save',
	function( $product ) {
		wc_get_logger()->info(
			'woocommerce_after_product_object_save from Product Editor: ' .
			( wc_rest_is_from_product_editor() ? 'yes' : 'no' )
		);
	}
);
```
- Try adding products with both the new product editor and with the classic editor. `woocommerce_before_product_object_save` and `woocommerce_after_product_object_save` should log correctly whether they are added from the product editor or not with the above test plugin and snippet.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
