### PR TITLE
Remove unused code introduced in 2014 but that looks never been used

### DIFF
--- a/plugins/woocommerce/changelog/46843-cleaning
+++ b/plugins/woocommerce/changelog/46843-cleaning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Remove unused order type registration property.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -435,7 +435,6 @@ class WC_Post_Types {
 					'public'                           => false,
 					'hierarchical'                     => false,
 					'supports'                         => false,
-					'exclude_from_orders_screen'       => false,
 					'add_order_meta_boxes'             => false,
 					'exclude_from_order_count'         => true,
 					'exclude_from_order_views'         => false,

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -287,8 +287,6 @@ function wc_get_order_type( $type ) {
  * post types are types of orders, and having them treated as such.
  *
  * $args are passed to register_post_type, but there are a few specific to this function:
- *      - exclude_from_orders_screen (bool) Whether or not this order type also get shown in the main.
- *      orders screen.
  *      - add_order_meta_boxes (bool) Whether or not the order type gets shop_order meta boxes.
  *      - exclude_from_order_count (bool) Whether or not this order type is excluded from counts.
  *      - exclude_from_order_views (bool) Whether or not this order type is visible by customers when.
@@ -320,7 +318,6 @@ function wc_register_order_type( $type, $args = array() ) {
 
 	// Register for WC usage.
 	$order_type_args = array(
-		'exclude_from_orders_screen'       => false,
 		'add_order_meta_boxes'             => true,
 		'exclude_from_order_count'         => false,
 		'exclude_from_order_views'         => false,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While developping over WooCommerce Order using wc_register_order_type(), I wondered what the `exclude_from_orders_screen` option was.

 Searching the existing code for `exclude_from_orders_screen` does only give some initialisation but no use of it (unlike the other ones listed along this one).


I also searched for "exclude_from_" occurences in case it was used with some variable.  
This code was added in 2014 in commit 755001f1 but even in this one, it doesn't look used.  
I didn't checked if it was used between 2014 & now, but it's not anymore so it should be removed

### How to test the changes in this Pull Request:
I guess it's mostly checking that I did all the necessary code checks / searchs

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Remove unused order type registration property.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>