### PR TITLE
Reenable global styles for coming soon entire site template

### DIFF
--- a/plugins/woocommerce/changelog/fix-lys-reenable-global-styles
+++ b/plugins/woocommerce/changelog/fix-lys-reenable-global-styles
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Reenable global styles in coming soon pages
+Reenable global styles in coming soon entire site template

--- a/plugins/woocommerce/changelog/fix-lys-reenable-global-styles
+++ b/plugins/woocommerce/changelog/fix-lys-reenable-global-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reenable global styles in coming soon pages

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -26,35 +26,8 @@ class ComingSoonRequestHandler {
 	final public function init( ComingSoonHelper $coming_soon_helper ) {
 		$this->coming_soon_helper = $coming_soon_helper;
 		add_filter( 'template_include', array( $this, 'handle_template_include' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'deregister_unnecessary_styles' ), 100 );
 	}
 
-	/**
-	 * Deregisters unnecessary styles for the coming soon page.
-	 *
-	 * @return void
-	 */
-	public function deregister_unnecessary_styles() {
-		global $wp;
-
-		if ( ! $this->should_show_coming_soon( $wp ) ) {
-			return;
-		}
-
-		if ( $this->coming_soon_helper->is_site_coming_soon() ) {
-			global $wp_styles;
-
-			foreach ( $wp_styles->registered as $handle => $registered_style ) {
-				// Deregister all styles except for block styles.
-				if (
-					strpos( $handle, 'wp-block' ) !== 0 &&
-					strpos( $handle, 'core-block' ) !== 0
-				) {
-					wp_deregister_style( $handle );
-				}
-			}
-		}
-	}
 
 	/**
 	 * Replaces the page template with a 'coming soon' when the site is in coming soon mode.
@@ -75,7 +48,7 @@ class ComingSoonRequestHandler {
 		nocache_headers();
 
 		add_theme_support( 'block-templates' );
-		wp_dequeue_style( 'global-styles' );
+
 		$coming_soon_template = get_query_template( 'coming-soon' );
 
 		if ( ! wc_current_theme_is_fse_theme() && $this->coming_soon_helper->is_store_coming_soon() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

p1715171565604419/1715166724.293329-slack-C06DJHTE04U

Reenable global styling that was disabled in https://github.com/woocommerce/woocommerce/pull/46619 in attempt to fix style changes in editor.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Testing editor styles being applied correctly

1. Go to `WooCommerce > Settings > Site visibility`
3. Ensure `Coming soon` is selected and `Restrict to store pages only` is disabled
4. Go to `Appearance > Editor > Templates > Page: Coming soon` and edit
5. Attempt to add any blocks, style it, and save
6. View the store frontend and ensure the coming soon page styling is correct
<img width="2281" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/50b3d769-4a2f-47db-bf43-12bb89f78995">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>