### PR TITLE
Tidy and update product attribute TypeScript types

### DIFF
--- a/packages/js/data/changelog/update-product-attribute-types
+++ b/packages/js/data/changelog/update-product-attribute-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Data: Tidy and fix Product Attribute types

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -94,6 +94,7 @@ export type {
 } from './product-variations/types';
 export {
 	QueryProductAttribute,
+	ProductAttribute,
 	ProductAttributeSelectors,
 } from './product-attributes/types';
 export * from './product-shipping-classes/types';

--- a/packages/js/data/src/product-attributes/types.ts
+++ b/packages/js/data/src/product-attributes/types.ts
@@ -8,11 +8,19 @@ import { DispatchFromMap } from '@automattic/data-stores';
  */
 import { CrudActions, CrudSelectors } from '../crud/types';
 
-export type QueryProductAttribute = {
+export type ProductAttribute = {
 	id: number;
 	slug: string;
 	name: string;
 	type: string;
+	order_by: string;
+	has_archives: boolean;
+};
+
+export type QueryProductAttribute = {
+	slug: string;
+	name: string;
+	type: 'select' | string;
 	order_by: string;
 	has_archives: boolean;
 	generate_slug: boolean;
@@ -30,7 +38,7 @@ type MutableProperties = Partial<
 
 type ProductAttributeActions = CrudActions<
 	'ProductAttribute',
-	QueryProductAttribute,
+	ProductAttribute,
 	MutableProperties
 >;
 
@@ -50,9 +58,9 @@ export type ActionDispatchers = DispatchFromMap< ProductAttributeActions >;
  */
 export interface CustomActionDispatchers extends ActionDispatchers {
 	createProductAttribute: (
-		x: Partial< Omit< QueryProductAttribute, 'id' > >,
+		x: Partial< QueryProductAttribute >,
 		options?: {
 			optimisticQueryUpdate: Partial< QueryProductAttribute > | boolean;
 		}
-	) => Promise< QueryProductAttribute >;
+	) => Promise< ProductAttribute >;
 }

--- a/packages/js/data/src/product-attributes/types.ts
+++ b/packages/js/data/src/product-attributes/types.ts
@@ -45,7 +45,7 @@ type ProductAttributeActions = CrudActions<
 export type ProductAttributeSelectors = CrudSelectors<
 	'ProductAttribute',
 	'ProductAttributes',
-	QueryProductAttribute,
+	ProductAttribute,
 	Query,
 	MutableProperties
 >;

--- a/packages/js/data/src/product-variations/actions.ts
+++ b/packages/js/data/src/product-variations/actions.ts
@@ -19,7 +19,7 @@ import type {
 import CRUD_ACTIONS from './crud-actions';
 import {
 	Product,
-	ProductAttribute,
+	ProductProductAttribute,
 	ProductDefaultAttribute,
 } from '../products/types';
 
@@ -50,7 +50,7 @@ export const generateProductVariations = function* (
 	idQuery: IdQuery,
 	productData: {
 		type?: string;
-		attributes: ProductAttribute[];
+		attributes: ProductProductAttribute[];
 		default_attributes?: ProductDefaultAttribute[];
 		meta_data?: Product[ 'meta_data' ];
 	},

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -28,7 +28,7 @@ export type ProductDownload = {
 	file: string;
 };
 
-export type ProductAttribute = {
+export type ProductProductAttribute = {
 	id: number;
 	name: string;
 	slug: string;
@@ -72,7 +72,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	Schema.Post,
 	'status' | 'categories'
 > & {
-	attributes: ProductAttribute[];
+	attributes: ProductProductAttribute[];
 	average_rating: string;
 	backordered: boolean;
 	backorders: 'no' | 'notify' | 'yes';

--- a/packages/js/product-editor/changelog/update-product-attribute-types
+++ b/packages/js/product-editor/changelog/update-product-attribute-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Block Editor: update code to data TS changes

--- a/packages/js/product-editor/src/blocks/product-fields/attributes/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/attributes/edit.tsx
@@ -4,7 +4,7 @@
 import { BlockAttributes } from '@wordpress/blocks';
 import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -20,7 +20,7 @@ export function AttributesBlockEdit( {
 	attributes,
 }: ProductEditorBlockEditProps< BlockAttributes > ) {
 	const [ entityAttributes, setEntityAttributes ] = useEntityProp<
-		ProductAttribute[]
+		ProductProductAttribute[]
 	>( 'postType', 'product', 'attributes' );
 
 	const productId = useEntityId( 'postType', 'product' );

--- a/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
@@ -12,7 +12,7 @@ import {
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	Product,
-	ProductAttribute,
+	ProductProductAttribute,
 	useUserPreferences,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -47,7 +47,7 @@ export function Edit( {
 	} = useUserPreferences();
 
 	const [ entityAttributes, setEntityAttributes ] = useEntityProp<
-		ProductAttribute[]
+		ProductProductAttribute[]
 	>( 'postType', 'product', 'attributes' );
 
 	const [ entityDefaultAttributes, setEntityDefaultAttributes ] =

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -9,7 +9,7 @@ import {
 	createInterpolateElement,
 } from '@wordpress/element';
 import { Button, Notice } from '@wordpress/components';
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 import {
 	Sortable,
 	__experimentalSelectControlMenuSlot as SelectControlMenuSlot,
@@ -77,7 +77,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	const [ defaultAttributeSearch, setDefaultAttributeSearch ] =
 		useState< string >();
 	const [ removingAttribute, setRemovingAttribute ] =
-		useState< null | ProductAttribute >();
+		useState< null | ProductProductAttribute >();
 	const [ currentAttributeId, setCurrentAttributeId ] = useState<
 		null | string
 	>( null );
@@ -97,7 +97,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		);
 	};
 
-	const handleRemove = ( attribute: ProductAttribute ) => {
+	const handleRemove = ( attribute: ProductProductAttribute ) => {
 		handleChange(
 			value.filter(
 				( attr ) =>
@@ -108,7 +108,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		setRemovingAttribute( null );
 	};
 
-	const showRemoveConfirmation = ( attribute: ProductAttribute ) => {
+	const showRemoveConfirmation = ( attribute: ProductProductAttribute ) => {
 		if ( useRemoveConfirmationModal ) {
 			setRemovingAttribute( attribute );
 			return;
@@ -132,7 +132,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		onNewModalClose();
 	};
 
-	const openEditModal = ( attribute: ProductAttribute ) => {
+	const openEditModal = ( attribute: ProductProductAttribute ) => {
 		recordEvent( 'product_options_edit', {
 			source: TRACKS_SOURCE,
 			attribute: attribute.name,
@@ -141,7 +141,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		onEditModalOpen( attribute );
 	};
 
-	const closeEditModal = ( attribute: ProductAttribute ) => {
+	const closeEditModal = ( attribute: ProductProductAttribute ) => {
 		setCurrentAttributeId( null );
 		onEditModalClose( attribute );
 	};
@@ -150,7 +150,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		const addedAttributesOnly = newAttributes.filter(
 			( newAttr ) =>
 				! value.some(
-					( current: ProductAttribute ) =>
+					( current: ProductProductAttribute ) =>
 						getAttributeId( newAttr ) === getAttributeId( current )
 				)
 		);
@@ -188,13 +188,13 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 
 	const attributeKeyValues = value.reduce(
 		(
-			keyValue: Record< number | string, ProductAttribute >,
-			attribute: ProductAttribute
+			keyValue: Record< number | string, ProductProductAttribute >,
+			attribute: ProductProductAttribute
 		) => {
 			keyValue[ getAttributeKey( attribute ) ] = attribute;
 			return keyValue;
 		},
-		{} as Record< number | string, ProductAttribute >
+		{} as Record< number | string, ProductProductAttribute >
 	);
 
 	const currentAttribute = value.find(

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -11,7 +11,7 @@ import {
 } from '@woocommerce/components';
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME,
-	ProductAttribute,
+	ProductProductAttribute,
 	ProductAttributeTerm,
 } from '@woocommerce/data';
 import { Button, Modal, Notice } from '@wordpress/components';
@@ -227,7 +227,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 						return function handleAttributeChange(
 							value?:
 								| Omit<
-										ProductAttribute,
+										ProductProductAttribute,
 										'position' | 'visible' | 'variation'
 								  >
 								| string

--- a/packages/js/product-editor/src/components/attribute-control/test/attribute-field.spec.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/test/attribute-field.spec.tsx
@@ -8,14 +8,14 @@ import {
 	createElement,
 	Fragment,
 } from '@wordpress/element';
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { AttributeControl } from '../attribute-control';
 
-const attributeList: ProductAttribute[] = [
+const attributeList: ProductProductAttribute[] = [
 	{
 		id: 15,
 		name: 'Automotive',

--- a/packages/js/product-editor/src/components/attribute-control/test/new-attribute-modal.spec.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/test/new-attribute-modal.spec.tsx
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import { ProductAttribute, ProductAttributeTerm } from '@woocommerce/data';
+import {
+	ProductProductAttribute,
+	ProductAttributeTerm,
+} from '@woocommerce/data';
 import { createElement } from '@wordpress/element';
 
 /**
@@ -10,14 +13,14 @@ import { createElement } from '@wordpress/element';
  */
 import { NewAttributeModal } from '../new-attribute-modal';
 
-let attributeOnChange: ( val: ProductAttribute ) => void;
+let attributeOnChange: ( val: ProductProductAttribute ) => void;
 jest.mock( '../../attribute-input-field', () => ( {
 	AttributeInputField: ( {
 		onChange,
 	}: {
 		onChange: (
 			value?: Omit<
-				ProductAttribute,
+				ProductProductAttribute,
 				'position' | 'visible' | 'variation'
 			>
 		) => void;
@@ -44,7 +47,7 @@ jest.mock( '../../attribute-term-input-field', () => ( {
 	},
 } ) );
 
-const attributeList: ProductAttribute[] = [
+const attributeList: ProductProductAttribute[] = [
 	{
 		id: 15,
 		name: 'Automotive',

--- a/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
+++ b/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import {
 	reorderSortableProductAttributePositions,
 } from '../utils';
 
-const attributeList: Record< number | string, ProductAttribute > = {
+const attributeList: Record< number | string, ProductProductAttribute > = {
 	15: {
 		id: 15,
 		name: 'Automotive',

--- a/packages/js/product-editor/src/components/attribute-control/types.ts
+++ b/packages/js/product-editor/src/components/attribute-control/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -17,16 +17,16 @@ export type AttributeControlProps = {
 	onAdd?: ( attribute: EnhancedProductAttribute[] ) => void;
 	onAddAnother?: () => void;
 	onRemoveItem?: () => void;
-	onChange: ( value: ProductAttribute[] ) => void;
-	onEdit?: ( attribute: ProductAttribute ) => void;
-	onRemove?: ( attribute: ProductAttribute ) => void;
-	onRemoveCancel?: ( attribute: ProductAttribute ) => void;
+	onChange: ( value: ProductProductAttribute[] ) => void;
+	onEdit?: ( attribute: ProductProductAttribute ) => void;
+	onRemove?: ( attribute: ProductProductAttribute ) => void;
+	onRemoveCancel?: ( attribute: ProductProductAttribute ) => void;
 	onNewModalCancel?: () => void;
 	onNewModalClose?: () => void;
 	onNewModalOpen?: () => void;
-	onEditModalCancel?: ( attribute?: ProductAttribute ) => void;
-	onEditModalClose?: ( attribute?: ProductAttribute ) => void;
-	onEditModalOpen?: ( attribute?: ProductAttribute ) => void;
+	onEditModalCancel?: ( attribute?: ProductProductAttribute ) => void;
+	onEditModalClose?: ( attribute?: ProductProductAttribute ) => void;
+	onEditModalOpen?: ( attribute?: ProductProductAttribute ) => void;
 	onNoticeDismiss?: () => void;
 	renderCustomEmptyState?: ( props: AttributeControlEmptyStateProps ) => void;
 	createNewAttributesAsGlobal?: boolean;

--- a/packages/js/product-editor/src/components/attribute-control/utils.ts
+++ b/packages/js/product-editor/src/components/attribute-control/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 
 /**
  * Returns the attribute key. The key will be the `id` or the `name` when the id is 0.
@@ -10,7 +10,7 @@ import { ProductAttribute } from '@woocommerce/data';
  * @return string|number
  */
 export function getAttributeKey(
-	attribute: ProductAttribute
+	attribute: ProductProductAttribute
 ): number | string {
 	return attribute.id !== 0 ? attribute.id : attribute.name;
 }
@@ -21,7 +21,7 @@ export function getAttributeKey(
  * @param attribute Product attribute.
  * @return string
  */
-export const getAttributeId = ( attribute: ProductAttribute ) =>
+export const getAttributeId = ( attribute: ProductProductAttribute ) =>
 	`${ attribute.id }-${ attribute.name }`;
 
 /**
@@ -32,10 +32,10 @@ export const getAttributeId = ( attribute: ProductAttribute ) =>
  */
 export function reorderSortableProductAttributePositions(
 	items: Record< number | string, number >,
-	attributeKeyValues: Record< number | string, ProductAttribute >
-): ProductAttribute[] {
+	attributeKeyValues: Record< number | string, ProductProductAttribute >
+): ProductProductAttribute[] {
 	return Object.keys( attributeKeyValues ).map(
-		( attributeKey: number | string ): ProductAttribute => {
+		( attributeKey: number | string ): ProductProductAttribute => {
 			if ( ! isNaN( items[ attributeKey ] ) ) {
 				return {
 					...attributeKeyValues[ attributeKey ],
@@ -57,8 +57,8 @@ export function reorderSortableProductAttributePositions(
 export function getProductAttributeObject(
 	attribute:
 		| string
-		| Omit< ProductAttribute, 'position' | 'visible' | 'variation' >
-): Omit< ProductAttribute, 'position' | 'visible' | 'variation' > {
+		| Omit< ProductProductAttribute, 'position' | 'visible' | 'variation' >
+): Omit< ProductProductAttribute, 'position' | 'visible' | 'variation' > {
 	return typeof attribute === 'string'
 		? {
 				id: 0,

--- a/packages/js/product-editor/src/components/attribute-control/utils.ts
+++ b/packages/js/product-editor/src/components/attribute-control/utils.ts
@@ -6,7 +6,7 @@ import { ProductProductAttribute } from '@woocommerce/data';
 /**
  * Returns the attribute key. The key will be the `id` or the `name` when the id is 0.
  *
- * @param { ProductAttribute } attribute product attribute.
+ * @param { ProductProductAttribute } attribute product attribute.
  * @return string|number
  */
 export function getAttributeKey(

--- a/packages/js/product-editor/src/components/attribute-input-field/test/attribute-input-field.spec.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/test/attribute-input-field.spec.tsx
@@ -4,7 +4,10 @@
 import { render, waitFor } from '@testing-library/react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, createElement } from '@wordpress/element';
-import { ProductAttribute, QueryProductAttribute } from '@woocommerce/data';
+import {
+	ProductProductAttribute,
+	QueryProductAttribute,
+} from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -104,7 +107,7 @@ jest.mock( '@woocommerce/components', () => {
 	};
 } );
 
-const attributeList: ProductAttribute[] = [
+const attributeList: ProductProductAttribute[] = [
 	{
 		id: 15,
 		name: 'Automotive',
@@ -285,7 +288,9 @@ describe( 'AttributeInputField', () => {
 				.fn()
 				.mockImplementation(
 					(
-						newAttribute: Partial< Omit< ProductAttribute, 'id' > >
+						newAttribute: Partial<
+							Omit< ProductProductAttribute, 'id' >
+						>
 					) => {
 						return Promise.resolve( {
 							name: newAttribute.name,

--- a/packages/js/product-editor/src/components/attribute-input-field/types.ts
+++ b/packages/js/product-editor/src/components/attribute-input-field/types.ts
@@ -1,20 +1,14 @@
 /**
  * External dependencies
  */
-import {
-	QueryProductAttribute,
-	ProductProductAttribute,
-} from '@woocommerce/data';
+import { ProductAttribute, ProductProductAttribute } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { EnhancedProductAttribute } from '../../hooks/use-product-attributes';
 
-export type NarrowedQueryAttribute = Pick<
-	QueryProductAttribute,
-	'id' | 'name'
-> & {
+export type NarrowedQueryAttribute = Pick< ProductAttribute, 'id' | 'name' > & {
 	slug?: string;
 	isDisabled?: boolean;
 };

--- a/packages/js/product-editor/src/components/attribute-input-field/types.ts
+++ b/packages/js/product-editor/src/components/attribute-input-field/types.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { QueryProductAttribute, ProductAttribute } from '@woocommerce/data';
+import {
+	QueryProductAttribute,
+	ProductProductAttribute,
+} from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -20,7 +23,10 @@ export type AttributeInputFieldProps = {
 	value?: EnhancedProductAttribute | null;
 	onChange: (
 		value?:
-			| Omit< ProductAttribute, 'position' | 'visible' | 'variation' >
+			| Omit<
+					ProductProductAttribute,
+					'position' | 'visible' | 'variation'
+			  >
 			| string
 	) => void;
 	label?: string;

--- a/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
+++ b/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
@@ -3,7 +3,7 @@
  */
 import { DragEventHandler } from 'react';
 import { ListItem, Tag } from '@woocommerce/components';
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/components';
 import { closeSmall } from '@wordpress/icons';
@@ -16,13 +16,13 @@ import NotFilterableIcon from './not-filterable-icon';
 import SeenIcon from '../../icons/seen-icon';
 
 type AttributeListItemProps = {
-	attribute: ProductAttribute;
+	attribute: ProductProductAttribute;
 	editLabel?: string;
 	removeLabel?: string;
 	onDragStart?: DragEventHandler< HTMLDivElement >;
 	onDragEnd?: DragEventHandler< HTMLDivElement >;
-	onEditClick?: ( attribute: ProductAttribute ) => void;
-	onRemoveClick?: ( attribute: ProductAttribute ) => void;
+	onEditClick?: ( attribute: ProductProductAttribute ) => void;
+	onRemoveClick?: ( attribute: ProductProductAttribute ) => void;
 };
 
 const VISIBLE_TEXT = __( 'Visible in product details', 'woocommerce' );

--- a/packages/js/product-editor/src/components/attribute-term-input-field/create-attribute-term-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-term-input-field/create-attribute-term-modal.tsx
@@ -16,7 +16,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME,
 	ProductAttributeTerm,
-	QueryProductAttribute,
+	ProductProductAttribute,
 } from '@woocommerce/data';
 
 /**
@@ -118,7 +118,7 @@ export const CreateAttributeTermModal: React.FC<
 					isValidForm,
 					setValue,
 					values,
-				}: FormContextType< QueryProductAttribute > ) => {
+				}: FormContextType< ProductProductAttribute > ) => {
 					const nameInputProps = getInputProps< string >( 'name' );
 					return (
 						<>

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createElement } from '@wordpress/element';
-import { ProductAttribute } from '@woocommerce/data';
+import { ProductProductAttribute } from '@woocommerce/data';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -13,8 +13,8 @@ import { AttributeControl } from '../attribute-control';
 import { useProductAttributes } from '../../hooks/use-product-attributes';
 
 type AttributesProps = {
-	value: ProductAttribute[];
-	onChange: ( value: ProductAttribute[] ) => void;
+	value: ProductProductAttribute[];
+	onChange: ( value: ProductProductAttribute[] ) => void;
 	productId?: number;
 };
 

--- a/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
@@ -4,7 +4,7 @@
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	PartialProductVariation,
-	ProductAttribute,
+	ProductProductAttribute,
 	ProductVariation,
 } from '@woocommerce/data';
 import { dispatch, resolveSelect } from '@wordpress/data';
@@ -208,7 +208,7 @@ export function useVariations( { productId }: UseVariationsProps ) {
 
 	// Filters
 
-	function onFilter( attribute: ProductAttribute ) {
+	function onFilter( attribute: ProductProductAttribute ) {
 		return function handleFilter( options: string[] ) {
 			let isPresent = false;
 
@@ -244,7 +244,7 @@ export function useVariations( { productId }: UseVariationsProps ) {
 		};
 	}
 
-	function getFilters( attribute: ProductAttribute ) {
+	function getFilters( attribute: ProductProductAttribute ) {
 		return (
 			filters.find( ( filter ) => filter.attribute === attribute.slug )
 				?.terms ?? []

--- a/packages/js/product-editor/src/components/variations-table/variations-filter/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variations-filter/types.ts
@@ -1,10 +1,13 @@
 /**
  * External dependencies
  */
-import { ProductAttribute, ProductAttributeTerm } from '@woocommerce/data';
+import {
+	ProductProductAttribute,
+	ProductAttributeTerm,
+} from '@woocommerce/data';
 
 export type VariationsFilterProps = {
 	initialValues: ProductAttributeTerm[ 'slug' ][];
-	attribute: ProductAttribute;
+	attribute: ProductProductAttribute;
 	onFilter( values: ProductAttributeTerm[ 'slug' ][] ): void;
 };

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/types.ts
@@ -4,13 +4,13 @@
 import { MouseEvent } from 'react';
 import {
 	PartialProductVariation,
-	ProductAttribute,
+	ProductProductAttribute,
 	ProductVariation,
 } from '@woocommerce/data';
 
 export type VariationsTableRowProps = {
 	variation: ProductVariation;
-	variableAttributes: ProductAttribute[];
+	variableAttributes: ProductProductAttribute[];
 	isUpdating?: boolean;
 	isSelected?: boolean;
 	isSelectionDisabled?: boolean;

--- a/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { renderHook, cleanup } from '@testing-library/react-hooks';
-import { ProductAttribute, ProductAttributeTerm } from '@woocommerce/data';
+import type {
+	ProductProductAttribute,
+	ProductAttributeTerm,
+} from '@woocommerce/data';
 import { resolveSelect } from '@wordpress/data';
 
 /**
@@ -100,7 +103,7 @@ jest.mock( '@wordpress/data', () => ( {
 	} ),
 } ) );
 
-const testAttributes: ProductAttribute[] = [
+const testAttributes: ProductProductAttribute[] = [
 	{
 		id: 0,
 		name: 'Local',

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -4,7 +4,7 @@
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME,
 	Product,
-	ProductAttribute,
+	type ProductProductAttribute,
 	ProductAttributeTerm,
 	ProductDefaultAttribute,
 } from '@woocommerce/data';
@@ -16,24 +16,24 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  */
 import { sift } from '../utils';
 
-export type EnhancedProductAttribute = ProductAttribute & {
+export type EnhancedProductAttribute = ProductProductAttribute & {
 	isDefault?: boolean;
 	terms?: ProductAttributeTerm[];
 	visible?: boolean;
 };
 
 type useProductAttributesProps = {
-	allAttributes: ProductAttribute[];
+	allAttributes: ProductProductAttribute[];
 	isVariationAttributes?: boolean;
 	onChange: (
-		attributes: ProductAttribute[],
+		attributes: ProductProductAttribute[],
 		defaultAttributes: ProductDefaultAttribute[]
 	) => void;
 	productId?: number;
 };
 
 const getFilteredAttributes = (
-	attr: ProductAttribute[],
+	attr: ProductProductAttribute[],
 	isVariationAttributes: boolean
 ) => {
 	return isVariationAttributes
@@ -95,7 +95,7 @@ export function useProductAttributes( {
 	);
 
 	const enhanceAttribute = (
-		globalAttribute: ProductAttribute,
+		globalAttribute: ProductProductAttribute,
 		allTerms: ProductAttributeTerm[]
 	) => {
 		return {
@@ -110,7 +110,7 @@ export function useProductAttributes( {
 		atts: EnhancedProductAttribute[],
 		variation: boolean,
 		startPosition: number
-	): ProductAttribute[] => {
+	): ProductProductAttribute[] => {
 		return atts.map( ( { isDefault, terms, ...attribute }, index ) => ( {
 			...attribute,
 			variation,
@@ -168,11 +168,13 @@ export function useProductAttributes( {
 	};
 
 	useEffect( () => {
-		const [ localAttributes, globalAttributes ]: ProductAttribute[][] =
-			sift(
-				getFilteredAttributes( allAttributes, isVariationAttributes ),
-				( attr: ProductAttribute ) => attr.id === 0
-			);
+		const [
+			localAttributes,
+			globalAttributes,
+		]: ProductProductAttribute[][] = sift(
+			getFilteredAttributes( allAttributes, isVariationAttributes ),
+			( attr: ProductProductAttribute ) => attr.id === 0
+		);
 
 		Promise.all(
 			globalAttributes.map( ( attr ) => fetchTerms( attr.id ) )

--- a/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import { Link, useFormContext } from '@woocommerce/components';
-import { Product, ProductAttribute } from '@woocommerce/data';
+import { Product, ProductProductAttribute } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -18,16 +18,14 @@ export const ProductVariationsSection: React.FC = () => {
 		values: { id: productId },
 	} = useFormContext< Product >();
 
-	const { value: attributes }: { value: ProductAttribute[] } = getInputProps(
-		'attributes',
-		{
+	const { value: attributes }: { value: ProductProductAttribute[] } =
+		getInputProps( 'attributes', {
 			productId,
-		}
-	);
+		} );
 
 	const options = attributes
 		? attributes.filter(
-				( attribute: ProductAttribute ) => attribute.variation
+				( attribute: ProductProductAttribute ) => attribute.variation
 		  )
 		: [];
 

--- a/plugins/woocommerce/changelog/update-product-attribute-types
+++ b/plugins/woocommerce/changelog/update-product-attribute-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woocommerce: update code to data TS changes


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR tidies and updates the Product Attribute TS types defined in the data CRUD implementation and updates another part of the code where it's required.

 ### Relevante changes

* **Rename `ProductAttribute` type with `ProductProductAttribute`**
It may not sound confusing, but it makes the difference between the `ProductAttribute` and `ProductProductAttribute` types more evident.
`ProductProductAttribute` is the object that belongs to the `Product` one. For instance, its what the `wc/v3/products/<product-id>` responses:

![image](https://github.com/woocommerce/woocommerce/assets/77539/430399c5-92be-4e51-b0fa-8bb82dccf6a7)
`position`, `options`, etc, are properties that make sense when the attribute belongs to a product instance.


* Introduce `ProductAttribute` type
It defines the types for the product attribute, decoupled of the product attribute object. For instance, what the `wc/v3/products/<product-id>/attributes` responses:

![image](https://github.com/woocommerce/woocommerce/assets/77539/e87d6902-6dfe-4cab-b3c9-08e9b47f32e4)

* Update the `QueryProductAttribute` type
It removes the `id` property from there. When creating a new attribute, the server-side doesn't take it from the request but it generates it

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Building the Product Block editor will check the TS definitions. It should be enough.

Additionally, you could use your IDE to easily check what the types of the Attribute selector and actions:

For instance, open the `packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx` file.
If you take a look at the type of the selector:

<img width="839" alt="Screenshot 2024-04-25 at 11 32 51" src="https://github.com/woocommerce/woocommerce/assets/77539/2aecb434-d371-49a0-a46c-7d2509f61a26">

The type is `ProductAttribute`.

Or when creating a new attribute:

<img width="930" alt="Screenshot 2024-04-25 at 11 35 47" src="https://github.com/woocommerce/woocommerce/assets/77539/b4fcbbd5-3f92-4751-b006-0cd96bef0b2e">

The type `QueryProductAttribute`, which doesn't include the `id`, for instance.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
