### PR TITLE
Use HTML tag processor to strip formatted addresses of tags

### DIFF
--- a/plugins/woocommerce/includes/class-wc-privacy-exporters.php
+++ b/plugins/woocommerce/includes/class-wc-privacy-exporters.php
@@ -279,7 +279,7 @@ class WC_Privacy_Exporters {
 					break;
 				case 'formatted_billing_address':
 				case 'formatted_shipping_address':
-					$value = preg_replace( '#<br\s*/?>#i', ', ', $order->{"get_$prop"}() );
+					$value = wc_get_address_plain_text( $order->{"get_$prop"}() );
 					break;
 				default:
 					if ( is_callable( array( $order, 'get_' . $prop ) ) ) {

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1574,3 +1574,23 @@ add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_ed
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_payment_methods_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_lost_password_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_logout_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+
+/**
+ * Get the address in plain text, stripped of tags.
+ *
+ * @param $address string Address to format.
+ * @return string
+ */
+function wc_get_address_plain_text( $address, $replace = ', ' ) {
+	$p = new WP_HTML_Tag_Processor( $address );
+	$content = '';
+	while ( $p->next_token() )  {
+		if( 'BR' === $p->get_tag() ) {
+			$content .= $replace;
+			continue;
+		}
+		$token    = $p->get_modifiable_text();
+		$content .= $token;
+	}
+	return $content;
+}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1080,7 +1080,7 @@ class ListTable extends WP_List_Table {
 		$address = $order->get_formatted_billing_address();
 
 		if ( $address ) {
-			echo esc_html( preg_replace( '#<br\s*/?>#i', ', ', $address ) );
+			echo wc_get_address_plain_text( $address );
 
 			if ( $order->get_payment_method() ) {
 				/* translators: %s: payment method */
@@ -1102,7 +1102,7 @@ class ListTable extends WP_List_Table {
 		$address = $order->get_formatted_shipping_address();
 
 		if ( $address ) {
-			echo '<a target="_blank" href="' . esc_url( $order->get_shipping_address_map_url() ) . '">' . esc_html( preg_replace( '#<br\s*/?>#i', ', ', $address ) ) . '</a>';
+			echo '<a target="_blank" href="' . esc_url( $order->get_shipping_address_map_url() ) . '">' . wc_get_address_plain_text( $address ) . '</a>';
 			if ( $order->get_shipping_method() ) {
 				/* translators: %s: shipping method */
 				echo '<span class="description">' . sprintf( esc_html__( 'via %s', 'woocommerce' ), esc_html( $order->get_shipping_method() ) ) . '</span>';

--- a/plugins/woocommerce/templates/emails/plain/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/plain/email-addresses.php
@@ -18,7 +18,7 @@
 defined( 'ABSPATH' ) || exit;
 
 echo "\n" . esc_html( wc_strtoupper( esc_html__( 'Billing address', 'woocommerce' ) ) ) . "\n\n";
-echo preg_replace( '#<br\s*/?>#i', "\n", $order->get_formatted_billing_address() ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo wc_get_address_plain_text( $order->get_formatted_billing_address() ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 if ( $order->get_billing_phone() ) {
 	echo $order->get_billing_phone() . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -45,7 +45,7 @@ if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() ) {
 
 	if ( $shipping ) {
 		echo "\n" . esc_html( wc_strtoupper( esc_html__( 'Shipping address', 'woocommerce' ) ) ) . "\n\n";
-		echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wc_get_address_plain_text( $shipping, "\n" ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( $order->get_shipping_phone() ) {
 			echo $order->get_shipping_phone() . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use the HTML tag processor to remove `br` tags from addresses instead of the regex currently used.

It's unclear whether or not other tags should be allowed in those addresses, but they're often escaped which could result in some funky formatting.

This PR strips out all tags and replaces `br` tags with a replacement in plain text.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Check the following to make sure that addresses are rendered correctly, including `br` and other HTML tags in their source.

1. Trigger some emails that contain billing/shipping addresses
2. Check that admin orders list table to verify address formatting
3. Export privacy data and verify address formatting

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
