### PR TITLE
Add an array_sum utility method to enhance PHP 8.3+ compatibility

### DIFF
--- a/plugins/woocommerce/changelog/fix-40660-array-sum
+++ b/plugins/woocommerce/changelog/fix-40660-array-sum
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid a warning in PHP 8.3 with some edge case uses of array_sum

--- a/plugins/woocommerce/includes/class-wc-order-item-fee.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-fee.php
@@ -10,6 +10,8 @@
  * @since   3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\NumberUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -82,7 +84,7 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 			// Apportion taxes to order items, shipping, and fees.
 			$order           = $this->get_order();
 			$tax_class_costs = $this->get_tax_class_costs( $order );
-			$total_costs     = array_sum( $tax_class_costs );
+			$total_costs     = NumberUtil::array_sum( $tax_class_costs );
 			$discount_taxes  = array();
 			if ( $total_costs ) {
 				foreach ( $tax_class_costs as $tax_class => $tax_class_cost ) {
@@ -182,9 +184,9 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 		$this->set_prop( 'taxes', $tax_data );
 
 		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-			$this->set_total_tax( array_sum( $tax_data['total'] ) );
+			$this->set_total_tax( NumberUtil::array_sum( $tax_data['total'] ) );
 		} else {
-			$this->set_total_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
+			$this->set_total_tax( NumberUtil::array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -7,6 +7,8 @@
  * @since   3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\NumberUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -171,18 +173,18 @@ class WC_Order_Item_Product extends WC_Order_Item {
 			$tax_data['total']    = array_map( 'wc_format_decimal', $raw_tax_data['total'] );
 
 			// Subtotal cannot be less than total!
-			if ( array_sum( $tax_data['subtotal'] ) < array_sum( $tax_data['total'] ) ) {
+			if ( NumberUtil::array_sum( $tax_data['subtotal'] ) < NumberUtil::array_sum( $tax_data['total'] ) ) {
 				$tax_data['subtotal'] = $tax_data['total'];
 			}
 		}
 		$this->set_prop( 'taxes', $tax_data );
 
 		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-			$this->set_total_tax( array_sum( $tax_data['total'] ) );
-			$this->set_subtotal_tax( array_sum( $tax_data['subtotal'] ) );
+			$this->set_total_tax( NumberUtil::array_sum( $tax_data['total'] ) );
+			$this->set_subtotal_tax( NumberUtil::array_sum( $tax_data['subtotal'] ) );
 		} else {
-			$this->set_total_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
-			$this->set_subtotal_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['subtotal'] ) ) );
+			$this->set_total_tax( NumberUtil::array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
+			$this->set_subtotal_tax( NumberUtil::array_sum( array_map( 'wc_round_tax_total', $tax_data['subtotal'] ) ) );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-order-item-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-shipping.php
@@ -7,6 +7,8 @@
  * @since   3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\NumberUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -144,9 +146,9 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 		$this->set_prop( 'taxes', $tax_data );
 
 		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-			$this->set_total_tax( array_sum( $tax_data['total'] ) );
+			$this->set_total_tax( NumberUtil::array_sum( $tax_data['total'] ) );
 		} else {
-			$this->set_total_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
+			$this->set_total_tax( NumberUtil::array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
 		}
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -268,7 +268,14 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 			$shipping_taxes = $shipping_item->get_taxes();
 
 			if ( ! empty( $shipping_taxes['total'] ) ) {
-				$shipping_line['total_tax'] = wc_format_decimal( array_sum( $shipping_taxes['total'] ), $dp );
+				// Ensure tax totals are all numeric before attempting to sum them, for PHP 8.3+ compatibility.
+				$tax_totals = array_filter(
+					$shipping_taxes['total'],
+					fn( $txtotal ) => is_numeric( $txtotal )
+				);
+				$total_tax = array_sum( $tax_totals );
+
+				$shipping_line['total_tax'] = wc_format_decimal( $total_tax, $dp );
 
 				foreach ( $shipping_taxes['total'] as $tax_rate_id => $tax ) {
 					$shipping_line['taxes'][] = array(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -10,8 +10,7 @@
  * @since    3.0.0
  */
 
-use Automattic\WooCommerce\Utilities\ArrayUtil;
-use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Utilities\{ ArrayUtil, NumberUtil, StringUtil };
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -268,12 +267,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 			$shipping_taxes = $shipping_item->get_taxes();
 
 			if ( ! empty( $shipping_taxes['total'] ) ) {
-				// Ensure tax totals are all numeric before attempting to sum them, for PHP 8.3+ compatibility.
-				$tax_totals = array_filter(
-					$shipping_taxes['total'],
-					fn( $txtotal ) => is_numeric( $txtotal )
-				);
-				$total_tax = array_sum( $tax_totals );
+				$total_tax = NumberUtil::array_sum( $shipping_taxes['total'] );
 
 				$shipping_line['total_tax'] = wc_format_decimal( $total_tax, $dp );
 

--- a/plugins/woocommerce/src/Utilities/NumberUtil.php
+++ b/plugins/woocommerce/src/Utilities/NumberUtil.php
@@ -40,12 +40,12 @@ final class NumberUtil {
 	 *
 	 * Note that, unlike the built-in array_sum, this one will always return a float, never an int.
 	 *
-	 * @param array $array The array of values to sum.
+	 * @param array $arr The array of values to sum.
 	 *
 	 * @return float
 	 */
-	public static function array_sum( array $array ): float {
-		$sanitized_array = array_map( 'floatval', $array );
+	public static function array_sum( array $arr ): float {
+		$sanitized_array = array_map( 'floatval', $arr );
 
 		return array_sum( $sanitized_array );
 	}

--- a/plugins/woocommerce/src/Utilities/NumberUtil.php
+++ b/plugins/woocommerce/src/Utilities/NumberUtil.php
@@ -9,7 +9,6 @@ namespace Automattic\WooCommerce\Utilities;
  * A class of utilities for dealing with numbers.
  */
 final class NumberUtil {
-
 	/**
 	 * Round a number using the built-in `round` function, but unless the value to round is numeric
 	 * (a number or a string that can be parsed as a number), apply 'floatval' first to it
@@ -30,5 +29,24 @@ final class NumberUtil {
 			$val = floatval( $val );
 		}
 		return round( $val, $precision, $mode );
+	}
+
+	/**
+	 * Get the sum of an array of values using the built-in array_sum function, but sanitize the array values
+	 * first to ensure they are all floats.
+	 *
+	 * This is needed because in PHP 8.3 non-numeric values that cannot be cast as an int or a float will
+	 * cause an E_WARNING to be emitted. Prior to PHP 8.3 these values were just ignored.
+	 *
+	 * Note that, unlike the built-in array_sum, this one will always return a float, never an int.
+	 *
+	 * @param array $array The array of values to sum.
+	 *
+	 * @return float
+	 */
+	public static function array_sum( array $array ): float {
+		$sanitized_array = array_map( 'floatval', $array );
+
+		return array_sum( $sanitized_array );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Utilities/NumberUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/NumberUtilTest.php
@@ -114,24 +114,24 @@ class NumberUtilTest extends \WC_Unit_Test_Case {
 	public function data_provider_for_test_array_sum(): iterable {
 		yield 'all numeric values' => array(
 			array( 0, '0', 1, '1', 1.1, '1.1', ' 1.1 ' ),
-			5.3
+			5.3,
 		);
 		yield 'all integers' => array(
 			array( 1, '1', 2, '2' ),
-			6
+			6,
 		);
 		yield 'numeric and non-numeric values' => array(
 			// "4th wall" will convert to a valid float since it begins with a number.
 			array( 1.1, '1.1', 'we 3 kings', '4th wall', null ),
-			6.2
+			6.2,
 		);
 		yield 'all non-numeric values' => array(
 			array( 'macaroni', '&', 'cheese' ),
-			0
+			0,
 		);
 		yield 'empty array' => array(
 			array(),
-			0
+			0,
 		);
 	}
 
@@ -140,9 +140,12 @@ class NumberUtilTest extends \WC_Unit_Test_Case {
 	 * values, and not triggering any warnings (especially with PHP 8.3+).
 	 *
 	 * @dataProvider data_provider_for_test_array_sum
+	 *
+	 * @param array $arr The input array for generating the actual value.
+	 * @param float $expected The expected result.
 	 */
-	public function test_array_sum( $array, $expected ) {
-		$actual_sum = NumberUtil::array_sum( $array );
+	public function test_array_sum( $arr, $expected ) {
+		$actual_sum = NumberUtil::array_sum( $arr );
 		$this->assertFloatEquals( $expected, $actual_sum );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Utilities/NumberUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/NumberUtilTest.php
@@ -8,7 +8,6 @@ use Automattic\WooCommerce\Utilities\NumberUtil;
  * A collection of tests for the string utility class.
  */
 class NumberUtilTest extends \WC_Unit_Test_Case {
-
 	/**
 	 * @testdox `round` should work as the built-in function of the same name when passing a number.
 	 */
@@ -107,5 +106,43 @@ class NumberUtilTest extends \WC_Unit_Test_Case {
 		$actual   = NumberUtil::round( true );
 		$expected = 1;
 		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Data provider for test_array_sum.
+	 */
+	public function data_provider_for_test_array_sum(): iterable {
+		yield 'all numeric values' => array(
+			array( 0, '0', 1, '1', 1.1, '1.1', ' 1.1 ' ),
+			5.3
+		);
+		yield 'all integers' => array(
+			array( 1, '1', 2, '2' ),
+			6
+		);
+		yield 'numeric and non-numeric values' => array(
+			// "4th wall" will convert to a valid float since it begins with a number.
+			array( 1.1, '1.1', 'we 3 kings', '4th wall', null ),
+			6.2
+		);
+		yield 'all non-numeric values' => array(
+			array( 'macaroni', '&', 'cheese' ),
+			0
+		);
+		yield 'empty array' => array(
+			array(),
+			0
+		);
+	}
+
+	/**
+	 * @testdox array_sum should return a sum of the numeric values in an array, ignoring non-numeric
+	 * values, and not triggering any warnings (especially with PHP 8.3+).
+	 *
+	 * @dataProvider data_provider_for_test_array_sum
+	 */
+	public function test_array_sum( $array, $expected ) {
+		$actual_sum = NumberUtil::array_sum( $array );
+		$this->assertFloatEquals( $expected, $actual_sum );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #40660 several people are reporting warnings such as the following when running on PHP 8.3:

```
PHP Warning: array_sum(): Addition is not supported on type string in /home/public_html/wp-content/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php on line 271
```

This seems to happen when for some reason a non-numeric value makes it into an array that should be all integers and floats, possibly due to legacy data that hasn't been sanitized correctly or extensions that inject incorrect data types.

Rather than fixing each case of this separately, this PR introduces a new `array_sum` method to the `NumberUtil` class that takes a similar approach to the `round` method that is already in that class. It acts as a wrapper around the built-in `array_sum`, while adding a sanitization step to ensure that all the values in the array are numeric.

Note that there are over 100 uses of `array_sum` in the WooCommerce codebase. Rather than updating every usage to the new method, which would cause this PR to have dozens of changed files and be difficult to test, as well as troubleshoot if something goes wrong, this simply fixes the usage cases that have already been reported to be problematic, as well as a few that seem especially likely to have the same issue.

Fixes #40660 

### How to test the changes in this Pull Request:

Code review, and executing the test suite under PHP 8.3, is probably the best way to assess this change. Some manual steps that can be performed for added confidence:

1. Make sure your test site is running on PHP 8.3, and that your site has `WP_DEBUG_LOG` set to true.
1. Set up a tax rate, shipping zone, and shipping method. Make sure the shipping method is marked as taxable.
2. Create an order. Add billing and shipping details that will make the order qualify for the tax rate and the shipping zone.
3. Add items to the order, including shipping.
4. Add this code snippet to your site. This will inject extra, invalid values into the shipping taxes when you make a REST API request:
    ```php
	add_filter(
		'woocommerce_order_item_get_taxes',
		function ( $value ) {
			$value['total'][] = '';
			$value['total'][] = 'asdf';
			$value['total'][] = '1,3';
	
			return $value;
		}
	);
    ```
6. Make the following request to the REST API (note that it's using **v1** of the API, not the current v3):
    ```
	curl --request GET \
		--url 'http://localhost:8888/wp-json/wc/v1/orders/53?_fields=id%2Cshipping_lines'
    ```
7. In the response, under the shipping_lines property and the taxes property within that, you should see the shipping tax you added to the order, plus the extra values injected by the code snippet. You should also see "total_tax", which should contain the correct sum of the valid tax items.
8. Now check your log file, enabled by `WP_DEBUG_LOG`. This is generally found at wp-content/debug.log. Ideally the file won't be there, because no PHP warning was logged. But if the file exists, check to make sure it does not have an entry like the one listed at the top of this PR.