### PR TITLE
Data: improve reducer with optimisticQueryUpdate test

### DIFF
--- a/packages/js/data/changelog/update-crud-reducer-tests
+++ b/packages/js/data/changelog/update-crud-reducer-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Data: improve reducer with optimisticQueryUpdate test

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -325,10 +325,6 @@ describe( 'crud reducer', () => {
 				status: 'draft',
 			};
 
-			const options = {
-				optimisticQueryUpdate: {},
-			};
-
 			const resourceName = getRequestIdentifier(
 				CRUD_ACTIONS.CREATE_ITEM,
 				item.id,
@@ -340,12 +336,18 @@ describe( 'crud reducer', () => {
 				key: item.id,
 				item,
 				query,
-				options,
+				options: {},
 			} );
 
 			expect( state.data[ 2 ].name ).toEqual( item.name );
 			expect( state.data[ 2 ].status ).toEqual( item.status );
 			expect( state.requesting[ resourceName ] ).toEqual( false );
+
+			// Test the items object is an empty object
+			expect( state.items ).toEqual( {} );
+
+			// Test the itemsCount object is an empty object
+			expect( state.itemsCount ).toEqual( {} );
 		} );
 
 		it( 'when optimisticQueryUpdate is {}', () => {
@@ -371,16 +373,6 @@ describe( 'crud reducer', () => {
 				options,
 			} );
 
-			const itemQuery = getRequestIdentifier(
-				CRUD_ACTIONS.GET_ITEMS,
-				options.optimisticQueryUpdate
-			);
-
-			const itemsCountQuery = getRequestIdentifier(
-				CRUD_ACTIONS.GET_ITEMS,
-				options.optimisticQueryUpdate
-			);
-
 			expect( state.data[ 7 ].name ).toEqual( item.name );
 			expect( state.data[ 7 ].status ).toEqual( item.status );
 
@@ -392,10 +384,19 @@ describe( 'crud reducer', () => {
 			expect( state.requesting[ resourceName ] ).toEqual( false );
 
 			// Items
+			const itemQuery = getRequestIdentifier(
+				CRUD_ACTIONS.GET_ITEMS,
+				options.optimisticQueryUpdate
+			);
+
 			expect( state.items[ itemQuery ].data ).toHaveLength( 1 );
 			expect( state.items[ itemQuery ].data[ 0 ] ).toEqual( item.id );
 
 			// Items Count
+			const itemsCountQuery = getRequestIdentifier(
+				CRUD_ACTIONS.GET_ITEMS,
+				options.optimisticQueryUpdate
+			);
 			expect( state.itemsCount[ itemsCountQuery ] ).toEqual( 1 );
 		} );
 	} );

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -404,11 +404,12 @@ describe( 'crud reducer', () => {
 				options.optimisticQueryUpdate
 			);
 
+			// ItemsCount Key
+			const itemsCountKey = Object.keys( state.itemsCount );
+
 			// ItemsCount should be 1
 			expect( state.itemsCount[ itemsCountQuery ] ).toEqual( 1 ); // Items count
 
-			// ItemsCount Key
-			const itemsCountKey = Object.keys( state.itemsCount );
 			expect( itemsCountKey ).toHaveLength( 1 );
 			expect( itemsCountKey[ 0 ] ).toEqual( itemsCountQuery );
 		} );

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -350,7 +350,7 @@ describe( 'crud reducer', () => {
 			expect( state.itemsCount ).toEqual( {} );
 		} );
 
-		it( 'when optimisticQueryUpdate is {}', () => {
+		it( 'when optimisticQueryUpdate is defined', () => {
 			const item: Item = {
 				id: 7,
 				name: 'Off the hook!',
@@ -362,7 +362,7 @@ describe( 'crud reducer', () => {
 			};
 
 			const options = {
-				optimisticQueryUpdate: {},
+				optimisticQueryUpdate: { order_by: 'name' },
 			};
 
 			const state = reducer( defaultState, {
@@ -389,15 +389,28 @@ describe( 'crud reducer', () => {
 				options.optimisticQueryUpdate
 			);
 
+			// Items should have the item id
 			expect( state.items[ itemQuery ].data ).toHaveLength( 1 );
-			expect( state.items[ itemQuery ].data[ 0 ] ).toEqual( item.id );
+			expect( state.items[ itemQuery ].data[ 0 ] ).toEqual( 7 ); // Item id
 
-			// Items Count
+			// Items Key
+			const itemsKey = Object.keys( state.items );
+			expect( itemsKey ).toHaveLength( 1 );
+			expect( itemsKey[ 0 ] ).toEqual( itemQuery );
+
+			// ItemsCount
 			const itemsCountQuery = getRequestIdentifier(
 				CRUD_ACTIONS.GET_ITEMS,
 				options.optimisticQueryUpdate
 			);
-			expect( state.itemsCount[ itemsCountQuery ] ).toEqual( 1 );
+
+			// ItemsCount should be 1
+			expect( state.itemsCount[ itemsCountQuery ] ).toEqual( 1 ); // Items count
+
+			// ItemsCount Key
+			const itemsCountKey = Object.keys( state.itemsCount );
+			expect( itemsCountKey ).toHaveLength( 1 );
+			expect( itemsCountKey[ 0 ] ).toEqual( itemsCountQuery );
 		} );
 	} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the tests for the reducer of the CRUD lib, checking the `optimisticQueryUpdate` option.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Just confirm tests are passing:

```cli
pnpm --filter=./packages/js/data run test:js packages/js/data/src/crud/test/reducer.ts
```

<img width="457" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/4c015935-6361-4910-a796-337ce2857731">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
