### PR TITLE
Checkout: fix a bug where the local pickup / shipping buttons are rendered incorrectly in the editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -4,12 +4,7 @@
  */
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import {
-	PanelBody,
-	ToggleControl,
-	__experimentalRadio as Radio,
-	__experimentalRadioGroup as RadioGroup,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Icon, store, shipping } from '@wordpress/icons';
 import { ADMIN_URL, getSetting } from '@woocommerce/settings';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -18,6 +18,7 @@ import {
 	useBlockProps,
 	RichText,
 } from '@wordpress/block-editor';
+import Button from '@woocommerce/base-components/button';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -45,17 +46,18 @@ const LocalPickupSelector = ( {
 	showIcon,
 	toggleText,
 	setAttributes,
+	onClick,
 }: {
 	checked: string;
 	rate: minMaxPrices;
 	showPrice: boolean;
 	showIcon: boolean;
 	toggleText: string;
+	onClick: () => void;
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ) => {
 	return (
-		<Radio
-			value="pickup"
+		<Button
 			className={ classnames(
 				'wc-block-checkout__shipping-method-option',
 				{
@@ -63,6 +65,8 @@ const LocalPickupSelector = ( {
 						checked === 'pickup',
 				}
 			) }
+			onClick={ onClick }
+			removeTextWrap
 		>
 			{ showIcon === true && (
 				<Icon
@@ -85,7 +89,7 @@ const LocalPickupSelector = ( {
 			{ showPrice === true && (
 				<RatePrice minRate={ rate.min } maxRate={ rate.max } />
 			) }
-		</Radio>
+		</Button>
 	);
 };
 
@@ -96,6 +100,7 @@ const ShippingSelector = ( {
 	showIcon,
 	toggleText,
 	setAttributes,
+	onClick,
 }: {
 	checked: string;
 	rate: minMaxPrices;
@@ -103,6 +108,7 @@ const ShippingSelector = ( {
 	showIcon: boolean;
 	toggleText: string;
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
+	onClick: () => void;
 } ) => {
 	const Price =
 		rate.min === undefined ? (
@@ -114,8 +120,7 @@ const ShippingSelector = ( {
 		);
 
 	return (
-		<Radio
-			value="shipping"
+		<Button
 			className={ classnames(
 				'wc-block-checkout__shipping-method-option',
 				{
@@ -123,6 +128,8 @@ const ShippingSelector = ( {
 						checked === 'shipping',
 				}
 			) }
+			onClick={ onClick }
+			removeTextWrap
 		>
 			{ showIcon === true && (
 				<Icon
@@ -143,7 +150,7 @@ const ShippingSelector = ( {
 				preserveWhiteSpace
 			/>
 			{ showPrice === true && Price }
-		</Radio>
+		</Button>
 	);
 };
 
@@ -271,18 +278,19 @@ export const Edit = ( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<RadioGroup
+			<div
 				id="shipping-method"
 				className="wc-block-checkout__shipping-method-container"
-				label="options"
-				onChange={ changeView }
-				checked={ prefersCollection ? 'pickup' : 'shipping' }
+				role="radiogroup"
 			>
 				<ShippingSelector
 					checked={ prefersCollection ? 'pickup' : 'shipping' }
 					rate={ getShippingPrices(
 						shippingRates[ 0 ]?.shipping_rates
 					) }
+					onClick={ () => {
+						changeView( 'shipping' );
+					} }
 					showPrice={ showPrice }
 					showIcon={ showIcon }
 					setAttributes={ setAttributes }
@@ -294,11 +302,14 @@ export const Edit = ( {
 						shippingRates[ 0 ]?.shipping_rates
 					) }
 					showPrice={ showPrice }
+					onClick={ () => {
+						changeView( 'pickup' );
+					} }
 					showIcon={ showIcon }
 					setAttributes={ setAttributes }
 					toggleText={ localPickupText }
 				/>
-			</RadioGroup>
+			</div>
 			<AdditionalFields block={ innerBlockAreas.SHIPPING_METHOD } />
 		</FormStepBlock>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -6,7 +6,7 @@
 }
 
 .edit-post-visual-editor
-.wc-block-components-button.wc-block-checkout__shipping-method-option,
+	.wc-block-components-button.wc-block-checkout__shipping-method-option,
 .wc-block-components-button.wc-block-checkout__shipping-method-option {
 	flex-grow: 1;
 	display: flex;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -5,6 +5,16 @@
 	justify-content: space-between;
 }
 
+// This nested selector is solely for specificity to override a quite specific style set in the button component.
+// We have avoided nesting all the styles in case specificity changes introduce regressions elsewhere.
+.edit-post-visual-editor {
+	.wc-block-checkout__shipping-method-container {
+		.wc-block-components-button.wc-block-checkout__shipping-method-option {
+			min-height: 80px;
+		}
+	}
+}
+
 .edit-post-visual-editor
 .wc-block-components-button.wc-block-checkout__shipping-method-option,
 .wc-block-components-button.wc-block-checkout__shipping-method-option {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -24,6 +24,7 @@
 	box-shadow: none !important;
 	outline: 1px solid $universal-border-light !important; // Overwriting Gutenberg styles
 	border-radius: $universal-border-radius;
+	cursor: pointer;
 	&.components-button:hover:not(:disabled),
 	&.components-button:focus:not(:disabled),
 	&:focus,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -6,7 +6,7 @@
 }
 
 .edit-post-visual-editor
-	.wc-block-components-button.wc-block-checkout__shipping-method-option,
+.wc-block-components-button.wc-block-checkout__shipping-method-option,
 .wc-block-components-button.wc-block-checkout__shipping-method-option {
 	flex-grow: 1;
 	display: flex;

--- a/plugins/woocommerce/changelog/47157-dev-fix-47138
+++ b/plugins/woocommerce/changelog/47157-dev-fix-47138
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Checkout: Fix the rendering of local pickup / shipping buttons in the editor
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47138

When I refactored the radiogroup in https://github.com/woocommerce/woocommerce/pull/45974 I forgot to refactor the rendering in the editor side. As a result the styles looked very incorrect for those buttons.

Here I've made them as close as possible to the rendered buttons in the front-end, although you might note the button height doesn't exactly match, I'd counter by saying quite a few visual elements don't match. For example there is a bug where all the section titles have scrollbars amongst other existing visual discrepancies.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Open the checkout page in the editor and see that the shipping and local pickup buttons are correctly rendered. Also test the functionality that allows you to switch between them in the editor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Checkout: Fix the rendering of local pickup / shipping buttons in the editor

</details>
