### PR TITLE
Logging: Ensure the woocommerce_format_log_entry filter hook still has access to the log source value

### DIFF
--- a/plugins/woocommerce/changelog/update-log-file-format-source
+++ b/plugins/woocommerce/changelog/update-log-file-format-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Ensure the woocommerce_format_log_entry filter hook still has access to the log source value

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -80,13 +80,15 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 		$time_string  = static::format_time( $timestamp );
 		$level_string = strtoupper( $level );
 
-		unset( $context['source'] );
-		if ( ! empty( $context ) ) {
-			if ( isset( $context['backtrace'] ) && true === filter_var( $context['backtrace'], FILTER_VALIDATE_BOOLEAN ) ) {
-				$context['backtrace'] = static::get_backtrace();
-			}
+		if ( isset( $context['backtrace'] ) && true === filter_var( $context['backtrace'], FILTER_VALIDATE_BOOLEAN ) ) {
+			$context['backtrace'] = static::get_backtrace();
+		}
 
-			$formatted_context = wp_json_encode( $context );
+		$context_for_entry = $context;
+		unset( $context_for_entry['source'] );
+
+		if ( ! empty( $context_for_entry ) ) {
+			$formatted_context = wp_json_encode( $context_for_entry );
 			$message          .= " CONTEXT: $formatted_context";
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It was pointed out in https://github.com/woocommerce/woocommerce/pull/41802#issuecomment-2067442692 that the `woocommerce_format_log_entry` filter hook no longer included the log entry's `source` value in the `$context` parameter, which made it harder to determine the source of the log entry when using that hook. This simply restores that source value so it's available to the hook.

### How to test the changes in this Pull Request:

1. Add the following code snippet to your test site, perhaps in a file in the mu-plugins folder:
    ```php
	add_filter(
		'woocommerce_format_log_entry',
		function( $entry, $data ) {
			echo '<pre>';
			var_dump( $entry );
			var_dump( $data );
			echo '</pre>';
			wp_die();
		},
		10,
		2
	);
	
	add_action(
		'admin_init',
		function() {
			wc_get_logger()->debug( 'Test', array(
				'source' => 'test1',
				'foo'    => 'bar',
			) );
		}
	);
    ```
2. Visit any WP Admin page. The snippet will attempt to add a log entry, and then the callback on the `woocommerce_format_log_entry` filter hook will show us the contents of the log entry before ending execution.
3. You should see that in the entry's context array, there is a `source` value of `test1`, but in the entry message itself, only the `foo:bar` value is included after the `CONTEXT` marker.
