### PR TITLE
Allows Children of WC_Order to use the Order backend (admin) order page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -63,7 +63,8 @@ class PageController {
 			wp_die( esc_html__( 'You attempted to edit an order that does not exist. Perhaps it was deleted?', 'woocommerce' ) );
 		}
 
-		if ( $this->order->get_type() !== $this->order_type ) {
+		$order_class_name = wc_get_order_type( $this->order_type )['class_name'];
+		if ( ! ( $this->order instanceof $order_class_name ) ) {
 			wp_die( esc_html__( 'Order type mismatch.', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Allows Children of WC_Order to use the Order backend (admin) order page.

### How to test the changes in this Pull Request:

1. Create a new class extending WC_Order + Data store + init
```
class SubOrder extends \WC_Order
{
    public const ORDER_TYPE = 'shop_sub_order';
    protected $data_store_name = self::ORDER_TYPE;
    
    public function get_type(): string
    {
        return self::ORDER_TYPE;
    }
}
```
```
class SubOrderDataStore extends OrdersTableDataStore
{
    // This is the "ugly quick fix" we discussed in #46704, it's required for this to prevent the `Uncaught Error: Call to a member function format_object_value_for_db() on null`
    public function __construct()
    {
	$container = wc_get_container();
        $this->init(
            $container->get(OrdersTableDataStoreMeta::class),
            $container->get(DatabaseUtil::class),
            $container->get(LegacyProxy::class),
        );
    }
}

```
```
add_action(
            'init',
            static function () {
                wc_register_order_type(
                    SubOrder::ORDER_TYPE,
                    [
                        'class_name' => SubOrder::class,
                    ]
                );
            }
        );
```
```
        add_filter(
            'woocommerce_data_stores',
            static function ($shops) {
                $shops[SubOrder::ORDER_TYPE] = SubOrderDataStore::class;

                return $shops;
            }
        );
```
2. Create and save a new order

```
$subOrder = new Suborder();
$subOrder->save();
```
3. Open order page in backoffice
`/wp-admin/admin.php?page=wc-orders&action=edit&id=SUB_ORDER_ID`


#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message
Allows Children of WC_Order to use the Order backend (admin) order page

#### Comment
There might be some additional places where some changes are required, I'll add them if necessary in this PR.
Also, this is related to #46704 