### PR TITLE
Try: Register variants of generic product editor blocks.

### DIFF
--- a/packages/js/product-editor/src/blocks/generic/checkbox/another-block.json
+++ b/packages/js/product-editor/src/blocks/generic/checkbox/another-block.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "woocommerce/variant-product-checkbox-field",
-	"title": "Product checkbox control (variant)",
+	"name": "woocommerce/another-product-checkbox-field",
+	"title": "Product checkbox control (New Block)",
 	"category": "woocommerce",
 	"description": "A reusable checkbox for the product editor.",
 	"keywords": [ "products", "checkbox", "input" ],

--- a/packages/js/product-editor/src/blocks/generic/checkbox/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/checkbox/index.ts
@@ -2,13 +2,12 @@
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
-import variantBlockConfiguration from './variant-block.json';
+import anotherBlockConfiguration from './another-block.json';
 import { Edit } from './edit';
 import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
-const { name: variantBlockName, ...variantBlockMetadata } =
-	variantBlockConfiguration;
+const { name: anotherName, ...anotherBlockMetadata } = anotherBlockConfiguration;
 
 export { metadata, name };
 
@@ -17,7 +16,7 @@ export const settings = {
 	edit: Edit,
 };
 
-export const variantSettings = {
+export const anotherSettings = {
 	example: {},
 	edit: Edit,
 };
@@ -29,8 +28,8 @@ export const init = () => {
 		settings: settings as never,
 	} );
 	registerProductEditorBlockType( {
-		name: variantBlockName,
-		metadata: variantBlockMetadata as never,
-		settings: variantSettings as never,
+		name: anotherName,
+		metadata: anotherBlockMetadata as never,
+		settings: anotherSettings as never,
 	} );
 };

--- a/packages/js/product-editor/src/blocks/generic/checkbox/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/checkbox/index.ts
@@ -2,10 +2,13 @@
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
+import variantBlockConfiguration from './variant-block.json';
 import { Edit } from './edit';
 import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
+const { name: variantBlockName, ...variantBlockMetadata } =
+	variantBlockConfiguration;
 
 export { metadata, name };
 
@@ -14,9 +17,20 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () =>
+export const variantSettings = {
+	example: {},
+	edit: Edit,
+};
+
+export const init = () => {
 	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,
 	} );
+	registerProductEditorBlockType( {
+		name: variantBlockName,
+		metadata: variantBlockMetadata as never,
+		settings: variantSettings as never,
+	} );
+};

--- a/packages/js/product-editor/src/blocks/generic/checkbox/variant-block.json
+++ b/packages/js/product-editor/src/blocks/generic/checkbox/variant-block.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/variant-product-checkbox-field",
+	"title": "Product checkbox control (variant)",
+	"category": "woocommerce",
+	"description": "A reusable checkbox for the product editor.",
+	"keywords": [ "products", "checkbox", "input" ],
+	"textdomain": "default",
+	"attributes": {
+		"title": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"label": {
+			"type": "string"
+		},
+		"property": {
+			"type": "string"
+		},
+		"tooltip": {
+			"type": "string"
+		},
+		"checkedValue": {
+			"type": "string"
+		},
+		"uncheckedValue": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"editorStyle": "file:./editor.css",
+	"usesContext": [ "postType" ]
+}

--- a/packages/js/product-editor/webpack.config.js
+++ b/packages/js/product-editor/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
 		new CopyWebpackPlugin( {
 			patterns: [
 				{
-					from: './src/**/block.json',
+					from: './src/**/*block.json',
 					to( { absoluteFilename } ) {
 						const blockMetaData = getBlockMetaData(
 							path.resolve( __dirname, absoluteFilename )

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -27,7 +27,6 @@ class BlockRegistry {
 	const GENERIC_BLOCKS = array(
 		'woocommerce/conditional',
 		'woocommerce/product-checkbox-field',
-		'woocommerce/product-checkbox-field',
 		'woocommerce/product-collapsible',
 		'woocommerce/product-radio-field',
 		'woocommerce/product-pricing-field',

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -1005,6 +1005,29 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				),
 			)
 		);
+
+		$product_inventory_advanced_wrapper->add_block(
+			array(
+				'id'         => 'product-limit-purchase-2',
+				'blockName'  => 'woocommerce/variant-product-checkbox-field',
+				'order'      => 20,
+				'attributes' => array(
+					'title'    => __(
+						'Restrictions',
+						'woocommerce'
+					),
+					'label'    => __(
+						'Limit purchases to 1 item per order',
+						'woocommerce'
+					),
+					'property' => 'sold_individually',
+					'tooltip'  => __(
+						'When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods.',
+						'woocommerce'
+					),
+				),
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -1009,18 +1009,18 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		$product_inventory_advanced_wrapper->add_block(
 			array(
 				'id'         => 'product-limit-purchase-2',
-				'blockName'  => 'woocommerce/variant-product-checkbox-field',
+				'blockName'  => 'woocommerce/another-product-checkbox-field',
 				'order'      => 20,
 				'attributes' => array(
 					'title'    => __(
-						'Restrictions (Variant)',
+						'Restrictions (Newly Registered Block)',
 						'woocommerce'
 					),
 					'label'    => __(
 						'Limit purchases to 1 item per order',
 						'woocommerce'
 					),
-					'property' => 'sold_individually_variant',
+					'property' => 'sold_individually_secondary',
 					'tooltip'  => __(
 						'When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods.',
 						'woocommerce'

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -1013,14 +1013,14 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'order'      => 20,
 				'attributes' => array(
 					'title'    => __(
-						'Restrictions',
+						'Restrictions (Variant)',
 						'woocommerce'
 					),
 					'label'    => __(
 						'Limit purchases to 1 item per order',
 						'woocommerce'
 					),
-					'property' => 'sold_individually',
+					'property' => 'sold_individually_variant',
 					'tooltip'  => __(
 						'When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods.',
 						'woocommerce'


### PR DESCRIPTION
This PR registers a new block type based on a second `new-block.json` in the original block definition directory but shares the same code as the original. One thing that is outstanding here is providing an interface for 3PDs to register their own from their plugin/theme based on the original block.

## Example usage with Block Hooks API

Currently block hooks will not work with this PR because the templates are not being loaded via the standard templates API. However this is how with a newly created block you might use block hooks.

```php

function register_loginout_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'woocommerce/another-product-checkbox-field' && $position === 'after' ) {
		$hooked_blocks[] = 'some-plugin/custom-product-checkbox-field';
	}

	return $hooked_blocks;
}
```

### Testing:

**See the existing example in this PR:**

Variant checkbox is present under Simple Product > Inventory > Advanced dropdown

![Screenshot 2024-05-02 at 13 25 23](https://github.com/woocommerce/woocommerce/assets/8639742/60252678-4a5b-472a-a980-024f8f6734a7)

#### Create a new block

* Go to `packages/js/product-editor/src/blocks/generic` and create another `variant-one-block.json` file for your generic block
* Within `index.ts` import the metadata and register the new block
* Go to `plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php` and add your new block using the block name.
* Build project and load the new editor to view it in a simple product.