### PR TITLE
Fix a11y issues in Cart/Checkout

### DIFF
--- a/plugins/woocommerce-blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce-blocks/assets/css/abstracts/_colors.scss
@@ -20,5 +20,5 @@ $image-placeholder-border-color: #f2f2f2;
 $universal-border-light: rgba(17, 17, 17, 0.11); // #e7e7e7 on white. Used for low contrast decorative elements such as section borders.
 $universal-border-medium: rgba(25, 23, 17, 0.48); // Used for radio and checkbox resting state.
 $universal-border-strong: rgba(17, 17, 17, 0.8); // #1e1e1e on white. Used for low contrast decorative elements such as input borders.
-$universal-body-low-emphasis: rgba(17, 17, 17, 0.5); // Used for low emphasis text such as input labels.
+$universal-body-low-emphasis: rgba(17, 17, 17, 0.7); // Used for low emphasis text such as input labels.
 $universal-background: rgba(17, 17, 17, 0.02); // Used for low contrast decorative elements background color.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
@@ -8,7 +8,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import type { ShippingAddress, FormFields } from '@woocommerce/settings';
 import { VALIDATION_STORE_KEY, CART_STORE_KEY } from '@woocommerce/block-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-
+import { useFocusReturn } from '@woocommerce/base-utils';
 /**
  * Internal dependencies
  */
@@ -29,7 +29,7 @@ const ShippingCalculatorAddress = ( {
 }: ShippingCalculatorAddressProps ): JSX.Element => {
 	const [ address, setAddress ] = useState( initialAddress );
 	const { showAllValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
-
+	const focusReturnRef = useFocusReturn();
 	const { hasValidationErrors, isCustomerDataUpdating } = useSelect(
 		( select ) => {
 			return {
@@ -47,7 +47,10 @@ const ShippingCalculatorAddress = ( {
 	};
 
 	return (
-		<form className="wc-block-components-shipping-calculator-address">
+		<form
+			className="wc-block-components-shipping-calculator-address"
+			ref={ focusReturnRef }
+		>
 			<Form
 				fields={ addressFields }
 				onChange={ setAddress }

--- a/plugins/woocommerce-blocks/assets/js/base/components/drawer/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/drawer/index.tsx
@@ -21,13 +21,12 @@ import {
 	useConstrainedTabbing,
 	useMergeRefs,
 } from '@wordpress/compose';
-
+import { useFocusReturn } from '@woocommerce/base-utils';
 /**
  * Internal dependencies
  */
 import Button from '../button';
 import * as ariaHelper from './utils/aria-helper';
-import useFocusReturn from './utils/use-focus-return';
 import './style.scss';
 
 interface DrawerProps {

--- a/plugins/woocommerce-blocks/assets/js/base/components/drawer/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/drawer/index.tsx
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/element';
 import { close, Icon } from '@wordpress/icons';
 import {
-	useFocusReturn,
 	useFocusOnMount,
 	useConstrainedTabbing,
 	useMergeRefs,
@@ -28,6 +27,7 @@ import {
  */
 import Button from '../button';
 import * as ariaHelper from './utils/aria-helper';
+import useFocusReturn from './utils/use-focus-return';
 import './style.scss';
 
 interface DrawerProps {

--- a/plugins/woocommerce-blocks/assets/js/base/components/drawer/utils/use-focus-return.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/drawer/utils/use-focus-return.ts
@@ -1,0 +1,69 @@
+/**
+ * Some code of the Drawer component is based on the Modal component from Gutenberg:
+ * https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/modal/index.tsx
+ */
+/**
+ * External dependencies
+ */
+import { useEffect, useRef, useCallback } from '@wordpress/element';
+
+let origin: Element | null = null;
+
+/**
+ * Adds the unmount behavior of returning focus to the element which had it
+ * previously as is expected for roles like menus or dialogs.
+ *
+ * This function is copied from Gutenberg's hook under the same name.
+ */
+export default function useFocusReturn(
+	onFocusReturn?: () => void
+): ( node: HTMLElement | null ) => void {
+	/** @type {import('react').MutableRefObject<null | HTMLElement>} */
+	const ref = useRef< HTMLElement >( null );
+	/** @type {import('react').MutableRefObject<null | Element>} */
+	const focusedBeforeMount = useRef< Element >( null );
+	const onFocusReturnRef = useRef( onFocusReturn );
+	useEffect( () => {
+		onFocusReturnRef.current = onFocusReturn;
+	}, [ onFocusReturn ] );
+
+	return useCallback( ( node ) => {
+		if ( node ) {
+			// Set ref to be used when unmounting.
+			ref.current = node;
+
+			// Only set when the node mounts.
+			if ( focusedBeforeMount.current ) {
+				return;
+			}
+
+			focusedBeforeMount.current = node.ownerDocument.activeElement;
+		} else if ( focusedBeforeMount.current ) {
+			const isFocused = ref.current?.contains(
+				ref.current?.ownerDocument.activeElement
+			);
+
+			if ( ref.current?.isConnected && ! isFocused ) {
+				origin ??= focusedBeforeMount.current;
+				// This return would cause the code to never actually return focus.
+				// return;
+			}
+
+			// Defer to the component's own explicit focus return behavior, if
+			// specified. This allows for support that the `onFocusReturn`
+			// decides to allow the default behavior to occur under some
+			// conditions.
+			if ( onFocusReturnRef.current ) {
+				onFocusReturnRef.current();
+			} else {
+				const focusedElement =
+					focusedBeforeMount.current as HTMLElement;
+				( focusedElement?.isConnected
+					? focusedElement
+					: ( origin as HTMLElement )
+				)?.focus();
+			}
+			origin = null;
+		}
+	}, [] );
+}

--- a/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/notice-banner/style.scss
@@ -51,14 +51,16 @@
 			margin: 0;
 			border: 0;
 			appearance: none;
-			opacity: 0.6;
+			opacity: 0.7;
 			text-decoration-line: underline;
 			text-underline-position: under;
+			transition: all 0.2s ease-in-out;
 
 			&:hover,
 			&:focus,
 			&:active {
 				opacity: 1;
+				text-decoration: none;
 			}
 		}
 	}

--- a/plugins/woocommerce-blocks/assets/js/base/utils/index.js
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/index.js
@@ -16,3 +16,4 @@ export * from './debounce';
 export * from './keyby';
 export * from './pick';
 export * from './get-inline-styles';
+export * from './use-return-focus';

--- a/plugins/woocommerce-blocks/assets/js/base/utils/use-return-focus.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/use-return-focus.ts
@@ -1,8 +1,4 @@
 /**
- * Some code of the Drawer component is based on the Modal component from Gutenberg:
- * https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/modal/index.tsx
- */
-/**
  * External dependencies
  */
 import { useEffect, useRef, useCallback } from '@wordpress/element';
@@ -15,12 +11,10 @@ let origin: Element | null = null;
  *
  * This function is copied from Gutenberg's hook under the same name.
  */
-export default function useFocusReturn(
+export function useFocusReturn(
 	onFocusReturn?: () => void
 ): ( node: HTMLElement | null ) => void {
-	/** @type {import('react').MutableRefObject<null | HTMLElement>} */
 	const ref = useRef< HTMLElement >( null );
-	/** @type {import('react').MutableRefObject<null | Element>} */
 	const focusedBeforeMount = useRef< Element >( null );
 	const onFocusReturnRef = useRef( onFocusReturn );
 	useEffect( () => {

--- a/plugins/woocommerce/changelog/47470-add-coupon-form-use-button
+++ b/plugins/woocommerce/changelog/47470-add-coupon-form-use-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update color contrast for Checkout fields. Update color contrast for notice buttons. Return focus when closing mini cart drawer. Return focus when closing shipping calculator.


### PR DESCRIPTION
I choose to go with a single PR instead of spamming multiple small PRs that take more time and effort to get setup than to actually fix the code.

This PR fixes the color contrast for the add to cart notice button, the cart/checkout labels, returns focus for the cart shipping calculator, button, and returns focus on whatever element opened the mini cart drawer.

The last one was tricky because we have the logic to return, it just never triggers because we don't unmount our drawer, we just hide it. Switching to removing the element from the page was too much a lift, so I customized the `useFocusReturn` hook to our usage.

I reused that one for the shipping calculator as well, because Gutenberg one didn't work as well.

Closes https://github.com/woocommerce/woocommerce/issues/43619
Closes https://github.com/woocommerce/woocommerce/issues/43615
Closes https://github.com/woocommerce/woocommerce/issues/43561
Closes https://github.com/woocommerce/woocommerce/issues/43621

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

### Notice color
1. On a product page, add the product to cart.
2. The page will refresh, and a notice will show a button that says 'View cart'.
3. Make sure the button contract is above 4.5, using inspect tools. Note that because opacity is a separate prop, the color will show as contrasting regardless in some browsers, so you might need to change the color to also include the opacity.

### Cart/Checkout labels
1. On Checkout, select the label of an input and ensure its contrast is above 4.5.
2. Switch Checkout to dark mode and ensure its contrast is still above 4.5.

### Return focus on Shipping Calculator
0. If you don't have Shipping Calcualtor enabled, you need to enable the option "Enable the shipping calculator on the cart page" in /wp-admin/admin.php?page=wc-settings&tab=shipping&section=options.
1. In Cart, click "Change Address"
2. Fill out the form and place it.
3. Ensure the Change address button still has focus, this means either an outline around the button, or tabbing forward should take you to the next object in the sidebar, not the top of the page.


### Return focus on Mini Cart
1. Open the mini cart via mini cart button.
2. Click X
3. Ensure the mini cart button is still focused, this means either an outline around the cart button, or tabbing forward should take you to the next object in the navbar/main body, not the top of the page.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Update color contrast for Checkout fields.
Update color contrast for notice buttons.
Return focus when closing mini cart drawer.
Return focus when closing shipping calculator.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
