### PR TITLE
HPOS - Made the query for retrieving meta keys more performant

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-cache-46806
+++ b/plugins/woocommerce/changelog/fix-add-cache-46806
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+HPOS - Made the query for retrieving meta keys more performant

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -252,7 +252,7 @@ abstract class CustomMetaDataStore {
 		if ( ! $include_private ) {
 			$query .= $wpdb->prepare( "WHERE meta_key NOT BETWEEN '_' AND '_z' HAVING meta_key NOT LIKE %s ", $wpdb->esc_like( '_' ) . '%' );
 		} else {
-			$query .= "WHERE meta_key != '' ";
+			$query .= "WHERE meta_key NOT BETWEEN '_' AND '_z' ";
 		}
 
 		$order  = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -250,7 +250,7 @@ abstract class CustomMetaDataStore {
 		$query = "SELECT DISTINCT meta_key FROM {$db_info['table']} ";
 
 		if ( ! $include_private ) {
-			$query .= $wpdb->prepare( 'WHERE meta_key != \'\' AND meta_key NOT LIKE %s ', $wpdb->esc_like( '_' ) . '%' );
+			$query .= $wpdb->prepare( "WHERE meta_key NOT BETWEEN '_' AND '_z' HAVING meta_key NOT LIKE %s ", $wpdb->esc_like( '_' ) . '%' );
 		} else {
 			$query .= "WHERE meta_key != '' ";
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -252,7 +252,7 @@ abstract class CustomMetaDataStore {
 		if ( ! $include_private ) {
 			$query .= $wpdb->prepare( "WHERE meta_key !='' AND meta_key NOT BETWEEN '_' AND '_z' AND meta_key NOT LIKE %s ", $wpdb->esc_like( '_' ) . '%' );
 		} else {
-			$query .= "WHERE meta_key !='' ";
+			$query .= "WHERE meta_key != '' ";
 		}
 
 		$order  = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -250,9 +250,9 @@ abstract class CustomMetaDataStore {
 		$query = "SELECT DISTINCT meta_key FROM {$db_info['table']} ";
 
 		if ( ! $include_private ) {
-			$query .= $wpdb->prepare( "WHERE meta_key NOT BETWEEN '_' AND '_z' HAVING meta_key NOT LIKE %s ", $wpdb->esc_like( '_' ) . '%' );
+			$query .= $wpdb->prepare( "WHERE meta_key !='' AND meta_key NOT BETWEEN '_' AND '_z' AND meta_key NOT LIKE %s ", $wpdb->esc_like( '_' ) . '%' );
 		} else {
-			$query .= "WHERE meta_key NOT BETWEEN '_' AND '_z' ";
+			$query .= "WHERE meta_key !='' ";
 		}
 
 		$order  = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? $order : 'ASC';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46806 

I've updated the query to make it slightly more performant, by using `BETWEEN` along with `!=` for `meta_keys`, it is similar to how [WP core](https://github.com/WordPress/wordpress-develop/blob/66b5d25be2b5e69833bacfe8f64de660ffc2bfa9/src/wp-admin/includes/template.php#L720-L731) is doing.

I've ran explain on both queries on our perf site.
#### Before
 ![Screenshot 2024-04-29 at 19 43 36](https://github.com/woocommerce/woocommerce/assets/15019298/a1e7f50f-c0e9-4927-a013-aff77d38cce9)
#### After
![Screenshot 2024-04-29 at 19 42 40](https://github.com/woocommerce/woocommerce/assets/15019298/4b330111-d3c7-492d-b45a-68e5328853c0)




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Switch to this branch `fix/add-cache-46806`
2. Build the zip
3. Make sure you have a large number of order and meta_keys, or you can just use the perf site for testing.
4. Now make sure you have [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin installed.
5. Open a single order with meta keys
6. Search for `get_meta_keys()` in the query monitor tab
7. Verify that the query isn't marked slow anymore.

#### Before
![Screenshot 2024-05-02 at 13 04 52](https://github.com/woocommerce/woocommerce/assets/15019298/6752ea63-7e2f-4ca4-8e10-5005871cf943)

#### After
![Screenshot 2024-05-02 at 13 31 29](https://github.com/woocommerce/woocommerce/assets/15019298/cdd8899e-7072-4844-b7ef-baa4621c083e)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
