### PR TITLE
reset state and postcode if it's not valid for the current country

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -164,22 +164,12 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 							{ ...fieldProps }
 							value={ values.country }
 							onChange={ ( newCountry ) => {
-								const newValues = {
+								onChange( {
 									...values,
 									country: newCountry,
 									state: '',
-								};
-								// Country will impact postcode too. Do we need to clear it?
-								if (
-									values.postcode &&
-									! isPostcode( {
-										postcode: values.postcode,
-										country: newCountry,
-									} )
-								) {
-									newValues.postcode = '';
-								}
-								onChange( newValues );
+									postcode: '',
+								} );
 							} }
 						/>
 					);

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isPostcode } from '@woocommerce/blocks-checkout';
 import {
 	ValidatedTextInput,
 	type ValidatedTextInputHandle,

--- a/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
@@ -68,6 +68,40 @@ const updateDirtyProps = () => {
 
 	// Update local cache of customer data so the next time this runs, it can compare against the latest data.
 	localState.customerData = newCustomerData;
+
+	const dirtyShippingAddress = localState.dirtyProps.shippingAddress;
+	const dirtyBillingAddress = localState.dirtyProps.billingAddress;
+
+	const customerShippingAddress = localState.customerData.shippingAddress;
+	const customerBillingAddress = localState.customerData.billingAddress;
+
+	// Check if country is changing without state
+	const shippingCountryChanged = dirtyShippingAddress.includes( 'country' );
+	const billingCountryChanged = dirtyBillingAddress.includes( 'country' );
+	const shippingStateChanged = dirtyShippingAddress.includes( 'state' );
+	const billingStateChanged = dirtyBillingAddress.includes( 'state' );
+	const shippingPostcodeChanged = dirtyShippingAddress.includes( 'postcode' );
+	const billingPostcodeChanged = dirtyBillingAddress.includes( 'postcode' );
+
+	if ( shippingCountryChanged && ! shippingPostcodeChanged ) {
+		dirtyShippingAddress.push( 'postcode' );
+		customerShippingAddress.postcode = '';
+	}
+
+	if ( billingCountryChanged && ! billingPostcodeChanged ) {
+		dirtyBillingAddress.push( 'postcode' );
+		customerBillingAddress.postcode = '';
+	}
+
+	if ( shippingCountryChanged && ! shippingStateChanged ) {
+		dirtyShippingAddress.push( 'state' );
+		customerShippingAddress.state = '';
+	}
+
+	if ( billingCountryChanged && ! billingStateChanged ) {
+		dirtyBillingAddress.push( 'state' );
+		customerBillingAddress.state = '';
+	}
 };
 
 /**

--- a/plugins/woocommerce/changelog/47369-fix-state-flickring-when-switching-countries
+++ b/plugins/woocommerce/changelog/47369-fix-state-flickring-when-switching-countries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly clear out state and postcode when switching countries.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -240,21 +240,8 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 * @return array
 	 */
 	protected function get_customer_billing_address( \WC_Customer $customer ) {
-		$validation_util = new ValidationUtils();
-		$billing_country = $customer->get_billing_country();
-		$billing_state   = $customer->get_billing_state();
-
 		$additional_fields = $this->additional_fields_controller->get_all_fields_from_object( $customer, 'billing' );
 
-		/**
-		 * There's a bug in WooCommerce core in which not having a state ("") would result in us validating against the store's state.
-		 * This resets the state to an empty string if it doesn't match the country.
-		 *
-		 * @todo Removing this handling once we fix the issue with the state value always being the store one.
-		 */
-		if ( ! $validation_util->validate_state( $billing_state, $billing_country ) ) {
-			$billing_state = '';
-		}
 		return array_merge(
 			[
 				'first_name' => $customer->get_billing_first_name(),
@@ -263,9 +250,9 @@ class CartUpdateCustomer extends AbstractCartRoute {
 				'address_1'  => $customer->get_billing_address_1(),
 				'address_2'  => $customer->get_billing_address_2(),
 				'city'       => $customer->get_billing_city(),
-				'state'      => $billing_state,
+				'state'      => $customer->get_billing_state(),
 				'postcode'   => $customer->get_billing_postcode(),
-				'country'    => $billing_country,
+				'country'    => $customer->get_billing_country(),
 				'phone'      => $customer->get_billing_phone(),
 				'email'      => $customer->get_billing_email(),
 			],

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -132,7 +132,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = $validation_util->validate_state( $address['state'], $address['country'] ) ? $validation_util->format_state( sanitize_text_field( wp_unslash( $address[ $key ] ) ), $address['country'] ) : '';
 						break;
 					case 'postcode':
-						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
+						$carry[ $key ] = \WC_Validation::is_postcode( $address['postcode'], $address['country'] ) ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
 						break;
 					default:
 						$carry[ $key ] = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema[ $key ], $key );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -123,13 +123,13 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$address = array_intersect_key( $address, $field_schema );
 		$address = array_reduce(
 			array_keys( $address ),
-			function( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
+			function ( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
 				switch ( $key ) {
 					case 'country':
 						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
 						break;
 					case 'state':
-						$carry[ $key ] = $validation_util->format_state( sanitize_text_field( wp_unslash( $address[ $key ] ) ), $address['country'] );
+						$carry[ $key ] = $validation_util->validate_state( $address['state'], $address['country'] ) ? $validation_util->format_state( sanitize_text_field( wp_unslash( $address[ $key ] ) ), $address['country'] ) : '';
 						break;
 					case 'postcode':
 						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
@@ -281,7 +281,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 
 		$address_fields = array_filter(
 			$fields,
-			function( $key ) use ( $additional_fields_keys ) {
+			function ( $key ) use ( $additional_fields_keys ) {
 				return in_array( $key, $additional_fields_keys, true );
 			},
 			ARRAY_FILTER_USE_KEY
@@ -298,7 +298,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 
 			if ( 'select' === $field['type'] ) {
 				$field_schema['enum'] = array_map(
-					function( $option ) {
+					function ( $option ) {
 						return $option['value'];
 					},
 					$field['options']

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -129,10 +129,10 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
 						break;
 					case 'state':
-						$carry[ $key ] = $validation_util->validate_state( $address['state'], $address['country'] ) ? $validation_util->format_state( sanitize_text_field( wp_unslash( $address[ $key ] ) ), $address['country'] ) : '';
+						$carry[ $key ] = $validation_util->format_state( sanitize_text_field( wp_unslash( $address[ $key ] ) ), $address['country'] );
 						break;
 					case 'postcode':
-						$carry[ $key ] = \WC_Validation::is_postcode( $address['postcode'], $address['country'] ) ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
+						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
 						break;
 					default:
 						$carry[ $key ] = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema[ $key ], $key );


### PR DESCRIPTION
When switching countries, Checkout would sometimes clear out state and zipcode, there are some cases in which those fields are not cleared correctly, and the server end up validating the current country against the old state and postcode. This PR resets them when changing country, and make sure to reset them as well if you're changing country, this is because state and postcode would always be validated client side first.

Initially I tried fixing this at server side, but it caused issues when placing an order, this feels like a good middleground.

Closes https://github.com/woocommerce/woocommerce/issues/46270

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Select a country with states, like Algeria, and fill out a fill valid address: Oran, Oran, 31000.
2. Switch to a country without states, like Afghanistan.
3. Switch back to a country with states like Spain, notice lack of error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Correctly clear out state and postcode when switching countries.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
