### PR TITLE
Prevent non used blocks to be registered in the product editor page

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-46502
+++ b/plugins/woocommerce/changelog/enhancement-46502
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Create a hook to filter the woocommerce blocks that can be registered

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -78,7 +78,7 @@ class Init {
 			add_action( 'rest_api_init', array( $this, 'register_layout_templates' ) );
 			add_action( 'rest_api_init', array( $this, 'register_user_metas' ) );
 
-			add_filter( 'register_block_type_args', array( $this, 'register_metadata_attribute' ) );			
+			add_filter( 'register_block_type_args', array( $this, 'register_metadata_attribute' ) );
 			add_filter( 'woocommerce_get_block_types', array( $this, 'get_block_types' ), 999, 1 );
 
 			// Make sure the block registry is initialized so that core blocks are registered.
@@ -453,14 +453,14 @@ class Init {
 
 	/**
 	 * Filters woocommerce block types.
-	 * 
+	 *
 	 * @param string[] $block_types Array of woocommerce block types.
 	 * @return array
 	 */
 	public function get_block_types( $block_types ) {
 		if ( PageController::is_admin_page() ) {
 			// Ignore all woocommerce blocks.
-			return [];
+			return array();
 		}
 
 		return $block_types;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -78,7 +78,8 @@ class Init {
 			add_action( 'rest_api_init', array( $this, 'register_layout_templates' ) );
 			add_action( 'rest_api_init', array( $this, 'register_user_metas' ) );
 
-			add_filter( 'register_block_type_args', array( $this, 'register_metadata_attribute' ) );
+			add_filter( 'register_block_type_args', array( $this, 'register_metadata_attribute' ) );			
+			add_filter( 'woocommerce_get_block_types', array( $this, 'get_block_types' ), 999, 1 );
 
 			// Make sure the block registry is initialized so that core blocks are registered.
 			BlockRegistry::get_instance();
@@ -448,5 +449,20 @@ class Init {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Filters woocommerce block types.
+	 * 
+	 * @param string[] $block_types Array of woocommerce block types.
+	 * @return array
+	 */
+	public function get_block_types( $block_types ) {
+		if ( PageController::is_admin_page() ) {
+			// Ignore all woocommerce blocks.
+			return [];
+		}
+
+		return $block_types;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -350,6 +350,13 @@ final class BlockTypesController {
 			);
 		}
 
+		/**
+		 * Filters the list of allowed block types.
+		 *
+		 * @since 9.0.0
+		 *
+		 * @param array $block_types List of block types.
+		 */
 		return apply_filters( 'woocommerce_get_block_types', $block_types );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -350,6 +350,6 @@ final class BlockTypesController {
 			);
 		}
 
-		return $block_types;
+		return apply_filters( 'woocommerce_get_block_types', $block_types );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #46502

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Deploy `enhancement/46502` and `trunk` branches in two different production like environments.
2. Make sure to have enable the new product editor experience from the woocommerce settings features.
3. Go to the Products > Add new page to visualize the new editor in both sites.
4. Open the Browser's DevTools in both sites.
5. Then go to Lighthouse tab.
6. Pick Desktop from the Device list
7. Click on Analyze page load button
8. Wait until the test runs in both sites and then compare the results

Before 
<img width="785" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/cf3a1112-65ad-41bc-a124-10a184f1b86a">

After
<img width="785" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/d29c19ce-e0d9-4475-bcb1-abe49faeb3cc">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
