### PR TITLE
Enable "Custom Fields" feature flag by default

### DIFF
--- a/plugins/woocommerce/changelog/dev-46829_remove_custom_fields_feature_flag
+++ b/plugins/woocommerce/changelog/dev-46829_remove_custom_fields_feature_flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Enable "Custom Fields" feature flag for by default #46832

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -25,7 +25,7 @@
 		"product-grouped": true,
 		"product-linked": true,
 		"product-pre-publish-modal": true,
-		"product-custom-fields": false,
+		"product-custom-fields": true,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR enables the "Custom Fields" feature flag by default.

Closes #46829.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a brand new JN site with WooCommerce 8.8.2 (the latest one) activated.
2. Enable the new product editor at `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` 
3. Go to Products > Add > Organization.
4. Verify the `Custom fields` toggle is not visible.

![Screenshot 2024-04-23 at 11 50 26 AM](https://github.com/woocommerce/woocommerce/assets/1314156/1fb439d4-45df-467b-8cc3-5b601c470d5f)

5. Checkout this branch and create a `.zip` by running: `pnpm --filter='@woocommerce/plugin-woocommerce' build:zip`.
6. Create a brand new JN site and install the `.zip` you created last step (`./plugins/woocommerce/woocommerce.zip`).
7. Enable the new product editor at `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` 
8. Go to Products > Add > Organization.
9. Verify the `Custom fields` toggle is now visible.

![Screenshot 2024-04-23 at 11 50 20 AM](https://github.com/woocommerce/woocommerce/assets/1314156/636c5d2f-e9d1-451b-9302-c0ca607b9bea)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
