### PR TITLE
Remove check for logged in user on the order received page for displaying billing/shipping addresses

### DIFF
--- a/plugins/woocommerce/changelog/47477-fix-31990-guest-order-billing-and-shipping-address-not-visible-on-order-received-page
+++ b/plugins/woocommerce/changelog/47477-fix-31990-guest-order-billing-and-shipping-address-not-visible-on-order-received-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Enable guest users to visualize shipping/billing information on the order received page.

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.5.0
+ * @version 9.0.0
  *
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -25,9 +25,9 @@ if ( ! $order ) {
 	return;
 }
 
-$order_items           = $order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) );
-$show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
-$downloads             = $order->get_downloadable_items();
+$order_items        = $order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) );
+$show_purchase_note = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
+$downloads          = $order->get_downloadable_items();
 
 // We make sure the order belongs to the user. This will also be true if the user is a guest, and the order belongs to a guest (userID === 0).
 $show_customer_details = $order->get_user_id() === get_current_user_id();

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -27,8 +27,10 @@ if ( ! $order ) {
 
 $order_items           = $order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) );
 $show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
-$show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
 $downloads             = $order->get_downloadable_items();
+
+// In the case the user is logged in, we make sure the order belongs to the user. This will also be true if the user is a guest, and the order belongs to a guest (userID === 0).
+$show_customer_details = $order->get_user_id() === get_current_user_id();
 
 if ( $show_downloads ) {
 	wc_get_template(

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -29,7 +29,7 @@ $order_items           = $order->get_items( apply_filters( 'woocommerce_purchase
 $show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
 $downloads             = $order->get_downloadable_items();
 
-// In the case the user is logged in, we make sure the order belongs to the user. This will also be true if the user is a guest, and the order belongs to a guest (userID === 0).
+// We make sure the order belongs to the user. This will also be true if the user is a guest, and the order belongs to a guest (userID === 0).
 $show_customer_details = $order->get_user_id() === get_current_user_id();
 
 if ( $show_downloads ) {

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -17,6 +17,8 @@
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */
 
+ // phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+
 defined( 'ABSPATH' ) || exit;
 
 $order = wc_get_order( $order_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR enables guest users to visualize shipping/billing addresses on the Order Received page. For a details on why this is needed, see #43987

Closes #31990 
Closes #43987

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate a non-blocks theme (eg Storefront)
2. **Without being logged in**, go to a product page and add a product to the cart.
3. Go to the checkout page.
4. Provide both a billing and a shipping address.
5. Place the order.
6. See that **billing and shipping address are visible on the order received page** as a guest.
7. Copy the Order Recived page link.
8. Log in as an user, and navigate to the link saved in the previous step.
9. Verify that billing and shipping addresses is not visible on the page

<img width="924" alt="image" src="https://github.com/woocommerce/woocommerce/assets/17236129/ffe01f50-bf5f-4e95-9816-a1817dd981da">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Enable guest users to visualize shipping/billing information on the order received page.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
