### PR TITLE
Add `is-busy` animation to save changes button in settings

### DIFF
--- a/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
+++ b/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
@@ -61,7 +61,7 @@
 
 body.woocommerce-admin-page {
 	.components-button.is-primary {
-		&:not(.woocommerce-save-button):not(:disabled):not([aria-disabled="true"]):hover {
+		&:not(:disabled):not([aria-disabled="true"]):hover {
 			color: $studio-white;
 		}
 	}

--- a/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
+++ b/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
@@ -61,7 +61,7 @@
 
 body.woocommerce-admin-page {
 	.components-button.is-primary {
-		&:not(:disabled):not([aria-disabled="true"]):hover {
+		&:not(.woocommerce-save-button):not(:disabled):not([aria-disabled="true"]):hover {
 			color: $studio-white;
 		}
 	}

--- a/plugins/woocommerce/changelog/tweak-save-button-loading-animation
+++ b/plugins/woocommerce/changelog/tweak-save-button-loading-animation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add busy animation for save button in settings screen

--- a/plugins/woocommerce/client/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings.js
@@ -261,5 +261,11 @@
 				available_payment_methods: payment_methods,
 			} );
 		} );
+
+		$( '.woocommerce-save-button.components-button' ).on( 'click', function ( e ) {
+			if ( ! $( this ).attr( 'disabled' ) ) {
+				$( this ).addClass( 'is-busy' );
+			}
+		} );
 	} );
 } )( jQuery, woocommerce_settings_params, wp );

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -203,6 +203,7 @@
 					$( '.tips' ).tipTip({ 'attribute': 'data-tip', 'fadeIn': 50, 'fadeOut': 50, 'delay': 50 });
 				},
 				onSubmit: function( event ) {
+					$save_button.addClass( 'is-busy' );
 					event.data.view.block();
 					event.data.view.model.save();
 					event.preventDefault();
@@ -269,7 +270,6 @@
 				clearUnloadConfirmation: function() {
 					this.needsUnloadConfirm = false;
 					$save_button.attr( 'disabled', 'disabled' );
-					$save_button.addClass( 'is-busy' );
 				},
 				unloadConfirmation: function( event ) {
 					if ( event.data.view.needsUnloadConfirm ) {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -467,7 +467,9 @@
 
 					priceInputs.addClass( `wc-shipping-currency-size-${ symbol.length }` );
 					priceInputs.addClass( `wc-shipping-currency-position-${ symbolPosition }` );
-					priceInputs.before( `<div class="wc-shipping-zone-method-currency wc-shipping-currency-position-${ symbolPosition }">${ symbol }</div>` );
+					priceInputs.before(
+						`<div class="wc-shipping-zone-method-currency wc-shipping-currency-position-${ symbolPosition }">${ symbol }</div>`
+					);
 
 					priceInputs.each( ( i ) => {
 						const priceInput = $( priceInputs[ i ] );
@@ -480,7 +482,11 @@
 				},
 				moveHTMLHelpTips: function( html ) {
 					// These help tips aren't moved.
-					const helpTipsToRetain = [ 'woocommerce_flat_rate_cost', 'woocommerce_flat_rate_no_class_cost', 'woocommerce_flat_rate_class_cost_' ];
+					const helpTipsToRetain = [
+						'woocommerce_flat_rate_cost',
+						'woocommerce_flat_rate_no_class_cost',
+						'woocommerce_flat_rate_class_cost_'
+					];
 
 					const htmlContent = $( html );
 					const labels = htmlContent.find( 'label' );
@@ -500,7 +506,8 @@
 							return;
 						}
 
-						// woocommerce_free_shipping_ignore_discounts gets a helpTip appended to its label. Otherwise, add the text as the last element in the fieldset.
+						// woocommerce_free_shipping_ignore_discounts gets a helpTip appended to its label.
+						// Otherwise, add the text as the last element in the fieldset.
 						if ( id === 'woocommerce_free_shipping_ignore_discounts' ) {
 							const input = htmlContent.find( `#${ id }` );
 							const fieldset = input.closest( 'fieldset' );
@@ -566,7 +573,8 @@
 									}
 								}
 
-								// Avoid triggering a rerender here because we don't want to show the method in the table in case merchant doesn't finish flow.
+								// Avoid triggering a rerender here because we don't want to show the method
+								// in the table in case merchant doesn't finish flow.
 								
 								shippingMethodView.model.set( 'methods', response.data.methods );
 

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -264,10 +264,12 @@
 				setUnloadConfirmation: function() {
 					this.needsUnloadConfirm = true;
 					$save_button.prop( 'disabled', false );
+					$save_button.removeClass( 'is-busy' );
 				},
 				clearUnloadConfirmation: function() {
 					this.needsUnloadConfirm = false;
 					$save_button.attr( 'disabled', 'disabled' );
+					$save_button.addClass( 'is-busy' );
 				},
 				unloadConfirmation: function( event ) {
 					if ( event.data.view.needsUnloadConfirm ) {

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -90,7 +90,7 @@ do_action( 'woocommerce_shipping_zone_before_methods_table', $zone );
 		<tr>
 			<th scope="row"></th>
 			<td>
-				<button type="submit" class="button button-primary wc-shipping-zone-add-method" value="<?php esc_attr_e( 'Add shipping method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add shipping method', 'woocommerce' ); ?></button>
+				<button type="submit" class="wc-shipping-zone-add-method components-button is-primary" value="<?php esc_attr_e( 'Add shipping method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add shipping method', 'woocommerce' ); ?></button>
 			</td>
 		</tr>
 	</tbody>
@@ -102,7 +102,7 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 ?>
 
 <p class="submit">
-	<button type="submit" name="submit" id="submit" class="button button-primary button-large wc-shipping-zone-method-save" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>" disabled><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
+	<button type="submit" name="submit" id="submit" class="button-primary button-large wc-shipping-zone-method-save components-button is-primary" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>" disabled><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
 </p>
 
 <script type="text/html" id="tmpl-wc-shipping-zone-method-row-blank">

--- a/plugins/woocommerce/includes/admin/views/html-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-settings.php
@@ -42,7 +42,7 @@ if ( ! $tab_exists ) {
 		?>
 		<p class="submit">
 			<?php if ( empty( $GLOBALS['hide_save_button'] ) ) : ?>
-				<button name="save" class="button-primary woocommerce-save-button" type="submit" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
+				<button name="save" class="woocommerce-save-button components-button is-primary" type="submit" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
 			<?php endif; ?>
 			<?php wp_nonce_field( 'woocommerce-settings' ); ?>
 		</p>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [#47305](https://github.com/woocommerce/woocommerce/issues/47305)

This PR attempts to add loading animations to Settings screen by hitchhiking CSS classes provided by Gutenberg components. This is meant to be an acceptable temporary UX improvment while we work on settings UI refresh.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Settings > General`
2. Click on `Save changes`
1. Go to `WooCommerce > Settings > Site visibility`
2. Click on any toggle to enable save button
3. Click on `Save changes`
4. Observe busy loading animations
5. Go to `WooCommerce > Settings > Shipping`
6. Click on `Add zone`
7. Observe `Save changes` and `Add shipping method` button is slightly larger
7. Enter a zone name
8. Save to see the busy animation, but most likely it's too quick to be observed
9. Test other settings screens and ensure nothing around saving is broken


https://github.com/woocommerce/woocommerce/assets/3747241/df95f182-9a15-45a7-8881-be5ccafd4363



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>