### PR TITLE
Make german state field visible but not required

### DIFF
--- a/plugins/woocommerce/changelog/47319-fix-show-germany-state
+++ b/plugins/woocommerce/changelog/47319-fix-show-germany-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show Germany state field in Checkout block.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -1051,7 +1051,6 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
-							'hidden'   => true,
 						),
 					),
 					'DK' => array(


### PR DESCRIPTION
Germany state field was always set to hidden and optional, at some point later, states were added to it https://github.com/woocommerce/woocommerce/pull/31825, but the field was never marked as visible.

Shortcode checkout will always show the state fields if there are states, but checkout block won't, and would respect whatever is in locale settings. That's a separate debate for now https://github.com/woocommerce/woocommerce/issues/47317.

This PR only marks the state as visible, following other patterns done for other countries.


### How to test the changes in this Pull Request:

1. In Checkout block, select Germany, make sure you can see german states list.
2. In Checkout shortcode, select Germany, make sure you can see german states list.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Show Germany state field in Checkout block.

#### Comment

</details>
