### PR TITLE
Fix fatal error when trying to download log files

### DIFF
--- a/plugins/woocommerce/changelog/pr-47398
+++ b/plugins/woocommerce/changelog/pr-47398
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error when trying to download log files

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileExporter.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileExporter.php
@@ -52,7 +52,7 @@ class FileExporter {
 	public function emit_file() {
 		try {
 			$filesystem  = FilesystemUtil::get_wp_filesystem();
-			$is_readable = ! $filesystem->is_file( $this->path ) || ! $filesystem->is_readable( $this->path );
+			$is_readable = $filesystem->is_file( $this->path ) && $filesystem->is_readable( $this->path );
 		} catch ( Exception $exception ) {
 			$is_readable = false;
 		}
@@ -106,11 +106,11 @@ class FileExporter {
 	 * @return void
 	 */
 	private function send_contents(): void {
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- No suitable alternative.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- No suitable alternative.
 		$stream = fopen( $this->path, 'rb' );
 
 		while ( is_resource( $stream ) && ! feof( $stream ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread -- No suitable alternative.
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- No suitable alternative.
 			$chunk = fread( $stream, self::CHUNK_SIZE );
 
 			if ( is_string( $chunk ) ) {
@@ -119,7 +119,7 @@ class FileExporter {
 			}
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- No suitable alternative.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- No suitable alternative.
 		fclose( $stream );
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -104,7 +104,7 @@ class PageController {
 		if ( ! $this->settings->logging_is_enabled() ) {
 			add_action(
 				'admin_notices',
-				function() {
+				function () {
 					?>
 					<div class="notice notice-warning">
 						<p>
@@ -395,7 +395,7 @@ class PageController {
 				if ( is_string( $line ) ) {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_line does the escaping.
 					echo $this->format_line( $line, $line_number );
-					$line_number ++;
+					++$line_number;
 				}
 				?>
 			<?php endwhile; ?>
@@ -464,7 +464,7 @@ class PageController {
 			array(
 				'file_id' => array(
 					'filter'  => FILTER_CALLBACK,
-					'options' => function( $file_id ) {
+					'options' => function ( $file_id ) {
 						return sanitize_file_name( wp_unslash( $file_id ) );
 					},
 				),
@@ -484,13 +484,13 @@ class PageController {
 				),
 				'search'  => array(
 					'filter'  => FILTER_CALLBACK,
-					'options' => function( $search ) {
+					'options' => function ( $search ) {
 						return esc_html( wp_unslash( $search ) );
 					},
 				),
 				'source'  => array(
 					'filter'  => FILTER_CALLBACK,
-					'options' => function( $source ) {
+					'options' => function ( $source ) {
 						return File::sanitize_source( wp_unslash( $source ) );
 					},
 				),
@@ -654,7 +654,7 @@ class PageController {
 		if ( is_numeric( $deleted ) ) {
 			add_action(
 				'admin_notices',
-				function() use ( $deleted ) {
+				function () use ( $deleted ) {
 					?>
 					<div class="notice notice-info is-dismissible">
 						<p>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -624,7 +624,7 @@ class PageController {
 					}
 
 					if ( is_wp_error( $export_error ) ) {
-						wp_die( wp_kses_post( $export_error ) );
+						wp_die( wp_kses_post( $export_error->get_error_message() ) );
 					}
 					break;
 				case 'delete':


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull request fixes two bugs related to log file downloads:

1. When attempting to download a log file (via WooCommerce - Status - Logs, "Download" button) the logic to determine if the file is readable in `FileExporter::emit_file` was reversed, causing the method to return an instance of `WP_Error`. This bug was introduced in https://github.com/woocommerce/woocommerce/pull/45914.

2. When `FileExporter::emit_file` returns an instance of `WP_Error`, the code in `PageController::handle_list_table_bulk_actions` was passing the entire object to `wp_kses_post` instead of passing only the error message. This was causing a fatal error (`preg_replace(): Argument #3 ($subject) must be of type array|string, WP_Error given`).

Closes #47389.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. First you need to create a log file if you don't have any. From command line you can just run `wp eval 'wc_get_logger()->info("This is info");'`.

2. Open the details page for any existing log file (WooCommerce - Status - Logs, click on the name of the log file). I'ts important to perform this step before proceeding further.

3. To test the fix in `PageController` you need to somehow force an error in `FileExporter::emit_file`. One way to achieve that is to make the log files non-readable. Get the path of the logs directory in your install (you can see it in WooCommerce - Status - System Status, under "WordPress Environment", key is "Log directory writable:"), `cd` into it from command line and do `chmod -r *`. Now try to download the log file you oepened in the previous step (click the "Download" button) and you'll get a proper error message, not a fatal error. _Don't forget to `chmod +r *` your log files back!_

4. Testing the fix in `FileExporter` is easier: just try to download the log file via the same "Download" button and it will succeed.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
