### PR TITLE
Change Checkout form step numbering so it can only be toggled for all blocks, not individually per-step

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.json
@@ -49,6 +49,10 @@
 		"align": {
 			"type": "string",
 			"default": "wide"
+		},
+		"showFormStepNumbers": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -65,6 +65,7 @@ const Checkout = ( {
 		requireApartmentField,
 		showPhoneField,
 		requirePhoneField,
+		showFormStepNumbers,
 	} = attributes;
 
 	if ( ! cartIsLoading && cartItems.length === 0 ) {
@@ -97,6 +98,7 @@ const Checkout = ( {
 					requireApartmentField,
 					showPhoneField,
 					requirePhoneField,
+					showFormStepNumbers,
 				} as Attributes
 			}
 		>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
@@ -18,6 +18,7 @@ export type CheckoutBlockContextProps = {
 	showReturnToCart: boolean;
 	cartPageId: number;
 	showRateAfterTaxName: boolean;
+	showFormStepNumbers: boolean;
 };
 
 export type CheckoutBlockControlsContextProps = {
@@ -37,6 +38,7 @@ export const CheckoutBlockContext: React.Context< CheckoutBlockContextProps > =
 		showReturnToCart: true,
 		cartPageId: 0,
 		showRateAfterTaxName: false,
+		showFormStepNumbers: false,
 	} );
 
 export const CheckoutBlockControlsContext: React.Context< CheckoutBlockControlsContextProps > =

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -66,6 +66,7 @@ export const Edit = ( {
 		showRateAfterTaxName,
 		cartPageId,
 		isPreview = false,
+		showFormStepNumbers = false,
 	} = attributes;
 
 	// This focuses on the block when a certain query param is found. This is used on the link from the task list.
@@ -97,6 +98,17 @@ export const Edit = ( {
 
 	const addressFieldControls = (): JSX.Element => (
 		<InspectorControls>
+			<PanelBody title={ __( 'Form Step Options', 'woocommerce' ) }>
+				<ToggleControl
+					label={ __( 'Show form step numbers', 'woocommerce' ) }
+					checked={ showFormStepNumbers }
+					onChange={ () =>
+						setAttributes( {
+							showFormStepNumbers: ! showFormStepNumbers,
+						} )
+					}
+				/>
+			</PanelBody>
 			<PanelBody title={ __( 'Address Fields', 'woocommerce' ) }>
 				<p className="wc-block-checkout__controls-text">
 					{ __(
@@ -215,6 +227,7 @@ export const Edit = ( {
 										showReturnToCart,
 										cartPageId,
 										showRateAfterTaxName,
+										showFormStepNumbers,
 									} }
 								>
 									<InnerBlocks

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/form-step/form-step-block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/form-step/form-step-block.tsx
@@ -3,19 +3,16 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import {
-	PlainText,
-	InspectorControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import { PlainText, useBlockProps } from '@wordpress/block-editor';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
  */
 import FormStepHeading from './form-step-heading';
+
 export interface FormStepBlockProps {
-	attributes: { title: string; description: string; showStepNumber: boolean };
+	attributes: { title: string; description: string };
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 	className?: string;
 	children?: React.ReactNode;
@@ -31,28 +28,17 @@ export const FormStepBlock = ( {
 	className = '',
 	children,
 }: FormStepBlockProps ): JSX.Element => {
-	const { title = '', description = '', showStepNumber = true } = attributes;
+	const { showFormStepNumbers } = useCheckoutBlockContext();
+
+	const { title = '', description = '' } = attributes;
 	const blockProps = useBlockProps( {
 		className: classnames( 'wc-block-components-checkout-step', className, {
 			'wc-block-components-checkout-step--with-step-number':
-				showStepNumber,
+				showFormStepNumbers,
 		} ),
 	} );
 	return (
 		<div { ...blockProps }>
-			<InspectorControls>
-				<PanelBody title={ __( 'Form Step Options', 'woocommerce' ) }>
-					<ToggleControl
-						label={ __( 'Show step number', 'woocommerce' ) }
-						checked={ showStepNumber }
-						onChange={ () =>
-							setAttributes( {
-								showStepNumber: ! showStepNumber,
-							} )
-						}
-					/>
-				</PanelBody>
-			</InspectorControls>
 			<FormStepHeading>
 				<PlainText
 					className={ '' }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
@@ -7,6 +7,7 @@ import { ORDER_FORM_KEYS } from '@woocommerce/block-settings';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
@@ -17,16 +18,15 @@ import attributes from './attributes';
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 }: {
 	title: string;
 	description: string;
-	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
 } ) => {
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
@@ -45,7 +45,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 		>
 			<Block />
 			{ children }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -22,16 +22,15 @@ import {
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 }: {
 	title: string;
 	description: string;
-	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
 } ): JSX.Element | null => {
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
@@ -65,7 +64,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 		>
 			<Block
 				showCompanyField={ showCompanyField }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
@@ -6,6 +6,7 @@ import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import LoginPrompt from './login-prompt';
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 }: {
@@ -31,6 +31,8 @@ const FrontendBlock = ( {
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
 
+	const { showFormStepNumbers } = useCheckoutBlockContext();
+
 	return (
 		<FormStep
 			id="contact-fields"
@@ -41,7 +43,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 			stepHeadingContent={ () => <LoginPrompt /> }
 		>
 			<Block />

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -10,7 +10,10 @@ import type { TemplateArray } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { useCheckoutBlockControlsContext } from '../../context';
+import {
+	useCheckoutBlockContext,
+	useCheckoutBlockControlsContext,
+} from '../../context';
 import {
 	useForcedLayout,
 	getAllowedBlocks,
@@ -35,6 +38,7 @@ export const Edit = ( {
 	} );
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CHECKOUT_FIELDS );
 
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const { addressFieldControls: Controls } =
 		useCheckoutBlockControlsContext();
 
@@ -62,7 +66,15 @@ export const Edit = ( {
 	return (
 		<Main { ...blockProps }>
 			<Controls />
-			<form className="wc-block-components-form wc-block-checkout__form">
+			<form
+				className={ classnames(
+					'wc-block-components-form wc-block-checkout__form',
+					{
+						'wc-block-checkout__form--with-step-numbers':
+							showFormStepNumbers,
+					}
+				) }
+			>
 				<InnerBlocks
 					allowedBlocks={ allowedBlocks }
 					templateLock={ false }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
@@ -25,13 +25,16 @@ const FrontendBlock = ( {
 	}, [] );
 
 	return (
-		<Main
-			className={ classnames( 'wc-block-checkout__main', className, {
-				'wc-block-checkout__main--with-step-numbers':
-					showFormStepNumbers,
-			} ) }
-		>
-			<form className="wc-block-components-form wc-block-checkout__form">
+		<Main className={ classnames( 'wc-block-checkout__main', className ) }>
+			<form
+				className={ classnames(
+					'wc-block-components-form wc-block-checkout__form',
+					{
+						'wc-block-checkout__form--with-step-numbers':
+							showFormStepNumbers,
+					}
+				) }
+			>
 				{ children }
 			</form>
 		</Main>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { useStoreEvents } from '@woocommerce/base-context/hooks';
 import { useEffect } from '@wordpress/element';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 const FrontendBlock = ( {
 	children,
@@ -15,6 +16,7 @@ const FrontendBlock = ( {
 	className?: string;
 } ): JSX.Element => {
 	const { dispatchCheckoutEvent } = useStoreEvents();
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 
 	// Ignore changes to dispatchCheckoutEvent callback so this is ran on first mount only.
 	useEffect( () => {
@@ -23,7 +25,12 @@ const FrontendBlock = ( {
 	}, [] );
 
 	return (
-		<Main className={ classnames( 'wc-block-checkout__main', className ) }>
+		<Main
+			className={ classnames( 'wc-block-checkout__main', className, {
+				'wc-block-checkout__main--with-step-numbers':
+					showFormStepNumbers,
+			} ) }
+		>
 			<form className="wc-block-components-form wc-block-checkout__form">
 				{ children }
 			</form>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/frontend.tsx
@@ -11,6 +11,7 @@ import {
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { noticeContexts } from '@woocommerce/base-context';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
@@ -21,16 +22,15 @@ import attributes from './attributes';
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 }: {
 	title: string;
 	description: string;
-	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
 } ) => {
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
@@ -49,7 +49,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 		>
 			<StoreNoticesContainer context={ noticeContexts.PAYMENTS } />
 			<Block />

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
@@ -7,6 +7,8 @@ import { FormStep } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
+
 /**
  * Internal dependencies
  */
@@ -16,7 +18,6 @@ import attributes from './attributes';
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 }: {
@@ -36,6 +37,8 @@ const FrontendBlock = ( {
 		}
 	);
 
+	const { showFormStepNumbers } = useCheckoutBlockContext();
+
 	if ( ! prefersCollection || ! LOCAL_PICKUP_ENABLED ) {
 		return null;
 	}
@@ -50,7 +53,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 		>
 			<Block />
 			{ children }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
@@ -17,13 +17,11 @@ import { useCheckoutBlockContext } from '../../context';
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 }: {
 	title: string;
 	description: string;
-	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
 } ) => {
@@ -38,6 +36,7 @@ const FrontendBlock = ( {
 		requireApartmentField,
 		showPhoneField,
 		requirePhoneField,
+		showFormStepNumbers,
 	} = useCheckoutBlockContext();
 
 	if ( ! showShippingFields ) {
@@ -54,7 +53,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 		>
 			<Block
 				showCompanyField={ showCompanyField }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
@@ -18,7 +19,6 @@ import attributes from './attributes';
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 	showPrice,
@@ -28,7 +28,6 @@ const FrontendBlock = ( {
 }: {
 	title: string;
 	description: string;
-	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
 	showPrice: boolean;
@@ -36,6 +35,7 @@ const FrontendBlock = ( {
 	shippingText: string;
 	localPickupText: string;
 } ) => {
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const { checkoutIsProcessing, prefersCollection } = useSelect(
 		( select ) => {
 			const checkoutStore = select( CHECKOUT_STORE_KEY );
@@ -81,7 +81,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 		>
 			<Block
 				checked={ prefersCollection ? 'pickup' : 'shipping' }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
@@ -7,6 +7,7 @@ import { FormStep } from '@woocommerce/blocks-components';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import attributes from './attributes';
 const FrontendBlock = ( {
 	title,
 	description,
-	showStepNumber,
 	children,
 	className,
 }: {
@@ -29,10 +29,10 @@ const FrontendBlock = ( {
 	requireApartmentField: boolean;
 	showPhoneField: boolean;
 	requirePhoneField: boolean;
-	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
 } ) => {
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
@@ -52,7 +52,7 @@ const FrontendBlock = ( {
 			) }
 			title={ title }
 			description={ description }
-			showStepNumber={ showStepNumber }
+			showStepNumber={ showFormStepNumbers }
 		>
 			<Block />
 			{ children }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -51,6 +51,27 @@ jest.mock( '@wordpress/element', () => {
 	};
 } );
 
+jest.mock( '../context', () => {
+	return {
+		...jest.requireActual( '../context' ),
+		useCheckoutBlockContext: jest.fn().mockReturnValue( {
+			showFormStepNumbers: false,
+			cartPageId: 0,
+			requireCompanyField: false,
+			requirePhoneField: false,
+			showApartmentField: false,
+			showCompanyField: false,
+			showOrderNotes: false,
+			showPhoneField: false,
+			showPolicyLinks: false,
+			showRateAfterTaxName: false,
+			showReturnToCart: false,
+		} ),
+	};
+} );
+
+import { useCheckoutBlockContext } from '../context';
+
 const CheckoutBlock = () => {
 	return (
 		<Checkout attributes={ {} }>
@@ -255,5 +276,43 @@ describe( 'Testing cart', () => {
 			allSettings.checkoutAllowsSignup = undefined;
 			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 1 );
 		} );
+	} );
+
+	it( 'Ensures correct classes are applied to FormStep when step numbers are shown/hidden', async () => {
+		const mockReturnValue = {
+			showFormStepNumbers: false,
+			cartPageId: 0,
+			requireCompanyField: false,
+			requirePhoneField: false,
+			showApartmentField: false,
+			showCompanyField: false,
+			showOrderNotes: false,
+			showPhoneField: false,
+			showPolicyLinks: false,
+			showRateAfterTaxName: false,
+			showReturnToCart: false,
+		};
+		useCheckoutBlockContext.mockReturnValue( mockReturnValue );
+		// Render the CheckoutBlock
+		const { container, rerender } = render( <CheckoutBlock /> );
+
+		let formStepsWithNumber = container.querySelectorAll(
+			'.wc-block-components-checkout-step--with-step-number'
+		);
+
+		expect( formStepsWithNumber ).toHaveLength( 0 );
+
+		useCheckoutBlockContext.mockReturnValue( {
+			...mockReturnValue,
+			showFormStepNumbers: true,
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		formStepsWithNumber = container.querySelectorAll(
+			'.wc-block-components-checkout-step--with-step-number'
+		);
+
+		expect( formStepsWithNumber.length ).not.toBe( 0 );
 	} );
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -104,7 +104,7 @@ const CheckoutBlock = () => {
 	);
 };
 
-describe( 'Testing cart', () => {
+describe( 'Testing Checkout', () => {
 	beforeEach( () => {
 		act( () => {
 			fetchMock.mockResponse( ( req ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/types.ts
@@ -12,6 +12,7 @@ export interface Attributes extends Record< string, boolean | number > {
 	requireApartmentField: boolean;
 	showPhoneField: boolean;
 	requirePhoneField: boolean;
+	showFormStepNumbers: boolean;
 	// Deprecated.
 	showOrderNotes: boolean;
 	showPolicyLinks: boolean;

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -10,10 +10,15 @@
 	padding: 0;
 
 	// The below CSS targets form steps, but only when the global option to show form step numbers is off (hence the :not)
+	// It will hide the number and the vertical line that runs down alongside the form step.
 	&:not(.wc-block-checkout__main--with-step-numbers &) {
 		padding: 0;
 
 		.wc-block-components-checkout-step__title::before {
+			display: none;
+		}
+
+		.wc-block-components-checkout-step__container::after {
 			display: none;
 		}
 	}

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -5,9 +5,9 @@
 .wc-block-components-form .wc-block-components-checkout-step {
 	position: relative;
 	border: none;
-	padding: 0 0 0 $gap-larger;
 	background: none;
 	margin: 0;
+	padding: 0;
 
 	.is-mobile &,
 	.is-small & {

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -9,24 +9,6 @@
 	margin: 0;
 	padding: 0;
 
-	// The below CSS targets form steps, but only when the global option to show form step numbers is off (hence the :not)
-	// It will hide the number and the vertical line that runs down alongside the form step.
-	&:not(.wc-block-checkout__main--with-step-numbers &) {
-		padding: 0;
-
-		.wc-block-components-checkout-step__title::before {
-			display: none;
-		}
-
-		.wc-block-components-checkout-step__container::after {
-			display: none;
-		}
-	}
-
-	&.wc-block-components-checkout-step--with-step-number {
-		padding: 0 0 0 $gap-larger;
-	}
-
 	.is-mobile &,
 	.is-small & {
 		padding-left: 0;
@@ -92,52 +74,57 @@
 	margin: 0 0 $gap;
 }
 
-.wc-block-components-checkout-step--with-step-number {
-	.wc-block-components-checkout-step__title::before {
-		@include reset-box();
-		background: transparent;
-		counter-increment: checkout-step;
-		content: "\00a0" counter(checkout-step) ".";
-		content: "\00a0" counter(checkout-step) "." / "";
-		position: absolute;
-		left: -$gap-large;
-		top: 0;
-		text-align: center;
-		transform: translateX(-50%);
-		white-space: nowrap;
+.wc-block-checkout__form--with-step-numbers {
+	.wc-block-components-checkout-step--with-step-number {
+		padding: 0 0 0 $gap-larger;
+
+		.wc-block-components-checkout-step__title::before {
+			@include reset-box();
+			background: transparent;
+			counter-increment: checkout-step;
+			content: "\00a0" counter(checkout-step) ".";
+			content: "\00a0" counter(checkout-step) "." / "";
+			position: absolute;
+			left: -$gap-large;
+			top: 0;
+			text-align: center;
+			transform: translateX(-50%);
+			white-space: nowrap;
+
+			.is-mobile &,
+			.is-small & {
+				position: static;
+				transform: none;
+				left: auto;
+				top: auto;
+				content: counter(checkout-step) ".\00a0";
+				content: counter(checkout-step) ".\00a0" / "";
+			}
+		}
+
+		.wc-block-components-checkout-step__container::after {
+			content: "";
+			height: 100%;
+			border-left: 1px solid $universal-border-light;
+			position: absolute;
+			left: -$gap-large;
+			top: 0;
+		}
 
 		.is-mobile &,
 		.is-small & {
-			position: static;
-			transform: none;
-			left: auto;
-			top: auto;
-			content: counter(checkout-step) ".\00a0";
-			content: counter(checkout-step) ".\00a0" / "";
-		}
-	}
+			.wc-block-components-checkout-step__title::before {
+				position: static;
+				transform: none;
+				left: auto;
+				top: auto;
+				content: counter(checkout-step) ".\00a0";
+				content: counter(checkout-step) ".\00a0" / "";
+			}
 
-	.wc-block-components-checkout-step__container::after {
-		content: "";
-		height: 100%;
-		border-left: 1px solid $universal-border-light;
-		position: absolute;
-		left: -$gap-large;
-		top: 0;
-	}
-
-	.is-mobile &,
-	.is-small & {
-		.wc-block-components-checkout-step__title::before {
-			position: static;
-			transform: none;
-			left: auto;
-			top: auto;
-			content: counter(checkout-step) ".\00a0";
-			content: counter(checkout-step) ".\00a0" / "";
-		}
-		.wc-block-components-checkout-step__container::after {
-			content: unset;
+			.wc-block-components-checkout-step__container::after {
+				content: unset;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -9,6 +9,19 @@
 	margin: 0;
 	padding: 0;
 
+	// The below CSS targets form steps, but only when the global option to show form step numbers is off (hence the :not)
+	&:not(.wc-block-checkout__main--with-step-numbers &) {
+		padding: 0;
+
+		.wc-block-components-checkout-step__title::before {
+			display: none;
+		}
+	}
+
+	&.wc-block-components-checkout-step--with-step-number {
+		padding: 0 0 0 $gap-larger;
+	}
+
 	.is-mobile &,
 	.is-small & {
 		padding-left: 0;

--- a/plugins/woocommerce-blocks/tests/e2e/tests/test-1.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/test-1.spec.ts
@@ -1,5 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('test', async ({ page }) => {
-  // Recording...
-});

--- a/plugins/woocommerce-blocks/tests/e2e/tests/test-1.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/test-1.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  // Recording...
+});

--- a/plugins/woocommerce/changelog/update-global-show-form-step-numbers
+++ b/plugins/woocommerce/changelog/update-global-show-form-step-numbers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Changed the Form Step blocks in the Checkout block so that the step nunbers cannot be turned off individually. This is now a global setting on the Checkout Fields block that will affect all child blocks. The FormStep component in the checkout pacakge remains unchanged.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the "Show step number" option from individual form steps and adds a new toggle to the `Checkout Fields` block to control all form steps.

I added a new property to the `CheckoutBlockContext` called `showFormStepNumbers` and the `frontend.tsx` file for each Checkout inner block that renders a form step consumes the value from here and passes it to the form step. In the editor, the `FormStepBlock` consumes this directly from the `CheckoutBlockContext`.

The reason I made each inner block pass the value to the `FormStep` is because the `FormStep` component is exported in the `@woocommerce/blocks-components`. I chose not to change the API of this or make it rely on `CheckoutBlockContext` as it is possible the component may be rendered outside of this context and would break consuming applications.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Have local pickup enabled, with valid locations. Have shipping enabled with valid methods. Have payment methods set up.
1. Go to the Checkout block in the editor.
2. Click on the `Contact Information` block and open the editor sidebar.
3. Ensure you do **not** see an option to `Show step number`
4. Go to the list view and select the `Checkout Fields Block`.
5. Open the editor sidebar and ensure you see an option to `Show form step numbers`
6. Turn it on and ensure each step in the form has a number (Express payment, Order notes and Terms and Conditions don't have one).
7. Turn it off and ensure none of the sections have a number.
8. Save the page. Keep this editor tab open, you'll need it later!
9. Open a new tab and add an item to your cart and go to the Checkout block in the front end.
10. Ensure none of the sections have a number.
11. Go back to the editor and toggle the `Show form step numbers` option on.
12. Reload the front-end Checkout block and ensure all sections (except order notes and T&C) have a number.
13. Check the `Use same address for billing` checkbox and ensure the numbers are still sequential when the billing form appears.
14. Uncheck the `Use same address for billing` checkbox and ensure the numbers are still sequential when the billing form appears.
15. Change the shipping method from Shipping to Local pickup and vice/versa checking the numbering is still OK in each configuration.
16. Go back to the editor, delete the Checkout block and re-insert it. Ensure the numbers are not shown by default.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
