### PR TITLE
[CYS] Fix error when repeating the prompt on consecutives runs

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -253,8 +253,8 @@ export const updateStorePatterns = async (
 			method: 'GET',
 		} );
 
-		if ( ! images.images.length ) {
-			if ( is_ai_generated ) {
+		if ( ! images ) {
+			if ( ! is_ai_generated ) {
 				throw new Error(
 					'AI content not generated: images not available'
 				);

--- a/plugins/woocommerce/changelog/46872-46839-fix-error-on-same-prompt
+++ b/plugins/woocommerce/changelog/46872-46839-fix-error-on-same-prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+[CYS] Fix bug making the AI flow fail on the same prompt.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the two issues that were causing a bug when re-using a prompt on two consecutive CYS runs:
1. When `images` is empty we were getting an error trying to access `images.images.length`.
2. The `if ( is_ai_generated )` condition was reversed, we want to error if the site was not previously image generated because on that case we would not have any images to show.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46839

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a WooExpress site, go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store`.
3. Click on `Design With AI` enter a store description and finish the flow until reaching the assembler.
4. Go again to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store`.
5. Click on `Design With AI` and enter **exactly the same store description** you used on step 2.
6. Finish the flow until reaching the assembler and make sure there's no error during the process.
7. Go again to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store`.
8. Enter a **different store description** and finish the flow, make sure there's no error and the results make sense according to the new description.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[CYS] Fix bug making the AI flow fail on the same prompt.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
