### PR TITLE
CYS: mutate the original instance of the block array

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/hero-pattern.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/hero-pattern.ts
@@ -12,8 +12,7 @@ export const findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate = (
 	blocks: BlockInstance[],
 	callback: ( buttonBlock: BlockInstance ) => void
 ) => {
-	const clonedBlocks = structuredClone( blocks );
-	const coverBlock = clonedBlocks.find(
+	const coverBlock = blocks.find(
 		( block ) =>
 			block.name === 'core/cover' &&
 			block.attributes.url.includes(
@@ -28,11 +27,11 @@ export const findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate = (
 	const buttonBlock = buttonsBlock?.innerBlocks[ 0 ];
 
 	if ( ! buttonBlock ) {
-		return clonedBlocks;
+		return blocks;
 	}
 
 	callback( buttonBlock );
-	return clonedBlocks;
+	return blocks;
 };
 
 export const PRODUCT_HERO_PATTERN_BUTTON_STYLE = {

--- a/plugins/woocommerce/changelog/47468-47467-cys-assembler-editor-crashes-when-revisiting-after-setting-up-a-store
+++ b/plugins/woocommerce/changelog/47468-47467-cys-assembler-editor-crashes-when-revisiting-after-setting-up-a-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: CYS: mutate the original instance of the block array.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the Assembler crash. This PR removes some "optimizations" that I added in https://github.com/woocommerce/woocommerce/pull/47220. 

The idea was to clone the array instance to avoid mutating the original one. However, this causes some errors with the Editor. I guess that we should always mutate the same instance of the blocks and not create new ones.

Closes #47467.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Head over to WooCommerce > Home > Customize your store.
2. Click on "Start designing" and proceed to the Pattern Assembler.
3. Click on "Choose your color palette".
4. Click on the first color palette
6. Ensure that the button block inside the cover block has a white background:

![D12Gkw.png](https://github.com/woocommerce/woocommerce/assets/4463174/6a9b1500-c36d-44d6-85f3-1353237c01a8)
7. Save.
8. Visit the homepage and ensure that the button block inside the cover block has a white background:
9. Visit the admin page.
10. Head over to WooCommerce > Home > Customize your store.
11. Click on "Customize your theme" and proceed to the Pattern Assembler.
12. Click on "Choose your color palette".
13. Click on another palette.
14. Ensure that the button background is updated and matches the color palette.
15. Save.
16. Visit the homepage and ensure that the button background is updated and matches the color palette.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
CYS: mutate the original instance of the block array.

</details>
