### PR TITLE
Do not urldecode search terms in HPOS searches

### DIFF
--- a/plugins/woocommerce/changelog/fix-45771
+++ b/plugins/woocommerce/changelog/fix-45771
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix HPOS order searches involving terms with characters resembling URL-encoded characters.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -41,7 +41,7 @@ class OrdersTableSearchQuery {
 	public function __construct( OrdersTableQuery $query ) {
 		$this->query          = $query;
 		$this->search_term    = $query->get( 's' );
-		$this->search_filters = $this->sanitize_search_filters( $query->get( 'search_filter' ) );
+		$this->search_filters = $this->sanitize_search_filters( $query->get( 'search_filter' ) ?? '' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -27,7 +27,7 @@ class OrdersTableSearchQuery {
 	/**
 	 * Limits the search to a specific field.
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	private $search_filters;
 
@@ -40,8 +40,8 @@ class OrdersTableSearchQuery {
 	 */
 	public function __construct( OrdersTableQuery $query ) {
 		$this->query          = $query;
-		$this->search_term    = urldecode( $query->get( 's' ) );
-		$this->search_filters = $this->sanitize_search_filters( urldecode( $query->get( 'search_filter' ) ) );
+		$this->search_term    = $query->get( 's' );
+		$this->search_filters = $this->sanitize_search_filters( $query->get( 'search_filter' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When search filters for HPOS were introduced in #43356 we included a `urldecode()` for the search term in the code, but this seems unnecessary: if called programmatically, we shouldn't be decoding the search term as that might not be necessary at all, and when called as part of a search on the orders admin, the parameters are passed via `$_GET` which PHP already decodes automatically, so we're actually performing a double decode.

This double decode is particularly problematic when the search term includes a `+` (for example, when searching for orders associated to certain e-mails) as the second decode turns the `+` into a blank space.

This PR removes any `urldecode`'ing for the search term in our HPOS search code.

Closes #45771.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is enabled in WC > Settings > Advanced > Features.
1. Manually create a few orders (if necessary). Make sure at least one is associated to a billing e-mail that includes a "+" as part of it (say "buyer+wc@proton.test").
1. Go to WC > Orders. Choose either "Customer Email" or "All" in the dropdown next to the search box.
1. Enter the e-mail address from step 2 and perform the search. Confirm that the expected order is in the results.
1. Perform a few other searches (entering product name, billing name or other criteria) to confirm things are working correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
