### PR TITLE
[testing worklflows] Consolidate the Slack channel used for test reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
                   fi
 
             - name: 'Send Slack notification'
-              if: github.event_name != 'pull_request'
+              if: github.event_name == 'pull_request'
               uses: automattic/action-test-results-to-slack@v0.3.0
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
                   fi
 
             - name: 'Send Slack notification'
-              if: github.event_name == 'pull_request'
+              if: github.event_name != 'pull_request'
               uses: automattic/action-test-results-to-slack@v0.3.0
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   slack_token: ${{ secrets.E2E_SLACK_TOKEN }}
-                  slack_channel: ${{ secrets.E2E_TRUNK_SLACK_CHANNEL }}
+                  slack_channel: ${{ secrets.TEST_REPORTS_SLACK_CHANNEL }}
                   playwright_report_path: ./out/test-results-*.json
                   playwright_output_dir: ./out/results-data
 
@@ -398,4 +398,4 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   slack_token: ${{ secrets.E2E_SLACK_TOKEN }}
-                  slack_channel: ${{ secrets.E2E_TRUNK_SLACK_CHANNEL }}
+                  slack_channel: ${{ secrets.TEST_REPORTS_SLACK_CHANNEL }}

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -476,7 +476,7 @@ jobs:
               id: send-slack-message
               uses: slackapi/slack-github-action@v1.23.0
               with:
-                  channel-id: ${{ secrets.DAILY_TEST_SLACK_CHANNEL }}
+                  channel-id: ${{ secrets.TEST_REPORTS_SLACK_CHANNEL }}
                   payload: ${{ steps.construct-slack-payload.outputs.payload }}
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}

--- a/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
@@ -12,6 +12,7 @@ test.describe( 'Coupons API tests', () => {
 	let couponId;
 
 	test( 'can create a coupon', async ( { request } ) => {
+		expect(1).toBe(2) // This will fail
 		//create testCoupon
 		const testCoupon = {
 			...coupon,

--- a/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
@@ -12,7 +12,6 @@ test.describe( 'Coupons API tests', () => {
 	let couponId;
 
 	test( 'can create a coupon', async ( { request } ) => {
-		expect( 1 ).toBe( 2 ); // This will fail
 		//create testCoupon
 		const testCoupon = {
 			...coupon,

--- a/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/coupons/coupons.test.js
@@ -12,7 +12,7 @@ test.describe( 'Coupons API tests', () => {
 	let couponId;
 
 	test( 'can create a coupon', async ( { request } ) => {
-		expect(1).toBe(2) // This will fail
+		expect( 1 ).toBe( 2 ); // This will fail
 		//create testCoupon
 		const testCoupon = {
 			...coupon,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).


### Changes proposed in this Pull Request:

Update the Slack channel used in all e2e tests workflows to use the same channel. This is a preparation step for future work that will consolidate all workflows into one. 

### How to test the changes in this Pull Request:

Tested by forcing a failure and updating the condition for notification to be sent on pull_request. Check the configured Slack channel.
