### PR TITLE
[e2e tests] Disable woocommerce_coming_soon during test environment setup

### DIFF
--- a/plugins/woocommerce/changelog/e2e-disable-coming-soon-in-env-setup
+++ b/plugins/woocommerce/changelog/e2e-disable-coming-soon-in-env-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: disable woocommerce_coming_soon during test environment setup

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -38,5 +38,7 @@ if [ $ENABLE_TRACKING == 1 ]; then
 	wp-env run tests-cli wp option update woocommerce_allow_tracking 'yes'
 fi
 
+wp-env run tests-cli wp option update woocommerce_coming_soon 'no'
+
 echo -e 'Upload test images \n'
 wp-env run tests-cli wp media import './test-data/images/image-01.png' './test-data/images/image-02.png' './test-data/images/image-03.png'

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -38,6 +38,7 @@ if [ $ENABLE_TRACKING == 1 ]; then
 	wp-env run tests-cli wp option update woocommerce_allow_tracking 'yes'
 fi
 
+echo -e 'Disabling coming soon option\n'
 wp-env run tests-cli wp option update woocommerce_coming_soon 'no'
 
 echo -e 'Upload test images \n'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

#46842 removed the setting of `woocommerce_coming_soon` in the global setup in favour of setting it in the `test-env-setup.sh`, but the latter was missed somehow.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Run all tests without sharding. There should be no failures caused by the site not being available.