### PR TITLE
Update tsconfigs to explicitly include files to avoid TS build errors

### DIFF
--- a/packages/js/admin-e2e-tests/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/admin-e2e-tests/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/admin-e2e-tests/tsconfig.json
+++ b/packages/js/admin-e2e-tests/tsconfig.json
@@ -1,11 +1,9 @@
 {
 	"extends": "../tsconfig.json",
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
-	"rootDir": "src",
-			"outDir": "build",
-			"typeRoots": [
-				"./typings",
-				"./node_modules/@types"
-			]
+		"rootDir": "src",
+		"outDir": "build",
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/admin-layout/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/admin-layout/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/admin-layout/tsconfig.json
+++ b/packages/js/admin-layout/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/ai/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/ai/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/ai/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/ai/changelog/47156-dev-fix-build-error-build-style
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
-

--- a/packages/js/ai/tsconfig.json
+++ b/packages/js/ai/tsconfig.json
@@ -7,7 +7,13 @@
 		"declarationMap": true,
 		"declarationDir": "./build-types",
 		"resolveJsonModule": true,
-		"typeRoots": [ "./node_modules/@types" ]
+		"typeRoots": [
+			"./node_modules/@types"
+		]
 	},
-	"include": [ "**/*.d.ts", "src/**/*", "src/**/*.json" ]
+	"include": [
+		"**/*.d.ts",
+		"src/**/*",
+		"src/**/*.json"
+	]
 }

--- a/packages/js/ai/tsconfig.json
+++ b/packages/js/ai/tsconfig.json
@@ -7,13 +7,7 @@
 		"declarationMap": true,
 		"declarationDir": "./build-types",
 		"resolveJsonModule": true,
-		"typeRoots": [
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./node_modules/@types" ]
 	},
-	"include": [
-		"**/*.d.ts",
-		"src/**/*",
-		"src/**/*.json"
-	]
+	"include": [ "**/*.d.ts", "src/**/*", "src/**/*.json" ]
 }

--- a/packages/js/components/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/components/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/components/tsconfig.json
+++ b/packages/js/components/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/csv-export/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/csv-export/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/csv-export/tsconfig.json
+++ b/packages/js/csv-export/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/currency/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/currency/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/currency/tsconfig.json
+++ b/packages/js/currency/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/**/*" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/currency/tsconfig.json
+++ b/packages/js/currency/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "../tsconfig",
-	"include": [ "src/**/*" ],
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",

--- a/packages/js/customer-effort-score/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/customer-effort-score/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/customer-effort-score/tsconfig.json
+++ b/packages/js/customer-effort-score/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "../tsconfig",
-	"include": [ "src/" ],
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",

--- a/packages/js/customer-effort-score/tsconfig.json
+++ b/packages/js/customer-effort-score/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/explat/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/explat/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/explat/tsconfig.json
+++ b/packages/js/explat/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/expression-evaluation/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/expression-evaluation/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/expression-evaluation/tsconfig.json
+++ b/packages/js/expression-evaluation/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/internal-js-tests/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/internal-js-tests/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/internal-js-tests/tsconfig.json
+++ b/packages/js/internal-js-tests/tsconfig.json
@@ -1,11 +1,9 @@
 {
 	"extends": "../tsconfig.json",
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/navigation/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/navigation/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/navigation/tsconfig.json
+++ b/packages/js/navigation/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/notices/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/notices/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/notices/tsconfig.json
+++ b/packages/js/notices/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/number/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/number/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/number/tsconfig.json
+++ b/packages/js/number/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/onboarding/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/onboarding/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/onboarding/tsconfig.json
+++ b/packages/js/onboarding/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }

--- a/packages/js/tracks/changelog/47156-dev-fix-build-error-build-style
+++ b/packages/js/tracks/changelog/47156-dev-fix-build-error-build-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings directories.
+

--- a/packages/js/tracks/tsconfig.json
+++ b/packages/js/tracks/tsconfig.json
@@ -1,14 +1,12 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In some packages a build-style.js file is built at root, then when TS tries to compile it, it fails with an error like:

```
│ . build:project: . build:project:esm: error TS5055: Cannot write file '<redacted>/woocommerce/packages/js/experimental/build-style.js' because it would overwrite input file.
│ . build:project: . build:project:esm: error TS6059: File '<redacted>/woocommerce/packages/js/experimental/build-style.js' is not under 'rootDir' '<redacted>/wo…
│ . build:project: . build:project:esm:   The file is in the program because:
│ . build:project: . build:project:esm:     Matched by default include pattern '**/*'
│ . build:project: . build:project:esm: ❌ [build:project:esm] exited with exit code 1.
│ . build:project: . build:project:esm: ❌ 1 script failed.
```

These build-style files are [built by webpack](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/experimental/webpack.config.js#L9). So it could be an intermittent error because of webpack build being run in parallel with the esm build. If webpack finishes first, TS will try to compile with the build-style file present.

TSConfig's `rootDir`, is not too well named and it's purpose is not to define which files should be compiled. That is the job of `include`.

I've updated packages that do not have an include to include the src and typings directories to ensure this build error never happens. And furthermore any other root directory generated JS files will not get mistakenly compiled by TSC without explicit opt in.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I believe a successful build and E2E tests should be enough here, but it would be great if the tester could double check the directories I've chosen for the `include`. I have checked them, but mistakes are possible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fix a persistent build bug where TS would try compile files outside of src and typings directories.
</details>
