### PR TITLE
Catch NotFoundException before `woocommerce_get_batch_processor`

### DIFF
--- a/plugins/woocommerce/changelog/pr-46975
+++ b/plugins/woocommerce/changelog/pr-46975
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Catch NotFoundException before woocommerce_get_batch_processor

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -275,11 +275,8 @@ class BatchProcessingController {
 	 */
 	private function get_processor_instance( string $processor_class_name ) : BatchProcessorInterface {
 
-		try {
-			$processor = wc_get_container()->get( $processor_class_name );
-		} catch ( \Exception $e) {
-			$processor = null;
-		}
+		$container = wc_get_container();
+		$processor = $container->has( $processor_class_name ) ? $container->get( $processor_class_name ) : null;
 
 		/**
 		 * Filters the instance of a processor for a given class name.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -274,7 +274,12 @@ class BatchProcessingController {
 	 * @throws \Exception If it's not possible to get an instance of the class.
 	 */
 	private function get_processor_instance( string $processor_class_name ) : BatchProcessorInterface {
-		$processor = wc_get_container()->get( $processor_class_name );
+
+		try {
+			$processor = wc_get_container()->get( $processor_class_name );
+		} catch ( \Exception $e) {
+			$processor = null;
+		}
 
 		/**
 		 * Filters the instance of a processor for a given class name.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Catchthing the NotFoundException allows the `woocommerce_get_batch_processor` filter to run for 3rd party plugins looking to use batch processing.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46974.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
See #46974 for instructions

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
