### PR TITLE
Fix missing shipping recommendation task

### DIFF
--- a/plugins/woocommerce/changelog/fix-missing-shipping-recommendation-task
+++ b/plugins/woocommerce/changelog/fix-missing-shipping-recommendation-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing shipping-recommendation task

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -417,7 +417,7 @@ class TaskList {
 
 		// We have no use for hidden lists, it's expensive to compute individual tasks completion.
 		// Exception: Secret tasklist is always hidden.
-		if ( $this->is_visible() || $this->id === 'secret_tasklist' ) {
+		if ( $this->is_visible() || 'secret_tasklist' === $this->id ) {
 			foreach ( $this->tasks as $task ) {
 				$json = $task->get_json();
 				if ( $json['canView'] ) {

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -416,7 +416,8 @@ class TaskList {
 		$tasks_json = array();
 
 		// We have no use for hidden lists, it's expensive to compute individual tasks completion.
-		if ( $this->is_visible() ) {
+		// Exception: Secret tasklist is always hidden.
+		if ( $this->is_visible() || $this->id === 'secret_tasklist' ) {
 			foreach ( $this->tasks as $task ) {
 				$json = $task->get_json();
 				if ( $json['canView'] ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Addresses https://github.com/woocommerce/woocommerce/pull/46929#issuecomment-2090374283 where clicking on `Get Started` on WCS&T recommendation navigates to a blank screen

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Set up a fresh store, go through setup wizard and select a US state as the store location and complete setup without installing plugins
4. Click on `Review shipping options`
5. Hide spotlight tour
6. Click on `Get started`
7. Observe you're redirected to shipping task

![trDI6t.png](https://github.com/woocommerce/woocommerce/assets/3747241/8eb6d9f4-a001-4fe2-9462-d9371c2bfd27)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>