### PR TITLE
[e2e tests] Remove BuildKite reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,29 +116,12 @@ jobs:
                   install: '${{ matrix.projectName }}...'
                   build: '${{ matrix.projectName }}'
 
-            - name: Get commit message
-              id: get_commit_message
-              run: |
-                  if [[ "${{ github.event_name }}" == "push" ]]; then
-                    COMMIT_MESSAGE=`echo "${{ github.event.head_commit.message }}" | head -1`
-                  elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    COMMIT_MESSAGE="${{ github.event.pull_request.title }}"
-                  else
-                    COMMIT_MESSAGE="${{ github.event_name }}"
-                  fi
-                
-                  echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
-              shell: bash
-
             - name: 'Prepare Test Environment'
               id: 'prepare-test-environment'
               if: ${{ matrix.testEnv.shouldCreate }}
               run: 'pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
 
             - name: 'Run tests'
-              env:
-                  BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
-                  BUILDKITE_ANALYTICS_MESSAGE: ${{ steps.get_commit_message.outputs.COMMIT_MESSAGE }}
               run: 'pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }}'
 
             - name: 'Upload artifacts'
@@ -170,29 +153,12 @@ jobs:
                   install: '${{ matrix.projectName }}...'
                   build: '${{ matrix.projectName }}'
 
-            - name: Get commit message
-              id: get_commit_message
-              run: |
-                  if [[ "${{ github.event_name }}" == "push" ]]; then
-                    COMMIT_MESSAGE=`echo "${{ github.event.head_commit.message }}" | head -1`
-                  elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    COMMIT_MESSAGE="${{ github.event.pull_request.title }}"
-                  else
-                    COMMIT_MESSAGE="${{ github.event_name }}"
-                  fi
-                
-                  echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
-              shell: bash
-
             - name: 'Prepare Test Environment'
               id: 'prepare-test-environment'
               if: ${{ matrix.testEnv.shouldCreate }}
               run: 'pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
 
             - name: 'Run tests'
-              env:
-                  BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_API_ANALYTICS_TOKEN }}
-                  BUILDKITE_ANALYTICS_MESSAGE: ${{ steps.get_commit_message.outputs.COMMIT_MESSAGE }}
               run: 'pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }}'
 
             - name: 'Upload artifacts'

--- a/plugins/woocommerce/changelog/e2e-remove-buildkite-reporter
+++ b/plugins/woocommerce/changelog/e2e-remove-buildkite-reporter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove BuildKite reporter from e2e tests

--- a/plugins/woocommerce/tests/api-core-tests/playwright.config.js
+++ b/plugins/woocommerce/tests/api-core-tests/playwright.config.js
@@ -48,7 +48,6 @@ const config = {
 					'./test-results/test-results.json',
 			},
 		],
-		[ 'buildkite-test-collector/playwright/reporter' ],
 	],
 	use: {
 		screenshot: 'only-on-failure',

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -31,7 +31,6 @@ const reporter = [
 
 if ( process.env.CI ) {
 	reporter.push( [ 'github' ] );
-	reporter.push( [ 'buildkite-test-collector/playwright/reporter' ] );
 } else {
 	reporter.push( [
 		'html',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The e2e tests jobs started failing because of BuildKite reporter exceeding the number of executions available on the free plan. 
More context: p1715656670502399-slack-C03CPM3UXDJ

Removing the integration as a quick fix to fix unblock the e2e jobs. We'll check again and add it back if needed.

### How to test the changes in this Pull Request:

Check CI, e2e tests should run successfully.