### PR TITLE
Attach WooCommerce templates to the theme

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -4,20 +4,15 @@
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
 
 const permalink = '/cart';
-const templatePath = 'woocommerce/woocommerce//page-cart';
+const templateName = 'Page: Cart';
 const templateType = 'wp_template';
 
 test.describe( 'Test the cart template', () => {
 	test( 'Template can be opened in the site editor', async ( {
-		admin,
 		page,
 		editorUtils,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: templatePath,
-			postType: templateType,
-		} );
-		await editorUtils.enterEditMode();
+		await editorUtils.visitTemplateEditor( templateName, templateType );
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
@@ -65,14 +60,10 @@ test.describe( 'Test the cart template', () => {
 
 test.describe( 'Test editing the cart template', () => {
 	test( 'Merchant can transform shortcode block into blocks', async ( {
-		admin,
 		editorUtils,
 		editor,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: templatePath,
-			postType: templateType,
-		} );
+		await editorUtils.visitTemplateEditor( templateName, templateType );
 		await editorUtils.enterEditMode();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"cart"} /-->'

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -13,6 +13,7 @@ test.describe( 'Test the cart template', () => {
 		editorUtils,
 	} ) => {
 		await editorUtils.visitTemplateEditor( templateName, templateType );
+		await editorUtils.enterEditMode();
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -29,7 +29,7 @@ test.describe( 'Test the checkout template', () => {
 		editorUtils,
 	} ) => {
 		await editorUtils.visitTemplateEditor( templateName, templateType );
-		await admin.visitAdminPage( 'site-editor.php', 'path=%2Fpage' );
+		await admin.visitSiteEditor( { path: '/page' } );
 		await editor.page
 			.getByRole( 'button', { name: 'Checkout', exact: true } )
 			.click();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -4,19 +4,15 @@
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
 
 const permalink = '/checkout';
-const templatePath = 'woocommerce/woocommerce//page-checkout';
+const templateName = 'Page: Checkout';
 const templateType = 'wp_template';
 
 test.describe( 'Test the checkout template', () => {
 	test( 'Template can be opened in the site editor', async ( {
-		admin,
 		page,
 		editorUtils,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: templatePath,
-			postType: templateType,
-		} );
+		await editorUtils.visitTemplateEditor( templateName, templateType );
 		await editorUtils.enterEditMode();
 		await expect(
 			page
@@ -32,11 +28,8 @@ test.describe( 'Test the checkout template', () => {
 		page,
 		editorUtils,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: templatePath,
-			postType: templateType,
-		} );
-		await admin.visitSiteEditor( { path: '/page' } );
+		await editorUtils.visitTemplateEditor( templateName, templateType );
+		await admin.visitAdminPage( 'site-editor.php', 'path=%2Fpage' );
 		await editor.page
 			.getByRole( 'button', { name: 'Checkout', exact: true } )
 			.click();
@@ -74,14 +67,10 @@ test.describe( 'Test the checkout template', () => {
 
 test.describe( 'Test editing the checkout template', () => {
 	test( 'Merchant can transform shortcode block into blocks', async ( {
-		admin,
 		editorUtils,
 		editor,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: templatePath,
-			postType: templateType,
-		} );
+		await editorUtils.visitTemplateEditor( templateName, templateType );
 		await editorUtils.enterEditMode();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"checkout"} /-->'

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
@@ -7,12 +7,11 @@ test.describe( 'Test the order confirmation template', () => {
 	test( 'Template can be opened in the site editor', async ( {
 		page,
 		editorUtils,
-		admin,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//order-confirmation',
-			postType: 'wp_template',
-		} );
+		await editorUtils.visitTemplateEditor(
+			'Order Confirmation',
+			'wp_template'
+		);
 		await editorUtils.enterEditMode();
 		await editorUtils.transformIntoBlocks();
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -19,7 +19,7 @@ const testToRun = CUSTOMIZABLE_WC_TEMPLATES.filter(
 for ( const testData of testToRun ) {
 	const userText = `Hello World in the ${ testData.templateName } template`;
 
-	test.describe( `${ testData.templateName } template`, async () => {
+	test.describe( `${ testData.templateName } template`, () => {
 		test( `user-modified ${ testData.templateName } template is attached to the theme`, async ( {
 			page,
 			editor,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.side_effects.spec.ts
@@ -18,69 +18,31 @@ const testToRun = CUSTOMIZABLE_WC_TEMPLATES.filter(
 
 for ( const testData of testToRun ) {
 	const userText = `Hello World in the ${ testData.templateName } template`;
-	const woocommerceTemplateUserText = `Hello World in the WooCommerce ${ testData.templateName } template`;
 
-	test.describe( `${ testData.templateName } template`, () => {
-		test( `user-modified ${ testData.templateName } template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {
+	test.describe( `${ testData.templateName } template`, async () => {
+		test( `user-modified ${ testData.templateName } template is attached to the theme`, async ( {
 			page,
-			admin,
 			editor,
 			requestUtils,
 			editorUtils,
 			frontendUtils,
 		} ) => {
-			// Edit the WooCommerce default template
 			await editorUtils.visitTemplateEditor(
 				testData.templateName,
 				testData.templateType
 			);
 			await editor.insertBlock( {
 				name: 'core/paragraph',
-				attributes: { content: woocommerceTemplateUserText },
-			} );
-			await editor.saveSiteEditorEntities();
-
-			await requestUtils.activateTheme( BLOCK_THEME_WITH_TEMPLATES_SLUG );
-
-			// Edit the theme template. The theme template is not
-			// directly available from the UI, because the customized
-			// one takes priority, so we go directly to its URL.
-			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
-				postType: testData.templateType,
-			} );
-			await editorUtils.enterEditMode();
-			await editorUtils.waitForSiteEditorFinishLoading();
-			await editorUtils.editor.insertBlock( {
-				name: 'core/paragraph',
 				attributes: { content: userText },
 			} );
 			await editor.saveSiteEditorEntities();
 
-			// Verify the template is the one modified by the user based on the theme.
 			await testData.visitPage( { frontendUtils, page } );
 			await expect( page.getByText( userText ).first() ).toBeVisible();
-			await expect(
-				page.getByText( woocommerceTemplateUserText )
-			).toHaveCount( 0 );
 
-			// Revert edition and verify the user-modified WC template is used.
-			// Note: we need to revert it from the admin (instead of calling
-			// `deleteAllTemplates()`). This way, we verify there are no
-			// duplicate templates with the same name.
-			// See: https://github.com/woocommerce/woocommerce/issues/42220
-			await admin.visitSiteEditor( {
-				path: `/${ testData.templateType }/all`,
-			} );
-			await editorUtils.revertTemplateCustomizations(
-				testData.templateName
-			);
+			await requestUtils.activateTheme( BLOCK_THEME_WITH_TEMPLATES_SLUG );
 
 			await testData.visitPage( { frontendUtils, page } );
-
-			await expect(
-				page.getByText( woocommerceTemplateUserText ).first()
-			).toBeVisible();
 			await expect( page.getByText( userText ) ).toHaveCount( 0 );
 
 			await requestUtils.activateTheme( BLOCK_THEME_SLUG );

--- a/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/page-checkout.html
+++ b/plugins/woocommerce-blocks/tests/mocks/theme-with-woo-templates/block-templates/page-checkout.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"checkout-header","tagName":"header"} /-->
 <!-- wp:paragraph -->
 <p>Page: Checkout template loaded from theme</p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/changelog/fix-42181-attach-woocommerce-templates-to-theme
+++ b/plugins/woocommerce/changelog/fix-42181-attach-woocommerce-templates-to-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Attach WooCommerce block templates to themes, so they don't persist after a theme switch

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -263,7 +263,7 @@ class BlockTemplatesController {
 
 		// This is a real edge-case, we are supporting users who have saved templates under the deprecated slug. See its definition for more information.
 		// You can likely ignore this code unless you're supporting/debugging early customised templates.
-		if ( BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG === strtolower( $template_id ) ) {
+		if ( BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG === strtolower( $template_id ) || BlockTemplateUtils::PLUGIN_SLUG === strtolower( $template_id ) ) {
 			// Because we are using get_block_templates we have to unhook this method to prevent a recursive loop where this filter is applied.
 			remove_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 			$template_with_deprecated_id = get_block_template( $id, $template_type );
@@ -276,7 +276,8 @@ class BlockTemplatesController {
 		}
 
 		// If we are not dealing with a WooCommerce template let's return early and let it continue through the process.
-		if ( BlockTemplateUtils::PLUGIN_SLUG !== $template_id ) {
+		$registry_template = BlockTemplateUtils::get_template( $template_slug );
+		if ( ! $registry_template ) {
 			return $template;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -277,7 +277,7 @@ class BlockTemplatesController {
 
 		// If we are not dealing with a WooCommerce template let's return early and let it continue through the process.
 		$registry_template = BlockTemplateUtils::get_template( $template_slug );
-		if ( ! $registry_template ) {
+		if ( ! $registry_template || ! ! BlockTemplateUtils::get_theme_template_path( $template_slug, $template_type ) ) {
 			return $template;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -257,7 +257,7 @@ class BlockTemplatesController {
 		// If the theme has an archive-product.html template, but not a taxonomy-product_cat/tag/attribute.html template let's use the themes archive-product.html template.
 		if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_theme( $template_slug ) ) {
 			$template_path   = BlockTemplateUtils::get_theme_template_path( ProductCatalogTemplate::SLUG );
-			$template_object = BlockTemplateUtils::create_new_block_template_object( $template_path, $template_type, $template_slug, true );
+			$template_object = BlockTemplateUtils::create_new_block_template_object( $template_path, $template_type, $template_slug );
 			return BlockTemplateUtils::build_template_result_from_file( $template_object, $template_type );
 		}
 
@@ -467,7 +467,7 @@ class BlockTemplatesController {
 			// If the theme has an archive-product.html template, but not a taxonomy-product_cat/tag/attribute.html template let's use the themes archive-product.html template.
 			if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_theme( $template_slug ) ) {
 				$template_file = BlockTemplateUtils::get_theme_template_path( ProductCatalogTemplate::SLUG );
-				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug, true );
+				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug );
 				continue;
 			}
 
@@ -475,7 +475,7 @@ class BlockTemplatesController {
 			// let's use the archive-product.html template from Blocks.
 			if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $template_slug ) ) {
 				$template_file = $this->get_template_path_from_woocommerce( ProductCatalogTemplate::SLUG );
-				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug, false );
+				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug );
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -599,7 +599,10 @@ class BlockTemplateUtils {
 				$query_result_template->slug === $template->slug
 				&& $query_result_template->theme === $template->theme
 			) {
-				$query_result_template->has_theme_file = true;
+				$registry_template = self::get_template( $template->slug );
+				if ( $registry_template ) {
+					$query_result_template->has_theme_file = true;
+				}
 
 				return true;
 			}

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -213,7 +213,7 @@ class BlockTemplateUtils {
 	 */
 	public static function build_template_result_from_file( $template_file, $template_type ) {
 		$template_file = (object) $template_file;
-		$theme_name    = wp_get_theme()->get( 'TextDomain' );
+		$theme_name    = get_stylesheet();
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$template_content  = file_get_contents( $template_file->path );
@@ -266,7 +266,7 @@ class BlockTemplateUtils {
 	 * @return object Block template object.
 	 */
 	public static function create_new_block_template_object( $template_file, $template_type, $template_slug ) {
-		$theme_name = wp_get_theme()->get( 'TextDomain' );
+		$theme_name = get_stylesheet();
 
 		$new_template_item = array(
 			'slug'        => $template_slug,

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -213,11 +213,7 @@ class BlockTemplateUtils {
 	 */
 	public static function build_template_result_from_file( $template_file, $template_type ) {
 		$template_file = (object) $template_file;
-
-		// If the theme has an archive-products.html template but does not have product taxonomy templates
-		// then we will load in the archive-product.html template from the theme to use for product taxonomies on the frontend.
-		$template_is_from_theme = 'theme' === $template_file->source;
-		$theme_name             = wp_get_theme()->get( 'TextDomain' );
+		$theme_name    = wp_get_theme()->get( 'TextDomain' );
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$template_content  = file_get_contents( $template_file->path );
@@ -266,11 +262,10 @@ class BlockTemplateUtils {
 	 * @param string $template_file Block template file path.
 	 * @param string $template_type wp_template or wp_template_part.
 	 * @param string $template_slug Block template slug e.g. single-product.
-	 * @param bool   $template_is_from_theme If the block template file is being loaded from the current theme instead of Woo Blocks.
 	 *
 	 * @return object Block template object.
 	 */
-	public static function create_new_block_template_object( $template_file, $template_type, $template_slug, $template_is_from_theme = false ) {
+	public static function create_new_block_template_object( $template_file, $template_type, $template_slug ) {
 		$theme_name = wp_get_theme()->get( 'TextDomain' );
 
 		$new_template_item = array(
@@ -794,7 +789,6 @@ class BlockTemplateUtils {
 		if ( count( $templates_from_db ) > 0 ) {
 			$template_slug_to_load = $templates_from_db[0]->theme;
 		} else {
-			$theme_has_template    = self::theme_has_template_part( $slug );
 			$template_slug_to_load = get_stylesheet();
 		}
 		$template_part = get_block_template( $template_slug_to_load . '//' . $slug, 'wp_template_part' );

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -222,8 +222,8 @@ class BlockTemplateUtils {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$template_content  = file_get_contents( $template_file->path );
 		$template          = new \WP_Block_Template();
-		$template->id      = $template_is_from_theme ? $theme_name . '//' . $template_file->slug : self::PLUGIN_SLUG . '//' . $template_file->slug;
-		$template->theme   = $template_is_from_theme ? $theme_name : self::PLUGIN_SLUG;
+		$template->id      = $theme_name . '//' . $template_file->slug;
+		$template->theme   = $theme_name;
 		$template->content = self::inject_theme_attribute_in_content( $template_content );
 		// Remove the term description block from the archive-product template
 		// as the Product Catalog/Shop page doesn't have a description.
@@ -238,7 +238,7 @@ class BlockTemplateUtils {
 		$template->description    = ! empty( $template_file->description ) ? $template_file->description : self::get_block_template_description( $template_file->slug );
 		$template->status         = 'publish';
 		$template->has_theme_file = true;
-		$template->origin         = $template_file->source;
+		$template->origin         = 'theme';
 		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 		$template->area           = self::get_block_template_area( $template->slug, $template_type );
@@ -276,12 +276,13 @@ class BlockTemplateUtils {
 
 		$new_template_item = array(
 			'slug'        => $template_slug,
-			'id'          => $template_is_from_theme ? $theme_name . '//' . $template_slug : self::PLUGIN_SLUG . '//' . $template_slug,
+			'id'          => $theme_name . '//' . $template_slug,
 			'path'        => $template_file,
 			'type'        => $template_type,
 			'theme'       => $template_is_from_theme ? $theme_name : self::PLUGIN_SLUG,
 			// Plugin was agreed as a valid source value despite existing inline docs at the time of creating: https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909.
 			'source'      => $template_is_from_theme ? 'theme' : 'plugin',
+			'origin'      => 'theme',
 			'title'       => self::get_block_template_title( $template_slug ),
 			'description' => self::get_block_template_description( $template_slug ),
 			'post_types'  => array(), // Don't appear in any Edit Post template selector dropdown.
@@ -797,7 +798,7 @@ class BlockTemplateUtils {
 			$template_slug_to_load = $templates_from_db[0]->theme;
 		} else {
 			$theme_has_template    = self::theme_has_template_part( $slug );
-			$template_slug_to_load = $theme_has_template ? get_stylesheet() : self::PLUGIN_SLUG;
+			$template_slug_to_load = get_stylesheet();
 		}
 		$template_part = get_block_template( $template_slug_to_load . '//' . $slug, 'wp_template_part' );
 

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -153,8 +153,7 @@ class BlockTemplateUtils {
 			return new \WP_Error( 'template_missing_theme', __( 'No theme is defined for this template.', 'woocommerce' ) );
 		}
 
-		$theme          = $terms[0]->name;
-		$has_theme_file = true;
+		$theme = $terms[0]->name;
 
 		$template                 = new \WP_Block_Template();
 		$template->wp_id          = $post->ID;
@@ -163,11 +162,12 @@ class BlockTemplateUtils {
 		$template->content        = $post->post_content;
 		$template->slug           = $post->post_name;
 		$template->source         = 'custom';
+		$template->origin         = 'theme';
 		$template->type           = $post->post_type;
 		$template->description    = $post->post_excerpt;
 		$template->title          = $post->post_title;
 		$template->status         = $post->post_status;
-		$template->has_theme_file = $has_theme_file;
+		$template->has_theme_file = true;
 		$template->is_custom      = false;
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 
@@ -230,8 +230,7 @@ class BlockTemplateUtils {
 		if ( ProductCatalogTemplate::SLUG === $template_file->slug ) {
 			$template->content = str_replace( '<!-- wp:term-description {"align":"wide"} /-->', '', $template->content );
 		}
-		// Plugin was agreed as a valid source value despite existing inline docs at the time of creating: https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909.
-		$template->source         = $template_file->source ? $template_file->source : 'plugin';
+		$template->source         = 'theme';
 		$template->slug           = $template_file->slug;
 		$template->type           = $template_type;
 		$template->title          = ! empty( $template_file->title ) ? $template_file->title : self::get_block_template_title( $template_file->slug );
@@ -279,9 +278,9 @@ class BlockTemplateUtils {
 			'id'          => $theme_name . '//' . $template_slug,
 			'path'        => $template_file,
 			'type'        => $template_type,
-			'theme'       => $template_is_from_theme ? $theme_name : self::PLUGIN_SLUG,
+			'theme'       => $theme_name,
 			// Plugin was agreed as a valid source value despite existing inline docs at the time of creating: https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909.
-			'source'      => $template_is_from_theme ? 'theme' : 'plugin',
+			'source'      => 'theme',
 			'origin'      => 'theme',
 			'title'       => self::get_block_template_title( $template_slug ),
 			'description' => self::get_block_template_description( $template_slug ),
@@ -605,9 +604,7 @@ class BlockTemplateUtils {
 				$query_result_template->slug === $template->slug
 				&& $query_result_template->theme === $template->theme
 			) {
-				if ( self::template_is_eligible_for_product_archive_fallback_from_theme( $template->slug ) ) {
-					$query_result_template->has_theme_file = true;
-				}
+				$query_result_template->has_theme_file = true;
 
 				return true;
 			}

--- a/plugins/woocommerce/templates/templates/blockified/page-checkout.html
+++ b/plugins/woocommerce/templates/templates/blockified/page-checkout.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"checkout-header","tagName":"header"} /-->
 <!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">

--- a/plugins/woocommerce/templates/templates/page-checkout.html
+++ b/plugins/woocommerce/templates/templates/page-checkout.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"checkout-header","tagName":"header"} /-->
 <!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -202,6 +202,7 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			'type'        => 'wp_template',
 			'theme'       => 'twentytwentytwo',
 			'source'      => 'theme',
+			'origin'      => 'theme',
 			'title'       => 'Single Product',
 			'description' => 'Displays a single product.',
 			'post_types'  => array(),

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -126,11 +126,11 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 		switch_theme( 'storefront' );
 		$template_file = array(
 			'slug'        => 'single-product',
-			'id'          => 'woocommerce/woocommerce//single-product',
+			'id'          => 'twentywentytwo//single-product',
 			'path'        => __DIR__ . '/single-product.html',
 			'type'        => 'wp_template',
-			'theme'       => 'woocommerce/woocommerce',
-			'source'      => 'plugin',
+			'theme'       => 'twentywentytwo',
+			'source'      => 'theme',
 			'title'       => 'Single Product',
 			'description' => 'Displays a single product.',
 		);
@@ -197,11 +197,11 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 	public function test_create_new_block_template_object() {
 		$expected_template = (object) array(
 			'slug'        => 'single-product',
-			'id'          => 'woocommerce/woocommerce//single-product',
+			'id'          => 'twentytwentytwo//single-product',
 			'path'        => __DIR__ . '/single-product.html',
 			'type'        => 'wp_template',
-			'theme'       => 'woocommerce/woocommerce',
-			'source'      => 'plugin',
+			'theme'       => 'twentytwentytwo',
+			'source'      => 'theme',
 			'title'       => 'Single Product',
 			'description' => 'Displays a single product.',
 			'post_types'  => array(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/42181.

This PR changes some of the logic of the templates introduced by WooCommerce so instead of being plugin templates they are considered regular theme templates. This makes that when the user switches themes, the templates aren't carried over, fixing #42181.

At the same time, it brings the regression that the theme name is shown as the author of the templates, instead of WooCommerce. Fixing this will likely require changes upstream.

Todo list:

* [x] Make it so WooCommerce templates are not carried-over when switching themes.
* [x] Update existing tests.
  * [ ] Fix `template-customization.block_theme_with_templates.spec.ts` tests.
* [ ] Update slugs test to test `woocommerce/woocommerce` slug as well.
* [ ] (Might be impossible) investigate if it's possible to keep 'WooCommerce' as the visible author of the templates.

### How to test the changes in this Pull Request:

1. With TT4 make some edits to WooCommerce templates.
2. Go to the frontend and verify the edits were applied correctly.
3. Switch to TT3.
4. Verify the edits you did to WooCommerce templates in step 1 are no longer visible, neither in the editor nor the frontend.
5. Switch back to TT4.
6. Verify the edits you did to WooCommerce templates in step 1 are visible as expected, in the editor and the frontend.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
