### PR TITLE
Use the term attribute sort order for the "Filter by attribute" block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
@@ -130,7 +130,7 @@ const AttributeFilterBlock = ( {
 			resourceName: 'products/attributes/terms',
 			resourceValues: [ attributeObject?.id || 0 ],
 			shouldSelect: blockAttributes.attributeId > 0,
-			query: { orderby: 'menu_order' },
+			query: { orderby: attributeObject.orderby },
 		} );
 
 	const { results: filteredCounts, isLoading: filteredCountsLoading } =

--- a/plugins/woocommerce-blocks/assets/js/utils/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/utils/attributes.ts
@@ -28,6 +28,7 @@ const attributeSettingToObject = ( attribute: AttributeSetting ) => {
 		name: attribute.attribute_name,
 		taxonomy: 'pa_' + attribute.attribute_name,
 		label: attribute.attribute_label,
+		orderby: attribute.attribute_orderby,
 	};
 };
 

--- a/plugins/woocommerce/changelog/47616-42417-attributes-order
+++ b/plugins/woocommerce/changelog/47616-42417-attributes-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use the term attribute sort order for displaying the "Filter by attribute" terms.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -63,6 +63,8 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	public function get_collection_params() {
 		$params                      = parent::get_collection_params();
 		$params['orderby']['enum'][] = 'menu_order';
+		$params['orderby']['enum'][] = 'name_num';
+		$params['orderby']['enum'][] = 'id';
 		return $params;
 	}
 

--- a/plugins/woocommerce/src/StoreApi/docs/product-attribute-terms.md
+++ b/plugins/woocommerce/src/StoreApi/docs/product-attribute-terms.md
@@ -5,11 +5,11 @@ GET /products/attributes/:id/terms
 GET /products/attributes/:id/terms?orderby=slug
 ```
 
-| Attribute | Type    | Required | Description                                                                                 |
-| :-------- | :------ | :------: | :------------------------------------------------------------------------------------------ |
-| `id`      | integer |   Yes    | The ID of the attribute to retrieve terms for.                                              |
-| `order`   | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                                |
-| `orderby` | string  |    no    | Sort collection by object attribute. Allowed values: `name`, `slug`, `count`, `menu_order`. |
+| Attribute | Type    | Required | Description                                                                                                   |
+| :-------- | :------ | :------: |:--------------------------------------------------------------------------------------------------------------|
+| `id`      | integer |   Yes    | The ID of the attribute to retrieve terms for.                                                                |
+| `order`   | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                                                  |
+| `orderby` | string  |    no    | Sort collection by object attribute. Allowed values: `id`, `name`, `name_num`, `slug`, `count`, `menu_order`. |
 
 ```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR uses the attribute `Default sort order` to sort the attribute terms in the `Filter by attribute` block.

Closes https://github.com/woocommerce/woocommerce/issues/42417

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `wp-admin/edit.php?post_type=product&page=product_attributes`.
2. Create a new attribute.
3. Click on `Configure terms`.
4. Create terms with the following names: `1`, `8`, and `10`.
5. Go to `Products` and assign products to the 3 terms you just created.
6. Go to the `Product Catalog` templates (`wp-admin/site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Farchive-product`).
7. Insert the `Filter by attribute` block, configure it with the attribute you created in step 2, and save.
8. Go to the `shop` page on the front-end.
9. Check the order of the terms in the filter is: `1`, `10`, `8`.
10. Go back to the list of attributes, hover over the one you just created, and click `Edit`.
11. Change the `Default sort order` to `Name (numeric)`, and save.
12. Refresh the front-end and check the order of the terms is now: `1`, `8`, `10`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Use the term attribute sort order for displaying the "Filter by attribute" terms.
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
