### PR TITLE
[testing workflows] Fix for multi-line commit message not triggering tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,9 @@ jobs:
                   if [[ "${{ github.event_name }}" == "push" ]]; then
                     COMMIT_MESSAGE=`echo "${{ github.event.head_commit.message }}" | head -1`
                   elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    COMMIT_MESSAGE=${{ github.event.pull_request.title }}
+                    COMMIT_MESSAGE="${{ github.event.pull_request.title }}"
                   else
-                    COMMIT_MESSAGE=${{ github.event_name }}
+                    COMMIT_MESSAGE="${{ github.event_name }}"
                   fi
                 
                   echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
@@ -176,9 +176,9 @@ jobs:
                   if [[ "${{ github.event_name }}" == "push" ]]; then
                     COMMIT_MESSAGE=`echo "${{ github.event.head_commit.message }}" | head -1`
                   elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    COMMIT_MESSAGE=${{ github.event.pull_request.title }}
+                    COMMIT_MESSAGE="${{ github.event.pull_request.title }}"
                   else
-                    COMMIT_MESSAGE=${{ github.event_name }}
+                    COMMIT_MESSAGE="${{ github.event_name }}"
                   fi
                 
                   echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,14 +120,14 @@ jobs:
               id: get_commit_message
               run: |
                   if [[ "${{ github.event_name }}" == "push" ]]; then
-                    echo "Commit message is ${{ github.event.head_commit.message }}"
-                    echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" >> "$GITHUB_OUTPUT"
+                    COMMIT_MESSAGE=`echo "${{ github.event.head_commit.message }}" | head -1`
                   elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    echo "Commit message is ${{ github.event.pull_request.title }}"
-                    echo "COMMIT_MESSAGE=${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"
+                    COMMIT_MESSAGE=${{ github.event.pull_request.title }}
                   else
-                    echo "Workflow triggered by other event"
+                    COMMIT_MESSAGE=${{ github.event_name }}
                   fi
+                
+                  echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
               shell: bash
 
             - name: 'Prepare Test Environment'
@@ -174,14 +174,14 @@ jobs:
               id: get_commit_message
               run: |
                   if [[ "${{ github.event_name }}" == "push" ]]; then
-                    echo "Commit message is ${{ github.event.head_commit.message }}"
-                    echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" >> "$GITHUB_OUTPUT"
+                    COMMIT_MESSAGE=`echo "${{ github.event.head_commit.message }}" | head -1`
                   elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    echo "Commit message is ${{ github.event.pull_request.title }}"
-                    echo "COMMIT_MESSAGE=${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"
+                    COMMIT_MESSAGE=${{ github.event.pull_request.title }}
                   else
-                    echo "Workflow triggered by other event"
+                    COMMIT_MESSAGE=${{ github.event_name }}
                   fi
+                
+                  echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
               shell: bash
 
             - name: 'Prepare Test Environment'

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -31,7 +31,7 @@ module.exports = async ( config ) => {
 	}
 	try {
 		fs.unlinkSync( process.env.CUSTOMERSTATE );
-		console.log( 'Customer state file deleted successfully.' );
+		console.log( 'Customer state file deleted successfully' );
 	} catch ( err ) {
 		if ( err.code === 'ENOENT' ) {
 			console.log( 'Customer state file does not exist.' );

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -31,7 +31,7 @@ module.exports = async ( config ) => {
 	}
 	try {
 		fs.unlinkSync( process.env.CUSTOMERSTATE );
-		console.log( 'Customer state file deleted successfully' );
+		console.log( 'Customer state file deleted successfully.' );
 	} catch ( err ) {
 		if ( err.code === 'ENOENT' ) {
 			console.log( 'Customer state file does not exist.' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/47202 introduced BuildKite analytics that uses the commit message on push events as the report title. Multi-line commit messages break the workflow, with `Error: Unable to process file command 'output' successfully.` See [this run](https://github.com/woocommerce/woocommerce/actions/runs/9029829770/job/24813117044#step:4:28).
This fixes the issue by only getting the first line of the commit message.


### How to test the changes in this Pull Request:


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Check the code, and check CI after merging to trunk.
