### PR TITLE
Free some in-memory usage when doing HPOS-related batch processing

### DIFF
--- a/plugins/woocommerce/changelog/hpos-cli-free-in-memory-usage
+++ b/plugins/woocommerce/changelog/hpos-cli-free-in-memory-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Free some in-memory usage when doing batch processing in HPOS


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Running `wc hpos cleanup all` on a store with 80GB+ wp_postmeta will likely hitting OOM, even with big memory limit. This PR adds in-memory cleanup from https://github.com/woocommerce/woocommerce/pull/44670 with the addition of clearing wpdb query log and moving it into a new method `free_in_memory_usage()` so that it can be used by other batch-processing CLI commands.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add debug line to note peak memory usage

   ```php
   <?php
   add_action(
       'shutdown',
       function() {
    	   printf( 'Peak memory usage: %s', size_format( memory_get_peak_usage(), 2 ) );
       }
   );
   ```

2. Make sure HPOS enabled.
3. Generate the orders, `wp wc generate orders 1000000`. In my case, peaked memory usage wasn't noticeable with small number of orders.
4. Sync to CPT, `wp wc hpos sync`.
5. Run `wp wc hpos cleanup all` .

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
