### PR TITLE
Blocks E2E: Remove obsolete waitForSiteEditorFinishLoading util

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -144,7 +144,7 @@ test.describe( 'Template customization', () => {
 					postType: testData.templateType,
 				} );
 				await editorUtils.enterEditMode();
-				await editorUtils.waitForSiteEditorFinishLoading();
+
 				await editorUtils.editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: { content: userText },

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -279,17 +279,6 @@ export class EditorUtils {
 		return firstBlockIndex < secondBlockIndex;
 	}
 
-	async waitForSiteEditorFinishLoading() {
-		await this.page
-			.frameLocator( 'iframe[title="Editor canvas"i]' )
-			.locator( 'body > *' )
-			.first()
-			.waitFor();
-		await this.page
-			.locator( '.edit-site-canvas-loader' )
-			.waitFor( { state: 'hidden' } );
-	}
-
 	async setLayoutOption(
 		option:
 			| 'Align Top'
@@ -417,9 +406,6 @@ export class EditorUtils {
 			await this.admin.visitSiteEditor( {
 				path: `/${ templateType }/all`,
 			} );
-			await this.page.goto(
-				`/wp-admin/site-editor.php?path=/${ templateType }/all`
-			);
 			const templateLink = this.page.getByRole( 'link', {
 				name: templateName,
 				exact: true,
@@ -437,7 +423,6 @@ export class EditorUtils {
 		}
 
 		await this.enterEditMode();
-		await this.waitForSiteEditorFinishLoading();
 
 		// Verify we are editing the correct template and it has the correct title.
 		const templateTypeName =

--- a/plugins/woocommerce/changelog/47547-e2e-remove-obsolete-util
+++ b/plugins/woocommerce/changelog/47547-e2e-remove-obsolete-util
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Remove obsolete waitForSiteEditorFinishLoading utility.


### PR DESCRIPTION
### What?

As a quick follow-up to https://github.com/woocommerce/woocommerce/pull/47541, let's remove the unneeded `waitForSiteEditorFinishLoading()` utility along with its calls. 

### How to test

All tests should pass. 