### PR TITLE
Add a warning text about the incompatibility of the legacy REST API and HPOS

### DIFF
--- a/plugins/woocommerce/changelog/pr-46841
+++ b/plugins/woocommerce/changelog/pr-46841
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add warnings about the incompatibility of the legacy REST API and HPOS

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -69,7 +69,7 @@ class WC_Admin_Notices {
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
-		self::add_action( 'admin_init', array( __CLASS__, 'maybe_remove_legacy_api_notices' ), 20 );
+		self::add_action( 'admin_init', array( __CLASS__, 'maybe_remove_legacy_api_removal_notice' ), 20 );
 
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
@@ -157,7 +157,6 @@ class WC_Admin_Notices {
 		self::add_min_version_notice();
 		self::add_maxmind_missing_license_key_notice();
 		self::maybe_add_legacy_api_removal_notice();
-		self::maybe_add_legacy_api_hpos_incompatibility_notice();
 	}
 
 	// phpcs:disable Generic.Commenting.Todo.TaskFound
@@ -215,42 +214,13 @@ class WC_Admin_Notices {
 	}
 
 	/**
-	 * Add a notice about the incompatibility between the Legacy REST API and HPOS if both are active
-	 * (regardless of whether the LEgacy REST API is in core or in the dedicated plugin )
-	 */
-	private static function maybe_add_legacy_api_hpos_incompatibility_notice() {
-		if ( ! ( 'yes' === get_option( 'woocommerce_api_enabled' ) && 'yes' === get_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ) ) ) {
-			return;
-		}
-
-		if ( is_plugin_active( 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php' ) ) {
-			$message = __( 'The Legacy REST API plugin and HPOS are both active on this site', 'woocommerce' );
-		} else {
-			$message = __( 'The Legacy REST API and HPOS are both active on this site', 'woocommerce' );
-		}
-
-		$features_page_url = admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' );
-		self::add_custom_notice(
-			'legacy_rest_api_is_incompatible_with_hpos',
-			sprintf(
-			// translators: 1 = "the legacy API plugin are both active on this site" message, 2 = URL
-				wpautop( __( '⚠ <b>%1$s.</b><br/><br/>Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS. <a target="_blank" href="%2$s">Manage features</a>', 'woocommerce' ) ),
-				$message,
-				$features_page_url
-			)
-		);
-	}
-
-	/**
-	 * - Remove the admin notice about the removal of the Legacy REST API if the said API is disabled
-	 *   or if the Legacy REST API extension is installed
-	 * - Rremove the notice about Legacy webhooks if no such webhooks exist anymore
-	 *   or if the Legacy REST API extension is installed.
-	 * - Remove the notice about the Legacy REST API incompatibility with HPOS if either of the two is disabled.
+	 * Remove the admin notice about the removal of the Legacy REST API if the said API is disabled
+	 * or if the Legacy REST API extension is installed, and remove the notice about Legacy webhooks
+	 * if no such webhooks exist anymore or if the Legacy REST API extension is installed.
 	 *
-	 * TODO: Change this method in WooCommerce 9.0 so that the first two notices get removed if the Legacy REST API extension is installed and active.
+	 * TODO: Change this method in WooCommerce 9.0 so that the notice get removed if the Legacy REST API extension is installed and active.
 	 */
-	private static function maybe_remove_legacy_api_notices() {
+	private static function maybe_remove_legacy_api_removal_notice() {
 		$plugin_is_active = is_plugin_active( 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php' );
 
 		if ( self::has_notice( 'legacy_api_removed_in_woo_90' ) && ( $plugin_is_active || 'yes' !== get_option( 'woocommerce_api_enabled' ) ) ) {

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -203,9 +203,35 @@ class PluginUtil {
 		$feature_warnings = array();
 		if ( 'custom_order_tables' === $feature_id && 'yes' === get_option( 'woocommerce_api_enabled' ) ) {
 			if ( is_plugin_active( 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php' ) ) {
-				$feature_warnings[] = __( "⚠ <b>The Legacy REST API plugin is installed and active on this site.</b> Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS.\n", 'woocommerce' );
+				$legacy_api_and_hpos_incompatibility_warning_text =
+					sprintf(
+						// translators: %s is a URL.
+						__( '⚠ <b><a target="_blank" href="%s">The Legacy REST API plugin</a> is installed and active on this site.</b> Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS.', 'woocommerce' ),
+						'https://wordpress.org/plugins/woocommerce-legacy-rest-api/'
+					);
 			} else {
-				$feature_warnings[] = __( "⚠ <b>The Legacy REST API is active on this site.</b> Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS.\n", 'woocommerce' );
+				$legacy_api_and_hpos_incompatibility_warning_text =
+				sprintf(
+					// translators: %s is a URL.
+					__( '⚠ <b><a target="_blank" href="%s">The Legacy REST API</a> is active on this site.</b> Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS.', 'woocommerce' ),
+					admin_url( 'admin.php?page=wc-settings&tab=advanced&section=legacy_api' )
+				);
+			}
+
+			/**
+			 * Filter to modify the warning text that appears in the HPOS section of the features settings page
+			 * when both the Legacy REST API is active (via WooCommerce core or via the Legacy REST API plugin)
+			 * and the orders table is in use as the primary data store for orders.
+			 *
+			 * @param string $legacy_api_and_hpos_incompatibility_warning_text Original warning text.
+			 * @returns string|null Actual warning text to use, or null to suppress the warning.
+			 *
+			 * @since 8.9.0
+			 */
+			$legacy_api_and_hpos_incompatibility_warning_text = apply_filters( 'woocommerce_legacy_api_and_hpos_incompatibility_warning_text', $legacy_api_and_hpos_incompatibility_warning_text );
+
+			if ( ! is_null( $legacy_api_and_hpos_incompatibility_warning_text ) ) {
+				$feature_warnings[] = "\n" . $legacy_api_and_hpos_incompatibility_warning_text;
 			}
 		}
 

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Utilities;
 
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
+use Automattic\WooCommerce\Internal\Utilities\PluginInstaller;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 /**
@@ -182,7 +183,10 @@ class PluginUtil {
 	}
 
 	/**
-	 * Util function to generate warning string for incompatible features based on active plugins.
+	 * Utility method to generate warning string for incompatible features based on active plugins.
+	 *
+	 * Additionally, this method will manually print a warning message on the HPOS feature if both
+	 * the Legacy REST API and HPOS are active.
 	 *
 	 * @param string $feature_id Feature id.
 	 * @param array  $plugin_feature_info Array of plugin feature info. See FeaturesControllers->get_compatible_plugins_for_feature() for details.
@@ -195,20 +199,29 @@ class PluginUtil {
 		$incompatibles      = array_filter( $incompatibles, 'is_plugin_active' );
 		$incompatibles      = array_values( array_diff( $incompatibles, $this->get_plugins_excluded_from_compatibility_ui() ) );
 		$incompatible_count = count( $incompatibles );
+
+		$feature_warnings = array();
+		if ( 'custom_order_tables' === $feature_id && 'yes' === get_option( 'woocommerce_api_enabled' ) ) {
+			if ( is_plugin_active( 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php' ) ) {
+				$feature_warnings[] = __( "⚠ <b>The Legacy REST API plugin is installed and active on this site.</b> Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS.\n", 'woocommerce' );
+			} else {
+				$feature_warnings[] = __( "⚠ <b>The Legacy REST API is active on this site.</b> Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS.\n", 'woocommerce' );
+			}
+		}
+
 		if ( $incompatible_count > 0 ) {
 			if ( 1 === $incompatible_count ) {
 				/* translators: %s = printable plugin name */
-				$feature_warning = sprintf( __( '⚠ 1 Incompatible plugin detected (%s).', 'woocommerce' ), $this->get_plugin_name( $incompatibles[0] ) );
+				$feature_warnings[] = sprintf( __( '⚠ 1 Incompatible plugin detected (%s).', 'woocommerce' ), $this->get_plugin_name( $incompatibles[0] ) );
 			} elseif ( 2 === $incompatible_count ) {
-				$feature_warning = sprintf(
+				$feature_warnings[] = sprintf(
 					/* translators: %1\$s, %2\$s = printable plugin names */
 					__( '⚠ 2 Incompatible plugins detected (%1$s and %2$s).', 'woocommerce' ),
 					$this->get_plugin_name( $incompatibles[0] ),
 					$this->get_plugin_name( $incompatibles[1] )
 				);
 			} else {
-
-				$feature_warning = sprintf(
+				$feature_warnings[] = sprintf(
 					/* translators: %1\$s, %2\$s = printable plugin names, %3\$d = plugins count */
 					_n(
 						'⚠ Incompatible plugins detected (%1$s, %2$s and %3$d other).',
@@ -229,18 +242,15 @@ class PluginUtil {
 				),
 				admin_url( 'plugins.php' )
 			);
-			$extra_desc_tip           = '<br>' . sprintf(
+			$feature_warnings[]       = sprintf(
 				/* translators: %1$s opening link tag %2$s closing link tag. */
 				__( '%1$sView and manage%2$s', 'woocommerce' ),
 				'<a href="' . esc_url( $incompatible_plugins_url ) . '">',
 				'</a>'
 			);
-
-			$feature_warning .= $extra_desc_tip;
-
 		}
 
-		return $feature_warning;
+		return str_replace( "\n", '<br>', implode( "\n", $feature_warnings ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -231,7 +231,7 @@ class PluginUtil {
 			$legacy_api_and_hpos_incompatibility_warning_text = apply_filters( 'woocommerce_legacy_api_and_hpos_incompatibility_warning_text', $legacy_api_and_hpos_incompatibility_warning_text );
 
 			if ( ! is_null( $legacy_api_and_hpos_incompatibility_warning_text ) ) {
-				$feature_warnings[] = "\n" . $legacy_api_and_hpos_incompatibility_warning_text;
+				$feature_warnings[] = $legacy_api_and_hpos_incompatibility_warning_text . "\n";
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds a static message inside the HPOS section in the features settings page, which appears if the Legacy REST API is active (regardless of the selected orders data storage option). "The Legacy REST API is active" means that either the API is still part of WooCommerce and is activated via settings, or [the dedicated plugin](https://github.com/woocommerce/woocommerce-legacy-rest-api) is installed and active.

Additionally, the `woocommerce_legacy_api_and_hpos_incompatibility_warning_text` filter is added to modify or suppress the warning text.

![image](https://github.com/woocommerce/woocommerce/assets/937723/98989076-da65-4b87-a687-a928e2df15e0)

### How to test the changes in this Pull Request:

1. If you have the Legacy REST API plugin active, deactivate it.
2. Enable the Legacy REST API in WooCommerce (WooCommerce - Settings - Advanced - Legacy API) and HPOS (WooCommerce - Settings - Advanced - Features - Order data storage, select "High-performance order storage").
3. Reload the features settings page, notice that the warning text in the HPOS section appear as in the screenshot above. Verify that the link to the Legacy API settings page works.
4. Disable the Legacy REST API from the corresponding settings page, reload the features settings page, the warning text has disappeared.
5. Repeat the tests with the Legacy REST API plugin active. The behavior is the same but the warning text is slightly different (it mentions the plugin now) and the link points to the plugin page in the wp.org directory.
6. Add the following snippet, reload the features settings page and verify that the text has changed:

```php
add_filter('woocommerce_legacy_api_and_hpos_incompatibility_warning_text', fn($text) => "⚠ I wouldn't enable that HPOS with the Legacy REST API active if I were you...");
```

7. Modify the snippet as follows and verify that the warning message disappears:

```php
add_filter('woocommerce_legacy_api_and_hpos_incompatibility_warning_text', fn($text) => null);
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
