### PR TITLE
Add error class to checkout endpoint response

### DIFF
--- a/plugins/woocommerce/changelog/47489-add-error-class-to-checkout-endpoint-response
+++ b/plugins/woocommerce/changelog/47489-add-error-class-to-checkout-endpoint-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add previous error class to checkout endpoint response

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -88,6 +88,7 @@ trait CheckoutTrait {
 		} catch ( \Exception $e ) {
 			$additional_data = [];
 
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 			/**
 			 * Allows to check if WP_DEBUG mode is enabled before returning previous Exception.
 			 *

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
+use Automattic\Jetpack\Constants;
 
 /**
  * CheckoutTrait
@@ -86,7 +87,8 @@ trait CheckoutTrait {
 			}
 		} catch ( \Exception $e ) {
 			$additional_data = [];
-			if ( $e->getPrevious() ) {
+
+			if ( apply_filters( 'woocommerce_return_previous_exceptions', Constants::is_true( 'WP_DEBUG' ) ) && $e->getPrevious() ) {
 				$additional_data = [
 					'previous' => get_class( $e->getPrevious() ),
 				];

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -85,10 +85,13 @@ trait CheckoutTrait {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woocommerce' ), 500 );
 			}
 		} catch ( \Exception $e ) {
-			$additional_data = [
-				'previous' => get_class( $e->getPrevious() )
-			];
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400, $additional_data );
+			if ( $e->getPrevious() ) {
+				$additional_data = [
+					'previous' => get_class( $e->getPrevious() )
+				];
+			}
+
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400, $additional_data=[] );
 		}
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -1,10 +1,10 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Utilities;
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
-use Automattic\Jetpack\Constants;
 
 /**
  * CheckoutTrait
@@ -88,6 +88,11 @@ trait CheckoutTrait {
 		} catch ( \Exception $e ) {
 			$additional_data = [];
 
+			/**
+			 * Allows to check if WP_DEBUG mode is enabled before returning previous Exception.
+			 *
+			 * @param bool The WP_DEBUG mode.
+			 */
 			if ( apply_filters( 'woocommerce_return_previous_exceptions', Constants::is_true( 'WP_DEBUG' ) ) && $e->getPrevious() ) {
 				$additional_data = [
 					'previous' => get_class( $e->getPrevious() ),

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -91,7 +91,7 @@ trait CheckoutTrait {
 				];
 			}
 
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400, $additional_data=[] );
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400, $additional_data );
 		}
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -88,11 +88,11 @@ trait CheckoutTrait {
 			$additional_data = [];
 			if ( $e->getPrevious() ) {
 				$additional_data = [
-					'previous' => get_class( $e->getPrevious() )
+					'previous' => get_class( $e->getPrevious() ),
 				];
 			}
 
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400, $additional_data );
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400, array_map( 'esc_attr', $additional_data ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -85,7 +85,10 @@ trait CheckoutTrait {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woocommerce' ), 500 );
 			}
 		} catch ( \Exception $e ) {
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400 );
+			$additional_data = [
+				'previous' => get_class( $e->getPrevious() )
+			];
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', esc_html( $e->getMessage() ), 400, $additional_data );
 		}
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -85,6 +85,7 @@ trait CheckoutTrait {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woocommerce' ), 500 );
 			}
 		} catch ( \Exception $e ) {
+			$additional_data = [];
 			if ( $e->getPrevious() ) {
 				$additional_data = [
 					'previous' => get_class( $e->getPrevious() )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
I chose to use `previous` inside the additional data because we can't guarantee what interfaces we are getting on thrown exceptions from `process_payment`.

[Alternative example that won't work:](https://github.com/Automattic/woocommerce-payments/blob/a3748bc347d41f7809014b15586056ed9cdea325/includes/class-wc-payment-gateway-wcpay.php#L1286):
```
catch ( $e ) {
    $exception_class = get_class( $e );
    // We can't guarantee what interface we get with the exception class, so the arguments might differ.
    $exception = new $exception_class( WC_Payments_Utils::get_filtered_error_message( $e, $blocked_by_fraud_rules ) 
    throw $exception;
);
```
<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Throw an error using the snippet below:
```
use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;

add_action( 
	'woocommerce_rest_checkout_process_payment_with_context', 
	function() {
		throw new \Exception( 
			'woocommerce_test_exception',
			0,
			new RouteException(
				'woocommerce_test_previous',
				'exception message',
				0
			)
		);
	}
);

add_action( 'woocommerce_store_api_disable_nonce_check', '__return_true' ); // Make sure to remove this after you are done with testing.
```

2. Update `WP_DEBUG` mode to `true`

3. Add an item to your cart by POSTing to `{YOUR_DOMAIN}/wp-json/wc/store/v1/cart/add-item`
```
Body - Raw - JSON
{
  "id": 2040,
  "quantity": 1
}
```
4. Checkout with the cart by POSTing to `{YOUR_DOMAIN}/wp-json/wc/store/v1/checkout`
```
{
  "billing_address": {
        "first_name": "Test",
        "last_name": "Billing",
        "company": "",
        "address_1": "123 test",
        "address_2": "",
        "city": "San Diego",
        "state": "CA",
        "postcode": "92103",
        "country": "US",
        "email": "test@test.com",
        "phone": "+14708274627"
    },
    "shipping_address": {
        "first_name": "Test",
        "last_name": "Shipping",
        "company": "",
        "address_1": "123 test",
        "address_2": "",
        "city": "San Diego",
        "state": "CA",
        "postcode": "92103",
        "country": "US",
        "phone": "+14708274627"
    },
  "payment_method": "woocommerce_payments"
}
```

5. Should see 
```
{
    "code": "woocommerce_rest_checkout_process_payment_error",
    "message": "woocommerce_test_exception",
    "data": {
        "previous": "Automattic\\WooCommerce\\StoreApi\\Exceptions\\RouteException",
        "status": 400
    }
}
```

6. Update `WP_DEBUG` mode to `false`
7. You should see:
```
{
    "code": "woocommerce_rest_checkout_process_payment_error",
    "message": "woocommerce_test_exception",
    "data": {
        "status": 400
    }
}
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add previous error class to checkout endpoint response

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
