### PR TITLE
Add support to HPOS CLI tool for handling deleted orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-45865
+++ b/plugins/woocommerce/changelog/fix-45865
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow HPOS CLI cleanup tool to remove metadata for deleted orders.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -91,6 +91,8 @@ class LegacyDataHandler {
 	private function build_sql_query_for_cleanup( array $order_ids = array(), string $result = 'ids', int $limit = 0 ): string {
 		global $wpdb;
 
+		$hpos_orders_table = $this->data_store->get_orders_table_name();
+
 		$sql_where = '';
 
 		if ( $order_ids ) {
@@ -123,7 +125,7 @@ class LegacyDataHandler {
 		$sql_where .= '(';
 		$sql_where .= "{$wpdb->posts}.post_type IN ('" . implode( "', '", esc_sql( wc_get_order_types( 'cot-migration' ) ) ) . "')";
 		$sql_where .= $wpdb->prepare(
-			" OR (post_type = %s AND EXISTS(SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID))",
+			" OR (post_type = %s AND ( {$hpos_orders_table}.id IS NULL OR EXISTS(SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID)) )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$this->data_synchronizer::PLACEHOLDER_ORDER_POST_TYPE
 		);
 		$sql_where .= ')';
@@ -135,11 +137,12 @@ class LegacyDataHandler {
 			$sql_fields = 'COUNT(*)';
 			$sql_limit  = '';
 		} else {
-			$sql_fields = 'ID';
+			$sql_fields = "{$wpdb->posts}.ID";
 			$sql_limit  = $limit > 0 ? $wpdb->prepare( 'LIMIT %d', $limit ) : '';
 		}
 
-		return "SELECT {$sql_fields} FROM {$wpdb->posts} WHERE {$sql_where} {$sql_limit}";
+		$sql = "SELECT {$sql_fields} FROM {$wpdb->posts} LEFT JOIN {$hpos_orders_table} ON {$wpdb->posts}.ID = {$hpos_orders_table}.id WHERE {$sql_where} {$sql_limit}";
+		return $sql;
 	}
 
 	/**
@@ -153,10 +156,15 @@ class LegacyDataHandler {
 	public function cleanup_post_data( int $order_id, bool $skip_checks = false ): void {
 		global $wpdb;
 
-		$post_is_placeholder = get_post_type( $order_id ) === $this->data_synchronizer::PLACEHOLDER_ORDER_POST_TYPE;
-		if ( ! $post_is_placeholder ) {
-			$order = wc_get_order( $order_id );
+		$post_type = get_post_type( $order_id );
+		if ( ! in_array( $post_type, array_merge( wc_get_order_types( 'cot-migration' ), array( $this->data_synchronizer::PLACEHOLDER_ORDER_POST_TYPE ) ), true ) ) {
+			// translators: %d is an order ID.
+			throw new \Exception( esc_html( sprintf( __( '%d is not of a valid order type.', 'woocommerce' ), $order_id ) ) );
+		}
 
+		$order_exists = $this->data_store->order_exists( $order_id );
+		if ( $order_exists ) {
+			$order = wc_get_order( $order_id );
 			if ( ! $order ) {
 				// translators: %d is an order ID.
 				throw new \Exception( esc_html( sprintf( __( '%d is not a valid order ID.', 'woocommerce' ), $order_id ) ) );
@@ -168,24 +176,24 @@ class LegacyDataHandler {
 			}
 		}
 
-		// Delete all metadata.
-		$wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM {$wpdb->postmeta} WHERE post_id = %d",
-				$order_id
-			)
-		);
+		$wpdb->delete( $wpdb->postmeta, array( 'post_id' => $order_id ), array( '%d' ) ); // Delete all metadata.
 
-		// wp_update_post() changes the post modified date, so we do this manually.
-		// Also, we suspect using wp_update_post() could lead to integrations mistakenly updating the entity.
-		$wpdb->query(
-			$wpdb->prepare(
-				"UPDATE {$wpdb->posts} SET post_type = %s, post_status = %s WHERE ID = %d",
-				$this->data_synchronizer::PLACEHOLDER_ORDER_POST_TYPE,
-				'draft',
-				$order_id
-			)
-		);
+		if ( $order_exists ) {
+			// wp_update_post() changes the post modified date, so we do this manually.
+			// Also, we suspect using wp_update_post() could lead to integrations mistakenly updating the entity.
+			$wpdb->update(
+				$wpdb->posts,
+				array(
+					'post_type'   => $this->data_synchronizer::PLACEHOLDER_ORDER_POST_TYPE,
+					'post_status' => 'draft',
+				),
+				array( 'ID' => $order_id ),
+				array( '%s', '%s' ),
+				array( '%d' )
+			);
+		} else {
+			$wpdb->delete( $wpdb->posts, array( 'ID' => $order_id ), array( '%d' ) );
+		}
 
 		clean_post_cache( $order_id );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, when the cleanup tool is used, it'll attempt to compare the order from posts and also HPOS, and will fail when the order doesn't exist (on the HPOS side).
Given a prerequisite for using the cleanup tool is that HPOS is authoritative and sync is disabled, I believe it's safe to assume that those posts can be deleted.

This PR lets the cleanup tool remove meta for such posts and then delete the post itself if there's no corresponding order on the HPOS side.

Closes #45865 and #46592.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is enabled in WC > Settings > Advanced > Features and compatibility mode is *disabled*.
2. Create a few test orders on your site. Take note of the ID for at least two of those orders.
3. Sync orders by running `wp wc hpos sync`.
4. Manually "delete" **one** of the orders from step 2 by running this command:
   ```
   wp db query "DELETE FROM $(wp db prefix)wc_orders WHERE id = <order_id>"
   ```
5. Run `wp wc hpos cleanup all` to perform a cleanup and confirm the command runs successfully.
6. Run `wp post meta list <order_id>` for both IDs from step 2 and confirm that:
   - For the ID removed in step 4, the command fails with a "Could not find the post with ID XXX" which means the post was truly removed.
   - For the other ID, the list is empty (meaning all metadata was cleaned up).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
