### PR TITLE
Ensuring only single product creation with unique SKU for concurrent requests

### DIFF
--- a/plugins/woocommerce/changelog/sku-check-before-product-creation
+++ b/plugins/woocommerce/changelog/sku-check-before-product-creation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Ensuring product creation with unique sku for concurrent requests

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -113,11 +113,19 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	private function obtain_lock_on_sku_for_concurrent_requests( $product ) {
 		global $wpdb;
+		$product_id = $product->get_id();
+		$sku        = $product->get_sku();
+
 		$query = $wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			"INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
-			SELECT {$product->get_id()},{$product->get_sku()} FROM $wpdb->wc_product_meta_lookup
-			WHERE NOT EXISTS (SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = '{$product->get_sku()}') limit 1;"
+			SELECT %d, %s
+			WHERE NOT EXISTS (
+				SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = %s
+			) LIMIT 1;",
+			$product_id,
+			$sku,
+			$sku
 		);
 		$result = $wpdb->query( $query );
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -98,10 +98,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 
 	/**
-	 * Method to obtain lock on SKU to make sure
-	 * we have product with unique SKU for concurrent requests.
+	 * Method to obtain DB lock on SKU to make sure we only
+	 * create product with unique SKU for concurrent requests.
+	 * 
+	 * We are doing so by inserting a row in the wc_product_meta_lookup table
+	 * upfront with the SKU of the product we are trying to insert.
+	 * 
+	 * If the SKU is already present in the table, it means that another
+	 * request is already processing the same SKU and we should not proceed
+	 * with the insert.
 	 *
 	 * @param WC_Product $product Product object.
+	 * @return bool True if lock is obtained, false otherwise.
 	 */
 	private function obtain_lock_on_sku_for_concurrent_requests( $product ) {
 		global $wpdb;

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -106,7 +106,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 *
 	 * If the SKU is already present in the table, it means that another
 	 * request is already processing the same SKU and we should not proceed
-	 * with the insert.
+	 * with the insert..
 	 *
 	 * @param WC_Product $product Product object.
 	 * @return bool True if lock is obtained (unique SKU), false otherwise.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -123,7 +123,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			SELECT %d, %s FROM $wpdb->options
 			WHERE NOT EXISTS (
 				SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = %s LIMIT 1
-			) LIMIT 1 FOR UPDATE;",
+			) LIMIT 1;",
 			$product_id,
 			$sku,
 			$sku
@@ -183,7 +183,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			 * because of concurrent requests, then we should not proceed
 			 * Delete the product and throw an exception.
 			 */
-			if ( ! empty( $sku ) && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
+			if ( ! empty( $sku ) && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) && $product->is_rest_request ) {
 				$product->delete( true );
 				// translators: 1: SKU, 2: Product Id.
 				throw new Exception( esc_html( sprintf( __( 'The SKU (%1$s) you are trying to insert with Product Id (%2$s) is already under processing', 'woocommerce' ), $sku, $id ) ) );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -118,7 +118,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$query = $wpdb->prepare(
 			"INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
-			SELECT %d, %s FROM DUAL
+			SELECT %d, %s FROM $wpdb->options
 			WHERE NOT EXISTS (
 				SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = %s LIMIT 1
 			) LIMIT 1 FOR UPDATE;",

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -121,7 +121,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			SELECT %d, %s FROM $wpdb->wc_product_meta_lookup
 			WHERE NOT EXISTS (
 				SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = %s LIMIT 1
-			) LIMIT 1;",
+			) LIMIT 1 FOR UPDATE
+			ON DUPLICATE KEY UPDATE sku = VALUES(sku);",
 			$product_id,
 			$sku,
 			$sku

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -184,7 +184,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			if ( ! empty( $sku ) && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
 				$product->delete();
 				// translators: 1: SKU, 2: Product Id.
-				throw new Exception( sprintf( __( 'The SKU (%1$s) you are trying to insert with Product Id (%2$s) is already under processing', 'woocommerce' ), esc_html( $sku ), esc_html( $id ) ) );
+				throw new Exception( esc_html( sprintf( __( 'The SKU (%1$s) you are trying to insert with Product Id (%2$s) is already under processing', 'woocommerce' ), $sku, $id ) ) );
 			}
 
 			$this->update_post_meta( $product, true );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -113,9 +113,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	private function obtain_lock_on_sku_for_concurrent_requests( $product ) {
 		global $wpdb;
-		$query  = "INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
-		SELECT {$product->get_id()},{$product->get_sku()} FROM $wpdb->wc_product_meta_lookup
-		WHERE NOT EXISTS (SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = '{$product->get_sku()}') limit 1;";
+		$query = $wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
+			SELECT {$product->get_id()},{$product->get_sku()} FROM $wpdb->wc_product_meta_lookup
+			WHERE NOT EXISTS (SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = '{$product->get_sku()}') limit 1;"
+		);
 		$result = $wpdb->query( $query );
 
 		return (bool) $result;
@@ -131,6 +134,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * Method to create a new product in the database.
 	 *
 	 * @param WC_Product $product Product object.
+	 * @throws Exception If SKU is already under processing.
 	 */
 	public function create( &$product ) {
 		if ( ! $product->get_date_created( 'edit' ) ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -106,7 +106,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 *
 	 * If the SKU is already present in the table, it means that another
 	 * request is already processing the same SKU and we should not proceed
-	 * with the insert..
+	 * with the insert.
 	 *
 	 * @param WC_Product $product Product object.
 	 * @return bool True if lock is obtained (unique SKU), false otherwise.
@@ -182,7 +182,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			 * Delete the product and throw an exception.
 			 */
 			if ( ! empty( $sku ) && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
-				$product->delete();
+				$product->delete( true );
 				// translators: 1: SKU, 2: Product Id.
 				throw new Exception( esc_html( sprintf( __( 'The SKU (%1$s) you are trying to insert with Product Id (%2$s) is already under processing', 'woocommerce' ), $sku, $id ) ) );
 			}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -100,10 +100,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * Method to obtain DB lock on SKU to make sure we only
 	 * create product with unique SKU for concurrent requests.
-	 * 
+	 *
 	 * We are doing so by inserting a row in the wc_product_meta_lookup table
 	 * upfront with the SKU of the product we are trying to insert.
-	 * 
+	 *
 	 * If the SKU is already present in the table, it means that another
 	 * request is already processing the same SKU and we should not proceed
 	 * with the insert.
@@ -113,7 +113,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	private function obtain_lock_on_sku_for_concurrent_requests( $product ) {
 		global $wpdb;
-		$query = "INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
+		$query  = "INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
 		SELECT {$product->get_id()},{$product->get_sku()} FROM $wpdb->wc_product_meta_lookup
 		WHERE NOT EXISTS (SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = '{$product->get_sku()}') limit 1;";
 		$result = $wpdb->query( $query );
@@ -163,7 +163,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( $id && ! is_wp_error( $id ) ) {
 			$product->set_id( $id );
 
-			if ( !$this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
+			if ( ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
 				$product->delete();
 
 				throw new Exception( __( 'The SKU you are trying to insert is already under processing', 'woocommerce' ) );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -188,7 +188,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			 */
 			if ( ! empty( $sku ) && WC()->is_rest_api_request() && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
 				$product->delete( true );
-				// translators: 1: SKU
+				// translators: 1: SKU.
 				throw new Exception( esc_html( sprintf( __( 'The SKU (%1$s) you are trying to insert is already under processing', 'woocommerce' ), $sku ) ) );
 			}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -126,7 +126,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$sku,
 			$sku
 		);
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query( $query );
 
 		return (bool) $result;

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -117,7 +117,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$sku        = $product->get_sku();
 
 		$query = $wpdb->prepare(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			"INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
 			SELECT %d, %s
 			WHERE NOT EXISTS (
@@ -127,6 +126,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$sku,
 			$sku
 		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$result = $wpdb->query( $query );
 
 		return (bool) $result;
@@ -183,8 +183,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			 */
 			if ( ! empty( $sku ) && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
 				$product->delete();
-
-				throw new Exception( sprintf( __( 'The SKU (%1$s) you are trying to insert with Product Id (%2$s) is already under processing', 'woocommerce' ), $sku, $id ) );
+				// translators: 1: SKU, 2: Product Id.
+				throw new Exception( sprintf( __( 'The SKU (%1$s) you are trying to insert with Product Id (%2$s) is already under processing', 'woocommerce' ), esc_html( $sku ), esc_html( $id ) ) );
 			}
 
 			$this->update_post_meta( $product, true );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -108,6 +108,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * request is already processing the same SKU and we should not proceed
 	 * with the insert.
 	 *
+	 * using $wpdb->options as it always has some data
+	 *
 	 * @param WC_Product $product Product object.
 	 * @return bool True if lock is obtained (unique SKU), false otherwise.
 	 */

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -188,7 +188,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			 */
 			if ( ! empty( $sku ) && WC()->is_rest_api_request() && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
 				$product->delete( true );
-				// translators: 1: SKU, 2: Product Id.
+				// translators: 1: SKU
 				throw new Exception( esc_html( sprintf( __( 'The SKU (%1$s) you are trying to insert is already under processing', 'woocommerce' ), $sku ) ) );
 			}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -118,11 +118,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$query = $wpdb->prepare(
 			"INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
-			SELECT %d, %s FROM $wpdb->wc_product_meta_lookup
+			SELECT %d, %s FROM DUAL
 			WHERE NOT EXISTS (
 				SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = %s LIMIT 1
-			) LIMIT 1 FOR UPDATE
-			ON DUPLICATE KEY UPDATE sku = VALUES(sku);",
+			) LIMIT 1 FOR UPDATE;",
 			$product_id,
 			$sku,
 			$sku

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -118,9 +118,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$query = $wpdb->prepare(
 			"INSERT INTO $wpdb->wc_product_meta_lookup (product_id, sku)
-			SELECT %d, %s
+			SELECT %d, %s FROM $wpdb->wc_product_meta_lookup
 			WHERE NOT EXISTS (
-				SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = %s
+				SELECT * FROM $wpdb->wc_product_meta_lookup WHERE sku = %s LIMIT 1
 			) LIMIT 1;",
 			$product_id,
 			$sku,

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -109,7 +109,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * with the insert.
 	 *
 	 * @param WC_Product $product Product object.
-	 * @return bool True if lock is obtained, false otherwise.
+	 * @return bool True if lock is obtained (unique SKU), false otherwise.
 	 */
 	private function obtain_lock_on_sku_for_concurrent_requests( $product ) {
 		global $wpdb;
@@ -174,11 +174,17 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( $id && ! is_wp_error( $id ) ) {
 			$product->set_id( $id );
+			$sku = $product->get_sku();
 
-			if ( ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
+			/**
+			 * If SKU is already under processing aka Duplicate SKU
+			 * because of concurrent requests, then we should not proceed
+			 * Delete the product and throw an exception.
+			 */
+			if ( ! empty( $sku ) && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
 				$product->delete();
 
-				throw new Exception( __( 'The SKU you are trying to insert is already under processing', 'woocommerce' ) );
+				throw new Exception( sprintf( __( 'The SKU (%1$s) you are trying to insert with Product Id (%2$s) is already under processing', 'woocommerce' ), $sku, $id ) );
 			}
 
 			$this->update_post_meta( $product, true );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -167,7 +167,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			}
 
 			/**
-			 * Setting a magic property to indicate that this is a REST request.
+			 * Setting a dynamic property to indicate that this is a REST request.
 			 * We are doing this to ensure that unique SKU validation
 			 * is only triggered for REST requests where we are handling the exception.
 			 */

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -175,7 +175,17 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			try {
 				$object->save();
 			} catch ( Exception $e ) {
-				return new WP_Error( "woocommerce_rest_{$this->post_type}_not_created", $e->getMessage(), array( 'status' => 400 ) );
+				$error = "woocommerce_rest_{$this->post_type}_not_created";
+
+				wc_get_logger()->error(
+					$e->getMessage(),
+					array(
+						'source' => 'woocommerce-rest-api',
+						'error'  => $error,
+						'code'   => 400,
+					)
+				);
+				return new WP_Error( $error, $e->getMessage(), array( 'status' => 400 ) );
 			}
 
 			return $this->get_object( $object->get_id() );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -166,12 +166,6 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 				return $object;
 			}
 
-			/**
-			 * Setting a dynamic property to indicate that this is a REST request.
-			 * We are doing this to ensure that unique SKU validation
-			 * is only triggered for REST requests where we are handling the exception.
-			 */
-			$object->is_rest_request = true;
 			try {
 				$object->save();
 			} catch ( Exception $e ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -191,7 +191,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		try {
 			$object = $this->save_object( $request, true );
 		} catch ( Exception $e ) {
-			return new WP_Error( "woocommerce_rest_{$this->post_type}_not_created", $e->getMessage(), array( 'status' => 500 ) );
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_not_created", $e->getMessage(), array( 'status' => 400 ) );
 		}
 
 		if ( is_wp_error( $object ) ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -167,7 +167,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			}
 
 			/**
-			 * Setting a migic property to indicate that this is a REST request.
+			 * Setting a magic property to indicate that this is a REST request.
 			 * We are doing this to ensure that unique SKU validation
 			 * is only triggered for REST requests where we are handling the exception.
 			 */

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -188,7 +188,11 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
 		}
 
-		$object = $this->save_object( $request, true );
+		try {
+			$object = $this->save_object( $request, true );
+		} catch ( Exception $e ) {
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_not_created", $e->getMessage(), array( 'status' => 500 ) );
+		}
 
 		if ( is_wp_error( $object ) ) {
 			return $object;

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
@@ -14,6 +14,8 @@ class WC_Helper_Product {
 
 	/**
 	 * Counter to insert unique SKU for concurrent tests.
+	 * 
+	 * @var int $sku_counter
 	 */
 	private static $sku_counter = 0;
 
@@ -44,7 +46,7 @@ class WC_Helper_Product {
 				'name'          => 'Dummy Product',
 				'regular_price' => 10,
 				'price'         => 10,
-				'sku'           => "DUMMY SKU" . self::$sku_counter,
+				'sku'           => 'DUMMY SKU' . self::$sku_counter,
 				'manage_stock'  => false,
 				'tax_status'    => 'taxable',
 				'downloadable'  => false,

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
@@ -13,6 +13,11 @@
 class WC_Helper_Product {
 
 	/**
+	 * Counter to insert unique SKU for concurrent tests.
+	 */
+	private static $sku_counter = 0;
+
+	/**
 	 * Delete a product.
 	 *
 	 * @param int $product_id ID to delete.
@@ -39,7 +44,7 @@ class WC_Helper_Product {
 				'name'          => 'Dummy Product',
 				'regular_price' => 10,
 				'price'         => 10,
-				'sku'           => 'DUMMY SKU',
+				'sku'           => "DUMMY SKU" . self::$sku_counter,
 				'manage_stock'  => false,
 				'tax_status'    => 'taxable',
 				'downloadable'  => false,
@@ -47,6 +52,8 @@ class WC_Helper_Product {
 				'stock_status'  => 'instock',
 				'weight'        => '1.1',
 			);
+		
+		self::$sku_counter++;
 
 		$product->set_props( array_merge( $default_props, $props ) );
 

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
@@ -14,7 +14,7 @@ class WC_Helper_Product {
 
 	/**
 	 * Counter to insert unique SKU for concurrent tests.
-	 * 
+	 *
 	 * @var int $sku_counter
 	 */
 	private static $sku_counter = 0;
@@ -54,8 +54,8 @@ class WC_Helper_Product {
 				'stock_status'  => 'instock',
 				'weight'        => '1.1',
 			);
-		
-		self::$sku_counter++;
+
+		++self::$sku_counter;
 
 		$product->set_props( array_merge( $default_props, $props ) );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-simple.php
@@ -65,7 +65,7 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 	 * @since 2.3
 	 */
 	public function test_get_sku() {
-		$this->assertEquals( 'DUMMY SKU', $this->product->get_sku() );
+		$this->assertMatchesRegularExpression( '/^DUMMY SKU\d+$/', $this->product->get_sku() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/ProductHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/ProductHelper.php
@@ -24,6 +24,8 @@ class ProductHelper {
 
 	/**
 	 * Counter to insert unique SKU for concurrent tests.
+	 * 
+	 * @var int $sku_counter
 	 */
 	private static $sku_counter = 0;
 
@@ -53,7 +55,7 @@ class ProductHelper {
 				'name'          => 'Dummy Product',
 				'regular_price' => 10,
 				'price'         => 10,
-				'sku'           => "DUMMY SKU" . self::$sku_counter,
+				'sku'           => 'DUMMY SKU' . self::$sku_counter,
 				'manage_stock'  => false,
 				'tax_status'    => 'taxable',
 				'downloadable'  => false,

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/ProductHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/ProductHelper.php
@@ -24,7 +24,7 @@ class ProductHelper {
 
 	/**
 	 * Counter to insert unique SKU for concurrent tests.
-	 * 
+	 *
 	 * @var int $sku_counter
 	 */
 	private static $sku_counter = 0;
@@ -65,7 +65,7 @@ class ProductHelper {
 			)
 		);
 
-		self::$sku_counter++;
+		++self::$sku_counter;
 
 		if ( $save ) {
 			$product->save();

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/ProductHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/ProductHelper.php
@@ -23,6 +23,11 @@ use WC_Cache_Helper;
 class ProductHelper {
 
 	/**
+	 * Counter to insert unique SKU for concurrent tests.
+	 */
+	private static $sku_counter = 0;
+
+	/**
 	 * Delete a product.
 	 *
 	 * @param int $product_id ID to delete.
@@ -48,7 +53,7 @@ class ProductHelper {
 				'name'          => 'Dummy Product',
 				'regular_price' => 10,
 				'price'         => 10,
-				'sku'           => 'DUMMY SKU',
+				'sku'           => "DUMMY SKU" . self::$sku_counter,
 				'manage_stock'  => false,
 				'tax_status'    => 'taxable',
 				'downloadable'  => false,
@@ -57,6 +62,8 @@ class ProductHelper {
 				'weight'        => '1.1',
 			)
 		);
+
+		self::$sku_counter++;
 
 		if ( $save ) {
 			$product->save();

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/products.php
@@ -57,7 +57,7 @@ class Products_API_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 2, count( $products ) );
 		$this->assertEquals( 'Dummy Product', $products[0]['name'] );
-		$this->assertEquals( 'DUMMY SKU', $products[0]['sku'] );
+		$this->assertMatchesRegularExpression( '/^DUMMY SKU\d+$/', $products[0]['sku'] );
 		$this->assertEquals( 'Dummy External Product', $products[1]['name'] );
 		$this->assertEquals( 'DUMMY EXTERNAL SKU', $products[1]['sku'] );
 	}
@@ -171,7 +171,7 @@ class Products_API_V2 extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 'DUMMY SKU', $data['sku'] );
+		$this->assertMatchesRegularExpression( '/^DUMMY SKU\d+$/', $data['sku']  );
 		$this->assertEquals( 10, $data['regular_price'] );
 		$this->assertEmpty( $data['sale_price'] );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/products.php
@@ -171,7 +171,7 @@ class Products_API_V2 extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
 		$data     = $response->get_data();
 
-		$this->assertMatchesRegularExpression( '/^DUMMY SKU\d+$/', $data['sku']  );
+		$this->assertMatchesRegularExpression( '/^DUMMY SKU\d+$/', $data['sku'] );
 		$this->assertEquals( 10, $data['regular_price'] );
 		$this->assertEmpty( $data['sale_price'] );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -61,7 +61,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 2, count( $products ) );
 		$this->assertEquals( 'Dummy Product', $products[0]['name'] );
-		$this->assertEquals( 'DUMMY SKU', $products[0]['sku'] );
+		$this->assertMatchesRegularExpression( '/^DUMMY SKU\d+$/', $products[0]['sku'] );
 		$this->assertEquals( 'Dummy External Product', $products[1]['name'] );
 		$this->assertEquals( 'DUMMY EXTERNAL SKU', $products[1]['sku'] );
 	}
@@ -228,7 +228,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$data         = $response->get_data();
 		$date_created = gmdate( 'Y-m-d\TH:i:s', current_time( 'timestamp' ) );
 
-		$this->assertEquals( 'DUMMY SKU', $data['sku'] );
+		$this->assertMatchesRegularExpression( '/^DUMMY SKU\d+$/', $data['sku'] );
 		$this->assertEquals( 10, $data['regular_price'] );
 		$this->assertEmpty( $data['sale_price'] );
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -66,4 +66,50 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$product = wc_get_product( $product->get_id() );
 		$this->assertEquals( 10, $product->get_rating_count(), 'The product rating count is the expected value.' );
 	}
+
+	/**
+	 * Test that only one product is created with a unique SKU
+	 * during concurrent requests.
+	 *
+	 * Throw error when two concurrent requests try to create a product with the same SKU.
+	 *
+	 * @return void
+	 */
+	public function test_create_product_with_unique_sku_on_concurrent_requests() {
+		try {
+			$this->create_products_concurrently();
+		} catch ( Exception $e ) {
+			$this->assertMatchesRegularExpression(
+				'/The SKU \(DUMMY SKU\) you are trying to insert with Product Id \(\d+\) is already under processing/',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Helper function to create products concurrently with same SKU
+	 *
+	 * @return void
+	 */
+	private static function create_products_concurrently() {
+		$default_props =
+			array(
+				'name'          => 'Dummy Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'DUMMY SKU',
+			);
+
+		$product1 = new WC_Product_Simple();
+		$product2 = new WC_Product_Simple();
+		$product3 = new WC_Product_Simple();
+
+		$product1->set_props( $default_props );
+		$product2->set_props( $default_props );
+		$product3->set_props( $default_props );
+
+		$product1->save();
+		$product2->save();
+		$product3->save();
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -108,6 +108,10 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$product2->set_props( $default_props );
 		$product3->set_props( $default_props );
 
+		$product1->is_rest_request = true;
+		$product2->is_rest_request = true;
+		$product3->is_rest_request = true;
+
 		$product1->save();
 		$product2->save();
 		$product3->save();

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -83,7 +83,7 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			'The SKU (DUMMY SKU) you are trying to insert is already under processing'
 		);
 
-		// exception is only thrown during the REST API request
+		// exception is only thrown during the REST API request.
 		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
 		$this->create_products_concurrently();
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -13,6 +13,8 @@ class FiltererTest extends \WC_Unit_Test_Case {
 
 	/**
 	 * Counter to insert unique SKU for concurrent tests.
+	 * 
+	 * @var int $sku_counter
 	 */
 	private static $sku_counter = 0;
 
@@ -166,7 +168,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 				'name'          => 'Product',
 				'regular_price' => 1,
 				'price'         => 1,
-				'sku'           => "DUMMY SKU" . self::$sku_counter,
+				'sku'           => 'DUMMY SKU' . self::$sku_counter,
 				'manage_stock'  => false,
 				'tax_status'    => 'taxable',
 				'downloadable'  => false,
@@ -174,7 +176,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 			)
 		);
 
-		self::$sku_counter++;
+		++self::$sku_counter;
 
 		$product->set_attributes( $attributes );
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -12,9 +12,10 @@ use Automattic\WooCommerce\Utilities\ArrayUtil;
 class FiltererTest extends \WC_Unit_Test_Case {
 
 	/**
-	 * Counter to insert unique SKU
+	 * Counter to insert unique SKU for concurrent tests.
 	 */
-	private $sku_counter = 0;
+	private static $sku_counter = 0;
+
 	/**
 	 * Runs before all the tests in the class.
 	 */
@@ -165,7 +166,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 				'name'          => 'Product',
 				'regular_price' => 1,
 				'price'         => 1,
-				'sku'           => "DUMMY SKU {$this->sku_counter}",
+				'sku'           => "DUMMY SKU" . self::$sku_counter,
 				'manage_stock'  => false,
 				'tax_status'    => 'taxable',
 				'downloadable'  => false,
@@ -173,7 +174,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 			)
 		);
 
-		$this->sku_counter++;
+		self::$sku_counter++;
 
 		$product->set_attributes( $attributes );
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -12,6 +12,10 @@ use Automattic\WooCommerce\Utilities\ArrayUtil;
 class FiltererTest extends \WC_Unit_Test_Case {
 
 	/**
+	 * Counter to insert unique SKU
+	 */
+	private static $sku_counter = 0;
+	/**
 	 * Runs before all the tests in the class.
 	 */
 	public static function setUpBeforeClass(): void {
@@ -161,13 +165,15 @@ class FiltererTest extends \WC_Unit_Test_Case {
 				'name'          => 'Product',
 				'regular_price' => 1,
 				'price'         => 1,
-				'sku'           => 'DUMMY SKU',
+				'sku'           => "DUMMY SKU {$this->sku_counter}",
 				'manage_stock'  => false,
 				'tax_status'    => 'taxable',
 				'downloadable'  => false,
 				'virtual'       => false,
 			)
 		);
+
+		$this->sku_counter++;
 
 		$product->set_attributes( $attributes );
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -14,7 +14,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 	/**
 	 * Counter to insert unique SKU
 	 */
-	private static $sku_counter = 0;
+	private $sku_counter = 0;
 	/**
 	 * Runs before all the tests in the class.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -13,7 +13,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 
 	/**
 	 * Counter to insert unique SKU for concurrent tests.
-	 * 
+	 *
 	 * @var int $sku_counter
 	 */
 	private static $sku_counter = 0;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Closes #27295 
<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Added a method in the V2 product controller that check unique SKUs in the post meta before going ahead and creating the product.

### Before (on `trunk`)
![image](https://github.com/woocommerce/woocommerce/assets/15019298/27f3f48e-4b83-4b38-a27d-0dfafdf80f5f)

### After
![image](https://github.com/woocommerce/woocommerce/assets/15019298/b7128534-215c-4799-b454-26c83022fa77)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Copy the following script locally.
2. Now enter your credentials, you can get them from `woocommerce>settings>advanced>REST API`
3. Create new API keys if you don't have one already.
4. Add the CK and CS in the respective placeholders.
5. Replace the URL to the endpoint
6. Change the initial product SKU to something which is already not present on the table
7. Now run the script in `trunk` first, check the ` log_error_counts.txt` file, note the output
8. Check the products page in WC admin, you'll see multiple products created with the same SKU.
9. Run the script in this branch, check the ` log_error_counts.txt` file the output should be 1, 1
10. Check the products page in WC admin, you'll see only one product created with the same SKU.

I've created this bash script to test the change

```
#!/bin/bash

# Define the URL and authentication
URL="https://d.w.test/wp-json/wc/v3/products/batch"
CK="ck_7b87bfb00d141081ea0b2be4c443b939ac60677e"
CS="cs_0fbab889a09db5d83af5f2096ec553cf011c47c0"
CONTENT_TYPE="Content-Type: application/json"


INITIAL_SKU=4048

ROUNDS=5

CONCURRENT_REQUESTS=10

echo "Sending $ROUNDS rounds of $CONCURRENT_REQUESTS concurrent requests..."

count_errors() {
    local round=$1
    local error_count=0

    for i in $(seq 1 $CONCURRENT_REQUESTS); do
        if grep -q "error" "log_${round}_${i}.txt"; then
            error_count=$((error_count + 1))
        fi
    done

    echo $((CONCURRENT_REQUESTS - $error_count))
}

for j in $(seq 1 $ROUNDS); do
    SKU=$(($INITIAL_SKU + $j - 1)) 
    echo "Round $j with SKU $SKU..."

    for i in $(seq 1 $CONCURRENT_REQUESTS); do
        JSON_DATA=$(cat <<EOF
{
    "create": [
        {
            "name": "${j}-${i} New Test Product",
            "type": "simple",
            "sku": "${SKU}"
        }
    ]
}
EOF
)
        curl -X POST $URL \
            -u "$CK:$CS" \
            -H "$CONTENT_TYPE" \
            -d "$JSON_DATA" -k > "log_${j}_${i}.txt" 2>&1 &
    done

    wait
    echo "Completed round $j."

    error_count=$(count_errors $j)
    echo "Total products created in round $j with sku $SKU: $error_count" >> log_error_counts.txt
done

echo "All requests sent. Check log files for output."

```

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
