### PR TITLE
Trigger doing_it_wrong for CPT order queries with HPOS query args

### DIFF
--- a/plugins/woocommerce/changelog/fix-46076
+++ b/plugins/woocommerce/changelog/fix-46076
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Trigger doing_it_wrong() when using HPOS query args for CPT order queries.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With HPOS we introduced a few new capabilities [in order querying](https://developer.woocommerce.com/docs/hpos-order-querying-apis/). In particular, when HPOS is the backing datastore for orders, you can create complex queries using `meta_query` and `field_query`.

We have explored adding a compat layer that would allow some of those queries to work with the CPT datastore, but due to the differences in the underlying db structure this is not always possible, and might not be worth the effort given we want to push HPOS over CPT.

This PR introduces a "doing it wrong" warning when either `meta_query` or `field_query` are being used in an order query and the datastore is the CPT one. Currently, those special arguments are silently ignored, producing a result set that can be confusing.

The PR also adds filter `woocommerce_order_data_store_cpt_query_unsupported_args` which can be used to customize which query vars trigger the notice.

Closes #46076.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure **WordPress posts storage** is selected in WC > Settings > Advanced > Features > Order data storage.
   If necessary, run `wp hpos sync` to sync so that the option becomes available.
1. Make sure that `WP_DEBUG` is set on your test instance so that "doing it wrong" messages are actually logged/triggered.
1. Run the following script (line by line) and confirm that after each command is executed the results match the description in the comment above. 
   ```
   wp> $args = [ 'return' => 'ids', ];
   wp> error_reporting( E_ALL ); 
   wp> ini_set( 'display_errors', true );

   // Test 1 -- Produces no notice.
   wp> wc_get_orders( $args );

   // Test 2 -- Produces a "doing it wrong" notice about 'field_query'.
   wp> wc_get_orders( $args + [ 'field_query' => [ 1, 2, 3, ] ] );

   // Test 3 -- Produces a "doing it wrong" notice about 'meta_query'.
   wp> wc_get_orders( $args + [ 'meta_query' => [ 1, 2, 3, ] ] );

   // Test 4 -- Produces a "doing it wrong" notice about both 'field_query' and 'meta_query'.
   wp> wc_get_orders( $args + [ 'field_query' => [ 1, 2, 3, ], 'meta_query' => [ 1, 2, 3, ] ] );
   ```
1. Still in the WP shell, limit notices to `field_query`:
   ```
   add_filter( 'woocommerce_order_data_store_cpt_query_unsupported_args', fn() => [ 'field_query' ] );
   ```
   Repeat the tests 1-4 in step 3 and confirm that only tests 2 and 4 produce a notice.
1. Drop the following snippet somewhere suitable (like wp-content/mu-plugins/) to "simulate" the default CPT order datastore being extended in 3rd party code:
   ```php
   <?php
   add_filter(
       'woocommerce_order_data_store',
       function ( $ds ) {
 	      if ( ! class_exists( 'MyOwnDatastore', false ) ) {
 		      class MyOwnDatastore extends WC_Order_Data_Store_CPT {
 		      }
	      }
   
 		   return new MyOwnDatastore;
       }
   );
   ```
1. Confirm that no notice is triggered when you run the commands in step 3.
1. Remove the PHP snippet introduced in step 5.
1. Change the order data storage back to HPOS in WC > Settings > Advanced > Features.
1. Confirm that no notice is triggered when you run the commands in step 3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
