### PR TITLE
[ci] Only evaluate jobs statuses for pull request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
                 'project-api-test-jobs',
                 'project-performance-test-jobs'
             ]
-        if: ${{ always() && github.event_name == 'push' }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         steps:
             - uses: 'actions/checkout@v4'
               name: 'Checkout'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
                 'project-api-test-jobs',
                 'project-performance-test-jobs'
             ]
-        if: ${{ always() && github.event_name != 'pull_request' }}
+        if: ${{ always() && github.event_name == 'push' }}
         steps:
             - uses: 'actions/checkout@v4'
               name: 'Checkout'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
                 'project-api-test-jobs',
                 'project-performance-test-jobs'
             ]
-        if: ${{ always() }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         steps:
             - uses: 'actions/checkout@v4'
               name: 'Checkout'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
                 'project-api-test-jobs',
                 'project-performance-test-jobs'
             ]
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name != 'pull_request' }}
         steps:
             - uses: 'actions/checkout@v4'
               name: 'Checkout'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/47533

The scope of the 'Evaluate Project Job Statuses' job is to block PRs in case of required jobs failing. It is not needed to run on any other events than `pull_request`.

### How to test the changes in this Pull Request:

- Tested with a condition for `push` event to check the syntax works. See [this run](https://github.com/woocommerce/woocommerce/actions/runs/9159231560/job/25179293401), the job was skipped.
- Check code changes.
- Check runs for this PR, the job should run.
- To check after merging, the job should be skipped.