### PR TITLE
Update the version number of some methods in AbstractTemplateCompatibility

### DIFF
--- a/plugins/woocommerce/changelog/update-class-property-since-tbd
+++ b/plugins/woocommerce/changelog/update-class-property-since-tbd
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update the version number of some methods in AbstractTemplateCompatibility

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -29,13 +29,13 @@ abstract class AbstractTemplateCompatibility {
 
 		add_filter(
 			'render_block_data',
-			function( $parsed_block, $source_block, $parent_block ) {
+			function ( $parsed_block, $source_block, $parent_block ) {
 				/**
 				* Filter to disable the compatibility layer for the blockified templates.
 				*
 				* This hook allows to disable the compatibility layer for the blockified templates.
 				*
-				* @since TBD
+				* @since 7.6.0
 				* @param boolean.
 				*/
 				$is_disabled_compatility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
@@ -45,7 +45,6 @@ abstract class AbstractTemplateCompatibility {
 				}
 
 				return $this->update_render_block_data( $parsed_block, $source_block, $parent_block );
-
 			},
 			10,
 			3
@@ -59,7 +58,7 @@ abstract class AbstractTemplateCompatibility {
 				*
 				* This hook allows to disable the compatibility layer for the blockified.
 				*
-				* @since TBD
+				* @since 7.6.0
 				* @param boolean.
 				*/
 				$is_disabled_compatility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Small PR replacing two `@since TBD` with the correct WooCommerce version.

For reference, those methods were introduced in https://github.com/woocommerce/woocommerce-blocks/pull/8442, which was merged into WC Blocks 9.8.0, which was released with WC core 7.6.0.

Closes https://github.com/woocommerce/woocommerce/issues/46874.

### How to test the changes in this Pull Request:

_(No need to test during the release)_

1. Make sure the version number is correct.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
