### PR TITLE
Fix RIN Display Logic for Banner Alert Notifications

### DIFF
--- a/plugins/woocommerce/changelog/fix-rin-alert-notes
+++ b/plugins/woocommerce/changelog/fix-rin-alert-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix RIN Display Logic for Banner Alert Notifications

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -114,7 +114,7 @@ class SpecRunner {
 		$matching_wp_locales = array_values(
 			array_filter(
 				$locales,
-				function( $l ) use ( $wp_locale ) {
+				function ( $l ) use ( $wp_locale ) {
 					return $wp_locale === $l->locale;
 				}
 			)
@@ -128,7 +128,7 @@ class SpecRunner {
 		$en_us_locales = array_values(
 			array_filter(
 				$locales,
-				function( $l ) {
+				function ( $l ) {
 					return $l->locale === 'en_US';
 				}
 			)
@@ -168,7 +168,7 @@ class SpecRunner {
 		$en_us_locales = array_values(
 			array_filter(
 				$action_locales,
-				function( $l ) {
+				function ( $l ) {
 					return $l->locale === 'en_US';
 				}
 			)

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluateAndGetStatus.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluateAndGetStatus.php
@@ -47,7 +47,7 @@ class EvaluateAndGetStatus {
 		}
 
 		// If the spec is an alert type and the note is unactioned, set to pending if the spec no longer applies.
-		if ( in_array( $spec->type, array( 'error', 'update' ), true )
+		if ( isset( $spec->type ) && in_array( $spec->type, array( 'error', 'update' ), true )
 			&& Note::E_WC_ADMIN_NOTE_UNACTIONED === $current_status
 			&& ! $evaluated_result ) {
 			return Note::E_WC_ADMIN_NOTE_PENDING;

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluateAndGetStatus.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluateAndGetStatus.php
@@ -46,6 +46,13 @@ class EvaluateAndGetStatus {
 				: Note::E_WC_ADMIN_NOTE_PENDING;
 		}
 
+		// If the spec is an alert type and the note is unactioned, set to pending if the spec no longer applies.
+		if ( in_array( $spec->type, array( 'error', 'update' ), true )
+			&& Note::E_WC_ADMIN_NOTE_UNACTIONED === $current_status
+			&& ! $evaluated_result ) {
+			return Note::E_WC_ADMIN_NOTE_PENDING;
+		}
+
 		// When allow_redisplay isn't set, just leave the note alone.
 		if ( ! isset( $spec->allow_redisplay ) || ! $spec->allow_redisplay ) {
 			return $current_status;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/evaluate-and-get-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/evaluate-and-get-status.php
@@ -237,4 +237,30 @@ class WC_Admin_Tests_RemoteInboxNotifications_EvaluateAndGetStatus extends WC_Un
 
 		$this->assertEquals( 'pending', $result );
 	}
+
+	/**
+	 * Tests that for an alert note that is unactioned and eval to true,
+	 * The current status is returned.
+	 *
+	 * @group fast
+	 */
+	public function test_unactioned_info_note_return_current_status_when_eval_to_false() {
+		$spec = json_decode(
+			'{
+				"slug": "test",
+				"type": "info",
+				"rules": []
+			}'
+		);
+
+		$current_status = 'unactioned';
+		$result         = EvaluateAndGetStatus::evaluate(
+			$spec,
+			$current_status,
+			new stdClass(),
+			new FailingRuleEvaluator()
+		);
+
+		$this->assertEquals( $current_status, $result );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/evaluate-and-get-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/evaluate-and-get-status.php
@@ -215,7 +215,7 @@ class WC_Admin_Tests_RemoteInboxNotifications_EvaluateAndGetStatus extends WC_Un
 
 	/**
 	 * Tests that for an alert note that is unactioned and eval to true,
-	 * status is changed to pending.
+	 * The pending status is returned.
 	 *
 	 * @group fast
 	 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/evaluate-and-get-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/evaluate-and-get-status.php
@@ -212,4 +212,29 @@ class WC_Admin_Tests_RemoteInboxNotifications_EvaluateAndGetStatus extends WC_Un
 
 		$this->assertEquals( 'unactioned', $result );
 	}
+
+	/**
+	 * Tests that for an alert note that is unactioned and eval to true,
+	 * status is changed to pending.
+	 *
+	 * @group fast
+	 */
+	public function test_unactioned_alert_note_return_pending_when_eval_to_false() {
+		$spec = json_decode(
+			'{
+				"slug": "test",
+				"type": "error",
+				"rules": []
+			}'
+		);
+
+		$result = EvaluateAndGetStatus::evaluate(
+			$spec,
+			'unactioned',
+			new stdClass(),
+			new FailingRuleEvaluator()
+		);
+
+		$this->assertEquals( 'pending', $result );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47128.

Update the RIN display logic to hide banner alert notifications when the display conditions are unmet.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site 
2. Install and activate the [Code Snippets](https://wordpress.org/plugins/code-snippets/), [woocommerce-payments 7.5.2](https://github.com/Automattic/woocommerce-payments/releases/download/7.5.2/woocommerce-payments.zip) and [WooCommerce PayPal Payments](https://wordpress.org/plugins/woocommerce-paypal-payments/) plugin.
3. Create a new snippet with the following code:

```php
add_filter( 'data_source_poller_data_sources', 'custom_data_source', 10, 2 );

function custom_data_source( $data_sources, $id ) {
	if ($id === 'remote_inbox_notifications') {
		return array(
			'https://gist.githubusercontent.com/chihsuan/e2aff67165428d2fd749b68cb7c75e74/raw/b1b7a0792a17a78fb10e204d81c4f44a629fade5/test_remote_inbox_specs'
		);
	}
    return $data_sources;
}
```

4. Skip WooCommerce setup wizard
5. Go to `Tools > WCA Test Helper > Tools`
6. Click on `Run wc_admin_daily job`
7. Go to `WooCommerce > Home`
8. Check that `Action required: Security update of WooCommerce Payments` banner is displayed
9. Check that `Share your feedback on PayPal` note is displayed in Inbox
10. Update woocommerce-payments to latest version
11. Deactivate the WooCommerce PayPal Payments plugin
12. Run `Run wc_admin_daily job` again
13. Check that `Action required: Security update of WooCommerce Payments` banner is hidden
14. Check that `Share your feedback on PayPal` note is still displayed in Inbox

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
