### PR TITLE
Product Editor: Fix modal block editor undo granularity

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-modal-block-editor-undo-granularity
+++ b/packages/js/product-editor/changelog/fix-product-editor-modal-block-editor-undo-granularity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make editor history in modal block editor less granular to match post editor behavior.

--- a/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { BlockInstance } from '@wordpress/blocks';
+import { useDebounce } from '@wordpress/compose';
 import { useCallback, useState } from '@wordpress/element';
 
 type useEditorHistoryProps = {
@@ -18,16 +19,21 @@ export function useEditorHistory( {
 	const [ edits, setEdits ] = useState< BlockInstance[][] >( [] );
 	const [ offsetIndex, setOffsetIndex ] = useState< number >( 0 );
 
-	const appendEdit = useCallback(
-		( edit: BlockInstance[] ) => {
-			const currentEdits = edits.slice( 0, offsetIndex + 1 );
-			const newEdits = [ ...currentEdits, edit ].slice( maxHistory * -1 );
-			setEdits( newEdits );
-			setOffsetIndex( newEdits.length - 1 );
+	const appendEdit = useDebounce(
+		useCallback(
+			( edit: BlockInstance[] ) => {
+				const currentEdits = edits.slice( 0, offsetIndex + 1 );
+				const newEdits = [ ...currentEdits, edit ].slice(
+					maxHistory * -1
+				);
+				setEdits( newEdits );
+				setOffsetIndex( newEdits.length - 1 );
 
-			console.log( 'appendEdit', newEdits );
-		},
-		[ edits, maxHistory, offsetIndex ]
+				console.log( 'appendEdit', newEdits );
+			},
+			[ edits, maxHistory, offsetIndex ]
+		),
+		500
 	);
 
 	const undo = useCallback( () => {

--- a/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
@@ -30,23 +30,23 @@ export function useEditorHistory( {
 		[ edits, maxHistory, offsetIndex ]
 	);
 
-	function undo() {
+	const undo = useCallback( () => {
 		const newIndex = Math.max( 0, offsetIndex - 1 );
 		if ( ! edits[ newIndex ] ) {
 			return;
 		}
 		setBlocks( edits[ newIndex ] );
 		setOffsetIndex( newIndex );
-	}
+	}, [ edits, offsetIndex, setBlocks ] );
 
-	function redo() {
+	const redo = useCallback( () => {
 		const newIndex = Math.min( edits.length - 1, offsetIndex + 1 );
 		if ( ! edits[ newIndex ] ) {
 			return;
 		}
 		setBlocks( edits[ newIndex ] );
 		setOffsetIndex( newIndex );
-	}
+	}, [ edits, offsetIndex, setBlocks ] );
 
 	function hasUndo() {
 		return !! edits.length && offsetIndex > 0;

--- a/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BlockInstance } from '@wordpress/blocks';
-import { useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 
 type useEditorHistoryProps = {
 	maxHistory?: number;
@@ -18,12 +18,17 @@ export function useEditorHistory( {
 	const [ edits, setEdits ] = useState< BlockInstance[][] >( [] );
 	const [ offsetIndex, setOffsetIndex ] = useState< number >( 0 );
 
-	function appendEdit( edit: BlockInstance[] ) {
-		const currentEdits = edits.slice( 0, offsetIndex + 1 );
-		const newEdits = [ ...currentEdits, edit ].slice( maxHistory * -1 );
-		setEdits( newEdits );
-		setOffsetIndex( newEdits.length - 1 );
-	}
+	const appendEdit = useCallback(
+		( edit: BlockInstance[] ) => {
+			const currentEdits = edits.slice( 0, offsetIndex + 1 );
+			const newEdits = [ ...currentEdits, edit ].slice( maxHistory * -1 );
+			setEdits( newEdits );
+			setOffsetIndex( newEdits.length - 1 );
+
+			console.log( 'appendEdit', newEdits );
+		},
+		[ edits, maxHistory, offsetIndex ]
+	);
 
 	function undo() {
 		const newIndex = Math.max( 0, offsetIndex - 1 );

--- a/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
@@ -28,8 +28,6 @@ export function useEditorHistory( {
 				);
 				setEdits( newEdits );
 				setOffsetIndex( newEdits.length - 1 );
-
-				console.log( 'appendEdit', newEdits );
 			},
 			[ edits, maxHistory, offsetIndex ]
 		),

--- a/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/hooks/use-editor-history.ts
@@ -37,22 +37,26 @@ export function useEditorHistory( {
 	);
 
 	const undo = useCallback( () => {
+		appendEdit.flush();
+
 		const newIndex = Math.max( 0, offsetIndex - 1 );
 		if ( ! edits[ newIndex ] ) {
 			return;
 		}
 		setBlocks( edits[ newIndex ] );
 		setOffsetIndex( newIndex );
-	}, [ edits, offsetIndex, setBlocks ] );
+	}, [ appendEdit, edits, offsetIndex, setBlocks ] );
 
 	const redo = useCallback( () => {
+		appendEdit.flush();
+
 		const newIndex = Math.min( edits.length - 1, offsetIndex + 1 );
 		if ( ! edits[ newIndex ] ) {
 			return;
 		}
 		setBlocks( edits[ newIndex ] );
 		setOffsetIndex( newIndex );
-	}, [ edits, offsetIndex, setBlocks ] );
+	}, [ appendEdit, edits, offsetIndex, setBlocks ] );
 
 	function hasUndo() {
 		return !! edits.length && offsetIndex > 0;

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -5,7 +5,7 @@ import { BlockInstance } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, useEffect, useState } from '@wordpress/element';
-import { useResizeObserver } from '@wordpress/compose';
+import { useDebounce, useResizeObserver } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
 import classNames from 'classnames';
 import { isWpVersion } from '@woocommerce/settings';
@@ -137,10 +137,15 @@ export function IframeEditor( {
 		updateSettings( productBlockEditorSettings );
 	}, [] );
 
+	const debouncedAppendToEditorHistory = useDebounce(
+		appendToEditorHistory,
+		250
+	);
+
 	const handleBlockEditorProviderOnChange = (
 		updatedBlocks: BlockInstance[]
 	) => {
-		appendToEditorHistory( updatedBlocks );
+		debouncedAppendToEditorHistory( updatedBlocks );
 		setTemporalBlocks( updatedBlocks );
 		onChange( updatedBlocks );
 	};
@@ -148,6 +153,7 @@ export function IframeEditor( {
 	const handleBlockEditorProviderOnInput = (
 		updatedBlocks: BlockInstance[]
 	) => {
+		debouncedAppendToEditorHistory( updatedBlocks );
 		setTemporalBlocks( updatedBlocks );
 		onInput( updatedBlocks );
 	};

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -139,7 +139,7 @@ export function IframeEditor( {
 
 	const debouncedAppendToEditorHistory = useDebounce(
 		appendToEditorHistory,
-		250
+		500
 	);
 
 	const handleBlockEditorProviderOnChange = (

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -137,6 +137,21 @@ export function IframeEditor( {
 		updateSettings( productBlockEditorSettings );
 	}, [] );
 
+	const handleBlockEditorProviderOnChange = (
+		updatedBlocks: BlockInstance[]
+	) => {
+		appendToEditorHistory( updatedBlocks );
+		setTemporalBlocks( updatedBlocks );
+		onChange( updatedBlocks );
+	};
+
+	const handleBlockEditorProviderOnInput = (
+		updatedBlocks: BlockInstance[]
+	) => {
+		setTemporalBlocks( updatedBlocks );
+		onInput( updatedBlocks );
+	};
+
 	const settings = __settings || parentEditorSettings;
 
 	const inlineFixedBlockToolbar =
@@ -164,15 +179,8 @@ export function IframeEditor( {
 						templateLock: false,
 					} }
 					value={ temporalBlocks }
-					onChange={ ( updatedBlocks: BlockInstance[] ) => {
-						appendToEditorHistory( updatedBlocks );
-						setTemporalBlocks( updatedBlocks );
-						onChange( updatedBlocks );
-					} }
-					onInput={ ( updatedBlocks: BlockInstance[] ) => {
-						setTemporalBlocks( updatedBlocks );
-						onInput( updatedBlocks );
-					} }
+					onChange={ handleBlockEditorProviderOnChange }
+					onInput={ handleBlockEditorProviderOnInput }
 					useSubRegistry={ true }
 				>
 					<RegisterStores />

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -84,7 +84,7 @@ export function IframeEditor( {
 		useDispatch( productEditorUiStore );
 
 	const {
-		appendEdit: tempAppendEdit,
+		appendEdit: appendToEditorHistory,
 		hasRedo,
 		hasUndo,
 		redo,
@@ -98,7 +98,7 @@ export function IframeEditor( {
 	 * @todo: probably we can get rid of the initialBlocks prop.
 	 */
 	useEffect( () => {
-		tempAppendEdit( blocks );
+		appendToEditorHistory( blocks );
 		setTemporalBlocks( blocks );
 	}, [] ); // eslint-disable-line
 
@@ -165,12 +165,12 @@ export function IframeEditor( {
 					} }
 					value={ temporalBlocks }
 					onChange={ ( updatedBlocks: BlockInstance[] ) => {
-						tempAppendEdit( updatedBlocks );
+						appendToEditorHistory( updatedBlocks );
 						setTemporalBlocks( updatedBlocks );
 						onChange( updatedBlocks );
 					} }
 					onInput={ ( updatedBlocks: BlockInstance[] ) => {
-						tempAppendEdit( updatedBlocks );
+						appendToEditorHistory( updatedBlocks );
 						setTemporalBlocks( updatedBlocks );
 						onInput( updatedBlocks );
 					} }

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -5,7 +5,7 @@ import { BlockInstance } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, useEffect, useState } from '@wordpress/element';
-import { useDebounce, useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
 import classNames from 'classnames';
 import { isWpVersion } from '@woocommerce/settings';
@@ -137,15 +137,10 @@ export function IframeEditor( {
 		updateSettings( productBlockEditorSettings );
 	}, [] );
 
-	const debouncedAppendToEditorHistory = useDebounce(
-		appendToEditorHistory,
-		500
-	);
-
 	const handleBlockEditorProviderOnChange = (
 		updatedBlocks: BlockInstance[]
 	) => {
-		debouncedAppendToEditorHistory( updatedBlocks );
+		appendToEditorHistory( updatedBlocks );
 		setTemporalBlocks( updatedBlocks );
 		onChange( updatedBlocks );
 	};
@@ -153,7 +148,7 @@ export function IframeEditor( {
 	const handleBlockEditorProviderOnInput = (
 		updatedBlocks: BlockInstance[]
 	) => {
-		debouncedAppendToEditorHistory( updatedBlocks );
+		appendToEditorHistory( updatedBlocks );
 		setTemporalBlocks( updatedBlocks );
 		onInput( updatedBlocks );
 	};

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -170,7 +170,6 @@ export function IframeEditor( {
 						onChange( updatedBlocks );
 					} }
 					onInput={ ( updatedBlocks: BlockInstance[] ) => {
-						appendToEditorHistory( updatedBlocks );
 						setTemporalBlocks( updatedBlocks );
 						onInput( updatedBlocks );
 					} }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the undo/redo granularity in the product editor's modal block editor to behave more similar to the post editor. Specifically, not every individual keystroke is added to the edit history. Instead, changes are debounced so that only larger changes are added.

I originally thought I could take care of this by simply not adding to the edit history for `onInput` of `BlockEditorProvider` and only adding to the history for `onChange`. However, this doesn't work. I observed situations where `onChange` was never called. In addition, the granularity did not match the post editor behavior. Using a debounce resulted in a more robust implementation that didn't miss any history entries and behaved like the post editor.

Closes #47508.

#### Before

https://github.com/woocommerce/woocommerce/assets/2098816/147b1006-2579-4184-9d9a-237907ca7132

#### After

https://github.com/woocommerce/woocommerce/assets/2098816/10ed4a44-3e87-44ea-8d76-d14c813889b5

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Click on **Description** > **Full Editor** to bring up the modal editor
3. Type some text
4. Undo/redo and verify that not every keystroke is undone (unless you are typing very slow)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
