### PR TITLE
Blocks E2E: Remove discouraged waitForTimeout from tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -260,9 +260,6 @@ class ProductCollectionPage {
 		await this.page
 			.getByRole( 'button', { name: 'Filters options' } )
 			.click();
-		// We should refactor this code. We should not wait for timeout.
-		// eslint-disable-next-line playwright/no-wait-for-timeout
-		await this.page.waitForTimeout( 500 );
 		await this.page
 			.getByRole( 'menuitemcheckbox', {
 				name,
@@ -431,9 +428,6 @@ class ProductCollectionPage {
 		const input = sidebarSettings.getByLabel( 'Keyword' );
 		await input.clear();
 		await input.fill( keyword );
-		// Timeout is needed because of debounce in the block.
-		// eslint-disable-next-line playwright/no-wait-for-timeout
-		await this.page.waitForTimeout( 300 );
 		await this.refreshLocators( 'editor' );
 	}
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.side_effects.spec.ts
@@ -189,10 +189,6 @@ test.describe( `${ blockData.name }`, () => {
 				)
 				.click();
 
-			// We should refactor this.
-			// eslint-disable-next-line playwright/no-wait-for-timeout
-			await page.waitForTimeout( 500 );
-
 			const groupBlock = (
 				await editorUtils.getBlockByTypeWithParent(
 					'core/group',
@@ -278,10 +274,6 @@ test.describe( `${ blockData.name }`, () => {
 					blockData.selectors.editor.bottomPositionThumbnailsOption
 				)
 				.click();
-
-			// We should refactor this.
-			// eslint-disable-next-line playwright/no-wait-for-timeout
-			await page.waitForTimeout( 500 );
 
 			const groupBlock = (
 				await editorUtils.getBlockByTypeWithParent(
@@ -369,10 +361,6 @@ test.describe( `${ blockData.name }`, () => {
 					blockData.selectors.editor.rightPositionThumbnailsOption
 				)
 				.click();
-
-			// We should refactor this.
-			// eslint-disable-next-line playwright/no-wait-for-timeout
-			await page.waitForTimeout( 500 );
 
 			const groupBlock = (
 				await editorUtils.getBlockByTypeWithParent(

--- a/plugins/woocommerce/changelog/472140-refacor-e2e-remove-wait-for-timeout
+++ b/plugins/woocommerce/changelog/472140-refacor-e2e-remove-wait-for-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Remove discouraged waitForTimeout from tests


### PR DESCRIPTION
## What?

Refactor out the use of [`page.waitForTimeout`](https://playwright.dev/docs/api/class-frame#frame-wait-for-timeout) in our E2E tests as it's inherently flaky and should never be used in production. 

## How to test

Tests that used `page.waitForTimeout` should pass in CI. They should also be rerun several times to ensure they're not flaky.