### PR TITLE
Update to display full woocommerce version on status page rather than a shortened milestone style version

### DIFF
--- a/plugins/woocommerce/changelog/46906-update-woocommerce-version-on-status-page
+++ b/plugins/woocommerce/changelog/46906-update-woocommerce-version-on-status-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the WooCommerce Status page to use the full plugin version to show dev, Beta and RC versions as opposed to only the milestone number

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -29,6 +29,20 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Cons
 $active_plugins_count   = is_countable( $active_plugins ) ? count( $active_plugins ) : 0;
 $inactive_plugins_count = is_countable( $inactive_plugins ) ? count( $inactive_plugins ) : 0;
 
+// Include necessary WordPress file to use get_plugin_data()
+if ( ! function_exists( 'get_plugin_data' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+// Define the path to the main WooCommerce plugin file using the correct constant
+$plugin_path = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+// Initialize the WooCommerce version variable
+$wc_version = '';
+// Check if the plugin file exists before trying to access it
+if (file_exists($plugin_path)) {
+    $plugin_data = get_plugin_data($plugin_path);
+    $wc_version = $plugin_data["Version"] ?? ''; // Use null coalescing operator to handle undefined index
+}
+
 ?>
 <div class="updated woocommerce-message inline">
 	<p>
@@ -75,7 +89,8 @@ $inactive_plugins_count = is_countable( $inactive_plugins ) ? count( $inactive_p
 		<tr>
 			<td data-export-label="WC Version"><?php esc_html_e( 'WooCommerce version', 'woocommerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of WooCommerce installed on your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
-			<td><?php echo esc_html( $environment['version'] ); ?></td>
+			<td><?php echo esc_html( !empty($wc_version) ? $wc_version : $environment['version'] ); ?></td>
+
 		</tr>
 		<tr>
 			<td data-export-label="REST API Version"><?php esc_html_e( 'WooCommerce REST API package', 'woocommerce' ); ?>:</td>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, the nightly build is not displaying the `-dev` part of the version in the WooCommere > Status page. e.g.  `8.7.0` would be displayed rather than `8.7.0-dev`

This PR pulls the version from the plugin to more accurately reflect the version for nightlies, Betas and RCs

Closes https://github.com/woocommerce/woocommerce-quality/issues/767 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install a previous nightly version of WooCommerce - witness `8.9.0` on the WooCommerce > Status page
2. Pull this branch and install - witness `8.9.0-dev` or similar on the WooCommerce > Status page
3. Extra validations - 
- update `woocommerce.php` to have  ` * Version: 8.9.0-beta.1` in the header then rebuild and install - witness `8.9.0-beta.1` on the WooCommerce > Status page
- repeat the previous step with an RC version
- repeat the previous step with a Release version

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Update the WooCommerce Status page to use the full plugin version to show dev, Beta and RC versions as opposed to only the milestone number

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
