### PR TITLE
Show 'up' and 'down' chevron in SelectTree and remove suffix prop

### DIFF
--- a/packages/js/components/changelog/fix-select-tree-chevron
+++ b/packages/js/components/changelog/fix-select-tree-chevron
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Show 'up' and 'down' chevron in SelectTree and remove suffix prop

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { chevronDown } from '@wordpress/icons';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
@@ -23,7 +23,6 @@ interface SelectTreeProps extends TreeControlProps {
 	id: string;
 	selected?: Item | Item[];
 	treeRef?: React.ForwardedRef< HTMLOListElement >;
-	suffix?: JSX.Element | null;
 	isLoading?: boolean;
 	disabled?: boolean;
 	label: string | JSX.Element;
@@ -34,7 +33,6 @@ interface SelectTreeProps extends TreeControlProps {
 export const SelectTree = function SelectTree( {
 	items,
 	treeRef: ref,
-	suffix = <SuffixIcon icon={ chevronDown } />,
 	placeholder,
 	isLoading,
 	disabled,
@@ -179,7 +177,11 @@ export const SelectTree = function SelectTree( {
 								'aria-owns': `${ props.id }-menu`,
 							} }
 							inputProps={ inputProps }
-							suffix={ suffix }
+							suffix={
+								<SuffixIcon
+									icon={ isOpen ? chevronUp : chevronDown }
+								/>
+							}
 						>
 							<SelectedItems
 								isReadOnly={ isReadOnly }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Show 'up' and 'down' chevron in SelectTree and remove suffix prop

Closes #38227 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Go to the Organization tab
4. Click on the "Category" field
5. Check that the "down chevron" icon turns into an "open chevron"

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
