### PR TITLE
Various improvements to HPOS settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-43268
+++ b/plugins/woocommerce/changelog/fix-43268
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improvements to HPOS settings screen.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5133,6 +5133,10 @@ img.help_tip {
 
 			p.description {
 				margin-bottom: 8px;
+
+				&.is-error, span.is-error {
+					color: $red;
+				}
 			}
 
 			&:first-child {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -805,7 +805,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				$description = $value['desc'];
 			}
 
-			$error_class = ( ! empty ($value['description_is_error'] ) ) ? 'is-error' : '';
+			$error_class = ( ! empty( $value['description_is_error'] ) ) ? 'is-error' : '';
 
 			if ( $description && in_array( $value['type'], array( 'textarea', 'radio' ), true ) ) {
 				$description = '<p style="margin-top:0">' . wp_kses_post( $description ) . '</p>';

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -805,19 +805,18 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				$description = $value['desc'];
 			}
 
-			$description_is_error    = $value['description_is_error'] ?? false;
-			$extra_description_style = $description_is_error ? " style='color:red'" : '';
+			$error_class = ( ! empty ($value['description_is_error'] ) ) ? 'is-error' : '';
 
 			if ( $description && in_array( $value['type'], array( 'textarea', 'radio' ), true ) ) {
 				$description = '<p style="margin-top:0">' . wp_kses_post( $description ) . '</p>';
 			} elseif ( $description && in_array( $value['type'], array( 'checkbox' ), true ) ) {
 				$description = wp_kses_post( $description );
 			} elseif ( $description ) {
-				$description = '<p class="description"' . $extra_description_style . '>' . wp_kses_post( $description ) . '</p>';
+				$description = '<p class="description ' . $error_class . '">' . wp_kses_post( $description ) . '</p>';
 			}
 
 			if ( $tooltip_html && in_array( $value['type'], array( 'checkbox' ), true ) ) {
-				$tooltip_html = '<p class="description"' . $extra_description_style . '>' . $tooltip_html . '</p>';
+				$tooltip_html = '<p class="description ' . $error_class . '">' . $tooltip_html . '</p>';
 			} elseif ( $tooltip_html ) {
 				$tooltip_html = wc_help_tip( $tooltip_html );
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -588,8 +588,8 @@ class CustomOrdersTableController {
 					sprintf(
 						// translators: %s: number of pending orders.
 						_n(
-							"There's %s order pending sync. <b>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</b>",
-							'There are %s orders pending sync. <b>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</b>',
+							"There's %s order pending sync. <strong>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</strong>",
+							'There are %s orders pending sync. <strong>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</strong>',
 							$orders_pending_sync_count,
 							'woocommerce'
 						),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -658,8 +658,8 @@ class CustomOrdersTableController {
 						sprintf(
 							// translators: %s: number of pending orders.
 							_n(
-								"There's %s order pending sync. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.",
-								'There are %s orders pending sync. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
+								"You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>. There's currently %s order out of sync.",
+								'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>. There are currently %s orders out of sync. ',
 								$orders_pending_sync_count,
 								'woocommerce'
 							),
@@ -671,16 +671,7 @@ class CustomOrdersTableController {
 				$sync_message[] = sprintf(
 					'<a href="%1$s" class="button button-link">%2$s</a>',
 					esc_url( $sync_now_url ),
-					sprintf(
-						// translators: %d: number of pending orders.
-						_n(
-							'Sync %s pending order',
-							'Sync %s pending orders',
-							$orders_pending_sync_count,
-							'woocommerce'
-						),
-						number_format_i18n( $orders_pending_sync_count )
-					)
+					__( 'Sync orders now', 'woocommerce' )
 				);
 			}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -586,14 +586,14 @@ class CustomOrdersTableController {
 			if ( $is_dangerous ) {
 				$sync_message[] = wp_kses_data(
 					sprintf(
-					// translators: %d: number of pending orders.
+						// translators: %s: number of pending orders.
 						_n(
-							"There's %d order pending sync. <b>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</b>",
-							'There are %d orders pending sync. <b>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</b>',
+							"There's %s order pending sync. <b>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</b>",
+							'There are %s orders pending sync. <b>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</b>',
 							$orders_pending_sync_count,
 							'woocommerce'
 						),
-						$orders_pending_sync_count,
+						number_format_i18n( $orders_pending_sync_count ),
 					)
 				);
 			}
@@ -604,9 +604,9 @@ class CustomOrdersTableController {
 
 			if ( $sync_in_progress && $sync_is_pending ) {
 				$sync_message[] = sprintf(
-					// translators: %d: number of pending orders.
-					__( 'Currently syncing orders... %d pending', 'woocommerce' ),
-					$orders_pending_sync_count
+					// translators: %s: number of pending orders.
+					__( 'Currently syncing orders... %s pending', 'woocommerce' ),
+					number_format_i18n( $orders_pending_sync_count )
 				);
 			} elseif ( $sync_is_pending ) {
 				$sync_now_url = wp_nonce_url(
@@ -622,14 +622,14 @@ class CustomOrdersTableController {
 				if ( ! $is_dangerous ) {
 					$sync_message[] = wp_kses_data(
 						sprintf(
-						// translators: %d: number of pending orders.
+							// translators: %s: number of pending orders.
 							_n(
-								"There's %d order pending sync. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.",
-								'There are %d orders pending sync. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
+								"There's %s order pending sync. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.",
+								'There are %s orders pending sync. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
 								$orders_pending_sync_count,
 								'woocommerce'
 							),
-							$orders_pending_sync_count
+							number_format_i18n( $orders_pending_sync_count )
 						)
 					);
 				}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -529,7 +529,7 @@ class CustomOrdersTableController {
 
 		$get_disabled = function () {
 			$plugin_compatibility = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
-			$sync_complete        = 0 === $this->get_orders_pending_sync_count();
+			$sync_complete        = 0 === $this->data_synchronizer->get_current_orders_pending_sync_count();
 			$disabled             = array();
 			// Changing something here? might also want to look at `enable|disable` functions in CLIRunner.
 			$incompatible_plugins = array_merge( $plugin_compatibility['uncertain'], $plugin_compatibility['incompatible'] );
@@ -575,7 +575,7 @@ class CustomOrdersTableController {
 		};
 
 		$get_sync_message = function () {
-			$orders_pending_sync_count = $this->get_orders_pending_sync_count();
+			$orders_pending_sync_count = $this->data_synchronizer->get_current_orders_pending_sync_count( true );
 			$sync_in_progress          = $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) );
 			$sync_enabled              = $this->data_synchronizer->data_sync_is_enabled();
 			$sync_is_pending           = $orders_pending_sync_count > 0;
@@ -654,7 +654,7 @@ class CustomOrdersTableController {
 		};
 
 		$get_description_is_error = function () {
-			$sync_is_pending = $this->get_orders_pending_sync_count() > 0;
+			$sync_is_pending = $this->data_synchronizer->get_current_orders_pending_sync_count( true ) > 0;
 
 			return $sync_is_pending && $this->changing_data_source_with_sync_pending_is_allowed();
 		};
@@ -689,15 +689,6 @@ class CustomOrdersTableController {
 		 * @since 8.3.0
 		 */
 		return apply_filters( 'wc_allow_changing_orders_storage_while_sync_is_pending', false );
-	}
-
-	/**
-	 * Returns the count of orders pending synchronization.
-	 *
-	 * @return int
-	 */
-	private function get_orders_pending_sync_count(): int {
-		return $this->data_synchronizer->get_sync_status()['current_pending_count'];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -603,14 +603,13 @@ class CustomOrdersTableController {
 				$sync_message[] = wp_kses_data(
 					sprintf(
 						// translators: %s: number of pending orders.
-						_n(
-							"There's %s order pending sync. <strong>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</strong>",
-							'There are %s orders pending sync. <strong>Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!</strong>',
-							$orders_pending_sync_count,
-							'woocommerce'
-						),
+						_n( "There's %s order pending sync.", 'There are %s orders pending sync.', $orders_pending_sync_count, 'woocommerce' ),
 						number_format_i18n( $orders_pending_sync_count ),
 					)
+					. ' '
+					. '<strong>'
+					. __( 'Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!', 'woocommerce' )
+					. '</strong>'
 				);
 			}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -425,8 +425,16 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 * The information is meaningful only if pending_data_sync_is_in_progress return true.
 	 *
 	 * @return array
+	 *
+	 * @deprecated 9.0.0
 	 */
 	public function get_sync_status() {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.0.0',
+			'get_current_orders_pending_sync_count()'
+		);
+
 		return array(
 			'initial_pending_count' => (int) 0,
 			'current_pending_count' => $this->get_total_pending_count(),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -456,7 +456,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		global $wpdb;
 
 		if ( $use_cache ) {
-			$pending_count = wp_cache_get( 'woocommerce_hpos_pending_sync_count' );
+			$pending_count = wp_cache_get( 'woocommerce_hpos_pending_sync_count', 'counts' );
 			if ( false !== $pending_count ) {
 				return (int) $pending_count;
 			}
@@ -548,7 +548,7 @@ SELECT(
 		);
 		$pending_count += $deleted_count;
 
-		wp_cache_set( 'woocommerce_hpos_pending_sync_count', $pending_count );
+		wp_cache_set( 'woocommerce_hpos_pending_sync_count', $pending_count, 'counts' );
 		return $pending_count;
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -27,7 +27,6 @@ class DataSynchronizer implements BatchProcessorInterface {
 	use AccessiblePrivateMethods;
 
 	public const ORDERS_DATA_SYNC_ENABLED_OPTION           = 'woocommerce_custom_orders_table_data_sync_enabled';
-	private const INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION = 'woocommerce_initial_orders_pending_sync_count';
 	public const PLACEHOLDER_ORDER_POST_TYPE               = 'shop_order_placehold';
 
 	public const DELETED_RECORD_META_KEY        = '_deleted_from';
@@ -430,7 +429,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 */
 	public function get_sync_status() {
 		return array(
-			'initial_pending_count' => (int) get_option( self::INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION, 0 ),
+			'initial_pending_count' => (int) 0,
 			'current_pending_count' => $this->get_total_pending_count(),
 		);
 	}
@@ -686,7 +685,7 @@ ORDER BY orders.id ASC
 	 * or because there's nothing left to synchronize.
 	 */
 	public function cleanup_synchronization_state() {
-		delete_option( self::INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION );
+		delete_option( 'woocommerce_initial_orders_pending_sync_count' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\Caches\OrderCacheController;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\Admin\Orders\EditLock;
 use Automattic\WooCommerce\Internal\BatchProcessing\{ BatchProcessingController, BatchProcessorInterface };
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -25,8 +25,8 @@ class DataSynchronizer implements BatchProcessorInterface {
 
 	use AccessiblePrivateMethods;
 
-	public const ORDERS_DATA_SYNC_ENABLED_OPTION           = 'woocommerce_custom_orders_table_data_sync_enabled';
-	public const PLACEHOLDER_ORDER_POST_TYPE               = 'shop_order_placehold';
+	public const ORDERS_DATA_SYNC_ENABLED_OPTION = 'woocommerce_custom_orders_table_data_sync_enabled';
+	public const PLACEHOLDER_ORDER_POST_TYPE     = 'shop_order_placehold';
 
 	public const DELETED_RECORD_META_KEY        = '_deleted_from';
 	public const DELETED_FROM_POSTS_META_VALUE  = 'posts_table';
@@ -1049,5 +1049,4 @@ ORDER BY orders.id ASC
 			$order->delete( true );
 		}
 	}
-
 }

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -78,8 +78,7 @@ class COTMigrationUtil {
 			return false;
 		}
 
-		$sync_status = $this->data_synchronizer->get_sync_status();
-		return 0 === $sync_status['current_pending_count'];
+		return 0 === $this->data_synchronizer->get_total_pending_count();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -664,7 +664,7 @@ class DataSynchronizerTests extends HposTestCase {
 		);
 		$sync_setting = array_values( $sync_setting )[0];
 		$this->assertEquals( $sync_setting['value'], 'no' );
-		$this->assertTrue( str_contains( $sync_setting['desc_tip'], "There's 1 order pending sync" ) );
+		$this->assertTrue( str_contains( $sync_setting['desc_tip'], $auth_table_change_allowed_with_sync_pending ? "There's 1 order pending sync" : "There's currently 1 order out of sync" ) );
 		$this->assertTrue(
 			str_contains(
 				$sync_setting['desc_tip'],

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
@@ -92,10 +92,10 @@ class COTMigrationUtilTest extends WC_Unit_Test_Case {
 	 */
 	public function test_is_custom_order_tables_in_sync_is_true() {
 		$data_sync_mock = $this->getMockBuilder( DataSynchronizer::class )
-			->setMethods( array( 'get_sync_status', 'data_sync_is_enabled' ) )
+			->setMethods( array( 'get_current_orders_pending_sync_count', 'data_sync_is_enabled' ) )
 			->getMock();
 
-		$data_sync_mock->method( 'get_sync_status' )->willReturn( array( 'current_pending_count' => 0 ) );
+		$data_sync_mock->method( 'get_current_orders_pending_sync_count' )->willReturn( 0 );
 		$data_sync_mock->method( 'data_sync_is_enabled' )->willReturn( true );
 
 		// This is needed to prevent "Call to private method Mock_DataSynchronizer_xxxx::process_added_option" errors.
@@ -113,10 +113,10 @@ class COTMigrationUtilTest extends WC_Unit_Test_Case {
 	 */
 	public function test_is_custom_order_tables_in_sync_is_false() {
 		$data_sync_mock = $this->getMockBuilder( DataSynchronizer::class )
-							->setMethods( array( 'get_sync_status', 'data_sync_is_enabled' ) )
+							->setMethods( array( 'get_current_orders_pending_sync_count', 'data_sync_is_enabled' ) )
 							->getMock();
 
-		$data_sync_mock->method( 'get_sync_status' )->willReturn( array( 'current_pending_count' => 0 ) );
+		$data_sync_mock->method( 'get_current_orders_pending_sync_count' )->willReturn( 0 );
 		$data_sync_mock->method( 'data_sync_is_enabled' )->willReturn( false );
 
 		// This is needed to prevent "Call to private method Mock_DataSynchronizer_xxxx::process_added_option" errors.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR makes a few changes to the HPOS settings screen (and some related functions). This is based on feedback we've received, but also things we've been notices (such as duplicate queries, unused functions, etc.).

Some of the changes contained in this PR:

- In 902e1ec2f6f2d2cb99629ddf71a509cf7d60321c, we remove a hard-coded style for settings and make it a CSS class instead, which is more flexible and also plays better with colors defined elsewhere. This might seem unrelated to HPOS, but was added specifically in the context of HPOS settings, so seems reasonable to update that here too.
- Removal of an internal sync option (`woocommerce_initial_orders_pending_sync_count`) that is not used at all in the sync code. This allows us to deprecate `DataSynchronizer::get_sync_status()`, which at this point, is nothing but an unnecessary wrapper over methods counting the number of orders pending sync.
- When generating settings/labels for HPOS, we now use the "cached" version of the orders pending sync count function, which removes query duplication on this screen.
- Some UI changes such as removal of an unnecessary tooltip, and proper formatting for numbers. Also, screens were tweaked as described below:

   | Before | Now | Why? |
   |--------|--------|--------|
   | <img width="1066" alt="Screenshot 2024-05-13 at 11 27 03" src="https://github.com/woocommerce/woocommerce/assets/184724/32aa1fd0-b83b-4b79-b7ca-bd91c1c79e8b"> | <img width="1108" alt="Screenshot 2024-05-13 at 11 27 10" src="https://github.com/woocommerce/woocommerce/assets/184724/177db290-4f81-4680-aa46-c60ed1c616df"> | The "pending sync" wording has been reported (several times) as confusing users, as even with compatibility mode disabled, it seems to imply you _have_ to sync orders. I've changed this for "out of sync" and moved the bit about changing datastores first, to make it clear that it's only when changing datastores that this is relevant. |
   | <img width="721" alt="Screenshot 2024-05-13 at 11 27 24" src="https://github.com/woocommerce/woocommerce/assets/184724/64424749-1ac7-41d5-93a5-587233334085"> | <img width="717" alt="Screenshot 2024-05-13 at 11 27 31" src="https://github.com/woocommerce/woocommerce/assets/184724/ffc9ae8d-970a-407d-87d5-aac92003cad5"> | It's now possible to stop the manual sync, which means merchants no longer have to wait until it completes if they clicked it by mistake. |

Closes #43268.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your site has a few orders or use Smooth Generator (if needed).
2. Go to WC > Settings > Advanced > Features and make sure HPOS is selected as order data storage and that compatibility mode is _disabled_.
   If necessary, use `wp wc hpos sync` to first sync orders so that all options become available.
3. **Check that there's no synchronization query duplication.**
   1. Install and activate [Query Monitor](https://wordpress.org/plugins/query-monitor/) to be able to detect duplicate queries.
   2. Go to WC > Settings > Advanced > Features and make sure that Query Monitor doesn't report any duplication of queries related to `Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer`.
   3. (Optional) Contrast this with `trunk` where duplication is reported:
      <img width="1331" alt="Screenshot 2024-05-13 at 11 29 58" src="https://github.com/woocommerce/woocommerce/assets/184724/1c0aeff0-05ab-4e42-b96b-bc185b97e275">
4. Run `wp wc hpos cleanup all` so that order storage is no longer in sync.
5. Go to WC > Settings > Advanced > Features and confirm that you see a message about orders being out of sync.
6. **Check that sync can be manually started and stopped.**
   i. On WC > Settings > Advanced > Features click "Sync orders now" to start a manual order sync.
   ii. Confirm that after the page refreshes, you see a message about orders being synced and there's a link to "Stop sync".
   iii. Refresh the page until you see number of unsynced orders go down (might take a bit depending on when A-S runs).
   iv. Quickly click "Stop sync".
   v. Refresh the page and confirm that orders have stopped syncing and that "Sync orders now" appears once again.
7. Run `wp wc hpos cleanup all` again to make sure the datastores are not in sync.
8. Enable compatibility mode on the WC > Settings > Advanced > Features screen, and confirm that orders are syncing and that you can't choose a different data storage until the process is complete.

#### Test `description_is_error`

This PR also introduces a change in how settings with `description_is_error` are treated. Instead of hardcoding the styles in the HTML tags, we now use a CSS class that uses the color defined via SCSS.

1. Build WC so that legacy assets are properly built and linked.
2. Make sure datastores are not in sync. Run `wp wc hpos cleanup all` if necessary.
3. Go to WC > Settings > Advanced > Features and you should see the following message inside the HPOS section:
   <img width="884" alt="Screenshot 2024-05-20 at 09 44 01" src="https://github.com/woocommerce/woocommerce/assets/184724/21411681-32f3-4b8a-b3f2-899b73ebc013">
4. Activate the following snippet on your site:
   ```php
   add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
   ````
5. Go back to WC > Settings > Advanced > Features and the message from step 3, should've changed to the following and be displayed in red:
   <img width="1003" alt="Screenshot 2024-05-20 at 09 46 45" src="https://github.com/woocommerce/woocommerce/assets/184724/64ac3d0e-6ca6-4b3a-a352-81f99943bddb">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
