### PR TITLE
Hide Business Services tab heading in marketplace

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -55,7 +55,7 @@ const LABELS = {
 
 export default function Products( props: ProductsProps ) {
 	const marketplaceContextValue = useContext( MarketplaceContext );
-	const { isLoading } = marketplaceContextValue;
+	const { isLoading, selectedTab } = marketplaceContextValue;
 	const label = LABELS[ props.type ].label;
 	const singularLabel = LABELS[ props.type ].singularLabel;
 	const query = useQuery();
@@ -64,6 +64,7 @@ export default function Products( props: ProductsProps ) {
 	interface Theme {
 		stylesheet?: string;
 	}
+	const tab = selectedTab;
 
 	const currentTheme = useSelect( ( select ) => {
 		return select( 'core' ).getCurrentTheme() as Theme;
@@ -169,9 +170,11 @@ export default function Products( props: ProductsProps ) {
 	return (
 		<div className={ containerClassName }>
 			<PluginInstallNotice />
-			<h2 className={ productListTitleClassName }>
-				{ isLoading ? ' ' : title }
-			</h2>
+			{ tab !== 'business-services' && (
+				<h2 className={ productListTitleClassName }>
+					{ isLoading ? ' ' : title }
+				</h2>
+			) }
 			<div className="woocommerce-marketplace__sub-header">
 				{ props.categorySelector && (
 					<CategorySelector type={ props.type } />

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -64,7 +64,6 @@ export default function Products( props: ProductsProps ) {
 	interface Theme {
 		stylesheet?: string;
 	}
-	const tab = selectedTab;
 
 	const currentTheme = useSelect( ( select ) => {
 		return select( 'core' ).getCurrentTheme() as Theme;
@@ -170,7 +169,7 @@ export default function Products( props: ProductsProps ) {
 	return (
 		<div className={ containerClassName }>
 			<PluginInstallNotice />
-			{ tab !== 'business-services' && (
+			{ selectedTab !== 'business-services' && (
 				<h2 className={ productListTitleClassName }>
 					{ isLoading ? ' ' : title }
 				</h2>

--- a/plugins/woocommerce-admin/client/marketplace/components/search-results/search-results.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/search-results/search-results.tsx
@@ -37,7 +37,8 @@ export default function SearchResults( props: SearchResultProps ): JSX.Element {
 	const hasThemes = themeList.length > 0;
 	const hasBusinessServices = businessServiceList.length > 0;
 	const marketplaceContextValue = useContext( MarketplaceContext );
-	const { isLoading } = marketplaceContextValue;
+	const { isLoading, hasBusinessServices: canShowBusinessServices } =
+		marketplaceContextValue;
 
 	const query = useQuery();
 	const showCategorySelector = query.section ? true : false;
@@ -123,10 +124,17 @@ export default function SearchResults( props: SearchResultProps ): JSX.Element {
 				<NoResults
 					type={ SearchResultType.all }
 					showHeading={ true }
-					heading={ __(
-						'No extensions, themes or business services found…',
-						'woocommerce'
-					) }
+					heading={
+						canShowBusinessServices
+							? __(
+									'No extensions, themes or business services found…',
+									'woocommerce'
+							  )
+							: __(
+									'No extensions or themes found…',
+									'woocommerce'
+							  )
+					}
 				/>
 			);
 		}

--- a/plugins/woocommerce-admin/client/marketplace/utils/tracking.ts
+++ b/plugins/woocommerce-admin/client/marketplace/utils/tracking.ts
@@ -33,8 +33,12 @@ function recordMarketplaceView( props: MarketplaceViewProps ) {
 		...( category && { category } ),
 	};
 
-	// User sees the default extensions or themes view
-	if ( view && [ 'extensions', 'themes' ].includes( view ) && ! category ) {
+	// User sees the default extensions, themes or business services view
+	if (
+		view &&
+		[ 'extensions', 'themes', 'business-services' ].includes( view ) &&
+		! category
+	) {
 		eventProps.category = '_all';
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
There won't be many Business Service products, so we want to hide the results count at the top of the Business Services tab to optimise the "above the fold" space on this tab.

Also making sure tracks event for viewing this tab passes the `_all` category for the default view.

Closes https://github.com/Automattic/woocommerce.com/issues/20465

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your WCCOM dev environment has products in the `business-services` category, and one or more of its child categories, e.g. `finance`, `accounting`
2. Check out this branch
3. In `plugins/woocommerce-admin/client/marketplace/components/constants.ts`, edit the `MARKETPLACE_HOST` const to be `https://woocommerce.test`
4. Go to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
5. Visit the [in-app marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions).
6. Switch to the Business Services tab. Confirm it doesn't show a heading with a count of the number of products. Same if you filter by category.
7. Confirm the Browse and Themes tabs still show the counter
8. Do a search using a term that should return a Business Service product. You should see the counter on the Search results tab
9. Test around this issue.

![Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/f1952a21-7b03-4523-b756-f7b26729dbec)
![Cursor_and_Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/4c0709da-4f8f-4099-a634-ef301de6f699)
![Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/703cc4fb-c1eb-48b1-86bd-a7ae0f5c3b09)
![Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/bf2dde0a-0873-4ebe-9948-3eaab978e6f9)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
