### PR TITLE
[e2e tests] Don't exit if the consumer token is not cleared in teardown

### DIFF
--- a/plugins/woocommerce/changelog/e2e-dont-exit-if-cannot-clear-consumer-token
+++ b/plugins/woocommerce/changelog/e2e-dont-exit-if-cannot-clear-consumer-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: don't exit if the consumer token was not cleared in teardown

--- a/plugins/woocommerce/tests/e2e-pw/global-teardown.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-teardown.js
@@ -1,4 +1,4 @@
-const { chromium } = require( '@playwright/test' );
+const { chromium, expect } = require( '@playwright/test' );
 const { admin } = require( './test-data/data' );
 
 module.exports = async ( config ) => {
@@ -95,8 +95,5 @@ module.exports = async ( config ) => {
 		}
 	}
 
-	if ( ! consumerTokenCleared ) {
-		console.error( 'Could not clear consumer token.' );
-		process.exit( 1 );
-	}
+	await expect( consumerTokenCleared ).toBe( true );
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`process.exit(1)` is called if the consumer token is not successfully cleared in the global teardown, breaking any post testing task, like generating test reports.
Replaced that part with an assertion, so that we still fail if the token is not cleared, but still generate the reports.
More context: p1714375345503039-slack-C066L9EDP6Z

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Make the `consumerTokenCleared` be false before the assertion and run any test. An error will be reported, but the execution continues and test reports are generated in `test-results`.