### PR TITLE
Fix one more instance of unspecified include in tsconfig.

### DIFF
--- a/packages/js/experimental/changelog/47207-dev-fix-experimental-tsconfig
+++ b/packages/js/experimental/changelog/47207-dev-fix-experimental-tsconfig
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix a persistent build bug where TS would try compile files outside of src and typings in packages/js/experimental
+

--- a/packages/js/experimental/tsconfig.json
+++ b/packages/js/experimental/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "../tsconfig",
+	"include": [ "src/", "typings/" ],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "build-module",
@@ -7,9 +8,6 @@
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
-		"typeRoots": [
-			"./typings",
-			"./node_modules/@types"
-		]
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Following on from https://github.com/woocommerce/woocommerce/pull/47156 this is one tsconfig I missed that also needed the fix applied.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

CI passing should be sufficient. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Fix a persistent build bug where TS would try compile files outside of src and typings in packages/js/experimental

</details>
