### PR TITLE
POC: Block Hooks API: Cart and Checkout Integration

### DIFF
--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -69,3 +69,25 @@ $GLOBALS['woocommerce'] = WC();
 if ( class_exists( \Automattic\Jetpack\Connection\Rest_Authentication::class ) ) {
 	\Automattic\Jetpack\Connection\Rest_Authentication::init();
 }
+
+function add_paragraph_after_order_summary_heading( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+	if ( 'woocommerce/cart-order-summary-heading-block' === $anchor_block_type && 'after' === $relative_position ) {
+		$hooked_block_types[] = 'core/paragraph';
+	}
+	return $hooked_block_types;
+}
+add_filter( 'hooked_block_types', 'add_paragraph_after_order_summary_heading', 10, 4 );
+
+function modify_hooked_paragraph_block_after_order_summary_heading( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
+
+	// Has the hooked block been suppressed by a previous filter?
+	if ( is_null( $parsed_hooked_block ) ) {
+		return $parsed_hooked_block;
+	}
+	$parsed_hooked_block['innerContent'] = array(
+		'<p>Hello</p>',
+	);
+
+		return $parsed_hooked_block;
+}
+add_filter( 'hooked_block_core/paragraph', 'modify_hooked_paragraph_block_after_order_summary_heading', 10, 5 );


### PR DESCRIPTION
**Note**: This code should probably be moved to a more relevant part of the codebase. It's currently here just to prove a concept.

Add filter to `the_content` to allow the hooked blocks algorithm to auto-insert blocks into the cart and checkout pages.

- [x] Show hooked blocks on the frontend
- [x] Show hooked blocks within the editor

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the below code to your store
2. Check the hooked block renders frontend
3. Check the hooked block renders editor side

```php
function hooked_loginout_into_cart( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'woocommerce/cart' && $position === 'after' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'hooked_loginout_into_cart', 10, 4 );

function hooked_loginout_into_checkout( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'woocommerce/checkout-contact-information-block' && $position === 'after' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'hooked_loginout_into_checkout', 10, 4 );

```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
