### PR TITLE
Move templates slug into a variable instead of hardcoding it in tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -3,11 +3,7 @@
  */
 import { BlockData } from '@woocommerce/e2e-types';
 import { expect, test } from '@woocommerce/e2e-playwright-utils';
-import { EditorUtils } from '@woocommerce/e2e-utils';
-
-/**
- * Internal dependencies
- */
+import { WC_TEMPLATES_SLUG, EditorUtils } from '@woocommerce/e2e-utils';
 
 const blockData: BlockData = {
 	name: 'Add to Cart with Options',
@@ -60,7 +56,7 @@ test.describe( `${ blockData.name } Block`, () => {
 	} ) => {
 		// Add to Cart with Options in the Site Editor is only available as inner block of the Single Product Block except for the Single Product Template
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ WC_TEMPLATES_SLUG }//archive-product`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();
@@ -87,7 +83,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		editorUtils,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//single-product`,
+			postId: `${ WC_TEMPLATES_SLUG }//single-product`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-block.merchant.block_theme.spec.ts
@@ -3,6 +3,7 @@
  */
 import { BlockData } from '@woocommerce/e2e-types';
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 const blockData: BlockData = {
 	name: 'Cart',
@@ -27,7 +28,7 @@ test.describe( 'Merchant → Cart', () => {
 	test.describe( 'in page editor', () => {
 		test.beforeEach( async ( { editorUtils, admin } ) => {
 			await admin.visitSiteEditor( {
-				postId: 'woocommerce/woocommerce//page-cart',
+				postId: `${ WC_TEMPLATES_SLUG }//page-cart`,
 				postType: 'wp_template',
 			} );
 			await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -3,6 +3,7 @@
  */
 import { BlockData } from '@woocommerce/e2e-types';
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -44,7 +45,7 @@ test.describe( 'Merchant → Checkout', () => {
 
 	test.beforeEach( async ( { editorUtils, admin, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ WC_TEMPLATES_SLUG }//page-checkout`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();
@@ -145,7 +146,7 @@ test.describe( 'Merchant → Checkout', () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ WC_TEMPLATES_SLUG }//page-checkout`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();
@@ -188,7 +189,7 @@ test.describe( 'Merchant → Checkout', () => {
 		).toBeVisible();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ WC_TEMPLATES_SLUG }//page-checkout`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.side_effects.spec.ts
@@ -3,7 +3,11 @@
  */
 import { expect, test as base } from '@woocommerce/e2e-playwright-utils';
 import { BlockData } from '@woocommerce/e2e-types';
-import { customerFile, guestFile } from '@woocommerce/e2e-utils';
+import {
+	customerFile,
+	guestFile,
+	WC_TEMPLATES_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -237,31 +241,34 @@ test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 	// `as string` is safe here because we know the variable is a string, it is defined above.
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
-	test.beforeEach( async ( { editor, admin, editorUtils, page } ) => {
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
-			postType: 'wp_template',
-		} );
-		await editorUtils.enterEditMode();
-		await editor.openDocumentSettingsSidebar();
-		await editor.selectBlocks(
-			blockSelectorInEditor +
-				'  [data-type="woocommerce/checkout-shipping-address-block"]'
-		);
+	test.beforeEach(
+		async ( { editor, frontendUtils, admin, editorUtils, page } ) => {
+			await admin.visitSiteEditor( {
+				postId: `${ WC_TEMPLATES_SLUG }//page-checkout`,
+				postType: 'wp_template',
+			} );
+			await editorUtils.enterEditMode();
+			await editor.openDocumentSettingsSidebar();
+			await editor.selectBlocks(
+				blockSelectorInEditor +
+					'  [data-type="woocommerce/checkout-shipping-address-block"]'
+			);
 
-		const checkbox = page.getByRole( 'checkbox', {
-			name: 'Company',
-			exact: true,
-		} );
-		await checkbox.check();
-		await expect( checkbox ).toBeChecked();
-		await expect(
-			editor.canvas.locator(
-				'div.wc-block-components-address-form__company'
-			)
-		).toBeVisible();
-		await editorUtils.saveSiteEditorEntities();
-	} );
+			const checkbox = page.getByRole( 'checkbox', {
+				name: 'Company',
+				exact: true,
+			} );
+			await checkbox.check();
+			await expect( checkbox ).toBeChecked();
+			await expect(
+				editor.canvas.locator(
+					'div.wc-block-components-address-form__company'
+				)
+			).toBeVisible();
+			await editorUtils.saveSiteEditorEntities();
+			await frontendUtils.emptyCart();
+		}
+	);
 
 	test( 'User can add postcodes for different countries', async ( {
 		frontendUtils,
@@ -497,7 +504,7 @@ test.describe( 'Billing Address Form', () => {
 		editorUtils,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ WC_TEMPLATES_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
-import { guestFile } from '@woocommerce/e2e-utils';
+import { guestFile, WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ test.describe( 'Shopper → Order Confirmation (logged in user)', () => {
 		await localPickupUtils.disableLocalPickup();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//order-confirmation',
+			postId: `${ WC_TEMPLATES_SLUG }//order-confirmation`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.side_effects.spec.ts
@@ -3,7 +3,7 @@
  */
 import { BlockData } from '@woocommerce/e2e-types';
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-import { cli } from '@woocommerce/e2e-utils';
+import { cli, WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ test.describe( `${ blockData.name } Block `, () => {
 			editor,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ template.slug }`,
+				postId: `${ WC_TEMPLATES_SLUG }//${ template.slug }`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -84,7 +84,7 @@ test.describe( `${ blockData.name } Block `, () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ template.slug }`,
+				postId: `${ WC_TEMPLATES_SLUG }//${ template.slug }`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.side_effects.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 	} ) => {
 		// First update the title via the site editor then check the local pickup settings.
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ WC_TEMPLATES_SLUG }//page-checkout`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();
@@ -73,7 +74,7 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		await localPickupUtils.saveLocalPickupSettings();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ WC_TEMPLATES_SLUG }//page-checkout`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
@@ -3,6 +3,7 @@
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
 import { BlockData } from '@woocommerce/e2e-types';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 const blockData: BlockData = {
 	name: 'Mini-Cart',
@@ -25,7 +26,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 			admin,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ WC_TEMPLATES_SLUG }//single-product`,
 				postType: 'wp_template',
 			} );
 			await editorUtils.enterEditMode();
@@ -41,7 +42,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 
 		test( 'can only be inserted once', async ( { editorUtils, admin } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ WC_TEMPLATES_SLUG }//single-product`,
 				postType: 'wp_template',
 			} );
 			await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.side_effects.spec.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
-import { EditorUtils, FrontendUtils } from '@woocommerce/e2e-utils';
+import {
+	EditorUtils,
+	FrontendUtils,
+	WC_TEMPLATES_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -74,7 +78,7 @@ test.describe( `${ blockData.name }`, () => {
 	test.describe( `On the Single Product Template`, () => {
 		test.beforeEach( async ( { admin, editorUtils, editor } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ blockData.slug }`,
+				postId: `${ WC_TEMPLATES_SLUG }//${ blockData.slug }`,
 				postType: 'wp_template',
 			} );
 			await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/compatibility-layer.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/compatibility-layer.block_theme.side_effects.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -99,7 +100,7 @@ test.describe( 'Compatibility Layer with Product Collection block', () => {
 			);
 
 			await pageObject.replaceProductsWithProductCollectionInTemplate(
-				'woocommerce/woocommerce//archive-product'
+				`${ WC_TEMPLATES_SLUG }//archive-product`
 			);
 			await pageObject.goToProductCatalogFrontend();
 		} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.side_effects.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 import type { Request, Locator } from '@playwright/test';
 
 /**
@@ -123,7 +124,7 @@ test.describe( 'Product Collection', () => {
 			editor,
 		} ) => {
 			await pageObject.replaceProductsWithProductCollectionInTemplate(
-				'woocommerce/woocommerce//archive-product'
+				`${ WC_TEMPLATES_SLUG }//archive-product`
 			);
 			await insertProductElements( pageObject );
 			await editor.saveSiteEditorEntities();
@@ -953,7 +954,7 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//taxonomy-product_cat`,
+				postId: `${ WC_TEMPLATES_SLUG }//taxonomy-product_cat`,
 				postType: 'wp_template',
 			} );
 			await editorUtils.enterEditMode();
@@ -982,7 +983,7 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//taxonomy-product_tag`,
+				postId: `${ WC_TEMPLATES_SLUG }//taxonomy-product_tag`,
 				postType: 'wp_template',
 			} );
 			await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { Locator, Page } from '@playwright/test';
-import { TemplateApiUtils, EditorUtils } from '@woocommerce/e2e-utils';
+import {
+	TemplateApiUtils,
+	EditorUtils,
+	WC_TEMPLATES_SLUG,
+} from '@woocommerce/e2e-utils';
 import { Editor, Admin } from '@wordpress/e2e-test-utils-playwright';
 
 /**
@@ -234,7 +238,7 @@ class ProductCollectionPage {
 
 	async goToProductCatalogAndInsertCollection( collection?: Collections ) {
 		await this.goToTemplateAndInsertCollection(
-			'woocommerce/woocommerce//archive-product',
+			`${ WC_TEMPLATES_SLUG }//archive-product`,
 			collection
 		);
 	}

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.side_effects.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -89,7 +90,7 @@ const test = base.extend< { pageObject: ProductGalleryPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editorUtils } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ WC_TEMPLATES_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/utils.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { EditorUtils } from '@woocommerce/e2e-utils';
+import { EditorUtils, WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 import { Admin, Editor } from '@wordpress/e2e-test-utils-playwright';
 
 export const addBlock = async (
@@ -10,7 +10,7 @@ export const addBlock = async (
 	editorUtils: EditorUtils
 ) => {
 	await admin.visitSiteEditor( {
-		postId: `woocommerce/woocommerce//single-product`,
+		postId: `${ WC_TEMPLATES_SLUG }//single-product`,
 		postType: 'wp_template',
 	} );
 	await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.side_effects.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ const test = base.extend< { pageObject: ProductGalleryPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editorUtils, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ WC_TEMPLATES_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-pager/product-gallery-pager.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-pager/product-gallery-pager.block_theme.side_effects.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -46,7 +47,7 @@ const test = base.extend< { pageObject: ProductGalleryPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editorUtils, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ WC_TEMPLATES_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
@@ -3,6 +3,7 @@
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
 import { Locator, Page } from '@playwright/test';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -50,7 +51,7 @@ const test = base.extend< { pageObject: ProductGalleryPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editorUtils } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ WC_TEMPLATES_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/utils.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { EditorUtils } from '@woocommerce/e2e-utils';
+import { EditorUtils, WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 import { Admin, Editor } from '@wordpress/e2e-test-utils-playwright';
 
 // Define a utility function to add the "woocommerce/product-gallery" block to the editor
@@ -12,7 +12,7 @@ export const addBlock = async (
 ) => {
 	// Visit the site editor for the specific product page
 	await admin.visitSiteEditor( {
-		postId: `woocommerce/woocommerce//single-product`,
+		postId: `${ WC_TEMPLATES_SLUG }//single-product`,
 		postType: 'wp_template',
 	} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.side_effects.spec.ts
@@ -3,6 +3,7 @@
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
 import { Locator } from '@playwright/test';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -85,7 +86,7 @@ const getThumbnailImageIdByNth = async (
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editorUtils } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ WC_TEMPLATES_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();
@@ -530,7 +531,7 @@ test.describe( `${ blockData.name }`, () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//product-gallery`,
+				postId: `${ WC_TEMPLATES_SLUG }//product-gallery`,
 				postType: 'wp_template_part',
 			} );
 			await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/products/products.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/products/products.block_theme.side_effects.spec.ts
@@ -3,6 +3,7 @@
  */
 import { BlockData } from '@woocommerce/e2e-types';
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -63,7 +64,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		page,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ WC_TEMPLATES_SLUG }//archive-product`,
 			postType: 'wp_template',
 		} );
 
@@ -91,7 +92,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		page,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ WC_TEMPLATES_SLUG }//archive-product`,
 			postType: 'wp_template',
 		} );
 
@@ -130,7 +131,7 @@ for ( const {
 			editorUtils,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ slug }`,
+				postId: `${ WC_TEMPLATES_SLUG }//${ slug }`,
 				postType: 'wp_template',
 			} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
@@ -3,6 +3,7 @@
  */
 import { BlockData } from '@woocommerce/e2e-types';
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		editorUtils,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ WC_TEMPLATES_SLUG }//archive-product`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();
@@ -53,7 +54,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		editorUtils,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//single-product`,
+			postId: `${ WC_TEMPLATES_SLUG }//single-product`,
 			postType: 'wp_template',
 		} );
 		await editorUtils.enterEditMode();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
@@ -148,5 +148,3 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 		canBeOverriddenByThemes: true,
 	},
 ];
-
-export const WC_TEMPLATES_SLUG = 'woocommerce/woocommerce';

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/legacy-templates.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/legacy-templates.block_theme.spec.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
-import { cli } from '@woocommerce/e2e-utils';
+import { cli, WC_TEMPLATES_SLUG } from '@woocommerce/e2e-utils';
 
 test.describe( 'Legacy templates', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
@@ -23,7 +23,7 @@ test.describe( 'Legacy templates', () => {
 
 		await test.step( 'Customize existing template to create DB entry', async () => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ template.id }`,
+				postId: `${ WC_TEMPLATES_SLUG }//${ template.id }`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -94,7 +94,7 @@ test.describe( 'Legacy templates', () => {
 				`npm run wp-env run tests-cli -- \
 					wp term update wp_theme woocommerce \
 						--by="slug" \
-						--name="woocommerce/woocommerce" \
+						--name="${ WC_TEMPLATES_SLUG }" \
 						--slug="woocommerce-woocommerce"`
 			);
 

--- a/plugins/woocommerce-blocks/tests/e2e/utils/constants.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/constants.ts
@@ -17,6 +17,8 @@ export const CLASSIC_CHILD_THEME_WITH_BLOCK_NOTICES_TEMPLATE_SLUG = `${ CLASSIC_
 export const CLASSIC_CHILD_THEME_WITH_CLASSIC_NOTICES_TEMPLATE_SLUG = `${ CLASSIC_THEME_SLUG }-child__classic-notices-template`;
 export const BASE_URL = 'http://localhost:8889';
 
+export const WC_TEMPLATES_SLUG = 'woocommerce/woocommerce';
+
 export const WP_ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH ||
 	path.join( process.cwd(), 'tests/e2e/artifacts' );

--- a/plugins/woocommerce/changelog/fix-template-slugs-variable
+++ b/plugins/woocommerce/changelog/fix-template-slugs-variable
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Move templates slug into a variable instead of hardcoding it in blocks tests
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In several tests, we were hard-coding the WooCommerce block templates slug (`woocommerce/woocommerce`). This PR moves it into a variable, so if at some point we need to change it (like in https://github.com/woocommerce/woocommerce/pull/46831), it will be easier.

### How to test the changes in this Pull Request:

Note: No need to test when testing the release.

1. Verify e2e JS tests keep passing.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
