### PR TITLE
Fix git clone failing in Highlight Template Changes workflow after Git 2.45.1 release

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -20,6 +20,8 @@ jobs:
       - name: 'Analyze'
         id: 'analyze'
         working-directory: 'tools/code-analyzer'
+        env:
+          GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
           HEAD_REF=$(git rev-parse HEAD)
           exclude="plugins/woocommerce/tests plugins/woocommerce-admin/tests plugins/woocommerce-blocks/tests"

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Playwright End to End Tests
 
-This is the documentation for the e2e testing setup based on Playwright and wp-env. It superseedes the Puppeteer and e2e-environment [setup](../tests/e2e), which we will gradually deprecate.
+This is the documentation for the e2e testing setup based on Playwright and wp-env. It supersedes the Puppeteer and e2e-environment [setup](../tests/e2e), which we will gradually deprecate.
 
 ## Table of contents
 

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Playwright End to End Tests
 
-This is the documentation for the e2e testing setup based on Playwright and wp-env. It supersedes the Puppeteer and e2e-environment [setup](../tests/e2e), which we will gradually deprecate.
+This is the documentation for the e2e testing setup based on Playwright and wp-env. It superseedes the Puppeteer and e2e-environment [setup](../tests/e2e), which we will gradually deprecate.
 
 ## Table of contents
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

With the release of Git 2.45.1 a regression was introduced breaking the git clone action in  the `pr-highlight-chamges.yml` workflow.
More context: p1715946811820029-slack-C03CPM3UXDJ
Setting the env variable `GIT_CLONE_PROTECTION_ACTIVE=false` for that step fixes this. We should re-evaluate this with the next Git release.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Tested with [this run](https://github.com/woocommerce/woocommerce/actions/runs/9128476462?pr=47579) and it passed.