### PR TITLE
Prevent Additional Checkout Fields values being shown on shortcode order confirmation

### DIFF
--- a/plugins/woocommerce/changelog/fix-additional-checkbox-shortcodes
+++ b/plugins/woocommerce/changelog/fix-additional-checkbox-shortcodes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent empty checkboxes added by Additional Checkout Fields API showing in the order confirmation when the order was placed using the shortcode checkout experience.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFieldsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFieldsWrapper.php
@@ -31,6 +31,8 @@ class AdditionalFieldsWrapper extends AbstractOrderConfirmationBlock {
 		}
 
 		// Contact and additional fields are currently grouped in this section.
+		// If none of the additional fields for contact or order have values then the "Additional fields' section should
+		// not show in the order confirmation.
 		$additional_field_values = array_merge(
 			Package::container()->get( CheckoutFields::class )->get_order_additional_fields_with_values( $order, 'contact' ),
 			Package::container()->get( CheckoutFields::class )->get_order_additional_fields_with_values( $order, 'order' )

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFieldsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AdditionalFieldsWrapper.php
@@ -31,12 +31,12 @@ class AdditionalFieldsWrapper extends AbstractOrderConfirmationBlock {
 		}
 
 		// Contact and additional fields are currently grouped in this section.
-		$additional_fields = array_merge(
-			Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'contact' ),
-			Package::container()->get( CheckoutFields::class )->get_fields_for_location( 'order' )
+		$additional_field_values = array_merge(
+			Package::container()->get( CheckoutFields::class )->get_order_additional_fields_with_values( $order, 'contact' ),
+			Package::container()->get( CheckoutFields::class )->get_order_additional_fields_with_values( $order, 'order' )
 		);
 
-		return empty( $additional_fields ) ? '' : $content;
+		return empty( $additional_field_values ) ? '' : $content;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -1279,6 +1279,15 @@ class CheckoutFields {
 	 * @return array An array of fields definitions as well as their values formatted for display.
 	 */
 	public function get_order_additional_fields_with_values( WC_Order $order, string $location, string $group = 'other', string $context = 'edit' ) {
+
+		// Because the Additional Checkout Fields API only applies to orders created with Store API, we should not
+		// return any values unless it was created using Store API. This is mainly to prevent "empty" checkbox values
+		// from being shown on the order confirmation page for orders placed using the shortcode. It's rare that this
+		// will happen but not impossible.
+		if ( 'store-api' !== $order->get_created_via() ) {
+			return [];
+		}
+
 		if ( 'additional' === $location ) {
 			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
 			$location = 'order';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using the shortcode checkout, no fields added by the Additional Checkout Fields API are shown, which is the intended behaviour, but because we show "No" for unchecked checkboxes on the order confirmation screen, it appeared like the user had intentionally selected that during checkout despite the field not being present on the front end.

This PR checks the source of the order before determining what fields to show. If it was not made via the Store API then no fields will be shown.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47265 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the https://github.com/woocommerce/additional-checkout-fields-tester plugin ((https://github.com/woocommerce/woocommerce/files/15265418/additional-checkout-fields-tester-main.5.zip))
2. Add an item to your cart and go to the Checkout block - ensure the additional fields show up (as per the readme of the above repository).
3. Fill in the form, ensuring all fields are filled, and check out.
4. Ensure the order confirmation contains the values of the additional field.
5. Check the email sent to the shopper and the merchant and ensure both have the fields.
6. Check the order in the WooCommerce dashboard, ensure the fields are there.
7. Add an item to your cart and check out using the shortcode checkout experience.
8. Ensure the fields _don't_ show, then check out.
9. Ensure the order confirmation contains the values of the additional field.
10. Check the email sent to the shopper and the merchant and ensure neither show any of the fields.
11. Check the order in the WooCommerce dashboard, ensure the fields are not there.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
