### PR TITLE
Update `WC_Admin_Tests_API_Plugins` to use different plugins for testing

### DIFF
--- a/plugins/woocommerce/changelog/try-plugin-api-unit-tests
+++ b/plugins/woocommerce/changelog/try-plugin-api-unit-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update unit tests to be more reliable. No production code changed.
+
+

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -33,6 +33,15 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Cleanup after each test.
+	 */
+	public function tearDown(): void {
+		deactivate_plugins( 'akismet/akismet.php', true );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Test that installation without permission is unauthorized.
 	 */
 	public function test_install_without_permission() {
@@ -49,17 +58,20 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/install' );
 		$request->set_query_params(
 			array(
-				'plugins' => 'facebook-for-woocommerce',
+				'plugins' => 'woocommerce-legacy-rest-api',
 			)
 		);
 		$response = $this->server->dispatch( $request );
+
+		// TODO: This test should be skipped if WordPress.org's plugins API endpoint cannot be reached.
+
 		$data     = $response->get_data();
 		$plugins  = get_plugins();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array( 'facebook-for-woocommerce' ), $data['data']['installed'] );
+		$this->assertEquals( array( 'woocommerce-legacy-rest-api' ), $data['data']['installed'] );
 		$this->assertEquals( true, $data['success'] );
-		$this->assertArrayHasKey( 'facebook-for-woocommerce/facebook-for-woocommerce.php', $plugins );
+		$this->assertArrayHasKey( 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php', $plugins );
 	}
 
 	/**
@@ -72,10 +84,13 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$request->set_query_params(
 			array(
 				'async'   => true,
-				'plugins' => 'facebook-for-woocommerce',
+				'plugins' => 'woocommerce-legacy-rest-api',
 			)
 		);
 		$response = $this->server->dispatch( $request );
+
+		// TODO: This test should be skipped if WordPress.org's plugins API endpoint cannot be reached.
+
 		$data     = $response->get_data();
 		$plugins  = get_plugins();
 
@@ -105,7 +120,7 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
 		$request->set_query_params(
 			array(
-				'plugins' => 'facebook-for-woocommerce',
+				'plugins' => 'akismet',
 			)
 		);
 		$response       = $this->server->dispatch( $request );
@@ -113,9 +128,9 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$active_plugins = Plugins::get_active_plugins();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains( 'facebook-for-woocommerce', $data['data']['activated'] );
+		$this->assertContains( 'akismet', $data['data']['activated'] );
 		$this->assertEquals( true, $data['success'] );
-		$this->assertContains( 'facebook-for-woocommerce', $active_plugins );
+		$this->assertContains( 'akismet', $active_plugins );
 	}
 
 	/**
@@ -128,7 +143,7 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$request->set_query_params(
 			array(
 				'async'   => true,
-				'plugins' => 'facebook-for-woocommerce',
+				'plugins' => 'akismet',
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/plugins.php
@@ -65,8 +65,8 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 
 		// TODO: This test should be skipped if WordPress.org's plugins API endpoint cannot be reached.
 
-		$data     = $response->get_data();
-		$plugins  = get_plugins();
+		$data    = $response->get_data();
+		$plugins = get_plugins();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( array( 'woocommerce-legacy-rest-api' ), $data['data']['installed'] );
@@ -91,8 +91,8 @@ class WC_Admin_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 
 		// TODO: This test should be skipped if WordPress.org's plugins API endpoint cannot be reached.
 
-		$data     = $response->get_data();
-		$plugins  = get_plugins();
+		$data    = $response->get_data();
+		$plugins = get_plugins();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertArrayHasKey( 'job_id', $data['data'] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the tests in `WC_Admin_Tests_API_Plugins` to use plugins other than `facebook-for-woocommerce` to hopefully be more reliable in the future.

### How to test the changes in this Pull Request:

Make sure unit tests still pass.
