### PR TITLE
CYS - fix crash Product Collection block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/tracks-utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/tracks-utils.ts
@@ -29,7 +29,7 @@ const templateSlugToTemplateMap: {
 	'page-checkout': Locations.CHECKOUT,
 };
 
-export const useTracksLocation = ( templateSlug: string ) => {
+export const useTracksLocation = ( templateSlug: string | undefined ) => {
 	const postType = useSelect( ( select ) => {
 		// @ts-expect-error Type definitions are missing
 		// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/wordpress__blocks/store/selectors.d.ts
@@ -38,6 +38,10 @@ export const useTracksLocation = ( templateSlug: string ) => {
 
 	if ( postType === Locations.PAGE || postType === Locations.POST ) {
 		return postType;
+	}
+
+	if ( ! templateSlug ) {
+		return Locations.OTHER;
 	}
 
 	const template = templateSlugToTemplateMap[ templateSlug ];

--- a/plugins/woocommerce/changelog/47511-47469-cys-product-collection-on-the-homepage-preview-the-product-collection-isnt-rendered-correctly
+++ b/plugins/woocommerce/changelog/47511-47469-cys-product-collection-on-the-homepage-preview-the-product-collection-isnt-rendered-correctly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS - fix crash Product Collection block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As described in #47469, the Product Collection block crashes on the homepage pattern previews. This happens because the `templateSlug` is undefined and this case hasn't been handled. This PR ensure that `templateSlug` is defined.

Closes #47469.

| Before | After |
|--------|--------|
|![image](https://github.com/woocommerce/woocommerce/assets/4463174/5049df55-7c52-41f5-a01d-853ef9568a45)|![image](https://github.com/woocommerce/woocommerce/assets/4463174/ead1d496-b34c-4fbb-9223-f71cb38bd153)| 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Head over to WooCommerce > Home > Customize your store.
2. Click on "Start designing" and proceed to the Pattern Assembler.
3. Click on "Design your Homepage".
4. Ensure that the Product Collection block doesn't crash in the patterns.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS - fix crash Product Collection block

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
