### PR TITLE
Enable inline actions in the variations table for images 

### DIFF
--- a/packages/js/data/changelog/add-47036
+++ b/packages/js/data/changelog/add-47036
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Set some fields as optional on ProductVariationImage type

--- a/packages/js/data/src/product-variations/types.ts
+++ b/packages/js/data/src/product-variations/types.ts
@@ -27,19 +27,19 @@ export interface ProductVariationImage {
 	/**
 	 * The date the image was created, in the site's timezone.
 	 */
-	readonly date_created: string;
+	readonly date_created?: string;
 	/**
 	 * The date the image was created, as GMT.
 	 */
-	readonly date_created_gmt: string;
+	readonly date_created_gmt?: string;
 	/**
 	 * The date the image was last modified, in the site's timezone.
 	 */
-	readonly date_modified: string;
+	readonly date_modified?: string;
 	/**
 	 * The date the image was last modified, as GMT.
 	 */
-	readonly date_modified_gmt: string;
+	readonly date_modified_gmt?: string;
 	/**
 	 * Image URL.
 	 */

--- a/packages/js/product-editor/changelog/add-47036
+++ b/packages/js/product-editor/changelog/add-47036
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable inline actions in the variations table for images

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -11,6 +11,11 @@
 	flex-direction: column;
 	position: relative;
 
+	&__attributes-cell {
+		display: flex;
+		align-items: center;
+	}
+
 	&__table {
 		&-header {
 			.woocommerce-product-variations__table-row {
@@ -180,5 +185,22 @@
 		.components-button--hidden {
 			color: $alert-red;
 		}
+	}
+	&__add-image-button {
+		border-radius: 2px;
+		border: 1px dashed $gray-400;
+		margin-right: $gap-small;
+		width: 32px;
+		padding: 0;
+	}
+	&__image-button {
+		margin-right: $gap-small;
+		width: 32px;
+		max-height: 32px;
+		padding: 0;
+	}
+	&__image {
+		width: 32px;
+		max-height: 32px;
 	}
 }

--- a/packages/js/product-editor/src/components/variations-table/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/types.ts
@@ -5,7 +5,7 @@ import { PartialProductVariation, ProductVariation } from '@woocommerce/data';
 
 export type VariationActionsMenuItemProps = {
 	selection: ProductVariation[];
-	onChange( values: PartialProductVariation[] ): void;
+	onChange( values: PartialProductVariation[], showSuccess: boolean ): void;
 	onClose(): void;
 	supportsMultipleSelection?: boolean;
 };

--- a/packages/js/product-editor/src/components/variations-table/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/types.ts
@@ -5,7 +5,7 @@ import { PartialProductVariation, ProductVariation } from '@woocommerce/data';
 
 export type VariationActionsMenuItemProps = {
 	selection: ProductVariation[];
-	onChange( values: PartialProductVariation[], showSuccess: boolean ): void;
+	onChange( values: PartialProductVariation[], showSuccess?: boolean ): void;
 	onClose(): void;
 	supportsMultipleSelection?: boolean;
 };

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menus/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menus/types.ts
@@ -6,7 +6,7 @@ import { PartialProductVariation, ProductVariation } from '@woocommerce/data';
 export type VariationActionsMenuProps = {
 	disabled?: boolean;
 	selection: ProductVariation[];
-	onChange( values: PartialProductVariation[], showSuccess: boolean ): void;
+	onChange( values: PartialProductVariation[], showSuccess?: boolean ): void;
 	onDelete( values: PartialProductVariation[] ): void;
 };
 
@@ -14,7 +14,7 @@ export type VariationQuickUpdateSlotProps = {
 	group: string;
 	supportsMultipleSelection: boolean;
 	selection: ProductVariation[];
-	onChange( values: PartialProductVariation[], showSuccess: boolean ): void;
+	onChange( values: PartialProductVariation[], showSuccess?: boolean ): void;
 	onClose: () => void;
 };
 

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menus/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menus/types.ts
@@ -6,7 +6,7 @@ import { PartialProductVariation, ProductVariation } from '@woocommerce/data';
 export type VariationActionsMenuProps = {
 	disabled?: boolean;
 	selection: ProductVariation[];
-	onChange( values: PartialProductVariation[] ): void;
+	onChange( values: PartialProductVariation[], showSuccess: boolean ): void;
 	onDelete( values: PartialProductVariation[] ): void;
 };
 
@@ -14,7 +14,7 @@ export type VariationQuickUpdateSlotProps = {
 	group: string;
 	supportsMultipleSelection: boolean;
 	selection: ProductVariation[];
-	onChange: ( values: PartialProductVariation[] ) => void;
+	onChange( values: PartialProductVariation[], showSuccess: boolean ): void;
 	onClose: () => void;
 };
 

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/types.ts
@@ -15,7 +15,7 @@ export type VariationsTableRowProps = {
 	isSelected?: boolean;
 	isSelectionDisabled?: boolean;
 	hideActionButtons?: boolean;
-	onChange( variation: PartialProductVariation ): void;
+	onChange( variation: PartialProductVariation, showSuccess: boolean ): void;
 	onDelete( variation: PartialProductVariation ): void;
 	onEdit( event: MouseEvent< HTMLAnchorElement > ): void;
 	onSelect( value: boolean ): void;

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
@@ -13,9 +13,10 @@ import {
 	useContext,
 	useMemo,
 } from '@wordpress/element';
+import { plus, info, Icon } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, info } from '@wordpress/icons';
 import classNames from 'classnames';
+import { MediaUpload } from '@wordpress/media-utils';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ import {
 } from '../../../utils';
 import { SingleUpdateMenu } from '../variation-actions-menus';
 import { VariationsTableRowProps } from './types';
+import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 
@@ -90,8 +92,11 @@ export function VariationsTableRow( {
 		[ variableAttributes, variation ]
 	);
 
-	function handleChange( values: PartialProductVariation[] ) {
-		onChange( values[ 0 ] );
+	function handleChange(
+		values: PartialProductVariation[],
+		showSuccess: boolean
+	) {
+		onChange( values[ 0 ], showSuccess );
 	}
 
 	function handleDelete( values: PartialProductVariation[] ) {
@@ -134,35 +139,79 @@ export function VariationsTableRow( {
 				) }
 			</div>
 			<div
-				className="woocommerce-product-variations__attributes"
+				className="woocommerce-product-variations__attributes-cell"
 				role="cell"
 			>
-				{ tags.map( ( tagInfo ) => {
-					const tag = (
-						<Tag
-							id={ tagInfo.id }
-							className="woocommerce-product-variations__attribute"
-							key={ tagInfo.id }
-							label={ truncate(
-								tagInfo.label,
-								PRODUCT_VARIATION_TITLE_LIMIT
+				<MediaUpload
+					value={ variation.id }
+					onSelect={ ( image ) =>
+						handleChange(
+							[
+								{
+									id: variation.id,
+									image:
+										mapUploadImageToImage( image ) ||
+										undefined,
+								},
+							],
+							false
+						)
+					}
+					allowedTypes={ [ 'image' ] }
+					multiple={ false }
+					render={ ( { open } ) => (
+						<Button
+							className={ classNames(
+								variation.image
+									? 'woocommerce-product-variations__image-button'
+									: 'woocommerce-product-variations__add-image-button'
 							) }
-							screenReaderLabel={ tagInfo.label }
-						/>
-					);
-
-					return tags.length <= PRODUCT_VARIATION_TITLE_LIMIT ? (
-						tag
-					) : (
-						<Tooltip
-							key={ tagInfo.id }
-							text={ tagInfo.label }
-							position="top center"
+							icon={ variation.image ? undefined : plus }
+							iconSize={ variation.image ? undefined : 16 }
+							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+							// @ts-ignore this exists in the props but is not typed
+							size="compact"
+							onClick={ open }
 						>
-							<span>{ tag }</span>
-						</Tooltip>
-					);
-				} ) }
+							{ variation.image && (
+								<img
+									className="woocommerce-product-variations__image"
+									src={ variation.image.src }
+									alt={ variation.image.alt }
+								/>
+							) }
+						</Button>
+					) }
+				/>
+
+				<div className="woocommerce-product-variations__attributes">
+					{ tags.map( ( tagInfo ) => {
+						const tag = (
+							<Tag
+								id={ tagInfo.id }
+								className="woocommerce-product-variations__attribute"
+								key={ tagInfo.id }
+								label={ truncate(
+									tagInfo.label,
+									PRODUCT_VARIATION_TITLE_LIMIT
+								) }
+								screenReaderLabel={ tagInfo.label }
+							/>
+						);
+
+						return tags.length <= PRODUCT_VARIATION_TITLE_LIMIT ? (
+							tag
+						) : (
+							<Tooltip
+								key={ tagInfo.id }
+								text={ tagInfo.label }
+								position="top center"
+							>
+								<span>{ tag }</span>
+							</Tooltip>
+						);
+					} ) }
+				</div>
 			</div>
 			<div
 				className={ classNames(

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -198,7 +198,10 @@ export const VariationsTable = forwardRef<
 			} );
 	}
 
-	function handleVariationChange( variation: PartialProductVariation ) {
+	function handleVariationChange(
+		variation: PartialProductVariation,
+		showSuccess = true
+	) {
 		onUpdate( variation )
 			.then( ( response ) => {
 				recordEvent( 'product_variations_change', {
@@ -206,9 +209,15 @@ export const VariationsTable = forwardRef<
 					product_id: productId,
 					variation_id: variation.id,
 				} );
-				createSuccessNotice(
-					getSnackbarText( response as ProductVariation, 'update' )
-				);
+				if ( showSuccess ) {
+					createSuccessNotice(
+						getSnackbarText(
+							response as ProductVariation,
+							'update'
+						)
+					);
+				}
+
 				onVariationTableChange( 'update', [ variation ] );
 			} )
 			.catch( () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Enable inline actions in the variations table for images 

I took some liberty with the original acceptance criteria. Since our "Choose an image" button opens the media library directly, I've done it the same on this functionality, for consistency.

Closes #47036 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Go to Variations tab
4. Add variation options
5. In the Variations section, check the newly added + button. Click one of them to add an image to the Variation.
6. You should be able to upload or select from the media library.
7. After confirming, check that the + button turns into a miniature of the image.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
