### PR TITLE
Blocks E2E: Wait for Site Editor canvas loader

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -223,7 +223,14 @@ export class EditorUtils {
 			} )
 			.dispatchEvent( 'click' );
 
-		await this.page.locator( '.edit-site-layout__sidebar' ).waitFor( {
+		const sidebar = this.page.locator( '.edit-site-layout__sidebar' );
+		const canvasLoader = this.page.locator( '.edit-site-canvas-loader' );
+
+		await sidebar.waitFor( {
+			state: 'hidden',
+		} );
+
+		await canvasLoader.waitFor( {
 			state: 'hidden',
 		} );
 	}

--- a/plugins/woocommerce/changelog/47541-fix-e2e-site-editor-canvas-loader
+++ b/plugins/woocommerce/changelog/47541-fix-e2e-site-editor-canvas-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Wait for Site Editor canvas loader in the `enterEditMore()` utility.


### PR DESCRIPTION
### What?

The Site Editor's canvas loader not being properly awaited has been a major source of flakiness in our tests. There's an upstream fix for it in https://github.com/WordPress/gutenberg/pull/61629, but it's going to take a while until we can use it, so let's apply the same fix in our `enterEditMode()` utility for now.

### How to test

All the tests should pass, and the CI output should contain fewer (preferably no more 🙏) flaky tests.