### PR TITLE
only make order summary sticky when it's not longer than view

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/sidebar-layout/sidebar.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/sidebar-layout/sidebar.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
  */
 import { ForwardRefProps } from './types';
 
-const Sidebar = forwardRef< HTMLInputElement, ForwardRefProps >(
+const Sidebar = forwardRef< HTMLDivElement, ForwardRefProps >(
 	( { children, className = '' }, ref ): JSX.Element => {
 		return (
 			<div

--- a/plugins/woocommerce-blocks/assets/js/base/hooks/index.js
+++ b/plugins/woocommerce-blocks/assets/js/base/hooks/index.js
@@ -8,3 +8,4 @@ export * from './use-typography-props';
 export * from './use-is-mounted';
 export * from './use-spoken-message';
 export * from './use-style-props';
+export * from './use-observed-viewport';

--- a/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
@@ -18,8 +18,8 @@ import { useState, useRef, useEffect } from '@wordpress/element';
  * };
  * ```
  */
-export function useObservedViewport(): [
-	React.Ref< HTMLDivElement >,
+export function useObservedViewport< T extends HTMLElement >(): [
+	React.Ref< T >,
 	{ height: number; width: number },
 	{ height: number; width: number }
 ] {
@@ -33,7 +33,7 @@ export function useObservedViewport(): [
 		width: 0,
 	} );
 
-	const observedRef = useRef< HTMLDivElement >( null );
+	const observedRef = useRef< T >( null );
 
 	useEffect( () => {
 		if ( ! observedRef.current ) {

--- a/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
@@ -44,7 +44,10 @@ export function useObservedViewport(): [
 			entries.forEach( ( entry ) => {
 				if ( entry.target === element ) {
 					const { height, width } = entry.contentRect;
-					setObservedElement( { height, width } );
+					setObservedElement( {
+						height: height + element.offsetTop,
+						width,
+					} );
 				}
 			} );
 		} );

--- a/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
@@ -45,12 +45,10 @@ export function useObservedViewport(): [
 				if ( entry.target === element ) {
 					const { height, width } = entry.contentRect;
 					const elementTop =
-						parseInt(
-							element.computedStyleMap().get( 'top' )?.value,
-							10
-						) || 0;
+						element.computedStyleMap().get( 'top' )?.toString() ||
+						'0';
 					setObservedElement( {
-						height: height + elementTop,
+						height: height + parseInt( elementTop, 10 ),
 						width,
 					} );
 				}

--- a/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
@@ -44,8 +44,13 @@ export function useObservedViewport(): [
 			entries.forEach( ( entry ) => {
 				if ( entry.target === element ) {
 					const { height, width } = entry.contentRect;
+					const elementTop =
+						parseInt(
+							element.computedStyleMap().get( 'top' )?.value,
+							10
+						) || 0;
 					setObservedElement( {
-						height: height + element.offsetTop,
+						height: height + elementTop,
 						width,
 					} );
 				}

--- a/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { useState, useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Returns a ref, its dimensions, and its visible viewport dimensions. Useful to know if an element should be sticky or not. This hook only runs when an element changes its intersection or dimensions.
+ *
+ * @example
+ *
+ * ```js
+ * const App = () => {
+ * 	const [ observedRef, observedElement, viewWindow ] = useObservedViewport();
+ *
+ * 	return (
+ * 		<MyElement ref={ observedRef } className={ observedElement.height < viewWindow.height ? 'is-sticky': '' } />
+ * 	);
+ * };
+ * ```
+ */
+export function useObservedViewport(): [
+	React.Ref< HTMLElement >,
+	{ height: number; width: number },
+	{ height: number; width: number }
+] {
+	const [ observedElement, setObservedElement ] = useState( {
+		height: 0,
+		width: 0,
+	} );
+
+	const [ viewWindow, setViewWindow ] = useState( {
+		height: 0,
+		width: 0,
+	} );
+
+	const observedRef = useRef< HTMLElement >( null );
+
+	useEffect( () => {
+		if ( ! observedRef.current ) {
+			return;
+		}
+		const element = observedRef.current;
+		const resizeObserver = new ResizeObserver( ( entries ) => {
+			entries.forEach( ( entry ) => {
+				if ( entry.target === element ) {
+					const { height, width } = entry.contentRect;
+					setObservedElement( { height, width } );
+				}
+			} );
+		} );
+
+		const intersectionObserver = new IntersectionObserver(
+			( entries ) => {
+				entries.forEach( ( entry ) => {
+					const { height, width } = entry.boundingClientRect;
+					setObservedElement( { height, width } );
+					if ( entry.target.ownerDocument.defaultView ) {
+						setViewWindow( {
+							height: entry.target.ownerDocument.defaultView
+								?.innerHeight,
+							width: entry.target.ownerDocument.defaultView
+								?.innerWidth,
+						} );
+					}
+				} );
+			},
+			{
+				root: null,
+				rootMargin: '0px',
+				threshold: 1,
+			}
+		);
+
+		resizeObserver.observe( element );
+		intersectionObserver.observe( element );
+
+		return () => {
+			if ( ! element ) {
+				return;
+			}
+
+			resizeObserver.unobserve( element );
+			intersectionObserver.unobserve( element );
+		};
+	}, [] );
+	return [ observedRef, observedElement, viewWindow ];
+}

--- a/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/hooks/use-observed-viewport.ts
@@ -19,7 +19,7 @@ import { useState, useRef, useEffect } from '@wordpress/element';
  * ```
  */
 export function useObservedViewport(): [
-	React.Ref< HTMLElement >,
+	React.Ref< HTMLDivElement >,
 	{ height: number; width: number },
 	{ height: number; width: number }
 ] {
@@ -33,7 +33,7 @@ export function useObservedViewport(): [
 		width: 0,
 	} );
 
-	const observedRef = useRef< HTMLElement >( null );
+	const observedRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
 		if ( ! observedRef.current ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
@@ -12,7 +12,8 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ): JSX.Element => {
-	const [ observedRef, observedElement, viewWindow ] = useObservedViewport();
+	const [ observedRef, observedElement, viewWindow ] =
+		useObservedViewport< HTMLDivElement >();
 	const isSticky = observedElement.height < viewWindow.height;
 	return (
 		<Sidebar

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
@@ -4,7 +4,7 @@
 import classnames from 'classnames';
 import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
-
+import { useObservedViewport } from '@woocommerce/base-hooks';
 const FrontendBlock = ( {
 	children,
 	className,
@@ -12,9 +12,14 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ): JSX.Element => {
+	const [ observedRef, observedElement, viewWindow ] = useObservedViewport();
+	const isSticky = observedElement.height < viewWindow.height;
 	return (
 		<Sidebar
-			className={ classnames( 'wc-block-checkout__sidebar', className ) }
+			ref={ observedRef }
+			className={ classnames( 'wc-block-checkout__sidebar', className, {
+				'is-sticky': isSticky,
+			} ) }
 		>
 			<StoreNoticesContainer
 				context={ 'woocommerce/checkout-totals-block' }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/style.scss
@@ -24,9 +24,9 @@
 .is-large {
 	.wc-block-checkout__sidebar {
 		align-self: flex-start;
+		top: $gap-large;
 		&.is-sticky {
 			position: sticky;
-			top: $gap-largest;
 		}
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/style.scss
@@ -23,8 +23,10 @@
 
 .is-large {
 	.wc-block-checkout__sidebar {
-		position: sticky;
-		top: $gap-largest;
 		align-self: flex-start;
+		&.is-sticky {
+			position: sticky;
+			top: $gap-largest;
+		}
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/styles/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/styles/editor.scss
@@ -31,6 +31,12 @@
 			position: relative;
 		}
 	}
+
+	.is-large {
+		.wc-block-checkout__sidebar {
+			top: 0;
+		}
+	}
 }
 
 body.wc-lock-selected-block--move {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -42,6 +42,18 @@ jest.mock( '@wordpress/compose', () => ( {
 	useResizeObserver: jest.fn().mockReturnValue( [ null, { width: 0 } ] ),
 } ) );
 
+global.ResizeObserver = jest.fn().mockImplementation( () => ( {
+	observe: jest.fn(),
+	unobserve: jest.fn(),
+	disconnect: jest.fn(),
+} ) );
+
+global.IntersectionObserver = jest.fn().mockImplementation( () => ( {
+	observe: jest.fn(),
+	unobserve: jest.fn(),
+	disconnect: jest.fn(),
+} ) );
+
 jest.mock( '@wordpress/element', () => {
 	return {
 		...jest.requireActual( '@wordpress/element' ),

--- a/plugins/woocommerce/changelog/47680-fix-only-sticky-summary-if-smaller-than-screen
+++ b/plugins/woocommerce/changelog/47680-fix-only-sticky-summary-if-smaller-than-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: This is a follow up to another PR not yet shipped.
+


### PR DESCRIPTION
This PR changes when we mark an element as sticky, for the order summary, we should only make it sticky if its height is smaller than the viewport. For this, I created a new hook `useObservedViewport` that should help detect its height and other elements' height. This will be needed once we start solving other zoom issues https://github.com/woocommerce/woocommerce/issues?q=is:open+is:issue+label:%22focus:+accessibility%22+label:%22team:+Rubik%22+zoom

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add some items to cart and go to Checkout.
2. Reduce the window height so that it's smaller than the order summary.
3. Try scrolling, the order summary should not be sticky.
4. Collapse the items in order summary and expand the window height.
5. Try scrolling now, the order summary should be sticky.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment 
This is a follow up to another PR not yet shipped.

</details>
