### PR TITLE
Customer Account: Don't hook block unless filter is available.

### DIFF
--- a/plugins/woocommerce/changelog/fix-customer-account-hooked-block-attributes
+++ b/plugins/woocommerce/changelog/fix-customer-account-hooked-block-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Don't automatically insert hooked customer account block into header for sites running less than WP 6.5

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -46,8 +46,7 @@ class CustomerAccount extends AbstractBlock {
 		 * We are the only code adding the filter 'hooked_block_woocommerce/customer-account'.
 		 * Using has_filter() for a compatibility check won't work because add_filter() is used in the same file.
 		 */
-		global $wp_version;
-		if ( version_compare( $wp_version, '6.5', '>=' ) ) {
+		if ( version_compare( get_bloginfo( 'version' ), '6.5', '>=' ) ) {
 			add_filter( 'hooked_block_woocommerce/customer-account', array( $this, 'modify_hooked_block_attributes' ), 10, 5 );
 			add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -41,8 +41,16 @@ class CustomerAccount extends AbstractBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
-		add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
-		add_filter( 'hooked_block_woocommerce/customer-account', array( $this, 'modify_hooked_block_attributes' ), 10, 5 );
+		/**
+		 * The hooked_block_{$hooked_block_type} filter was added in WordPress 6.5.
+		 * We are the only code adding the filter 'hooked_block_woocommerce/customer-account'.
+		 * Using has_filter() for a compatibility check won't work because add_filter() is used in the same file.
+		 */
+		global $wp_version;
+		if ( version_compare( $wp_version, '6.5', '>=' ) ) {
+			add_filter( 'hooked_block_woocommerce/customer-account', array( $this, 'modify_hooked_block_attributes' ), 10, 5 );
+			add_filter( 'hooked_block_types', array( $this, 'register_hooked_block' ), 9, 4 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Before hooking the Customer Account block we need to check that the `hooked_block_{$hooked_block_type}` filter is available which was added in 6.5 (`hooked_block_types` was added in 6.4) so we can hide the label of the hooked block.

I tried to think of a way of checking compatibility without checking `$wp_version` but since we are the only code adding the filter 'hooked_block_woocommerce/customer-account' it means using `has_filter()` for a compatibility check won't work because `add_filter()` is used in the same file.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/47168

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce and Core Rollback plugin
2. Check Customer Account is added to the header of TT4 without a label on latest WP
3. Use Core Rollback to re-install 6.4.4
4. Check that the Customer Account block is now omitted from the header.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Don't automatically insert hooked customer account block into header for sites running less than WP 6.5

#### Comment

Check we can use filter hooked_block_woocommerce/customer-account to hide label before adding block to the header

</details>
