### PR TITLE
Make method getAttributionData globally accessible

### DIFF
--- a/plugins/woocommerce/changelog/tweak-surface-order-attribution-data-js
+++ b/plugins/woocommerce/changelog/tweak-surface-order-attribution-data-js
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make order attribution data globally accessible client side.

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -152,10 +152,10 @@
 			this._fieldNames = Object.keys( wc_order_attribution.fields );
 			// Allow values to be lazily set before CE upgrade.
 			if ( this.hasOwnProperty( '_values' ) ) {
-			  let values = this.values;
-			  // Restore the setter.
-			  delete this.values;
-			  this.values = values || {};
+				let values = this.values;
+				// Restore the setter.
+				delete this.values;
+				this.values = values || {};
 			}
 		}
 		/**
@@ -167,7 +167,7 @@
 		connectedCallback() {
 			let inputs = '';
 			for( const fieldName of this._fieldNames ) {
-				const value = stringifyFalsyInputValue( this.values[ fieldName ] );
+				const value = stringifyFalsyInputValue( ( this.values && this.values[ fieldName ] ) || '' );
 				inputs += `<input type="hidden" name="${params.prefix}${fieldName}" value="${value}"/>`;
 			}
 			this.innerHTML = inputs;

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -19,7 +19,7 @@
 	 *
 	 * @returns {Object} Schema compatible object.
 	 */
-	function getData() {
+	wc_order_attribution.getAttributionData = function() {
 		const accessor = params.allowTracking ? propertyAccessor : returnNull;
 		const entries = Object.entries( wc_order_attribution.fields )
 				.map( ( [ key, property ] ) => [ key, accessor( sbjs.get, property ) ] );
@@ -75,7 +75,7 @@
 				timezone_offset: '0', // utc
 			} );
 		}
-		const values = getData();
+		const values = wc_order_attribution.getAttributionData();
 		updateFormValues( values );
 		updateCheckoutBlockData( values );
 	}
@@ -117,7 +117,7 @@
 			// Update checkout block data once more if the checkout store was loaded after this script.
 			const unsubscribe = window.wp.data.subscribe( function () {
 				unsubscribe();
-				updateCheckoutBlockData( getData() );
+				updateCheckoutBlockData( wc_order_attribution.getAttributionData() );
 			}, CHECKOUT_STORE_KEY );
 		}
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

### Changes proposed in this Pull Request:

- This minor tweak makes the `getData()` method in `order-attributes.js` accessible globally, as part of a possible fix for https://github.com/woocommerce/woocommerce/issues/46309.
- The method is renamed to `getAttributeData()` and is accessible as `wc_order_attribution.getAttributeData()`
- It returns a key-value object of the **unprefixed** attribution names and their values as retrieved from the Sourcebuster JS object.
- If sourcebuster is blocked or hasn't loaded (see #46723), then the object will have keys with null values.

~Closes~ Related to #46309.


### How to test the changes in this Pull Request:
**Test that the data is globally accessible:**
1. Visit the shop with added UTM params: `myshop.test/shop/?utm_source=TEST-SOURCE&utm_medium=TEST-MEDIUM&utm_campaign=🐸`
2. On the shop page, check that the attribution data is available by executing `wc_order_attribution.getAttributionData()` in the console:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/515767e0-a918-4164-a35f-466d7d22d088)
3. Add some items to the cart, go to the checkout page. Execute the same snippet in the console to make sure the data is still available.
4. Complete the purchase, and check in the order edit form that the data was correctly saved.
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/b35014fb-6ad4-4d42-b0c0-b67e65741cdd)
5. Edit the checkout page to use the other checkout type (checkout block or classic checkout).
6. Repeat steps 3-5 to make sure the data is available, and correctly assigned to the order on checkout.
7. Reload the shop one more time, but update the UTM params: `myshop.test/shop/?utm_source=new_source&utm_medium=new_medium&utm_campaign=🐔`
8. Run the JS snippet in the console to confirm that the new values are correctly returned.
9. Complete the checkout (with whichever checkout form) and confirm that the attribution data is correctly assigned to the order.

**Check if sourcebuster not available or tracking disallowed**
1. Break the sourcebuster script (delete or rename `assets/js/sourcebuster/sourcebuster.min.js`).
2. Visit the shop with added UTM params: `myshop.test/shop/?utm_source=test_source_dos&utm_medium=test_source_dos&utm_campaign=🐶`
3. Confirm there are no errors in the dev console.
4. Confirm the snippet `wc_order_attribution.getAttributionData()` in the console gives an object with all null values.
5. Complete checkout with both classic and block checkouts to confirm no console errors. (The orders also shouldn't have any attribution data associated).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
