### PR TITLE
fix: removed live explat test

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-live-explat-test
+++ b/plugins/woocommerce/changelog/fix-remove-live-explat-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+
+Removed explat test that calls live explat server
+

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -51,7 +51,7 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests retrieve the test variation when consent is false
+	 * Tests retrieve the default control variation when consent is false
 	 */
 	public function test_get_variation_return_control_when_no_consent() {
 		$exp = new Experimental_Abtest( 'anon', 'platform', false );
@@ -62,7 +62,7 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests retrieve the test variation when consent is false
+	 * Tests retrieve the treatment variation when consent is true and experiment name is valid
 	 */
 	public function test_get_variation() {
 		delete_transient( 'abtest_variation_control' );
@@ -102,15 +102,6 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 			is_wp_error( $exp->request_assignment( 'test_experiment_name' ) ),
 			true
 		);
-	}
-
-	/**
-	 * Test get_variation with valid experiment name.
-	 */
-	public function test_fetch_variation_with_valid_name() {
-		$exp       = new Experimental_Abtest( 'anon', 'platform', true );
-		$variation = $exp->get_variation( 'valid_experiment_name_2' );
-		$this->assertNotInstanceOf( 'WP_Error', $variation );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A test I added in https://github.com/woocommerce/woocommerce/pull/44535 was causing tests to hit the live explat server which I didn't anticipate being an issue. This test has been removed since the experiment name validation is already covered in an earlier test which mocks the HTTP response. The inline comments have been updated to reflect this.

Closes https://github.com/woocommerce/team-ghidorah/issues/313

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. This is a bit hard to verify but it's removal of test code so inspection should suffice

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>