### PR TITLE
[e2e tests] Update max failures number to 90

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -124,7 +124,7 @@ jobs:
               id: run_playwright_e2e_tests
               env:
                   USE_WP_ENV: 1
-                  E2E_MAX_FAILURES: 15
+                  E2E_MAX_FAILURES: 90
                   FORCE_COLOR: 1
                   ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
                   ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
@@ -301,7 +301,7 @@ jobs:
                   playwright-config: ignore-plugin-tests.playwright.config.js
                   report-name: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
               env:
-                  E2E_MAX_FAILURES: 15
+                  E2E_MAX_FAILURES: 90
 
             - name: Create context block and save as JSON file
               if: success() || failure()

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -219,7 +219,7 @@ jobs:
                   CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
                   CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
                   DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  E2E_MAX_FAILURES: 25
+                  E2E_MAX_FAILURES: 90
                   RESET_SITE: true
 
             - name: Download 'e2e-update-wc' artifact
@@ -386,7 +386,7 @@ jobs:
               timeout-minutes: 60
               uses: ./.github/actions/tests/run-e2e-tests
               env:
-                  E2E_MAX_FAILURES: 15
+                  E2E_MAX_FAILURES: 90
                   ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
                   ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
                   DEFAULT_TIMEOUT_OVERRIDE: 120000
@@ -538,7 +538,7 @@ jobs:
                   ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
                   ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
                   DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  E2E_MAX_FAILURES: 15
+                  E2E_MAX_FAILURES: 90
               with:
                   report-name: ${{ env.E2E_ARTIFACT }}
 
@@ -668,7 +668,7 @@ jobs:
                   playwright-config: ignore-plugin-tests.playwright.config.js
                   report-name: ${{ env.ARTIFACT_NAME }}
               env:
-                  E2E_MAX_FAILURES: 15
+                  E2E_MAX_FAILURES: 90
 
             - name: Upload Allure artifacts to bucket
               if: |


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Increase the number of max failed tests before Playwright stops execution in the daily and the release workflows. 15 is quickly reached as Playwright doesn't account for retries, so all it takes is only 5 failed test.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

After merging, check the daily run or trigger a release workflow run.
Locally, set the E2E_MAX_FAILURES env variable and make enough tests fail to exceed the set value. Execution should stop.

