### PR TITLE
Blocks E2E: Fix flaky block insertion tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/breadcrumbs/breadcrumbs.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/breadcrumbs/breadcrumbs.block_theme.spec.ts
@@ -58,9 +58,10 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
 
-		await editorUtils.enterEditMode();
+		await expect( editor.canvas.getByText( 'howdy' ) ).toBeVisible();
 
 		await editor.insertBlock( {
 			name: blockData.slug,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/breadcrumbs/breadcrumbs.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/breadcrumbs/breadcrumbs.block_theme.spec.ts
@@ -25,24 +25,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		);
 	} );
 
-	test( 'block should be already added in the Product Catalog Template', async ( {
-		editorUtils,
-		admin,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
-			postType: 'wp_template',
-		} );
-		await editorUtils.enterEditMode();
-		const alreadyPresentBlock = await editorUtils.getBlockByName(
-			blockData.slug
-		);
-
-		await expect( alreadyPresentBlock ).toHaveText(
-			'Breadcrumbs / Navigation / Path'
-		);
-	} );
-
 	test( 'block can be inserted in the Site Editor', async ( {
 		admin,
 		requestUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/catalog-sorting/catalog-sorting.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/catalog-sorting/catalog-sorting.block_theme.spec.ts
@@ -22,22 +22,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		);
 	} );
 
-	test( 'block should be already added in the Product Catalog Template', async ( {
-		editorUtils,
-		admin,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
-			postType: 'wp_template',
-		} );
-		await editorUtils.enterEditMode();
-		const alreadyPresentBlock = await editorUtils.getBlockByName(
-			blockData.slug
-		);
-
-		await expect( alreadyPresentBlock ).toHaveText( 'Default sorting' );
-	} );
-
 	test( 'block can be inserted in the Site Editor', async ( {
 		admin,
 		requestUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/catalog-sorting/catalog-sorting.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/catalog-sorting/catalog-sorting.block_theme.spec.ts
@@ -53,9 +53,10 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
 
-		await editorUtils.enterEditMode();
+		await expect( editor.canvas.getByText( 'howdy' ) ).toBeVisible();
 
 		await editor.insertBlock( {
 			name: blockData.slug,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-results-count/product-results-count.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-results-count/product-results-count.block_theme.spec.ts
@@ -22,24 +22,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		);
 	} );
 
-	test( 'block should be already added in the Product Catalog Template', async ( {
-		editorUtils,
-		admin,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
-			postType: 'wp_template',
-		} );
-		await editorUtils.enterEditMode();
-		const alreadyPresentBlock = await editorUtils.getBlockByName(
-			blockData.slug
-		);
-
-		await expect( alreadyPresentBlock ).toHaveText(
-			'Showing 1-X of X results'
-		);
-	} );
-
 	test( 'block can be inserted in the Site Editor', async ( {
 		admin,
 		requestUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-results-count/product-results-count.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-results-count/product-results-count.block_theme.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect, test } from '@woocommerce/e2e-playwright-utils';
+import exp from 'constants';
 
 const blockData = {
 	name: 'Product Results Count',
@@ -55,9 +56,10 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
 
-		await editorUtils.enterEditMode();
+		await expect( editor.canvas.getByText( 'howdy' ) ).toBeVisible();
 
 		await editor.insertBlock( {
 			name: blockData.slug,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-results-count/product-results-count.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-results-count/product-results-count.block_theme.spec.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect, test } from '@woocommerce/e2e-playwright-utils';
-import exp from 'constants';
 
 const blockData = {
 	name: 'Product Results Count',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -25,24 +25,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		);
 	} );
 
-	test( 'block should be already added in the Single Product Template', async ( {
-		editorUtils,
-		admin,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
-			postType: 'wp_template',
-		} );
-		await editorUtils.enterEditMode();
-		const alreadyPresentBlock = await editorUtils.getBlockByName(
-			blockData.slug
-		);
-
-		await expect( alreadyPresentBlock ).toHaveText(
-			/This block lists description, attributes and reviews for a single product./
-		);
-	} );
-
 	test( 'block can be inserted in the Site Editor', async ( {
 		admin,
 		requestUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -59,9 +59,10 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
 
-		await editorUtils.enterEditMode();
+		await expect( editor.canvas.getByText( 'howdy' ) ).toBeVisible();
 
 		await editor.insertBlock( {
 			name: blockData.slug,

--- a/plugins/woocommerce/changelog/47213-fix-flaky-e2e-block-insertion-tests
+++ b/plugins/woocommerce/changelog/47213-fix-flaky-e2e-block-insertion-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Fix flaky block insertion tests


### PR DESCRIPTION
## What?

Fix tests where block insertion is flaky. The flakiness is caused by the `editor.insertBlock` utility sometimes being called too early (before the canvas is ready), resulting in the target block not being inserted.

Example failing job: https://github.com/woocommerce/woocommerce/actions/runs/8984600365/job/24676777759?pr=47211

<img width="1277" alt="Screenshot 2024-05-07 at 13 53 20" src="https://github.com/woocommerce/woocommerce/assets/1451471/d0534240-0cfa-444c-8171-3f4a3b341e1e">

## How to test

The fixed tests should be rerun in CI a couple of times to ensure they're no longer flaky.