### PR TITLE
Add manual_update parameter to v3/orders/<id> endpoint

### DIFF
--- a/plugins/woocommerce/changelog/46900-manual_update-parameter-in-api-request
+++ b/plugins/woocommerce/changelog/46900-manual_update-parameter-in-api-request
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added a "manual_update" parameter to the Orders REST API endpoint that will make it so that, when set to "true", status changes to an order will be attributed to a specific user in the order notes.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -219,7 +219,8 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 			// Set status.
 			if ( ! empty( $request['status'] ) ) {
-				$object->set_status( $request['status'] );
+				$manual_update = isset( $request['manual_update'] ) ? $request['manual_update'] : false;
+				$object->set_status( $request['status'], '', $manual_update );
 			}
 
 			$object->save();

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -300,6 +300,13 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		$schema['properties']['coupon_lines']['items']['properties']['discount']['readonly'] = true;
 
+		$schema['properties']['manual_update'] = array(
+			'default'     => false,
+			'description' => __( 'Set the action as manual so that the order note registers as "added by user".', 'woocommerce' ),
+			'type'        => 'boolean',
+			'context'     => array( 'edit' ),
+		);
+
 		return $schema;
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -1143,7 +1143,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 46, count( $properties ) );
+		$this->assertEquals( 47, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35035 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using cURL or [an API client](https://www.usebruno.com/), send a POST request to `wc/v3/orders` to create a new order with this payload:
    ```
	{
		"status": "processing",
		"manual_update": true
	}
    ```
2. Send another request to create a second order, but this time omit the `manual_update` parameter.
3. Now visit the Orders screen in WP Admin. Click to view each of the two orders you just created. On the first order, in the "Order notes" sidebar, there should be a note that says something like "Order status changed from Pending payment to Processing" and beneath that, a date and an attribution to the user account that you used to authenticate to the REST API. In the second order (the one without "manual_update"), the order note should look similar, but not have the attribution to a specific user.
4. Now pick one of those orders and note the order ID. Make a POST request to `wc/v3/orders/{order ID}` with a similar payload to above, but change "status" to "on-hold". Keep the "manual_update" parameter. In WP Admin, there should be a new order note describing this status change, and it should once again be attributed to the user account.
5. Do another request to change the order status back to "processing", but remove the "manual_update" parameter. This time the order note should not have the user attribution.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Added a "manual_update" parameter to the Orders REST API endpoint that will make it so that, when set to "true", status changes to an order will be attributed to a specific user in the order notes.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
