### PR TITLE
Stamp the order attribution HTML element (only once) on a wider set of checkout form actions

### DIFF
--- a/plugins/woocommerce/changelog/tweak-more-robust-oa-field-injection
+++ b/plugins/woocommerce/changelog/tweak-more-robust-oa-field-injection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Inject order attribution checkout fields (only once) on a wider set of checkout form actions.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -59,7 +59,9 @@ class OrderAttributionController implements RegisterHooksInterface {
 	private $proxy;
 
 	/**
-	 * @var bool Whether the `stamp_checkout_html_element` method has been called.
+	 *  Whether the `stamp_checkout_html_element` method has been called.
+	 *
+	 * @var bool
 	 */
 	private static $is_stamp_checkout_html_called = false;
 

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -118,10 +118,10 @@ class OrderAttributionController implements RegisterHooksInterface {
 			}
 		);
 
-		add_action( 'woocommerce_after_checkout_billing_form', array( $this, 'stamp_checkout_html_element' ) );
-		add_action( 'woocommerce_checkout_shipping', array( $this, 'stamp_checkout_html_element' ) );
-		add_action( 'woocommerce_after_order_notes', array( $this, 'stamp_checkout_html_element' ) );
-		add_action( 'woocommerce_checkout_after_customer_details', array( $this, 'stamp_checkout_html_element' ) );
+		add_action( 'woocommerce_after_checkout_billing_form', array( $this, 'stamp_checkout_html_element_once' ) );
+		add_action( 'woocommerce_checkout_shipping', array( $this, 'stamp_checkout_html_element_once' ) );
+		add_action( 'woocommerce_after_order_notes', array( $this, 'stamp_checkout_html_element_once' ) );
+		add_action( 'woocommerce_checkout_after_customer_details', array( $this, 'stamp_checkout_html_element_once' ) );
 
 		add_action( 'woocommerce_register_form', array( $this, 'stamp_html_element' ) );
 
@@ -356,7 +356,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 	 *
 	 * @return void
 	 */
-	public function stamp_checkout_html_element() {
+	public function stamp_checkout_html_element_once() {
 		if ( self::$is_stamp_checkout_html_called ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -59,6 +59,11 @@ class OrderAttributionController implements RegisterHooksInterface {
 	private $proxy;
 
 	/**
+	 * @var bool Whether the `stamp_checkout_html_element` method has been called.
+	 */
+	private static $is_stamp_checkout_html_called = false;
+
+	/**
 	 * Initialization method.
 	 *
 	 * Takes the place of the constructor within WooCommerce Dependency injection.
@@ -111,7 +116,11 @@ class OrderAttributionController implements RegisterHooksInterface {
 			}
 		);
 
-		add_action( 'woocommerce_checkout_after_customer_details', array( $this, 'stamp_html_element' ) );
+		add_action( 'woocommerce_after_checkout_billing_form', array( $this, 'stamp_checkout_html_element' ) );
+		add_action( 'woocommerce_checkout_shipping', array( $this, 'stamp_checkout_html_element' ) );
+		add_action( 'woocommerce_after_order_notes', array( $this, 'stamp_checkout_html_element' ) );
+		add_action( 'woocommerce_checkout_after_customer_details', array( $this, 'stamp_checkout_html_element' ) );
+
 		add_action( 'woocommerce_register_form', array( $this, 'stamp_html_element' ) );
 
 		// Update order based on submitted fields.
@@ -339,8 +348,25 @@ class OrderAttributionController implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Add `<wc-order-attribution-inputs>` element that contributes the order attribution values to the enclosing form.
-	 * Used for checkout & customer register forms.
+	 * Handles the `<wc-order-attribution-inputs>` element for checkout forms, ensuring that the field is only output once.
+	 *
+	 * @since 9.0.0
+	 *
+	 * @return void
+	 */
+	public function stamp_checkout_html_element() {
+		if ( self::$is_stamp_checkout_html_called ) {
+			return;
+		}
+		$this->stamp_html_element();
+		self::$is_stamp_checkout_html_called = true;
+	}
+
+	/**
+	 * Output `<wc-order-attribution-inputs>` element that contributes the order attribution values to the enclosing form.
+	 * Used customer register forms, and for checkout forms through `stamp_checkout_html_element()`.
+	 *
+	 * @return void
 	 */
 	public function stamp_html_element() {
 		printf( '<wc-order-attribution-inputs></wc-order-attribution-inputs>' );

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -118,10 +118,26 @@ class OrderAttributionController implements RegisterHooksInterface {
 			}
 		);
 
-		add_action( 'woocommerce_after_checkout_billing_form', array( $this, 'stamp_checkout_html_element_once' ) );
-		add_action( 'woocommerce_checkout_shipping', array( $this, 'stamp_checkout_html_element_once' ) );
-		add_action( 'woocommerce_after_order_notes', array( $this, 'stamp_checkout_html_element_once' ) );
-		add_action( 'woocommerce_checkout_after_customer_details', array( $this, 'stamp_checkout_html_element_once' ) );
+		/**
+		 * Filter set of actions used to stamp the unique checkout order attribution HTML container element.
+		 *
+		 * @since 9.0.0
+		 *
+		 * @param array $stamp_checkout_html_actions The set of actions used to stamp the unique checkout order attribution HTML container element.
+		 */
+		$stamp_checkout_html_actions = apply_filters(
+			'wc_order_attribution_stamp_checkout_html_actions',
+			array(
+				'woocommerce_checkout_billing',
+				'woocommerce_after_checkout_billing_form',
+				'woocommerce_checkout_shipping',
+				'woocommerce_after_order_notes',
+				'woocommerce_checkout_after_customer_details',
+			)
+		);
+		foreach ( $stamp_checkout_html_actions as $action ) {
+			add_action( $action, array( $this, 'stamp_checkout_html_element_once' ) );
+		}
 
 		add_action( 'woocommerce_register_form', array( $this, 'stamp_html_element' ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Builds on the changes in #44333 to include more checkout form hooks in order to increase the likelihood that at least one will be invoked in a custom checkout form and the attribution fields will be stamped (only once). There [have been reports](https://wordpress.org/support/topic/order-attribution-no-longer-works/#post-17532862) of third party payment gateways and [possibly custom page builders](https://wordpress.org/support/topic/order-attribution-origin-unknown/page/2/#post-17562435) that don't register the current action.

This PR reinstates the hooks `woocommerce_checkout_shipping` and `woocommerce_after_order_notes`, and adds `woocommerce_after_checkout_billing_form`, to the currently included `woocommerce_checkout_after_customer_details` among the list of hooks that will stamp the checkout HTML element once the first of the set is fired.


### How to test the changes in this Pull Request:

Prerequisite: a store with a classic checkout, products and payment method. For each step, ensure there are no related errors in the web console nor in the debug log.

**Basic Functionality**
_Changes don't affect basic checkout flow_
1. Visit the store with UTM parameters like `store.com/shop/?utm_source=basic_source&utm_medium=basic_medium`
2. Add items to the cart and visit the checkout.
3. Confirm that in the checkout page source, the attribution input element appears **once and only once** `<wc-order-attribution-inputs></wc-order-attribution-inputs>`
4. Confirm that in the checkout page DOM, the attribution input element is populated with `wc_order_attribution_*` input elements:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/9f726198-8d72-4260-bd69-3718756a5b57)
5. Place the order and confirm that the order attribution has been correctly assigned to the order:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/7dae382d-0d61-4e04-a413-0a4abfa1a579)

**Robust functionality**
_Confirm that with one or more missing hooks, the HTML element is still stamped onto the page._
1. Add the following snippet to disable specific WooCommerce checkout hooks on `init`:
<details><summary>PHP Snippet</summary>
<p>

```
add_action('init', 'wc_disable_checkout_hooks', 100);
function wc_disable_checkout_hooks() {
	remove_all_actions( 'woocommerce_checkout_billing' );
	remove_all_actions( 'woocommerce_after_checkout_billing_form' );
	remove_all_actions( 'woocommerce_checkout_shipping' );
	remove_all_actions( 'woocommerce_after_order_notes' );
	remove_all_actions( 'woocommerce_checkout_after_customer_details' );
}
```

</p>
</details> 

2. Navigate to the site using new UTM parameters, like `?utm_source=robust_test_0`
3. Add item(s) to the cart and go to the checkout page.
4. With all `remove_all_actions` 5 lines present, confirm that the `<wc-order-attribution-inputs>` no longer appears in the page source.
5. Complete the order and confirm that, with no actions fired, the order attribution data is not captured (Origin is `Unknown`).
6. Comment out **one** `remove_all_actions` line, such as .
7. Visit the store again with update UTM params (`?utm_source=robust_test_custdetails`).
8. Add item(s) to the cart and go to the checkout page.
9. Confirm that the `<wc-order-attribution-inputs>` element appears in the source.
10. Complete the order and confirm the the UTM source was properly captured for the order.
11. Repeat steps 6-10 four more times, but commenting out **just one** different `remove_all_actions` line each time and updating the UTM source accordingly. 
12. Confirm the `<wc-order-attribution-inputs>` HTML element appears only once at checkout each time, and that the source data is captured correctly for each order.
13. Repeat steps 6-10 two more times, but first with any **two** lines commented out, and then with any **three** lines commented out.
14. In both cases, the `<wc-order-attribution-inputs>` HTML element should appear only once, and the checkout data should be correctly captured.

**Checkout Block**
_These changes shouldn't have any effect on the checkout block, which doesn't use the `<wc-order-attribution-inputs>` HTML element._
1. Change the checkout page to use the checkout block.
2. Leave all `remove_all_actions` lines active.
8. Add item(s) to the cart and go to the checkout page.
9. Confirm that no `<wc-order-attribution-inputs>` appear in the page source.
10. Complete the order and confirm that the order attribution data **was correctly captured**
11. Disable the custom snippet (meaning all hooks are left intact), and go through the checkout process again, steps 8-10.


**New Accounts**
_Make sure the attribution elements are still added to the register form_
1. Enable creating a user from the My Account page
2. Visit the registration form in a logged out browser
1. Confirm that in the registration page source, the attribution input element appears **once and only once** `<wc-order-attribution-inputs></wc-order-attribution-inputs>`
4. Confirm that in the registration page DOM, the attribution input element is populated with `wc_order_attribution_*` input elements.
5. Complete registration to ensure no errors.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>