### PR TITLE
LYS - Add padding-left to the copy link

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
@@ -43,7 +43,8 @@
 			font-style: normal;
 			font-weight: 400;
 			line-height: 20px;
-
+			padding-left: 15px;
+			
 			&:focus {
 				outline: none !important;
 				box-shadow: none;

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
@@ -44,7 +44,7 @@
 			font-weight: 400;
 			line-height: 20px;
 			padding-left: 15px;
-			
+
 			&:focus {
 				outline: none !important;
 				box-shadow: none;

--- a/plugins/woocommerce/changelog/47313-update-47302-add-spacing-to-copy-link
+++ b/plugins/woocommerce/changelog/47313-update-47302-add-spacing-to-copy-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Added `padding-left: 15px` to the copy link to provide equal spacing around the button

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -101,7 +101,9 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_activate_plugin() {
 		wp_set_current_user( $this->user );
-
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			activate_plugin( 'woocommerce/woocommerce.php' );
+		}
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
 		$request->set_query_params(
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47302 .

This PR adds `padding-left: 15px` to the copy link to provide equal spacing around the button

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Go to `WooCommerce -> Settings -> Site Visibility`
3. Click on `Coming soon` and toggle `Share your site with a private link`
4. Confirm the added padding.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Added `padding-left: 15px` to the copy link to provide equal spacing around the button

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
