### PR TITLE
Blocks E2E: Provide correct expected translation

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-translations.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-translations.shopper.block_theme.side_effects.spec.ts
@@ -126,7 +126,7 @@ test.describe( 'Shopper → Translations', () => {
 
 		await expect( page.getByText( 'Subtotaal' ) ).toBeVisible();
 
-		await expect( page.getByText( 'Verzendmethoden' ) ).toBeVisible();
+		await expect( page.getByText( 'Verzending' ) ).toBeVisible();
 
 		await expect(
 			page.getByText( 'Totaal', { exact: true } )

--- a/plugins/woocommerce/changelog/fix-e2e-translation-test
+++ b/plugins/woocommerce/changelog/fix-e2e-translation-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Fix translation test where "Verzendmethoden" label is not visible


### PR DESCRIPTION
### Proposed changes

This PR fixes a translation test where the `Verzendmethoden` label is expected but not found on the page:

```
Error: Timed out 5000ms waiting for expect(locator).toBeVisible()

    Locator: getByText('Verzendmethoden')
    Expected: visible
    Received: hidden
    Call log:
      - expect.toBeVisible with timeout 5000ms
      - waiting for getByText('Verzendmethoden')


     		await expect( page.getByText( 'Subtotaal' ) ).toBeVisible();
      
     		await expect( page.getByText( 'Verzendmethoden' ) ).toBeVisible();
     		                                                    ^
    
     		await expect(
     			page.getByText( 'Totaal', { exact: true } )

    at /home/runner/work/woocommerce/woocommerce/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-translations.shopper.block_theme.side_effects.spec.ts:129:55
```


#### What happened?

That translation test was unskipped in January (#43852), where the expected label [was changed](https://github.com/woocommerce/woocommerce/commit/30dfa013f9b5c0942de437ac18e5e3eb93d820f8#diff-897e1a1a8047c737fa10c74831844daa7f98da6766a0db3ab67aec9699c86957L113-R107) from `Verzending` to `Verzendmethoden`. That assertion should not have been updated, though, since it was the very reason to skip the test: a `woocommerce` translation (`Verzendmethoden`) overriding the expected woocommerce-blocks one (`Verzending`). That translation logic must have been fixed recently, so the test has started failing.

Please see https://github.com/woocommerce/woocommerce-blocks/issues/7775 for more details on the original issue.

Related conversation: p1669290696400829-slack-C02UBB1EPEF

cc @nielslange @roykho 

### How to test

Locally, run the following and ensure it's passing:
```
pnpm test:e2e cart/cart-checkout-block-translations.shopper.block_theme.spec.ts
```

All the CI tests should pass.
