### PR TITLE
LYS - Disable the save changes button until changes are made

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -34,25 +34,20 @@ import {
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
 const SiteVisibility = () => {
-	const shareKey =
-		window?.wcSettings?.admin?.siteVisibilitySettings
-			?.woocommerce_share_key;
+	const setting = window?.wcSettings?.admin?.siteVisibilitySettings || {};
+	const shareKey = setting?.woocommerce_share_key;
 
 	const [ comingSoon, setComingSoon ] = useState(
-		window?.wcSettings?.admin?.siteVisibilitySettings
-			?.woocommerce_coming_soon || 'no'
+		setting?.woocommerce_coming_soon || 'no'
 	);
 	const [ storePagesOnly, setStorePagesOnly ] = useState(
-		window?.wcSettings?.admin?.siteVisibilitySettings
-			?.woocommerce_store_pages_only || 'no'
+		setting?.woocommerce_store_pages_only || 'no'
 	);
 	const [ privateLink, setPrivateLink ] = useState(
-		window?.wcSettings?.admin?.siteVisibilitySettings
-			?.woocommerce_private_link || 'no'
+		setting?.woocommerce_private_link || 'no'
 	);
 
 	useEffect( () => {
-		const setting = window?.wcSettings?.admin?.siteVisibilitySettings || {};
 		const initValues = {
 			comingSoon: setting.woocommerce_coming_soon,
 			storePagesOnly: setting.woocommerce_store_pages_only,

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -55,10 +55,8 @@ const SiteVisibility = () => {
 		const setting = window?.wcSettings?.admin?.siteVisibilitySettings || {};
 		const initValues = {
 			comingSoon: setting.woocommerce_coming_soon,
-			storePagesOnly:
-				setting.woocommerce_store_pages_only === false ? 'no' : 'yes',
-			privateLink:
-				setting.woocommerce_private_link === false ? 'no' : 'yes',
+			storePagesOnly: setting.woocommerce_store_pages_only,
+			privateLink: setting.woocommerce_private_link || 'no',
 		};
 
 		const currentValues = { comingSoon, storePagesOnly, privateLink };

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -11,6 +11,7 @@ import {
 	useState,
 	createInterpolateElement,
 	createElement,
+	useEffect,
 } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
@@ -18,6 +19,7 @@ import classNames from 'classnames';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { recordEvent } from '@woocommerce/tracks';
 import { getSetting } from '@woocommerce/settings';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,12 +44,31 @@ const SiteVisibility = () => {
 	);
 	const [ storePagesOnly, setStorePagesOnly ] = useState(
 		window?.wcSettings?.admin?.siteVisibilitySettings
-			?.woocommerce_store_pages_only
+			?.woocommerce_store_pages_only || 'no'
 	);
 	const [ privateLink, setPrivateLink ] = useState(
 		window?.wcSettings?.admin?.siteVisibilitySettings
-			?.woocommerce_private_link
+			?.woocommerce_private_link || 'no'
 	);
+
+	useEffect( () => {
+		const setting = window?.wcSettings?.admin?.siteVisibilitySettings || {};
+		const initValues = {
+			comingSoon: setting.woocommerce_coming_soon,
+			storePagesOnly:
+				setting.woocommerce_store_pages_only === false ? 'no' : 'yes',
+			privateLink:
+				setting.woocommerce_private_link === false ? 'no' : 'yes',
+		};
+
+		const currentValues = { comingSoon, storePagesOnly, privateLink };
+		const saveButton = document.getElementsByClassName(
+			'woocommerce-save-button'
+		)[ 0 ];
+		if ( saveButton ) {
+			saveButton.disabled = isEqual( initValues, currentValues );
+		}
+	}, [ comingSoon, storePagesOnly, privateLink ] );
 
 	const copyLink = __( 'Copy link', 'woocommerce' );
 	const copied = __( 'Copied!', 'woocommerce' );

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -19,7 +19,6 @@ import classNames from 'classnames';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { recordEvent } from '@woocommerce/tracks';
 import { getSetting } from '@woocommerce/settings';
-import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -59,7 +58,10 @@ const SiteVisibility = () => {
 			'woocommerce-save-button'
 		)[ 0 ];
 		if ( saveButton ) {
-			saveButton.disabled = isEqual( initValues, currentValues );
+			saveButton.disabled =
+				initValues.comingSoon === currentValues.comingSoon &&
+				initValues.storePagesOnly === currentValues.storePagesOnly &&
+				initValues.privateLink === currentValues.privateLink;
 		}
 	}, [ comingSoon, storePagesOnly, privateLink ] );
 

--- a/plugins/woocommerce/changelog/47316-update-47304-disable-save-button-until-changes-are-made
+++ b/plugins/woocommerce/changelog/47316-update-47304-disable-save-button-until-changes-are-made
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+LYS: disables the "Save changes" button until changes are made.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -116,9 +116,6 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_activate_plugin() {
 		wp_set_current_user( $this->user );
-		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-			activate_plugin( 'woocommerce/woocommerce.php' );
-		}
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
 		$request->set_query_params(
 			array(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -125,7 +125,6 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$response       = $this->server->dispatch( $request );
 		$data           = $response->get_data();
 		$active_plugins = Plugins::get_active_plugins();
-		var_dump($data);
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertContains( 'akismet', $data['data']['activated'] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -117,9 +117,6 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	public function test_activate_plugin() {
 		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
-		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-			activate_plugin( 'woocommerce/woocommerce.php' );
-		}
 		$request->set_query_params(
 			array(
 				'plugins' => 'akismet',

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -117,6 +117,9 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	public function test_activate_plugin() {
 		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			activate_plugin( 'woocommerce/woocommerce.php' );
+		}
 		$request->set_query_params(
 			array(
 				'plugins' => 'akismet',

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -125,6 +125,7 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$response       = $this->server->dispatch( $request );
 		$data           = $response->get_data();
 		$active_plugins = Plugins::get_active_plugins();
+		var_dump($data);
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertContains( 'akismet', $data['data']['activated'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47304 

This PR disables the `Save changes` button until changes are made.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Go to `WooCommerce -> Settings -> Site Visibility`
3. Confirm the `Save changes` button is in disabled state.
4. Make changes.
5. Confirm the button changes to enabled.
6. Make changes back to the original.
7. Confirm the button is back to disabled state.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

LYS: disables the "Save changes" button until changes are made.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
