### PR TITLE
Correctly build up dynamic translation paths on Windows

### DIFF
--- a/plugins/woocommerce/changelog/47625-fix-translation-on-windows
+++ b/plugins/woocommerce/changelog/47625-fix-translation-on-windows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly load up Cart/Checkout translations on Windows machines.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -194,7 +194,7 @@ abstract class AbstractBlock {
 		if ( ! is_dir( $build_path . $chunks_folder ) ) {
 			return [];
 		}
-		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $chunks_folder ) ) as $block_name ) {
+		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $chunks_folder, \FilesystemIterator::UNIX_PATHS ) ) as $block_name ) {
 			$blocks[] = str_replace( $build_path, '', $block_name );
 		}
 


### PR DESCRIPTION
This PR fixes a long standing issue in our translations for windows. 

In WordPress, translations are loaded when you register a script and pass the `i18n` param to it, WordPress would use the script path, create a hash from it, and load up the correct `json` translation file for it. All good.

Cart/Checkout have several dynamic blocks that only render in frontend if needed, those scripts don't go via WordPress script process, yet we still want to load the translation for them, to do that, we traverse the build folder for cart/checkout, build up the script path, register a fake script, and ask WordPress to load translation for it.

The issue here is that the function we used to traverse files would return a platform dependent slash (backward slash for Mac), this would cause the hash to be inconsistent, because the original hash is created on wordpress.org on a linux system, and the fake one is created locally with a windows provided path.

What we did is simply ask the `RecursiveDirectoryIterator` to always return a linux path.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/43185
Closes https://github.com/woocommerce/woocommerce/issues/45438

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->
To fully test this, you need a windows machine, @opr helped me here.

1. On Windows, change the website translation to french.
2. In Updates `wp-admin/update-core.php`, make sure translations are up to date.
3. Add a product to cart, Go to Checkout page, make sure all strings are in French.

#### Regression testing.

1. On a Mac/Linux setup, change the website translation to french.
2. In Updates `wp-admin/update-core.php`, make sure translations are up to date.
3. Add a product to cart, Go to Checkout page, make sure all strings are in French.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Correctly load up Cart/Checkout translations on Windows machines.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
