### PR TITLE
Product Gallery block: Fix error on revisiting template without reloading the page

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/blocks-registration-manager/template-change-detector.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/blocks-registration-manager/template-change-detector.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { subscribe, select } from '@wordpress/data';
+import { subscribe } from '@wordpress/data';
 import { getPath, getQueryArg } from '@wordpress/url';
 import { isNumber } from '@woocommerce/types';
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/blocks-registration-manager/template-change-detector.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/blocks-registration-manager/template-change-detector.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { subscribe, select } from '@wordpress/data';
+import { getPath, getQueryArg } from '@wordpress/url';
 import { isNumber } from '@woocommerce/types';
 
 interface TemplateChangeDetectorSubject {
@@ -81,6 +82,20 @@ export class TemplateChangeDetector implements TemplateChangeDetectorSubject {
 		return templateId?.split( '//' )[ 1 ];
 	}
 
+	private getCurrentTemplateIdFromUrl( url: string ): string | undefined {
+		const path = getPath( url );
+		const isTemplatePage = path
+			? path.includes( 'site-editor.php' )
+			: false;
+		let templateId;
+
+		if ( isTemplatePage ) {
+			templateId = getQueryArg( url, 'postId' );
+		}
+
+		return templateId as string;
+	}
+
 	/**
 	 * Checks if the current template or page has changed and notifies subscribers.
 	 *
@@ -95,11 +110,10 @@ export class TemplateChangeDetector implements TemplateChangeDetectorSubject {
 
 		this.isPostOrPage = Boolean( postOrPageId );
 
-		const editedPostId =
-			postOrPageId ||
-			select( 'core/edit-site' )?.getEditedPostId<
-				string | number | undefined
-			>();
+		const editedPostId = this.getCurrentTemplateIdFromUrl(
+			window.location.href
+		);
+
 		this.currentTemplateId = this.parseTemplateId( editedPostId );
 
 		const hasChangedTemplate =

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/blocks-registration-manager/template-change-detector.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/blocks-registration-manager/template-change-detector.ts
@@ -104,17 +104,11 @@ export class TemplateChangeDetector implements TemplateChangeDetectorSubject {
 	public checkIfTemplateHasChangedAndNotifySubscribers(): void {
 		this.previousTemplateId = this.currentTemplateId;
 
-		const postOrPageId = select( 'core/editor' )?.getCurrentPostId<
-			string | number | undefined
-		>();
-
-		this.isPostOrPage = Boolean( postOrPageId );
-
-		const editedPostId = this.getCurrentTemplateIdFromUrl(
+		const templateId = this.getCurrentTemplateIdFromUrl(
 			window.location.href
 		);
 
-		this.currentTemplateId = this.parseTemplateId( editedPostId );
+		this.currentTemplateId = this.parseTemplateId( templateId );
 
 		const hasChangedTemplate =
 			this.previousTemplateId !== this.currentTemplateId;

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -83,8 +83,9 @@ const getThumbnailImageIdByNth = async (
 };
 
 test.describe( `${ blockData.name }`, () => {
+	let template;
 	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
-		const template = await requestUtils.createTemplate( 'wp_template', {
+		template = await requestUtils.createTemplate( 'wp_template', {
 			slug: blockData.slug,
 			title: 'Custom Single Product',
 			content: 'placeholder',
@@ -599,5 +600,28 @@ test.describe( `${ blockData.name }`, () => {
 		expect(
 			width === height + 1 || width === height - 1 || width === height
 		).toBeTruthy();
+	} );
+
+	test( 'should persistently display the block when navigating back to the template without a page reload', async ( {
+		editor,
+		pageObject,
+		page,
+	} ) => {
+		await pageObject.addProductGalleryBlock( { cleanContent: true } );
+		await editor.saveSiteEditorEntities();
+
+		await page.getByLabel( 'Open Navigation' ).click();
+		await page.getByLabel( 'Back' ).click();
+		await page
+			.getByRole( 'button', { name: 'Custom Single Product' } )
+			.click();
+
+		const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
+
+		const productGalleryBlock = editorFrame.getByLabel(
+			'Block: Product Gallery (Beta)'
+		);
+
+		await expect( productGalleryBlock ).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -83,9 +83,8 @@ const getThumbnailImageIdByNth = async (
 };
 
 test.describe( `${ blockData.name }`, () => {
-	let template;
 	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
-		template = await requestUtils.createTemplate( 'wp_template', {
+		const template = await requestUtils.createTemplate( 'wp_template', {
 			slug: blockData.slug,
 			title: 'Custom Single Product',
 			content: 'placeholder',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -611,12 +611,22 @@ test.describe( `${ blockData.name }`, () => {
 		await editor.saveSiteEditorEntities();
 
 		await page.getByLabel( 'Open Navigation' ).click();
-		await page.getByLabel( 'Back' ).click();
+		const navigationSidebar = page.getByLabel( 'Navigation' );
+		const navigationBackButton = navigationSidebar.getByLabel( 'Back' );
+		await expect( navigationBackButton ).toBeVisible();
+		await navigationSidebar.getByLabel( 'Back' ).click();
+		await page.getByRole( 'button', { name: 'Index' } ).click();
+
+		const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
+		const headerTitle = editorFrame.getByRole( 'document', {
+			name: 'Block: Site Title',
+		} );
+		await expect( headerTitle ).toBeVisible();
+
+		await navigationSidebar.getByLabel( 'Back' ).click();
 		await page
 			.getByRole( 'button', { name: 'Custom Single Product' } )
 			.click();
-
-		const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
 
 		const productGalleryBlock = editorFrame.getByLabel(
 			'Block: Product Gallery (Beta)'

--- a/plugins/woocommerce/changelog/47636-fix-46274-product-gallery-error-on-revisit-page
+++ b/plugins/woocommerce/changelog/47636-fix-46274-product-gallery-error-on-revisit-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix Product Gallery block error on revisiting Single Product template without fully reloading the page.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In this PR, I've changed the way we identify the current selected template. Previously, we relied on the WP Data stores. However, I noticed that when we leave the template and revisit the page using the Navigation sidebar instead of reloading the page, the state wasn't correctly updated. This meant that the template detector didn't trigger a template change, and consequently, the Product Gallery block wasn't registered on the Single Product template.

With this change, we now detect the current template from the URL, which always points to the correct template. I've also added an E2E test to cover this change and catch similar errors in the future.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46274 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Single Product template (Appearance > Editor > Templates > Product Catalog template - or any archive template).
2. Click on "Edit" to open the WordPress editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block". Click on it.
4. Search for "Product Gallery (Beta)" in the block inserter or browse the available blocks until you find them. Add it to your content.
5. Click on the Save button.
6. Click on the WordPress logo at the top left corner - to open the Navigation sidebar.
7. Click on the Back button - to go back to the templates list.
8. Visit another template, for example: click on the Index template. Wait for the template to load.
9. On the Navigation sidebar, click on the Back button again to visit the templates list.
10. Visit the Single Product template.
11. Make sure you can see the Product Gallery block that was previously added and no block error is shown in the editor.

| Before | After |
|--------|--------|
| ![CleanShot 2024-05-21 at 17 31 28@2x](https://github.com/woocommerce/woocommerce/assets/20469356/733c735f-05d8-4e84-b1ba-80df3397fdc6) | ![CleanShot 2024-05-21 at 17 29 40@2x](https://github.com/woocommerce/woocommerce/assets/20469356/f46e618f-2907-4ac3-a228-94d1c070bdce) | 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix Product Gallery block error on revisiting Single Product template without fully reloading the page.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
