### PR TITLE
Add support for insert_or_update and use it for concurrency.

### DIFF
--- a/plugins/woocommerce/changelog/fix-concurrency-for-update
+++ b/plugins/woocommerce/changelog/fix-concurrency-for-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add support for insert_or_update for better concurrency.

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
@@ -86,4 +86,49 @@ class DatabaseUtilTest extends WC_Unit_Test_Case {
 		}
 		$this->assertTrue( $this->sut->fts_index_on_order_item_table_exists() );
 	}
+
+	/**
+	 * @testDox Insert or update works as expected.
+	 */
+	public function test_insert_or_update() {
+		global $wpdb;
+		$table_name   = $wpdb->posts;
+		$data         = array(
+			'post_title'   => 'Test Post',
+			'post_content' => 'Test Content',
+			'post_name'    => 'test-post',
+		);
+		$where        = array(
+			'post_title' => 'Test Post',
+			'post_name'  => 'test-post',
+		);
+		$format       = array( '%s', '%s', '%s' );
+		$format_where = array( '%s', '%s' );
+
+		$count_query   = "SELECT COUNT(*) FROM $table_name WHERE post_title = 'Test Post' AND post_name = 'test-post'";
+		$content_query = "SELECT post_content FROM $table_name WHERE post_title = 'Test Post' AND post_name = 'test-post'";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Hardcoded query.
+		$this->assertEquals( 0, $wpdb->get_var( $count_query ) );
+
+		$result = $this->sut->insert_or_update( $table_name, $data, $where, $format, $format_where );
+		$this->assertEquals( 1, $result );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Hardcoded query.
+		$this->assertEquals( 'Test Content', $wpdb->get_var( $content_query ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Hardcoded query.
+		$this->assertEquals( 1, $wpdb->get_var( $count_query ) );
+
+		$data['post_content'] = 'Updated Content';
+		$result               = $this->sut->insert_or_update( $table_name, $data, $where, $format, $format_where );
+		$this->assertEquals( 1, $result );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Hardcoded query.
+		$this->assertEquals( 'Updated Content', $wpdb->get_var( $content_query ) );
+
+		$result = $this->sut->insert_or_update( $table_name, $data, $where, $format, $format_where );
+		$this->assertEquals( 0, $result ); // No row updated.
+		$this->assertTrue( false !== $result ); // Ensure boolean false.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Hardcoded query.
+		$this->assertEquals( 'Updated Content', $wpdb->get_var( $content_query ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the way we update orders in HPOS from using a `INSERT INTO ... ON DUPLICATE KEY UPDATE` pattern to using `SELECT ... WHERE <unique_key condition>` and then doing an insert/update based on the results of that. This allows for better concurrency when transactions are used (such as when renewing subscriptions) and allow for more concurrent processing, since it will hold fewer locks than the `ON DUPLICATE KEY UPDATE` query.

As an example, open two different MySQL sessions and run the following queries like so:

1st session:
```sql
start transaction;
INSERT INTO wp_wc_order_addresses (order_id, address_type ) VALUES (563, 'billing')
ON DUPLICATE KEY UPDATE order_id = order_id, address_type = address_type;
INSERT INTO wp_wc_order_addresses (order_id, address_type ) VALUES (563, 'shipping')
ON DUPLICATE KEY UPDATE order_id = order_id, address_type = address_type;
```

where `563` is ID of some order. Note that we don't commit the transaction just yet (as we'd like to simulate the block).

2nd session:
```sql
start transaction;
INSERT INTO wp_wc_order_addresses (order_id, address_type ) VALUES (564, 'billing')
ON DUPLICATE KEY UPDATE order_id = order_id, address_type = address_type;
INSERT INTO wp_wc_order_addresses (order_id, address_type ) VALUES (564, 'shipping')
ON DUPLICATE KEY UPDATE order_id = order_id, address_type = address_type;
```

When executing the second session you will see that queries are not blocked, because a range lock is being held by the first group of transaction.

![Screenshot 2024-05-16 at 4 39 24 PM](https://github.com/woocommerce/woocommerce/assets/7571618/f9c076b6-3873-4d54-a8d3-5f770537b5d5)

After converting them to select...insert/update pattern, we see that queries are not blocked anymore:

First session
```sql
select id, order_id, address_type from wp_wc_order_addresses where order_id = 563 and address_type = 'billing';
update wp_wc_order_addresses set order_id = 563, address_type = 'billing' where order_id = 563 and address_type = 'billing';
select id, order_id, address_type from wp_wc_order_addresses where order_id = 563 and address_type = 'billing';
update wp_wc_order_addresses set order_id = 563, address_type = 'shipping' where order_id = 563 and address_type = 'shipping';
```
Second session

```sql
start transaction;
select id, order_id, address_type from wp_wc_order_addresses where order_id = 564 and address_type = 'billing';
update wp_wc_order_addresses set order_id = 564, address_type = 'billing' where order_id = 564 and address_type = 'billing';
select id, order_id, address_type from wp_wc_order_addresses where order_id = 564 and address_type = 'billing';
update wp_wc_order_addresses set order_id = 564, address_type = 'shipping' where order_id = 564 and address_type = 'shipping';
```


![Screenshot 2024-05-16 at 4 43 11 PM](https://github.com/woocommerce/woocommerce/assets/7571618/29eede0d-e519-418e-b320-869d5e00cf52)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that this is performance/concurrency PR, and as such no functionality is changed. For exploratory testing, with HPOS authoritative, try creating and updating orders from admin and checkout.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
