### PR TITLE
get settings in correct format for Local Pickup

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -65,11 +65,6 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		await editor.canvas.getByText( 'This is a test' ).isVisible();
 		await editor.saveSiteEditorEntities();
 
-		// Make sure the result is visible in frontend
-		await frontendUtils.goToCheckout();
-
-		await expect( page.getByText( 'This is a test' ) ).toBeVisible();
-
 		// Now check if it's visible in the local pickup settings.
 		await localPickupUtils.openLocalPickupSettings();
 		await expect( page.getByLabel( 'Title' ) ).toHaveValue(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -64,6 +64,13 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		await fakeInput.pressSequentially( 'This is a test' );
 		await editor.canvas.getByText( 'This is a test' ).isVisible();
 		await editor.saveSiteEditorEntities();
+
+		// Make sure the result is visible in frontend
+		await frontendUtils.goToCheckout();
+
+		await expect( page.getByText( 'This is a test' ) ).toBeVisible();
+
+		// Now check if it's visible in the local pickup settings.
 		await localPickupUtils.openLocalPickupSettings();
 		await expect( page.getByLabel( 'Title' ) ).toHaveValue(
 			'This is a test'

--- a/plugins/woocommerce/changelog/46799-fix-local-pickup-not-visible-after-edit
+++ b/plugins/woocommerce/changelog/46799-fix-local-pickup-not-visible-after-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fixes a regression that's only in trunk for now.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -267,7 +267,7 @@ class Checkout extends AbstractBlock {
 		if ( ( ! empty( $post->post_type ) && ! empty( $post->post_name ) && 'page-checkout' !== $post->post_name && 'wp_template' === $post->post_type ) || false === has_block( 'woocommerce/checkout', $post ) ) {
 			return;
 		}
-		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings();
+		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings( 'edit' );
 
 		if ( ! isset( $pickup_location_settings['title'] ) ) {
 			return;

--- a/plugins/woocommerce/src/StoreApi/Utilities/LocalPickupUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/LocalPickupUtils.php
@@ -9,8 +9,10 @@ class LocalPickupUtils {
 
 	/**
 	 * Gets the local pickup location settings.
+	 *
+	 * @param string $context The context for the settings. Defaults to 'view'.
 	 */
-	public static function get_local_pickup_settings() {
+	public static function get_local_pickup_settings( $context = 'view' ) {
 		$pickup_location_settings = get_option(
 			'woocommerce_pickup_location_settings',
 			[
@@ -25,6 +27,11 @@ class LocalPickupUtils {
 
 		if ( empty( $pickup_location_settings['enabled'] ) ) {
 			$pickup_location_settings['enabled'] = 'no';
+		}
+
+		// Return settings as is if we're editing them.
+		if ( 'edit' === $context ) {
+			return $pickup_location_settings;
 		}
 
 		// All consumers of this turn it into a bool eventually. Doing it here removes the need for that.


### PR DESCRIPTION
### Submission Review Guidelines:

In https://github.com/woocommerce/woocommerce/pull/45720 we added local pickup title sync between the editor and settings, that change didn't consider that the settings call would parse data into unsable state, it parsed `"yes"/"no"` into boolean, and saved that back instead of returning it again into `"yes"/"no"`.

This PR adds a `$context` param that's common in WordPress, it accepts `view` and `edit`, if you pass edit, it returns the value in its raw format.

Ideally, we should skip calling `get_local_pickup_settings` and load up the setting as is, because we risk editing things we don't want to edit, for now, those only things are title and enable/disable, but for now it doesn't seem to cause a problem because you can't have an empty title.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46790

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
1. Enable Local pickup.
2. In the checkout edit page, edit something and save.
3. In frontend, ensure Local Pickup is still showing.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment Fixes a regression that's only in trunk for now.

</details>
