### PR TITLE
Prevent calling wccom when the payload is empty for update check

### DIFF
--- a/plugins/woocommerce/changelog/47507-prevent-calling-wccom-on-empty-payload
+++ b/plugins/woocommerce/changelog/47507-prevent-calling-wccom-on-empty-payload
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent calling woocommerce.com on empty update-check and update-check-public payload.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -439,6 +439,9 @@ class WC_Helper_Updater {
 	 * @return array Update data for each requested product.
 	 */
 	private static function _update_check( $payload ) {
+		if ( empty( $payload ) ) {
+			return array();
+		}
 		ksort( $payload );
 		$hash = md5( wp_json_encode( $payload ) );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the store doesn't have any wccom products installed, no need to contact wccom to check for product updates.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

- Run the woocommerce pnpm -- wp-env start. 
- Change helper API base to `https://woocommerce.test/wp-json/helper/1.0` in `load` function of `plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php`
- Make sure the store is not connected to woocommerce.test
- Filter woocommerce.test logs to see if requests are comming from wc site like `docker logs -ft -n 1000 woocommerce.test__wp 2>&1 | grep --line-buffered -i --color "update-check"`
- Install any wccom extenstion
- Go to `Plugins->Installed Plugins` page in wp-admin
- You should see requests in wccom log to public update check endpoint
- Uninstall the wccom extenstion. Make sure you have no wccom extenstions installed
- Go to `Plugins->Installed Plugins` page in wp-admin
- You should not see any requests in wccom log

### Alternative way to test
- Run the woocommerce `pnpm -- wp-env start`
- Apply these following patch
```
Index: plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php	(revision 72f5776ef79590e08b31d3dd13f2a1c08a6cb832)
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php	(date 1715831243937)
@@ -440,6 +440,12 @@
 	 */
 	private static function _update_check( $payload ) {
 		if ( empty( $payload ) ) {
+			wc_get_logger()->info(
+				'empty payload',
+				array(
+					'source'        => 'update-check-test',
+				)
+			);
 			return array();
 		}
 		ksort( $payload );
Index: plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php b/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php	(revision 72f5776ef79590e08b31d3dd13f2a1c08a6cb832)
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php	(date 1715831617992)
@@ -187,6 +187,13 @@
 	 */
 	public static function post( $endpoint, $args = array() ) {
 		$args['method'] = 'POST';
+		wc_get_logger()->info(
+			sprintf( 'POST called for %s', $endpoint ),
+			array(
+				'source'        => 'update-check-test',
+				'body'          => $args['body'] ?? '',
+			)
+		);
 		return self::request( $endpoint, $args );
 	}
 
```

- Run `pnpm -- wp-env run cli wp shell` and wipe update transient `delete_transient('_woocommerce_helper_updates');`
- Open the Plugin list http://localhost:8888/wp-admin/plugins.php Install an outdated WC marketplace product and activate, after that deactivate and remove the plugin
- Open the logs list http://localhost:8888/wp-admin/admin.php?page=wc-status&tab=logs and see that there is a `update-check-test` source, open it
- Verify the log contents, see that there is a log for POST update-check-public with a payload, no log for POST update-check-public without a payload, and there is log for empty payload
<img width="1547" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1663428/b5a2be11-a6f7-4d98-9ec4-708df267519d">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
