### PR TITLE
Fix width of the button to set the variation prices

### DIFF
--- a/plugins/woocommerce/changelog/fix-38054_set_price_to_variations_button
+++ b/plugins/woocommerce/changelog/fix-38054_set_price_to_variations_button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix width of the button to set the variation prices #47682

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5137,6 +5137,10 @@ img.help_tip {
 
 			p.description {
 				margin-bottom: 8px;
+
+				&.is-error, span.is-error {
+					color: $red;
+				}
 			}
 
 			&:first-child {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -969,7 +969,7 @@ $font-sf-pro-text: helveticaneue-light, "Helvetica Neue Light",
 		filter: brightness(50%);
 	}
 	.woocommerce-add-variation-price-container {
-		width: 15%;
+		width: auto;
 		display: flex;
 		justify-content: flex-end;
 		> button {
@@ -994,7 +994,7 @@ $font-sf-pro-text: helveticaneue-light, "Helvetica Neue Light",
 			margin-top: 20px;
 			> button {
 				margin-left: 16px;
-				width: 88px;
+				width: auto;
 				display: unset;
 			}
 		}
@@ -5137,10 +5137,6 @@ img.help_tip {
 
 			p.description {
 				margin-bottom: 8px;
-
-				&.is-error, span.is-error {
-					color: $red;
-				}
 			}
 
 			&:first-child {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the width of the button to set the variation prices in the legacy experience.

Before

![Screenshot 2024-05-21 at 11 38 36 AM](https://github.com/woocommerce/woocommerce/assets/1314156/df62138c-58b9-439f-9cd4-f5ceab7d18ec)

![Screenshot 2024-05-21 at 11 38 54 AM](https://github.com/woocommerce/woocommerce/assets/1314156/fec792bb-65ba-49eb-a883-13307f4b124b)


After

![Screenshot 2024-05-21 at 11 35 02 AM](https://github.com/woocommerce/woocommerce/assets/1314156/57dcf2d9-c4d9-4b78-9973-b8380af9fef0)

![Screenshot 2024-05-21 at 11 35 18 AM](https://github.com/woocommerce/woocommerce/assets/1314156/f3935978-ba34-4bc5-a2ad-f93c793a8790)

Closes #38054.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Be sure you're using the legacy editor and you're in a site that uses the Deutsch `de_DE` language.
2. Create a variant product with an attribute (like size).
3. You will see an option that mentions the variations without price, which opens a modal.
4. Verify that the button looks correct.

![Screenshot 2024-05-21 at 3 10 06 PM](https://github.com/woocommerce/woocommerce/assets/1314156/e402d903-df18-4c0d-9d3a-55d8d55ee672)

5. Press the button and confirm that the `Add price` button inside the modal looks good. 

![Screenshot 2024-05-21 at 3 10 17 PM](https://github.com/woocommerce/woocommerce/assets/1314156/e102c9f2-e067-4e99-9522-212fdd79ffe8)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
