### PR TITLE
Add order attribution GA4 UTM parameters

### DIFF
--- a/plugins/woocommerce/changelog/add-order-attribution-ga4-utm-parameters
+++ b/plugins/woocommerce/changelog/add-order-attribution-ga4-utm-parameters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds 3 additional UTM parameters recognized in GA4 documentation.

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -26,23 +26,26 @@ trait OrderAttributionMeta {
 	 * */
 	private $default_fields = array(
 		// main fields.
-		'source_type'        => 'current.typ',
-		'referrer'           => 'current_add.rf',
+		'source_type'          => 'current.typ',
+		'referrer'             => 'current_add.rf',
 
 		// utm fields.
-		'utm_campaign'       => 'current.cmp',
-		'utm_source'         => 'current.src',
-		'utm_medium'         => 'current.mdm',
-		'utm_content'        => 'current.cnt',
-		'utm_id'             => 'current.id',
-		'utm_term'           => 'current.trm',
+		'utm_campaign'         => 'current.cmp',
+		'utm_source'           => 'current.src',
+		'utm_medium'           => 'current.mdm',
+		'utm_content'          => 'current.cnt',
+		'utm_id'               => 'current.id',
+		'utm_term'             => 'current.trm',
+		'utm_source_platform'  => 'current.plt',
+		'utm_creative_format'  => 'current.fmt',
+		'utm_marketing_tactic' => 'current.tct',
 
 		// additional fields.
-		'session_entry'      => 'current_add.ep',
-		'session_start_time' => 'current_add.fd',
-		'session_pages'      => 'session.pgs',
-		'session_count'      => 'udata.vst',
-		'user_agent'         => 'udata.uag',
+		'session_entry'        => 'current_add.ep',
+		'session_start_time'   => 'current_add.fd',
+		'session_pages'        => 'session.pgs',
+		'session_count'        => 'udata.vst',
+		'user_agent'           => 'udata.uag',
 	);
 
 	/** @var array */

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -66,7 +66,6 @@ defined( 'ABSPATH' ) || exit;
 		<?php if ( array_key_exists( 'utm_source', $meta ) ) : ?>
 			<h4>
 				<?php esc_html_e( 'Source', 'woocommerce' ); ?>
-
 			</h4>
 			<span class="order-attribution-utm-source">
 				<?php echo esc_html( $meta['utm_source'] ); ?>
@@ -82,11 +81,11 @@ defined( 'ABSPATH' ) || exit;
 			</span>
 		<?php endif; ?>
 
-		<?php if ( array_key_exists('utm_source_platform', $meta ) ) : ?>
-		<h4>
-			<?php esc_html_e( 'Source platform', 'woocommerce' ); ?>
-		</h4>
-		<span class="order-attribution-utm-source-platform">
+		<?php if ( array_key_exists( 'utm_source_platform', $meta ) ) : ?>
+			<h4>
+				<?php esc_html_e( 'Source platform', 'woocommerce' ); ?>
+			</h4>
+			<span class="order-attribution-utm-source-platform">
 				<?php echo esc_html( $meta['utm_source_platform'] ); ?>
 			</span>
 		<?php endif; ?>

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -6,7 +6,7 @@
  *
  * @see     Automattic\WooCommerce\Internal\Orders\OrderAttributionController
  * @package WooCommerce\Templates
- * @version 8.6.0-dev
+ * @version 9.0.0
  */
 
 declare( strict_types=1 );

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -82,6 +82,33 @@ defined( 'ABSPATH' ) || exit;
 			</span>
 		<?php endif; ?>
 
+		<?php if ( array_key_exists('utm_source_platform', $meta ) ) : ?>
+		<h4>
+			<?php esc_html_e( 'Source platform', 'woocommerce' ); ?>
+		</h4>
+		<span class="order-attribution-utm-source-platform">
+				<?php echo esc_html( $meta['utm_source_platform'] ); ?>
+			</span>
+		<?php endif; ?>
+
+		<?php if ( array_key_exists( 'utm_creative_format', $meta ) ) : ?>
+			<h4>
+				<?php esc_html_e( 'Creative format', 'woocommerce' ); ?>
+			</h4>
+			<span class="order-attribution-utm-creative-format">
+				<?php echo esc_html( $meta['utm_creative_format'] ); ?>
+			</span>
+		<?php endif; ?>
+
+		<?php if ( array_key_exists( 'utm_marketing_tactic', $meta ) ) : ?>
+			<h4>
+				<?php esc_html_e( 'Marketing tactic', 'woocommerce' ); ?>
+			</h4>
+			<span class="order-attribution-utm-marketing-tactic">
+				<?php echo esc_html( $meta['utm_marketing_tactic'] ); ?>
+			</span>
+		<?php endif; ?>
+
 	</div>
 
 	<?php if ( array_key_exists( 'device_type', $meta ) ) : ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the 3 new UTM parameters captured by default in Sourcebuster, and stores with with the order data. They're also presented in the dropdown on the order edit for when present.

The parameters are:
- `utm_source_platform`
- `utm_creative_format`
- `utm_marketing_tactic`

See the Sourcebuster PR for more information: https://github.com/woocommerce/sourcebuster-js/pull/7

### How to test the changes in this Pull Request:

Summary: visit the shop with the new UTM parameters, complete a checkout. Confirm no errors, data is available in JS console, data is visible in Orders edit page. Confirm fields don't appear for purchases without those parameters. Test with both checkout types.
1. Visit the shop with a URL with the new parameters, like `site.com/shop/?utm_source=github_pr_test&utm_medium=cpc&utm_campaign=wc-testing&utm_term=SpécialChärs🐶&utm_content=ad1&utm_id=20110927&utm_source_platform=gads&utm_creative_format=img&utm_marketing_tactic=rkt`
2. Check that all the params are captured:
    In the dev console, execute `wc_order_attribution.getAttributionData()` and confirm that all the UTM parameters are present and have the correct value in the result (especially these 3 new params):
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/d3153433-d024-4a93-a18b-a6bbb2d01d3a)
4. Complete checkout, then view the order in the admin panel.
5. Confirm the new UTM parameter values are visible in the expanded **Details** values:
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/be8166f2-d337-42da-a4b7-52d96dd3128a)
6. In a new browser session, visit with a subset of UTM params and make a purchase (`site.com/shop/?utm_source=github_pr_test2`)
7. Confirm that the new parameters are no longer present in the dropdown
6. Change the checkout type (Classic↔Block) and repeat all steps (since attribution data is sent differently depending on checkout type).
    ![image](https://github.com/woocommerce/woocommerce/assets/228780/093ab10b-315c-47df-83af-55bd1925f7e3)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
