### PR TITLE
Fix crashes in mini-cart by externalizing the wc types package.

### DIFF
--- a/plugins/woocommerce-blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce-blocks/bin/webpack-entries.js
@@ -218,6 +218,7 @@ const entries = {
 		wcBlocksSharedContext: './assets/js/shared/context/index.js',
 		wcBlocksSharedHocs: './assets/js/shared/hocs/index.js',
 		priceFormat: './packages/prices/index.js',
+		wcTypes: './assets/js/types/index.ts',
 
 		// interactivity components, exported as separate entries for now
 		'wc-interactivity-dropdown':

--- a/plugins/woocommerce-blocks/bin/webpack-helpers.js
+++ b/plugins/woocommerce-blocks/bin/webpack-helpers.js
@@ -19,6 +19,7 @@ const wcDepMap = {
 	'@woocommerce/blocks-checkout': [ 'wc', 'blocksCheckout' ],
 	'@woocommerce/blocks-components': [ 'wc', 'blocksComponents' ],
 	'@woocommerce/interactivity': [ 'wc', '__experimentalInteractivity' ],
+	'@woocommerce/types': [ 'wc', 'wcTypes' ],
 };
 
 const wcHandleMap = {
@@ -32,6 +33,7 @@ const wcHandleMap = {
 	'@woocommerce/blocks-checkout': 'wc-blocks-checkout',
 	'@woocommerce/blocks-components': 'wc-blocks-components',
 	'@woocommerce/interactivity': 'wc-interactivity',
+	'@woocommerce/types': 'wc-types',
 };
 
 const getAlias = ( options = {} ) => {

--- a/plugins/woocommerce/changelog/46814-dev-externalize-woo-types
+++ b/plugins/woocommerce/changelog/46814-dev-externalize-woo-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix crashes in the mini-cart when combined with product and filter blocks. Closes #46542.

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -50,6 +50,7 @@ final class AssetsController {
 		$this->register_style( 'wc-blocks-style', plugins_url( $this->api->get_block_asset_build_path( 'wc-blocks', 'css' ), dirname( __DIR__ ) ), array(), 'all', true );
 		$this->register_style( 'wc-blocks-editor-style', plugins_url( $this->api->get_block_asset_build_path( 'wc-blocks-editor-style', 'css' ), dirname( __DIR__ ) ), array( 'wp-edit-blocks' ), 'all', true );
 
+		$this->api->register_script( 'wc-types', $this->api->get_block_asset_build_path( 'wc-types' ), array(), false );
 		$this->api->register_script( 'wc-blocks-middleware', 'assets/client/blocks/wc-blocks-middleware.js', array(), false );
 		$this->api->register_script( 'wc-blocks-data-store', 'assets/client/blocks/wc-blocks-data.js', array( 'wc-blocks-middleware' ) );
 		$this->api->register_script( 'wc-blocks-vendors', $this->api->get_block_asset_build_path( 'wc-blocks-vendors' ), array(), false );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This will close https://github.com/woocommerce/woocommerce/issues/46542 and if you're testing this also confirm it does not reintroduce: 

https://github.com/woocommerce/woocommerce-blocks/issues/12032

and

https://github.com/woocommerce/woocommerce/pull/46714#pullrequestreview-2014287525

I understand what is happening that causes this bug, but I do not understand why.

What happens is, when you include a block on the page like price filters, it will load and cache the `@woocommerce/types ` module first.

If it has tree-shaken differently based on used or unused code the import will be broken for other modules. This is because packages that require the module will all generate the same module ID for it. It will be requested from the cache and if it was tree-shaken differently it will crash.

Marking this package as having `sideEffects` should stop the problem but it does not. This issue is not generated by Terser optimization either as I've tried disabling Terser. This only happens with mini-cart and I suspect its related to it being lazy-loaded, but I still don't think this problem should exist.

Anyway, to solve this I have instead externalized the problem module for sharing amongst bundles. Incidentally this will improve the bundle size too, because this module is duplicated many, many times within the front-end bundle (looks like we shave about 40kb gzipped off the entire bundle, while only loading types once as a very small package).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Test with content of:

1. Mini cart and price filter block. To test simply go to frontend and hover the mini-cart, click it, interact with functionality of mini-cart

2. Mini cart and all products block. To test simply go to frontend and hover the mini-cart, click it, interact with functionality of mini-cart

3. Mini cart and product collection (beta) block. To test simply go to frontend and hover the mini-cart, click it, interact with functionality of mini-cart

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix crashes in the mini-cart when combined with product and filter blocks. Closes #46542.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
