### PR TITLE
CYS - Core: Invert the color of the button block inside the cover block when the active style variation is New - Neutral

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -37,6 +37,11 @@ import { useEditorBlocks } from './hooks/use-editor-blocks';
 import { useScrollOpacity } from './hooks/use-scroll-opacity';
 import { isEqual } from 'lodash';
 import { COLOR_PALETTES } from './sidebar/global-styles/color-palette-variations/constants';
+import { BlockInstance } from '@wordpress/blocks';
+import {
+	PRODUCT_HERO_PATTERN_BUTTON_STYLE,
+	findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate,
+} from './utils/hero-pattern';
 
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -179,7 +184,7 @@ export const BlockEditorContainer = () => {
 	// @ts-expect-error No types for this exist yet.
 	const { user } = useContext( GlobalStylesContext );
 
-	const isActive = useMemo(
+	const isActiveNewNeutralVariation = useMemo(
 		() =>
 			isEqual( COLOR_PALETTES[ 0 ].settings.color, user.settings.color ),
 		[ user ]
@@ -206,17 +211,30 @@ export const BlockEditorContainer = () => {
 		const buttonBlock = buttonsBlock?.innerBlocks[ 0 ];
 		const clientId = buttonBlock?.clientId;
 
-		if ( ! isActive ) {
+		if ( ! isActiveNewNeutralVariation ) {
+			findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate(
+				blocks,
+				( block: BlockInstance ) => {
+					updateBlockAttributes( block.clientId, {
+						style: {},
+					} );
+				}
+			);
 			updateBlockAttributes( clientId, {
 				style: {},
 			} );
 			return;
 		}
 
-		updateBlockAttributes( clientId, {
-			style: { color: { background: '#ffffff', text: '#000000' } },
-		} );
-	}, [ blocks, isActive, updateBlockAttributes ] );
+		findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate(
+			blocks,
+			( block: BlockInstance ) => {
+				updateBlockAttributes( block.clientId, {
+					style: PRODUCT_HERO_PATTERN_BUTTON_STYLE,
+				} );
+			}
+		);
+	}, [ blocks, isActiveNewNeutralVariation, updateBlockAttributes ] );
 
 	useEffect( () => {
 		const { blockIdToHighlight, restOfBlockIds } = clientIds.reduce(

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -206,6 +206,7 @@ export const BlockEditorContainer = () => {
 			( block: BlockInstance ) => {
 				updateBlockAttributes( block.clientId, {
 					style: PRODUCT_HERO_PATTERN_BUTTON_STYLE,
+					// This is necessary; otherwise, the style won't be applied on the frontend during the style variation change.
 					className: '',
 				} );
 			}

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -176,6 +176,7 @@ export const BlockEditorContainer = () => {
 	// @ts-expect-error No types for this exist yet.
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
+	// @ts-expect-error No types for this exist yet.
 	const { user } = useContext( GlobalStylesContext );
 
 	const isActive = useMemo(

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -3,10 +3,10 @@
 /**
  * External dependencies
  */
-// @ts-expect-error No types for this exist yet.
 import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
+	// @ts-expect-error No types for this exist yet.
 } from '@wordpress/block-editor';
 // @ts-expect-error No types for this exist yet.
 import { store as coreStore, useEntityRecords } from '@wordpress/core-data';

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -190,11 +190,6 @@ export const BlockEditorContainer = () => {
 		[ user ]
 	);
 
-	/**
-	 * This is temporary solution to change the button color on the cover block when the color palette is New - Neutral.
-	 * The real fix should be done on Gutenberg side: https://github.com/WordPress/gutenberg/issues/58004
-	 *
-	 */
 	useEffect( () => {
 		const coverBlock = blocks.find(
 			( block ) =>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -184,27 +184,11 @@ export const BlockEditorContainer = () => {
 	// @ts-expect-error No types for this exist yet.
 	const { user } = useContext( GlobalStylesContext );
 
-	const isActiveNewNeutralVariation = useMemo(
-		() =>
-			isEqual( COLOR_PALETTES[ 0 ].settings.color, user.settings.color ),
-		[ user ]
-	);
-
 	useEffect( () => {
-		const coverBlock = blocks.find(
-			( block ) =>
-				block.name === 'core/cover' &&
-				block.attributes.url.includes(
-					'music-black-and-white-white-photography.jpg'
-				)
+		const isActiveNewNeutralVariation = isEqual(
+			COLOR_PALETTES[ 0 ].settings.color,
+			user.settings.color
 		);
-
-		const buttonsBlock = coverBlock?.innerBlocks[ 0 ].innerBlocks.find(
-			( block ) => block.name === 'core/buttons'
-		);
-
-		const buttonBlock = buttonsBlock?.innerBlocks[ 0 ];
-		const clientId = buttonBlock?.clientId;
 
 		if ( ! isActiveNewNeutralVariation ) {
 			findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate(
@@ -215,21 +199,18 @@ export const BlockEditorContainer = () => {
 					} );
 				}
 			);
-			updateBlockAttributes( clientId, {
-				style: {},
-			} );
 			return;
 		}
-
 		findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate(
 			blocks,
 			( block: BlockInstance ) => {
 				updateBlockAttributes( block.clientId, {
 					style: PRODUCT_HERO_PATTERN_BUTTON_STYLE,
+					className: '',
 				} );
 			}
 		);
-	}, [ blocks, isActiveNewNeutralVariation, updateBlockAttributes ] );
+	}, [ blocks, updateBlockAttributes, user.settings.color ] );
 
 	useEffect( () => {
 		const { blockIdToHighlight, restOfBlockIds } = clientIds.reduce(

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -13,10 +13,15 @@ import {
 } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
 import { Spinner } from '@wordpress/components';
+// @ts-expect-error Missing type.
+import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 // @ts-expect-error No types for this exist yet.
 import { store as coreStore } from '@wordpress/core-data';
-// @ts-expect-error Missing type in core-data.
-import { __experimentalBlockPatternsList as BlockPatternList } from '@wordpress/block-editor';
+import {
+	privateApis as blockEditorPrivateApis,
+	__experimentalBlockPatternsList as BlockPatternList,
+	// @ts-expect-error No types for this exist yet.
+} from '@wordpress/block-editor';
 // @ts-expect-error Missing type in core-data.
 import { useIsSiteEditorLoading } from '@wordpress/edit-site/build-module/components/layout/hooks';
 
@@ -33,7 +38,16 @@ import { useEditorScroll } from '../hooks/use-editor-scroll';
 import { FlowType } from '~/customize-store/types';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
 import { useSelect } from '@wordpress/data';
+
 import { trackEvent } from '~/customize-store/tracking';
+import {
+	PRODUCT_HERO_PATTERN_BUTTON_STYLE,
+	findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate,
+} from '../utils/hero-pattern';
+import { isEqual } from 'lodash';
+import { COLOR_PALETTES } from './global-styles/color-palette-variations/constants';
+
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 export const SidebarNavigationScreenHomepage = () => {
 	const { scroll } = useEditorScroll( {
@@ -72,9 +86,47 @@ export const SidebarNavigationScreenHomepage = () => {
 
 	const isEditorLoading = useIsSiteEditorLoading();
 
+	// @ts-expect-error No types for this exist yet.
+	const { user } = useContext( GlobalStylesContext );
+
+	const isActiveNewNeutralVariation = useMemo(
+		() =>
+			isEqual( COLOR_PALETTES[ 0 ].settings.color, user.settings.color ),
+		[ user ]
+	);
+
 	const homePatterns = useMemo( () => {
 		return Object.entries( homeTemplates ).map(
 			( [ templateName, patterns ] ) => {
+				if ( templateName === 'template1' ) {
+					return {
+						name: templateName,
+						title: templateName,
+						blocks: patterns.reduce(
+							( acc: BlockInstance[], pattern ) => {
+								if ( ! isActiveNewNeutralVariation ) {
+									return [ ...acc, ...pattern.blocks ];
+								}
+								const updatedBlocks =
+									findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate(
+										pattern.blocks,
+										( buttonBlock: BlockInstance ) => {
+											buttonBlock.attributes.style =
+												PRODUCT_HERO_PATTERN_BUTTON_STYLE;
+										}
+									);
+
+								return [ ...acc, ...updatedBlocks ];
+							},
+							[]
+						),
+						blockTypes: [ '' ],
+						categories: [ '' ],
+						content: '',
+						source: '',
+					};
+				}
+
 				return {
 					name: templateName,
 					title: templateName,
@@ -92,7 +144,7 @@ export const SidebarNavigationScreenHomepage = () => {
 				};
 			}
 		);
-	}, [ homeTemplates ] );
+	}, [ homeTemplates, isActiveNewNeutralVariation ] );
 
 	useEffect( () => {
 		if (

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/hero-pattern.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/hero-pattern.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { BlockInstance } from '@wordpress/blocks';
+
+export const findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate = (
+	blocks: BlockInstance[],
+	callback: ( buttonBlock: BlockInstance ) => void
+) => {
+	const clonedBlocks = structuredClone( blocks );
+	const coverBlock = clonedBlocks.find(
+		( block ) =>
+			block.name === 'core/cover' &&
+			block.attributes.url.includes(
+				'music-black-and-white-white-photography.jpg'
+			)
+	);
+
+	const buttonsBlock = coverBlock?.innerBlocks[ 0 ].innerBlocks.find(
+		( block ) => block.name === 'core/buttons'
+	);
+
+	const buttonBlock = buttonsBlock?.innerBlocks[ 0 ];
+
+	if ( ! buttonBlock ) {
+		return clonedBlocks;
+	}
+
+	callback( buttonBlock );
+	return clonedBlocks;
+};
+
+export const PRODUCT_HERO_PATTERN_BUTTON_STYLE = {
+	color: { background: '#ffffff', text: '#000000' },
+};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/hero-pattern.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/hero-pattern.ts
@@ -3,6 +3,11 @@
  */
 import { BlockInstance } from '@wordpress/blocks';
 
+/**
+ * This is temporary solution to change the button color on the cover block when the color palette is New - Neutral.
+ * The real fix should be done on Gutenberg side: https://github.com/WordPress/gutenberg/issues/58004
+ *
+ */
 export const findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate = (
 	blocks: BlockInstance[],
 	callback: ( buttonBlock: BlockInstance ) => void

--- a/plugins/woocommerce/changelog/47220-fix-cover-button-white
+++ b/plugins/woocommerce/changelog/47220-fix-cover-button-white
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: CYS - Core: Invert the color of the button block inside the cover block when the active style variation is New - Neutral.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


Closes https://github.com/woocommerce/woocommerce/issues/47222.

This PR is just a workaround. The real fix should occur on Gutenberg: https://github.com/WordPress/gutenberg/issues/58004


| Before | After |
|--------|--------|
| ![b765YG.png](https://github.com/woocommerce/woocommerce/assets/4463174/67414e62-6441-49df-bb4a-495487ff1806) |![image](https://github.com/woocommerce/woocommerce/assets/4463174/e38ed15e-928a-494a-bbd5-fae106de5910)| 


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to WooCommerce > Home > Customize your store.
2. Click on "Start designing" and proceed to the Pattern Assembler.
3. Click on "Choose your color palette".
4. Click on the first color palette
6. Ensure that the button block inside the cover block has a white background:

![D12Gkw.png](https://github.com/woocommerce/woocommerce/assets/4463174/6a9b1500-c36d-44d6-85f3-1353237c01a8)
7. Save.
8. Visit the homepage and ensure that the button block inside the cover block has a white background:
9. Visit the admin page.
10. Head over to WooCommerce > Home > Customize your store.
11. Click on "Customize your theme" and proceed to the Pattern Assembler.
12. Click on "Choose your color palette".
13. Click on another palette.
14. Ensure that the button background is updated and matches the color palette.
15. Save.
16. Visit the homepage and ensure that the button background is updated and matches the color palette.



⚠️ There is an edge case: when the site is setup and the user doesn't click save, the background color of the button will be black.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

CYS - Core: Invert the color of the button block inside the cover block when the active style variation is New - Neutral.

</details>