### PR TITLE
Replace Options API usage with LaunchYourStore endpoint for LYS

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/actions.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/actions.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { DoneActorEvent } from 'xstate5';
-import { dispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME, TaskListType } from '@woocommerce/data';
+import { TaskListType } from '@woocommerce/data';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -12,8 +12,12 @@ import type { MainContentMachineContext } from '../../../main-content/xstate';
 
 export const assignCompleteSurvey = {
 	congratsScreen: ( { context }: { context: MainContentMachineContext } ) => {
-		dispatch( OPTIONS_STORE_NAME ).updateOptions( {
-			woocommerce_admin_launch_your_store_survey_completed: 'yes',
+		apiFetch( {
+			path: '/wc-admin/launch-your-store/update-survey-status',
+			data: {
+				status: 'yes',
+			},
+			method: 'POST',
 		} );
 
 		return {

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/actions.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/actions.tsx
@@ -18,7 +18,7 @@ export const assignCompleteSurvey = {
 				status: 'yes',
 			},
 			method: 'POST',
-		} );
+		} ).catch( () => {} );
 
 		return {
 			...context.congratsScreen,

--- a/plugins/woocommerce/changelog/47252-add-46306-use-cuystom-api-controller-for-lys-success-screen
+++ b/plugins/woocommerce/changelog/47252-add-46306-use-cuystom-api-controller-for-lys-success-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace Options API usage with LaunchYourStore endpoint for LYS

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -56,7 +56,7 @@ class LaunchYourStore {
 					'methods'             => 'POST',
 					'callback'            => array( $this, 'update_survey_status' ),
 					'permission_callback' => array( $this, 'must_be_shop_manager_or_admin' ),
-					'args' => array(
+					'args'                => array(
 						'status' => array(
 							'type' => 'string',
 							'enum' => array( 'yes', 'no' ),
@@ -114,6 +114,13 @@ class LaunchYourStore {
 		return true;
 	}
 
+	/**
+	 * Update woocommerce_admin_launch_your_store_survey_completed to yes or no
+	 *
+	 * @param \WP_REST_Request $request WP_REST_Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
 	public function update_survey_status( \WP_REST_Request $request ) {
 		update_option( 'woocommerce_admin_launch_your_store_survey_completed', $request->get_param( 'status' ) );
 		return new \WP_REST_Response();

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -47,6 +47,24 @@ class LaunchYourStore {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/update-survey-status',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'update_survey_status' ),
+					'permission_callback' => array( $this, 'must_be_shop_manager_or_admin' ),
+					'args' => array(
+						'status' => array(
+							'type' => 'string',
+							'enum' => array( 'yes', 'no' ),
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -94,5 +112,10 @@ class LaunchYourStore {
 		);
 
 		return true;
+	}
+
+	public function update_survey_status( \WP_REST_Request $request ) {
+		update_option( 'woocommerce_admin_launch_your_store_survey_completed', $request->get_param( 'status' ) );
+		return new \WP_REST_Response();
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -220,7 +220,6 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_admin_customize_store_completed',
 			'woocommerce_admin_customize_store_completed_theme_id',
 			'woocommerce_admin_customize_store_survey_completed',
-			'woocommerce_admin_launch_your_store_survey_completed',
 			'woocommerce_coming_soon',
 			'woocommerce_store_pages_only',
 			'woocommerce_private_link',

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -101,7 +101,9 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_activate_plugin() {
 		wp_set_current_user( $this->user );
-
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			activate_plugin( 'woocommerce/woocommerce.php' );
+		}
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
 		$request->set_query_params(
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46306  .

This PR replaces Options API usage with LaunchYourStore endpoint for LYS.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Go to `WooCommerce -> Home` and click on `Launch Your Store` task.
3. Click on `Launch your store` button.
4. Open your browser's inspector and move to `Network` tab.
5. Click on one of the emojis and submit your survey. 
6. Confirm `update-survey-status` endpoint is used.



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Replace Options API usage with LaunchYourStore endpoint for LYS

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
