### PR TITLE
[CYS] Fix logo position after saving on the assembler

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -594,8 +594,7 @@
 }
 
 .woocommerce-customize-store__step-assemblerHub,
-.woocommerce-customize-store__step-transitionalScreen,
-{
+.woocommerce-customize-store__step-transitionalScreen {
 	.edit-site-layout {
 		.edit-site-site-hub__view-mode-toggle-container {
 			padding: 16px 12px 0 16px;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -593,9 +593,13 @@
 	}
 }
 
-.woocommerce-customize-store__step-assemblerHub {
-	.edit-site-site-hub__view-mode-toggle-container {
-		padding: 16px 12px 0 16px;
+.woocommerce-customize-store__step-assemblerHub,
+.woocommerce-customize-store__step-transitionalScreen,
+{
+	.edit-site-layout {
+		.edit-site-site-hub__view-mode-toggle-container {
+			padding: 16px 12px 0 16px;
+		}
 	}
 }
 

--- a/plugins/woocommerce/changelog/46833-fix-cys-logo-styles
+++ b/plugins/woocommerce/changelog/46833-fix-cys-logo-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+[CYS] Fix logo position styles while saving.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a WooExpress site, go to `WooCommerce > Home > Customize your store`.
2. Click on `Design With AI` and proceed to the assembler.
3. Click save and check the logo on the left top corner position is always correct (should not behave like this: https://github.com/woocommerce/woocommerce/assets/186112/097c9e42-258a-4ba5-bbae-1678151607e6)
4. Repeat the process on a local or JN site.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[CYS] Fix logo position styles while saving.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
