### PR TITLE
Use cached data, if available, in admin order list page

### DIFF
--- a/plugins/woocommerce/changelog/cache-queries
+++ b/plugins/woocommerce/changelog/cache-queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Cache some queries in admin order list page

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -595,8 +595,6 @@ class ListTable extends WP_List_Table {
 	 * @return int
 	 */
 	private function count_orders_by_status( $status ): int {
-		global $wpdb;
-
 		// Compute all counts and cache if necessary.
 		if ( is_null( $this->status_count_cache ) ) {
 			$this->status_count_cache = OrderUtil::get_count_for_type( $this->order_type );

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -197,7 +197,7 @@ final class OrderUtil {
 		global $wpdb;
 
 		$cache_key        = \WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'order-count-' . $order_type;
-		$count_per_status = wp_cache_get( $cache_key, 'counts' );
+		$count_per_status = wp_cache_get( $cache_key, 'orders' );
 
 		if ( false === $count_per_status ) {
 			if ( self::custom_orders_table_usage_is_enabled() ) {
@@ -222,7 +222,7 @@ final class OrderUtil {
 				$count_per_status
 			);
 
-			wp_cache_set( $cache_key, $count_per_status, 'counts' );
+			wp_cache_set( $cache_key, $count_per_status, 'orders' );
 		}
 
 		return $count_per_status;


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is used, admin order list page can be slow. This PR attempts to reduce the DB queries total time by caching followings:

1. Order counts per status. Use `OrderUtil::get_count_for_type()` that counts order per status and cache it
2. Dates dropdown. Cache it.

Closes #47350

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set some test orders and use any query debug tools (i.e. QM) to check queries being executed on `/wp-admin/admin.php?page=wc-orders`
2. Verify the query from `ListTable::count_orders_by_status()` to count orders per status is not executed, but the count of orders per status is still correct
    <img width="746" alt="image" src="https://github.com/woocommerce/woocommerce/assets/78313/236071db-e138-418c-917b-46ec18e40262">

4. Verify the query from `ListTable::months_filter()` to list dates dropdown is not executed, but the dropdown is dispayed correctly
    <img width="649" alt="image" src="https://github.com/woocommerce/woocommerce/assets/78313/763b57a5-53cc-4663-b36b-0ffce487603f">

6. Try adding and removing orders, it should be reflected on the UI

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
