### PR TITLE
Tracks event for WooCommerce.com connect notice

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/connect-notice/connect-notice.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/connect-notice/connect-notice.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -58,17 +59,29 @@ export default function ConnectNotice(): JSX.Element | null {
 		)
 	);
 
+	const handleClick = () => {
+		recordEvent( 'woo_connect_notice_in_marketplace_clicked' );
+		return true;
+	};
+
+	const handleClose = () => {
+		localStorage.setItem( localStorageKey, new Date().toString() );
+		recordEvent( 'woo_connect_notice_in_marketplace_dismissed' );
+	};
+
 	return (
 		<Notice
 			id="woo-connect-notice"
 			description={ description }
 			isDismissible={ true }
 			variant="error"
-			onClose={ () => {
-				localStorage.setItem( localStorageKey, new Date().toString() );
-			} }
+			onClose={ handleClose }
 		>
-			<Button href={ connectUrl() } variant="secondary">
+			<Button
+				href={ connectUrl() }
+				variant="secondary"
+				onClick={ handleClick }
+			>
 				{ __( 'Connect', 'woocommerce' ) }
 			</Button>
 		</Notice>

--- a/plugins/woocommerce-admin/client/marketplace/components/connect-notice/connect-notice.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/connect-notice/connect-notice.tsx
@@ -69,6 +69,10 @@ export default function ConnectNotice(): JSX.Element | null {
 		recordEvent( 'woo_connect_notice_in_marketplace_dismissed' );
 	};
 
+	const handleLoad = () => {
+		recordEvent( 'woo_connect_notice_in_marketplace_shown' );
+	};
+
 	return (
 		<Notice
 			id="woo-connect-notice"
@@ -76,6 +80,7 @@ export default function ConnectNotice(): JSX.Element | null {
 			isDismissible={ true }
 			variant="error"
 			onClose={ handleClose }
+			onLoad={ handleLoad }
 		>
 			<Button
 				href={ connectUrl() }

--- a/plugins/woocommerce-admin/client/marketplace/components/notice/notice.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/notice/notice.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { Icon, check, closeSmall, info, percent } from '@wordpress/icons'; // See: https://wordpress.github.io/gutenberg/?path=/docs/icons-icon--docs
 
 /**
@@ -19,6 +19,7 @@ export interface NoticeProps {
 	isDismissible: boolean;
 	variant: string;
 	onClose?: () => void;
+	onLoad?: () => void;
 }
 
 type IconKey = keyof typeof iconMap;
@@ -39,6 +40,7 @@ export default function Notice( props: NoticeProps ): JSX.Element | null {
 		isDismissible = true,
 		variant = 'info',
 		onClose,
+		onLoad,
 	} = props;
 	const [ isVisible, setIsVisible ] = useState(
 		localStorage.getItem( `wc-marketplaceNoticeClosed-${ id }` ) !== 'true'
@@ -51,6 +53,14 @@ export default function Notice( props: NoticeProps ): JSX.Element | null {
 			onClose();
 		}
 	};
+
+	useEffect(() => {
+		if ( isVisible && typeof onLoad === 'function' ) {
+			onLoad();
+		}
+		// only run once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isVisible ] );
 
 	if ( ! isVisible ) return null;
 

--- a/plugins/woocommerce-admin/client/marketplace/components/notice/notice.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/notice/notice.tsx
@@ -54,7 +54,7 @@ export default function Notice( props: NoticeProps ): JSX.Element | null {
 		}
 	};
 
-	useEffect(() => {
+	useEffect( () => {
 		if ( isVisible && typeof onLoad === 'function' ) {
 			onLoad();
 		}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/woo-connect-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/woo-connect-notice/index.js
@@ -1,6 +1,12 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
 window.jQuery( document ).ready( function () {
 	// hide the notice when the customer clicks the dismiss button up until 1 month, then it will be shown again.
 	const wooConnectNoticeSelector = '.woo-connect-notice';
+	const wooConnectNoticeLinkSelector = '#woo-connect-notice-url';
 	const localStorageKey = 'woo-connect-notice-settings-dismissed';
 
 	window
@@ -10,7 +16,13 @@ window.jQuery( document ).ready( function () {
 				localStorageKey,
 				new Date().toString()
 			);
+			recordEvent( 'woo_connect_notice_in_settings_dismissed' );
 		} );
+
+	window.jQuery( wooConnectNoticeLinkSelector ).on( 'click', function () {
+		recordEvent( 'woo_connect_notice_in_settings_clicked' );
+		return true;
+	} );
 
 	let shouldHideNotice = false;
 
@@ -28,5 +40,7 @@ window.jQuery( document ).ready( function () {
 
 	if ( shouldHideNotice ) {
 		window.jQuery( wooConnectNoticeSelector ).remove();
+	} else {
+		recordEvent( 'woo_connect_notice_in_settings_shown' );
 	}
 } );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/woo-plugin-update-connect-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/woo-plugin-update-connect-notice/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { recordEvent } from '@woocommerce/tracks';
+
+domReady( () => {
+	const connectYourStoreLinks = document.querySelectorAll(
+		'.woocommerce-connect-your-store'
+	);
+
+	if ( connectYourStoreLinks.length > 0 ) {
+		recordEvent( 'woo_connect_notice_in_plugins_shown' );
+		connectYourStoreLinks.forEach( ( link ) => {
+			link.addEventListener( 'click', function () {
+				recordEvent( 'woo_connect_notice_in_plugins_clicked' );
+			} );
+		} );
+	}
+} );

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -74,6 +74,7 @@ const wpAdminScripts = [
 	'command-palette',
 	'command-palette-analytics',
 	'woo-connect-notice',
+	'woo-plugin-update-connect-notice',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/47003-add-tracks-woo-connect-notice
+++ b/plugins/woocommerce/changelog/47003-add-tracks-woo-connect-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Send tracks event for woocommerce.com connect notices

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -184,10 +184,11 @@ class WC_Helper_Updater {
 		printf(
 			wp_kses(
 			/* translators: 1: Woo Update Manager plugin install URL */
-				__( ' <a href="%1$s">Connect your store</a> to woocommerce.com to update.', 'woocommerce' ),
+				__( ' <a href="%1$s" class="woocommerce-connect-your-store">Connect your store</a> to woocommerce.com to update.', 'woocommerce' ),
 				array(
 					'a' => array(
-						'href' => array(),
+						'href'  => array(),
+						'class' => array(),
 					),
 				)
 			),

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -571,7 +571,7 @@ class PluginsHelper {
 
 		$notice_string .= sprintf(
 			/* translators: %s: Connect page URL */
-			__( '<a href="%s">Connect your store</a> to WooCommerce.com to get updates and streamlined support for your subscriptions.', 'woocommerce' ),
+			__( '<a id="woo-connect-notice-url" href="%s">Connect your store</a> to WooCommerce.com to get updates and streamlined support for your subscriptions.', 'woocommerce' ),
 			esc_url( $connect_page_url )
 		);
 

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -582,7 +582,7 @@ class PluginsHelper {
 	}
 
 	/**
-	 * Enqueue scripts for connect notice.
+	 * Enqueue scripts for connect notice in WooCommerce settings page.
 	 *
 	 * @return void
 	 */
@@ -601,6 +601,11 @@ class PluginsHelper {
 		wp_enqueue_script( 'woo-connect-notice' );
 	}
 
+	/**
+	 * Enqueue scripts for connect notice in plugin list page.
+	 *
+	 * @return void
+	 */
 	public static function maybe_enqueue_scripts_for_connect_notice_in_plugins() {
 		if ( 'plugins' !== get_current_screen()->id ) {
 			return;

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -40,6 +40,7 @@ class PluginsHelper {
 		add_action( 'woocommerce_plugins_activate_callback', array( __CLASS__, 'activate_plugins' ), 10, 2 );
 		add_action( 'admin_notices', array( __CLASS__, 'maybe_show_connect_notice_in_plugin_list' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_scripts_for_connect_notice' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_scripts_for_connect_notice_in_plugins' ) );
 	}
 
 	/**
@@ -600,4 +601,12 @@ class PluginsHelper {
 		wp_enqueue_script( 'woo-connect-notice' );
 	}
 
+	public static function maybe_enqueue_scripts_for_connect_notice_in_plugins() {
+		if ( 'plugins' !== get_current_screen()->id ) {
+			return;
+		}
+
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'woo-plugin-update-connect-notice' );
+		wp_enqueue_script( 'woo-plugin-update-connect-notice' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add track events for connect to woocommerce.com notice in the woocommerce settings and woocommerce marketplace wp-admin page.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**WooCommerce settings and WooCommerce extensions page**

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow instruction here: https://github.com/woocommerce/woocommerce/pull/45536 to setup the notices
2. Verify that showing the notice, dismissing the notice, and clicking the hyperlink/button on the notice triggers track events (verify it by using the "Network" tab, filter it by "pixel" and check that the track event actions are fired)
<img width="1437" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1663428/c4ebe76e-d36f-4fbb-94e1-24e6f321edf9">

#### List of tracks events (all prefixed by `wcadmin_` in tracks)
- woo_connect_notice_in_settings_shown
- woo_connect_notice_in_settings_clicked
- woo_connect_notice_in_settings_dismissed
- woo_connect_notice_in_marketplace_shown
- woo_connect_notice_in_marketplace_clicked
- woo_connect_notice_in_marketplace_dismissed

**Plugins list page**

1. Opt-in to allow tracking, set `woocommerce_allow_tracking` option to `yes`
2. Follow test instructions in https://github.com/woocommerce/woocommerce/pull/46082
3. Verify Tracks event is fired when notice is shown and connect link is clicked

#### List of tracks events (all prefixed by `wcadmin_` in tracks)

- woo_connect_notice_in_plugins_shown
- woo_connect_notice_in_plugins_clicked

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
