### PR TITLE
Product Block Editor: adjust the attribute modal height based on attribute options

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-increase-attribute-row-according-to-options
+++ b/packages/js/product-editor/changelog/update-product-editor-increase-attribute-row-according-to-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Block Editor: change attribute row based on the form token field component

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, useEffect, useRef, useState } from '@wordpress/element';
+import { createElement, useEffect, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import {
 	Button,
@@ -39,7 +39,6 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 	onNewAttributeAdd,
 	onAttributeSelect,
 
-	termLabel = undefined,
 	termPlaceholder,
 	onTermsSelect,
 
@@ -200,40 +199,19 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 		onTermsSelect( [ ...selectedTerms, ...newItems ], index, attribute );
 	}
 
-	const rowElementRef = useRef< HTMLTableRowElement >( null );
-
 	/*
-	 * Visual hack to tweak the row height
-	 * when the token field is expanded
+	 * Check if there are available suggestions
+	 * to show the values column,
+	 * comparing the suggestions length with the selected values length.
 	 */
-	useEffect( () => {
-		if ( ! rowElementRef.current ) {
-		}
-
-		const tokenFieldElement = rowElementRef.current?.querySelector(
-			'.components-form-token-field'
-		) as HTMLElement;
-
-		const optionsWrapperElement = tokenFieldElement?.querySelector(
-			'.components-form-token-field__input-container .components-flex'
-		);
-
-		if ( ! tokenFieldElement || ! optionsWrapperElement ) {
-			return;
-		}
-
-		// Options wrapper height
-		const height = optionsWrapperElement.clientHeight;
-
-		// Set the height of the token field
-		tokenFieldElement.style.height = `${ height }px`;
-	}, [ selectedValues ] ); // need to know the height when the selected values change
+	const hasAvailableSuggestions =
+		suggestions?.length &&
+		suggestions.length > ( selectedValues?.length || 0 );
 
 	return (
 		<tr
 			key={ index }
 			className={ `woocommerce-new-attribute-modal__table-row woocommerce-new-attribute-modal__table-row-${ index }` }
-			ref={ rowElementRef }
 		>
 			<td className="woocommerce-new-attribute-modal__table-attribute-column">
 				<AttributesComboboxControl
@@ -257,9 +235,12 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 				/>
 			</td>
 
-			<td className="woocommerce-new-attribute-modal__table-attribute-value-column">
+			<td
+				className={ `woocommerce-new-attribute-modal__table-attribute-value-column${
+					hasAvailableSuggestions ? ' has-values' : ''
+				}` }
+			>
 				<FormTokenField
-					label={ termLabel }
 					placeholder={ termPlaceholder }
 					disabled={ ! attribute }
 					suggestions={ suggestions }

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, useEffect, useState } from '@wordpress/element';
+import { createElement, useEffect, useRef, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import {
 	Button,
@@ -200,10 +200,40 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 		onTermsSelect( [ ...selectedTerms, ...newItems ], index, attribute );
 	}
 
+	const rowElementRef = useRef< HTMLTableRowElement >( null );
+
+	/*
+	 * Visual hack to tweak the row height
+	 * when the token field is expanded
+	 */
+	useEffect( () => {
+		if ( ! rowElementRef.current ) {
+		}
+
+		const tokenFieldElement = rowElementRef.current?.querySelector(
+			'.components-form-token-field'
+		) as HTMLElement;
+
+		const optionsWrapperElement = tokenFieldElement?.querySelector(
+			'.components-form-token-field__input-container .components-flex'
+		);
+
+		if ( ! tokenFieldElement || ! optionsWrapperElement ) {
+			return;
+		}
+
+		// Options wrapper height
+		const height = optionsWrapperElement.clientHeight;
+
+		// Set the height of the token field
+		tokenFieldElement.style.height = `${ height }px`;
+	}, [ selectedValues ] ); // need to know the height when the selected values change
+
 	return (
 		<tr
 			key={ index }
 			className={ `woocommerce-new-attribute-modal__table-row woocommerce-new-attribute-modal__table-row-${ index }` }
+			ref={ rowElementRef }
 		>
 			<td className="woocommerce-new-attribute-modal__table-attribute-column">
 				<AttributesComboboxControl

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -29,6 +29,11 @@
 
 		.woocommerce-new-attribute-modal__table-row {
 			min-height: 80px;
+
+			.components-form-token-field__input-container .components-form-token-field__suggestions-list {
+				position: absolute;
+				z-index: 10;
+			}
 		}
 	}
 
@@ -65,21 +70,20 @@
 
 		.components-form-token-field {
 			position: relative;
-			transition: height 0.3s;
 		}
 
 		.components-form-token-field__help {
 			position: absolute;
 			top: 36px;
 			z-index: 0;
+			display: none;
+		}
+
+		.components-form-token-field__label {
+			display: none;
 		}
 
 		.components-form-token-field__input-container {
-			position: absolute;
-			top: 0;
-			min-height: 34px;
-			z-index: 1;
-
 			> .components-flex {
 				min-height: 34px;
 			}
@@ -144,5 +148,16 @@
 		.components-button.has-icon {
 			padding: 8px;
 		}
+	}
+}
+
+.woocommerce-new-attribute-modal__table-attribute-value-column.has-values {
+	.components-form-token-field__suggestions-list {
+		border: 1px solid var( --wp-admin-theme-color );
+		border-top: 0;
+		width: calc(100% + 2px);
+		margin-left: -1px;
+		margin-top: -1px;
+		background-color: white;
 	}
 }

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -65,6 +65,7 @@
 
 		.components-form-token-field {
 			position: relative;
+			transition: height 0.3s;
 		}
 
 		.components-form-token-field__help {

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -273,7 +273,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 					function addNewAttribute(
 						newAttributeName: string,
 						index: number
-					) {
+					): void {
 						if ( ! createNewAttributesAsGlobal ) {
 							return setValue( `attributes[${ index }]`, {
 								id: 0,

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -382,6 +382,9 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 								}
 							} }
 							className="woocommerce-new-attribute-modal"
+							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+							// @ts-ignore
+							size="medium"
 						>
 							{ notice && (
 								<Notice isDismissible={ false }>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR sets the attribute row height when the options dropdown height changes, fixing the issues described [here](https://github.com/woocommerce/woocommerce/issues/47648).

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/47648

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product editor
2. Go to the Variations section
3. Create a new attribute
4. Create options for this attribute
5. Confirm that when the terms token field increases its height, the row gets increased too.

 

https://github.com/woocommerce/woocommerce/assets/77539/5664fdec-d6b6-4984-afcf-41730db8239e



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
