### PR TITLE
Fix flaky Attributes and Variations E2E tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-flacky_attributes_and_variations_e2e_tests
+++ b/plugins/woocommerce/changelog/fix-flacky_attributes_and_variations_e2e_tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix flaky Attributes and Variations E2E tests #47471

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -211,6 +211,10 @@ test.describe( 'Variations tab', () => {
 
 			await clickOnTab( 'Variations', page );
 
+			await page.waitForSelector(
+				'[data-title="Product variations items"]'
+			);
+
 			await page
 				.locator( '.woocommerce-product-variations__table-body > div' )
 				.first()
@@ -268,6 +272,10 @@ test.describe( 'Variations tab', () => {
 			);
 
 			await clickOnTab( 'Variations', page );
+
+			await page.waitForSelector(
+				'[data-title="Product variations items"]'
+			);
 
 			await page
 				.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -209,11 +209,18 @@ test.describe( 'Variations tab', () => {
 				} )
 				.click();
 
+			const getVariationsResponsePromise = page.waitForResponse(
+				( response ) =>
+					response
+						.url()
+						.includes(
+							`/wp-json/wc/v3/products/${ productId_editVariations }/variations`
+						) && response.status() === 200
+			);
+
 			await clickOnTab( 'Variations', page );
 
-			await page.waitForSelector(
-				'[data-title="Product variations items"]'
-			);
+			await getVariationsResponsePromise;
 
 			await page
 				.locator( '.woocommerce-product-variations__table-body > div' )
@@ -271,11 +278,18 @@ test.describe( 'Variations tab', () => {
 				`/wp-admin/admin.php?page=wc-admin&path=/product/${ productId_deleteVariations }`
 			);
 
+			const getVariationsResponsePromise = page.waitForResponse(
+				( response ) =>
+					response
+						.url()
+						.includes(
+							`/wp-json/wc/v3/products/${ productId_deleteVariations }/variations`
+						) && response.status() === 200
+			);
+
 			await clickOnTab( 'Variations', page );
 
-			await page.waitForSelector(
-				'[data-title="Product variations items"]'
-			);
+			await getVariationsResponsePromise;
 
 			await page
 				.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -210,7 +210,13 @@ test.skip( 'can add existing attributes', async ( {
 } ) => {
 	await test.step( 'go to product editor, Organization tab', async () => {
 		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
+		const getAttributesResponsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/terms?attribute_id=' ) &&
+				response.status() === 200
+		);
 		await page.getByRole( 'button', { name: 'Organization' } ).click();
+		await getAttributesResponsePromise;
 	} );
 
 	await test.step( 'add an existing attribute', async () => {
@@ -382,8 +388,13 @@ test( 'can remove product attributes', async ( {
 		await page.goto(
 			`wp-admin/post.php?post=${ productWithAttributes.id }&action=edit`
 		);
+		const getAttributesResponsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/terms?attribute_id=' ) &&
+				response.status() === 200
+		);
 		await page.getByRole( 'button', { name: 'Organization' } ).click();
-		await page.waitForSelector( '[data-title="Product attributes"]' );
+		await getAttributesResponsePromise;
 	} );
 
 	const attributeItemLocator = page.getByRole( 'listitem' ).filter( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -383,6 +383,7 @@ test( 'can remove product attributes', async ( {
 			`wp-admin/post.php?post=${ productWithAttributes.id }&action=edit`
 		);
 		await page.getByRole( 'button', { name: 'Organization' } ).click();
+		await page.waitForSelector( '[data-title="Product attributes"]' );
 	} );
 
 	const attributeItemLocator = page.getByRole( 'listitem' ).filter( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After the PRs: [47361](https://github.com/woocommerce/woocommerce/pull/47361) and https://github.com/woocommerce/woocommerce/pull/47360, we make some REST API conditionally (preventing loading them unnecessarily). Despite the fact that this shouldn't affect our E2E tests suite, sometimes the tests continue even when the requests aren't finished, adding some flakiness to the tests.

This PR adds the code to wait for those requests to be completed to ensure that everything is loaded before continuing.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run E2E tests
```
cd plugins/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js
```
 
2. All the E2E tests should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
