### PR TITLE
[CYS] Fix the triggered event when starting the "no AI" flow

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -323,7 +323,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 					target: 'designWithAi',
 				},
 				DESIGN_WITHOUT_AI: {
-					actions: [ 'recordTracksDesignWithAIClicked' ],
+					actions: [ 'recordTracksDesignWithoutAIClicked' ],
 					target: 'designWithoutAi',
 				},
 				SELECTED_NEW_THEME: {

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -53,6 +53,10 @@ export const recordTracksDesignWithAIClicked = () => {
 	trackEvent( 'customize_your_store_intro_design_with_ai_click' );
 };
 
+export const recordTracksDesignWithoutAIClicked = () => {
+	trackEvent( 'customize_your_store_intro_design_without_ai_click' );
+};
+
 export const recordTracksThemeSelected = (
 	_context: customizeStoreStateMachineContext,
 	event: Extract<

--- a/plugins/woocommerce/changelog/47181-fix-cys-no-ai-event
+++ b/plugins/woocommerce/changelog/47181-fix-cys-no-ai-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+[CYS]: Fix event name when starting the no-AI flow.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the event name that it's triggered when starting the flow **without AI**. Until now we were sending the same AI event for both flows: https://github.com/woocommerce/woocommerce/blob/cce1e224ad37c6624a4e57317e7bcf2015479bc8/plugins/woocommerce-admin/client/customize-store/index.tsx#L321-L328

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

No manual testing required.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[CYS]: Fix event name when starting the no-AI flow.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
