### PR TITLE
PHP unit tests: Activate WC in the bootstrap rather than just loading files

### DIFF
--- a/plugins/woocommerce/changelog/try-activate-wc-in-php-tests
+++ b/plugins/woocommerce/changelog/try-activate-wc-in-php-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: A change to the php unit test setup, no production code is affected
+
+

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -208,6 +208,9 @@ class WC_Unit_Tests_Bootstrap {
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_onboarding_opt_in', 'yes' );
 
+		require_once $this->plugin_dir . '/woocommerce.php';
+		FeaturePlugin::instance()->init();
+
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		activate_plugin( 'woocommerce/woocommerce.php', '', false, true );
 	}

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -208,8 +208,8 @@ class WC_Unit_Tests_Bootstrap {
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_onboarding_opt_in', 'yes' );
 
-		require_once $this->plugin_dir . '/woocommerce.php';
-		FeaturePlugin::instance()->init();
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		activate_plugin( 'woocommerce/woocommerce.php', '', false, true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/plugins-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/plugins-helper.php
@@ -49,24 +49,18 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 	 * Test get_active_plugin_slugs()
 	 */
 	public function test_get_active_plugin_slugs() {
-
-		// Get active slugs.
 		$active_slugs = PluginsHelper::get_active_plugin_slugs();
 
-		// Phpunit test environment active plugins option is empty.
-		$this->assertEquals( array(), $active_slugs, 'Should not be any active slugs.' );
+		$this->assertEquals( array( 'woocommerce' ), $active_slugs, 'WooCommerce should be the only active slug.' );
 
-		// Get facebook plugin path.
+		// Activate Akismet.
 		$akismet_path = PluginsHelper::get_plugin_path_from_slug( 'akismet' );
-
-		// Activate facebook plugin.
 		activate_plugin( $akismet_path );
 
-		// Get active slugs.
-		$active_slugs = PluginsHelper::get_active_plugin_slugs();
+		$expected_slugs = array( 'akismet', 'woocommerce' );
+		$actual_slugs   = PluginsHelper::get_active_plugin_slugs();
 
-		// Phpunit test environment active plugins option is empty.
-		$this->assertEquals( array( 'akismet' ), $active_slugs, 'Akismet should be listed as active.' );
+		$this->assertEquals( $expected_slugs, $actual_slugs, 'Akismet should be listed as active.' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Recently [this test](https://github.com/woocommerce/woocommerce/blob/d81ab3c9d3b7be912b4dc870a4b37585876adcab/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php#L102-L102) started failing for all PRs. Investigating, I noticed that the plugin used in the test, [Facebook for WooCommerce](https://wordpress.org/plugins/facebook-for-woocommerce/), had released a new version two days before with this changelog entry:

> Tweak – Adds WooCommerce as a dependency to the plugin header.

After checking the internal state of things during the course of the unit test, I determined that the plugin was, in fact, installed, but that the activation call was failing with the message "The requested plugin `facebook-for-woocommerce` could not be activated." Looking further, I realized that in our unit test environment, we have been loading all the code for the WooCommerce plugin directly, and it is not actually considered "activated" by WordPress.

The main benefits of activating the plugin in this context are that the plugin slug will be included in the `active_plugins` option in wp_options, and the activation process will produce an error if any unexpected output is generated (meaning error messages or other content gets printed to the output buffer).

This PR is a bit of an experiment to see how the entire test suite fairs if we actually activate the WooCommerce plugin rather than just loading its code directly.

### How to test the changes in this Pull Request:

See if all the tests still pass.
