### PR TITLE
Skip serialization for customer meta and be more defensive around loading it.

### DIFF
--- a/plugins/woocommerce/changelog/47514-fix-skip-serialization-for-customer-meta
+++ b/plugins/woocommerce/changelog/47514-fix-skip-serialization-for-customer-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix warning when loading guest sessions from previous sessions.

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -97,6 +97,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				$allowed_keys      = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
 				$session_value     = array_map(
 					function ( $meta_data ) {
+						// Data comes to us a WC_Meta_Data, we cast it to an array to ensure it is serializable when doing WC()->session->set.
 							return array(
 								'key'   => $meta_data->key,
 								'value' => $meta_data->value,

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -94,22 +94,17 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				 * @param array $allowed_keys The allowed meta data keys.
 				 * @param WC_Customer $customer The customer object.
 				 */
-				$allowed_keys      = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
-				$session_value     = array_map(
-					function ( $meta_data ) {
-						// Data comes to us a WC_Meta_Data, we cast it to an array to ensure it is serializable when doing WC()->session->set.
-							return array(
-								'key'   => $meta_data->key,
-								'value' => $meta_data->value,
-							);
-					},
-					array_filter(
-						$customer->get_meta_data(),
-						function ( $meta_data ) use ( $allowed_keys ) {
-								return in_array( $meta_data->key, $allowed_keys, true );
-						}
-					)
-				);
+				$allowed_keys = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
+
+				$session_value = array();
+				foreach ( $customer->get_meta_data() as $meta_data ) {
+					if ( in_array( $meta_data->key, $allowed_keys, true ) ) {
+						$session_value[] = array(
+							'key'   => $meta_data->key,
+							'value' => $meta_data->value,
+						);
+					}
+				}
 				$data['meta_data'] = $session_value;
 			} else {
 				$session_value        = $customer->{"get_$function_key"}( 'edit' );
@@ -145,9 +140,8 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				}
 				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
 					if ( 'meta_data' === $session_key ) {
-						$meta_data_values = is_serialized( $data[ $session_key ], true ) ? maybe_unserialize( $data[ $session_key ] ) : $data[ $session_key ];
-						if ( is_array( $meta_data_values ) ) {
-							foreach ( $meta_data_values as $meta_data_value ) {
+						if ( is_array( $data[ $session_key ] ) ) {
+							foreach ( $data[ $session_key ] as $meta_data_value ) {
 								if ( ! isset( $meta_data_value['key'], $meta_data_value['value'] ) ) {
 									continue;
 								}

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -95,28 +95,26 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				 * @param WC_Customer $customer The customer object.
 				 */
 				$allowed_keys  = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
-				$session_value = maybe_serialize(
-					array_map(
-						function ( $meta_data ) {
-							// Data comes to us a WC_Meta_Data, we cast it to an array to ensure it is serializable.
-								return array(
-									'key'   => $meta_data->key,
-									'value' => $meta_data->value,
-								);
-						},
-						array_filter(
-							$customer->get_meta_data(),
-							function ( $meta_data ) use ( $allowed_keys ) {
-									return in_array( $meta_data->key, $allowed_keys, true );
-							}
-						)
+				$session_value = array_map(
+					function ( $meta_data ) {
+						// Data comes to us a WC_Meta_Data, we cast it to an array to ensure it is serializable.
+							return array(
+								'key'   => $meta_data->key,
+								'value' => $meta_data->value,
+							);
+					},
+					array_filter(
+						$customer->get_meta_data(),
+						function ( $meta_data ) use ( $allowed_keys ) {
+								return in_array( $meta_data->key, $allowed_keys, true );
+						}
 					)
 				);
 
 			} else {
 				$session_value = $customer->{"get_$function_key"}( 'edit' );
 			}
-			$data[ $session_key ] = (string) $session_value;
+			$data[ $session_key ] = $session_value;
 		}
 		WC()->session->set( 'customer', $data );
 	}
@@ -147,8 +145,8 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				}
 				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
 					if ( 'meta_data' === $session_key ) {
-						$meta_data_values = maybe_unserialize( $data[ $session_key ] );
-						if ( $meta_data_values ) {
+						$meta_data_values = is_serialized( $data[ $session_key ], true ) ? maybe_unserialize( $data[ $session_key ] ) : $data[ $session_key ];
+						if ( is_array( $meta_data_values ) ) {
 							foreach ( $meta_data_values as $meta_data_value ) {
 								if ( ! isset( $meta_data_value['key'], $meta_data_value['value'] ) ) {
 									continue;

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -94,8 +94,8 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				 * @param array $allowed_keys The allowed meta data keys.
 				 * @param WC_Customer $customer The customer object.
 				 */
-				$allowed_keys  = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
-				$session_value = array_map(
+				$allowed_keys      = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
+				$session_value     = array_map(
 					function ( $meta_data ) {
 						// Data comes to us a WC_Meta_Data, we cast it to an array to ensure it is serializable.
 							return array(
@@ -110,11 +110,11 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 						}
 					)
 				);
-
+				$data['meta_data'] = $session_value;
 			} else {
-				$session_value = $customer->{"get_$function_key"}( 'edit' );
+				$session_value        = $customer->{"get_$function_key"}( 'edit' );
+				$data[ $session_key ] = (string) $session_value;
 			}
-			$data[ $session_key ] = $session_value;
 		}
 		WC()->session->set( 'customer', $data );
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -97,7 +97,6 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				$allowed_keys      = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
 				$session_value     = array_map(
 					function ( $meta_data ) {
-						// Data comes to us a WC_Meta_Data, we cast it to an array to ensure it is serializable.
 							return array(
 								'key'   => $meta_data->key,
 								'value' => $meta_data->value,


### PR DESCRIPTION
This PR skips customer meta data serialization as we already serialize data when doing `session->set`, it's also more defensive around loading it and only loop over it if it's an array.

Closes https://github.com/woocommerce/woocommerce/issues/47485

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

// From 8.8.x, json_decode to nothing:
1. In WooCommerce 8.8.x, logged out, start a session, add an item to Cart, go to checkout, and fill out the fields.
2. Update to this PR, refresh checkout, whatever fields you filled should still be there, there shouldn't be any warnings or errors.

// From 8.9.0, maybe_serialize to nothing
1. In WooCommerce 8.9.x, logged out, start a session, add an item to Cart, go to checkout, and fill out the fields.
2. Update to this PR, refresh checkout, whatever fields you filled should still be there, there shouldn't be any warnings or errors.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Fix warning when loading guest sessions from previous sessions.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
