### PR TITLE
Track skip guided setup click 

### DIFF
--- a/plugins/woocommerce/changelog/47180-track-for-skip-guided-setup
+++ b/plugins/woocommerce/changelog/47180-track-for-skip-guided-setup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add track for skip guided setup click and updated the new design for skip guided setup

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
@@ -9,6 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { CoreProfilerStateMachineContext } from '..';
 import {
+	IntroSkippedEvent,
 	UserProfileEvent,
 	BusinessInfoEvent,
 	PluginsLearnMoreLinkClickedEvent,
@@ -37,6 +38,16 @@ const recordTracksStepSkipped = ( _: unknown, params: { step: string } ) => {
 const recordTracksIntroCompleted = () => {
 	recordEvent( 'coreprofiler_step_complete', {
 		step: 'intro_opt_in',
+		wc_version: getSetting( 'wcVersion' ),
+	} );
+};
+
+const recordSkipGuidedSetup = ( { event }: { event: IntroSkippedEvent } ) => {
+	if ( ! event?.payload?.optInDataSharing ) {
+		return;
+	}
+
+	recordEvent( 'coreprofiler_skip_guided_setup', {
 		wc_version: getSetting( 'wcVersion' ),
 	} );
 };
@@ -213,6 +224,7 @@ export default {
 	recordTracksStepViewed,
 	recordTracksStepSkipped,
 	recordTracksIntroCompleted,
+	recordSkipGuidedSetup,
 	recordTracksUserProfileCompleted,
 	recordTracksSkipBusinessLocationCompleted,
 	recordTracksBusinessInfoCompleted,

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
@@ -42,8 +42,15 @@ const recordTracksIntroCompleted = () => {
 	} );
 };
 
-const recordSkipGuidedSetup = ( { event }: { event: IntroSkippedEvent } ) => {
-	if ( ! event?.payload?.optInDataSharing ) {
+const recordSkipGuidedSetup = (
+	_: unknown,
+	{
+		optInDataSharing,
+	}: {
+		optInDataSharing: boolean;
+	}
+) => {
+	if ( ! optInDataSharing ) {
 		return;
 	}
 

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
@@ -9,7 +9,6 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { CoreProfilerStateMachineContext } from '..';
 import {
-	IntroSkippedEvent,
 	UserProfileEvent,
 	BusinessInfoEvent,
 	PluginsLearnMoreLinkClickedEvent,

--- a/plugins/woocommerce/client/admin/client/core-profiler/events.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/events.tsx
@@ -30,8 +30,8 @@ export type IntroCompletedEvent = {
 
 export type IntroSkippedEvent = {
 	type: 'INTRO_SKIPPED';
-	payload: { optInDataSharing: false };
-}; // always false for now
+	payload: { optInDataSharing: boolean };
+};
 
 export type UserProfileEvent =
 	| {

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -840,7 +840,6 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 										return event.payload;
 									},
 								} ),
-								'recordSkipGuidedSetup',
 							],
 						},
 						INTRO_BUILDER: {
@@ -1193,6 +1192,12 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 				{
 					type: 'updateQueryStep',
 					params: { step: 'skip-guided-setup' },
+				},
+				{
+					type: 'recordSkipGuidedSetup',
+					params: ( { context } ) => ( {
+						optInDataSharing: context.optInDataSharing,
+					} ),
 				},
 			],
 			states: {

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -830,7 +830,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							target: '#skipGuidedSetup',
 							actions: [
 								'assignOptInDataSharing',
-								spawnChild( 'updateTrackingOption ', {
+								spawnChild( 'updateTrackingOption', {
 									input: ( {
 										event,
 									}: {
@@ -840,6 +840,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 										return event.payload;
 									},
 								} ),
+								'recordSkipGuidedSetup',
 							],
 						},
 						INTRO_BUILDER: {

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -1193,12 +1193,6 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					type: 'updateQueryStep',
 					params: { step: 'skip-guided-setup' },
 				},
-				{
-					type: 'recordSkipGuidedSetup',
-					params: ( { context } ) => ( {
-						optInDataSharing: context.optInDataSharing,
-					} ),
-				},
 			],
 			states: {
 				preSkipFlowBusinessLocation: {
@@ -1229,6 +1223,12 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 						{
 							type: 'recordTracksStepViewed',
 							params: { step: 'skip_business_location' },
+						},
+						{
+							type: 'recordSkipGuidedSetup',
+							params: ( { context } ) => ( {
+								optInDataSharing: context.optInDataSharing,
+							} ),
 						},
 					],
 					meta: {

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/IntroOptIn.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/IntroOptIn.tsx
@@ -29,16 +29,7 @@ export const IntroOptIn = ( {
 			className="woocommerce-profiler-intro-opt-in"
 			data-testid="core-profiler-intro-opt-in-screen"
 		>
-			<Navigation
-				percentage={ navigationProgress }
-				skipText={ __( 'Skip guided setup', 'woocommerce' ) }
-				onSkip={ () =>
-					sendEvent( {
-						type: 'INTRO_SKIPPED',
-						payload: { optInDataSharing: false },
-					} )
-				}
-			/>
+			<Navigation percentage={ navigationProgress } />
 			<div className="woocommerce-profiler-page__content woocommerce-profiler-intro-opt-in__content">
 				<div className="woocommerce-profiler-welcome-image" />
 				<Heading
@@ -64,6 +55,18 @@ export const IntroOptIn = ( {
 					}
 				>
 					{ __( 'Set up my store', 'woocommerce' ) }
+				</Button>
+				<Button
+					className="woocommerce-profiler-setup-store__button"
+					variant="tertiary"
+					onClick={ () =>
+						sendEvent( {
+							type: 'INTRO_SKIPPED',
+							payload: { optInDataSharing: iOptInDataSharing },
+						} )
+					}
+				>
+					{ __( 'Skip guided setup', 'woocommerce' ) }
 				</Button>
 				{ window.wcAdminFeatures?.blueprint && (
 					<Button

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/test/intro-opt-in.test.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/test/intro-opt-in.test.tsx
@@ -73,11 +73,30 @@ describe( 'IntroOptIn', () => {
 		} );
 	} );
 
-	it( 'should call sendEvent with INTRO_SKIPPED event when skip button is clicked', () => {
+	it( 'should call sendEvent with INTRO_SKIPPED event and optInDataSharing: true when skip button is clicked and the checkbox is checked', () => {
 		render(
 			// @ts-ignore
 			<IntroOptIn { ...props } />
 		);
+		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+		screen
+			.getByRole( 'button', {
+				name: /Skip guided setup/i,
+			} )
+			.click();
+		expect( props.sendEvent ).toHaveBeenCalledWith( {
+			type: 'INTRO_SKIPPED',
+			payload: { optInDataSharing: true },
+		} );
+	} );
+
+	it( 'should call sendEvent with INTRO_SKIPPED event and optInDataSharing: false when skip button is clicked and the checkbox is unchecked', () => {
+		render(
+			// @ts-ignore
+			<IntroOptIn { ...props } />
+		);
+		screen.getByRole( 'checkbox' ).click();
+		expect( screen.getByRole( 'checkbox' ) ).not.toBeChecked();
 		screen
 			.getByRole( 'button', {
 				name: /Skip guided setup/i,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds `coreprofiler_skip_guided_setup` track for the `skip guided setup` click.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47180 

Slack thread: p1714164814689059-slack-C06K8HHQPJ5

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. When you're redirected to the core profiler, open your browser's inspector and type `localStorage.setItem( 'debug', 'wc-admin:*' );` and select `Verbose` from the log levels.
3. Make sure the usage tracking checkbox is checked.
4. Click on `Skip guided setup`
5. Confirm `recordevent wcadmin_coreprofiler_skip_guided_setup ` track gets fired.
6. Confirm that the "Enable Tracking" checkbox on `./wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` is checked
7. Go back to the `Welcome to Woo!` page.
8. Uncheck the usage tracking checkbox.
9. Click on `Skip guided setup`
10. Confirm `recordevent wcadmin_coreprofiler_skip_guided_setup ` track does not get fired for this time.
11. Confirm that the "Enable Tracking" checkbox on `./wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` is not checked

![image](https://github.com/user-attachments/assets/5949a05d-e209-4d6f-b387-5fc41c83b730)

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/fff9a487-1955-4046-a0ab-26a57ee7d84f">


<!-- End testing instructions -->
