### PR TITLE
Fetch Marketplace promotions - ensure callback is always registered for `woocommerce_marketplace_fetch_promotions` action

### DIFF
--- a/plugins/woocommerce/changelog/fix-woocommerce_marketplace_fetch_promotions-broken-with-cron
+++ b/plugins/woocommerce/changelog/fix-woocommerce_marketplace_fetch_promotions-broken-with-cron
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Ensure that callback to woocommerce_marketplace_fetch_promotions scheduled action is always registered.
+Switch marketplace promotions from Action Scheduler to cron.

--- a/plugins/woocommerce/changelog/fix-woocommerce_marketplace_fetch_promotions-broken-with-cron
+++ b/plugins/woocommerce/changelog/fix-woocommerce_marketplace_fetch_promotions-broken-with-cron
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure that callback to woocommerce_marketplace_fetch_promotions scheduled action is always registered.

--- a/plugins/woocommerce/changelog/fix-woocommerce_marketplace_fetch_promotions-broken-with-cron
+++ b/plugins/woocommerce/changelog/fix-woocommerce_marketplace_fetch_promotions-broken-with-cron
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Switch marketplace promotions from Action Scheduler to cron.
+Switch marketplace promotions from Action Scheduler to transient.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -558,7 +558,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			// Marketplace promotions.
 			if ( in_array( $screen_id, array( 'woocommerce_page_wc-admin' ), true ) ) {
 
-				$promotions = get_transient( WC_Admin_Marketplace_Promotions::TRANSIENT_NAME );
+				$promotions = WC_Admin_Marketplace_Promotions::get_active_promotions();
 
 				if ( false === $promotions ) {
 					return;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -38,8 +38,8 @@ class WC_Admin_Marketplace_Promotions {
 	 */
 	public static function init() {
 		// A legacy hook that can be triggered by action scheduler.
-		add_action( 'woocommerce_marketplace_fetch_promotions', '__return_true' );
-		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
+		add_action( 'woocommerce_marketplace_fetch_promotions', array( __CLASS__, 'clear_deprecated_action' ) );
+		add_action( 'woocommerce_marketplace_fetch_promotions_clear', array( __CLASS__, 'clear_scheduled_event' ) );
 
 		if (
 			defined( 'DOING_AJAX' ) && DOING_AJAX
@@ -334,6 +334,17 @@ class WC_Admin_Marketplace_Promotions {
 	public static function clear_scheduled_event() {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( 'woocommerce_marketplace_fetch_promotions' );
+		}
+	}
+
+	/**
+	 * We can't clear deprecated action from AS when it's running,
+	 * so we schedule a new single action to clear the deprecated
+	 * `woocommerce_marketplace_fetch_promotions` action.
+	 */
+	public static function clear_deprecated_action() {
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( time(), 'woocommerce_marketplace_fetch_promotions_clear' );
 		}
 	}
 }

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -15,9 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Admin_Marketplace_Promotions {
 
-	const TRANSIENT_NAME            = 'woocommerce_marketplace_promotions_v2';
-	const TRANSIENT_LIFE_SPAN       = DAY_IN_SECONDS;
-	const PROMOTIONS_API_URL        = 'https://woocommerce.com/wp-json/wccom-extensions/3.0/promotions';
+	const TRANSIENT_NAME      = 'woocommerce_marketplace_promotions_v2';
+	const TRANSIENT_LIFE_SPAN = DAY_IN_SECONDS;
+	const PROMOTIONS_API_URL  = 'https://woocommerce.com/wp-json/wccom-extensions/3.0/promotions';
 
 	/**
 	 * The user's locale, for example en_US.
@@ -37,7 +37,7 @@ class WC_Admin_Marketplace_Promotions {
 	 * @return void
 	 */
 	public static function init() {
-		// legacy hook that can be triggered by action scheduler
+		// A legacy hook that can be triggered by action scheduler.
 		add_action( 'woocommerce_marketplace_fetch_promotions', '__return_true' );
 
 		if (

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -15,10 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Admin_Marketplace_Promotions {
 
-	const TRANSIENT_NAME            = 'woocommerce_marketplace_promotions';
-	const SCHEDULED_ACTION_HOOK     = 'woocommerce_marketplace_fetch_promotions';
+	const TRANSIENT_NAME            = 'woocommerce_marketplace_promotions_v2';
+	const TRANSIENT_LIFE_SPAN       = DAY_IN_SECONDS;
 	const PROMOTIONS_API_URL        = 'https://woocommerce.com/wp-json/wccom-extensions/3.0/promotions';
-	const SCHEDULED_ACTION_INTERVAL = 12 * HOUR_IN_SECONDS;
 
 	/**
 	 * The user's locale, for example en_US.
@@ -28,7 +27,7 @@ class WC_Admin_Marketplace_Promotions {
 	public static string $locale;
 
 	/**
-	 * On all admin pages, schedule an action to fetch promotions data.
+	 * On all admin pages, try go get Marketplace promotions every day.
 	 * Shows notice and adds menu badge to WooCommerce Extensions item
 	 * if the promotions API requests them.
 	 *
@@ -38,24 +37,8 @@ class WC_Admin_Marketplace_Promotions {
 	 * @return void
 	 */
 	public static function init() {
-		add_action( self::SCHEDULED_ACTION_HOOK, array( __CLASS__, 'fetch_marketplace_promotions' ) );
-		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
-
-		/**
-		 * Filter to suppress the requests for and showing of marketplace promotions.
-		 *
-		 * @since 8.8
-		 */
-		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
-			return;
-		}
-
-		if ( ! is_admin() ) {
-			return;
-		}
-
-		// Schedule (using Action Scheduler) the action to fetch promotions data.
-		self::schedule_promotion_fetch();
+		// legacy hook that can be triggered by action scheduler
+		add_action( 'woocommerce_marketplace_fetch_promotions', '__return_true' );
 
 		if (
 			defined( 'DOING_AJAX' ) && DOING_AJAX
@@ -65,38 +48,71 @@ class WC_Admin_Marketplace_Promotions {
 			return;
 		}
 
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		self::maybe_update_promotions();
+
 		self::$locale = ( self::$locale ?? get_user_locale() ) ?? 'en_US';
 		self::maybe_show_bubble_promotions();
 	}
 
 	/**
-	 * Schedule the action to fetch promotions data.
-	 */
-	public static function schedule_promotion_fetch() {
-		// Schedule the action twice a day using Action Scheduler.
-		if (
-			function_exists( 'as_has_scheduled_action' )
-			&& function_exists( 'as_schedule_recurring_action' )
-			&& false === as_has_scheduled_action( self::SCHEDULED_ACTION_HOOK )
-		) {
-			as_schedule_recurring_action( time(), self::SCHEDULED_ACTION_INTERVAL, self::SCHEDULED_ACTION_HOOK );
-		}
-	}
-
-	/**
-	 * Get promotions to show in the Woo in-app marketplace and load them into a transient
-	 * with a 12-hour life. Run as a recurring scheduled action.
+	 * Fetch promotions from the API and store them in a transient.
+	 * Fetching can be suppressed by the `woocommerce_marketplace_suppress_promotions` filter.
 	 *
 	 * @return void
 	 */
-	public static function fetch_marketplace_promotions() {
+	private static function maybe_update_promotions() {
+		// Fetch promotions if they're not in the transient.
+		if ( false !== get_transient( self::TRANSIENT_NAME ) ) {
+			return;
+		}
+
+		// Fetch promotions from the API.
+		$promotions = self::fetch_marketplace_promotions();
+		set_transient( self::TRANSIENT_NAME, $promotions, self::TRANSIENT_LIFE_SPAN );
+	}
+
+	/**
+	 * Get active Marketplace promotions from the transient.
+	 * Use `woocommerce_marketplace_suppress_promotions` filter to suppress promotions.
+	 *
+	 * @since 9.0
+	 */
+	public static function get_active_promotions() {
 		/**
 		 * Filter to suppress the requests for and showing of marketplace promotions.
 		 *
 		 * @since 8.8
 		 */
 		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
-			return;
+			return array();
+		}
+
+		$promotions = get_transient( self::TRANSIENT_NAME );
+		if ( ! $promotions ) {
+			return array();
+		}
+
+		return self::filter_out_inactive_promotions( $promotions );
+	}
+
+	/**
+	 * Get promotions to show in the Woo in-app marketplace and load them into a transient
+	 * with a 12-hour life. Run as a recurring scheduled action.
+	 *
+	 * @return array
+	 */
+	private static function fetch_marketplace_promotions() {
+		/**
+		 * Filter to suppress the requests for and showing of marketplace promotions.
+		 *
+		 * @since 8.8
+		 */
+		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
+			return array();
 		}
 
 		// Fetch promotions from the API.
@@ -139,9 +155,7 @@ class WC_Admin_Marketplace_Promotions {
 		}
 		// phpcs:enable WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		// Filter out any expired promotions.
-		$active_promotions = self::get_active_promotions( $promotions );
-		set_transient( self::TRANSIENT_NAME, $active_promotions, 12 * HOUR_IN_SECONDS );
+		return $promotions;
 	}
 
 	/**
@@ -149,10 +163,21 @@ class WC_Admin_Marketplace_Promotions {
 	 * add a filter to show a bubble on the Extensions item in the
 	 * WooCommerce menu.
 	 *
+	 * Use `woocommerce_marketplace_suppress_promotions` filter to suppress the bubble.
+	 *
 	 * @return void
 	 * @throws Exception  If we are unable to create a DateTime from the date_to_gmt.
 	 */
 	private static function maybe_show_bubble_promotions() {
+		/**
+		 * Filter to suppress the requests for and showing of marketplace promotions.
+		 *
+		 * @since 8.8
+		 */
+		if ( apply_filters( 'woocommerce_marketplace_suppress_promotions', false ) ) {
+			return;
+		}
+
 		$promotions = get_transient( self::TRANSIENT_NAME );
 		if ( ! $promotions ) {
 			return;
@@ -219,7 +244,7 @@ class WC_Admin_Marketplace_Promotions {
 	 *
 	 * @return array
 	 */
-	private static function get_active_promotions( $promotions = array() ) {
+	private static function filter_out_inactive_promotions( $promotions = array() ) {
 		$now_date_time     = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		$active_promotions = array();
 
@@ -300,13 +325,14 @@ class WC_Admin_Marketplace_Promotions {
 	}
 
 	/**
-	 * When WooCommerce is deactivated, clear the scheduled action.
+	 * Clear event that was used for fetching promotions in WC Core 8.8.
+	 * It's no longer needed as a transient is used to store the data.
 	 *
 	 * @return void
 	 */
 	public static function clear_scheduled_event() {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( self::SCHEDULED_ACTION_HOOK );
+			as_unschedule_all_actions( 'woocommerce_marketplace_fetch_promotions' );
 		}
 	}
 }

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -39,6 +39,7 @@ class WC_Admin_Marketplace_Promotions {
 	public static function init() {
 		// A legacy hook that can be triggered by action scheduler.
 		add_action( 'woocommerce_marketplace_fetch_promotions', '__return_true' );
+		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_scheduled_event' ) );
 
 		if (
 			defined( 'DOING_AJAX' ) && DOING_AJAX
@@ -325,7 +326,7 @@ class WC_Admin_Marketplace_Promotions {
 	}
 
 	/**
-	 * Clear event that was used for fetching promotions in WC Core 8.8.
+	 * Clear the scheduled action that was used to fetch promotions in WooCommerce 8.8.
 	 * It's no longer needed as a transient is used to store the data.
 	 *
 	 * @return void

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -585,6 +585,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/queue/class-wc-action-queue.php';
 		include_once WC_ABSPATH . 'includes/queue/class-wc-queue.php';
 		include_once WC_ABSPATH . 'includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php';
+		include_once WC_ABSPATH . 'includes/admin/class-wc-admin-marketplace-promotions.php';
 		include_once WC_ABSPATH . 'includes/blocks/class-wc-blocks-utils.php';
 
 		/**
@@ -650,10 +651,6 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'admin' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
-		}
-
-		if ( $this->is_request( 'admin' ) || $this->is_request( 'cron' ) ) {
-			include_once WC_ABSPATH . 'includes/admin/class-wc-admin-marketplace-promotions.php';
 		}
 
 		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.


### PR DESCRIPTION
We started getting errors 'Scheduled action for woocommerce_marketplace_fetch_promotions will not be executed as no callbacks are registered.' on some environments.

In this commit we ensure that WC_Admin_Marketplace_Promotions::fetch_marketplace_promotions() is always added as a calback to our action hook.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

1. Ensure that file `plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php` is always loaded. This is to ensure that callback for previously scheduled action (added in WC Core 8.8) is always there.
2. Change how we fetch Marketplace promotions by switching from Action Scheduler to transients. This makes it easier to ensure that action is called only in admin context and has no impact on frontend users.
3. Reuse the `woocommerce_marketplace_suppress_promotions` filter in more places to ensure that it suppresses fetching data and displaying it.

Closes #46923 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Check out this branch.
2. Apply the following patch (it adds 2 `error_log()` entries and changes URL for fetching promotions) 
[promotions_transients.patch](https://github.com/woocommerce/woocommerce/files/15317832/promotions_transients.patch)

3. Build WooCommerce
```
cd plugins/woocommerce
nvm use
pnpm install
pnpm --filter='@woocommerce/plugin-woocommerce' build
```
4. Enter docker running at port 8888 (`wordpress-1`) and tail debug logs
```
cd wp-content
tail -f debug.log
```
5. Enter CLI docker (Name: `cli-1`) separately
6. Use the site as a regular user
   - confirm that there are no new log entries
   - Ensure that transient is not set - `wp transient get woocommerce_marketplace_promotions_v2` should be empty 
8. View site as admin
   - confirm there's one log for `fetch promotions`
   - browse through admin pages and confirm that remaining logs are `skip fetching promotions`
   - Go back to CLI docker and confirm that there's a value for the transient `wp transient get woocommerce_marketplace_promotions_v2`
9. Confirm that you see Sale bubble in the menu and that Sale notification is displayed in the In-App Marketplace
![image](https://github.com/woocommerce/woocommerce/assets/4765119/ec2b45d8-763d-4220-9ea1-e977483df45e)
10. In CLI docker enter wp shell by running `wp shell` and run `WC_Admin_Marketplace_Promotions::get_active_promotions();` - confirm that active promotions return only what is matching current dates
11. Still in WP shell, remove the transient `delete_transient('woocommerce_marketplace_promotions_v2');`
12. Refresh admin pages and ensure that log `fetch promotions` is there
13. Add filter `add_filter( 'woocommerce_marketplace_suppress_promotions', '__return_true' );` and ensure that both sale bubble and notification inside In-App are no longer visible
14. Go to http://wccore.test:8888/wp-admin/admin.php?page=wc-status&tab=action-scheduler&action=-1&action2=-1&status=pending
2. Check if you have `woocommerce_marketplace_fetch_promotions` in pending actions
3. If yes, run the action
4. Make sure that afterward action `woocommerce_marketplace_fetch_promotions_clear` runs too and that when it's done you see neither `woocommerce_marketplace_fetch_promotions` nor `woocommerce_marketplace_fetch_promotions_clear` in pending actions
15. Please test around this issue / Try to break things

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
