### PR TITLE
Graduate Additional Fields to stable and rename it.

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/context/event-emit/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/event-emit/utils.ts
@@ -35,7 +35,7 @@ export enum noticeContexts {
 	BILLING_ADDRESS = 'wc/checkout/billing-address',
 	SHIPPING_METHODS = 'wc/checkout/shipping-methods',
 	CHECKOUT_ACTIONS = 'wc/checkout/checkout-actions',
-	ADDITIONAL_INFORMATION = 'wc/checkout/additional-information',
+	ORDER_INFORMATION = 'wc/checkout/additional-information',
 }
 
 export interface ResponseType extends Record< string, unknown > {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
@@ -5,7 +5,7 @@ import { noticeContexts } from '@woocommerce/base-context';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
-import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
+import { ORDER_FORM_KEYS } from '@woocommerce/block-settings';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import type { FunctionComponent } from 'react';
 
@@ -27,21 +27,21 @@ const Block: FunctionComponent = () => {
 		...additionalFields,
 	};
 
-	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
+	if ( ORDER_FORM_KEYS.length === 0 ) {
 		return null;
 	}
 
 	return (
 		<>
 			<StoreNoticesContainer
-				context={ noticeContexts.ADDITIONAL_INFORMATION }
+				context={ noticeContexts.ORDER_INFORMATION }
 			/>
 			<Form
 				id="additional-information"
 				addressType="additional-information"
 				onChange={ onChangeForm }
 				values={ additionalFieldValues }
-				fields={ ADDITIONAL_FORM_KEYS }
+				fields={ ORDER_FORM_KEYS }
 			/>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
@@ -4,7 +4,7 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { FormStepBlock } from '@woocommerce/blocks/checkout/form-step';
 import classnames from 'classnames';
-import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
+import { ORDER_FORM_KEYS } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ) => {
-	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
+	if ( ORDER_FORM_KEYS.length === 0 ) {
 		return null;
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
@@ -3,7 +3,7 @@
  */
 import classnames from 'classnames';
 import { FormStep } from '@woocommerce/blocks-components';
-import { ADDITIONAL_FORM_KEYS } from '@woocommerce/block-settings';
+import { ORDER_FORM_KEYS } from '@woocommerce/block-settings';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
@@ -31,7 +31,7 @@ const FrontendBlock = ( {
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
 
-	if ( ADDITIONAL_FORM_KEYS.length === 0 ) {
+	if ( ORDER_FORM_KEYS.length === 0 ) {
 		return null;
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/component-metadata.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/component-metadata.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import CHECKOUT_ACTIONS from './checkout-actions-block/block.json';
-import CHECKOUT_ADDITIONAL_INFORMATION from './checkout-additional-information-block/block.json';
+import CHECKOUT_ORDER_INFORMATION from './checkout-additional-information-block/block.json';
 import CHECKOUT_BILLING_ADDRESS from './checkout-billing-address-block/block.json';
 import CHECKOUT_CONTACT_INFORMATION from './checkout-contact-information-block/block.json';
 import CHECKOUT_EXPRESS_PAYMENT from './checkout-express-payment-block/block.json';
@@ -27,7 +27,7 @@ import CHECKOUT_ORDER_SUMMARY_TOTALS from './checkout-order-summary-totals/block
 
 export default {
 	CHECKOUT_ACTIONS,
-	CHECKOUT_ADDITIONAL_INFORMATION,
+	CHECKOUT_ORDER_INFORMATION,
 	CHECKOUT_BILLING_ADDRESS,
 	CHECKOUT_CONTACT_INFORMATION,
 	CHECKOUT_EXPRESS_PAYMENT,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
@@ -110,7 +110,7 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
-	metadata: metadata.CHECKOUT_ADDITIONAL_INFORMATION,
+	metadata: metadata.CHECKOUT_ORDER_INFORMATION,
 	component: lazy(
 		() =>
 			import(

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/additional-fields-wrapper/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/additional-fields-wrapper/block.json
@@ -2,9 +2,11 @@
 	"name": "woocommerce/order-confirmation-additional-fields-wrapper",
 	"version": "1.0.0",
 	"title": "Additional Fields",
-	"description": "Display additional checkout fields from the 'contact' and 'additional' locations.",
+	"description": "Display additional checkout fields from the 'contact' and 'order' locations.",
 	"category": "woocommerce",
-	"keywords": [ "WooCommerce" ],
+	"keywords": [
+		"WooCommerce"
+	],
 	"attributes": {
 		"heading": {
 			"type": "string"
@@ -12,7 +14,10 @@
 	},
 	"supports": {
 		"multiple": false,
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"html": false,
 		"spacing": {
 			"padding": true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/additional-fields-wrapper/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/additional-fields-wrapper/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import {
-	ADDITIONAL_FORM_FIELDS,
+	ORDER_FORM_FIELDS,
 	CONTACT_FORM_FIELDS,
 } from '@woocommerce/block-settings';
 
@@ -26,7 +26,7 @@ const Edit = ( {
 	} );
 
 	const additionalFields = {
-		...ADDITIONAL_FORM_FIELDS,
+		...ORDER_FORM_FIELDS,
 		...CONTACT_FORM_FIELDS,
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/additional-fields/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/additional-fields/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import {
-	ADDITIONAL_FORM_FIELDS,
+	ORDER_FORM_FIELDS,
 	CONTACT_FORM_FIELDS,
 } from '@woocommerce/block-settings';
 import { AdditionalFieldsPlaceholder } from '@woocommerce/base-components/cart-checkout';
@@ -19,7 +19,7 @@ const Edit = (): JSX.Element => {
 	} );
 
 	const additionalFields = {
-		...ADDITIONAL_FORM_FIELDS,
+		...ORDER_FORM_FIELDS,
 		...CONTACT_FORM_FIELDS,
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -141,8 +141,8 @@ const getErrorContextFromAdditionalFieldLocation = (
 	switch ( location ) {
 		case 'contact':
 			return noticeContexts.CONTACT_INFORMATION;
-		case 'additional':
-			return noticeContexts.ADDITIONAL_INFORMATION;
+		case 'order':
+			return noticeContexts.ORDER_INFORMATION;
 		default:
 			return undefined;
 	}

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
@@ -51,7 +51,7 @@ export const LOCAL_PICKUP_ENABLED = getSetting< boolean >(
 type FieldsLocations = {
 	address: string[];
 	contact: string[];
-	additional: string[];
+	order: string[];
 };
 
 // Contains country names.
@@ -123,7 +123,7 @@ const defaultFieldsLocations: FieldsLocations = {
 		'phone',
 	],
 	contact: [ 'email' ],
-	additional: [],
+	order: [],
 };
 
 export const ADDRESS_FORM_KEYS = getSetting< FieldsLocations >(
@@ -136,10 +136,10 @@ export const CONTACT_FORM_KEYS = getSetting< FieldsLocations >(
 	defaultFieldsLocations
 ).contact;
 
-export const ADDITIONAL_FORM_KEYS = getSetting< FieldsLocations >(
+export const ORDER_FORM_KEYS = getSetting< FieldsLocations >(
 	'addressFieldsLocations',
 	defaultFieldsLocations
-).additional;
+).order;
 
 export interface CheckoutField {
 	label: string;
@@ -147,8 +147,8 @@ export interface CheckoutField {
 	options: { label: string; value: string }[];
 }
 
-export const ADDITIONAL_FORM_FIELDS = getSetting< CheckoutField[] >(
-	'additionalFields',
+export const ORDER_FORM_FIELDS = getSetting< CheckoutField[] >(
+	'additionalOrderFields',
 	{}
 );
 export const CONTACT_FORM_FIELDS = getSetting< CheckoutField[] >(

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -22,15 +22,15 @@
     - [The select input when focused](#the-select-input-when-focused)
 - [Validation and sanitization](#validation-and-sanitization)
     - [Sanitization](#sanitization)
-        - [Using the `_experimental_woocommerce_blocks_sanitize_additional_field` filter](#using-the-_experimental_woocommerce_blocks_sanitize_additional_field-filter)
+        - [Using the `woocommerce_blocks_sanitize_additional_field` filter](#using-the-woocommerce_blocks_sanitize_additional_field-filter)
             - [Example of sanitization](#example-of-sanitization)
     - [Validation](#validation)
         - [Single field validation](#single-field-validation)
-            - [Using the `__experimental_woocommerce_blocks_validate_additional_field` action](#using-the-__experimental_woocommerce_blocks_validate_additional_field-action)
+            - [Using the `woocommerce_blocks_validate_additional_field` action](#using-the-woocommerce_blocks_validate_additional_field-action)
                 - [The `WP_Error` object](#the-wp_error-object)
                 - [Example of single-field validation](#example-of-single-field-validation)
         - [Multiple field validation](#multiple-field-validation)
-            - [Using the `__experimental_woocommerce_blocks_validate_location_{location}_fields` action](#using-the-__experimental_woocommerce_blocks_validate_location_location_fields-action)
+            - [Using the `woocommerce_blocks_validate_location_{location}_fields` action](#using-the-woocommerce_blocks_validate_location_location_fields-action)
             - [Example of location validation](#example-of-location-validation)
 - [A full example](#a-full-example)
 
@@ -226,7 +226,7 @@ There are plans to expand this list, but for now these are the types available.
 
 ## Using the API
 
-To register additional checkout fields you must use the `__experimental_woocommerce_blocks_register_checkout_field` function.
+To register additional checkout fields you must use the `woocommerce_blocks_register_checkout_field` function.
 
 It is recommended to run this function after the `woocommerce_blocks_loaded` action.
 
@@ -341,7 +341,7 @@ This example demonstrates rendering a text field in the address section:
 add_action(
 	'woocommerce_blocks_loaded',
 	function() {
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'            => 'namespace/gov-id',
 				'label'         => 'Government ID',
@@ -384,7 +384,7 @@ This example demonstrates rendering a checkbox field in the contact information 
 add_action(
 	'woocommerce_blocks_loaded',
 	function() {
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'namespace/marketing-opt-in',
 				'label'    => 'Do you want to subscribe to our newsletter?',
@@ -410,7 +410,7 @@ This example demonstrates rendering a select field in the additional information
 add_action(
 	'woocommerce_blocks_loaded',
 	function() {
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'namespace/how-did-you-hear-about-us',
 				'label'    => 'How did you hear about us?',
@@ -465,9 +465,9 @@ These actions happen in two places:
 
 Sanitization is used to ensure the value of a field is in a specific format. An example is when taking a government ID, you may want to format it so that all letters are capitalized and there are no spaces. At this point, the value should **not** be checked for _validity_. That will come later. This step is only intended to set the field up for validation.
 
-#### Using the `_experimental_woocommerce_blocks_sanitize_additional_field` filter
+#### Using the `woocommerce_blocks_sanitize_additional_field` filter
 
-To run a custom sanitization function for a field you can use the `sanitize_callback` function on registration, or the `__experimental_woocommerce_blocks_sanitize_additional_field` filter.
+To run a custom sanitization function for a field you can use the `sanitize_callback` function on registration, or the `woocommerce_blocks_sanitize_additional_field` filter.
 
 | Argument     | Type              | Description                                                             |
 |--------------|-------------------|-------------------------------------------------------------------------|
@@ -480,7 +480,7 @@ This example shows how to remove whitespace and capitalize all letters in the ex
 
 ```php
 add_action(
-	'_experimental_woocommerce_blocks_sanitize_additional_field',
+	'woocommerce_blocks_sanitize_additional_field',
 	function ( $field_value, $field_key ) {
 		if ( 'namespace/gov-id' === $field_key ) {
 			$field_value = str_replace( ' ', '', $field_key );
@@ -499,9 +499,9 @@ There are two phases of validation in the additional checkout fields system. The
 
 #### Single field validation
 
-##### Using the `__experimental_woocommerce_blocks_validate_additional_field` action
+##### Using the `woocommerce_blocks_validate_additional_field` action
 
-When the `__experimental_woocommerce_blocks_validate_additional_field` action is fired  the callback receives the field's key, the field's value, and a `WP_Error` object.
+When the `woocommerce_blocks_validate_additional_field` action is fired  the callback receives the field's key, the field's value, and a `WP_Error` object.
 
 To add validation errors to the response, use the [`WP_Error::add`](https://developer.wordpress.org/reference/classes/wp_error/add/) method.
 
@@ -521,7 +521,7 @@ The below example shows how to apply custom validation to the `namespace/gov-id`
 
 ```php
 add_action(
-'__experimental_woocommerce_blocks_validate_additional_field',
+'woocommerce_blocks_validate_additional_field',
 	function ( WP_Error $errors, $field_key, $field_value ) {
 		if ( 'namespace/gov-id' === $field_key ) {
 			$match = preg_match( '/[A-Z0-9]{5}/', $field_value );
@@ -541,11 +541,11 @@ If no validation errors are encountered the function can just return void.
 
 #### Multiple field validation
 
-There are cases where the validity of a field depends on the value of another field, for example validating the format of a government ID based on what country the shopper is in. In this case, validating only single fields (as above) is not sufficient as the country may be unknown during the `__experimental_woocommerce_blocks_validate_additional_field` action.
+There are cases where the validity of a field depends on the value of another field, for example validating the format of a government ID based on what country the shopper is in. In this case, validating only single fields (as above) is not sufficient as the country may be unknown during the `woocommerce_blocks_validate_additional_field` action.
 
 To solve this, it is possible to validate a field in the context of the location it renders in. The other fields in that location will be passed to this action.
 
-##### Using the `__experimental_woocommerce_blocks_validate_location_{location}_fields` action
+##### Using the `woocommerce_blocks_validate_location_{location}_fields` action
 
 This action will be fired for each location that additional fields can render in (`address`, `contact`, and `additional`). For `address` it fires twice, once for the billing address and once for the shipping address.
 
@@ -562,13 +562,13 @@ It is important to note that any fields rendered in other locations will not be 
 There are several places where these hooks are fired.
 
 - When checking out using the Checkout block or Store API.
-    - `__experimental_woocommerce_blocks_validate_location_address_fields` (x2)
-    - `__experimental_woocommerce_blocks_validate_location_contact_fields`
-    - `__experimental_woocommerce_blocks_validate_location_additional_fields`
+    - `woocommerce_blocks_validate_location_address_fields` (x2)
+    - `woocommerce_blocks_validate_location_contact_fields`
+    - `woocommerce_blocks_validate_location_additional_fields`
 - When updating addresses in the "My account" area
-    - `__experimental_woocommerce_blocks_validate_location_address_fields` (**x1** - only the address being edited)
+    - `woocommerce_blocks_validate_location_address_fields` (**x1** - only the address being edited)
 - When updating the "Account details" section in the "My account" area
-    - `__experimental_woocommerce_blocks_validate_location_contact_fields`
+    - `woocommerce_blocks_validate_location_contact_fields`
 
 ##### Example of location validation
 
@@ -578,7 +578,7 @@ The example below illustrates how to verify that the value of the confirmation f
 
 ```php
 add_action(
-	'__experimental_woocommerce_blocks_validate_location_address_fields',
+	'woocommerce_blocks_validate_location_address_fields',
 	function ( \WP_Error $errors, $fields, $group ) {
 		if ( $fields['namespace/gov-id'] !== $fields['namespace/confirm-gov-id'] ) {
 			$errors->add( 'gov_id_mismatch', 'Please ensure your government ID matches the confirmation.' );
@@ -589,7 +589,7 @@ add_action(
 );
 ```
 
-If these fields were rendered in the "contact" location instead, the code would be the same except the hook used would be: `__experimental_woocommerce_blocks_validate_location_contact_fields`.
+If these fields were rendered in the "contact" location instead, the code would be the same except the hook used would be: `woocommerce_blocks_validate_location_contact_fields`.
 
 ## A full example
 
@@ -601,7 +601,7 @@ This example is just a combined version of the examples shared above.
 add_action(
 	'woocommerce_blocks_loaded',
 	function() {
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'            => 'namespace/gov-id',
 				'label'         => 'Government ID',
@@ -614,7 +614,7 @@ add_action(
 				),
 			),
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'            => 'namespace/confirm-gov-id',
 				'label'         => 'Confirm government ID',
@@ -629,7 +629,7 @@ add_action(
 		);
 
 		add_action(
-			'_experimental_woocommerce_blocks_sanitize_additional_field',
+			'woocommerce_blocks_sanitize_additional_field',
 			function ( $field_value, $field_key ) {
 				if ( 'namespace/gov-id' === $field_key || 'namespace/confirm-gov-id' === $field_key ) {
 					$field_value = str_replace( ' ', '', $field_key );
@@ -642,7 +642,7 @@ add_action(
 		);
 
 		add_action(
-		'__experimental_woocommerce_blocks_validate_additional_field',
+		'woocommerce_blocks_validate_additional_field',
 			function ( WP_Error $errors, $field_key, $field_value ) {
 				if ( 'namespace/gov-id' === $field_key ) {
 					$match = preg_match( '/[A-Z0-9]{5}/', $field_value );
@@ -659,7 +659,7 @@ add_action(
 );
 
 add_action(
-	'__experimental_woocommerce_blocks_validate_location_address_fields',
+	'woocommerce_blocks_validate_location_address_fields',
 	function ( \WP_Error $errors, $fields, $group ) {
 		if ( $fields['namespace/gov-id'] !== $fields['namespace/confirm-gov-id'] ) {
 			$errors->add( 'gov_id_mismatch', 'Please ensure your government ID matches the confirmation.' );

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md
@@ -5,7 +5,7 @@
 - [Available field locations](#available-field-locations)
     - [Contact information](#contact-information)
     - [Address](#address)
-    - [Additional information](#additional-information)
+    - [Order information](#order-information)
 - [Supported field types](#supported-field-types)
 - [Using the API](#using-the-api)
     - [Options](#options)

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-checkout-fields-plugin.php
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-checkout-fields-plugin.php
@@ -49,7 +49,7 @@ class Additional_Checkout_Fields_Test_Helper {
 	 */
 	public function register_custom_checkout_fields() {
 		// Address fields, checkbox, textbox, select
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => 'first-plugin-namespace/government-ID',
 				'label'             => 'Government ID',
@@ -67,7 +67,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				},
 			),
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/confirm-government-ID',
 				'label'    => 'Confirm government ID',
@@ -85,7 +85,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				},
 			),
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/truck-size-ok',
 				'label'    => 'Can a truck fit down your road?',
@@ -93,7 +93,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'checkbox',
 			)
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/road-size',
 				'label'    => 'How wide is your road?',
@@ -155,7 +155,7 @@ class Additional_Checkout_Fields_Test_Helper {
 		);
 
 		// Contact fields, one checkbox, select, and text input.
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/marketing-opt-in',
 				'label'    => 'Do you want to subscribe to our newsletter?',
@@ -163,7 +163,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'checkbox',
 			)
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/gift-message-in-package',
 				'label'    => 'Enter a gift message to include in the package',
@@ -171,7 +171,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'text',
 			)
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/type-of-purchase',
 				'label'    => 'Is this a personal purchase or a business purchase?',
@@ -193,7 +193,7 @@ class Additional_Checkout_Fields_Test_Helper {
 
 		// A field of each type in additional information section.
 
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/please-send-me-a-free-gift',
 				'label'    => 'Would you like a free gift with your order?',
@@ -202,7 +202,7 @@ class Additional_Checkout_Fields_Test_Helper {
 			)
 		);
 
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/what-is-your-favourite-colour',
 				'label'    => 'What is your favourite colour?',
@@ -211,7 +211,7 @@ class Additional_Checkout_Fields_Test_Helper {
 			)
 		);
 
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/how-did-you-hear-about-us',
 				'label'    => 'How did you hear about us?',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-checkout-fields-plugin.php
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-checkout-fields-plugin.php
@@ -49,7 +49,7 @@ class Additional_Checkout_Fields_Test_Helper {
 	 */
 	public function register_custom_checkout_fields() {
 		// Address fields, checkbox, textbox, select
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => 'first-plugin-namespace/government-ID',
 				'label'             => 'Government ID',
@@ -67,7 +67,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				},
 			),
 		);
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/confirm-government-ID',
 				'label'    => 'Confirm government ID',
@@ -85,7 +85,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				},
 			),
 		);
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/truck-size-ok',
 				'label'    => 'Can a truck fit down your road?',
@@ -93,7 +93,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'checkbox',
 			)
 		);
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/road-size',
 				'label'    => 'How wide is your road?',
@@ -155,7 +155,7 @@ class Additional_Checkout_Fields_Test_Helper {
 		);
 
 		// Contact fields, one checkbox, select, and text input.
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/marketing-opt-in',
 				'label'    => 'Do you want to subscribe to our newsletter?',
@@ -163,7 +163,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'checkbox',
 			)
 		);
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/gift-message-in-package',
 				'label'    => 'Enter a gift message to include in the package',
@@ -171,7 +171,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'text',
 			)
 		);
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/type-of-purchase',
 				'label'    => 'Is this a personal purchase or a business purchase?',
@@ -193,7 +193,7 @@ class Additional_Checkout_Fields_Test_Helper {
 
 		// A field of each type in additional information section.
 
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/please-send-me-a-free-gift',
 				'label'    => 'Would you like a free gift with your order?',
@@ -202,7 +202,7 @@ class Additional_Checkout_Fields_Test_Helper {
 			)
 		);
 
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/what-is-your-favourite-colour',
 				'label'    => 'What is your favourite colour?',
@@ -211,7 +211,7 @@ class Additional_Checkout_Fields_Test_Helper {
 			)
 		);
 
-		woocommerce_blocks_register_checkout_field(
+		__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/how-did-you-hear-about-us',
 				'label'    => 'How did you hear about us?',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-checkout-fields-plugin.php
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-checkout-fields-plugin.php
@@ -49,7 +49,7 @@ class Additional_Checkout_Fields_Test_Helper {
 	 */
 	public function register_custom_checkout_fields() {
 		// Address fields, checkbox, textbox, select
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => 'first-plugin-namespace/government-ID',
 				'label'             => 'Government ID',
@@ -67,7 +67,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				},
 			),
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/confirm-government-ID',
 				'label'    => 'Confirm government ID',
@@ -85,7 +85,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				},
 			),
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/truck-size-ok',
 				'label'    => 'Can a truck fit down your road?',
@@ -93,7 +93,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'checkbox',
 			)
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/road-size',
 				'label'    => 'How wide is your road?',
@@ -118,7 +118,7 @@ class Additional_Checkout_Fields_Test_Helper {
 
 		// Fake sanitization function that removes full stops from the Government ID string.
 		add_filter(
-			'__experimental_woocommerce_blocks_sanitize_additional_field',
+			'woocommerce_blocks_sanitize_additional_field',
 			function ( $field_value, $field_key ) {
 				if ( 'first-plugin-namespace/government-ID' === $field_key ) {
 					$field_value = str_replace( '.', '', $field_value );
@@ -130,7 +130,7 @@ class Additional_Checkout_Fields_Test_Helper {
 		);
 
 		add_action(
-			'__experimental_woocommerce_blocks_validate_additional_field',
+			'woocommerce_blocks_validate_additional_field',
 			function ( WP_Error $errors, $field_key, $field_value ) {
 				if ( 'first-plugin-namespace/government-ID' === $field_key || 'first-plugin-namespace/confirm-government-ID' === $field_key ) {
 					$match = preg_match( '/[A-Z0-9]{5}/', $field_value );
@@ -144,7 +144,7 @@ class Additional_Checkout_Fields_Test_Helper {
 		);
 
 		add_action(
-			'__experimental_woocommerce_blocks_validate_location_address_fields',
+			'woocommerce_blocks_validate_location_address_fields',
 			function ( \WP_Error $errors, $fields, $group ) {
 				if ( $fields['first-plugin-namespace/government-ID'] !== $fields['first-plugin-namespace/confirm-government-ID'] ) {
 					$errors->add( 'gov_id_mismatch', 'Please ensure your government ID matches the confirmation.' );
@@ -155,7 +155,7 @@ class Additional_Checkout_Fields_Test_Helper {
 		);
 
 		// Contact fields, one checkbox, select, and text input.
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/marketing-opt-in',
 				'label'    => 'Do you want to subscribe to our newsletter?',
@@ -163,7 +163,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'checkbox',
 			)
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/gift-message-in-package',
 				'label'    => 'Enter a gift message to include in the package',
@@ -171,7 +171,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'text',
 			)
 		);
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'second-plugin-namespace/type-of-purchase',
 				'label'    => 'Is this a personal purchase or a business purchase?',
@@ -193,29 +193,29 @@ class Additional_Checkout_Fields_Test_Helper {
 
 		// A field of each type in additional information section.
 
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/please-send-me-a-free-gift',
 				'label'    => 'Would you like a free gift with your order?',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'checkbox',
 			)
 		);
 
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/what-is-your-favourite-colour',
 				'label'    => 'What is your favourite colour?',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'text',
 			)
 		);
 
-		__experimental_woocommerce_blocks_register_checkout_field(
+		woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => 'third-plugin-namespace/how-did-you-hear-about-us',
 				'label'    => 'How did you hear about us?',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'select',
 				'options'  => array(
 					array(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.side_effects.spec.ts
@@ -67,7 +67,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '54321',
 						},
 					},
-					additional: {
+					order: {
 						'How did you hear about us?': 'Other',
 						'What is your favourite colour?': 'Blue',
 					},
@@ -119,7 +119,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '54321',
 						},
 					},
-					additional: {
+					order: {
 						'How did you hear about us?': 'Other',
 						'What is your favourite colour?': 'Blue',
 					},

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.side_effects.spec.ts
@@ -67,7 +67,7 @@ test.describe( 'Merchant → Additional Checkout Fields', () => {
 						'Confirm government ID': '54321',
 					},
 				},
-				additional: {
+				order: {
 					'How did you hear about us?': 'Other',
 					'What is your favourite colour?': 'Blue',
 				},
@@ -203,7 +203,7 @@ test.describe( 'Merchant → Additional Checkout Fields', () => {
 						'Confirm government ID': '54321',
 					},
 				},
-				additional: {
+				order: {
 					'How did you hear about us?': 'Other',
 					'What is your favourite colour?': 'Blue',
 				},

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.side_effects.spec.ts
@@ -70,7 +70,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '54321',
 						},
 					},
-					additional: {
+					order: {
 						'How did you hear about us?': 'Other',
 						'What is your favourite colour?': 'Blue',
 					},
@@ -258,7 +258,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '54321',
 						},
 					},
-					additional: {
+					order: {
 						'How did you hear about us?': 'Other',
 						'What is your favourite colour?': 'Blue',
 					},
@@ -351,7 +351,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '43210',
 						},
 					},
-					additional: {
+					order: {
 						'What is your favourite colour?': 'Red',
 					},
 				}
@@ -442,7 +442,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '543 21',
 						},
 					},
-					additional: {
+					order: {
 						'How did you hear about us?': 'Other',
 						'What is your favourite colour?': 'Blue',
 					},
@@ -629,7 +629,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '12345',
 						},
 					},
-					additional: { 'How did you hear about us?': 'Other' },
+					order: { 'How did you hear about us?': 'Other' },
 				}
 			);
 
@@ -682,7 +682,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '54321',
 						},
 					},
-					additional: { 'How did you hear about us?': 'Other' },
+					order: { 'How did you hear about us?': 'Other' },
 				}
 			);
 
@@ -743,7 +743,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 							'Confirm government ID': '54321',
 						},
 					},
-					additional: { 'How did you hear about us?': 'Other' },
+					order: { 'How did you hear about us?': 'Other' },
 				}
 			);
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -60,10 +60,10 @@ export class CheckoutPage {
 				billing?: Record< string, string >;
 			};
 			contact?: Record< string, string >;
-			additional?: Record< string, string >;
+			order?: Record< string, string >;
 		} = {
 			address: { shipping: {}, billing: {} },
-			additional: {},
+			order: {},
 			contact: {},
 		}
 	) {
@@ -100,11 +100,11 @@ export class CheckoutPage {
 		}
 
 		if (
-			typeof additionalFields.additional !== 'undefined' &&
-			Object.keys( additionalFields.additional ).length > 0
+			typeof additionalFields.order !== 'undefined' &&
+			Object.keys( additionalFields.order ).length > 0
 		) {
 			await this.fillAdditionalInformationSection(
-				additionalFields.additional
+				additionalFields.order
 			);
 		}
 

--- a/plugins/woocommerce/changelog/46805-add-graduate-additional-fields
+++ b/plugins/woocommerce/changelog/46805-add-graduate-additional-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Additional Checkout Fields has been graduated to stable.

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -610,8 +610,8 @@ class WC_Emails {
 
 		$checkout_fields = Package::container()->get( CheckoutFields::class );
 		$fields          = array_merge(
-			$checkout_fields->get_order_additional_fields_with_values( $order, 'contact', 'additional', 'view' ),
-			$checkout_fields->get_order_additional_fields_with_values( $order, 'additional', 'additional', 'view' ),
+			$checkout_fields->get_order_additional_fields_with_values( $order, 'contact', 'other', 'view' ),
+			$checkout_fields->get_order_additional_fields_with_values( $order, 'order', 'other', 'view' ),
 		);
 
 		if ( ! $fields ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFields.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFields.php
@@ -35,8 +35,8 @@ class AdditionalFields extends AbstractOrderConfirmationBlock {
 		$content   .= $this->render_additional_fields(
 			$controller->filter_fields_for_order_confirmation(
 				array_merge(
-					$controller->get_order_additional_fields_with_values( $order, 'contact', 'additional', 'view' ),
-					$controller->get_order_additional_fields_with_values( $order, 'additional', 'additional', 'view' ),
+					$controller->get_order_additional_fields_with_values( $order, 'contact', 'other', 'view' ),
+					$controller->get_order_additional_fields_with_values( $order, 'order', 'other', 'view' ),
 				)
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFieldsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFieldsWrapper.php
@@ -33,7 +33,7 @@ class AdditionalFieldsWrapper extends AbstractOrderConfirmationBlock {
 		// Contact and additional fields are currently grouped in this section.
 		$additional_fields = array_merge(
 			Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'contact' ),
-			Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'additional' )
+			Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'order' )
 		);
 
 		return empty( $additional_fields ) ? '' : $content;
@@ -48,7 +48,7 @@ class AdditionalFieldsWrapper extends AbstractOrderConfirmationBlock {
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
-		$this->asset_data_registry->add( 'additionalFields', Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'additional' ) );
+		$this->asset_data_registry->add( 'additionalFields', Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'order' ) );
 		$this->asset_data_registry->add( 'additionalContactFields', Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'contact' ) );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -663,9 +663,20 @@ class CheckoutFields {
 			 * @param mixed  $field_value The value of the field being sanitized.
 			 * @param string $field_key   Key of the field being sanitized.
 			 *
+			 * @since 8.6.0
+			 * @deprecated 8.7.0 Use woocommerce_blocks_sanitize_additional_field instead.
+			 */
+			$field_value = apply_filters_deprecated( '__experimental_woocommerce_blocks_sanitize_additional_field', array( $field_value, $field_key ), '8.7.0', 'woocommerce_blocks_sanitize_additional_field', 'This action has been graduated, use woocommerce_blocks_sanitize_additional_field instead.' );
+
+			/**
+			 * Allow custom sanitization of an additional field.
+			 *
+			 * @param mixed  $field_value The value of the field being sanitized.
+			 * @param string $field_key   Key of the field being sanitized.
+			 *
 			 * @since 8.7.0
 			 */
-			return apply_filters( '__experimental_woocommerce_blocks_sanitize_additional_field', $field_value, $field_key );
+			return apply_filters_deprecated( 'woocommerce_blocks_sanitize_additional_field', $field_value, $field_key );
 
 		} catch ( \Throwable $e ) {
 			// One of the filters errored so skip it. This allows the checkout process to continue.
@@ -713,9 +724,20 @@ class CheckoutFields {
 			 * @param string   $field_key   Key of the field being sanitized.
 			 * @param mixed    $field_value The value of the field being validated.
 			 *
+			 * @since 8.6.0
+			 * @deprecated 8.7.0 Use woocommerce_blocks_validate_additional_field instead.
+			 */
+			wc_do_deprecated_action( '__experimental_woocommerce_blocks_validate_additional_field', array( $errors, $field_key, $field_value ), '8.7.0', 'woocommerce_blocks_validate_additional_field', 'This action has been graduated, use woocommerce_blocks_validate_additional_field instead.' );
+			/**
+			 * Pass an error object to allow validation of an additional field.
+			 *
+			 * @param WP_Error $errors      A WP_Error object that extensions may add errors to.
+			 * @param string   $field_key   Key of the field being sanitized.
+			 * @param mixed    $field_value The value of the field being validated.
+			 *
 			 * @since 8.7.0
 			 */
-			do_action( '__experimental_woocommerce_blocks_validate_additional_field', $errors, $field_key, $field_value );
+			do_action( 'woocommerce_blocks_validate_additional_field', $errors, $field_key, $field_value );
 
 		} catch ( \Throwable $e ) {
 
@@ -816,9 +838,21 @@ class CheckoutFields {
 			 * @param mixed    $fields  List of fields (key value pairs) in this location.
 			 * @param string   $group   The group of this location (shipping|billing|'').
 			 *
+			 * @since 8.6.0
+			 * @deprecated 8.7.0 Use woocommerce_blocks_validate_location_{location}_fields instead.
+			 */
+			wc_do_deprecated_action( '__experimental_woocommerce_blocks_validate_location_' . $location . '_fields', array( $errors, $fields, $group ), '8.7.0', 'woocommerce_blocks_validate_location_' . $location . '_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_' . $location . '_fields instead.' );
+
+			/**
+			 * Pass an error object to allow validation of an additional field.
+			 *
+			 * @param WP_Error $errors  A WP_Error object that extensions may add errors to.
+			 * @param mixed    $fields  List of fields (key value pairs) in this location.
+			 * @param string   $group   The group of this location (shipping|billing|'').
+			 *
 			 * @since 8.7.0
 			 */
-			do_action( '__experimental_woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group );
+			do_action( 'woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group );
 
 		} catch ( \Throwable $e ) {
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -399,7 +399,7 @@ class CheckoutFields {
 	 * @param array $options The options supplied during field registration.
 	 * @return bool false if an error was encountered, true otherwise.
 	 */
-	private function validate_options( $options ) {
+	private function validate_options( &$options ) {
 		if ( empty( $options['id'] ) ) {
 			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0' );
 			return false;
@@ -689,7 +689,7 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			return apply_filters_deprecated( 'woocommerce_blocks_sanitize_additional_field', $field_value, $field_key );
+			return apply_filters( 'woocommerce_blocks_sanitize_additional_field', $field_value, $field_key );
 
 		} catch ( \Throwable $e ) {
 			// One of the filters errored so skip it. This allows the checkout process to continue.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -228,9 +228,9 @@ class CheckoutFields {
 
 		$this->fields_locations = [
 			// omit email from shipping and billing fields.
-			'address'    => array_merge( \array_diff_key( array_keys( $this->core_fields ), array( 'email' ) ) ),
-			'contact'    => array( 'email' ),
-			'order' => [],
+			'address' => array_merge( \array_diff_key( array_keys( $this->core_fields ), array( 'email' ) ) ),
+			'contact' => array( 'email' ),
+			'order'   => [],
 		];
 
 		add_filter( 'woocommerce_get_country_locale_default', array( $this, 'update_default_locale_with_fields' ) );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -393,32 +393,32 @@ class CheckoutFields {
 	 */
 	private function validate_options( $options ) {
 		if ( empty( $options['id'] ) ) {
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0' );
 			return false;
 		}
 
 		// Having fewer than 2 after exploding around a / means there is no namespace.
 		if ( count( explode( '/', $options['id'] ) ) < 2 ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'A checkout field id must consist of namespace/name.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( empty( $options['label'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field label is required.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( empty( $options['location'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is required.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( ! in_array( $options['location'], array_keys( $this->fields_locations ), true ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is invalid.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
@@ -429,7 +429,7 @@ class CheckoutFields {
 		// Check to see if field is already in the array.
 		if ( ! empty( $this->additional_fields[ $id ] ) || in_array( $id, $this->fields_locations[ $location ], true ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The field is already registered.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
@@ -441,27 +441,27 @@ class CheckoutFields {
 					$options['type'],
 					implode( ', ', $this->supported_field_types )
 				);
-				_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 				return false;
 			}
 		}
 
 		if ( ! empty( $options['sanitize_callback'] ) && ! is_callable( $options['sanitize_callback'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The sanitize_callback must be a valid callback.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		if ( ! empty( $options['validate_callback'] ) && ! is_callable( $options['validate_callback'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		// Hidden fields are not supported right now. They will be registered with hidden => false.
 		if ( ! empty( $options['hidden'] ) && true === $options['hidden'] ) {
 			$message = sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			// Don't return here unlike the other fields because this is not an issue that will prevent registration.
 		}
 
@@ -481,7 +481,7 @@ class CheckoutFields {
 
 		if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options".' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 		$cleaned_options = [];
@@ -491,7 +491,7 @@ class CheckoutFields {
 		foreach ( $options['options'] as $option ) {
 			if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
 				$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.' );
-				_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 				return false;
 			}
 
@@ -500,7 +500,7 @@ class CheckoutFields {
 
 			if ( in_array( $sanitized_value, $added_values, true ) ) {
 				$message = sprintf( 'Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', $id, $sanitized_value );
-				_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+				_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 				continue;
 			}
 
@@ -546,7 +546,7 @@ class CheckoutFields {
 
 		if ( isset( $options['required'] ) && true === $options['required'] ) {
 			$message = sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 		}
 
 		return $field_data;
@@ -569,7 +569,7 @@ class CheckoutFields {
 
 		if ( ! is_array( $attributes ) || 0 === count( $attributes ) ) {
 			$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 			return [];
 		}
 
@@ -595,7 +595,7 @@ class CheckoutFields {
 		if ( count( $attributes ) !== count( $valid_attributes ) ) {
 			$invalid_attributes = array_keys( array_diff_key( $attributes, $valid_attributes ) );
 			$message            = sprintf( 'Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode( ', ', $invalid_attributes ) );
-			_doing_it_wrong( '__experimental_woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
+			_doing_it_wrong( 'woocommerce_blocks_register_checkout_field', esc_html( $message ), '8.6.0' );
 		}
 
 		// Escape attributes to remove any malicious code and return them.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsAdmin.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsAdmin.php
@@ -32,7 +32,7 @@ class CheckoutFieldsAdmin {
 		add_filter( 'woocommerce_admin_billing_fields', array( $this, 'admin_address_fields' ), 10, 3 );
 		add_filter( 'woocommerce_admin_billing_fields', array( $this, 'admin_contact_fields' ), 10, 3 );
 		add_filter( 'woocommerce_admin_shipping_fields', array( $this, 'admin_address_fields' ), 10, 3 );
-		add_filter( 'woocommerce_admin_shipping_fields', array( $this, 'admin_additional_fields' ), 10, 3 );
+		add_filter( 'woocommerce_admin_shipping_fields', array( $this, 'admin_order_fields' ), 10, 3 );
 	}
 
 	/**
@@ -125,10 +125,10 @@ class CheckoutFieldsAdmin {
 			return $fields;
 		}
 
-		$additional_fields = $this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'contact', 'additional', $context );
+		$additional_fields = $this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'contact', 'other', $context );
 
 		foreach ( $additional_fields as $key => $field ) {
-			$prefixed_key              = CheckoutFields::get_group_key( 'additional' ) . $key;
+			$prefixed_key              = CheckoutFields::get_group_key( 'other' ) . $key;
 			$additional_fields[ $key ] = $this->format_field_for_meta_box( $field, $prefixed_key );
 		}
 
@@ -143,15 +143,15 @@ class CheckoutFieldsAdmin {
 	 * @param string            $context The context to show the fields for.
 	 * @return array
 	 */
-	public function admin_additional_fields( $fields, $order = null, $context = 'edit' ) {
+	public function admin_order_fields( $fields, $order = null, $context = 'edit' ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return $fields;
 		}
 
-		$additional_fields = $this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'additional', 'additional', $context );
+		$additional_fields = $this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'order', 'other', $context );
 
 		foreach ( $additional_fields as $key => $field ) {
-			$prefixed_key              = CheckoutFields::get_group_key( 'additional' ) . $key;
+			$prefixed_key              = CheckoutFields::get_group_key( 'other' ) . $key;
 			$additional_fields[ $key ] = $this->format_field_for_meta_box( $field, $prefixed_key );
 		}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
@@ -32,7 +32,7 @@ class CheckoutFieldsFrontend {
 	public function init() {
 		// Show custom checkout fields on the order details page.
 		add_action( 'woocommerce_order_details_after_customer_address', array( $this, 'render_order_address_fields' ), 10, 2 );
-		add_action( 'woocommerce_order_details_after_customer_details', array( $this, 'render_order_additional_fields' ), 10 );
+		add_action( 'woocommerce_order_details_after_customer_details', array( $this, 'render_order_other_fields' ), 10 );
 
 		// Show custom checkout fields on the My Account page.
 		add_action( 'woocommerce_my_account_after_my_address', array( $this, 'render_address_fields' ), 10, 1 );
@@ -87,10 +87,10 @@ class CheckoutFieldsFrontend {
 	 *
 	 * @param WC_Order $order Order object.
 	 */
-	public function render_order_additional_fields( $order ) {
+	public function render_order_other_fields( $order ) {
 		$fields = array_merge(
-			$this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'contact', 'additional', 'view' ),
-			$this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'additional', 'additional', 'view' ),
+			$this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'contact', 'other', 'view' ),
+			$this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'order', 'other', 'view' ),
 		);
 
 		if ( ! $fields ) {
@@ -160,7 +160,7 @@ class CheckoutFieldsFrontend {
 		$fields   = $this->checkout_fields_controller->get_fields_for_location( 'contact' );
 
 		foreach ( $fields as $key => $field ) {
-			$field_key           = CheckoutFields::get_group_key( 'additional' ) . $key;
+			$field_key           = CheckoutFields::get_group_key( 'other' ) . $key;
 			$form_field          = $field;
 			$form_field['id']    = $field_key;
 			$form_field['value'] = $this->checkout_fields_controller->get_field_from_object( $key, $customer, 'contact' );
@@ -192,7 +192,7 @@ class CheckoutFieldsFrontend {
 		$field_values      = array();
 
 		foreach ( array_keys( $additional_fields ) as $key ) {
-			$post_key = CheckoutFields::get_group_key( 'additional' ) . $key;
+			$post_key = CheckoutFields::get_group_key( 'other' ) . $key;
 			if ( ! isset( $_POST[ $post_key ] ) ) {
 				continue;
 			}
@@ -210,11 +210,11 @@ class CheckoutFieldsFrontend {
 
 		// Persist individual additional fields to customer.
 		foreach ( $field_values as $key => $value ) {
-			$this->checkout_fields_controller->persist_field_for_customer( $key, $value, $customer, 'additional' );
+			$this->checkout_fields_controller->persist_field_for_customer( $key, $value, $customer, 'other' );
 		}
 
 		// Validate all fields for this location.
-		$location_validation = $this->checkout_fields_controller->validate_fields_for_location( $field_values, 'contact', 'additional' );
+		$location_validation = $this->checkout_fields_controller->validate_fields_for_location( $field_values, 'contact', 'other' );
 
 		if ( is_wp_error( $location_validation ) && $location_validation->has_errors() ) {
 			wc_add_notice( $location_validation->get_error_message(), 'error' );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
@@ -3,14 +3,14 @@
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 
-if ( ! function_exists( '__experimental_woocommerce_blocks_register_checkout_field' ) ) {
+if ( ! function_exists( 'woocommerce_blocks_register_checkout_field' ) ) {
 	/**
 	 * Register a checkout field.
 	 *
 	 * @param array $options Field arguments. See CheckoutFields::register_checkout_field() for details.
 	 * @throws \Exception If field registration fails.
 	 */
-	function __experimental_woocommerce_blocks_register_checkout_field( $options ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
+	function woocommerce_blocks_register_checkout_field( $options ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
 
 		// Check if `woocommerce_blocks_loaded` ran. If not then the CheckoutFields class will not be available yet.
 		// In that case, re-hook `woocommerce_blocks_loaded` and try running this again.
@@ -19,7 +19,7 @@ if ( ! function_exists( '__experimental_woocommerce_blocks_register_checkout_fie
 			add_action(
 				'woocommerce_blocks_loaded',
 				function () use ( $options ) {
-					__experimental_woocommerce_blocks_register_checkout_field( $options );
+					woocommerce_blocks_register_checkout_field( $options );
 				}
 			);
 			return;
@@ -32,6 +32,20 @@ if ( ! function_exists( '__experimental_woocommerce_blocks_register_checkout_fie
 	}
 }
 
+if ( ! function_exists( '__experimental_woocommerce_blocks_register_checkout_field' ) ) {
+
+	/**
+	 * Register a checkout field.
+	 *
+	 * @param array $options Field arguments. See CheckoutFields::register_checkout_field() for details.
+	 * @throws \Exception If field registration fails.
+	 * @deprecated 5.6.0 Use woocommerce_blocks_register_checkout_field() instead.
+	 */
+	function __experimental_woocommerce_blocks_register_checkout_field( $options ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
+		_deprecated_function( __FUNCTION__, '8.9.0', 'woocommerce_blocks_register_checkout_field' );
+		woocommerce_blocks_register_checkout_field( $options );
+	}
+}
 
 if ( ! function_exists( '__internal_woocommerce_blocks_deregister_checkout_field' ) ) {
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/functions.php
@@ -42,7 +42,7 @@ if ( ! function_exists( '__experimental_woocommerce_blocks_register_checkout_fie
 	 * @deprecated 5.6.0 Use woocommerce_blocks_register_checkout_field() instead.
 	 */
 	function __experimental_woocommerce_blocks_register_checkout_field( $options ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
-		_deprecated_function( __FUNCTION__, '8.9.0', 'woocommerce_blocks_register_checkout_field' );
+		wc_deprecated_function( __FUNCTION__, '8.9.0', 'woocommerce_blocks_register_checkout_field' );
 		woocommerce_blocks_register_checkout_field( $options );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -262,8 +262,8 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	protected function get_additional_fields_response( \WC_Order $order ) {
 		$fields = wp_parse_args(
-			$this->additional_fields_controller->get_all_fields_from_object( $order, 'additional' ),
-			$this->additional_fields_controller->get_all_fields_from_object( wc()->customer, 'additional' )
+			$this->additional_fields_controller->get_all_fields_from_object( $order, 'other' ),
+			$this->additional_fields_controller->get_all_fields_from_object( wc()->customer, 'other' )
 		);
 
 		$additional_field_schema = $this->get_additional_fields_schema();
@@ -291,7 +291,7 @@ class CheckoutSchema extends AbstractSchema {
 	protected function get_additional_fields_schema() {
 		return $this->generate_additional_fields_schema(
 			$this->additional_fields_controller->get_fields_for_location( 'contact' ),
-			$this->additional_fields_controller->get_fields_for_location( 'additional' )
+			$this->additional_fields_controller->get_fields_for_location( 'order' )
 		);
 	}
 
@@ -420,11 +420,11 @@ class CheckoutSchema extends AbstractSchema {
 		}
 
 		// Validate groups of properties per registered location.
-		$locations = array( 'contact', 'additional' );
+		$locations = array( 'contact', 'order' );
 
 		foreach ( $locations as $location ) {
 			$location_fields = $this->additional_fields_controller->filter_fields_for_location( $fields, $location );
-			$result          = $this->additional_fields_controller->validate_fields_for_location( $location_fields, $location, 'additional' );
+			$result          = $this->additional_fields_controller->validate_fields_for_location( $location_fields, $location, 'other' );
 
 			if ( is_wp_error( $result ) && $result->has_errors() ) {
 				$errors->merge_from( $result );

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -194,12 +194,12 @@ trait CheckoutTrait {
 		$request_fields = $request['additional_fields'] ?? [];
 		foreach ( $request_fields as $key => $value ) {
 			try {
-				$this->additional_fields_controller->validate_field_for_location( $key, $value, 'additional' );
+				$this->additional_fields_controller->validate_field_for_location( $key, $value, 'order' );
 			} catch ( \Exception $e ) {
 				$errors[] = $e->getMessage();
 				continue;
 			}
-			$this->additional_fields_controller->persist_field_for_order( $key, $value, $this->order, 'additional', false );
+			$this->additional_fields_controller->persist_field_for_order( $key, $value, $this->order, 'other', false );
 		}
 
 		if ( $errors->has_errors() ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -142,7 +142,7 @@ class AdditionalFields extends MockeryTestCase {
 				'type'     => 'checkbox',
 			),
 		);
-		array_map( 'woocommerce_blocks_register_checkout_field', $this->fields );
+		array_map( '__experimental_woocommerce_blocks_register_checkout_field', $this->fields );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -138,11 +138,11 @@ class AdditionalFields extends MockeryTestCase {
 			array(
 				'id'       => 'plugin-namespace/leave-on-porch',
 				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'checkbox',
 			),
 		);
-		array_map( '__experimental_woocommerce_blocks_register_checkout_field', $this->fields );
+		array_map( 'woocommerce_blocks_register_checkout_field', $this->fields );
 	}
 
 	/**
@@ -287,11 +287,11 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_optional_field_in_schema() {
 		$id = 'plugin-namespace/optional-field';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Optional Field',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'text',
 				'required' => false,
 			)
@@ -338,10 +338,10 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'label'    => 'Invalid ID',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'text',
 				'required' => false,
 			)
@@ -381,11 +381,11 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid ID',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'text',
 				'required' => false,
 			)
@@ -424,10 +424,10 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'text',
 				'required' => false,
 			)
@@ -466,7 +466,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'    => $id,
 				'label' => 'Missing Location',
@@ -508,7 +508,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Location',
@@ -553,7 +553,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Government ID',
@@ -602,11 +602,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Type',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'invalid',
 				'required' => false,
 			)
@@ -647,11 +647,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Invalid Sanitize',
-				'location'          => 'additional',
+				'location'          => 'order',
 				'type'              => 'text',
 				'sanitize_callback' => 'invalid_sanitize_callback',
 				'required'          => false,
@@ -693,11 +693,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Invalid Validate',
-				'location'          => 'additional',
+				'location'          => 'order',
 				'type'              => 'text',
 				'validate_callback' => 'invalid_validate_callback',
 				'required'          => false,
@@ -739,11 +739,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'         => $id,
 				'label'      => 'Invalid Attribute',
-				'location'   => 'additional',
+				'location'   => 'order',
 				'attributes' => 'invalid',
 			)
 		);
@@ -809,11 +809,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'         => $id,
 				'label'      => 'Invalid Attribute Values',
-				'location'   => 'additional',
+				'location'   => 'order',
 				'attributes' => array(
 					'title'            => 'title',
 					'maxLength'        => '20',
@@ -883,11 +883,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Missing Options',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'select',
 				'required' => false,
 			)
@@ -928,11 +928,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Options',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'select',
 				'options'  => array( // numeric array instead of associative array.
 					'invalidValue',
@@ -975,11 +975,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Duplicate Options',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'select',
 				'options'  => array(
 					array(
@@ -1026,11 +1026,11 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_optional_select_has_empty_value() {
 		$id = 'plugin-namespace/optional-select';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Optional Select',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'select',
 				'options'  => array(
 					array(
@@ -1083,11 +1083,11 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Checkbox Only Optional',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'checkbox',
 				'required' => true,
 			)
@@ -1142,7 +1142,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Hidden Field',
@@ -1280,11 +1280,11 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_placing_order_sanitize_text() {
 		$id = 'plugin-namespace/sanitize-text';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Sanitize Text',
-				'location'          => 'additional',
+				'location'          => 'order',
 				'type'              => 'text',
 				'sanitize_callback' => function ( $value ) {
 					return 'sanitized-' . $value;
@@ -1346,11 +1346,11 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_placing_order_validate_text() {
 		$id = 'plugin-namespace/validate-text';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Validate Text',
-				'location'          => 'additional',
+				'location'          => 'order',
 				'type'              => 'text',
 				'validate_callback' => function ( $value ) {
 					if ( 'invalid' === $value ) {
@@ -1415,17 +1415,17 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_sanitize_filter() {
 		$id = 'plugin-namespace/filter-sanitize';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Filter Sanitize',
-				'location' => 'additional',
+				'location' => 'order',
 				'type'     => 'text',
 			)
 		);
 
 		add_filter(
-			'__experimental_woocommerce_blocks_sanitize_additional_field',
+			'woocommerce_blocks_sanitize_additional_field',
 			function ( $value, $key ) use ( $id ) {
 				if ( $key === $id ) {
 					return 'sanitized-' . $value;
@@ -1492,7 +1492,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_validate_filter() {
 		$id = 'plugin-namespace/filter-validate';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Filter Validate',
@@ -1503,7 +1503,7 @@ class AdditionalFields extends MockeryTestCase {
 		);
 
 		add_action(
-			'__experimental_woocommerce_blocks_validate_additional_field',
+			'woocommerce_blocks_validate_additional_field',
 			function ( \WP_Error $errors, $key, $value ) use ( $id ) {
 				if ( $key === $id && 'invalid' === $value ) {
 					$errors->add( 'my_invalid_value', 'Invalid value provided.' );
@@ -1569,7 +1569,7 @@ class AdditionalFields extends MockeryTestCase {
 	public function test_place_order_required_address_field() {
 		$id    = 'plugin-namespace/my-required-field';
 		$label = 'My Required Field';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => $label,
@@ -1633,7 +1633,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_place_order_required_contact_field() {
 		$id = 'plugin-namespace/my-required-contact-field';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'My Required Field',

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -142,7 +142,7 @@ class AdditionalFields extends MockeryTestCase {
 				'type'     => 'checkbox',
 			),
 		);
-		array_map( '__experimental_woocommerce_blocks_register_checkout_field', $this->fields );
+		array_map( 'woocommerce_blocks_register_checkout_field', $this->fields );
 	}
 
 	/**
@@ -287,7 +287,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_optional_field_in_schema() {
 		$id = 'plugin-namespace/optional-field';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Optional Field',
@@ -324,7 +324,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				'A checkout field cannot be registered without an id.',
 			)
 		)->once();
@@ -338,7 +338,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'label'    => 'Invalid ID',
 				'location' => 'additional',
@@ -366,7 +366,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( \sprintf( 'Unable to register field with id: "%s". A checkout field id must consist of namespace/name.', $id ) ),
 
 			)
@@ -381,7 +381,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid ID',
@@ -410,7 +410,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( \sprintf( 'Unable to register field with id: "%s". The field label is required.', $id ) ),
 			)
 		)->once();
@@ -424,7 +424,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'location' => 'additional',
@@ -452,7 +452,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( \sprintf( 'Unable to register field with id: "%s". The field location is required.', $id ) ),
 			)
 		)->once();
@@ -466,7 +466,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'    => $id,
 				'label' => 'Missing Location',
@@ -493,7 +493,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( \sprintf( 'Unable to register field with id: "%s". The field location is invalid.', $id ) ),
 			)
 		)->once();
@@ -508,7 +508,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Location',
@@ -538,7 +538,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( \sprintf( 'Unable to register field with id: "%s". The field is already registered.', $id ) ),
 			)
 		)->once();
@@ -553,7 +553,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Government ID',
@@ -580,7 +580,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html(
 					sprintf(
 						'Unable to register field with id: "%s". Registering a field with type "%s" is not supported. The supported types are: %s.',
@@ -602,7 +602,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Type',
@@ -632,7 +632,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Unable to register field with id: "%s". %s', $id, 'The sanitize_callback must be a valid callback.' ) ),
 			)
 		)->once();
@@ -647,7 +647,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Invalid Sanitize',
@@ -678,7 +678,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.' ) ),
 			)
 		)->once();
@@ -693,7 +693,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Invalid Validate',
@@ -724,7 +724,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' ) ),
 			)
 		)->once();
@@ -739,7 +739,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'         => $id,
 				'label'      => 'Invalid Attribute',
@@ -794,7 +794,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode( ', ', $invalid_attributes ) ) ),
 			)
 		)->once();
@@ -809,7 +809,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'         => $id,
 				'label'      => 'Invalid Attribute Values',
@@ -868,7 +868,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options".' ) ),
 			)
 		)->once();
@@ -883,7 +883,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Missing Options',
@@ -913,7 +913,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.' ) ),
 			)
 		)->once();
@@ -928,7 +928,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Options',
@@ -960,7 +960,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', $id, 'duplicate' ) ),
 			)
 		)->once();
@@ -975,7 +975,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Duplicate Options',
@@ -1026,7 +1026,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_optional_select_has_empty_value() {
 		$id = 'plugin-namespace/optional-select';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Optional Select',
@@ -1068,7 +1068,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id ) ),
 			)
 		)->once();
@@ -1083,7 +1083,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Checkbox Only Optional',
@@ -1127,7 +1127,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
-				'__experimental_woocommerce_blocks_register_checkout_field',
+				'woocommerce_blocks_register_checkout_field',
 				\esc_html( sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id ) ),
 			)
 		)->once();
@@ -1142,7 +1142,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Hidden Field',
@@ -1280,7 +1280,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_placing_order_sanitize_text() {
 		$id = 'plugin-namespace/sanitize-text';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Sanitize Text',
@@ -1346,7 +1346,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_placing_order_validate_text() {
 		$id = 'plugin-namespace/validate-text';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Validate Text',
@@ -1415,7 +1415,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_sanitize_filter() {
 		$id = 'plugin-namespace/filter-sanitize';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Filter Sanitize',
@@ -1492,7 +1492,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_validate_filter() {
 		$id = 'plugin-namespace/filter-validate';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Filter Validate',
@@ -1569,7 +1569,7 @@ class AdditionalFields extends MockeryTestCase {
 	public function test_place_order_required_address_field() {
 		$id    = 'plugin-namespace/my-required-field';
 		$label = 'My Required Field';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => $label,
@@ -1633,7 +1633,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_place_order_required_contact_field() {
 		$id = 'plugin-namespace/my-required-contact-field';
-		\__experimental_woocommerce_blocks_register_checkout_field(
+		\woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'My Required Field',

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -287,7 +287,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_optional_field_in_schema() {
 		$id = 'plugin-namespace/optional-field';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Optional Field',
@@ -338,7 +338,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'label'    => 'Invalid ID',
 				'location' => 'additional',
@@ -381,7 +381,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid ID',
@@ -424,7 +424,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'location' => 'additional',
@@ -466,7 +466,7 @@ class AdditionalFields extends MockeryTestCase {
 			10,
 			2
 		);
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'    => $id,
 				'label' => 'Missing Location',
@@ -508,7 +508,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Location',
@@ -553,7 +553,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Government ID',
@@ -602,7 +602,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Type',
@@ -647,7 +647,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Invalid Sanitize',
@@ -693,7 +693,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Invalid Validate',
@@ -739,7 +739,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'         => $id,
 				'label'      => 'Invalid Attribute',
@@ -809,7 +809,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'         => $id,
 				'label'      => 'Invalid Attribute Values',
@@ -883,7 +883,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Missing Options',
@@ -928,7 +928,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Invalid Options',
@@ -975,7 +975,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Duplicate Options',
@@ -1026,7 +1026,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_optional_select_has_empty_value() {
 		$id = 'plugin-namespace/optional-select';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Optional Select',
@@ -1083,7 +1083,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Checkbox Only Optional',
@@ -1142,7 +1142,7 @@ class AdditionalFields extends MockeryTestCase {
 			2
 		);
 
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Hidden Field',
@@ -1280,7 +1280,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_placing_order_sanitize_text() {
 		$id = 'plugin-namespace/sanitize-text';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Sanitize Text',
@@ -1346,7 +1346,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_placing_order_validate_text() {
 		$id = 'plugin-namespace/validate-text';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'                => $id,
 				'label'             => 'Validate Text',
@@ -1415,7 +1415,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_sanitize_filter() {
 		$id = 'plugin-namespace/filter-sanitize';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Filter Sanitize',
@@ -1492,7 +1492,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_validate_filter() {
 		$id = 'plugin-namespace/filter-validate';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'Filter Validate',
@@ -1569,7 +1569,7 @@ class AdditionalFields extends MockeryTestCase {
 	public function test_place_order_required_address_field() {
 		$id    = 'plugin-namespace/my-required-field';
 		$label = 'My Required Field';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => $label,
@@ -1633,7 +1633,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	public function test_place_order_required_contact_field() {
 		$id = 'plugin-namespace/my-required-contact-field';
-		\woocommerce_blocks_register_checkout_field(
+		\__experimental_woocommerce_blocks_register_checkout_field(
 			array(
 				'id'       => $id,
 				'label'    => 'My Required Field',


### PR DESCRIPTION
### Submission Review Guidelines:
This PR graduates the additional fields API to stable, and renames certain values to their correct ones.

For now, I didn't migrate tests, and left them on old values, they should pass regardless, once they all pass fine, I will update their values.

Everything is done in backward-compatible manner except reading values, which will not work going forward, the goal was to have this continue working without breaking, but I decided to kip migrating values or reading from 2 places, if you're a plugin developer that already have this in the wild in production in client websites (which you shouldn't), you will need to run a migration system:

- Access the meta fields of `_additional_billing_fields` from both customers and orders, decode it from JSON, get your fields values out of it, and save to individual meta keys named `_wc_billing/{id_here_with_namespace}`.
- Access the meta fields of `_additional_shipping_fields` from both customers and order, decode it from JSON, get your fields values out of it, and save to individual meta keys named `_wc_shipping/{id_here_with_namespace}`.
- Access the meta fields of `_additional_fields` from both customers and orders, decode it from JSON, get your fields values out of it, and save to individual meta keys named `_wc_other/{id_here_with_namespace}`.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46804
Closes https://github.com/woocommerce/woocommerce/issues/45841

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
 
1. Install the additional fields plugin: [additional-checkout-fields-tester-main-2.1.zip](https://github.com/woocommerce/woocommerce/files/14856787/additional-checkout-fields-tester-main-2.1.zip).
2. Do a general smoke testing, including adding fields, refreshing the page to ensure they're there, placing the order, seeing them in order confirmation screen and admin order screen, placing another order and seeing there as well.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Additional Checkout Fields has been graduated to stable.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
