### PR TITLE
Move all HPOS CLI tools to the "hpos" namespace

### DIFF
--- a/plugins/woocommerce/changelog/hpos-alias-cli-tools
+++ b/plugins/woocommerce/changelog/hpos-alias-cli-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Deprecate CLI tools under "cot" namespace and add aliases in "hpos" namespace.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -87,7 +87,7 @@ class CLIRunner {
 	 *
 	 * @return bool Whether the COT feature is enabled.
 	 */
-	private function is_enabled( $log = true ) : bool {
+	private function is_enabled( $log = true ): bool {
 		if ( ! $this->controller->custom_orders_table_usage_is_enabled() ) {
 			if ( $log ) {
 				WP_CLI::log(
@@ -108,7 +108,7 @@ class CLIRunner {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp wc cot count_unmigrated
+	 *     wp wc hpos count_unmigrated
 	 *
 	 * @param array $args Positional arguments passed to the command.
 	 *
@@ -116,7 +116,7 @@ class CLIRunner {
 	 *
 	 * @return int The number of orders to be migrated.*
 	 */
-	public function count_unmigrated( $args = array(), $assoc_args = array() ) : int {
+	public function count_unmigrated( $args = array(), $assoc_args = array() ): int {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$order_count = $this->synchronizer->get_current_orders_pending_sync_count();
 
@@ -157,7 +157,7 @@ class CLIRunner {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp wc cot sync --batch-size=500
+	 *     wp wc hpos sync --batch-size=500
 	 *
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
@@ -222,7 +222,7 @@ class CLIRunner {
 				)
 			);
 
-			$batch_count ++;
+			++$batch_count;
 			$total_time += $batch_total_time;
 
 			$progress->tick();
@@ -262,7 +262,7 @@ class CLIRunner {
 	}
 
 	/**
-	 * [Deprecated] Use `wp wc cot sync` instead.
+	 * [Deprecated] Use `wp wc hpos sync` instead.
 	 * Copy order data into the postmeta table.
 	 *
 	 * Note that this could dramatically increase the size of your postmeta table, but is recommended
@@ -280,11 +280,8 @@ class CLIRunner {
 	 *
 	 *     # Copy all order data into the post meta table, 500 posts at a time.
 	 *     wp wc cot migrate --batch-size=500
-	 *
-	 * @param array $args Positional arguments passed to the command.
-	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
-	public function migrate( $args = array(), $assoc_args = array() ) {
+	public function migrate() {
 		WP_CLI::log( __( 'Migrate command is deprecated. Please use `sync` instead.', 'woocommerce' ) );
 	}
 
@@ -329,7 +326,7 @@ class CLIRunner {
 	 * ## EXAMPLES
 	 *
 	 *     # Verify migrated order data, 500 orders at a time.
-	 *     wp wc cot verify_cot_data --batch-size=500 --start-from=0 --end-at=10000
+	 *     wp wc hpos verify_cot_data --batch-size=500 --start-from=0 --end-at=10000
 	 *
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
@@ -424,7 +421,7 @@ class CLIRunner {
 			$error_processing            = $error_processing || ! empty( $failed_ids_in_current_batch );
 			$processed                  += count( $order_ids );
 			$batch_total_time            = microtime( true ) - $batch_start_time;
-			$batch_count ++;
+			++$batch_count;
 			$total_time += $batch_total_time;
 
 			if ( count( $failed_ids_in_current_batch ) > 0 ) {
@@ -477,7 +474,7 @@ class CLIRunner {
 						} else {
 							array_walk(
 								$errors_in_remigrate_batch,
-								function( &$errors_for_order ) {
+								function ( &$errors_for_order ) {
 									$errors_for_order[] = array( 'remigrate_failed' => true );
 								}
 							);
@@ -569,7 +566,7 @@ class CLIRunner {
 	 *
 	 * @return int Order count.
 	 */
-	private function get_verify_order_count( int $order_id_start, int $order_id_end, array $order_types, bool $log = true ) : int {
+	private function get_verify_order_count( int $order_id_start, int $order_id_end, array $order_types, bool $log = true ): int {
 		global $wpdb;
 
 		$order_types_placeholder = implode( ',', array_fill( 0, count( $order_types ), '%s' ) );
@@ -615,7 +612,7 @@ class CLIRunner {
 	 *
 	 * @return array Failed IDs with meta details.
 	 */
-	private function verify_meta_data( array $order_ids, array $failed_ids ) : array {
+	private function verify_meta_data( array $order_ids, array $failed_ids ): array {
 		$meta_keys_to_ignore = $this->synchronizer->get_ignored_order_props();
 
 		global $wpdb;
@@ -695,7 +692,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 *
 	 * @return array Normalized data.
 	 */
-	private function normalize_raw_meta_data( array $data ) : array {
+	private function normalize_raw_meta_data( array $data ): array {
 		$clubbed_data = array();
 		foreach ( $data as $row ) {
 			if ( ! isset( $clubbed_data[ $row['entity_id'] ] ) ) {
@@ -729,7 +726,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * ### EXAMPLES
 	 *
 	 *      # Enable HPOS on new shops.
-	 *      wp wc cot enable --for-new-shop
+	 *      wp wc hpos enable --for-new-shop
 	 *
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
@@ -788,7 +785,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 				sprintf(
 					// translators: %s is the command to run (wp wc cot sync).
 					__( '[Failed] There are orders pending sync. Please run `%s` to sync pending orders.', 'woocommerce' ),
-					'wp wc cot sync',
+					'wp wc hpos sync',
 				)
 			);
 			$enable_hpos = false;
@@ -836,7 +833,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * ### EXAMPLES
 	 *
 	 *  # Disable HPOS.
-	 *  wp wc cot disable
+	 *  wp wc hpos disable
 	 *
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
@@ -859,7 +856,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 				sprintf(
 					// translators: %s is the command to run (wp wc cot sync).
 					__( '[Failed] There are orders pending sync. Please run `%s` to sync pending orders.', 'woocommerce' ),
-					'wp wc cot sync',
+					'wp wc hpos sync',
 				)
 			);
 		}
@@ -968,7 +965,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			foreach ( $order_ids as $order_id ) {
 				try {
 					$handler->cleanup_post_data( $order_id, $force );
-					$count++;
+					++$count;
 
 					// translators: %d is an order ID.
 					WP_CLI::debug( sprintf( __( 'Cleanup completed for order %d.', 'woocommerce' ), $order_id ) );
@@ -1018,11 +1015,8 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * Displays a summary of HPOS situation on this site.
 	 *
 	 * @since 8.6.0
-	 *
-	 * @param array $args       Positional arguments passed to the command.
-	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
-	public function status( array $args = array(), array $assoc_args = array() ) {
+	public function status() {
 		$legacy_handler = wc_get_container()->get( LegacyDataHandler::class );
 
 		// translators: %s is either 'yes' or 'no'.
@@ -1094,7 +1088,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 
 		// Format the diff array.
 		$diff = array_map(
-			function( $key, $hpos_value, $cpt_value ) {
+			function ( $key, $hpos_value, $cpt_value ) {
 				// Format for dates.
 				$hpos_value = is_a( $hpos_value, \WC_DateTime::class ) ? $hpos_value->format( DATE_ATOM ) : $hpos_value;
 				$cpt_value  = is_a( $cpt_value, \WC_DateTime::class ) ? $cpt_value->format( DATE_ATOM ) : $cpt_value;
@@ -1213,5 +1207,4 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			)
 		);
 	}
-
 }

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -280,8 +280,11 @@ class CLIRunner {
 	 *
 	 *     # Copy all order data into the post meta table, 500 posts at a time.
 	 *     wp wc cot migrate --batch-size=500
+	 *
+	 * @param array $args Positional arguments passed to the command.
+	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
-	public function migrate() {
+	public function migrate( array $args = array(), array $assoc_args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- for backwards compat.
 		WP_CLI::log( __( 'Migrate command is deprecated. Please use `sync` instead.', 'woocommerce' ) );
 	}
 
@@ -1015,8 +1018,11 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	 * Displays a summary of HPOS situation on this site.
 	 *
 	 * @since 8.6.0
+	 *
+	 * @param array $args       Positional arguments passed to the command.
+	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
-	public function status() {
+	public function status( array $args = array(), array $assoc_args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- for backwards compat.
 		$legacy_handler = wc_get_container()->get( LegacyDataHandler::class );
 
 		// translators: %s is either 'yes' or 'no'.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -58,16 +58,26 @@ class CLIRunner {
 	 * Registers commands for CLI.
 	 */
 	public function register_commands() {
-		WP_CLI::add_command( 'wc cot count_unmigrated', array( $this, 'count_unmigrated' ) );
-		WP_CLI::add_command( 'wc cot migrate', array( $this, 'migrate' ) );
-		WP_CLI::add_command( 'wc cot sync', array( $this, 'sync' ) );
-		WP_CLI::add_command( 'wc cot verify_cot_data', array( $this, 'verify_cot_data' ) );
-		WP_CLI::add_command( 'wc cot enable', array( $this, 'enable' ) );
-		WP_CLI::add_command( 'wc cot disable', array( $this, 'disable' ) );
+		$legacy_commands = array( 'count_unmigrated', 'sync', 'verify_cot_data', 'enable', 'disable' );
+		foreach ( $legacy_commands as $cmd ) {
+			$new_cmd_name = 'verify_cot_data' === $cmd ? 'verify_data' : $cmd;
+
+			WP_CLI::add_command( "wc hpos {$new_cmd_name}", array( $this, $cmd ) );
+			WP_CLI::add_command(
+				"wc cot {$cmd}",
+				function ( array $args = array(), array $assoc_args = array() ) use ( $cmd, $new_cmd_name ) {
+					WP_CLI::warning( "Command `wc cot {$cmd}` is deprecated since 8.9.0. Please use `wc hpos {$new_cmd_name}` instead." );
+					return call_user_func( array( $this, $cmd ), $args, $assoc_args );
+				}
+			);
+		}
+
 		WP_CLI::add_command( 'wc hpos cleanup', array( $this, 'cleanup_post_data' ) );
 		WP_CLI::add_command( 'wc hpos status', array( $this, 'status' ) );
 		WP_CLI::add_command( 'wc hpos diff', array( $this, 'diff' ) );
 		WP_CLI::add_command( 'wc hpos backfill', array( $this, 'backfill' ) );
+
+		WP_CLI::add_command( 'wc cot migrate', array( $this, 'migrate' ) ); // Fully deprecated. No longer works.
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When we first started working on HPOS it was called COT (Custom Order Tables) and so that's what we used for the initial CLI tools (`wc cot <tool>`). The latest tools do use the HPOS namespace (`wc hpos <tool>`) and with this PR we bring the old tools to this namespace too.

As to not break anything, tools in the old namespace still work but will display a deprecation warning before running.

In particular, the tools are remapped as follows:

- `wc cot count_unmigrated` -> `wc hpos count_unmigrated`.
- `wc cot sync` -> `wc hpos sync`.
- `wc cot verify_cot_data` -> `wc hpos verify_data`.
- `wc cot enable` -> `wc hpos enable`.
- `wc cot disable` -> `wc hpos disable`.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. For each of the tools (`count_unmigrated`, `sync`, `verify_cot_data`, `enable` and `disable`) confirm that `wc cot <tool>` still works but displays a deprecation warning like the following:

   > Warning: Command `wc cot count_unmigrated` is deprecated since 8.9.0. Please use `wc hpos count_unmigrated` instead.
3. For each tool, confirm that `wc hpos <tool>` works too but doesn't display any warnings.
   In the particular case of `verify_cot_data`, note that this has been remapped as `wc hpos verify_data`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
