### PR TITLE
Override `get_edit_post_link()` URL for HPOS placeholder posts

### DIFF
--- a/plugins/woocommerce/changelog/fix-45806
+++ b/plugins/woocommerce/changelog/fix-45806
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Return HPOS edit links for calls to `get_edit_post_link()` on placeholder posts.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -145,6 +145,7 @@ class CustomOrdersTableController {
 		self::add_action( 'woocommerce_sections_advanced', array( $this, 'sync_now' ) );
 		self::add_filter( 'removable_query_args', array( $this, 'register_removable_query_arg' ) );
 		self::add_action( 'woocommerce_register_feature_definitions', array( $this, 'add_feature_definition' ) );
+		self::add_filter( 'get_edit_post_link', array( $this, 'maybe_rewrite_order_edit_link' ), 10, 2 );
 	}
 
 	/**
@@ -697,5 +698,23 @@ class CustomOrdersTableController {
 	 */
 	private function get_orders_pending_sync_count(): int {
 		return $this->data_synchronizer->get_sync_status()['current_pending_count'];
+	}
+
+	/**
+	 * Rewrites post edit links for HPOS placeholder posts so that they go to the HPOS order itself.
+	 * Hooked onto `get_edit_post_link`.
+	 *
+	 * @since 9.0.0
+	 *
+	 * @param string $link    The edit link.
+	 * @param int    $post_id Post ID.
+	 * @return string
+	 */
+	private function maybe_rewrite_order_edit_link( $link, $post_id ) {
+		if ( DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE === get_post_type( $post_id ) ) {
+			$link = OrderUtil::get_order_admin_edit_url( $post_id );
+		}
+
+		return $link;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Since we moved to HPOS `get_edit_post_link( $order_id )` will either return an empty string (when sync mode is disabled) or a CPT URL (when sync is enabled). In the latter case, our redirection code makes that a valid URL as it gets redirected to the HPOS edit screen. In the former case, however, you get... well... an empty string, since placeholders are not really "editable".

This PR tries to makes things easier for 3rd party code by rewriting the URL you get for placeholder posts so that it points to the corresponding HPOS order edit screen.

Closes #45806.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Settings > Advanced > Features and make sure HPOS is enabled and compatibility mode is disabled. If a sync is necessary, run `wp wc hpos sync` to sync orders.
2. Run `wp wc hpos cleanup all` to remove legacy data for all orders. This turns the corresponding posts into placeholders.
3. If there are no orders on your site, create an order first in WC > Orders > Add Order (or by placing one on the frontend).
4. Go to WC > Orders and take note of an order ID. 
5. Run the following command on the CLI:
   ```
   wp eval "echo get_edit_post_link( <order_id> );" --user=<user_id>
   ```

   Replace `<order_id>` with the order ID from step 4 and `<user_id>` with an admin user (or some other with enough permissions).
6. Copy & paste the resulting URL to your browser's address bar and make sure you're taken to the order edit page for `<order_id>`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
