### PR TITLE
Blocks E2E: Remove the DB snapshot on env reset

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/bin/test-env-setup.sh
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/test-env-setup.sh
@@ -6,6 +6,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 head_dir=$(cd "$(dirname "$script_dir")" && cd ../../.. && pwd)
 relative_path=${script_dir#$head_dir/}
 
+# Remove the database snapshot if it exists.
+wp-env run tests-cli -- rm blocks_e2e.sql 2> /dev/null
 # Run the main script in the container for better performance.
 wp-env run tests-cli -- bash wp-content/plugins/woocommerce/blocks-bin/playwright/scripts/index.sh
+# Disable the LYS Coming Soon banner.
 wp-env run tests-cli wp option update woocommerce_coming_soon 'no'

--- a/plugins/woocommerce/changelog/47416-remove-e2e-db-snapshot-on-env-reset
+++ b/plugins/woocommerce/changelog/47416-remove-e2e-db-snapshot-on-env-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Remove the DB snapshot on env reset


### PR DESCRIPTION
### What

After merging https://github.com/woocommerce/woocommerce/pull/46409, I realized that the env reset (`pnpm env:reset`) does not remove the DB snapshot, which might cause env conflicts when rerunning multiple times locally. This PR fixes that.

### How to test

Ensure the DB snapshot is removed after calling `pnpm env:restart`. You'll need to run some tests first so that the snapshot is created. 