### PR TITLE
REST API: Add missing line item schemas to refunds endpoint

### DIFF
--- a/plugins/woocommerce/changelog/fix-43444-refund-schema
+++ b/plugins/woocommerce/changelog/fix-43444-refund-schema
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add missing line item data to the REST API refunds schema in versions 2 and 3

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -564,7 +564,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 						),
 					),
 				),
-				'tax_lines'            => array(
+				'tax_lines'        => array(
 					'description' => __( 'Tax lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
@@ -643,7 +643,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 						),
 					),
 				),
-				'shipping_lines'       => array(
+				'shipping_lines'   => array(
 					'description' => __( 'Shipping lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
@@ -734,7 +734,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 						),
 					),
 				),
-				'fee_lines'            => array(
+				'fee_lines'        => array(
 					'description' => __( 'Fee lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -564,6 +564,274 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 						),
 					),
 				),
+				'tax_lines'            => array(
+					'description' => __( 'Tax lines data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'                 => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'rate_code'          => array(
+								'description' => __( 'Tax rate code.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'rate_id'            => array(
+								'description' => __( 'Tax rate ID.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'label'              => array(
+								'description' => __( 'Tax rate label.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'compound'           => array(
+								'description' => __( 'Show if is a compound tax rate.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'tax_total'          => array(
+								'description' => __( 'Tax total (not including shipping taxes).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'shipping_tax_total' => array(
+								'description' => __( 'Shipping tax total.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'meta_data'          => array(
+								'description' => __( 'Meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id'    => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key'   => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'mixed',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+				'shipping_lines'       => array(
+					'description' => __( 'Shipping lines data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'           => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'method_title' => array(
+								'description' => __( 'Shipping method name.', 'woocommerce' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'method_id'    => array(
+								'description' => __( 'Shipping method ID.', 'woocommerce' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'instance_id'  => array(
+								'description' => __( 'Shipping instance ID.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total'        => array(
+								'description' => __( 'Line total (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total_tax'    => array(
+								'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'taxes'        => array(
+								'description' => __( 'Line taxes.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id'    => array(
+											'description' => __( 'Tax rate ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'total' => array(
+											'description' => __( 'Tax total.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+									),
+								),
+							),
+							'meta_data'    => array(
+								'description' => __( 'Meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id'    => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key'   => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'mixed',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+				'fee_lines'            => array(
+					'description' => __( 'Fee lines data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'         => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name'       => array(
+								'description' => __( 'Fee name.', 'woocommerce' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_class'  => array(
+								'description' => __( 'Tax class of fee.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_status' => array(
+								'description' => __( 'Tax status of fee.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'enum'        => array( 'taxable', 'none' ),
+							),
+							'total'      => array(
+								'description' => __( 'Line total (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total_tax'  => array(
+								'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'taxes'      => array(
+								'description' => __( 'Line taxes.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id'       => array(
+											'description' => __( 'Tax rate ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'total'    => array(
+											'description' => __( 'Tax total.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'subtotal' => array(
+											'description' => __( 'Tax subtotal.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+									),
+								),
+							),
+							'meta_data'  => array(
+								'description' => __( 'Meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id'    => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key'   => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'mixed',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
 				'api_refund'       => array(
 					'description' => __( 'When true, the payment gateway API is used to generate the refund.', 'woocommerce' ),
 					'type'        => 'boolean',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #28241, `fee_lines`, `shipping_lines`, and `tax_lines` properties were all added to the refund data object sent by v2 and v3 of the REST API. However, the schema was never updated, so the characteristics of those properties have not been very discoverable. This simply copies the relevant schema data from the orders endpoint over to the refunds endpoint.

Towards #43444

The other part of this is an update to the REST API docs to also show these properties for the refunds endpoint. That will happen in a separate PR.

### How to test the changes in this Pull Request:

1. Create an order, and then refund part or all of it. Note the ID of the order.
1. Using cURL or an API client such as [Bruno](https://www.usebruno.com/), make a request to `wc/v3/orders/{order ID}/refunds`, but make the _type_ of request `OPTIONS` instead of `GET`. This will return the args and schema of the endpoint, rather than any actual data. Example for cURL:
    >  curl -X OPTIONS http://localhost/wp-json/wc/v3/orders/0/refunds
1. Make sure the schema includes `fee_lines`, `shipping_lines`, and `tax_lines`.