### PR TITLE
Fix incorrectly used aria-describedby in add to cart button of variable product

### DIFF
--- a/plugins/woocommerce/changelog/46897-dev-fix-a11y-add-to-cart
+++ b/plugins/woocommerce/changelog/46897-dev-fix-a11y-add-to-cart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix an accessibility error in the add to cart button template.

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -53,6 +53,8 @@ class WC_Product_Variable extends WC_Product {
 
 	/**
 	 * Get the aria-describedby description for the add to cart button.
+	 * Note that this is to provide the description, not the describedby attribute
+	 * itself.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1378,6 +1378,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 						)
 					)
 				),
+				'aria-describedby_text' => $product->add_to_cart_aria_describedby(),
 				'attributes' => array(
 					'data-product_id'  => $product->get_id(),
 					'data-product_sku' => $product->get_sku(),

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -470,7 +470,7 @@ function wc_get_loop_class() {
 	$loop_index = wc_get_loop_prop( 'loop', 0 );
 	$columns    = absint( max( 1, wc_get_loop_prop( 'columns', wc_get_default_products_per_row() ) ) );
 
-	$loop_index ++;
+	++$loop_index;
 	wc_set_loop_prop( 'loop', $loop_index );
 
 	if ( 0 === ( $loop_index - 1 ) % $columns || 1 === $columns ) {
@@ -1365,8 +1365,8 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 
 		if ( $product ) {
 			$defaults = array(
-				'quantity'   => 1,
-				'class'      => implode(
+				'quantity'              => 1,
+				'class'                 => implode(
 					' ',
 					array_filter(
 						array(
@@ -1379,11 +1379,10 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 					)
 				),
 				'aria-describedby_text' => $product->add_to_cart_aria_describedby(),
-				'attributes' => array(
+				'attributes'            => array(
 					'data-product_id'  => $product->get_id(),
 					'data-product_sku' => $product->get_sku(),
 					'aria-label'       => $product->add_to_cart_description(),
-					'aria-describedby' => $product->add_to_cart_aria_describedby(),
 					'rel'              => 'nofollow',
 				),
 			);
@@ -3520,7 +3519,7 @@ if ( ! function_exists( 'wc_display_item_downloads' ) ) {
 		if ( ! empty( $downloads ) ) {
 			$i = 0;
 			foreach ( $downloads as $file ) {
-				$i ++;
+				++$i;
 
 				if ( $args['show_url'] ) {
 					$strings[] = '<strong class="wc-item-download-label">' . esc_html( $file['name'] ) . ':</strong> ' . esc_html( $file['download_url'] );
@@ -3990,7 +3989,7 @@ function wc_get_pay_buttons() {
 
 	echo '<div class="woocommerce-pay-buttons">';
 	foreach ( $supported_gateways as $pay_button_id ) {
-		echo sprintf( '<div class="woocommerce-pay-button__%1$s %1$s" id="%1$s"></div>', esc_attr( $pay_button_id ) );
+		printf( '<div class="woocommerce-pay-button__%1$s %1$s" id="%1$s"></div>', esc_attr( $pay_button_id ) );
 	}
 	echo '</div>';
 }

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     3.3.1
+ * @version     8.9.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -24,8 +24,9 @@ global $product;
 echo apply_filters(
 	'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
 	sprintf(
-		'<a href="%s" id="woocommerce_loop_add_to_cart_link_describedby" data-quantity="%s" class="%s" %s>%s</a>',
+		'<a href="%s" id="woocommerce_loop_add_to_cart_link_describedby_%s" data-quantity="%s" class="%s" %s>%s</a>',
 		esc_url( $product->add_to_cart_url() ),
+		esc_attr( $product->id ),
 		esc_attr( isset( $args['quantity'] ) ? $args['quantity'] : 1 ),
 		esc_attr( isset( $args['class'] ) ? $args['class'] : 'button' ),
 		isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
@@ -35,6 +36,6 @@ echo apply_filters(
 	$args
 );
 ?>
-<span id="woocommerce_loop_add_to_cart_link_describedby" class="screen-reader-text">
+<span id="woocommerce_loop_add_to_cart_link_describedby_<?php echo esc_attr( $product->id ); ?>" class="screen-reader-text">
 	<?php echo esc_html( $args['aria-describedby_text'] ); ?>
 </span>

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     3.3.0
+ * @version     3.3.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,7 +24,7 @@ global $product;
 echo apply_filters(
 	'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
 	sprintf(
-		'<a href="%s" data-quantity="%s" class="%s" %s>%s</a>',
+		'<a href="%s" id="woocommerce_loop_add_to_cart_link_describedby" data-quantity="%s" class="%s" %s>%s</a>',
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( isset( $args['quantity'] ) ? $args['quantity'] : 1 ),
 		esc_attr( isset( $args['class'] ) ? $args['class'] : 'button' ),
@@ -34,3 +34,7 @@ echo apply_filters(
 	$product,
 	$args
 );
+?>
+<span id="woocommerce_loop_add_to_cart_link_describedby" class="screen-reader-text">
+	<?php echo esc_html( $args['aria-describedby_text'] ); ?>
+</span>

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -24,7 +24,7 @@ global $product;
 echo apply_filters(
 	'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
 	sprintf(
-		'<a href="%s" id="woocommerce_loop_add_to_cart_link_describedby_%s" data-quantity="%s" class="%s" %s>%s</a>',
+		'<a href="%s" aria-describedby="woocommerce_loop_add_to_cart_link_describedby_%s" data-quantity="%s" class="%s" %s>%s</a>',
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( $product->id ),
 		esc_attr( isset( $args['quantity'] ) ? $args['quantity'] : 1 ),

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     8.9.0
+ * @version     9.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/loop/add-to-cart.php
+++ b/plugins/woocommerce/templates/loop/add-to-cart.php
@@ -26,7 +26,7 @@ echo apply_filters(
 	sprintf(
 		'<a href="%s" aria-describedby="woocommerce_loop_add_to_cart_link_describedby_%s" data-quantity="%s" class="%s" %s>%s</a>',
 		esc_url( $product->add_to_cart_url() ),
-		esc_attr( $product->id ),
+		esc_attr( $product->get_id() ),
 		esc_attr( isset( $args['quantity'] ) ? $args['quantity'] : 1 ),
 		esc_attr( isset( $args['class'] ) ? $args['class'] : 'button' ),
 		isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
@@ -36,6 +36,6 @@ echo apply_filters(
 	$args
 );
 ?>
-<span id="woocommerce_loop_add_to_cart_link_describedby_<?php echo esc_attr( $product->id ); ?>" class="screen-reader-text">
+<span id="woocommerce_loop_add_to_cart_link_describedby_<?php echo esc_attr( $product->get_id() ); ?>" class="screen-reader-text">
 	<?php echo esc_html( $args['aria-describedby_text'] ); ?>
 </span>


### PR DESCRIPTION

### Changes proposed in this Pull Request:

As correctly raised in #38801 the aria-describedby attribute should contain an ID pointing to an element which contains the description. To maintain backwards compatibility I have avoided renaming the filter, but rather described in the comments that it is intended to contain the text not the ID. internally in the template we generate a unique per product ID for the description and hide it using the screen-reader-text class.

Closes https://github.com/woocommerce/woocommerce/issues/38801

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. With a non-block theme such as storefront enabled, ensure you have some variable products
2. Visit the shop page
3. Inspect the "Select options" button and see that the aria-describedby attribute specifies an ID and that a span is rendered next to the button that contains the description. make sure the span is not visible.

Also you can test with the [wave chrome extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh) on trunk you'll see one error if you load the same shop page as above.

on this branch there should be no errors.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix an accessibility error in the add to cart button template.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
