### PR TITLE
Product Block Editor: tweak styles/layout of attribute modal implementation

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-tweak-attributes-layout
+++ b/packages/js/product-editor/changelog/update-product-editor-tweak-attributes-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Block Editor: tweak styles/layout of attribute modal implementation

--- a/packages/js/product-editor/src/components/attribute-combobox-field/styles.scss
+++ b/packages/js/product-editor/src/components/attribute-combobox-field/styles.scss
@@ -52,7 +52,7 @@
 	.components-spinner {
 		margin: 0 4px 0 0;
 		padding: 2px;
-		width: 20px;
-		height: 20px;
+		width: 18px;
+		height: 18px;
 	}
 }

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -65,7 +65,7 @@
 
 		.components-form-token-field__help {
 			position: absolute;
-			top: 32px;
+			top: 36px;
 			z-index: 0;
 		}
 

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -94,6 +94,11 @@
 			&:not(.is-disabled) {
 				background-color: white;
 			}
+
+			&:focus-within {
+				outline: none;
+				box-shadow: none;
+			}
 		}
 
 		.components-form-token-field__input {

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -26,6 +26,10 @@
 	&__body {
 		min-height: 200px;
 		flex: 1 1 auto;
+
+		.woocommerce-new-attribute-modal__table-row {
+			min-height: 80px;
+		}
 	}
 
 	&__table {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->


This polishes the Attributes modal implementation:

1. Align the help component of the Attribute terms
2. Reduce Spinner size to fit correctly in the Attributes help area
3. Set the height for each row to avoid flicks effects
4. Remove focus styles in the terms component user selects it


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

1. Enable the Product Editor
2. Go to the Variations section
3. Start to add a new attribute

4. Confirm "Align the help component of the Attribute terms":

<img width="772" alt="Screenshot 2024-05-10 at 18 08 20" src="https://github.com/woocommerce/woocommerce/assets/77539/c4411772-c8d9-4adc-943f-a2aa3e008018">

5. Confirm "Reduce Spinner size to fit correctly in the Attributes help area"

<img width="345" alt="Screenshot 2024-05-10 at 18 09 14" src="https://github.com/woocommerce/woocommerce/assets/77539/5650abc2-2ed9-4750-9df1-796e9c0d4df2">

6. Set the height for each row to avoid flicks effects

Confirm each row has a `min-height` of `80px`:

<img width="597" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/da6bad0f-4ec1-4bdb-ba8f-74a61120340d">


7. Remove focus styles in the terms component user selects it

Confirm it doesn't add an `outline` style when clicking on it:

<img width="446" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/c127edf7-025d-4ca6-ab85-5a6d34969daf">


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
