### PR TITLE
Try: Block insertion via HTML processor

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockInserter.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockInserter.php
@@ -29,7 +29,7 @@ class BlockInserter {
                 continue;
             }
 
-            $post->post_content = $this->get_content_with_block_insertions( $post->post_content );
+            $post->post_content = $this->get_content_with_block_insertions( $post->post_content, $post );
             $posts[ $index ]    = $post;
         }
 
@@ -39,10 +39,11 @@ class BlockInserter {
     /**
      * Get the post content with added block insertions.
      *
+     * @param string  $content Content.
      * @param WP_Post $post Post.
      * @return string
      */
-    private function get_content_with_block_insertions( $content ) {
+    private function get_content_with_block_insertions( $content, $post ) {
         $new_content = '';
         $p           = new \WP_HTML_Tag_Processor( $content );
 
@@ -58,8 +59,10 @@ class BlockInserter {
                                 'block_insertions',
                                 '',
                                 $block_name,
-                                $is_closer ? 'last_child' : 'before'
-                            )
+                                $is_closer ? 'last_child' : 'before',
+                                $post
+                            ),
+                            $post
                         );
                     }
 
@@ -71,8 +74,10 @@ class BlockInserter {
                                 'block_insertions',
                                 '',
                                 $block_name,
-                                $is_closer ? 'after' : 'first_child'
-                            )
+                                $is_closer ? 'after' : 'first_child',
+                                $post
+                            ),
+                            $post
                         );
                     }
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockInserter.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockInserter.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * WooCommerce Block Inserter
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+/**
+ * Class that assists in template extensibility and block insertion.
+ */
+class BlockInserter {
+
+    /**
+     * Init.
+     */
+    public function init() {
+        add_filter( 'posts_results', array( $this, 'extend_post_content' ) );
+    }
+
+    /**
+     * Extend the post content.
+     *
+     * @param array $posts Array of WP_Post
+     * @return array
+     */
+    public function extend_post_content( $posts ) {
+        foreach ( $posts as $index => $post ) {
+            if ( ! $post->post_content ) {
+                continue;
+            }
+
+            $post->post_content = $this->get_content_with_block_insertions( $post->post_content );
+            $posts[ $index ]    = $post;
+        }
+
+        return $posts;
+    }
+
+    /**
+     * Get the post content with added block insertions.
+     *
+     * @param WP_Post $post Post.
+     * @return string
+     */
+    private function get_content_with_block_insertions( $content ) {
+        $new_content = '';
+        $p           = new \WP_HTML_Tag_Processor( $content );
+
+        while( $p->next_token() ) {
+            switch ( $p->get_token_type() ) {
+                case '#comment':
+                    $block_name = $this->get_block_name_from_comment( $p->get_modifiable_text() );
+                    $is_closer  = strpos( $p->get_modifiable_text(), ' /wp:' ) === 0;
+
+                    if ( $block_name ) {
+                        $new_content   .= $this->get_content_with_block_insertions(
+                            apply_filters(
+                                'block_insertions',
+                                '',
+                                $block_name,
+                                $is_closer ? 'last_child' : 'before'
+                            )
+                        );
+                    }
+
+                    $new_content   .= '<!--' . $p->get_modifiable_text() . '-->';
+
+                    if ( $block_name ) {
+                        $new_content   .= $this->get_content_with_block_insertions(
+                            apply_filters(
+                                'block_insertions',
+                                '',
+                                $block_name,
+                                $is_closer ? 'after' : 'first_child'
+                            )
+                        );
+                    }
+
+                    break;
+                case '#tag':
+                    $new_content .= ! $p->is_tag_closer()
+                        ? '<' . strtolower( $p->get_tag() ) . '>'
+                        : '</' . strtolower( $p->get_tag() ) . '>';
+                    break;
+                case '#text':
+                    $new_content .= $p->get_modifiable_text();
+                    break;
+            }
+        }
+
+        return $new_content;
+    }
+
+    /**
+     * Get a block name from a comment.
+     *
+     * @param string $comment_text Comment text.
+     * @return string|bool
+     */
+    private function get_block_name_from_comment( $comment_text ) {
+        preg_match( '/wp:([a-z_\-\/]*)/i', $comment_text, $matches );
+
+        if ( isset( $matches[1] ) ) {
+            return $matches[1];
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a comment is a block tag closer.
+     *
+     * @param string $comment_text Comment text.
+     * @return bool
+     */
+    private function is_block_tag_closer( $comment_text ) {
+        return strpos( $comment_text, ' /wp:' ) === 0;
+    }
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockInserter.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockInserter.php
@@ -84,7 +84,7 @@ class BlockInserter {
                     break;
                 case '#tag':
                     $new_content .= ! $p->is_tag_closer()
-                        ? '<' . strtolower( $p->get_tag() ) . '>'
+                        ? '<' . strtolower( $p->get_tag() ) . $this->get_attributes_string( $p ) . '>'
                         : '</' . strtolower( $p->get_tag() ) . '>';
                     break;
                 case '#text':
@@ -94,6 +94,26 @@ class BlockInserter {
         }
 
         return $new_content;
+    }
+
+    /**
+     * Get the attributes string used in tags.
+     *
+     * @param \WP_HTML_Tag_Processor $p WP HTML Tag Processor.
+     * @return string
+     */
+    public function get_attributes_string( $p ) {
+        $string = '';
+
+        if ( ! method_exists( $p, 'get_attributes' ) ) {
+            return $string;
+        }
+
+        $html   = $p->get_updated_html();
+        foreach ( $p->get_attributes() as $attribute ) {
+            $string .= ' ' . substr( $html, $attribute->start, $attribute->length );
+        }
+        return $string;
     }
 
     /**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -86,6 +86,9 @@ class Init {
 			$tracks = new Tracks();
 			$tracks->init();
 
+			$block_inserter = new BlockInserter();
+			$block_inserter->init();
+
 			$this->register_product_templates();
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Attempts to insert blocks by parsing the comment delimited format of blocks and allow direct insertion of content (HTML or blocks).  This is an alternative to blocks and one that would need to be maintained separately so that requires a good amount of consideration, but I wanted to see what this might look like.

The three primary advantages to this are:

1. Higher level of control and allowing insertion of HTML for 3PDs (3PDs seem to want this, but the downsides of this need to be debated since it could lead to inconsistent UI).
2. Quick insertion of nested blocks that don't result in multiple tedious calls (e.g. column insertion).
3. We can insert blocks on previously inserted blocks

This PR does not address:

* Alias/variation names for blocks
* Missing attributes and incomplete parsing of HTML
* Metadata properties to ignore previously inserted blocks

<img width="674" alt="Screenshot 2024-05-01 at 8 18 05 AM" src="https://github.com/woocommerce/woocommerce/assets/10561050/23f05a59-db29-494c-9bee-8619001e231b">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a post with a couple blocks, including a heading
2. Add the following snippet to a plugin:
```php
add_filter( 'block_insertions', function( $content, $block_name, $position ) {
	$content_to_insert = <<<HTML
		<!-- wp:columns -->
		<div class="wp-block-columns">
			<!-- wp:column {"width":"50%"} -->
			<div class="wp-block-column" style="flex-basis:50%">
				<!-- wp:paragraph --><p>Test insertion column 1</p><!-- /wp:paragraph -->
			</div>
			<!-- /wp:column -->
			<!-- wp:column {"width":"50%"} -->
			<div class="wp-block-column" style="flex-basis:50%">
				<!-- wp:paragraph --><p>Test insertion column 2</p><!-- /wp:paragraph -->
			</div>
			<!-- /wp:column -->
		</div>
		<!-- /wp:columns -->
HTML;

	if ( $block_name === 'heading' && $position === 'after' ) {
		$content .= $content_to_insert;
	}
	return $content;
}, 10, 3 );
```
3. See that the columns have been inserted in your post

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
