### PR TITLE
Fix plugin registration on woocommerce.com for active plugins

### DIFF
--- a/plugins/woocommerce/changelog/2024-04-22-04-49-18-213839
+++ b/plugins/woocommerce/changelog/2024-04-22-04-49-18-213839
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix registration of plugin on woocommerce.com if plugin is already active on site.

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
@@ -79,6 +79,11 @@ class WC_WCCOM_Site_Installation_Step_Activate_Product implements WC_WCCOM_Site_
 			throw new Installer_Error( Installer_Error_Codes::UNKNOWN_FILENAME );
 		}
 
+		// If the plugin is already active, make sure we call the registration hook.
+		if ( is_plugin_active( $filename ) ) {
+			WC_Helper::activated_plugin( $filename );
+		}
+
 		$result = activate_plugin( $filename );
 
 		if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When an already activated plugin was connected to WooCommerce.com, it wasn't registered correctly. This PR fixes that. See video below for difference in behaviour.

Behaviour before this PR:

https://github.com/woocommerce/woocommerce/assets/533/81fd6d7b-136d-41f9-abc2-613488b6d6e7

Behaviour after this PR:

https://github.com/woocommerce/woocommerce/assets/533/aa0ca7a5-be3b-4084-a6ed-c02c9a2ccd15

<!-- Begin testing instructions -->

### Replicate behaviour before this PR

1. Go to a site with WooCommerce stable and connect it to woocommerce.com (`/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions`)
2. Make sure you have some purchases on your account at woocommerce.com
3. Install one of those purchases to the site.
4. Now go to https://woocommerce.com/my-account/my-subscriptions/ and disconnect that product from this store.
5. Now on the same page, for the same product, Add to store for the same store.
6. Wait for installation to complete.
7. Go back to https://woocommerce.com/my-account/my-subscriptions/  and notice that the page still does not have the subscription connected to the store.

### Replicate the fix.

1. Go to a site with [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/15057940/woocommerce.zip) from this PR.
2. Follow steps 2-6 from the previous instructions.
3. Go back to https://woocommerce.com/my-account/my-subscriptions/  and notice that the page now has a subscription connected to the store.

<!-- End testing instructions -->
