### PR TITLE
Use wp_plugin_dependencies_slug in PluginVersionRuleProcessor

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/47235-update-47187-use-wp_plugin_dependencies_slug
+++ b/plugins/woocommerce-beta-tester/changelog/47235-update-47187-use-wp_plugin_dependencies_slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Applies `wp_plugin_dependencies_slug` filter to get the correct plugin name in PluginVersionRuleProcessor.

--- a/plugins/woocommerce-beta-tester/src/remote-spec-validator/data/actions.js
+++ b/plugins/woocommerce-beta-tester/src/remote-spec-validator/data/actions.js
@@ -14,7 +14,6 @@ export function* validate( jsonString ) {
 		const response = yield apiFetch( {
 			method: 'POST',
 			path: `${ API_NAMESPACE }/remote-spec-validator/validate`,
-			headers: { 'content-type': 'application/json' },
 			data: {
 				spec: JSON.stringify( JSON.parse( jsonString ) ),
 			},

--- a/plugins/woocommerce/changelog/47235-update-47187-use-wp_plugin_dependencies_slug
+++ b/plugins/woocommerce/changelog/47235-update-47187-use-wp_plugin_dependencies_slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Applies `wp_plugin_dependencies_slug` filter to get the correct plugin name in PluginVersionRuleProcessor.

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/PluginVersionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/PluginVersionRuleProcessor.php
@@ -45,12 +45,13 @@ class PluginVersionRuleProcessor implements RuleProcessorInterface {
 	 */
 	public function process( $rule, $stored_state ) {
 		$active_plugin_slugs = $this->plugins_provider->get_active_plugin_slugs();
+		$plugin_name = apply_filter( 'wp_plugin_dependencies_slug', $rule->plugin );
 
-		if ( ! in_array( $rule->plugin, $active_plugin_slugs, true ) ) {
+		if ( ! in_array( $plugin_name, $active_plugin_slugs, true ) ) {
 			return false;
 		}
 
-		$plugin_data = $this->plugins_provider->get_plugin_data( $rule->plugin );
+		$plugin_data = $this->plugins_provider->get_plugin_data( $plugin_name );
 
 		if ( ! is_array( $plugin_data ) || ! array_key_exists( 'Version', $plugin_data ) ) {
 			return false;

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/PluginVersionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/PluginVersionRuleProcessor.php
@@ -45,6 +45,13 @@ class PluginVersionRuleProcessor implements RuleProcessorInterface {
 	 */
 	public function process( $rule, $stored_state ) {
 		$active_plugin_slugs = $this->plugins_provider->get_active_plugin_slugs();
+		/**
+		 * Filters a plugin dependency’s slug before matching to the WordPress.org slug format.
+		 *
+		 * @since 9.0.0
+		 *
+		 * @param string $plugin_name requested plugin name
+		 */
 		$plugin_name = apply_filters( 'wp_plugin_dependencies_slug', $rule->plugin );
 
 		if ( ! in_array( $plugin_name, $active_plugin_slugs, true ) ) {

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/PluginVersionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/PluginVersionRuleProcessor.php
@@ -45,7 +45,7 @@ class PluginVersionRuleProcessor implements RuleProcessorInterface {
 	 */
 	public function process( $rule, $stored_state ) {
 		$active_plugin_slugs = $this->plugins_provider->get_active_plugin_slugs();
-		$plugin_name = apply_filter( 'wp_plugin_dependencies_slug', $rule->plugin );
+		$plugin_name = apply_filters( 'wp_plugin_dependencies_slug', $rule->plugin );
 
 		if ( ! in_array( $plugin_name, $active_plugin_slugs, true ) ) {
 			return false;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -101,7 +101,9 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_activate_plugin() {
 		wp_set_current_user( $this->user );
-
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			activate_plugin( 'woocommerce/woocommerce.php' );
+		}
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
 		$request->set_query_params(
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR applies `wp_plugin_dependencies_slug` filter to get the correct plugin name in PluginVersionRuleProcessor.

Closes #47187 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Checkout this branch locally and cd to `plugins/woocommerce-beta-tester`
3. Run `pnpm run build:zip` to create a new zip.
4. Upload the zip file to your JN site and replace the current WooCommerce Beta Tester.
5. Go to `Tools -> WCA Test Helper -> Remote Spec Rule Validator`
6. The validator already has a sample rule that uses `plugin_version` type. Click on `Validate`
7. The rule should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Applies `wp_plugin_dependencies_slug` filter to get the correct plugin name in PluginVersionRuleProcessor.


#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
