### PR TITLE
#46759 wc_product_pre_has_unique_sku

### DIFF
--- a/plugins/woocommerce/changelog/46763-dev-46759-wc-product-pre-has-unique-sku
+++ b/plugins/woocommerce/changelog/46763-dev-46759-wc-product-pre-has-unique-sku
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added the `wc_product_pre_has_unique_sku` filter hook to allow SKU uniqueness to be determined externally

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -620,7 +620,7 @@ function wc_product_has_unique_sku( $product_id, $sku ) {
 	 *
 	 * @param bool|null $has_unique_sku Can be set to a bool result to short-circuit the default existing SKU check.
 	 */
-	$has_unique_sku = apply_filters( 'wc_product_pre_has_unique_sku', $product_id, $sku );
+	$has_unique_sku = apply_filters( 'wc_product_pre_has_unique_sku', null, $product_id, $sku );
 	if ( null !== $has_unique_sku ) {
 		return boolval( $has_unique_sku );
 	}

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -615,6 +615,10 @@ function wc_get_product_types() {
  * @return bool
  */
 function wc_product_has_unique_sku( $product_id, $sku ) {
+	if ( apply_filters( 'wc_product_pre_has_unique_sku', $product_id, $sku ) ) {
+		return true;
+	}
+
 	$data_store = WC_Data_Store::load( 'product' );
 	$sku_found  = $data_store->is_existing_sku( $product_id, $sku );
 

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -615,8 +615,14 @@ function wc_get_product_types() {
  * @return bool
  */
 function wc_product_has_unique_sku( $product_id, $sku ) {
-	if ( apply_filters( 'wc_product_pre_has_unique_sku', $product_id, $sku ) ) {
-		return true;
+	/**
+	 * Gives plugins an opportunity verify SKU uniqueness themselves.
+	 *
+	 * @param bool|null $has_unique_sku Can be set to a bool result to short-circuit the default existing SKU check.
+	 */
+	$has_unique_sku = apply_filters( 'wc_product_pre_has_unique_sku', $product_id, $sku );
+	if ( null !== $has_unique_sku ) {
+		return boolval( $has_unique_sku );
 	}
 
 	$data_store = WC_Data_Store::load( 'product' );

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -621,7 +621,7 @@ function wc_product_has_unique_sku( $product_id, $sku ) {
 	 * @param bool|null $has_unique_sku Can be set to a bool result to short-circuit the default existing SKU check.
 	 */
 	$has_unique_sku = apply_filters( 'wc_product_pre_has_unique_sku', null, $product_id, $sku );
-	if ( null !== $has_unique_sku ) {
+	if ( ! is_null( $has_unique_sku ) ) {
 		return boolval( $has_unique_sku );
 	}
 

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -618,7 +618,11 @@ function wc_product_has_unique_sku( $product_id, $sku ) {
 	/**
 	 * Gives plugins an opportunity verify SKU uniqueness themselves.
 	 *
-	 * @param bool|null $has_unique_sku Can be set to a bool result to short-circuit the default existing SKU check.
+	 * @since 9.0.0
+	 *
+	 * @param bool|null $has_unique_sku Set to a boolean value to short-circuit the default SKU check.
+	 * @param int $product_id The ID of the current product.
+	 * @param string $sku The SKU to check for uniqueness.
 	 */
 	$has_unique_sku = apply_filters( 'wc_product_pre_has_unique_sku', null, $product_id, $sku );
 	if ( ! is_null( $has_unique_sku ) ) {

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -616,7 +616,7 @@ function wc_get_product_types() {
  */
 function wc_product_has_unique_sku( $product_id, $sku ) {
 	/**
-	 * Gives plugins an opportunity verify SKU uniqueness themselves.
+	 * Gives plugins an opportunity to verify SKU uniqueness themselves.
 	 *
 	 * @since 9.0.0
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR enables the possibility to extend the `wc_product_has_unique_sku` function to allow:
 * integration of an external SKU duplicates check #31720
 * disabling SKU uniqueness check during large volume batch products imports #46759

Closes #46759 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

To test this, we need to basically try to create multiple products with the same SKU, with and without using the new filter hook. WP-CLI and REST API calls are two ways to do this, but you can use whatever method you want. For these testing instructions, I'll use WP-CLI.

1. Create a new product with a SKU: `wp wc product create --sku=test1`
2. Create another new product with the same SKU (repeat the same command).
3. You should get an error message about a duplicated SKU.
4. Now add this snippet to your test site, perhaps in a file in the mu-plugins directory:
    ```php
	add_filter( 'wc_product_pre_has_unique_sku', '__return_true' );
    ```
5. Now if you run the same command again, it should this time successfully create the product. If you go to the Products list table screen, you should see two products that have the same SKU.

Note that you could also test the filter by returning `false` instead of `true`, but if you do this without any conditional logic (always return false), it will create an infinite loop because it tries to generate a new unique SKU and then runs the same check on it. You will end up with a 500 internal server error.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Added the `wc_product_pre_has_unique_sku` filter hook to allow SKU uniqueness to be determined externally

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
