### PR TITLE
Fix invalid date format errors in certain languages

### DIFF
--- a/packages/js/components/changelog/fix-invalid-date-formats
+++ b/packages/js/components/changelog/fix-invalid-date-formats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix invalid date format errors in certain languages

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -53,13 +53,6 @@ const formatMap: Record<
 	l: 'dddd',
 	N: 'E',
 
-	/**
-	 * Gets the ordinal suffix.
-	 *
-	 * @param {Moment} momentDate Moment instance.
-	 *
-	 * @return {string} Formatted date.
-	 */
 	S( momentDate: Moment ) {
 		// Do - D.
 		const num = momentDate.format( 'D' );
@@ -68,13 +61,6 @@ const formatMap: Record<
 	},
 
 	w: 'd',
-	/**
-	 * Gets the day of the year (zero-indexed).
-	 *
-	 * @param {Moment} momentDate Moment instance.
-	 *
-	 * @return {string} Formatted date.
-	 */
 	z( momentDate: Moment ) {
 		// DDD - 1.
 		return ( parseInt( momentDate.format( 'DDD' ), 10 ) - 1 ).toString();
@@ -92,14 +78,6 @@ const formatMap: Record<
 		return momentDate.daysInMonth();
 	},
 
-	// Year.
-	/**
-	 * Gets whether the current year is a leap year.
-	 *
-	 * @param {Moment} momentDate Moment instance.
-	 *
-	 * @return {string} Formatted date.
-	 */
 	L( momentDate: Moment ) {
 		return momentDate.isLeapYear() ? '1' : '0';
 	},
@@ -110,13 +88,6 @@ const formatMap: Record<
 	// Time.
 	a: 'a',
 	A: 'A',
-	/**
-	 * Gets the current time in Swatch Internet Time (.beats).
-	 *
-	 * @param {Moment} momentDate Moment instance.
-	 *
-	 * @return {number} Formatted date.
-	 */
 	B( momentDate: Moment ) {
 		const timezoned = moment( momentDate ).utcOffset( 60 );
 		const seconds = parseInt( timezoned.format( 's' ), 10 ),
@@ -164,13 +135,6 @@ const formatMap: Record<
 	},
 	// Full date/time.
 	c: 'YYYY-MM-DDTHH:mm:ssZ', // .toISOString.
-	/**
-	 * Formats the date as RFC2822.
-	 *
-	 * @param {Moment} momentDate Moment instance.
-	 *
-	 * @return {string} Formatted date.
-	 */
 	r( momentDate: Moment ) {
 		return momentDate
 			.locale( 'en' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The issue was happening due to moment not being able to parse the date without having the correct format informed.

[I copied some code from gutenberg](https://github.com/WordPress/gutenberg/blob/trunk/packages/date/src/index.js#L289), mostly a map from PHP date formats and moment date formats, since it is not exposed in the module. It was needed to make it work. I plan on creating a follow-up issue to maybe have this object exposed upstream after this issue gets reviewed.

Closes #44216 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Switch WordPress language to Simplified Chinese (简体中文) in Settings > General.
2. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
3. Go to Products > Add
4. Fill name
5. Go to Pricing tab, fill a valid combination of list and sale price
6. Check "schedule sale"
7. Pick a valid combination of "from" and "to" dates.
8. You should not see a validation error.
9. Test with other languages to check for regressions.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
