### PR TITLE
Fix: Deleting a shop coupon using API returns a 500 error

### DIFF
--- a/plugins/woocommerce/changelog/pr-47199
+++ b/plugins/woocommerce/changelog/pr-47199
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coupon rest api returning 500 error on delete.

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -224,6 +224,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			do_action( 'woocommerce_delete_coupon', $id );
 		} else {
 			wp_trash_post( $id );
+			$coupon->set_status( 'trash' );
 			do_action( 'woocommerce_trash_coupon', $id );
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
@@ -137,7 +137,7 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$coupon = WC_Helper_Coupon::create_coupon();
 		$coupon->save();
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/v3/coupons/' . $coupon->get_id() );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v3/coupons/' . $coupon->get_id() );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
@@ -128,4 +128,19 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $coupon->get_id(), $response->data['id'] );
 		$this->assertEquals( $coupon->get_status(), $response->data['status'] );
 	}
+
+	/**
+	 * @testDox Coupon is deleted as expected.
+	 */
+	public function test_delete_coupon() {
+		wp_set_current_user( $this->user );
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$coupon->save();
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v3/coupons/' . $coupon->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'trash', get_post_status( $coupon->get_id() ) );
+	}
 }


### PR DESCRIPTION
Copied over from #47199 to add a unit test and a changelog.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #45829 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions: 

1. Create a coupon and note it's ID (or use an existing coupon).
2. Delete the coupon via REST API, like so: `/wp-json/wc/v3/coupons/COUPON_ID`. Make sure that there is no 500 error.

![CleanShot 2024-05-07 at 02 24 58@2x](https://github.com/woocommerce/woocommerce/assets/36501099/e2784c45-bdf0-430a-935d-9388935e5a5d)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix coupon REST API error when deleting a coupon.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

