### PR TITLE
Run wc_update_900_add_launch_your_store_tour_option on WC 9.0 update

### DIFF
--- a/plugins/woocommerce/changelog/47634-update-apply-coming-soon-mode-db-update-for-9
+++ b/plugins/woocommerce/changelog/47634-update-apply-coming-soon-mode-db-update-for-9
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add a new update function for WC 9.0 to add woocommerce_show_lys_tour option.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -256,7 +256,7 @@ class WC_Install {
 			'wc_update_891_create_plugin_autoinstall_history_option',
 		),
 		'9.0.0' => array(
-			'wc_update_900_add_launch_your_store_tour_option'
+			'wc_update_900_add_launch_your_store_tour_option',
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -255,6 +255,9 @@ class WC_Install {
 		'8.9.1' => array(
 			'wc_update_891_create_plugin_autoinstall_history_option',
 		),
+		'9.0.0' => array(
+			'wc_update_900_add_launch_your_store_tour_option'
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2731,4 +2731,3 @@ function wc_update_891_create_plugin_autoinstall_history_option() {
 function wc_update_900_add_launch_your_store_tour_option() {
 	add_option( 'woocommerce_show_lys_tour', 'yes' );
 }
-

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2724,3 +2724,11 @@ function wc_update_891_create_plugin_autoinstall_history_option() {
 		}
 	}
 }
+
+/**
+ * Add woocommerce_show_lys_tour.
+ */
+function wc_update_900_add_launch_your_store_tour_option() {
+	update_option( 'woocommerce_show_lys_tour', 'yes' );
+}
+

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2729,6 +2729,6 @@ function wc_update_891_create_plugin_autoinstall_history_option() {
  * Add woocommerce_show_lys_tour.
  */
 function wc_update_900_add_launch_your_store_tour_option() {
-	update_option( 'woocommerce_show_lys_tour', 'yes' );
+	add_option( 'woocommerce_show_lys_tour', 'yes' );
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47603 .


This PR adds a new update function to add `woocommerce_show_lys_tour` option on WC 9.0 update.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an empty JN site.
1. Install WC 8.9.0
2. Checkout this branch locally and build a zip by running `pnpm run build:zip` in `plugins/woocommerce` directory.
3. Upload the zip and activate WooCommerce.
4. Confirm `woocommerce_show_lys_tour` option exist. 
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a new update function for WC 9.0 to add woocommerce_show_lys_tour option.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
