### PR TITLE
Hide notices on Business Services tab in marketplace

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -186,12 +186,9 @@ export default function Content(): JSX.Element {
 		<div className="woocommerce-marketplace__content">
 			<Promotions />
 			<InstallNewProductModal products={ products } />
-			{ selectedTab !== 'business-services' && (
-				<>
-					<ConnectNotice />
-					<PluginInstallNotice />
-				</>
-			) }
+			{ selectedTab !== 'business-services' &&
+				selectedTab !== 'my-subscriptions' && <ConnectNotice /> }
+			{ selectedTab !== 'business-services' && <PluginInstallNotice /> }
 			{ renderContent() }
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -24,6 +24,7 @@ import {
 import InstallNewProductModal from '../install-flow/install-new-product-modal';
 import Promotions from '../promotions/promotions';
 import ConnectNotice from '~/marketplace/components/connect-notice/connect-notice';
+import PluginInstallNotice from '../woo-update-manager-plugin/plugin-install-notice';
 
 export default function Content(): JSX.Element {
 	const marketplaceContextValue = useContext( MarketplaceContext );
@@ -185,7 +186,12 @@ export default function Content(): JSX.Element {
 		<div className="woocommerce-marketplace__content">
 			<Promotions />
 			<InstallNewProductModal products={ products } />
-			<ConnectNotice />
+			{ selectedTab !== 'business-services' && (
+				<>
+					<ConnectNotice />
+					<PluginInstallNotice />
+				</>
+			) }
 			{ renderContent() }
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/discover/discover.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/discover/discover.tsx
@@ -13,7 +13,6 @@ import ProductLoader from '../product-loader/product-loader';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 import { ProductType } from '../product-list/types';
 import './discover.scss';
-import PluginInstallNotice from '../woo-update-manager-plugin/plugin-install-notice';
 
 export default function Discover(): JSX.Element | null {
 	const [ productGroups, setProductGroups ] = useState<
@@ -71,7 +70,6 @@ export default function Discover(): JSX.Element | null {
 	const groupsList = productGroups.flatMap( ( group ) => group );
 	return (
 		<div className="woocommerce-marketplace__discover">
-			<PluginInstallNotice />
 			{ groupsList.map( ( groups ) => (
 				<ProductList
 					key={ groups.id }

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -25,7 +25,6 @@ import { RefreshButton } from './table/actions/refresh-button';
 import Notices from './notices';
 import InstallModal from './table/actions/install-modal';
 import { connectUrl } from '../../utils/functions';
-import PluginInstallNotice from '../woo-update-manager-plugin/plugin-install-notice';
 
 export default function MySubscriptions(): JSX.Element {
 	const { subscriptions, isLoading } = useContext( SubscriptionsContext );
@@ -90,7 +89,6 @@ export default function MySubscriptions(): JSX.Element {
 			<section className="woocommerce-marketplace__my-subscriptions__notices">
 				<Notices />
 			</section>
-			<PluginInstallNotice />
 			<section className="woocommerce-marketplace__my-subscriptions-section woocommerce-marketplace__my-subscriptions__installed">
 				<header className="woocommerce-marketplace__my-subscriptions__header">
 					<div className="woocommerce-marketplace__my-subscriptions__header-content">

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -168,11 +168,13 @@ export default function Products( props: ProductsProps ) {
 
 	return (
 		<div className={ containerClassName }>
-			<PluginInstallNotice />
 			{ selectedTab !== 'business-services' && (
-				<h2 className={ productListTitleClassName }>
-					{ isLoading ? ' ' : title }
-				</h2>
+				<>
+					<PluginInstallNotice />
+					<h2 className={ productListTitleClassName }>
+						{ isLoading ? ' ' : title }
+					</h2>
+				</>
 			) }
 			<div className="woocommerce-marketplace__sub-header">
 				{ props.categorySelector && (

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -27,7 +27,6 @@ import { Product, ProductType, SearchResultType } from '../product-list/types';
 import { MARKETPLACE_ITEMS_PER_PAGE } from '../constants';
 import { ADMIN_URL } from '~/utils/admin-settings';
 import { ThemeSwitchWarningModal } from '~/customize-store/intro/warning-modals';
-import PluginInstallNotice from '../woo-update-manager-plugin/plugin-install-notice';
 
 interface ProductsProps {
 	categorySelector?: boolean;
@@ -169,12 +168,9 @@ export default function Products( props: ProductsProps ) {
 	return (
 		<div className={ containerClassName }>
 			{ selectedTab !== 'business-services' && (
-				<>
-					<PluginInstallNotice />
-					<h2 className={ productListTitleClassName }>
-						{ isLoading ? ' ' : title }
-					</h2>
-				</>
+				<h2 className={ productListTitleClassName }>
+					{ isLoading ? ' ' : title }
+				</h2>
 			) }
 			<div className="woocommerce-marketplace__sub-header">
 				{ props.categorySelector && (

--- a/plugins/woocommerce-admin/client/marketplace/components/search-results/search-results.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/search-results/search-results.tsx
@@ -163,57 +163,24 @@ export default function SearchResults( props: SearchResultProps ): JSX.Element {
 			} );
 		}
 
-		if ( hasExtensions && hasThemes && ! hasBusinessServices ) {
-			return (
-				<>
-					{ extensionsComponent( {
-						perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-					} ) }
-					{ themesComponent( {
-						perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-					} ) }
-				</>
-			);
-		}
-
-		if ( hasExtensions && hasBusinessServices && ! hasThemes ) {
-			return (
-				<>
-					{ extensionsComponent( {
-						perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-					} ) }
-					{ businessServicesComponent( {
-						perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-					} ) }
-				</>
-			);
-		}
-
-		if ( hasThemes && hasBusinessServices && ! hasExtensions ) {
-			return (
-				<>
-					{ themesComponent( {
-						perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-					} ) }
-					{ businessServicesComponent( {
-						perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-					} ) }
-				</>
-			);
-		}
-
 		// If we're done loading, we can put these components on the page.
 		return (
 			<>
-				{ extensionsComponent( {
-					perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-				} ) }
-				{ themesComponent( {
-					perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-				} ) }
-				{ businessServicesComponent( {
-					perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
-				} ) }
+				{ hasExtensions
+					? extensionsComponent( {
+							perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
+					  } )
+					: null }
+				{ hasThemes
+					? themesComponent( {
+							perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
+					  } )
+					: null }
+				{ hasBusinessServices
+					? businessServicesComponent( {
+							perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
+					  } )
+					: null }
 			</>
 		);
 	};

--- a/plugins/woocommerce-admin/client/marketplace/components/search-results/search-results.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/search-results/search-results.tsx
@@ -33,9 +33,16 @@ export default function SearchResults( props: SearchResultProps ): JSX.Element {
 	const businessServiceList = props.products.filter(
 		( product ) => product.type === ProductType.businessService
 	);
+
 	const hasExtensions = extensionList.length > 0;
 	const hasThemes = themeList.length > 0;
 	const hasBusinessServices = businessServiceList.length > 0;
+	const hasOnlyExtensions =
+		hasExtensions && ! hasThemes && ! hasBusinessServices;
+	const hasOnlyThemes = hasThemes && ! hasExtensions && ! hasBusinessServices;
+	const hasOnlyBusinessServices =
+		hasBusinessServices && ! hasExtensions && ! hasThemes;
+
 	const marketplaceContextValue = useContext( MarketplaceContext );
 	const { isLoading, hasBusinessServices: canShowBusinessServices } =
 		marketplaceContextValue;
@@ -139,46 +146,39 @@ export default function SearchResults( props: SearchResultProps ): JSX.Element {
 			);
 		}
 
-		if ( hasExtensions && ! hasThemes && ! hasBusinessServices ) {
-			return extensionsComponent( {
-				categorySelector: true,
-				showAllButton: false,
-				perPage: MARKETPLACE_ITEMS_PER_PAGE,
-			} );
-		}
-
-		if ( hasThemes && ! hasBusinessServices && ! hasExtensions ) {
-			return themesComponent( {
-				categorySelector: true,
-				showAllButton: false,
-				perPage: MARKETPLACE_ITEMS_PER_PAGE,
-			} );
-		}
-
-		if ( hasBusinessServices && ! hasThemes && ! hasExtensions ) {
-			return businessServicesComponent( {
-				categorySelector: true,
-				showAllButton: false,
-				perPage: MARKETPLACE_ITEMS_PER_PAGE,
-			} );
-		}
-
 		// If we're done loading, we can put these components on the page.
 		return (
 			<>
 				{ hasExtensions
 					? extensionsComponent( {
-							perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
+							categorySelector: hasOnlyExtensions || undefined,
+							showAllButton: hasOnlyExtensions
+								? false
+								: undefined,
+							perPage: hasOnlyExtensions
+								? MARKETPLACE_ITEMS_PER_PAGE
+								: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
 					  } )
 					: null }
 				{ hasThemes
 					? themesComponent( {
-							perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
+							categorySelector: hasOnlyThemes || undefined,
+							showAllButton: hasOnlyThemes ? false : undefined,
+							perPage: hasOnlyThemes
+								? MARKETPLACE_ITEMS_PER_PAGE
+								: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
 					  } )
 					: null }
 				{ hasBusinessServices
 					? businessServicesComponent( {
-							perPage: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
+							categorySelector:
+								hasOnlyBusinessServices || undefined,
+							showAllButton: hasOnlyBusinessServices
+								? false
+								: undefined,
+							perPage: hasOnlyBusinessServices
+								? MARKETPLACE_ITEMS_PER_PAGE
+								: MARKETPLACE_SEARCH_RESULTS_PER_PAGE,
 					  } )
 					: null }
 			</>

--- a/plugins/woocommerce-admin/client/marketplace/components/search/search.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/search/search.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon, search } from '@wordpress/icons';
-import { useEffect, useState } from '@wordpress/element';
+import { useContext, useEffect, useState } from '@wordpress/element';
 import { navigateTo, getNewPath, useQuery } from '@woocommerce/navigation';
 
 /**
@@ -11,9 +11,15 @@ import { navigateTo, getNewPath, useQuery } from '@woocommerce/navigation';
  */
 import './search.scss';
 import { MARKETPLACE_PATH } from '../constants';
+import { MarketplaceContext } from '../../contexts/marketplace-context';
 
 const searchPlaceholder = __(
 	'Search for extensions, themes, and business services',
+	'woocommerce'
+);
+
+const searchPlaceholderNoBusinessServices = __(
+	'Search for extensions and themes',
 	'woocommerce'
 );
 
@@ -24,8 +30,13 @@ const searchPlaceholder = __(
  */
 function Search(): JSX.Element {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
+	const { hasBusinessServices } = useContext( MarketplaceContext );
 
 	const query = useQuery();
+
+	const placeholder = hasBusinessServices
+		? searchPlaceholder
+		: searchPlaceholderNoBusinessServices;
 
 	useEffect( () => {
 		if ( query.term ) {
@@ -80,7 +91,7 @@ function Search(): JSX.Element {
 				className="screen-reader-text"
 				htmlFor="woocommerce-marketplace-search-query"
 			>
-				{ searchPlaceholder }
+				{ placeholder }
 			</label>
 			<input
 				id="woocommerce-marketplace-search-query"
@@ -88,7 +99,7 @@ function Search(): JSX.Element {
 				className="woocommerce-marketplace__search-input"
 				type="search"
 				name="woocommerce-marketplace-search-query"
-				placeholder={ searchPlaceholder }
+				placeholder={ placeholder }
 				onChange={ handleInputChange }
 				onKeyUp={ handleKeyUp }
 			/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
If someone has a WCCOM extension installed, we show a notice to connect their store to WCCOM in the in-app marketplace. 

If their store is connected, we show a notice to install/activate the WooCommerce.com Update Manager plugin as needed.

We don't want these notices to appear on the Business Services tab, as this type of product requires neither a connection to WCCOM nor do they need to update.

This PR also fixes a bug where the WUM notice appeared multiple times on the search results tab, once for every product type, and includes a small refactor to the Search Results tab to simplify the code a little.

Closes https://github.com/Automattic/woocommerce.com/issues/20493

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your WCCOM environment is running on the latest version of the `feature/business-services-tab` branch.
2. Make sure you have a few products on the Business Services category
3. Check out this branch
4. In `plugins/woocommerce-admin/client/marketplace/components/constants.ts`, edit the `MARKETPLACE_HOST` const to be `https://woocommerce.test`
5. Go to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
6. Visit [WooCommerce.com](https://woocommerce.com/my-account/downloads/) and download any plugin. Install it on your local site and activate.
7. Visit the [in-app marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions). Provided your site is not connected to WCCOM, you should see a notice prompting you to connect your site
![Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/62c79c3c-4f69-437b-9719-954d5933e7f8)
8. Check all the tabs (including Search results by searching for something and also My Subscriptions) and confirm the notice appears on all tabs except Business Services
9. Click the user icon top-left and connect your store to your WCCOM account.
10. Return to the in-app marketplace. Now you should see a notice prompting you to install the WooCommerce.com Update Manager plugin:
![Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/woocommerce/woocommerce/assets/11873759/402d9554-b9e5-415a-adbb-03acb7e97b5b)
11. Again check all the tabs and confirm the notice does not appear on the Business Services tab
12. Search for a term that will return multiple product types ("business" works for me). Confirm that multiple sections load on the search results tab, based on the results, but that the WUM notice only appears once at the top, not before every section.
13. If search results don't include all three product types, confirm the tab doesn't show empty components for the types not included in results (e.g. if results don't include business service products, the Search Results tab shouldn't show a Business Services section)
14. See what you can break ;)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
