### PR TITLE
Add some unit tests to cover changes in PR 46972

### DIFF
--- a/plugins/woocommerce/changelog/tests-test-46972
+++ b/plugins/woocommerce/changelog/tests-test-46972
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Only adding a few unit tests to our code to cover the changes in PR 46972.
+
+

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -410,7 +410,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	public function test_query_s_argument() {
 		$order1 = new \WC_Order();
 		$order1->set_billing_first_name( '%ir Woo' );
-		$order1->set_billing_email( 'test_user@woo.test' );
+		$order1->set_billing_email( 'test_user+shop@woo.test' );
 		$order1->save();
 
 		$order2 = new \WC_Order();
@@ -433,6 +433,22 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$query_args['s'] = 'test_user';
 		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
+
+		$query_args['s'] = 'test_user+shop';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
+
+		$query_args['s'] = 'test_user+shop@woo.test';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
+
+		$query_args['s'] = urlencode( 'test_user+shop@woo.test' );
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertCount( 0, $query->orders );
+
+		$query_args['s'] = 'other_user';
+		$query           = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order2->get_id() ), $query->orders );
 
 		$query_args['s'] = 'woo.test';
 		$query           = new OrdersTableQuery( $query_args );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -442,7 +442,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
 
-		$query_args['s'] = urlencode( 'test_user+shop@woo.test' );
+		$query_args['s'] = rawurlencode( 'test_user+shop@woo.test' );
 		$query           = new OrdersTableQuery( $query_args );
 		$this->assertCount( 0, $query->orders );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In #46972 we fixed an issue with HPOS searches and terms including possibly url-encoded characters. This PR adds some unit tests to cover those changes.
It's basically a failing test for the prior behavior.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

From within the `plugins/woocommerce` directory:

1. Run the new tests and make sure they pass:
   ```vendor/bin/phpunit --filter=test_query_s_argument```
   or (if using wpenv)
   ```pnpm test:php:env --filter=test_query_s_argument```
1. (Optional) Confirm the tests don't pass in 8.8.3 (which has the bug):
   ```
   git co 8.8.3
   git co tests/test-46972 -- tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
   vendor/bin/phpunit --filter=test_query_s_argument
   ```
   If you do this, reset the local changes by running `git reset --hard`.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
