### PR TITLE
LYS - Update toolbar store link text 

### DIFF
--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -46,6 +46,7 @@ import { getUrlParams } from '~/utils';
 import { useActiveSetupTasklist } from '~/task-lists';
 import { getSegmentsFromPath } from '~/utils/url-helpers';
 import { FeedbackIcon } from '~/products/images/feedback-icon';
+import { useLaunchYourStore } from '~/launch-your-store';
 
 const HelpPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
@@ -72,6 +73,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const hasExtendedNotifications = Boolean( fills?.length );
 	const { updateUserPreferences, ...userData } = useUserPreferences();
 	const activeSetupList = useActiveSetupTasklist();
+	const { comingSoon } = useLaunchYourStore();
 
 	const closePanel = () => {
 		setIsPanelClosing( true );
@@ -372,7 +374,11 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const previewStore = {
 			name: 'previewStore',
-			title: __( 'Preview store', 'woocommerce' ),
+			title:
+				( comingSoon === 'yes' &&
+					__( 'Preview store', 'woocommerce' ) ) ||
+				( comingSoon === 'no' && __( 'View store', 'woocommerce' ) ) ||
+				'',
 			visible: isHomescreen() && query.task !== 'appearance',
 			onClick: () => {
 				window.open( getAdminSetting( 'shopUrl' ) );

--- a/plugins/woocommerce-admin/client/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/index.js
@@ -32,6 +32,14 @@ jest.mock( '@woocommerce/admin-layout', () => {
 	};
 } );
 
+jest.mock( '~/launch-your-store', () => ( {
+	useLaunchYourStore: jest.fn( () => ( {
+		comingSoon: 'yes',
+		launchYourStoreEnabled: true,
+		isLoading: true,
+	} ) ),
+} ) );
+
 jest.mock( '@woocommerce/data', () => ( {
 	...jest.requireActual( '@woocommerce/data' ),
 	useUser: jest.fn().mockReturnValue( { currentUserCan: () => true } ),

--- a/plugins/woocommerce/changelog/47315-update-47308-toolbar-should-say-view-store-when-site-is-live
+++ b/plugins/woocommerce/changelog/47315-update-47308-toolbar-should-say-view-store-when-site-is-live
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updated the toolbar's store link based on the site's visibility settings.


### PR DESCRIPTION
"Preview store" when coming soon mode is enabled
"View store" when the site is set to live

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47308 

This pull updates the toolbar's store link based on the site's visibility settings.

It now displays "Preview store" when coming soon mode is active and "View store" when the site is live.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Go to `WooCommerce -> Settings -> Site Visibility` and change the setting to `Live`
3. Go to `WooCommerce -> Home`
4. Confirm the toolbar link says `View store`
5. Change the setting to `Coming soon`
6. Confirm the toolbar link says `Preview store`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Updated the toolbar's store link based on the site's visibility settings.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
