### PR TITLE
Block Hooks: Revert opening up hooked blocks to all block themes

### DIFF
--- a/plugins/woocommerce/changelog/46935-revert-hooked_blocks_on_all_block_themes
+++ b/plugins/woocommerce/changelog/46935-revert-hooked_blocks_on_all_block_themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Reverts auto-injecting specific Woo Blocks in every block theme and restores only auto-injecting in themes found in the allow list.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
@@ -32,7 +32,16 @@ trait BlockHooksTrait {
 			$active_theme_name = wp_get_theme()->get( 'Name' );
 		}
 
-		if ( $context ) {
+		/**
+		 * A list of theme slugs to execute this with. This is a temporary
+		 * measure until improvements to the Block Hooks API allow for exposing
+		 * to all block themes.
+		 *
+		 * @since $VID:$
+		 */
+		$theme_include_list = apply_filters( 'woocommerce_hooked_blocks_theme_include_list', array( 'Twenty Twenty-Four', 'Twenty Twenty-Three', 'Twenty Twenty-Two', 'Tsubaki', 'Zaino', 'Thriving Artist', 'Amulet', 'Tazza' ) );
+
+		if ( $context && in_array( $active_theme_name, $theme_include_list, true ) ) {
 			foreach ( $this->hooked_block_placements as $placement ) {
 
 				if ( $placement['position'] === $position && $placement['anchor'] === $anchor_block ) {

--- a/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockHooksTrait.php
@@ -37,7 +37,7 @@ trait BlockHooksTrait {
 		 * measure until improvements to the Block Hooks API allow for exposing
 		 * to all block themes.
 		 *
-		 * @since $VID:$
+		 * @since 8.4.0
 		 */
 		$theme_include_list = apply_filters( 'woocommerce_hooked_blocks_theme_include_list', array( 'Twenty Twenty-Four', 'Twenty Twenty-Three', 'Twenty Twenty-Two', 'Tsubaki', 'Zaino', 'Thriving Artist', 'Amulet', 'Tazza' ) );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #45581, the WooCommerce implementation of the WP Block Hooks API auto-injects the mini-cart and customer account block on all sites with a block theme (running WooCommerce of course). After the release of WC 8.8 (where this change was introduced), we've discovered that impact on existing sites is greater than expected and are reverting until we can implement this more safely.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The only themes this should apply to now are: "Twenty Twenty-Four, Twenty Twenty-Three, Twenty Twenty-Two, Tsubaki, Zaino, Thriving Artist, Amulet, Tazza" which were where the hooks were implemented as of WC 8.7.

1. Make sure that the mini-cart block is auto-injected in the header template parts and header patterns for the above list of themes.
2. Make sure that the mini-cart block is _not_ auto-injected in the header template parts and header patterns for any block theme not in the above list.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Reverts auto-injecting specific Woo Blocks in every block theme and restores only auto-injecting in themes found in the allow list.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
