### PR TITLE
[WIP] add setting to auto-enable experimental features

### DIFF
--- a/plugins/woocommerce/changelog/46743-update-auto-enable-experimental
+++ b/plugins/woocommerce/changelog/46743-update-auto-enable-experimental
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add setting to auto-enable experimental features.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -966,6 +966,7 @@ class WC_Tracker {
 			'hpos_transactions_enabled'             => get_option( 'woocommerce_use_db_transactions_for_custom_orders_table_data_sync' ),
 			'hpos_transactions_level'               => get_option( 'woocommerce_db_transactions_isolation_level_for_custom_orders_table_data_sync' ),
 			'show_marketplace_suggestions'          => get_option( 'woocommerce_show_marketplace_suggestions' ),
+			'experimental_features_auto_enable'     => get_option( 'woocommerce_experimental_features_auto_enable' ),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -702,7 +702,7 @@ class FeaturesController {
 					$auto_enable_experimental = array(
 						'title'   => __( 'All Experimental Features', 'woocommerce' ),
 						'desc'    => __( 'Automatically enable all experimental features', 'woocommerce' ),
-						'id'      => 'experimental_features_auto_enable',
+						'id'      => 'woocommerce_experimental_features_auto_enable',
 						'type'    => 'checkbox',
 						'default' => 'no',
 						'disabled' => ! ( $is_tracking_allowed ),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -694,7 +694,7 @@ class FeaturesController {
 					$feature_settings[] = array(
 						'title' => __( 'Experimental features', 'woocommerce' ),
 						'type'  => 'title',
-						'desc'  => __( 'These features are either experimental or incomplete, enable them at your own risk!', 'woocommerce' ),
+						'desc'  => __( 'These features are either experimental or incomplete. They might change or go away in the future. Enable them at your own risk.', 'woocommerce' ),
 						'id'    => 'experimental_features_options',
 					);
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -100,8 +100,8 @@ class FeaturesController {
 		self::add_filter( 'views_plugins', array( $this, 'handle_plugins_page_views_list' ), 10, 1 );
 		self::add_filter( 'woocommerce_admin_shared_settings', array( $this, 'set_change_feature_enable_nonce' ), 20, 1 );
 		self::add_action( 'admin_init', array( $this, 'change_feature_enable_from_query_params' ), 20, 0 );
-		self::add_filter( 'update_option_woocommerce_allow_tracking', array( $this, 'woocommerce_allow_tracking_updated' ), 999, 2 );
-		self::add_filter( 'update_option_woocommerce_experimental_features_auto_enable', array( $this, 'woocommerce_experimental_features_auto_enable_updated' ), 999, 2 );
+		self::add_filter( 'update_option_woocommerce_allow_tracking', array( $this, 'woocommerce_allow_tracking_updated' ), 10, 2 );
+		self::add_filter( 'update_option_woocommerce_experimental_features_auto_enable', array( $this, 'woocommerce_experimental_features_auto_enable_updated' ), 10, 2 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -717,6 +717,8 @@ class FeaturesController {
 							),
 							admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' )
 						);
+					} else {
+						$auto_enable_experimental['desc_tip'] = __( '⚠️ <b>We do not recommend using this option in live stores.</b>', 'woocommerce' );
 					}
 
 					$feature_settings[] = $auto_enable_experimental;

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -697,6 +697,29 @@ class FeaturesController {
 						'desc'  => __( 'These features are either experimental or incomplete, enable them at your own risk!', 'woocommerce' ),
 						'id'    => 'experimental_features_options',
 					);
+
+					$is_tracking_allowed = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
+					$auto_enable_experimental = array(
+						'title'   => __( 'All Experimental Features', 'woocommerce' ),
+						'desc'    => __( 'Automatically enable all experimental features', 'woocommerce' ),
+						'id'      => 'experimental_features_auto_enable',
+						'type'    => 'checkbox',
+						'default' => 'no',
+						'disabled' => ! ( $is_tracking_allowed ),
+					);
+			
+					if ( ! $is_tracking_allowed ) {
+						$auto_enable_experimental['desc_tip'] = sprintf(
+						// translators: Placeholders are URLs.
+							__(
+								'⚠️ <b>To enable this you need to <a href="%1$s">opt in to usage tracking here</a>.</b>',
+								'woocommerce'
+							),
+							admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' )
+						);
+					}
+
+					$feature_settings[] = $auto_enable_experimental;
 				}
 				continue;
 			}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -357,6 +357,8 @@ class FeaturesController {
 
 	/**
 	 * Enable or disable all experimental features.
+	 *
+	 * @param bool $enable True to enable, false to disable all experimental features.
 	 */
 	public function enable_experimental_features( bool $enable = true ): void {
 		$features = $this->get_features( true );
@@ -369,6 +371,9 @@ class FeaturesController {
 
 	/**
 	 * Enable all experimental features if the `woocommerce_experimental_features_auto_enable` option was set to `yes`.
+	 *
+	 * @param string $old_value The old value of the option.
+	 * @param string $value The new value of the option.
 	 */
 	public function woocommerce_experimental_features_auto_enable_updated( $old_value, $value ): void {
 		if ( 'yes' === $value ) {
@@ -380,6 +385,9 @@ class FeaturesController {
 
 	/**
 	 * Disable all experimental features if the `woocommerce_experimental_features_auto_enable` option was set to `no`.
+	 *
+	 * @param string $old_value The old value of the option.
+	 * @param string $value The new value of the option.
 	 */
 	public function woocommerce_allow_tracking_updated( $old_value, $value ): void {
 		if ( 'no' === $value ) {
@@ -741,14 +749,14 @@ class FeaturesController {
 					);
 
 					$auto_enable_experimental = array(
-						'title'   => __( 'All Experimental Features', 'woocommerce' ),
-						'desc'    => __( 'Automatically enable all experimental features', 'woocommerce' ),
-						'id'      => 'woocommerce_experimental_features_auto_enable',
-						'type'    => 'checkbox',
-						'default' => 'no',
+						'title'    => __( 'All Experimental Features', 'woocommerce' ),
+						'desc'     => __( 'Automatically enable all experimental features', 'woocommerce' ),
+						'id'       => 'woocommerce_experimental_features_auto_enable',
+						'type'     => 'checkbox',
+						'default'  => 'no',
 						'disabled' => ! ( self::is_tracking_allowed() ),
 					);
-			
+
 					if ( ! self::is_tracking_allowed() ) {
 						$auto_enable_experimental['desc_tip'] = sprintf(
 						// translators: Placeholders are URLs.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -632,6 +632,13 @@ class FeaturesController {
 	}
 
 	/**
+	 * Local shorthand for whether tracking is enabled, might possibly be useful globally.
+	 */
+	private static function is_tracking_allowed(): bool {
+		return ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) );
+	}
+
+	/**
 	 * Handler for the 'woocommerce_get_settings_advanced' hook,
 	 * it adds the settings UI for all the existing features.
 	 *
@@ -698,17 +705,16 @@ class FeaturesController {
 						'id'    => 'experimental_features_options',
 					);
 
-					$is_tracking_allowed = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
 					$auto_enable_experimental = array(
 						'title'   => __( 'All Experimental Features', 'woocommerce' ),
 						'desc'    => __( 'Automatically enable all experimental features', 'woocommerce' ),
 						'id'      => 'woocommerce_experimental_features_auto_enable',
 						'type'    => 'checkbox',
 						'default' => 'no',
-						'disabled' => ! ( $is_tracking_allowed ),
+						'disabled' => ! ( self::is_tracking_allowed() ),
 					);
 			
-					if ( ! $is_tracking_allowed ) {
+					if ( ! self::is_tracking_allowed() ) {
 						$auto_enable_experimental['desc_tip'] = sprintf(
 						// translators: Placeholders are URLs.
 							__(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -736,7 +736,7 @@ class FeaturesController {
 					$feature_settings[] = array(
 						'title' => __( 'Experimental features', 'woocommerce' ),
 						'type'  => 'title',
-						'desc'  => __( 'These features are either experimental or incomplete. They might change or go away in the future. Enable them at your own risk.', 'woocommerce' ),
+						'desc'  => __( 'These features are either experimental or incomplete. They might change or be discontinued in the future. Enable them at your own risk.', 'woocommerce' ),
 						'id'    => 'experimental_features_options',
 					);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a setting to automatically opt in to new experimental features. 

To try it out:

- go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
- if tracking is turned off, note the notice and disabled checkbox under "Experimental features"
- follow the link to enable tracking
- go back to the Features tab and enable the "All Experimental Features" option
- observe that "New product editor" was enabled
- go back to the WooCommerce.com (tracking) tab
- disable tracking and safe
- go back to the Features tab and observe that the "All Experimental Features" option along with all experimental features has been disabled

Note:

- Doesn't yet enable features as they are added via a version update.
- Doesn't yet track enabling / disabling of the setting or features.
- Possibly adding another class of features makes more sense? E.g.: 
  - "stable but optional" (now just "Features")
  - "beta" (now "Experimental Features", can opt-in to automatic activation -- the setting this PR adds)
  - "experimental" (too risky for automatic opt-in)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. TBD

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add setting to auto-enable experimental features.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
