### PR TITLE
Fix positioning of search filter in orders admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-44129
+++ b/plugins/woocommerce/changelog/fix-44129
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix orders search filter position in admin list table.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2966,9 +2966,9 @@ ul.wc_coupon_list_block {
 		display: none;
 	}
 
-	select.search-filter {
-		margin-right: 4px;
-		margin-bottom: 3px;
+	select#order-search-filter {
+		margin: 0 4px 0 0;
+		float: left;
 	}
 
 	.tablenav {
@@ -3366,6 +3366,10 @@ ul.wc_coupon_list_block {
 }
 
 @media screen and (max-width: 782px) {
+	.woocommerce_page_wc-orders #order-search-filter {
+		display: none;
+	}
+
 	.wc-order-preview footer {
 		.wc-action-button-group .wc-action-button-group__items {
 			display: flex;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR addresses a misalignment in the orders search filter available on the HPOS orders screen in the admin.

Closes #44129.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build the WC plugin to make sure assets are built and linked.
2. Make sure HPOS is set as datastore in WC > Settings > Advanced > Features.
3. Go to WC > Orders.
4. Confirm that the search filter lines up correctly with the surrounding input and buttons:
   <img width="466" alt="Screenshot 2024-05-20 at 20 03 15" src="https://github.com/woocommerce/woocommerce/assets/184724/a2431a49-9e16-4b69-aa39-afd401b0e116">
5. Reduce the window size until it is less than ~780px so that the UI adapts to the new size.
6. Confirm that in this setting, the filter is hidden:
   <img width="711" alt="Screenshot 2024-05-20 at 20 03 22" src="https://github.com/woocommerce/woocommerce/assets/184724/f0bc2ea4-63a1-4449-bd04-32b5311045b4">

    

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
