### PR TITLE
Add support for 'customer' field to REST orders controller (v2/v3)

### DIFF
--- a/plugins/woocommerce/changelog/fix-46604
+++ b/plugins/woocommerce/changelog/fix-46604
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make REST order queries involving 'customer' field compatible with HPOS in v2 API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -615,15 +615,19 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		}
 
 		if ( isset( $request['customer'] ) ) {
-			if ( ! empty( $args['meta_query'] ) ) {
-				$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			}
+			if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+				$args['customer_id'] = $request['customer'];
+			} else {
+				if ( ! empty( $args['meta_query'] ) ) {
+					$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				}
 
-			$args['meta_query'][] = array(
-				'key'   => '_customer_user',
-				'value' => $request['customer'],
-				'type'  => 'NUMERIC',
-			);
+				$args['meta_query'][] = array(
+					'key'   => '_customer_user',
+					'value' => $request['customer'],
+					'type'  => 'NUMERIC',
+				);
+			}
 		}
 
 		// Search by product.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -251,17 +251,6 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		$statuses = $request['status'];
 		unset( $request['status'] );
 
-		// Prevents WC_REST_Orders_V2_Controller::prepare_objects_query() from generating a meta_query for 'customer'.
-		// which COT can handle as a native field.
-		$cot_customer =
-			( OrderUtil::custom_orders_table_usage_is_enabled() && isset( $request['customer'] ) )
-			? $request['customer']
-			: null;
-
-		if ( ! is_null( $cot_customer ) ) {
-			unset( $request['customer'] );
-		}
-
 		$args = parent::prepare_objects_query( $request );
 
 		$args['post_status'] = array();
@@ -279,12 +268,6 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		// Put the statuses back for further processing (next/prev links, etc).
 		$request['status'] = $statuses;
-
-		// Add back 'customer' to args and request.
-		if ( ! is_null( $cot_customer ) ) {
-			$args['customer']    = $cot_customer;
-			$request['customer'] = $cot_customer;
-		}
 
 		return $args;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46604.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Even though the fixes here are for the REST API, they can be tested with the CLI too (which was the original context of issue #46604) and what we're going to test here.

1. Make sure your site has a few orders and at least one is assigned to a known user and one with a known product. Take note of both the user and the product IDs.
2. Go to WC > Settings > Advanced > Features and choose "High-Performance Storage" as order storage, compatibility mode disabled.
   If this is not possible due to unsynced orders, sync those first with CLI command `wp wc cot sync`.
3. Run the following commands and confirm the output is correct:
   - `wp wc shop_order list --fields=id,total,customer_id --per_page=10 --user=1` should get you 10 orders tops and only print id, total and customer_id for those orders.
   - `wp wc shop_order list --customer=123456 --user=1` should return the orders in which you assigned the known user `123456` as customer (from step 2).
   - `wp wc shop_order list --product=123456 --user=1` should return orders in which the product with ID `123456` is included.

   **Note:** Since these commands are privileged (and go through the REST API), change the ID in `--user=1` to an admin user on your site or a user with enough permissions.

<!-- End testing instructions -->

### Alternative testing instructions (via REST API)

1. Follow steps 1 and 2 from the previous section.
2. Go to WC > Settings > Advanced > REST API and create a new API key with any description and "Read" permissions. Take note of the consumer key and secret.
3. Use an API client (such as Insomnia, Postman or RapidAPI) to create a new GET request to `https://<site>/wp-json/wc/v2/orders/` with the following details:
    - Choose "Basic" as auth method and enter the consumer key and secret as username and password (respectively).
    - Pass `_fields=id,total,customer_id` and `per_page=10` as URL parameters.
4. Confirm that the request is successful and the first 10 orders are returned.
5. Repeat the request from step 3 but add a new URL parameter `customer=123456` where `123456` is a known user ID and confirm that only orders belonging to said user are returned.
6. Repeat the request from step 3, this time passing `product=123456` as URL parameter, where `123456` is a known product ID. Make sure the returned orders contain said product.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
