### PR TITLE
Produc Editor API: Modal block editor more menu extensibility (description field)

### DIFF
--- a/packages/js/product-editor/changelog/add-product-editor-modal-block-editor-more-menu
+++ b/packages/js/product-editor/changelog/add-product-editor-modal-block-editor-more-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added support for extension more menu items in modal block editor (description field).

--- a/packages/js/product-editor/src/components/iframe-editor/constants.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/constants.ts
@@ -1,2 +1,4 @@
 export const SIDEBAR_COMPLEMENTARY_AREA_SCOPE =
 	'woocommerce/product-editor/modal-block-editor/sidebar';
+
+export const MORE_MENU_ACTION_ITEM_SLOT_NAME = `${ SIDEBAR_COMPLEMENTARY_AREA_SCOPE }/plugin-more-menu`;

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
@@ -18,7 +18,7 @@ import {
 import { ToolsMenuGroup } from './tools-menu-group';
 import { WritingMenu } from '../writing-menu';
 import { getGutenbergVersion } from '../../../../utils/get-gutenberg-version';
-import { SIDEBAR_COMPLEMENTARY_AREA_SCOPE } from '../../constants';
+import { MORE_MENU_ACTION_ITEM_SLOT_NAME } from '../../constants';
 
 export const MoreMenu = () => {
 	const renderBlockToolbar =
@@ -31,7 +31,7 @@ export const MoreMenu = () => {
 					{ renderBlockToolbar && <WritingMenu /> }
 
 					<ActionItem.Slot
-						name={ `${ SIDEBAR_COMPLEMENTARY_AREA_SCOPE }/plugin-more-menu` }
+						name={ MORE_MENU_ACTION_ITEM_SLOT_NAME }
 						label={ __( 'Plugins', 'woocommerce' ) }
 						as={ MenuGroup }
 						fillProps={ { onClick: onClose } }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/index.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin-more-menu-item';

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/plugin-more-menu-item.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/plugin-more-menu-item.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { MenuItem } from '@woocommerce/components';
+import { withPluginContext } from '@wordpress/plugins';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { ActionItem } from '@wordpress/interface';
+
+/**
+ * Internal dependencies
+ */
+import { MORE_MENU_ACTION_ITEM_SLOT_NAME } from '../../constants';
+
+type PluginMoreMenuItemProps = {
+	as?: React.ElementType;
+	icon?: string | React.ReactNode;
+};
+
+export const PluginMoreMenuItem = compose(
+	withPluginContext( ( context, ownProps: PluginMoreMenuItemProps ) => {
+		return {
+			as: ownProps.as ?? MenuItem,
+			icon: ownProps.icon || context.icon,
+			name: MORE_MENU_ACTION_ITEM_SLOT_NAME,
+		};
+	} )
+)( ActionItem );

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/plugin-more-menu-item.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/plugin-more-menu-item.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { compose } from '@wordpress/compose';
-import { MenuItem } from '@woocommerce/components';
+import { MenuItem } from '@wordpress/components';
 import { withPluginContext } from '@wordpress/plugins';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.

--- a/packages/js/product-editor/src/components/iframe-editor/index.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/index.ts
@@ -1,2 +1,3 @@
 export * from './iframe-editor';
 export * from './sidebar/plugin-sidebar';
+export * from './header-toolbar/plugin-more-menu-item';

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -103,3 +103,4 @@ export {
 } from './custom-fields';
 
 export { PluginSidebar as __experimentalModalBlockEditorPluginSidebar } from './iframe-editor';
+export { PluginMoreMenuItem as __experimentalModalBlockEditorPluginMoreMenuItem } from './iframe-editor';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42880 (part of #46025).

This PR implements the following, which can be used to extend the modal block editor used by the description field:

* `__experimentalModalBlockEditorPluginMoreMenuItem` component (a fill for an `ActionItem` to be specific) that can be used by extensions to add "more menu" items to the modal block editor

Demo of the more menu in action with the test plugin mentioned below:

https://github.com/woocommerce/woocommerce/assets/2098816/7c4ddc1d-fd0d-4bff-b362-76386bd26a88

Known issues not included (will be handled by follow-up PRs; issues will be created):

* https://github.com/woocommerce/woocommerce/issues/47152
* https://github.com/woocommerce/woocommerce/issues/47197

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Install the following test plugin: [test-47436-modal-block-editor-more-menu.zip](https://github.com/woocommerce/woocommerce/files/15300012/test-47436-modal-block-editor-more-menu.zip)

<details>

<summary>Test code included in the above plugin</summary>

```js
(() => {
    const el = wp?.element?.createElement;

    const BlocksMoreMenuItem = () => {
        const { blocks } = wp.data.useSelect( ( select ) => {
            return {
                blocks: select( 'core/block-editor' ).getBlocks(),
            };
        } );
    
        const { resetBlocks } = wp.data.useDispatch( 'core/block-editor' );

        function reverseBlocks() {
            resetBlocks( blocks.toReversed() );
        }

        return el(
            wc.productEditor.__experimentalModalBlockEditorPluginMoreMenuItem,
            {
                icon: 'image-flip-vertical',
                onClick: reverseBlocks,
            },
            'Reverse blocks'
        );
    }
    
    const ProductMoreMenuItem = () => {
        const postType = wp.element.useContext( wc.productEditor.PostTypeContext );
        const [ id ] = wp.coreData.useEntityProp( 'postType', postType, 'id' );
        const { editedRecord: product } = wp.coreData.useEntityRecord(
            'postType',
            postType,
            id,
        );

        const { insertBlock } = wp.data.useDispatch( 'core/block-editor' );

        function insertProductNameBlock() {
            insertBlock(
                wp.blocks.createBlock(
                    'core/paragraph',
                    {
                        content: `Product name: ${ product.name }`,
                    },
                )
            );
        }

        return el(
            wc.productEditor.__experimentalModalBlockEditorPluginMoreMenuItem,
            {
                icon: 'insert-after',
                onClick: insertProductNameBlock,
            },
            'Insert product name paragraph'
        );
    }
    
    console.log('registerPlugin');
    
    wp.plugins?.registerPlugin( 'test-47436-modal-block-editor-more-menu', {
        scope: 'woocommerce-product-editor-modal-block-editor',
        icon: 'code-standards',
        render: function() {
            console.log('render');
    
            return el(
                wp.element.Fragment,
                {},
    
                // Product More Menu Item
                el(
                    ProductMoreMenuItem,
                    {}
                ),
    
                // Blocks More Menu Item
                el(
                    BlocksMoreMenuItem,
                    {}
                ),
            );
        }
    } );
})();


```

</details>

With a WooCommerce dev env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Click on **Description** > **Full Editor** to bring up the modal editor
3. Verify that the modal editor's "more menu" looks correct

<img width="1274" alt="Screenshot 2024-05-13 at 17 14 14" src="https://github.com/woocommerce/woocommerce/assets/2098816/377aa32f-3d07-4324-886d-644d4400e7db">

4. Install the test plugin mentioned above
5. Go to **Products** > **Add New**
6. Click on **Description** > **Full Editor** to bring up the modal editor
7. Verify that the modal editor's "more menu" contains the two test menu items implemented by the test plugin (also note the **Plugins** section in the more menu)

<img width="1274" alt="Screenshot 2024-05-13 at 17 14 53" src="https://github.com/woocommerce/woocommerce/assets/2098816/2119eb92-dfc1-4b26-82b1-a54fcb84a2f4">

8. Verify that the **Insert product name paragraph** menu item inserts a paragraph with the product name at the end of the blocks:

<img width="1274" alt="Screenshot 2024-05-13 at 17 15 11" src="https://github.com/woocommerce/woocommerce/assets/2098816/16e901fc-ac9d-4adc-a8a4-1ccfcb9ba9b9">

9. Add some more blocks in the modal editor
10. Verify that the Reverse blocks menu item reverses the order of the blocks
11. Click Done in the modal editor header and verify that the description is updated.

<img width="1274" alt="Screenshot 2024-05-13 at 17 16 29" src="https://github.com/woocommerce/woocommerce/assets/2098816/744cd86f-2b96-473a-ada5-f7aeed70c700">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
