### PR TITLE
Turn Cart change address link to button

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/calculator-button.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/calculator-button.tsx
@@ -15,9 +15,7 @@ export const CalculatorButton = ( {
 	setIsShippingCalculatorOpen,
 }: CalculatorButtonProps ): JSX.Element => {
 	return (
-		<a
-			role="button"
-			href="#wc-block-components-shipping-calculator-address__link"
+		<button
 			className="wc-block-components-totals-shipping__change-address__link"
 			id="wc-block-components-totals-shipping__change-address__link"
 			onClick={ ( e ) => {
@@ -28,7 +26,7 @@ export const CalculatorButton = ( {
 			aria-expanded={ isShippingCalculatorOpen }
 		>
 			{ label }
-		</a>
+		</button>
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -30,10 +30,10 @@
 	.wc-block-components-totals-shipping__change-address__link {
 		font-weight: normal;
 		background: none;
-    border: none;
-    padding: 0;
-    text-decoration: underline;
-    cursor: pointer;
+		border: none;
+		padding: 0;
+		text-decoration: underline;
+		cursor: pointer;
 	}
 	.wc-block-components-totals-shipping__change-address-button {
 		@include link-button();

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -29,6 +29,11 @@
 
 	.wc-block-components-totals-shipping__change-address__link {
 		font-weight: normal;
+		background: none;
+    border: none;
+    padding: 0;
+    text-decoration: underline;
+    cursor: pointer;
 	}
 	.wc-block-components-totals-shipping__change-address-button {
 		@include link-button();

--- a/plugins/woocommerce/changelog/47460-fix-turn-change-address-to-button
+++ b/plugins/woocommerce/changelog/47460-fix-turn-change-address-to-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make sure "Change Address" button in Cart block is accessible.


### PR DESCRIPTION
This PR turns the Change address button on Cart into a button so that it's accessible.

Closes https://github.com/woocommerce/woocommerce/issues/43620

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Focus on change address button.
2. Click space, it should expand the form.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Make sure "Change Address" button in Cart block is accessible.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
