### PR TITLE
Fix core profiler email field overlapping with continue button in mobile screen

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -417,6 +417,12 @@
 			height: 100%;
 			max-width: 404px;
 			width: 100%;
+
+			&:has(.woocommerce-profiler-geolocation-notice) {
+				@include breakpoint( "<782px" ) {
+					margin-bottom: 82px;
+				}
+			}
 		}
 
 		.woocommerce-profiler-question-label,
@@ -541,10 +547,6 @@
 			margin-bottom: 0;
 			padding-right: 0;
 			color: $gray-900;
-
-			@include breakpoint( "<782px" ) {
-				margin-bottom: 100px;
-			}
 
 			.components-notice__dismiss > svg {
 				height: 16px;

--- a/plugins/woocommerce/changelog/fix-core-profiler-email-field-overlapping
+++ b/plugins/woocommerce/changelog/fix-core-profiler-email-field-overlapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix core profiler email field is not positioned correctly in mobile screens


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46301.

Core profiler email address field is not positioned correctly in mobile screens when country warning is shown

This PR updates the CSS to fix the issue.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Setup Wizard
2. Continue until the `Tell us a bit about your store` step
3. Ensure there's automated country selection, if not you probably need to disable tracker blockers or privacy settings
4. Select a different country so the warning is shown
5. Reduce the screen width to mobile screen
6. Observe the email field is not overlapping with `Continue` button

<img src="https://github.com/woocommerce/woocommerce/assets/4344253/7e783a60-d132-43dd-8e99-9474636e6633" width="300px" />


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
