### PR TITLE
Select a shipping rate after they load 

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -43,7 +43,9 @@ const PackageRates = ( {
 			return selectedRateId;
 		}
 		// Default to first rate if no rate is selected.
-		return rates[ 0 ]?.rate_id;
+		if ( rates.length > 0 ) {
+			return rates[ 0 ].rate_id;
+		}
 	} );
 
 	// Update the selected option if cart state changes in the data store.
@@ -57,20 +59,21 @@ const PackageRates = ( {
 		}
 	}, [ selectedRateId, selectedOption, previousSelectedRateId ] );
 
+	// Update the selected option if there is no rate selected on mount.
+	useEffect( () => {
+		// The useState callback run only once, so we need this to update it right fetching new rates.
+		if ( ! selectedOption && rates.length > 0 ) {
+			setSelectedOption( rates[ 0 ].rate_id );
+			onSelectRate( rates[ 0 ].rate_id );
+		}
+	}, [ onSelectRate, rates, selectedOption ] );
+
 	// Update the data store when the local selected rate changes.
 	useEffect( () => {
 		if ( selectedOption ) {
 			onSelectRate( selectedOption );
 		}
 	}, [ onSelectRate, selectedOption ] );
-
-	// Update the selected option if there is no rate selected on mount.
-	useEffect( () => {
-		if ( ! selectedOption && rates.length > 0 ) {
-			setSelectedOption( rates[ 0 ].rate_id );
-			onSelectRate( rates[ 0 ].rate_id );
-		}
-	}, [ onSelectRate, rates, selectedOption ] );
 
 	if ( rates.length === 0 ) {
 		return noResultsMessage;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -64,6 +64,14 @@ const PackageRates = ( {
 		}
 	}, [ onSelectRate, selectedOption ] );
 
+	// Update the selected option if there is no rate selected on mount.
+	useEffect( () => {
+		if ( ! selectedOption && rates.length > 0 ) {
+			setSelectedOption( rates[ 0 ].rate_id );
+			onSelectRate( rates[ 0 ].rate_id );
+		}
+	}, [ onSelectRate, rates, selectedOption ] );
+
 	if ( rates.length === 0 ) {
 		return noResultsMessage;
 	}

--- a/plugins/woocommerce/changelog/47120-fix-select-shipping-rate-after-loading
+++ b/plugins/woocommerce/changelog/47120-fix-select-shipping-rate-after-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Select the first shipping rate when local pickup is enabled and customer switches to shipping.


### PR DESCRIPTION

When switching from Local Pickup to Shipping options set, Local pickup is still selected. However, once you add an address and rates are returned, the first rate should be selected, but it's still stuck at local pickup. This PR fixes it.

Closes https://github.com/woocommerce/woocommerce/issues/47115

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Local Pickup with a location and Enable shipping rates for specific countries (Europe for example.
2. Set store default location to US, and set customer default location to store location.
3. On an incognito window, go to Checkout, see that Local Pickup is selected.
4. Switch to shipping, see that there are not rates and local pickup is still selected, change the address to one in europe.
5. Notice that the server returns rates and the first one is selected after that.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Select the first shipping rate when local pickup is enabled and customer switches to shipping.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
