### PR TITLE
REST API: Add standalone wc/v3/refunds endpoint

### DIFF
--- a/plugins/woocommerce/changelog/fix-27568-refund-endpoint
+++ b/plugins/woocommerce/changelog/fix-27568-refund-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds a wc/v3/refunds REST API endpoint so refunds can be queried collectively, unconnected to their orders

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * REST API Refunds controller
+ *
+ * Handles requests to the /refunds endpoint.
+ * Allows for querying refunds directly regardless of associated orders.
+ *
+ * @package WooCommerce\RestApi
+ * @since   9.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Order Refunds controller class.
+ *
+ * @package WooCommerce\RestApi
+ * @extends WC_REST_Order_Refunds_Controller
+ */
+class WC_REST_Refunds_Controller extends WC_REST_Order_Refunds_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'refunds';
+
+	/**
+	 * Post type.
+	 *
+	 * @var string
+	 */
+	protected $post_type = 'shop_order_refund';
+
+	/**
+	 * Register the routes for order refunds.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Prepare objects query.
+	 *
+	 * @since  9.0.0
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		$args = parent::prepare_objects_query( $request );
+		unset( $args['post_parent__in'] );
+
+		/**
+		 * Filter the query arguments for a request.
+		 *
+		 * Enables adding extra arguments or setting defaults for an order collection request.
+		 *
+		 * @param array           $args    Key value array of query var to query value.
+		 * @param WP_REST_Request $request The request used.
+		 *
+		 * @since 9.0.0.
+		 */
+		$args = apply_filters( 'woocommerce_rest_refunds_prepare_object_query', $args, $request );
+
+		return $args;
+	}
+
+	/**
+	 * Prepare a single order output for response.
+	 *
+	 * @since  9.0.0
+	 *
+	 * @param  WC_Data         $object  Object data.
+	 * @param  WP_REST_Request $request Request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function prepare_object_for_response( $object, $request ) {
+		$this->request       = $request;
+		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : absint( $this->request['dp'] );
+
+		$data    = $this->get_formatted_item_data( $object );
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $object, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->post_type,
+		 * refers to object type being prepared for the response.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param WC_Data          $object   Object data.
+		 * @param WP_REST_Request  $request  Request object.
+		 */
+		return apply_filters( "woocommerce_rest_prepare_{$this->post_type}_object", $response, $object, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param WC_Data         $object  Object data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array                   Links for the given post.
+	 */
+	protected function prepare_links( $object, $request ) {
+		$base  = str_replace( '(?P<order_id>[\d]+)', $object->get_parent_id(), 'orders/(?P<order_id>[\d]+)/refunds' );
+		$links = array(
+			'self'       => array(
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $base, $object->get_id() ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $base ) ),
+			),
+			'up'         => array(
+				'href' => rest_url( sprintf( '/%s/orders/%d', $this->namespace, $object->get_parent_id() ) ),
+			),
+		);
+
+		return $links;
+	}
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
@@ -89,16 +89,16 @@ class WC_REST_Refunds_Controller extends WC_REST_Order_Refunds_Controller {
 	 *
 	 * @since  9.0.0
 	 *
-	 * @param  WC_Data         $object  Object data.
+	 * @param  WC_Order_Refund $refund  Refund data.
 	 * @param  WP_REST_Request $request Request object.
 	 *
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function prepare_object_for_response( $object, $request ) {
+	public function prepare_object_for_response( $refund, $request ) {
 		$this->request       = $request;
 		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : absint( $this->request['dp'] );
 
-		$data    = $this->get_formatted_item_data( $object );
+		$data    = $this->get_formatted_item_data( $refund );
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
@@ -106,39 +106,32 @@ class WC_REST_Refunds_Controller extends WC_REST_Order_Refunds_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $object, $request ) );
+		$response->add_links( $this->prepare_links( $refund, $request ) );
 
-		/**
-		 * Filter the data for a response.
-		 *
-		 * The dynamic portion of the hook name, $this->post_type,
-		 * refers to object type being prepared for the response.
-		 *
-		 * @param WP_REST_Response $response The response object.
-		 * @param WC_Data          $object   Object data.
-		 * @param WP_REST_Request  $request  Request object.
-		 */
-		return apply_filters( "woocommerce_rest_prepare_{$this->post_type}_object", $response, $object, $request );
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		/** This filter is documented in includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php */
+		return apply_filters( "woocommerce_rest_prepare_{$this->post_type}_object", $response, $refund, $request );
+		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**
 	 * Prepare links for the request.
 	 *
-	 * @param WC_Data         $object  Object data.
+	 * @param WC_Order_Refund $refund  Refund data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return array                   Links for the given post.
 	 */
-	protected function prepare_links( $object, $request ) {
-		$base  = str_replace( '(?P<order_id>[\d]+)', $object->get_parent_id(), 'orders/(?P<order_id>[\d]+)/refunds' );
+	protected function prepare_links( $refund, $request ) {
+		$base  = str_replace( '(?P<order_id>[\d]+)', $refund->get_parent_id(), 'orders/(?P<order_id>[\d]+)/refunds' );
 		$links = array(
 			'self'       => array(
-				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $base, $object->get_id() ) ),
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $base, $refund->get_id() ) ),
 			),
 			'collection' => array(
 				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $base ) ),
 			),
 			'up'         => array(
-				'href' => rest_url( sprintf( '/%s/orders/%d', $this->namespace, $object->get_parent_id() ) ),
+				'href' => rest_url( sprintf( '/%s/orders/%d', $this->namespace, $refund->get_parent_id() ) ),
 			),
 		);
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
@@ -118,16 +118,16 @@ class WC_REST_Refunds_Controller extends WC_REST_Order_Refunds_Controller {
 	 * Get formatted item data.
 	 *
 	 * @since  9.0.0
-	 * @param  WC_Data $object WC_Data instance.
+	 * @param  WC_Order_Refund $refund The refund object.
 	 * @return array
 	 */
-	protected function get_formatted_item_data( $object ) {
-		$data = parent::get_formatted_item_data( $object );
+	protected function get_formatted_item_data( $refund ) {
+		$data = parent::get_formatted_item_data( $refund );
 
 		$data = array_merge(
 			array_slice( $data, 0, 1, true ),
 			array(
-				'parent_id' => $object->get_parent_id(),
+				'parent_id' => $refund->get_parent_id(),
 			),
 			array_slice( $data, 1, null, true )
 		);

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller.php
@@ -115,6 +115,27 @@ class WC_REST_Refunds_Controller extends WC_REST_Order_Refunds_Controller {
 	}
 
 	/**
+	 * Get formatted item data.
+	 *
+	 * @since  9.0.0
+	 * @param  WC_Data $object WC_Data instance.
+	 * @return array
+	 */
+	protected function get_formatted_item_data( $object ) {
+		$data = parent::get_formatted_item_data( $object );
+
+		$data = array_merge(
+			array_slice( $data, 0, 1, true ),
+			array(
+				'parent_id' => $object->get_parent_id(),
+			),
+			array_slice( $data, 1, null, true )
+		);
+
+		return $data;
+	}
+
+	/**
 	 * Prepare links for the request.
 	 *
 	 * @param WC_Order_Refund $refund  Refund data.
@@ -136,5 +157,29 @@ class WC_REST_Refunds_Controller extends WC_REST_Order_Refunds_Controller {
 		);
 
 		return $links;
+	}
+
+	/**
+	 * Get the refund schema, conforming to JSON Schema.
+	 *
+	 * @since  9.0.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties'] = array_merge(
+			array_slice( $schema['properties'], 0, 1, true ),
+			array(
+				'parent_id' => array(
+					'description' => __( 'Parent order ID.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+			array_slice( $schema['properties'], 1, null, true )
+		);
+
+		return $schema;
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -162,6 +162,7 @@ class Server {
 			'product-tags'             => 'WC_REST_Product_Tags_Controller',
 			'products'                 => 'WC_REST_Products_Controller',
 			'product-variations'       => 'WC_REST_Product_Variations_Controller',
+			'refunds'                  => 'WC_REST_Refunds_Controller',
 			'reports-sales'            => 'WC_REST_Report_Sales_Controller',
 			'reports-top-sellers'      => 'WC_REST_Report_Top_Sellers_Controller',
 			'reports-orders-totals'    => 'WC_REST_Report_Orders_Totals_Controller',

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller-tests.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Class WC_REST_Refunds_Controller_Test.
+ */
+class WC_REST_Refunds_Controller_Test extends WC_REST_Unit_Test_Case {
+	/**
+	 * @testdox Check that the refunds endpoint returns all refunds, from multiple orders.
+	 */
+	public function test_get_items_multiple_orders() {
+		wp_set_current_user( 1 );
+
+		$orders_and_refunds_count = 0;
+		$refund_ids               = array();
+
+		while ( $orders_and_refunds_count < 3 ) {
+			$order = WC_Helper_Order::create_order_with_fees_and_shipping();
+
+			$product_item  = current( $order->get_items( 'line_item' ) );
+			$fee_item      = current( $order->get_items( 'fee' ) );
+			$shipping_item = current( $order->get_items( 'shipping' ) );
+
+			$refund = wc_create_refund(
+				array(
+					'order_id'   => $order->get_id(),
+					'reason'     => 'testing',
+					'line_items' => array(
+						$product_item->get_id()  =>
+							array(
+								'qty'          => 1,
+								'refund_total' => 1,
+							),
+						$fee_item->get_id()      =>
+							array(
+								'refund_total' => 10,
+							),
+						$shipping_item->get_id() =>
+							array(
+								'refund_total' => 20,
+							),
+					),
+				)
+			);
+
+			$refund_ids[] = $refund->get_id();
+			$orders_and_refunds_count ++;
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/refunds' );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+
+		foreach ( $data as $refund ) {
+			$this->assertContains( $refund['id'], $refund_ids );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-refunds-controller-tests.php
@@ -43,13 +43,13 @@ class WC_REST_Refunds_Controller_Test extends WC_REST_Unit_Test_Case {
 			);
 
 			$refund_ids[] = $refund->get_id();
-			$orders_and_refunds_count ++;
+			++$orders_and_refunds_count;
 		}
 
 		$request = new WP_REST_Request( 'GET', '/wc/v3/refunds' );
 
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a `wc/v3/refunds` REST API endpoint so refunds can be queried collectively, unconnected to their orders.

Fixes #27568

### How to test the changes in this Pull Request:

1. You might need to run `composer dump-autoload` from the `plugins/woocommerce` directory after checking out this PR branch.
2. Create some test orders on your test site.
3. On at least three of these orders, go in and add a partial or full refund.
4. Now make a query to the new `wc/v3/refunds` endpoint using cURL or your favorite API client (I'm currently digging [Bruno](https://www.usebruno.com/)).
5. You should get back a response containing an array of refund objects. The objects should contain the same data as if you had retrieved them using `wc/v3/orders/123/refunds`.
6. Note that the `_links` property of each refund object shows URLs for the standard `wc/v3/orders/123/refunds` endpoint.
7. Try adding `order` and `orderby` query parameters with different values to change how the refunds are sorted.
8. Try adding `before` and/or `after` query parameters to limit the time range of the returned refunds.
