### PR TITLE
Add aria label to the customer account block link

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/customer-account/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/customer-account/block.tsx
@@ -56,12 +56,20 @@ export const CustomerAccountBlock = ( {
 } ): JSX.Element => {
 	const { displayStyle, iconStyle, iconClass } = attributes;
 
+	const ariaAttributes =
+		displayStyle === DisplayStyle.ICON_ONLY
+			? {
+					'aria-label': __( 'My Account', 'woocommerce' ),
+			  }
+			: {};
+
 	return (
 		<a
 			href={ getSetting(
 				'dashboardUrl',
 				getSetting( 'wpLoginUrl', '/wp-login.php' )
 			) }
+			{ ...ariaAttributes }
 		>
 			<AccountIcon
 				iconStyle={ iconStyle }

--- a/plugins/woocommerce/changelog/46899-dev-fix-a11y-icon-only-customer-account-block
+++ b/plugins/woocommerce/changelog/46899-dev-fix-a11y-icon-only-customer-account-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add aria-label to customer account block link when in icon-only display mode.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -122,10 +122,13 @@ class CustomerAccount extends AbstractBlock {
 			),
 		);
 
+		// Only provide aria-label if the display style is icon only.
+		$aria_label = self::ICON_ONLY === $attributes['displayStyle'] ? 'aria-label="' . esc_attr( $this->render_label() ) . '"' : '';
+
 		$label_markup = self::ICON_ONLY === $attributes['displayStyle'] ? '' : '<span class="label">' . wp_kses( $this->render_label(), array() ) . '</span>';
 
 		return "<div class='wp-block-woocommerce-customer-account " . esc_attr( $classes_and_styles['classes'] ) . "' style='" . esc_attr( $classes_and_styles['styles'] ) . "'>
-			<a href='" . esc_attr( $account_link ) . "'>
+			<a " . $aria_label . " href='" . esc_attr( $account_link ) . "'>
 				" . wp_kses( $this->render_icon( $attributes ), $allowed_svg ) . $label_markup . '
 			</a>
 		</div>';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As mentioned in https://github.com/woocommerce/woocommerce/issues/46754 there is no aria-label on the customer account when the setting is icon-only. It makes sense to add this to improve a11y in this situation.

Closes #46754 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Add the customer account block to some content
2. In the editor, set the block display style setting to "icon only"
3. In the inspector in editor and front-end, confirm that an aria label is assigned to the link when it is display icon only
4. Also ensure that the aria label is not displayed for other display modes.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add aria-label to customer account block link when in icon-only display mode.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
