### PR TITLE
Make sure JS tests run in blocks when configs change

### DIFF
--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -364,8 +364,8 @@
 						"tsconfig.json",
 						"assets/**/*.{js,ts,tsx,scss}",
 						"packages/**/*.{js,ts,tsx,scss}",
-						"tests/js/*",
-						"tests/utils/*"
+						"tests/js/**/*.{js,ts,tsx,scss,json}",
+						"tests/utils/**/.{js,ts,tsx,scss,json}"
 					],
 					"cascade": "test:js"
 				}

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -359,12 +359,13 @@
 					"name": "JavaScript",
 					"command": "test:js",
 					"changes": [
-						"jest.config.js",
 						"webpack.config.js",
 						"babel.config.js",
 						"tsconfig.json",
 						"assets/**/*.{js,ts,tsx,scss}",
-						"packages/**/*.{js,ts,tsx,scss}"
+						"packages/**/*.{js,ts,tsx,scss}",
+						"tests/js/*",
+						"tests/utils/*"
 					],
 					"cascade": "test:js"
 				}

--- a/plugins/woocommerce/changelog/47513-dev-add-relevant-changes-to-run-js-tests
+++ b/plugins/woocommerce/changelog/47513-dev-add-relevant-changes-to-run-js-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Run Blocks unit tests when relevant JS configs change.
+


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Recently in https://github.com/woocommerce/woocommerce/pull/46672 the jest configs we use for JS tests were accidentally removed. I'm resolving that in another PR, but the reason this mistake wasn't caught is due to the `changes` array not including some support config and files we use for jest testing. This adds those to the list to avoid making a mistake in future.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I'm not sure we need to test this, but I can update this PR tomorrow with some dummy changes to those listed files to ensure that it indeed causes the blocks JS tests to run.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->
Run Blocks unit tests when relevant JS configs change.
</details>
