### PR TITLE
Fix Merchant → Mini Cart in FSE editor can only be inserted once test

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.side_effects.spec.ts
@@ -51,13 +51,6 @@ test.describe( 'Merchant → Mini Cart', () => {
 				.getByLabel( 'Search for blocks and patterns' )
 				.fill( blockData.slug );
 
-			// Await for blocks commercial to be loaded in the Blocks inserter.
-			await expect(
-				editorUtils.page.locator(
-					'.block-directory-downloadable-block-list-item__details'
-				)
-			).toBeVisible();
-
 			const miniCartButton = editorUtils.page.getByRole( 'option', {
 				name: blockData.name,
 			} );

--- a/plugins/woocommerce/changelog/fix-mini-cart-block-merchant-only-once-test
+++ b/plugins/woocommerce/changelog/fix-mini-cart-block-merchant-only-once-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Merchant → Mini Cart in FSE editor can only be inserted once test
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the test _Merchant → Mini Cart in FSE editor can only be inserted once,_ which was failing because it couldn't find an element with selector `.block-directory-downloadable-block-list-item__details`.

This is partially reverting https://github.com/woocommerce/woocommerce/pull/46478. I'm a bit confused but in my tests sites the _Available to install_ section in the inserter doesn't load when searching for `woocommerce/mini-cart` in the block inserter.

### How to test the changes in this Pull Request:

_(No need to tests in the release)_

1. Verify the Mini-Cart block tests pass.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
