### PR TITLE
If the Legacy REST API plugin is auto-installed once, do not auto-install a second time.

### DIFF
--- a/plugins/woocommerce/changelog/fix-avoid-repeated-legacy-api-installation
+++ b/plugins/woocommerce/changelog/fix-avoid-repeated-legacy-api-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Automated installation of the Legacy REST API plugin should only happen once. After that, it must be installed manually (if needed).

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -252,6 +252,9 @@ class WC_Install {
 			'wc_update_890_update_connect_to_woocommerce_note',
 			'wc_update_890_update_paypal_standard_load_eligibility',
 		),
+		'9.0.0' => array(
+			'wc_update_900_create_plugin_autoinstall_history_option',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -269,11 +269,6 @@ class WC_Install {
 	const STORE_ID_OPTION = 'woocommerce_store_id';
 
 	/**
-	 * Option key, used to record if the Legacy REST API was installed by us.
-	 */
-	private const INSTALLED_LEGACY_REST_API_PLUGIN = 'woocommerce_installed_legacy_rest_api';
-
-	/**
 	 * Hook in tabs.
 	 */
 	public static function init() {

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1191,9 +1191,15 @@ class WC_Install {
 		}
 
 		// Did we previously install this plugin?
+		// We check both the woocommerce_history_of_autoinstalled_plugins options (introduced in 9.0)
+		// and the woocommerce_autoinstalled_plugins option (info should still exist here if the plugin has been uninstalled but not manually reinstalled).
 		$legacy_api_plugin          = 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php';
 		$autoinstalled_plugins      = (array) get_site_option( 'woocommerce_history_of_autoinstalled_plugins', array() );
 		$previously_installed_by_us = isset( $autoinstalled_plugins[ $legacy_api_plugin ] );
+		if ( ! $previously_installed_by_us ) {
+			$autoinstalled_plugins      = (array) get_site_option( 'woocommerce_autoinstalled_plugins', array() );
+			$previously_installed_by_us = isset( $autoinstalled_plugins[ $legacy_api_plugin ] );
+		}
 
 		/**
 		 * Filter to skip the automatic installation of the WooCommerce Legacy REST API plugin

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -252,8 +252,8 @@ class WC_Install {
 			'wc_update_890_update_connect_to_woocommerce_note',
 			'wc_update_890_update_paypal_standard_load_eligibility',
 		),
-		'9.0.0' => array(
-			'wc_update_900_create_plugin_autoinstall_history_option',
+		'8.9.1' => array(
+			'wc_update_891_create_plugin_autoinstall_history_option',
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1189,8 +1189,8 @@ class WC_Install {
 
 		// Did we previously install this plugin?
 		$legacy_api_plugin          = 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php';
-		$autoinstalled              = (array) get_site_option( 'woocommerce_autoinstalled_plugins', array() );
-		$previously_installed_by_us = isset( $autoinstalled[ $legacy_api_plugin ] );
+		$autoinstalled_plugins      = (array) get_site_option( 'woocommerce_history_of_autoinstalled_plugins', array() );
+		$previously_installed_by_us = isset( $autoinstalled_plugins[ $legacy_api_plugin ] );
 
 		/**
 		 * Filter to skip the automatic installation of the WooCommerce Legacy REST API plugin

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2710,3 +2710,17 @@ function wc_update_890_update_paypal_standard_load_eligibility() {
 		$paypal->update_option( '_should_load', wc_bool_to_string( false ) );
 	}
 }
+
+/**
+ * Create the woocommerce_history_of_autoinstalled_plugins option if it doesn't exist
+ * as a copy of woocommerce_autoinstalled_plugins if it exists.
+ */
+function wc_update_900_create_plugin_autoinstall_history_option() {
+	$autoinstalled_plugins_history_info = get_site_option( 'woocommerce_history_of_autoinstalled_plugins' );
+	if ( false === $autoinstalled_plugins_history_info ) {
+		$autoinstalled_plugins_info = get_site_option( 'woocommerce_autoinstalled_plugins' );
+		if ( false !== $autoinstalled_plugins_info ) {
+			update_site_option( 'woocommerce_history_of_autoinstalled_plugins', $autoinstalled_plugins_info );
+		}
+	}
+}

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2715,7 +2715,7 @@ function wc_update_890_update_paypal_standard_load_eligibility() {
  * Create the woocommerce_history_of_autoinstalled_plugins option if it doesn't exist
  * as a copy of woocommerce_autoinstalled_plugins if it exists.
  */
-function wc_update_900_create_plugin_autoinstall_history_option() {
+function wc_update_891_create_plugin_autoinstall_history_option() {
 	$autoinstalled_plugins_history_info = get_site_option( 'woocommerce_history_of_autoinstalled_plugins' );
 	if ( false === $autoinstalled_plugins_history_info ) {
 		$autoinstalled_plugins_info = get_site_option( 'woocommerce_autoinstalled_plugins' );

--- a/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
@@ -155,6 +155,12 @@ class PluginInstaller implements RegisterHooksInterface {
 			$auto_installed_plugins[ $plugin_name ] = $plugin_data;
 			update_site_option( 'woocommerce_autoinstalled_plugins', $auto_installed_plugins );
 
+			$auto_installed_plugins_history = get_site_option( 'woocommerce_history_of_autoinstalled_plugins', array() );
+			if ( ! isset( $auto_installed_plugins_history[ $plugin_name ] ) ) {
+				$auto_installed_plugins_history[ $plugin_name ] = $plugin_data;
+				update_site_option( 'woocommerce_history_of_autoinstalled_plugins', $auto_installed_plugins_history );
+			}
+
 			$post_install = function () use ( $plugin_name, $plugin_version, $installed_by, $plugin_url, $plugin_data ) {
 				$log_context = array(
 					'source'        => 'plugin_auto_installs',


### PR DESCRIPTION
Currently:

- When WooCommerce is updated, we check to see if the Legacy REST API is enabled.
- If it is enabled, we automatically install the Legacy REST API plugin (for continuity reasons).
- If the Legacy REST API plugin is subsequently removed, then on the next WooCommerce update we still perform the same check and will re-install (the legacy plugin) if needed.

This change makes it so automated installation ***only happens once.*** Therefore, if the plugin is subsequently removed merchants will A) need to manually re-install it if desired B) won't have to manually remove it on subsequent plugin updates.

To achieve this, these code changes are implemented:

1. `PluginInstaller` will now maintain a new option, `woocommerce_history_of_autoinstalled_plugins`, in addition to the already existing `woocommerce_autoinstalled_plugins`. Both contain the same information, the difference is that the information in the new option is never deleted (the information in the old option is deleted if the plugin is manually reinstalled).
2. `PluginInstaller::maybe_install_legacy_api_plugin` will now check if the Legacy REST API plugin is listed in either of the options (the new one should be enough, we check the old one too for robustness) and if so the plugin won't be installed (the `woocommerce_skip_legacy_rest_api_plugin_auto_install` filter still works as expected).
3. A migration is also added to create the new option from the contents of the old one.

### How to test the changes in this Pull Request:

#### Testing the usual flow

Setup:

1. Start with a clean installation of WordPress.
4. Install WooCommerce 8.8.0.
5. You may benefit from a tool (WooCommerce Beta Tester, or WP CLI) that makes it easy to switch between versions.

Special note for those using Jurassic Ninja: if you start with the latest version of WooCommerce, that's fine, but make sure you:

- Downgrade to 8.8.0.
- Reset the installed version information stored in the database. Using WP CLI:

```sh
wp option set woocommerce_version 8.8.0
```

From there:

1. Navigate to **WooCommerce ▸ Settings ▸ Advanced ▸ Legacy API** and enable the Legacy REST API.
2. Update to WooCommerce 8.9.0. You should find that the Legacy REST API plugin has been automatically installed (consider refreshing the plugin admin list to see this):

<img width="1500" alt="Screenshot 2024-05-16 at 16 21 24" src="https://github.com/woocommerce/woocommerce/assets/3594411/536dbbfd-5336-4004-a326-210e21bea970">

3. Deactivate and delete the Legacy REST API plugin.
6. Now upgrade to ***this branch.*** You may wish to do this by manually uploading the zip produced by the _build live branches_ action and overwriting the existing copy of WooCommerce.
7. The Legacy REST API plugin *should not* have been re-installed.

#### Testing the manual reinstall flow

From the current state:

8. Deactivate and delete the Legacy REST API plugin, then reinstall and activate it manually, then deactivate and delete again.
9. Run `wp option get woocommerce_autoinstalled_plugins`, it should say that the option doesn't exist.
10. Run `wp option get woocommerce_history_of_autoinstalled_plugins`, you should get the plugin information.
11. Trick WooCommerce into believing it's in an older version, so reinstalling the same version will trigger the install workflow again: `wp option set woocommerce_version 8.8.0`
12. Reinstall WooCommerce from the zip of this branch: again, the Legacy REST API plugin *should not* have been re-installed.

🔌 [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/15348667/woocommerce.zip) (pre-built plugin zip for this branch—last updated 2024-05-17 13:30 UTC)

