### PR TITLE
Remove `noindex` meta from coming soon pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-noindex-lys-coming-soon-pages
+++ b/plugins/woocommerce/changelog/fix-remove-noindex-lys-coming-soon-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove noindex robot call from lys coming soon pages

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -27,7 +27,6 @@ class ComingSoonRequestHandler {
 		$this->coming_soon_helper = $coming_soon_helper;
 		add_filter( 'template_include', array( $this, 'handle_template_include' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'deregister_unnecessary_styles' ), 100 );
-		add_filter( 'wp_robots', array( $this, 'disable_seo_indexing' ) );
 	}
 
 	/**
@@ -97,27 +96,6 @@ class ComingSoonRequestHandler {
 			// We need to exit to prevent further processing.
 			exit();
 		}
-	}
-
-	/**
-	 * Disable search engines in coming soon pages
-	 *
-	 * @since 9.0.0
-	 * @param array $robots Associative array of robots directives.
-	 * @return array Filtered robots directives.
-	 */
-	public function disable_seo_indexing( $robots ) {
-		// Early exit if LYS feature is disabled.
-		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
-			return $robots;
-		}
-
-		// Set no index when site is in coming soon mode.
-		if ( ! $this->coming_soon_helper->is_site_live() ) {
-			return wp_robots_no_robots( $robots );
-		}
-
-		return $robots;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

p1714979443109239/1714723935.893829-slack-C01SFMVEYAK

Follow-up to https://github.com/woocommerce/woocommerce/pull/47140

Remove the `noindex` meta from coming soon pages due to possible conflict with visibility settings. Also, we cannot assume `noindex` since users may want to index coming soon page, such as for lead generation purposes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Ensure site is in coming soon mode
2. Go to `Settings > Reading` and uncheck `Discourage search engines from indexing this site` and save
3. In incognito, open the site frontend page
4. View source, ensure `<meta name='robots' content='noindex, nofollow' />` **does not exist**
5. Go to `WooCommerce > Settings > Site visibility` and enable `Restrict to store pages only` and save
6. Refresh frontend page and ensure the same meta exists

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>