### PR TITLE
CYS > Ensure get_patterns_ai_data_post is triggered only if AI enabled and improve performance

### DIFF
--- a/plugins/woocommerce/changelog/46999-fix-fetch-patterns-ai-data-post-only-if-ai-enabled-and-improve-performance
+++ b/plugins/woocommerce/changelog/46999-fix-fetch-patterns-ai-data-post-only-if-ai-enabled-and-improve-performance
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+CYS > Ensure get_patterns_ai_data_post is triggered only if AI enabled and improve performance.

--- a/plugins/woocommerce/src/Blocks/AIContent/PatternsHelper.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/PatternsHelper.php
@@ -35,16 +35,12 @@ class PatternsHelper {
 	 * @return \WP_Post|null
 	 */
 	public static function get_patterns_ai_data_post() {
-		$arg = array(
+		$posts = get_posts( array(
 			'post_type'      => 'patterns_ai_data',
 			'posts_per_page' => 1,
-			'no_found_rows'  => true,
 			'cache_results'  => true,
-		);
+		) );
 
-		$query = new \WP_Query( $arg );
-
-		$posts = $query->get_posts();
 		return $posts[0] ?? null;
 	}
 
@@ -106,13 +102,17 @@ class PatternsHelper {
 			return new WP_Error( 'json_decode_error', __( 'Error decoding JSON.', 'woocommerce' ) );
 		}
 
-		$patterns_ai_data_post = self::get_patterns_ai_data_post();
 		$patterns_dictionary   = '';
-		if ( ! empty( $patterns_ai_data_post->post_content ) ) {
-			$patterns_dictionary = json_decode( $patterns_ai_data_post->post_content, true );
+		$ai_connection_allowed = get_option( 'woocommerce_blocks_allow_ai_connection' );
 
-			if ( json_last_error() !== JSON_ERROR_NONE ) {
-				return new WP_Error( 'json_decode_error', __( 'Error decoding JSON.', 'woocommerce' ) );
+		if ( $ai_connection_allowed ) {
+			$patterns_ai_data_post = self::get_patterns_ai_data_post();
+			if ( ! empty( $patterns_ai_data_post->post_content ) ) {
+				$patterns_dictionary = json_decode( $patterns_ai_data_post->post_content, true );
+
+				if ( json_last_error() !== JSON_ERROR_NONE ) {
+					return new WP_Error( 'json_decode_error', __( 'Error decoding JSON.', 'woocommerce' ) );
+				}
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/AIContent/PatternsHelper.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/PatternsHelper.php
@@ -35,11 +35,13 @@ class PatternsHelper {
 	 * @return \WP_Post|null
 	 */
 	public static function get_patterns_ai_data_post() {
-		$posts = get_posts( array(
-			'post_type'      => 'patterns_ai_data',
-			'posts_per_page' => 1,
-			'cache_results'  => true,
-		) );
+		$posts = get_posts(
+			array(
+				'post_type'      => 'patterns_ai_data',
+				'posts_per_page' => 1,
+				'cache_results'  => true,
+			)
+		);
 
 		return $posts[0] ?? null;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -75,16 +75,16 @@ class BlockPatterns {
 		$site_id = $ai_connection->get_site_id();
 
 		if ( is_wp_error( $site_id ) ) {
-			return update_option( 'woocommerce_blocks_allow_ai_connection', false );
+			return update_option( 'woocommerce_blocks_allow_ai_connection', false, true );
 		}
 
 		$token = $ai_connection->get_jwt_token( $site_id );
 
 		if ( is_wp_error( $token ) ) {
-			return update_option( 'woocommerce_blocks_allow_ai_connection', false );
+			return update_option( 'woocommerce_blocks_allow_ai_connection', false, true );
 		}
 
-		return update_option( 'woocommerce_blocks_allow_ai_connection', true );
+		return update_option( 'woocommerce_blocks_allow_ai_connection', true, true );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46988

- Ensures the `get_patterns_ai_data_post` method is triggered exclusively whenever AI is enabled for the store.
- Updates the `get_patterns_ai_data_post` method to rely on get_posts instead of new WP_Query for fetching the results.
- Enables autoload for the `'woocommerce_blocks_allow_ai_connection'` option to improve performance since it is invoked in almost all page loads.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh WordPress install outside of WooExpress.
2. Head over to WooCommerce > Home > Customize Your Store.
3. Make sure you can access the pattern assembler properly, and that all patterns are loaded as expected and without any errors.
4. Create a new post and try to insert a few WooCommerce patterns to it: make sure everything works as expected.
5. Create a fresh WooExpress install.
6. Via Settings > Hosting Configuration, access your site via SSH and replace the WooCommerce plugin with the following zip: [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/15138164/woocommerce.zip)
7. Repeat steps 2 to 4 on your WooExpress install and confirm things are working as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS > Ensure get_patterns_ai_data_post is triggered only if AI enabled and improve performance.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
