### PR TITLE
Add filter for limiting the number of order notes returned by wc_get_order_notes()

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -28,6 +28,13 @@ class WC_Meta_Box_Order_Notes {
 
 		$args = array( 'order_id' => $order_id );
 
+		// Allow plugins to filter the maximum number of comments returned.
+		$limit = apply_filters( 'woocommerce_order_notes_query_limit', -1 );
+
+		if ( $limit > 0 ) {
+			$args['number'] = $limit;
+		}
+
 		if ( 0 !== $order_id ) {
 			$notes = wc_get_order_notes( $args );
 		} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a filter to `WC_Meta_Box_Order_Notes::output` to pass a number argument to `wc_get_order_notes()` so that it's possible to limit the number of order notes returned.  

Recently, I ran into a situation where there were over 9,000 order notes added to a WooCommerce subscription.  That ended up triggering out-of-memory errors when loading the subscription in the UI.  

It's definitely unusual to have so many order notes and my team is looking into not using them to record some changes moving forward.  That said, we want to make sure we're not running limitless queries that can result in out-of-memory errors like this if possible.

So this PR adds a `woocommerce_order_notes_query_limit` filter which can be used to set a limit on the number of order notes returned to the UI.

Closes #46848 

### How to test the changes in this Pull Request:

1. Create an order and add multiple order notes to it, or edit an existing order that has order notes already present.
2. View the order and make sure that all order notes exist.  
3. Add this snippet to the system either in the theme's functions.php file or a plugin:

```php
add_filter( 'woocommerce_order_notes_query_limit', 'order_notes_query_limit' );

function order_notes_query_limit() {
	return 2;
}
```

4.  Refresh the order and make sure that only 2 notes are visible.  
5. Try experimenting with the return number in that snippet to make sure the maximum number of notes reflects the updated value.


### Changelog entry

-   [X] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [X] Enhancement - Improvement to existing functionality

#### Message 
Adds filter to allow limiting of order notes returned in WC_Meta_Box_Order_Notes

</details>
