### PR TITLE
Add assets to the dewp distribution as it is needed.

### DIFF
--- a/packages/js/dependency-extraction-webpack-plugin/changelog/46755-dev-add-files-to-dewp-dist
+++ b/packages/js/dependency-extraction-webpack-plugin/changelog/46755-dev-add-files-to-dewp-dist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug where the assets folder was not distributed with @woocommerce/dependency-extraction-webpack-plugin

--- a/packages/js/dependency-extraction-webpack-plugin/package.json
+++ b/packages/js/dependency-extraction-webpack-plugin/package.json
@@ -22,7 +22,8 @@
 	},
 	"main": "src/index.js",
 	"files": [
-		"src/"
+		"src/",
+		"assets/"
 	],
 	"dependencies": {
 		"@wordpress/dependency-extraction-webpack-plugin": "^3.7.0"

--- a/packages/js/dependency-extraction-webpack-plugin/package.json
+++ b/packages/js/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "2.4.1",
+	"version": "2.4.0",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/js/dependency-extraction-webpack-plugin/package.json
+++ b/packages/js/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This should resolve https://github.com/woocommerce/woocommerce/issues/46748

A new release will need to be done.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run `pnpm pack` from this package's directory
2. Uncompress the tarball
3. You should see assets folder bundled

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a bug where the assets folder was not distributed with @woocommerce/dependency-extraction-webpack-plugin

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
