### PR TITLE
Fix "Live Branches" item not shown in the WooCommerce menu

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/47691-fix-beta-teser-live-branch
+++ b/plugins/woocommerce-beta-tester/changelog/47691-fix-beta-teser-live-branch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Live Branches" item not shown in the WooCommerce menu

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-live-branches.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-live-branches.php
@@ -15,10 +15,6 @@ class WC_Beta_Tester_Live_Branches {
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( ! $this->woocommerce_is_installed() ) {
-			return;
-		}
-
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 		add_action( 'admin_init', array( $this, 'register_scripts' ) );
 	}
@@ -36,6 +32,10 @@ class WC_Beta_Tester_Live_Branches {
 	 * Register live branches scripts.
 	 */
 	public function register_scripts() {
+		if ( ! $this->woocommerce_is_installed() ) {
+			return;
+		}
+
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -65,6 +65,10 @@ class WC_Beta_Tester_Live_Branches {
 	 * Register live branches page.
 	 */
 	public function register_page() {
+		if ( ! $this->woocommerce_is_installed() ) {
+			return;
+		}
+
 		if ( ! function_exists( 'wc_admin_register_page' ) ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

p1716230946041249/1715297698.478379-slack-C01DT6U03HC

When spinning up a JN site with WooCommerce + beta tester plugin, the "Live Branches" item is not shown in the WooCommerce menu because `woocommerce_is_installed` check is too early.
 
This PR moves the check into hooks to fix this.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with WooCommerce plugin installed
2. Checkout this branch locally and cd to `plugins/woocommerce-beta-tester` and run `pnpm run build:zip` to create a new zip. Or using [woocommerce-beta-tester.zip](https://github.com/woocommerce/woocommerce/files/15397782/woocommerce-beta-tester.zip)
3. Upload the zip file to your JN site
4. Confirm `Live Branches` menu item shown in the WooCommerce menu

<img width="273" alt="Screenshot 2024-05-22 at 11 57 14" src="https://github.com/woocommerce/woocommerce/assets/4344253/00b39f2d-13d7-4cf0-b04b-76300b2e3e4f">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix "Live Branches" item not shown in the WooCommerce menu

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>