### PR TITLE
REST API: Add variation product type to response

### DIFF
--- a/plugins/woocommerce/changelog/try-rest-api-product-variation-type
+++ b/plugins/woocommerce/changelog/try-rest-api-product-variation-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+REST API: Add product variation type to response when getting variations.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -504,6 +504,12 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'type'                  => array(
+					'description' => __( 'Product type.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 				'date_created'          => array(
 					'description' => __( "The date the variation was created, in the site's timezone.", 'woocommerce' ),
 					'type'        => 'date-time',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -100,6 +100,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = array(
 			'id'                    => $object->get_id(),
+			'type'                  => $object->get_type(),
 			'date_created'          => wc_rest_prepare_date_response( $object->get_date_created(), false ),
 			'date_created_gmt'      => wc_rest_prepare_date_response( $object->get_date_created() ),
 			'date_modified'         => wc_rest_prepare_date_response( $object->get_date_modified(), false ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/product-variations.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/product-variations.php
@@ -400,7 +400,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 38, count( $properties ) );
+		$this->assertEquals( 39, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
 		$this->assertArrayHasKey( 'date_modified', $properties );
@@ -567,7 +567,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 			'regular_price' => '4.99'
 		) ) );
 		$response  = $this->server->dispatch( $request );
-		
+
 		$variation = $response->get_data();
 		$product   = wc_get_product( $product->get_id() );
 		$children  = $product->get_children();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR address the need to be able to distinguish the product type of a product variation by adding the following ~two properties~ property to the product variation REST API responses:

* `type` -- the product type for the variation
* ~`parent_type` -- the product type of the variation's parent~

This needs has been identified by third party extension developers when considering how to distinguish product variation types in the context of the new product editor:

* https://developer.woocommerce.com/2023/11/17/getting-to-know-woo-extensibility-in-the-new-product-editor/#comment-20676

Prior to this PR, no `type` property was returned for product variations, which made it impossible to determine the specific type of variation.

Questions:

* Is there any reason why the `type` property was not originally included with product variation responses?
    * This seems harmless to add, but I may be missing historical context.
* ~Is the `parent_type` property addition necessary?~
    * ~In theory, I see no inherent restriction in WooCommerce that would limit all variations of a variable product to be the exact same type, or a variation of a particular type to always have the same parent type, so this seems like a reasonable addition to help further cover different ways of distinguishing variations.~
    * ~But, it does have a potential performance implication...~
* ~Is the `parent_type` property addition a performance concern?~
    * ~How can I quantify the performance hit from this?~

_**Update: I removed the `parent_type` property for now because we do not have an immediate need for it.**_

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add some variable products with variations.
2. Install a plugin such as WooCommerce Subscriptions that adds additional variable/variation types.
3. Using a tool such as Postman, make REST API requests to get variations ([REST API doc](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variations))

    - REST endpoint for variations: `/wp-json/wc/v3/products/<product_id>/variations`

4. Verify that the `type` ~and `parent_type` properties~ property is correct

    - For Variable Product variations, the type is `variation`
    - For Variable Subscription variations, the type is `subscription_variation`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
