### PR TITLE
[e2e tests] Disable 'can remove product attributes' test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-disable-remove-atribute-test
+++ b/plugins/woocommerce/changelog/e2e-disable-remove-atribute-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: disable 'can remove product attributes' test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -379,7 +379,7 @@ test.skip( 'can update product attributes', async ( {
 	} );
 } );
 
-test( 'can remove product attributes', async ( {
+test.skip( 'can remove product attributes', async ( {
 	page,
 	productWithAttributes,
 	attributes,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -379,6 +379,7 @@ test.skip( 'can update product attributes', async ( {
 	} );
 } );
 
+// Disabled because it's too flaky.
 test.skip( 'can remove product attributes', async ( {
 	page,
 	productWithAttributes,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`products/block-editor/product-attributes-block-editor.spec.js > can remove product attributes` test is too flaky an is blocking PR merges. I tried fixing it but had a hard time reproducing the failure locally. I'll disable it for now.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

CI is green. `products/block-editor/product-attributes-block-editor.spec.js > can remove product attributes` is skipped.
