### PR TITLE
Fix flaky E2E admin marketing and loading screen tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-tests-admin
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-tests-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixing flaky admin marketing test

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -58,7 +58,7 @@ test.describe( 'Marketing page', () => {
 			page.getByText(
 				'Reach new customers and increase sales without leaving WooCommerce'
 			)
-		).not.toBeVisible();
+		).toBeHidden();
 
 		// Refresh the page to make sure the state is saved.
 		await page.reload();
@@ -68,14 +68,18 @@ test.describe( 'Marketing page', () => {
 			page.getByText(
 				'Reach new customers and increase sales without leaving WooCommerce'
 			)
-		).not.toBeVisible();
+		).toBeHidden();
 	} );
 
 	test( 'Learning section can be expanded', async ( { page } ) => {
+		// Go to the Dashboard page (this adds time for posts to be created)
+		await page.goto( 'wp-admin/index.php' );
+
 		// Go to the Marketing page.
 		await page.goto( 'wp-admin/admin.php?page=wc-admin&path=%2Fmarketing' );
 
 		// Expand the learning section
+		await page.getByLabel( 'Expand' ).waitFor();
 		await page.getByLabel( 'Expand' ).click( { timeout: 2000 } );
 
 		// The learning section should be expanded.
@@ -89,6 +93,6 @@ test.describe( 'Marketing page', () => {
 		await page.getByLabel( 'Collapse' ).nth( 2 ).click( { timeout: 2000 } );
 
 		// The learning section should be collapsed.
-		await expect( page.getByText( 'Page 1 of 4' ) ).not.toBeVisible();
+		await expect( page.getByText( 'Page 1 of 4' ) ).toBeHidden();
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -124,6 +124,8 @@ test.describe( 'Assembler - Loading Page', () => {
 
 		const assembler = await pageObject.getAssembler();
 		await assembler.getByRole( 'button', { name: 'Save' } ).click();
+		// Abort any additional unnecessary requests
+		await page.evaluate( () => window.stop() );
 		await pageObject.setupSite( baseURL );
 
 		const requestToSetupStore = createRequestsToSetupStoreDictionary();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47045 and #45839

This fixes 2 flaky tests (sorry for branch name)
In both tests there was race condition.

In the first one, I added one more step to first go to the WP dashboard and then to marketing page just for background job to create pages to verify further (I hope this was issue). Additionally, updated deprecated methods and added one `waitFor` to avoid future flakiness.

In the second test, I realized there was race condition after clicking Save button which sometimes trigger another flow which results in multiple/additional requests. Stopping the window after pressing Save should fix it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `pnpm test:e2e-pw ./tests/e2e-pw/tests/admin-marketing/overview.spec.js`
2. `pnpm test:e2e-pw ./tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js`
3. Check CI

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
