### PR TITLE
Blocks E2E: Restore the no-hooks rule

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/.eslintrc.js
+++ b/plugins/woocommerce-blocks/tests/e2e/.eslintrc.js
@@ -35,6 +35,7 @@ const config = {
 		'@typescript-eslint/no-floating-promises': 'error',
 		'@typescript-eslint/no-misused-promises': 'error',
 		'rulesdir/no-raw-playwright-test-import': 'error',
+		'playwright/no-hooks': [ 'error', { allow: [ 'beforeEach' ] } ],
 	},
 };
 

--- a/plugins/woocommerce-blocks/tests/e2e/.eslintrc.js
+++ b/plugins/woocommerce-blocks/tests/e2e/.eslintrc.js
@@ -37,7 +37,7 @@ const config = {
 		'rulesdir/no-raw-playwright-test-import': 'error',
 		// Since we're restoring the database for each test, hooks other than
 		// `beforeEach` don't make sense.
-		// {@see https://github.com/woocommerce/woocommerce/pull/46432}
+		// See https://github.com/woocommerce/woocommerce/pull/46432.
 		'playwright/no-hooks': [ 'error', { allow: [ 'beforeEach' ] } ],
 	},
 };

--- a/plugins/woocommerce-blocks/tests/e2e/.eslintrc.js
+++ b/plugins/woocommerce-blocks/tests/e2e/.eslintrc.js
@@ -35,6 +35,9 @@ const config = {
 		'@typescript-eslint/no-floating-promises': 'error',
 		'@typescript-eslint/no-misused-promises': 'error',
 		'rulesdir/no-raw-playwright-test-import': 'error',
+		// Since we're restoring the database for each test, hooks other than
+		// `beforeEach` don't make sense.
+		// {@see https://github.com/woocommerce/woocommerce/pull/46432}
 		'playwright/no-hooks': [ 'error', { allow: [ 'beforeEach' ] } ],
 	},
 };

--- a/plugins/woocommerce/changelog/47500-e2e-restore-no-hooks-eslint-rule
+++ b/plugins/woocommerce/changelog/47500-e2e-restore-no-hooks-eslint-rule
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Restore the playwright/no-hooks linter rule introduced in #46432 and accidentally removed in #47228.


### PR DESCRIPTION
### What?

Restore the `playwright/no-hooks` linter rule introduced in https://github.com/woocommerce/woocommerce/pull/46432 and accidentally removed in https://github.com/woocommerce/woocommerce/pull/47228.

### How to test

All CI checks should pass.