### PR TITLE
Use @octokit/action and @actions/core versions instead of latest workflows

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -27,10 +27,10 @@ jobs:
               uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
 
             - name: Install Octokit
-              run: npm --prefix .github/workflows/scripts install @octokit/action
+              run: npm --prefix .github/workflows/scripts install @octokit/action@~6.1.0
 
             - name: Install Actions Core
-              run: npm --prefix .github/workflows/scripts install @actions/core
+              run: npm --prefix .github/workflows/scripts install @actions/core@~1.10.1
 
             - name: Check if user is a community contributor
               id: check

--- a/.github/workflows/review-testing-instructions.yml
+++ b/.github/workflows/review-testing-instructions.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
 
       - name: Install Octokit
-        run: npm --prefix .github/workflows/scripts install @octokit/action
+        run: npm --prefix .github/workflows/scripts install @octokit/action@~6.1.0
 
       - name: Install Actions Core
-        run: npm --prefix .github/workflows/scripts install @actions/core
+        run: npm --prefix .github/workflows/scripts install @actions/core@~1.10.1
 
       - name: Check if user is a community contributor
         id: is-community-contributor


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`community-label.yml` and `review-testing-instructions.yml` started failing after @octokit/action version 7.0.0 was released. Both workflows install the latest version.
Quick fix is to pin down the previous working version.

### How to test the changes in this Pull Request:

In CI the workflows still fail because they're running on pull_request_target event which means they're running the base branch version (broken). 
Check this locally, by running the install commands and then the scripts as they are run in the affected workflows.

