### PR TITLE
Add help text under "Include downloads" toggle

### DIFF
--- a/plugins/woocommerce/changelog/dev-45921_add_help_text_to_downloads_toggle
+++ b/plugins/woocommerce/changelog/dev-45921_add_help_text_to_downloads_toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add help text under "Include downloads" toggle #46752

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/DownloadableProductTrait.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/DownloadableProductTrait.php
@@ -41,8 +41,11 @@ trait DownloadableProductTrait {
 					'blockName'  => 'woocommerce/product-toggle-field',
 					'order'      => 10,
 					'attributes' => array(
-						'property' => 'downloadable',
-						'label'    => __( 'Include downloads', 'woocommerce' ),
+						'property'      => 'downloadable',
+						'label'         => __( 'Include downloads', 'woocommerce' ),
+						'checkedHelp'   => __( 'Add any files you\'d like to make available for the customer to download after purchasing, such as instructions or warranty info.', 'woocommerce' ),
+						'uncheckedHelp' => __( 'Add any files you\'d like to make available for the customer to download after purchasing, such as instructions or warranty info.', 'woocommerce' ),
+
 					),
 				)
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to add a help text to `Include downloads` toggle.

Copy:
`Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.`

<img width="689" alt="image" src="https://github.com/woocommerce/woocommerce/assets/65582817/4c0ef92e-b7d4-44f5-aef1-acb3c8996520">

Closes #45921.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Scroll down and verify the `Include downloads` toggle has the following help text: `Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.`
4. Enable the toggle and verify the help text is still visible.
6. Create a few variations and edit a single variation.
7. The helper text should be visible inside the variations' downloads section.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
