### PR TITLE
Update when PayPal Standard is loaded to further reduce new store using this legacy payment method

### DIFF
--- a/plugins/woocommerce/changelog/restrict_paypal_standard
+++ b/plugins/woocommerce/changelog/restrict_paypal_standard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Only load the PayPal Standard payment method on stores that have connected their account or have existing PayPal orders.

--- a/plugins/woocommerce/changelog/restrict_paypal_standard-filter
+++ b/plugins/woocommerce/changelog/restrict_paypal_standard-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Deprecate the woocommerce_should_load_paypal_standard filter used to bypass loading PayPal Standard.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -250,6 +250,7 @@ class WC_Install {
 		),
 		'8.9.0' => array(
 			'wc_update_890_update_connect_to_woocommerce_note',
+			'wc_update_890_update_paypal_standard_load_eligibility',
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -222,7 +222,7 @@ class WC_Payment_Gateways {
 The payment gateway "%2$s" was just enabled on this site:
 %3$s
 
-If this was intentional you can safely ignore and delete this email. 
+If this was intentional you can safely ignore and delete this email.
 
 If you did not enable this payment gateway, please log in to your site and consider disabling it here:
 %4$s
@@ -400,6 +400,8 @@ All at %6$s
 	 * @return bool Whether PayPal Standard should be loaded or not.
 	 */
 	protected function should_load_paypal_standard() {
+		// Tech debt: This class needs to be initialized to make sure any existing subscriptions gets processed as expected, even if the gateway is not enabled for new orders.
+		// Eventually, we want to load this via a singleton pattern to avoid unnecessary instantiation.
 		$paypal = new WC_Gateway_Paypal();
 		return $paypal->should_load();
 	}

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -527,13 +527,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$should_load = $this->get_option( $option_key );
 
 		if ( '' === $should_load ) {
-
-			// New installs without PayPal Standard enabled don't load it.
-			if ( 'no' === $this->enabled && WC_Install::is_new_install() ) {
-				$should_load = false;
-			} else {
-				$should_load = true;
-			}
+			// Set default `_should_load` to 'yes' on existing stores with PayPal Standard setup or with existing PayPal Standard orders.
+			$should_load = ! $this->needs_setup() || $this->has_paypal_orders() ? true : false;
 
 			$this->update_option( $option_key, wc_bool_to_string( $should_load ) );
 		} else {

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -537,4 +537,21 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		return $should_load;
 	}
+
+	/**
+	 * Checks if the store has at least one PayPal Standand order.
+	 *
+	 * @return bool
+	 */
+	public function has_paypal_orders() {
+		$paypal_orders = wc_get_orders(
+			array(
+				'limit'          => 1,
+				'return'         => 'ids',
+				'payment_method' => 'paypal',
+			)
+		);
+
+		return is_countable( $paypal_orders ) ? 1 === count( $paypal_orders ) : false;
+	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -532,7 +532,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 			$this->update_option( $option_key, wc_bool_to_string( $should_load ) );
 		} else {
-			$should_load = wc_string_to_bool( $should_load );
+			// Enabled always takes precedence over the option.
+			$should_load = $this->enabled || wc_string_to_bool( $should_load );
 		}
 
 		/**
@@ -544,10 +545,12 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		 * @param WC_Gateway_Paypal $this        The WC_Gateway_Paypal instance.
 		 */
 		if ( ! $should_load && apply_filters( 'woocommerce_should_load_paypal_standard', $should_load, $this ) ) {
-			WC_Admin_Notices::add_custom_notice(
-				'woocommerce_load_paypal_standard_filter_unsupported',
-				__( '<strong>⚠️ Loading PayPal Standard using a filter is no longer supported.</strong> We have detected that a plugin or code snippet on your site is using the deprecated filter <code>woocommerce_should_load_paypal_standard</code>. Please note that as of WooCommerce 8.9, this filter can no longer be used to enable PayPal Standard.', 'woocommerce' ),
-			);
+			if ( ! WC_Admin_Notices::user_has_dismissed_notice( 'woocommerce_load_paypal_standard_filter_unsupported') ) {
+				WC_Admin_Notices::add_custom_notice(
+					'woocommerce_load_paypal_standard_filter_unsupported',
+					__( '<strong>⚠️ Loading PayPal Standard using a filter is no longer supported.</strong> We have detected that a plugin or code snippet on your site is using the deprecated filter <code>woocommerce_should_load_paypal_standard</code>. Please note that as of WooCommerce 8.9, this filter can no longer be used to enable PayPal Standard.', 'woocommerce' ),
+				);
+			}
 		}
 
 		return $should_load;

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -535,6 +535,14 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			$should_load = wc_string_to_bool( $should_load );
 		}
 
+		// Notify stores that are using the `woocommerce_should_load_paypal_standard` filter that it is no longer supported.
+		if ( ! $should_load && apply_filters( 'woocommerce_should_load_paypal_standard', $should_load, $this ) ) {
+			WC_Admin_Notices::add_custom_notice(
+				'woocommerce_load_paypal_standard_filter_unsupported',
+				__( '<strong>⚠️ Loading PayPal Standard using a filter is no longer supported.</strong> We have detected that a plugin or code snippet on your site is using the deprecated filter <code>woocommerce_should_load_paypal_standard</code>. Please note that as of WooCommerce 8.9, this filter can no longer be used to enable PayPal Standard.', 'woocommerce' ),
+			);
+		}
+
 		return $should_load;
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -536,23 +536,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			$should_load = $this->enabled || wc_string_to_bool( $should_load );
 		}
 
-		/**
-		 * Trigger this deprecated filter (`woocommerce_should_load_paypal_standard`) and display a notice on stores that are still using it.
-		 *
-		 * @since 8.9.0
-		 *
-		 * @param bool              $should_load Whether PayPal Standard should be loaded.
-		 * @param WC_Gateway_Paypal $this        The WC_Gateway_Paypal instance.
-		 */
-		if ( ! $should_load && apply_filters( 'woocommerce_should_load_paypal_standard', $should_load, $this ) ) {
-			if ( ! WC_Admin_Notices::user_has_dismissed_notice( 'woocommerce_load_paypal_standard_filter_unsupported') ) {
-				WC_Admin_Notices::add_custom_notice(
-					'woocommerce_load_paypal_standard_filter_unsupported',
-					__( '<strong>⚠️ Loading PayPal Standard using a filter is no longer supported.</strong> We have detected that a plugin or code snippet on your site is using the deprecated filter <code>woocommerce_should_load_paypal_standard</code>. Please note that as of WooCommerce 8.9, this filter can no longer be used to enable PayPal Standard.', 'woocommerce' ),
-				);
-			}
-		}
-
 		return $should_load;
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -533,7 +533,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			$this->update_option( $option_key, wc_bool_to_string( $should_load ) );
 		} else {
 			// Enabled always takes precedence over the option.
-			$should_load = $this->enabled || wc_string_to_bool( $should_load );
+			$should_load = wc_string_to_bool( $this->enabled ) || wc_string_to_bool( $should_load );
 		}
 
 		return $should_load;

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -535,14 +535,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			$should_load = wc_string_to_bool( $should_load );
 		}
 
-		/**
-		 * Allow third-parties to filter whether PayPal Standard should be loaded or not.
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param bool              $should_load Whether PayPal Standard should be loaded.
-		 * @param WC_Gateway_Paypal $this        The WC_Gateway_Paypal instance.
-		 */
-		return apply_filters( 'woocommerce_should_load_paypal_standard', $should_load, $this );
+		return $should_load;
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -528,7 +528,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		if ( '' === $should_load ) {
 			// Set default `_should_load` to 'yes' on existing stores with PayPal Standard enabled or with existing PayPal Standard orders.
-			$should_load = 'yes' === $this->enabled || $this->has_paypal_orders() ? true : false;
+			$should_load = 'yes' === $this->enabled || $this->has_paypal_orders();
 
 			$this->update_option( $option_key, wc_bool_to_string( $should_load ) );
 		} else {

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -535,7 +535,14 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			$should_load = wc_string_to_bool( $should_load );
 		}
 
-		// Notify stores that are using the `woocommerce_should_load_paypal_standard` filter that it is no longer supported.
+		/**
+		 * Trigger this deprecated filter (`woocommerce_should_load_paypal_standard`) and display a notice on stores that are still using it.
+		 *
+		 * @since 8.9.0
+		 *
+		 * @param bool              $should_load Whether PayPal Standard should be loaded.
+		 * @param WC_Gateway_Paypal $this        The WC_Gateway_Paypal instance.
+		 */
 		if ( ! $should_load && apply_filters( 'woocommerce_should_load_paypal_standard', $should_load, $this ) ) {
 			WC_Admin_Notices::add_custom_notice(
 				'woocommerce_load_paypal_standard_filter_unsupported',

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -527,8 +527,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$should_load = $this->get_option( $option_key );
 
 		if ( '' === $should_load ) {
-			// Set default `_should_load` to 'yes' on existing stores with PayPal Standard setup or with existing PayPal Standard orders.
-			$should_load = ! $this->needs_setup() || $this->has_paypal_orders() ? true : false;
+			// Set default `_should_load` to 'yes' on existing stores with PayPal Standard enabled or with existing PayPal Standard orders.
+			$should_load = 'yes' === $this->enabled || $this->has_paypal_orders() ? true : false;
 
 			$this->update_option( $option_key, wc_bool_to_string( $should_load ) );
 		} else {

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2705,14 +2705,12 @@ function wc_update_890_update_paypal_standard_load_eligibility() {
 		return;
 	}
 
-	$is_setup = $paypal->get_option( 'sandbox_api_username' ) || $paypal->get_option( 'api_username' );
-
-	// If PayPal is enabled or set to load, but the store hasn't setup PayPal standard and doesn't have any PayPal Orders, disable it and show a notice to Admin.
-	if ( ( 'yes' === $paypal->enabled || 'yes' === $paypal->get_option( '_should_load' ) ) && ! $is_setup && ! $paypal->has_paypal_orders() ) {
+	// If PayPal is enabled or set to load, but the store hasn't setup PayPal Standard live API keys and doesn't have any PayPal Orders, disable it and show a notice to Admin.
+	if ( ( 'yes' === $paypal->enabled || 'yes' === $paypal->get_option( '_should_load' ) ) && ! $paypal->get_option( 'api_username' ) && ! $paypal->has_paypal_orders() ) {
 		$paypal->update_option( '_should_load', wc_bool_to_string( false ) );
 
 		WC_Admin_Notices::add_custom_notice(
-			'legacy_unused_paypal_standard_disabled_on_upgrade_error',
+			'legacy_unused_paypal_standard_disabled_on_upgrade',
 			__( '<strong>⚠️ We have disabled the WooCommerce PayPal Standard on your store</strong>. This payment method was not setup or used by your store and been deprecated since WooCommerce 5.5. If you\'d like to offer PayPal as a payment option please <a href="https://woocommerce.com/products/woocommerce-paypal-payments/?utm_source=pps_disabled_notice&utm_medium=product">install PayPal Payments</a>.', 'woocommerce' )
 		);
 	}

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2713,7 +2713,7 @@ function wc_update_890_update_paypal_standard_load_eligibility() {
 
 		WC_Admin_Notices::add_custom_notice(
 			'legacy_unused_paypal_standard_disabled_on_upgrade_error',
-			__( '<strong>⚠️ We have disabled the WooCommerce PayPal Standard on your store</strong>. This payment method was not setup or used by your store and been deprecated since WooCommerce 5.5. If you\'d like to offer PayPal as a payment option please <a href="https://woocommerce.com/products/woocommerce-paypal-payments/?utm_source=pps_disabled_notice&utm_medium=product">install PayPal Payments</a>.', 'woocommerce' ),
+			__( '<strong>⚠️ We have disabled the WooCommerce PayPal Standard on your store</strong>. This payment method was not setup or used by your store and been deprecated since WooCommerce 5.5. If you\'d like to offer PayPal as a payment option please <a href="https://woocommerce.com/products/woocommerce-paypal-payments/?utm_source=pps_disabled_notice&utm_medium=product">install PayPal Payments</a>.', 'woocommerce' )
 		);
 	}
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2705,13 +2705,8 @@ function wc_update_890_update_paypal_standard_load_eligibility() {
 		return;
 	}
 
-	// If PayPal is enabled or set to load, but the store hasn't setup PayPal Standard live API keys and doesn't have any PayPal Orders, disable it and show a notice to Admin.
+	// If PayPal is enabled or set to load, but the store hasn't setup PayPal Standard live API keys and doesn't have any PayPal Orders, disable it.
 	if ( ( 'yes' === $paypal->enabled || 'yes' === $paypal->get_option( '_should_load' ) ) && ! $paypal->get_option( 'api_username' ) && ! $paypal->has_paypal_orders() ) {
 		$paypal->update_option( '_should_load', wc_bool_to_string( false ) );
-
-		WC_Admin_Notices::add_custom_notice(
-			'legacy_unused_paypal_standard_disabled_on_upgrade',
-			__( '<strong>⚠️ We have disabled the WooCommerce PayPal Standard on your store</strong>. This payment method was not setup or used by your store and been deprecated since WooCommerce 5.5. If you\'d like to offer PayPal as a payment option please <a href="https://woocommerce.com/products/woocommerce-paypal-payments/?utm_source=pps_disabled_notice&utm_medium=product">install PayPal Payments</a>.', 'woocommerce' )
-		);
 	}
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2688,3 +2688,32 @@ function wc_update_890_update_connect_to_woocommerce_note() {
 	$new_note = WooSubscriptionsNotes::get_note();
 	$new_note->save();
 }
+
+/**
+ * Disables the PayPal Standard gateway for stores that aren't using it.
+ *
+ * PayPal Standard has been deprecated since WooCommerce 5.5, but there are some stores that have it showing up in their
+ * list of available Payment methods even if it's not setup. In WooComerce 8.9 we will disable PayPal Standard for those stores
+ * to reduce the amount of new connections to the legacy gateway.
+ *
+ * Shows an admin notice to inform the store owner that PayPal Standard has been disabled and suggests installing PayPal Payments.
+ */
+function wc_update_890_update_paypal_standard_load_eligibility() {
+	$paypal = class_exists( 'WC_Gateway_Paypal' ) ? new WC_Gateway_Paypal() : null;
+
+	if ( ! $paypal ) {
+		return;
+	}
+
+	$is_setup = $paypal->get_option( 'sandbox_api_username' ) || $paypal->get_option( 'api_username' );
+
+	// If PayPal is enabled or set to load, but the store hasn't setup PayPal standard and doesn't have any PayPal Orders, disable it and show a notice to Admin.
+	if ( ( 'yes' === $paypal->enabled || 'yes' === $paypal->get_option( '_should_load' ) ) && ! $is_setup && ! $paypal->has_paypal_orders() ) {
+		$paypal->update_option( '_should_load', wc_bool_to_string( false ) );
+
+		WC_Admin_Notices::add_custom_notice(
+			'legacy_unused_paypal_standard_disabled_on_upgrade_error',
+			__( '<strong>⚠️ We have disabled the WooCommerce PayPal Standard on your store</strong>. This payment method was not setup or used by your store and been deprecated since WooCommerce 5.5. If you\'d like to offer PayPal as a payment option please <a href="https://woocommerce.com/products/woocommerce-paypal-payments/?utm_source=pps_disabled_notice&utm_medium=product">install PayPal Payments</a>.', 'woocommerce' ),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -208,12 +208,6 @@ class WC_Unit_Tests_Bootstrap {
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_onboarding_opt_in', 'yes' );
 
-		// Always load PayPal Standard for unit tests.
-		$paypal = class_exists( 'WC_Payment_Gateway' ) ? new WC_Payment_Gateway() : null;
-		if ( $paypal ) {
-			$paypal->update_option( '_should_load', wc_bool_to_string( true ) );
-		}
-
 		require_once $this->plugin_dir . '/woocommerce.php';
 		FeaturePlugin::instance()->init();
 	}
@@ -231,6 +225,12 @@ class WC_Unit_Tests_Bootstrap {
 
 		if ( ! getenv( 'HPOS' ) ) {
 			add_filter( 'woocommerce_enable_hpos_by_default_for_new_shops', '__return_false' );
+		}
+
+		// Always load PayPal Standard for unit tests.
+		$paypal = class_exists( 'WC_Gateway_Paypal' ) ? new WC_Gateway_Paypal() : null;
+		if ( $paypal ) {
+			$paypal->update_option( '_should_load', wc_bool_to_string( true ) );
 		}
 
 		WC_Install::install();

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -59,9 +59,6 @@ class WC_Unit_Tests_Bootstrap {
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';
 
-		// Always load PayPal Standard for unit tests.
-		tests_add_filter( 'woocommerce_should_load_paypal_standard', '__return_true' );
-
 		// load WC.
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
 
@@ -210,6 +207,12 @@ class WC_Unit_Tests_Bootstrap {
 		update_option( 'woocommerce_enable_coupons', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_onboarding_opt_in', 'yes' );
+
+		// Always load PayPal Standard for unit tests.
+		$paypal = class_exists( 'WC_Payment_Gateway' ) ? new WC_Payment_Gateway() : null;
+		if ( $paypal ) {
+			$paypal->update_option( '_should_load', wc_bool_to_string( true ) );
+		}
 
 		require_once $this->plugin_dir . '/woocommerce.php';
 		FeaturePlugin::instance()->init();


### PR DESCRIPTION
Internal discussion: pdOdsj-gD-p2
Slack: p1714678193230049-slack-C055WHLA98D

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

While investigating a PayPal Standard issue, I noticed an issue where deleting the `woocommerce_paypal_settings` from the wp-options table on an existing Woo Store resulted in PayPal Standard being now visible in my **WooCommerce > Settings > Payments** page.

![image](https://github.com/woocommerce/woocommerce/assets/2275145/fab25185-5272-45fd-a2b5-100e29f0ab52)

This problem is caused the logic inside `WC_Gateway_Paypal::should_load()` which sets the default value of `_should_load` to `'yes'` if the store is an existing store.

To reduce the number of stores connecting to PayPal Standard (which was deprecated in WC 5.5) and encourage stores to use our latest [PayPal Payments](https://wordpress.org/plugins/woocommerce-paypal-payments/) extension, this PR has made the following changes:

1. dce7c27c3305128e991e877b40e3c95504101815 Tighten the default logic that makes PayPal Standard visible.
   - With this change, PayPal Standard will now only be visible by default for stores that have set it up or have existing orders purchased with PayPal Standard.
2. 5551d5f641e439c8b5d6bff2e06cc0c300d21e40 Removed the ability to filter PayPal Standard to be visible on.
   - You can still workaround this by manually setting `_should_load` in the `woocommerce_paypal_settings` options to `'yes'`, however, the goal of this change is to remove the ability for 3rd-party plugins to make is easily visible.
3. 9aab68dbeea5de76908d3d82cf039bcde4031f0e Adds an upgrade script so that upon upgrading to WooCommerce 8.9, we will now hide PayPal Standard on any stores that have not set it up or have any orders purchased with PayPal Standard.
   - A notice also gets shown to stores that have had PayPal Standard disabled with a suggestion of installing PayPal Payments.
![image](https://github.com/woocommerce/woocommerce/assets/2275145/779f8cad-dcd8-4d20-a49b-36f949362a70)

> [!WARNING]
> ~~Removing the `woocommerce_should_load_paypal_standard` filter might break unit tests as I noticed it's used in our `bootstrap.php` file. We may need to update our tests to fix this, or re-introduce the filter for the time being.~~ I fixed the unit tests

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Upgrade script

1. Existing store:
   1. With PayPal Standard setup, with a PayPal order. PayPal Standard should still be loaded.
   2. With PayPal Standard setup, without PayPal orders. PayPal Standard should still be loaded.
   3. Without PayPal Standard setup, with a PayPal order. PayPal Standard should still be loaded.
   4. Without PayPal Standard setup, without PayPal orders, but it is enabled/loaded. PayPal Standard should still be hidden.
2. New store:
   1. Upgrade function shouldn't need to be ran since PayPal Standard needs to be enabled or have `_should_load` set to true.

I don't have existing PayPal Standard API creds to test this fully so to simplify testing all of these cases, I mocked PayPal Standard credentials and PayPal Standard orders and then copied the contents of `wc_update_890_update_paypal_standard_load_eligibility()` into a WP Console window to run the upgrade script manually. For example:

1. Make PayPal Standard visible by editing the `woocommerce_paypal_settings` option and setting `_should_load` to `"yes"`.
2. Go to **WooCommerce > Settings > Payments > PayPal Standard** and scroll to the bottom and save some dummy API credentials to simulate a store with PayPal Standard setup.
3. Simulate a store that has PayPal orders by editing an existing order's `payment_method` meta to `paypal`.
4. Open WP Console and copy the code from `wc_update_890_update_paypal_standard_load_eligibility()` and run it.
5. Visit **WooCommerce > Settings > Payments** and confirm PayPal Standard is still visible.
6. Delete the Dummy API credentials and revert the Order's payment method edited in step 3 back to its original
7. Run the `wc_update_890_update_paypal_standard_load_eligibility()` script again.
8. Confirm PayPal Standard has been disabled and cannot be viewed in **WooCommerce > Settings > Payments**

#### `WC_Gateway_Paypal::should_load()`

- If `_should_load` is empty, set it 'yes' if the store has PayPal standard enabled or is an existing store with PayPal orders, otherwise, set it to 'no'.
- If `_should_load` is already set in `woocommerce_paypal_settings`, return its value.

To test the changes coming to `WC_Gateway_Paypal::should_load()`:

1. Edit an existing order's `payment_method` meta directly via the `wc_orders` table and set it to `paypal`
2. Delete the `woocommerce_paypal_settings` from wp-options.
3. Reload any store page and check `woocommerce_paypal_settings`. Confirm `_should_load` is 'yes' and PayPal Standard is visible in **WooCommerce > Settings > Payments**
4. Change order orders `payment_method` meta back to simulate a store with no PayPal Standard orders
5. Delete the `woocommerce_paypal_settings` from wp-options.
6. Reload any store page and check `woocommerce_paypal_settings`. Confirm `_should_load` is 'no'.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
