### PR TITLE
The toolbar to edit linked text in the new product's editor disappears too fast

### DIFF
--- a/packages/js/product-editor/changelog/fix-links-toolbar
+++ b/packages/js/product-editor/changelog/fix-links-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix links popover disappearing rapidly after appearing

--- a/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/use-clear-selected-block-on-blur.ts
+++ b/packages/js/product-editor/src/hooks/use-clear-selected-block-on-blur/use-clear-selected-block-on-blur.ts
@@ -15,11 +15,12 @@ export const useClearSelectedBlockOnBlur = () => {
 	function handleBlur( event: {
 		relatedTarget: ( EventTarget & Element ) | null;
 	} ) {
-		const isToolbar = event?.relatedTarget?.closest(
-			'.block-editor-block-contextual-toolbar'
-		);
+		const isToolbarOrLinkPopover =
+			event?.relatedTarget?.closest(
+				'.block-editor-block-contextual-toolbar'
+			) || event?.relatedTarget?.closest( '.block-editor-link-control' );
 
-		if ( ! isToolbar ) {
+		if ( ! isToolbarOrLinkPopover ) {
 			clearSelectedBlock();
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This was happening because the block was being cleared when the toolbar lost focus to the link popover, so I added an additional clause to the statement.

Closes #45663 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. If you have the gutenberg plugin activated, please disable it.
4. In the summary field, add a link, and afterwards click it to edit it. The popover should appear normally and you should be able to edit the link
5. Do the same for the Description field, as it's a slightly different implementation.
6. Verify that PR #45608 is still fixed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
