### PR TITLE
Update Core Profiler Industries

### DIFF
--- a/packages/js/components/changelog/remove-scrollbar
+++ b/packages/js/components/changelog/remove-scrollbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove scrollbar when 9 items are in list

--- a/packages/js/components/src/select-control/style.scss
+++ b/packages/js/components/src/select-control/style.scss
@@ -126,7 +126,7 @@
 		top: 57px;
 		z-index: 10;
 		overflow-y: auto;
-		max-height: 350px;
+		max-height: 362px;
 
 		&.is-static {
 			position: static;

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -64,6 +64,10 @@ export const industryChoices = [
 		key: 'home_furniture_and_garden' as const,
 	},
 	{
+		label: __( 'Arts and crafts', 'woocommerce' ),
+		key: 'arts_and_crafts' as const,
+	},
+	{
 		label: __( 'Other', 'woocommerce' ),
 		key: 'other' as const,
 	},

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -68,6 +68,10 @@ export const industryChoices = [
 		key: 'arts_and_crafts' as const,
 	},
 	{
+		label: __( 'Sports and recreation', 'woocommerce' ),
+		key: 'sports_and_recreation' as const,
+	},
+	{
 		label: __( 'Other', 'woocommerce' ),
 		key: 'other' as const,
 	},

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -44,24 +44,24 @@ export const industryChoices = [
 		key: 'clothing_and_accessories' as const,
 	},
 	{
-		label: __( 'Health and beauty', 'woocommerce' ),
-		key: 'health_and_beauty' as const,
-	},
-	{
 		label: __( 'Food and drink', 'woocommerce' ),
 		key: 'food_and_drink' as const,
 	},
 	{
-		label: __( 'Home, furniture and garden', 'woocommerce' ),
-		key: 'home_furniture_and_garden' as const,
+		label: __( 'Electronics and computers', 'woocommerce' ),
+		key: 'electronics_and_computers' as const,
+	},
+	{
+		label: __( 'Health and beauty', 'woocommerce' ),
+		key: 'health_and_beauty' as const,
 	},
 	{
 		label: __( 'Education and learning', 'woocommerce' ),
 		key: 'education_and_learning' as const,
 	},
 	{
-		label: __( 'Electronics and computers', 'woocommerce' ),
-		key: 'electronics_and_computers' as const,
+		label: __( 'Home, furniture and garden', 'woocommerce' ),
+		key: 'home_furniture_and_garden' as const,
 	},
 	{
 		label: __( 'Other', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -588,6 +588,14 @@
 	}
 }
 
+@media screen and (max-height: 850px) {
+	.woocommerce-profiler-select-control__industry {
+		.woocommerce-select-control__listbox {
+			max-height: 162px;
+		}
+	}
+}
+
 // Override WP Core style where it applies padding-top: 46px
 // This style fixes devices with width between 601px and 782px (iPad and iPad Mini)
 @media screen and (min-width: 601px) and (max-width: 782px) {

--- a/plugins/woocommerce-admin/docs/features/core-profiler.md
+++ b/plugins/woocommerce-admin/docs/features/core-profiler.md
@@ -41,7 +41,7 @@ This stores the name of the store, which is used in the store header and in the 
         selling_online_answer: "yes_im_selling_online" | "no_im_selling_offline" | "im_selling_both_online_and_offline" | undefined
         selling_platforms: ("amazon" | "adobe_commerce" | "big_cartel" | "big_commerce" | "ebay" | "ecwid" | "etsy" | "facebook_marketplace" | "google_shopping" | "pinterest" | "shopify" | "square" | "squarespace" | "wix" | "wordpress")[] | undefined
         is_store_country_set: true | false
-        industry: "clothing_and_accessories" | "health_and_beauty" | "food_and_drink" | "home_furniture_and_garden" | "education_and_learning" | "electronics_and_computers" | "other"
+        industry: "clothing_and_accessories" | "health_and_beauty" | "food_and_drink" | "home_furniture_and_garden" | "education_and_learning" | "electronics_and_computers" | "arts_and_crafts" | "sports_and_recreation" | "other"
     }
     ```
 

--- a/plugins/woocommerce/changelog/update-core-profiler-industries
+++ b/plugins/woocommerce/changelog/update-core-profiler-industries
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Update core profiler industry list

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
@@ -61,12 +61,12 @@ class OnboardingIndustries {
 					'use_description'   => false,
 					'description_label' => '',
 				),
-				'sports-and-recreation'          => array(
+				'sports-and-recreation'           => array(
 					'label'             => __( 'Sports and recreation', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
-				'arts-and-crafts'          => array(
+				'arts-and-crafts'                 => array(
 					'label'             => __( 'Arts and crafts', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
@@ -61,6 +61,11 @@ class OnboardingIndustries {
 					'use_description'   => false,
 					'description_label' => '',
 				),
+				'sports-and-recreation'          => array(
+					'label'             => __( 'Sports and recreation', 'woocommerce' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
 				'arts-and-crafts'          => array(
 					'label'             => __( 'Arts and crafts', 'woocommerce' ),
 					'use_description'   => false,

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
@@ -61,6 +61,11 @@ class OnboardingIndustries {
 					'use_description'   => false,
 					'description_label' => '',
 				),
+				'arts-and-crafts'          => array(
+					'label'             => __( 'Arts and crafts', 'woocommerce' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
 				'other'                           => array(
 					'label'             => __( 'Other', 'woocommerce' ),
 					'use_description'   => true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updates the core profiler industry list in the following ways

* Re-orders industries according to popularity (most popular at the top)
* Adds more industries, "Arts and crafts" and "Sports and recreation"
* Tweaks the max height of the select component to allow 9 items in the list without a scrollbar
* Limits the height of the list to 4 items on a small screen to prevent it going over the fold

Closes #47609 and closes https://github.com/woocommerce/woocommerce/issues/47596 .

<img width="1792" alt="Screen Shot 2024-05-20 at 4 17 12 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/6e62fe7a-203a-44ea-bd07-33b4e16b4f57">

<img width="1792" alt="Screen Shot 2024-05-20 at 4 16 29 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/b436ce3a-68bd-4905-ac23-12541d36a5d5">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a fresh site, start the core profiler and stop at the "Tells us a bit about your store" screen.
2. See that the industry list is re-ordered as follows:
* Clothing and accessories
* Food and drink
* Electronics and computers
* Health and beauty
* Education and learning
* Home, furniture and garden
3. See that two more items appear above "Other"
*  "Arts and crafts"
* "Sports and recreation"
4. See that there is no scrollbar on the list in desktop view
5. Repeat the same using a mobile screen size and see that list's height is restricted to 4 items but has a scrollbar

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
