### PR TITLE
Address responsiveness issues with order list table in admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-responsive-ui
+++ b/plugins/woocommerce/changelog/fix-orders-responsive-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address responsiveness issues in orders list table.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3069,6 +3069,10 @@ ul.wc_coupon_list_block {
 
 		.column-order_number {
 			width: 20ch;
+
+			.order-date-and-status {
+				display: none;
+			}
 		}
 
 		.column-order_total {
@@ -3390,33 +3394,44 @@ ul.wc_coupon_list_block {
 		}
 	}
 
+	.woocommerce_page_wc-orders .wc-orders-list-table.wp-list-table,
 	.post-type-shop_order .wp-list-table {
-		td.check-column {
+		.check-column {
 			width: 1em;
+			vertical-align: top;
+		}
+
+		thead th.column-order_number {
+			width: 100%;
 		}
 
 		td.column-order_number {
-			padding-left: 0;
 			padding-bottom: 0.5em;
-		}
 
-		td.column-order_status,
-		td.column-order_date {
-			display: inline-block !important;
-			padding: 0 1em 1em 1em !important;
+			.order-date-and-status {
+				position: absolute;
+				display: block;
+				right: 60px;
 
-			&::before {
-				display: none !important;
+				time {
+					margin-right: 1.5em;
+				}
+			}
+
+			.order-preview {
+				margin-top: 13px;
 			}
 		}
 
-		td.column-order_date {
-			padding-left: 0 !important;
+		td.column-order_total,
+		td.column-wc_actions {
+			text-align: left;
 		}
 
-		td.column-order_status {
-			float: right;
+		td.column-wc_actions {
+			min-height: 2.0em !important;
 		}
+
 	}
 }
 
@@ -7539,9 +7554,9 @@ table.bar_chart {
 				overflow: visible;
 			}
 
-			.toggle-row {
-				top: -15px;
-			}
+			// .toggle-row {
+			// 	top: -15px;
+			// }
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3406,16 +3406,8 @@ ul.wc_coupon_list_block {
 		}
 
 		td.column-order_number {
-			padding-bottom: 0.5em;
-
-			.order-date-and-status {
-				position: absolute;
-				display: block;
-				right: 60px;
-
-				time {
-					margin-right: 1.5em;
-				}
+			.toggle-row {
+				height: 20px;
 			}
 
 			.order-preview {
@@ -3430,6 +3422,43 @@ ul.wc_coupon_list_block {
 
 		td.column-wc_actions {
 			min-height: 2.0em !important;
+		}
+
+		tr:not(.is-expanded) {
+			td.column-order_number {
+				vertical-align: top;
+
+				a.order-view {
+					display: inline-block;
+					width: calc(95% - 48px - 10ch - 20ch);
+					overflow: hidden;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+				}
+			}
+
+			td.column-order_date {
+				width: 10ch !important;
+				top: 1em;
+				right: calc(20ch + 48px);
+			}
+
+			td.column-order_status {
+				top: 1em;
+				right: 48px;
+			}
+
+			td.column-order_status,
+			td.column-order_date {
+				padding: 0 !important;
+				display: block !important;
+				float: right;
+				clear: none !important;
+
+				&::before {
+					display: none !important;
+				}
+			}
 		}
 
 	}
@@ -7553,10 +7582,6 @@ table.bar_chart {
 			.is-expanded td:not(.hidden) {
 				overflow: visible;
 			}
-
-			// .toggle-row {
-			// 	top: -15px;
-			// }
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3069,10 +3069,6 @@ ul.wc_coupon_list_block {
 
 		.column-order_number {
 			width: 20ch;
-
-			.order-date-and-status {
-				display: none;
-			}
 		}
 
 		.column-order_total {
@@ -3430,7 +3426,7 @@ ul.wc_coupon_list_block {
 
 				a.order-view {
 					display: inline-block;
-					width: calc(95% - 48px - 10ch - 20ch);
+					width: calc(100% - 48px - 10ch - 20ch);
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
@@ -3444,7 +3440,7 @@ ul.wc_coupon_list_block {
 			}
 
 			td.column-order_status {
-				top: 1em;
+				top: -1em;
 				right: 48px;
 			}
 
@@ -3453,7 +3449,6 @@ ul.wc_coupon_list_block {
 				padding: 0 !important;
 				display: block !important;
 				float: right;
-				clear: none !important;
 
 				&::before {
 					display: none !important;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -948,6 +948,11 @@ class ListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function render_order_number_column( WC_Order $order ): void {
+		echo '<div class="order-date-and-status">';
+			echo $this->render_order_date_column( $order );
+			echo $this->render_order_status_column( $order );
+		echo '</div>';
+
 		$buyer = '';
 
 		if ( $order->get_billing_first_name() || $order->get_billing_last_name() ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -948,11 +948,6 @@ class ListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function render_order_number_column( WC_Order $order ): void {
-		echo '<div class="order-date-and-status">';
-			echo $this->render_order_date_column( $order );
-			echo $this->render_order_status_column( $order );
-		echo '</div>';
-
 		$buyer = '';
 
 		if ( $order->get_billing_first_name() || $order->get_billing_last_name() ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
While working on #44129 I noticed that on smaller screens (i.e. less than 782px) the orders list table looks (and behaves) awfully:

![Untitled](https://github.com/woocommerce/woocommerce/assets/184724/0748ae02-8582-46ad-af33-61272aefd128)

This started to bother me so I've added some CSS to make this list behave more reasonably on smaller window sizes. That said, I'm no CSS expert so I'm more than open to any suggestions to simplify or make things work better across browsers (though FWIW I tested on FF, Safari and Chrome).


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Settings > Advanced > Features and make sure HPOS is set as datastore.
2. Create a few orders in WC > Orders, or use a tool such as Smooth Generator to generate a few.
3. Reduce the window size until you see the list table change to the following view:
   <img width="697" alt="Screenshot 2024-05-21 at 16 39 51" src="https://github.com/woocommerce/woocommerce/assets/184724/772d4aef-3547-453e-a4ed-01313f696fbe">

   If using Chrome, you can also use the "Device Toolbar" to simulate a particular window size.
   <img width="311" alt="Screenshot 2024-05-21 at 16 44 21" src="https://github.com/woocommerce/woocommerce/assets/184724/641c4477-6748-439d-9ec6-6a1fb081bac7">
4. Click on the toggle icon to display the expanded order view. Confirm things look ok.
   <img width="734" alt="Screenshot 2024-05-21 at 16 40 04" src="https://github.com/woocommerce/woocommerce/assets/184724/fde91657-785c-4801-9883-72158d31481a">
5. Note that if you reduce the window size further, some of the items (such as the order "title") will become ellipsized:
   <img width="547" alt="Screenshot 2024-05-21 at 16 39 55" src="https://github.com/woocommerce/woocommerce/assets/184724/a98ff34a-6028-4844-a147-d4b83a89e9f8">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
