### PR TITLE
[LYS] Coming soon full page mode

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/block.json
@@ -9,6 +9,10 @@
 		"storeOnly": {
 			"type": "boolean",
 			"default": false
+		},
+		"fullPageHeading": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/edit.tsx
@@ -15,12 +15,8 @@ import { PanelBody, ColorPicker, ToggleControl } from '@wordpress/components';
 import { generateEntireSiteStyles } from './styles';
 
 export default function Edit( { attributes, setAttributes } ) {
-<<<<<<< HEAD
-	const { color, storeOnly } = attributes;
-	const blockProps = { ...useBlockProps() };
-=======
 	const { color, storeOnly, fullPageHeading } = attributes;
->>>>>>> 313ad95b71 (Add fullPageHeading attribute)
+	const blockProps = { ...useBlockProps() };
 
 	if ( storeOnly ) {
 		return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/edit.tsx
@@ -7,16 +7,20 @@ import {
 	useBlockProps,
 	InnerBlocks,
 } from '@wordpress/block-editor';
-import { PanelBody, ColorPicker } from '@wordpress/components';
+import { PanelBody, ColorPicker, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { generateStyles } from './styles';
+import { generateEntireSiteStyles } from './styles';
 
 export default function Edit( { attributes, setAttributes } ) {
+<<<<<<< HEAD
 	const { color, storeOnly } = attributes;
 	const blockProps = { ...useBlockProps() };
+=======
+	const { color, storeOnly, fullPageHeading } = attributes;
+>>>>>>> 313ad95b71 (Add fullPageHeading attribute)
 
 	if ( storeOnly ) {
 		return (
@@ -32,7 +36,23 @@ export default function Edit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+				<PanelBody
+					title={ __( 'Coming soon page settings', 'woocommerce' ) }
+				>
+					<h3>{ __( 'Full page layout', 'woocommerce' ) }</h3>
+					<ToggleControl
+						label={ __(
+							'Display heading in full page mode',
+							'woocommerce'
+						) }
+						checked={ fullPageHeading }
+						onChange={ () =>
+							setAttributes( {
+								fullPageHeading: ! fullPageHeading,
+							} )
+						}
+					/>
+					<h3>{ __( 'Background color', 'woocommerce' ) }</h3>
 					<ColorPicker
 						color={ color }
 						onChange={ ( newColor: string ) =>
@@ -46,7 +66,9 @@ export default function Edit( { attributes, setAttributes } ) {
 			<div { ...blockProps }>
 				<InnerBlocks />
 			</div>
-			<style>{ generateStyles( color ) }</style>
+			<style>
+				{ generateEntireSiteStyles( color, fullPageHeading ) }
+			</style>
 		</>
 	);
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/save.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/save.tsx
@@ -6,10 +6,10 @@ import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { generateStyles } from './styles';
+import { generateEntireSiteStyles } from './styles';
 
 export default function Save( { attributes } ) {
-	const { color, storeOnly } = attributes;
+	const { color, storeOnly, fullPageHeading } = attributes;
 	const blockProps = { ...useBlockProps.save() };
 
 	if ( storeOnly ) {
@@ -24,7 +24,9 @@ export default function Save( { attributes } ) {
 	return (
 		<div { ...blockProps }>
 			<InnerBlocks.Content />
-			<style>{ generateStyles( color ) }</style>
+			<style>
+				{ generateEntireSiteStyles( color, fullPageHeading ) }
+			</style>
 		</div>
 	);
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/styles.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/styles.tsx
@@ -1,4 +1,7 @@
-export const generateStyles = ( color = '#bea0f2' ) => {
+export const generateEntireSiteStyles = (
+	color = '#bea0f2',
+	fullPageHeading = true
+) => {
 	return `@font-face {
         font-family: 'Inter';
         src: url( <?php echo esc_url( WC()->plugin_url() . '/assets/fonts/Inter-VariableFont_slnt,wght.woff2' ); ?>) format('woff2');
@@ -115,9 +118,9 @@ export const generateStyles = ( color = '#bea0f2' ) => {
         max-width: 820px;
     }
     .coming-soon-is-vertically-aligned-center:not(.block-editor-block-list__block) {
-        position: absolute;
+        position: ${ fullPageHeading ? 'absolute' : 'relative' };
         top: 50%;
-        transform: translateY(-50%);
+        transform: ${ fullPageHeading ? 'translateY(-50%)' : 'none' };
         margin-block-start: 0;
         width: 100%;
     }

--- a/plugins/woocommerce/patterns/coming-soon-entire-site.php
+++ b/plugins/woocommerce/patterns/coming-soon-entire-site.php
@@ -9,7 +9,7 @@
 
 ?>
 
-<!-- wp:woocommerce/coming-soon {"color":"#bea0f2","storeOnly":false,"className":"wp-block-woocommerce-background-color"} -->
+<!-- wp:woocommerce/coming-soon {"color":"#bea0f2",storeOnly":false,"fullPageHeading":true,"className":"wp-block-woocommerce-background-color"} -->
 <div class="wp-block-woocommerce-coming-soon wp-block-woocommerce-background-color"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"20px","bottom":"20px"}},"color":{"background":"#bea0f2"}},"className":"woocommerce-coming-soon-header","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide woocommerce-coming-soon-header has-background" style="background-color:#bea0f2;padding-top:20px;padding-bottom:20px"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex"}} -->

--- a/plugins/woocommerce/patterns/coming-soon-store-only.php
+++ b/plugins/woocommerce/patterns/coming-soon-store-only.php
@@ -9,7 +9,7 @@
 
 ?>
 
-<!-- wp:woocommerce/coming-soon {"storeOnly":true} -->
+<!-- wp:woocommerce/coming-soon {"storeOnly":true,"fullPageHeading":false} -->
 <div class="wp-block-woocommerce-coming-soon">
 
 <?php


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Coming soon page template for the entire store setting includes an `h1` heading that is vertically and horizontally centered, no matter the screen size. This concept doesn't play nicely in the block editor, which has been designed to add content blocks stacked relative to one another. I've used some custom CSS to achieve this and the design works nicely on its own.

<img width="800" alt="Screenshot 2024-04-16 at 15 06 42" src="https://github.com/woocommerce/woocommerce/assets/4344253/c28e928a-90ff-43a9-8d68-467c152bc842">

The problem arises when merchants attempt to edit this page. Additional blocks don't appear where you'd expect them to. To fix this, I've added a `fullPageHeading` attribute to the Coming soon block, which can be toggled off. Once off, the block editor will behave as you'd expect it to.

<img width="338" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/1cd4b96c-ce96-4dc7-afb2-d7ba04566a03">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit the template Appearance > Editor > Templates > Page: Coming soon
2. Select the Coming soon block
3. Untoggle the full page layout

<img width="272" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/224cb6c5-e560-4805-bdfc-eeafb79d34cf">

5. Make edits to the page and see the site in incognito mode. Do the edits reflect on the page in a way you'd expect them to?

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
