### PR TITLE
Correctly serialize data in additional fields API

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
@@ -55,7 +55,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				{
 					contact: {
 						'Enter a gift message to include in the package':
-							'This is for you!',
+							'For my non-ascii named friend: niño',
 					},
 					address: {
 						shipping: {
@@ -105,7 +105,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				{
 					contact: {
 						'Enter a gift message to include in the package':
-							'This is for you!',
+							'For my non-ascii named friend: niño',
 						'Is this a personal purchase or a business purchase?':
 							'business',
 					},
@@ -188,7 +188,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 					[ 'What is your favourite colour?', 'Blue' ],
 					[
 						'Enter a gift message to include in the package',
-						'This is for you!',
+						'For my non-ascii named friend: niño',
 					],
 					[ 'Do you want to subscribe to our newsletter?', 'Yes' ],
 					[ 'Would you like a free gift with your order?', 'Yes' ],
@@ -220,7 +220,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 					.getByLabel(
 						'Enter a gift message to include in the package'
 					)
-			).toHaveValue( 'This is for you!' );
+			).toHaveValue( 'For my non-ascii named friend: niño' );
 			await expect(
 				checkoutPageObject.page
 					.getByRole( 'group', {

--- a/plugins/woocommerce/changelog/fix-sanitize-data-fields
+++ b/plugins/woocommerce/changelog/fix-sanitize-data-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix sanitization of special letters in Additional fields API

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -95,14 +95,24 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				 * @param WC_Customer $customer The customer object.
 				 */
 				$allowed_keys  = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
-				$session_value = wp_json_encode(
-					array_filter(
-						$customer->get_meta_data(),
-						function( $meta_data ) use ( $allowed_keys ) {
-							return in_array( $meta_data->key, $allowed_keys, true );
-						}
+				$session_value = maybe_serialize(
+					array_map(
+						function ( $meta_data ) {
+							// Data comes to us a WC_Meta_Data, we cast it to an array to ensure it is serializable.
+								return array(
+									'key'   => $meta_data->key,
+									'value' => $meta_data->value,
+								);
+						},
+						array_filter(
+							$customer->get_meta_data(),
+							function ( $meta_data ) use ( $allowed_keys ) {
+									return in_array( $meta_data->key, $allowed_keys, true );
+							}
+						)
 					)
 				);
+
 			} else {
 				$session_value = $customer->{"get_$function_key"}( 'edit' );
 			}
@@ -137,7 +147,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				}
 				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
 					if ( 'meta_data' === $session_key ) {
-						$meta_data_values = json_decode( wp_unslash( $data[ $session_key ] ), true );
+						$meta_data_values = maybe_unserialize( $data[ $session_key ] );
 						if ( $meta_data_values ) {
 							foreach ( $meta_data_values as $meta_data_value ) {
 								if ( ! isset( $meta_data_value['key'], $meta_data_value['value'] ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

For additional fields, we added extra logic on the customer session data store, this allows us to save fields in it to be persisted to DB, problem is this was running through double serialization (json_encode => serialize => unserialize => json_decode) and this caused some data to be lost in the process, this PR updates it so we always serialize.

I added an E2E test for this as well.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46584

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add the following field somewhere:
```php
add_action(
	'woocommerce_blocks_loaded',
	function () {
		__experimental_woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'wcbrf/neighborhoodf-address',
				'label'    => 'Bairro',
				'location' => 'address',
				'required' => true,
				'index'    => 30,
			),
		);
		__experimental_woocommerce_blocks_register_checkout_field(
			array(
				'id'       => 'wcbrf/neighborhoodf-contact',
				'label'    => 'Bairro',
				'location' => 'contact',
				'required' => true,
				'index'    => 30,
			),
		);
	}
);
```
2. In Checkout, fill out the new fields (Bairro) with a special character field `São Paulo`.
4. Leave Checkout to Cart, then back to checkout, make sure the value for Address is still there and correct, the value in contact step would be gone.
5. Place the order, add an item back to cart, and go to Checkout, ensure both values are there and correct `São Paulo`.
