### PR TITLE
Order-pay can also use the session choosen gateway

### DIFF
--- a/plugins/woocommerce/changelog/47100-order-pay-can-use-session-choosen-gateway
+++ b/plugins/woocommerce/changelog/47100-order-pay-can-use-session-choosen-gateway
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Order-pay page can also use the session choosen gateway

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -195,11 +195,8 @@ class WC_Shortcode_Checkout {
 				);
 				WC()->customer->save();
 
-				$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-
-				if ( count( $available_gateways ) ) {
-					current( $available_gateways )->set_current();
-				}
+				$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+				WC()->payment_gateways()->set_current_gateway( $available_gateways );
 
 				/**
 				 * Allows the text of the submit button on the Pay for Order page to be changed.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:
Order pay should work similarly to how the  checkout payment works, by allowing to set / retrieve a potential session "chosen_payment_method".

I copied the line from `woocommerce_checkout_payment() ` method.

### How to test the changes in this Pull Request:
1) create an order, but don't pay for it
2) retrieve the pay link
3) in functions.php
```php
        $available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
        $payment_method = current($available_gateways); // Play with this to select the method
        if (!wc()->session) {
            wc()->initialize_session();
        }
        WC()->session->set('chosen_payment_method', $payment_method);
```
4) verify the right payment method is selected in form

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Order-pay page can also use the session choosen gateway

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
