### PR TITLE
[Launch Your Store] Fix failed to load coming-soon resources

### DIFF
--- a/plugins/woocommerce/changelog/47073-fix-coming-soon-assets-404
+++ b/plugins/woocommerce/changelog/47073-fix-coming-soon-assets-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix failed to load coming-soon resources

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ComingSoon.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ComingSoon.php
@@ -5,18 +5,39 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * ComingSoon class.
  */
 class ComingSoon extends AbstractBlock {
-		/**
-		 * Block name.
-		 *
-		 * @var string
-		 */
-		protected $block_name = 'coming-soon';
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'coming-soon';
 
-		/**
-		 * It is necessary to register and enqueue assets during the render phase because we want to load assets only if the block has the content.
-		 */
+	/**
+	 * It is necessary to register and enqueue assets during the render phase because we want to load assets only if the block has the content.
+	 */
 	protected function register_block_type_assets() {
 			parent::register_block_type_assets();
 			$this->register_chunk_translations( [ $this->block_name ] );
+	}
+
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ComingSoon.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ComingSoon.php
@@ -20,7 +20,6 @@ class ComingSoon extends AbstractBlock {
 			$this->register_chunk_translations( [ $this->block_name ] );
 	}
 
-
 	/**
 	 * Get the frontend style handle for this block type.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/47072

We created a ComingSoon Block type for the Launch Your Store feature. The block defaults to loading the coming-soon CSS/JS resources. However, we don't have those resources in the [coming-soon block](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-blocks/assets/js/blocks/coming-soon) and it causes 404 errors.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `launch-your-store` feature flag.
2. Go to `WooCommerce > Settings > Site Visibility` and enable `Coming soon` checkbox and save if it's not already enabled.
3. Open dev tools
4. Go to Frontend in incognito mode and check if there are no 404 errors for coming-soon resources.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
