### PR TITLE
Fix order counts in status widget for sites with Redis object cache

### DIFF
--- a/plugins/woocommerce/changelog/fix-46809
+++ b/plugins/woocommerce/changelog/fix-46809
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes order counts in the status widget for persistent caches.

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -196,7 +196,7 @@ final class OrderUtil {
 	public static function get_count_for_type( $order_type ) {
 		global $wpdb;
 
-		$cache_key        = 'wc-order-count-' . $order_type;
+		$cache_key        = \WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'order-count-' . $order_type;
 		$count_per_status = wp_cache_get( $cache_key, 'counts' );
 
 		if ( false === $count_per_status ) {

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -196,8 +196,8 @@ final class OrderUtil {
 	public static function get_count_for_type( $order_type ) {
 		global $wpdb;
 
-		$cache_key        = 'order-count-' . $order_type;
-		$count_per_status = wp_cache_get( $cache_key, 'orders' );
+		$cache_key        = 'wc-order-count-' . $order_type;
+		$count_per_status = wp_cache_get( $cache_key, 'counts' );
 
 		if ( false === $count_per_status ) {
 			if ( self::custom_orders_table_usage_is_enabled() ) {
@@ -222,7 +222,7 @@ final class OrderUtil {
 				$count_per_status
 			);
 
-			wp_cache_set( $cache_key, $count_per_status, 'orders' );
+			wp_cache_set( $cache_key, $count_per_status, 'counts' );
 		}
 
 		return $count_per_status;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When Redis persistent cache is in use, the order counts in the status widget on the dashboard might not reflect the correct numbers unless you manually flush the cache.

This PR moves that cache to the standard "counts" WordPress cache group, which is (by default) non-persistent and plays better with Redis.

Closes #46809.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure to start with a site that has a few orders.
1. Enable Redis on your environment (server + PHP extension) and a Redis plugin on your site.
   - On macOS, Redis can be installed by `brew install redis` and ran with `brew services start redis`.
   - The PHP extension can be installed, if necessary, with `pecl`: `pecl install redis`.
   - On the WP side, you can install the "Redis Object Cache" in Plugins > Add New Plugin. Make sure to enable the object cache in Settings > Redis.
1. Go to the WP dashboard and check the numbers in the "WooCommerce Status" widget.
   If not visible, make sure it is enabled inside "Screen Options". You might also need to run `wp option update woocommerce_task_list_hidden yes` if you didn't complete onboarding.
1. Go to WC > Orders and change the status of a few orders to "Processing" and others to "On hold".
1. Go back to the WP dashboard and make sure the order numbers reflect these changes.
1. Repeat the above with a different order datastore: run `wp wc cot sync` to sync orders and then go to WC > Settings > Advanced > Features and switch to the other "order data storage" option.


If the "WooCommerce Status" widget isn't displayed, make sure it is enabled inside "Screen Options". You might also need to complete the onboarding steps or skip them by running the following command:
`wp option update woocommerce_task_list_hidden yes`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
