### PR TITLE
Fix activation limit for single license subscriptions on woocommerce.com

### DIFF
--- a/plugins/woocommerce/changelog/47643-fix-woocommerce.com-single-license-activation
+++ b/plugins/woocommerce/changelog/47643-fix-woocommerce.com-single-license-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix activation limit for single license subscriptions on woocommerce.com

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1823,7 +1823,7 @@ class WC_Helper {
 			}
 
 			// No more sites available in this subscription.
-			if ( $_sub['maxed'] ) {
+			if ( isset( $_sub['maxed'] ) && $_sub['maxed'] ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1823,7 +1823,7 @@ class WC_Helper {
 			}
 
 			// No more sites available in this subscription.
-			if ( $_sub['sites_max'] && $_sub['sites_active'] >= $_sub['sites_max'] ) {
+			if ( $_sub['maxed'] ) {
 				continue;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to 19979-gh-Automattic/woocommerce.com

When activating single license products on woocommerce.com, we provide a grace of 2 license activations. This is to facilitate use of staging or development sites. The current activation logic checking for max activations does not check for the correct `maxed` property in the response body. This PR fixes that.

### How to test the changes in this Pull Request:

First, please replicate the bug:

1. Create a WooCommerce site and connect it to your woocommerce.com account (JN may help).
2. Make sure you have a single license product in your account.
3. Go to [the subscriptions page](https://woocommerce.com/my-account/my-subscriptions/) and activate the product on one site.
4. Go to the sites My Subscriptions page (WooCommerce > Extensions > My Subscriptions), refresh and ensure that the product is connected.
5. Now, activate the license on the second site.
6. When you go to this site's My Subscriptions page, you'll notice that it's not connected.

There is a video recording of the bug here:

https://github.com/woocommerce/woocommerce/assets/533/4a031b2e-f83a-40be-a104-09f49308e262

Now, replicate the fix:

1. On one of your sites, ensure that WooCommerce is installed [with the version in this branch](https://github.com/woocommerce/woocommerce/files/15385906/woocommerce.zip).
3. Replicate steps above and make sure that the second site you choose has the updated version in this branch.
4. Make sure that both licenses are now active.

**Note**: if these steps do not work, it may be that your subscriptions are cached. Disconnect and reconnect your site from woocommerce.com to flush the cache.

Make sure more than two licenses are not allowed.
1. Create a third site with the [WooCommerce version installed in the branch](https://github.com/woocommerce/woocommerce/files/15385906/woocommerce.zip).
2. You can still use back->forward buttons from previous activations to go to the Add site page (since the UI will now block further activations).
3. Ensure that the product is not installed (installation should fail).

<!-- End testing instructions -->