### PR TITLE
[e2e workflows] Increase actions timeout to 90 minutes for faily and release workflows

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -80,7 +80,7 @@ jobs:
     e2e-tests:
         name: E2E tests on nightly build
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 90
         strategy:
             fail-fast: false
             matrix:
@@ -120,7 +120,7 @@ jobs:
               run: pnpm exec playwright install chromium
 
             - name: Run E2E tests
-              timeout-minutes: 60
+              timeout-minutes: 90
               id: run_playwright_e2e_tests
               env:
                   USE_WP_ENV: 1
@@ -295,7 +295,7 @@ jobs:
                   
             - name: Run the rest of E2E tests
               id: run-e2e-composite-action
-              timeout-minutes: 60
+              timeout-minutes: 90
               uses: ./.github/actions/tests/run-e2e-tests
               with:
                   playwright-config: ignore-plugin-tests.playwright.config.js

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -58,7 +58,7 @@ jobs:
 
             - name: Run E2E tests
               id: run-e2e-composite-action
-              timeout-minutes: 60
+              timeout-minutes: 90
               uses: ./.github/actions/tests/run-e2e-tests
               with:
                   report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
@@ -206,7 +206,7 @@ jobs:
 
             - name: Run E2E tests
               id: run-e2e-composite-action
-              timeout-minutes: 60
+              timeout-minutes: 90
               uses: ./.github/actions/tests/run-e2e-tests
               with:
                   report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
@@ -383,7 +383,7 @@ jobs:
 
             - name: Run E2E tests
               id: run-e2e-composite-action
-              timeout-minutes: 60
+              timeout-minutes: 90
               uses: ./.github/actions/tests/run-e2e-tests
               env:
                   E2E_MAX_FAILURES: 90
@@ -532,7 +532,7 @@ jobs:
 
             - name: Run E2E tests
               id: run-e2e-composite-action
-              timeout-minutes: 60
+              timeout-minutes: 90
               uses: ./.github/actions/tests/run-e2e-tests
               env:
                   ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
@@ -650,7 +650,7 @@ jobs:
 
             - name: Run 'Upload plugin' test
               id: run-upload-test
-              timeout-minutes: 60
+              timeout-minutes: 90
               uses: ./.github/actions/tests/run-e2e-tests
               with:
                   report-name: ${{ env.ARTIFACT_NAME }}
@@ -662,7 +662,7 @@ jobs:
 
             - name: Run the rest of E2E tests
               id: run-e2e-composite-action
-              timeout-minutes: 60
+              timeout-minutes: 90
               uses: ./.github/actions/tests/run-e2e-tests
               with:
                   playwright-config: ignore-plugin-tests.playwright.config.js


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The daily e2e workflow which is not sharded started hitting the 60 minutes limit. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Check the daily workflow after merging.