### PR TITLE
Product Editor: Fix deprecation warnings about toolbar items in modal block editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-modal-block-editor-header-toolbars
+++ b/packages/js/product-editor/changelog/fix-product-editor-modal-block-editor-header-toolbars
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updated modal block editor header implementation to get rid of deprecation warnings.

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -8,7 +8,6 @@
 
 	.woocommerce-iframe-editor__header-inserter-toggle.components-button.has-icon {
 		height: 32px;
-		margin-right: 8px;
 		min-width: 32px;
 		padding: 0;
 		width: 32px;
@@ -33,10 +32,36 @@
 		display: flex;
 
 		.woocommerce-iframe-editor-document-tools {
-			display: block;
+			&__left {
+				align-items: center;
+				display: inline-flex;
+				gap: 8px;
+				margin-right: 8px;
 
-			padding-right: $gap-smaller;
-			margin-right: $gap-smaller;
+				// Copying how Gutenberg handles styling the toolbar buttons in the editor
+				// see: https://github.com/mattsherman/gutenberg/blob/d538f429f018aba34814b360c5adf37eb6013427/packages/editor/src/components/document-tools/style.scss#L39
+				// The Toolbar component adds different styles to buttons, so we reset them
+				// here to the original button styles
+				& > .components-button.has-icon,
+				& > .components-dropdown > .components-button.has-icon {
+					height: 32px;
+					min-width: 32px;
+					padding: $gap-smallest;
+
+					&.is-pressed {
+						background: $gray-900;
+					}
+
+					&:focus:not(:disabled) {
+						box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
+						outline: $border-width solid transparent;
+					}
+
+					&::before {
+						display: none;
+					}
+				}
+			}
 		}
 
 		.selected-block-tools-wrapper {

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -33,6 +33,8 @@
 		display: flex;
 
 		.woocommerce-iframe-editor-document-tools {
+			display: block;
+
 			padding-right: $gap-smaller;
 			margin-right: $gap-smaller;
 		}

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -1,4 +1,4 @@
-.woocommerce-iframe-editor__header-toolbar {
+.woocommerce-iframe-editor__header {
 	height: 60px;
 	border: 0;
 	border-bottom: 1px solid $gray-400;
@@ -6,7 +6,7 @@
 	align-items: center;
 	justify-content: space-between;
 
-	.woocommerce-iframe-editor__header-toolbar-inserter-toggle.components-button.has-icon {
+	.woocommerce-iframe-editor__header-inserter-toggle.components-button.has-icon {
 		height: 32px;
 		margin-right: 8px;
 		min-width: 32px;

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -124,7 +124,12 @@ export function HeaderToolbar( {
 	return (
 		<div className="woocommerce-iframe-editor__header">
 			<div className="woocommerce-iframe-editor__header-left">
-				<div className="woocommerce-iframe-editor-document-tools">
+				<NavigableToolbar
+					className="woocommerce-iframe-editor-document-tools"
+					aria-label={ __( 'Document tools', 'woocommerce' ) }
+					// @ts-expect-error variant prop exists
+					variant="unstyled"
+				>
 					<ToolbarItem
 						ref={ inserterButton }
 						as={ Button }
@@ -155,7 +160,7 @@ export function HeaderToolbar( {
 					<ToolbarItem as={ EditorHistoryUndo } />
 					<ToolbarItem as={ EditorHistoryRedo } />
 					<ToolbarItem as={ DocumentOverview } />
-				</div>
+				</NavigableToolbar>
 				{ hasFixedToolbar && isLargeViewport && renderBlockToolbar && (
 					<>
 						<div

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -202,22 +202,20 @@ export function HeaderToolbar( {
 				) }
 			</div>
 			<div className="woocommerce-iframe-editor__header-right">
-				<ToolbarItem
-					as={ Button }
+				<Button
 					variant="tertiary"
 					className="woocommerce-modal-actions__cancel-button"
 					onClick={ onCancel }
 					text={ __( 'Cancel', 'woocommerce' ) }
 				/>
-				<ToolbarItem
-					as={ Button }
+				<Button
 					variant="primary"
 					className="woocommerce-modal-actions__done-button"
 					onClick={ onSave }
 					text={ __( 'Done', 'woocommerce' ) }
 				/>
 				<PinnedItems.Slot scope={ SIDEBAR_COMPLEMENTARY_AREA_SCOPE } />
-				<ToolbarItem as={ MoreMenu } />
+				<MoreMenu />
 			</div>
 		</div>
 	);

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -122,10 +122,7 @@ export function HeaderToolbar( {
 		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.3;
 
 	return (
-		<NavigableToolbar
-			className="woocommerce-iframe-editor__header-toolbar"
-			aria-label={ toolbarAriaLabel }
-		>
+		<div className="woocommerce-iframe-editor__header-toolbar">
 			<div className="woocommerce-iframe-editor__header-toolbar-left">
 				<div className="woocommerce-iframe-editor-document-tools">
 					<ToolbarItem
@@ -217,6 +214,6 @@ export function HeaderToolbar( {
 				<PinnedItems.Slot scope={ SIDEBAR_COMPLEMENTARY_AREA_SCOPE } />
 				<ToolbarItem as={ MoreMenu } />
 			</div>
-		</NavigableToolbar>
+		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -103,13 +103,17 @@ export function HeaderToolbar( {
 		};
 	}, [] );
 
-	/* translators: accessibility text for the editor toolbar */
-	const toolbarAriaLabel = __( 'Document tools', 'woocommerce' );
-
-	const toggleInserter = useCallback(
-		() => setIsInserterOpened( ! isInserterOpened ),
-		[ isInserterOpened, setIsInserterOpened ]
-	);
+	const toggleInserter = useCallback( () => {
+		if ( isInserterOpened ) {
+			// Focusing the inserter button should close the inserter popover.
+			// However, there are some cases it won't close when the focus is lost.
+			// See https://github.com/WordPress/gutenberg/issues/43090 for more details.
+			inserterButton.current?.focus();
+			setIsInserterOpened( false );
+		} else {
+			setIsInserterOpened( true );
+		}
+	}, [ isInserterOpened, setIsInserterOpened ] );
 
 	useEffect( () => {
 		// If we have a new block selection, show the block tools

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -103,17 +103,10 @@ export function HeaderToolbar( {
 		};
 	}, [] );
 
-	const toggleInserter = useCallback( () => {
-		if ( isInserterOpened ) {
-			// Focusing the inserter button should close the inserter popover.
-			// However, there are some cases it won't close when the focus is lost.
-			// See https://github.com/WordPress/gutenberg/issues/43090 for more details.
-			inserterButton.current?.focus();
-			setIsInserterOpened( false );
-		} else {
-			setIsInserterOpened( true );
-		}
-	}, [ isInserterOpened, setIsInserterOpened ] );
+	const toggleInserter = useCallback(
+		() => setIsInserterOpened( ! isInserterOpened ),
+		[ isInserterOpened, setIsInserterOpened ]
+	);
 
 	useEffect( () => {
 		// If we have a new block selection, show the block tools

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -134,36 +134,39 @@ export function HeaderToolbar( {
 					// @ts-expect-error variant prop exists
 					variant="unstyled"
 				>
-					<ToolbarItem
-						ref={ inserterButton }
-						as={ Button }
-						className="woocommerce-iframe-editor__header-inserter-toggle"
-						variant="primary"
-						isPressed={ isInserterOpened }
-						onMouseDown={ (
-							event: MouseEvent< HTMLButtonElement >
-						) => {
-							event.preventDefault();
-						} }
-						onClick={ toggleInserter }
-						disabled={ ! isInserterEnabled }
-						icon={ plus }
-						label={
-							! isInserterOpened
-								? __( 'Add', 'woocommerce' )
-								: __( 'Close', 'woocommerce' )
-						}
-						showTooltip
-					/>
-					{ isLargeViewport && (
+					<div className="woocommerce-iframe-editor-document-tools__left">
 						<ToolbarItem
-							as={ ToolSelector }
-							disabled={ isTextModeEnabled }
+							ref={ inserterButton }
+							as={ Button }
+							className="woocommerce-iframe-editor__header-inserter-toggle"
+							variant="primary"
+							isPressed={ isInserterOpened }
+							onMouseDown={ (
+								event: MouseEvent< HTMLButtonElement >
+							) => {
+								event.preventDefault();
+							} }
+							onClick={ toggleInserter }
+							disabled={ ! isInserterEnabled }
+							icon={ plus }
+							label={
+								! isInserterOpened
+									? __( 'Add', 'woocommerce' )
+									: __( 'Close', 'woocommerce' )
+							}
+							showTooltip
 						/>
-					) }
-					<ToolbarItem as={ EditorHistoryUndo } />
-					<ToolbarItem as={ EditorHistoryRedo } />
-					<ToolbarItem as={ DocumentOverview } />
+						{ isLargeViewport && (
+							<ToolbarItem
+								as={ ToolSelector }
+								disabled={ isTextModeEnabled }
+								size="compact"
+							/>
+						) }
+						<ToolbarItem as={ EditorHistoryUndo } size="compact" />
+						<ToolbarItem as={ EditorHistoryRedo } size="compact" />
+						<ToolbarItem as={ DocumentOverview } size="compact" />
+					</div>
 				</NavigableToolbar>
 				{ hasFixedToolbar && isLargeViewport && renderBlockToolbar && (
 					<>

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -122,13 +122,13 @@ export function HeaderToolbar( {
 		isWpVersion( '6.5', '>=' ) || getGutenbergVersion() > 17.3;
 
 	return (
-		<div className="woocommerce-iframe-editor__header-toolbar">
-			<div className="woocommerce-iframe-editor__header-toolbar-left">
+		<div className="woocommerce-iframe-editor__header">
+			<div className="woocommerce-iframe-editor__header-left">
 				<div className="woocommerce-iframe-editor-document-tools">
 					<ToolbarItem
 						ref={ inserterButton }
 						as={ Button }
-						className="woocommerce-iframe-editor__header-toolbar-inserter-toggle"
+						className="woocommerce-iframe-editor__header-inserter-toggle"
 						variant="primary"
 						isPressed={ isInserterOpened }
 						onMouseDown={ (
@@ -196,7 +196,7 @@ export function HeaderToolbar( {
 					</>
 				) }
 			</div>
-			<div className="woocommerce-iframe-editor__header-toolbar-right">
+			<div className="woocommerce-iframe-editor__header-right">
 				<ToolbarItem
 					as={ Button }
 					variant="tertiary"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR addresses the deprecation warnings about using custom components as toolbar controls by adjusting the implementation of the modal block editor header to not be a single toolbar, but rather a regular div composed of separate toolbars. This follows the implementation of the header in the post editor, and is more accurate semantically.

Closes #47200.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Clear dev console in browser
3. Click on **Description** > **Full Editor** to bring up the modal block editor

<img width="1274" alt="Screenshot 2024-05-22 at 14 48 18" src="https://github.com/woocommerce/woocommerce/assets/2098816/aafd8d60-d2ed-413e-9692-b432631bed90">

4. Verify that there are no deprecation warnings about using custom components as toolbar controls

```
Using custom components as toolbar controls is deprecated since version 5.6. Please use ToolbarItem, ToolbarButton or ToolbarDropdownMenu components instead.
```

5. Verify header is styled correctly (no change/regression)
6. Verify buttons in header work properly  (no change/regression)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
