### PR TITLE
Correctly attribute focus back when opening the mini cart several times

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/utils/use-return-focus.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/use-return-focus.ts
@@ -26,11 +26,6 @@ export function useFocusReturn(
 			// Set ref to be used when unmounting.
 			ref.current = node;
 
-			// Only set when the node mounts.
-			if ( focusedBeforeMount.current ) {
-				return;
-			}
-
 			focusedBeforeMount.current = node.ownerDocument.activeElement;
 		} else if ( focusedBeforeMount.current ) {
 			const isFocused = ref.current?.contains(

--- a/plugins/woocommerce/changelog/47683-fix-focus-on-mini-cart-stuck
+++ b/plugins/woocommerce/changelog/47683-fix-focus-on-mini-cart-stuck
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: This PR is a follow up to https://github.com/woocommerce/woocommerce/pull/47470
+


### PR DESCRIPTION
The further fixes the `useFocusReturn` hook and ensures the original element is reset after each iteration. The function we copied assumed the element would umount after return, which means the function will be reset again, our element doesn't unmounted, so we I had to remove that check.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47662

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In shop page, open mini using the mini cart button.
2. Close the window, use tab and notice that the element currently focused or previously focused was the mini cart button.
3. Scroll down the page, add an item via the `add to cart` button.
4. Mini cart will open again, close it.
5. Using tab, notice that the currently focused or previously focused element is the add to cart button.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment 
This PR is a follow up to https://github.com/woocommerce/woocommerce/pull/47470

</details>
