### PR TITLE
Only validate fields present in Store API schema

### DIFF
--- a/plugins/woocommerce/changelog/47633-fix-email-in-address-warning
+++ b/plugins/woocommerce/changelog/47633-fix-email-in-address-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an issue in which a warning is emitted when placing an order using Checkout block.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -118,10 +118,12 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$validation_util   = new ValidationUtils();
 		$sanitization_util = new SanitizationUtils();
 		$address           = (array) $address;
-		$field_schema      = $this->get_properties();
-		$address           = array_reduce(
+		$schema            = $this->get_properties();
+		// omit all keys from address that are not in the schema. This should account for email.
+		$address = array_intersect_key( $address, $schema );
+		$address = array_reduce(
 			array_keys( $address ),
-			function ( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
+			function ( $carry, $key ) use ( $address, $validation_util, $schema ) {
 				switch ( $key ) {
 					case 'country':
 						$carry[ $key ] = wc_strtoupper( sanitize_text_field( wp_unslash( $address[ $key ] ) ) );
@@ -133,7 +135,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 						$carry[ $key ] = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
 						break;
 					default:
-						$carry[ $key ] = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $field_schema[ $key ], $key );
+						$carry[ $key ] = rest_sanitize_value_from_schema( wp_unslash( $address[ $key ] ), $schema[ $key ], $key );
 						break;
 				}
 				if ( $this->additional_fields_controller->is_field( $key ) ) {
@@ -238,16 +240,14 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 				continue;
 			}
 
-			$properties = $this->get_properties();
-
 			// Only run specific validation on properties that are defined in the schema and present in the address.
 			// This is for partial address pushes when only part of a customer address is sent.
 			// Full schema address validation still happens later, so empty, required values are disallowed.
-			if ( empty( $properties[ $key ] ) || empty( $address[ $key ] ) ) {
+			if ( empty( $schema[ $key ] ) || empty( $address[ $key ] ) ) {
 				continue;
 			}
 
-			$result = rest_validate_value_from_schema( $address[ $key ], $properties[ $key ], $key );
+			$result = rest_validate_value_from_schema( $address[ $key ], $schema[ $key ], $key );
 
 			// Check if a field is in the list of additional fields then validate the value against the custom validation rules defined for it.
 			// Skip additional validation if the schema validation failed.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -119,9 +119,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$sanitization_util = new SanitizationUtils();
 		$address           = (array) $address;
 		$field_schema      = $this->get_properties();
-		// omit all keys from address that are not in the schema. This should account for email.
-		$address = array_intersect_key( $address, $field_schema );
-		$address = array_reduce(
+		$address           = array_reduce(
 			array_keys( $address ),
 			function ( $carry, $key ) use ( $address, $validation_util, $field_schema ) {
 				switch ( $key ) {
@@ -164,6 +162,8 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$address         = (array) $address;
 		$validation_util = new ValidationUtils();
 		$schema          = $this->get_properties();
+		// omit all keys from address that are not in the schema. This should account for email.
+		$address = array_intersect_key( $address, $schema );
 
 		// The flow is Validate -> Sanitize -> Re-Validate
 		// First validation step is to ensure fields match their schema, then we sanitize to put them in the


### PR DESCRIPTION
This PR is a follow up to https://github.com/woocommerce/woocommerce/pull/45394

Previously, when copying billing to shipping, we also copied the email, but skipped it in sanitize, that seems to have solved the problem, but it now popped up again in validate.


### How to test the changes in this Pull Request:

1. Add an item to cart, go to checkout.
2. Fill out all your details, including shipping and billing.
3. Place an order, make sure the following warning is not logged in:
```
PHP Warning:  Undefined array key "email" in monorepo/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php on line 173
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Fix an issue in which a warning is emitted when placing an order using Checkout block.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
