### PR TITLE
Avoid duplicated product request

### DIFF
--- a/packages/js/product-editor/changelog/dev-46890_avoid_request_product_twice
+++ b/packages/js/product-editor/changelog/dev-46890_avoid_request_product_twice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Avoid duplicated product request #46934

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -12,11 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { starEmpty, starFilled } from '@wordpress/icons';
 import { cleanForSlug } from '@wordpress/url';
-import {
-	PRODUCTS_STORE_NAME,
-	WCDataSelector,
-	Product,
-} from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import classNames from 'classnames';
 import {
@@ -40,7 +36,7 @@ import { useValidation } from '../../../contexts/validation-context';
 import { useProductEdits } from '../../../hooks/use-product-edits';
 import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { ProductEditorBlockEditProps } from '../../../types';
-import { AUTO_DRAFT_NAME } from '../../../utils';
+import { AUTO_DRAFT_NAME, getPermalinkParts } from '../../../utils';
 import { NameBlockAttributes } from './types';
 
 export function NameBlockEdit( {
@@ -74,21 +70,8 @@ export function NameBlockEdit( {
 		'name'
 	);
 
-	const { permalinkPrefix, permalinkSuffix } = useSelect(
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		( select: WCDataSelector ) => {
-			const { getPermalinkParts } = select( PRODUCTS_STORE_NAME );
-			if ( productId ) {
-				const parts = getPermalinkParts( productId );
-				return {
-					permalinkPrefix: parts?.prefix,
-					permalinkSuffix: parts?.suffix,
-				};
-			}
-			return {};
-		}
-	);
+	const { prefix: permalinkPrefix, suffix: permalinkSuffix } =
+		getPermalinkParts( product );
 
 	const {
 		ref: nameRef,

--- a/packages/js/product-editor/src/components/details-name-field/details-name-field.tsx
+++ b/packages/js/product-editor/src/components/details-name-field/details-name-field.tsx
@@ -2,15 +2,10 @@
  * External dependencies
  */
 import { Button, TextControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { cleanForSlug } from '@wordpress/url';
 import { useFormContext } from '@woocommerce/components';
-import {
-	Product,
-	PRODUCTS_STORE_NAME,
-	WCDataSelector,
-} from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import {
 	useState,
 	createElement,
@@ -23,6 +18,7 @@ import {
 import { PRODUCT_DETAILS_SLUG } from '../../constants';
 import { EditProductLinkModal } from '../edit-product-link-modal';
 import { useProductHelper } from '../../hooks/use-product-helper';
+import { getPermalinkParts } from '../../utils';
 
 export const DetailsNameField = ( {} ) => {
 	const { updateProductWithStatus } = useProductHelper();
@@ -31,21 +27,8 @@ export const DetailsNameField = ( {} ) => {
 	const { getInputProps, values, touched, errors, setValue, resetForm } =
 		useFormContext< Product >();
 
-	const { permalinkPrefix, permalinkSuffix } = useSelect(
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		( select: WCDataSelector ) => {
-			const { getPermalinkParts } = select( PRODUCTS_STORE_NAME );
-			if ( values.id ) {
-				const parts = getPermalinkParts( values.id );
-				return {
-					permalinkPrefix: parts?.prefix,
-					permalinkSuffix: parts?.suffix,
-				};
-			}
-			return {};
-		}
-	);
+	const { prefix: permalinkPrefix, suffix: permalinkSuffix } =
+		getPermalinkParts( values );
 
 	const hasNameError = () => {
 		return Boolean( touched.name ) && Boolean( errors.name );

--- a/packages/js/product-editor/src/utils/get-permalink-parts.ts
+++ b/packages/js/product-editor/src/utils/get-permalink-parts.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+
+export type PermalinkParts = {
+	prefix: string | undefined;
+	postName: string | undefined;
+	suffix: string | undefined;
+};
+
+export const getPermalinkParts = ( product: Product ): PermalinkParts => {
+	let postName, prefix, suffix;
+	if ( product && product.permalink_template ) {
+		postName = product.slug || product.generated_slug;
+		[ prefix, suffix ] = product.permalink_template.split(
+			/%(?:postname|pagename)%/
+		);
+	}
+	return {
+		prefix,
+		postName,
+		suffix,
+	};
+};

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -8,6 +8,7 @@ import { getCheckboxTracks } from './get-checkbox-tracks';
 import { getCurrencySymbolProps } from './get-currency-symbol-props';
 import { getDerivedProductType } from './get-derived-product-type';
 import { getHeaderTitle } from './get-header-title';
+import { getPermalinkParts } from './get-permalink-parts';
 import { getProductStatus, PRODUCT_STATUS_LABELS } from './get-product-status';
 import {
 	getProductStockStatus,
@@ -42,6 +43,7 @@ export {
 	getCurrencySymbolProps,
 	getDerivedProductType,
 	getHeaderTitle,
+	getPermalinkParts,
 	getProductStatus,
 	getProductStockStatus,
 	getProductStockStatusClass,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a performance problem related to the product being requested two times.

![Screenshot 2024-04-25 at 3 31 22 PM](https://github.com/woocommerce/woocommerce/assets/1314156/a107de1c-b371-4ddc-8aff-0dd4288473c3)

The name field used `getPermalinkParts`, which used the product store, but we were using the entity store in the rest of the product editor.

Closes #46890.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and build the project.
2. Open the browser's devTools and go to the `Network` tab.
3. Refresh the page and verify that the product is not requested multiple times.

![Screenshot 2024-04-25 at 3 31 45 PM](https://github.com/woocommerce/woocommerce/assets/1314156/76590850-a434-4713-b94b-4b39d0926311)

4. Test with a new product and an existing one.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
