### PR TITLE
Add Playwright performance tests to Product editor

### DIFF
--- a/plugins/woocommerce/changelog/dev-47291_add_playwright_performance_tests
+++ b/plugins/woocommerce/changelog/dev-47291_add_playwright_performance_tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add Playwright performance tests to Product editor #47590

--- a/plugins/woocommerce/tests/metrics/specs/editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/editor.spec.js
@@ -16,18 +16,6 @@ const BROWSER_IDLE_WAIT = 1000;
 
 const results = {};
 
-async function editPost( admin, page, postId ) {
-	const query = new URLSearchParams();
-	query.set( 'post', String( postId ) );
-	query.set( 'action', 'edit' );
-
-	await admin.visitAdminPage( 'post.php', query.toString() );
-	await setPreferences( page, 'core/edit-post', {
-		welcomeGuide: false,
-		fullscreenMode: false,
-	} );
-}
-
 async function setPreferences( page, context, preferences ) {
 	await page.waitForFunction( () => window?.wp?.data );
 
@@ -43,6 +31,18 @@ async function setPreferences( page, context, preferences ) {
 		},
 		{ context, preferences }
 	);
+}
+
+async function editPost( admin, page, postId ) {
+	const query = new URLSearchParams();
+	query.set( 'post', String( postId ) );
+	query.set( 'action', 'edit' );
+
+	await admin.visitAdminPage( 'post.php', query.toString() );
+	await setPreferences( page, 'core/edit-post', {
+		welcomeGuide: false,
+		fullscreenMode: false,
+	} );
 }
 
 test.describe( 'Editor Performance', () => {

--- a/plugins/woocommerce/tests/metrics/specs/editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/editor.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-disable @woocommerce/dependency-group, jest/expect-expect, jest/no-test-callback, array-callback-return, jest/no-identical-title */
 
 /**
  * WordPress dependencies
@@ -125,12 +125,7 @@ test.describe( 'Editor Performance', () => {
 			console.log( draftId );
 		} );
 
-		test( 'Run the test', async ( {
-			admin,
-			page,
-			perfUtils,
-			metrics,
-		} ) => {
+		test( 'Run the test', async ( { admin, page, perfUtils, metrics } ) => {
 			await editPost( admin, page, draftId );
 			await perfUtils.disableAutosave();
 			const canvas = await perfUtils.getCanvas();
@@ -175,4 +170,4 @@ test.describe( 'Editor Performance', () => {
 	} );
 } );
 
-/* eslint-enable playwright/no-conditional-in-test, playwright/expect-expect */
+/* eslint-enable @woocommerce/dependency-group, jest/expect-expect, jest/no-test-callback, array-callback-return, jest/no-identical-title */

--- a/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
@@ -1,0 +1,187 @@
+/* eslint-disable @woocommerce/dependency-group, jest/expect-expect, jest/no-test-callback, array-callback-return, jest/no-identical-title */
+
+/**
+ * WordPress dependencies
+ */
+import { test, Metrics } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { PerfUtils } from '../fixtures';
+import { median } from '../utils';
+import { toggleBlockProductEditor } from '../../e2e-pw/utils/simple-products';
+
+// See https://github.com/WordPress/gutenberg/issues/51383#issuecomment-1613460429
+const BROWSER_IDLE_WAIT = 1000;
+const NEW_EDITOR_ADD_PRODUCT_URL =
+	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
+
+const results = {
+	totalBlockingTime: [],
+	cumulativeLayoutShift: [],
+	largestContentfulPaint: [],
+	type: [],
+};
+
+async function getTotalBlockingTime( page, idleWait ) {
+	const totalBlockingTime = await page.evaluate( async ( waitTime ) => {
+		return new Promise( ( resolve ) => {
+			const longTaskEntries = [];
+			// Create a performance observer to observe long task entries
+			new PerformanceObserver( ( list ) => {
+				const entries = list.getEntries();
+				// Store each long task entry in the longTaskEntries array
+				entries.forEach( ( entry ) => longTaskEntries.push( entry ) );
+			} ).observe( { type: 'longtask', buffered: true } );
+
+			// Give some time to collect entries
+			setTimeout( () => {
+				// Calculate the total blocking time by summing the durations of all long tasks
+				const tbt = longTaskEntries.reduce(
+					( acc, entry ) => acc + entry.duration,
+					0
+				);
+				resolve( tbt );
+			}, waitTime );
+		} );
+	}, idleWait );
+	return totalBlockingTime;
+}
+
+test.describe( 'Product editor Performance', () => {
+	test.use( {
+		perfUtils: async ( { page }, use ) => {
+			await use( new PerfUtils( { page } ) );
+		},
+		metrics: async ( { page }, use ) => {
+			await use( new Metrics( { page } ) );
+		},
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await toggleBlockProductEditor( 'enable', page );
+	} );
+
+	test.afterAll( async ( {}, testInfo ) => {
+		const medians = {};
+		Object.keys( results ).map( ( metric ) => {
+			medians[ metric ] = median( results[ metric ] );
+		} );
+		await testInfo.attach( 'results', {
+			body: JSON.stringify( medians, null, 2 ),
+			contentType: 'application/json',
+		} );
+	} );
+
+	test.describe( 'Loading', () => {
+		const samples = 2;
+		const throwaway = 1;
+		const iterations = samples + throwaway;
+		for ( let i = 1; i <= iterations; i++ ) {
+			test( `Run the test (${ i } of ${ iterations })`, async ( {
+				page,
+				// perfUtils,
+				metrics,
+			} ) => {
+				await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
+
+				// Wait for the Preview button.
+				await page
+					.locator( '[aria-label="Preview in new tab"]' )
+					.first()
+					.waitFor();
+
+				// Get the durations.
+				const loadingDurations = await metrics.getLoadingDurations();
+
+				// Measure CLS
+				const cumulativeLayoutShift =
+					await metrics.getCumulativeLayoutShift();
+
+				// Measure LCP
+				const largestContentfulPaint =
+					await metrics.getLargestContentfulPaint();
+
+				// Measure TBT
+				const totalBlockingTime = await getTotalBlockingTime(
+					page,
+					BROWSER_IDLE_WAIT
+				);
+
+				// Save the results.
+				if ( i > throwaway ) {
+					Object.entries( loadingDurations ).forEach(
+						( [ metric, duration ] ) => {
+							const metricKey =
+								metric === 'timeSinceResponseEnd'
+									? 'firstBlock'
+									: metric;
+							if ( ! results[ metricKey ] ) {
+								results[ metricKey ] = [];
+							}
+							results[ metricKey ].push( duration );
+						}
+					);
+					results.totalBlockingTime = results.tbt || [];
+					results.totalBlockingTime.push( totalBlockingTime );
+					results.cumulativeLayoutShift =
+						results.cumulativeLayoutShift || [];
+					results.cumulativeLayoutShift.push( cumulativeLayoutShift );
+					results.largestContentfulPaint =
+						results.largestContentfulPaint || [];
+					results.largestContentfulPaint.push(
+						largestContentfulPaint
+					);
+				}
+			} );
+		}
+	} );
+
+	test.describe( 'Typing', () => {
+		test( 'Run the test', async ( { page, perfUtils, metrics } ) => {
+			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
+
+			const interfaceSkeleton = await perfUtils.getInterfaceSkeleton();
+
+			const input = interfaceSkeleton.getByPlaceholder(
+				'e.g. 12 oz Coffee Mug'
+			);
+
+			// The first character typed triggers a longer time (isTyping change).
+			// It can impact the stability of the metric, so we exclude it. It
+			// probably deserves a dedicated metric itself, though.
+			const samples = 10;
+			const throwaway = 1;
+			const iterations = samples + throwaway;
+
+			// Start tracing.
+			await metrics.startTracing();
+
+			// Type the testing sequence into the empty input.
+			await input.type( 'x'.repeat( iterations ), {
+				delay: BROWSER_IDLE_WAIT,
+				// The extended timeout is needed because the typing is very slow
+				// and the `delay` value itself does not extend it.
+				timeout: iterations * BROWSER_IDLE_WAIT * 2, // 2x the total time to be safe.
+			} );
+
+			// Stop tracing.
+			await metrics.stopTracing();
+
+			// Get the durations.
+			const [ keyDownEvents, keyPressEvents, keyUpEvents ] =
+				metrics.getTypingEventDurations();
+
+			// Save the results.
+			results.type = [];
+			for ( let i = throwaway; i < iterations; i++ ) {
+				results.type.push(
+					keyDownEvents[ i ] + keyPressEvents[ i ] + keyUpEvents[ i ]
+				);
+			}
+		} );
+	} );
+} );
+
+/* eslint-enable @woocommerce/dependency-group, jest/expect-expect, jest/no-test-callback, array-callback-return, jest/no-identical-title */

--- a/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
@@ -8,7 +8,6 @@ import { test, Metrics } from '@wordpress/e2e-test-utils-playwright';
 /**
  * Internal dependencies
  */
-import { PerfUtils } from '../fixtures';
 import { median } from '../utils';
 import { toggleBlockProductEditor } from '../../e2e-pw/utils/simple-products';
 
@@ -51,9 +50,6 @@ async function getTotalBlockingTime( page, idleWait ) {
 
 test.describe( 'Product editor performance', () => {
 	test.use( {
-		perfUtils: async ( { page }, use ) => {
-			await use( new PerfUtils( { page } ) );
-		},
 		metrics: async ( { page }, use ) => {
 			await use( new Metrics( { page } ) );
 		},
@@ -81,7 +77,6 @@ test.describe( 'Product editor performance', () => {
 		for ( let i = 1; i <= iterations; i++ ) {
 			test( `Run the test (${ i } of ${ iterations })`, async ( {
 				page,
-				// perfUtils,
 				metrics,
 			} ) => {
 				await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );

--- a/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
@@ -139,14 +139,16 @@ test.describe( 'Product editor Performance', () => {
 	} );
 
 	test.describe( 'Typing', () => {
-		test( 'Run the test', async ( { page, perfUtils, metrics } ) => {
+		test( 'Run the test', async ( { page, metrics } ) => {
 			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
 
-			const interfaceSkeleton = await perfUtils.getInterfaceSkeleton();
+			// Wait for the Preview button.
+			await page
+				.locator( '[aria-label="Preview in new tab"]' )
+				.first()
+				.waitFor();
 
-			const input = interfaceSkeleton.getByPlaceholder(
-				'e.g. 12 oz Coffee Mug'
-			);
+			const input = page.getByPlaceholder( 'e.g. 12 oz Coffee Mug' );
 
 			// The first character typed triggers a longer time (isTyping change).
 			// It can impact the stability of the metric, so we exclude it. It

--- a/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/product-editor.spec.js
@@ -49,7 +49,7 @@ async function getTotalBlockingTime( page, idleWait ) {
 	return totalBlockingTime;
 }
 
-test.describe( 'Product editor Performance', () => {
+test.describe( 'Product editor performance', () => {
 	test.use( {
 		perfUtils: async ( { page }, use ) => {
 			await use( new PerfUtils( { page } ) );

--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -10,6 +10,10 @@ const resultsFiles = [
 		file: 'editor.performance-results.json',
 		metricsPrefix: 'editor-',
 	},
+	{
+		file: 'product-editor.performance-results.json',
+		metricsPrefix: 'product-editor-',
+	},
 ];
 
 const performanceResults = resultsFiles.map( ( { file } ) =>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds some Playwright performance tests to the Product editor.

The following are the metrics we will be measuring:

 - [totalBlockingTime](https://github.com/woocommerce/woocommerce/pull/47590/files#diff-9bcc17ad1dd9b9ed28559b4b89987e4810e496151ea4503b5e0eb7aac2034971R27-R50)
(TBT) is a performance metric that measures the total amount of time that a page is blocked from responding to user input.

 - [cumulativeLayoutShift](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L139-L161)
(CLS) is a metric that measures visual stability, indicating how much visible content shifts around on the screen during the viewport's lifetime. 

 - [largestContentfulPaint](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L113-L129).
(LCP) measures perceived load speed and marks the point in the page load timeline when the page's main content has likely loaded. 

 - [typing](https://github.com/woocommerce/woocommerce/pull/47590/files#diff-9bcc17ad1dd9b9ed28559b4b89987e4810e496151ea4503b5e0eb7aac2034971R164-R169)
Measures the typing performance in a text input field.

 - [serverResponse](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L196).
Time taken by the server to start sending a response to a client's request. 

 - [firstPaint](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L199)
The time when any visual change happens on the screen—anything that differs from the previous view.

 - [domContentLoaded](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L200)
Indicates that the initial HTML document has been completely loaded and parsed, without waiting for stylesheets, images, and subframes to finish loading.

 - [loaded](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L201)
Refers to the time it takes for the entire page to be fully loaded, including all sub-resources such as stylesheets, images, and scripts.

 - [firstContentfulPaint](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L202)
(FCP) is used to measure when the first piece of content from the DOM is rendered on the screen. 

 - [firstBlock](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/metrics/index.ts#L204)
Indicates the duration from when the browser has finished receiving the complete HTML response from the server to the current time. It shows how much time has passed since the server has finished sending the HTML until a particular point in the page load.


![Screenshot 2024-05-20 at 1 49 34 PM](https://github.com/woocommerce/woocommerce/assets/1314156/bf9fdc42-6f3f-4c20-aaeb-b8cd210cf2bc)

So far, we are only measuring `Type in the editor` and `First block in the editor`. As far as I know these metrics need to be also defined in the database of `codevitals.run`, so I think we will need the help of @youknowriad to create them.


Closes #47291.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. To run this process, you will have to run the following commands
```
cd plugins/woocommerce
pnpm test:metrics
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
