### PR TITLE
Fix: Product Collection block should respects 'Out of stock visibility' setting

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
@@ -27,6 +27,7 @@ import type { BlockEditProps, BlockInstance } from '@wordpress/blocks';
  */
 import { useGetLocation, useProductCollectionQueryContext } from './utils';
 import './editor.scss';
+import { getDefaultStockStatuses } from '../product-collection/constants';
 
 const DEFAULT_QUERY_CONTEXT_ATTRIBUTES = [ 'collection' ];
 
@@ -251,6 +252,14 @@ const ProductTemplateEdit = (
 					location,
 					productCollectionQueryContext,
 					previewState: __privateProductCollectionPreviewState,
+					/**
+					 * Use value of "Out of stock visibility" setting to determine
+					 * which stock statuses to include if inherit query
+					 * from template is true.
+					 */
+					...( inherit && {
+						woocommerceStockStatus: getDefaultStockStatuses(),
+					} ),
 				} ),
 				blocks: getBlocks( clientId ),
 			};

--- a/plugins/woocommerce/changelog/47537-fix-47536-product-collection-out-of-stock-products-still-visible-despite-hide-out-of-stock-items-setting
+++ b/plugins/woocommerce/changelog/47537-fix-47536-product-collection-out-of-stock-products-still-visible-despite-hide-out-of-stock-items-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Product Collection Block Respects 'Out of stock visibility' Setting


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I updated the logic to always use "Out of stock visibility" setting, whenever "Sync with current query" toggle is ON in inspector control of Product Collection block. This ensures that out-of-stock products are hidden in the Product Collection block on Editor side when the "Hide out of stock items from the catalog" option is enabled.

For more info about the issue, see: #47536


Closes #47536 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Prerequisite**
1. Make sure that following checkbox isn't ticked in WooCommerce settings
![image](https://github.com/woocommerce/woocommerce/assets/16707866/c26381c0-91c2-4b5e-9ff5-3e56f0e3c00a)

2. Ensure the presence of some out-of-stock products. If possible, rename an out-of-stock product to "1st product" to show it as 1st product in grid.

**Steps:**
1. Insert a Product Collection block into the Product Catalog template & save the template.
	- Verify that "Sync with current query" toggle is ON in inspector control for Product Collection block. 
	- Verify that out-of-stock products are visible in Product Collection block
2. Check the checkbox & save (Make sure it isn't checked when Product Collection block was inserted in 1st step):
![image](https://github.com/woocommerce/woocommerce/assets/16707866/47d2d0ac-d86a-4f56-a9c1-8e78d5f18466)


3. Refresh the Product Catalog template in the Editor.
	- Verify that out-of-stock products aren't visible in Editor anymore. 
4. Save and go to frontend. Verify that out-of-stock products aren't visible on Frontend too. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Product Collection block should respects 'Out of stock visibility' setting

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
