### PR TITLE
Fix the issue that the React-powered admin routing page added after initialization could not be displayed

### DIFF
--- a/plugins/woocommerce-admin/client/layout/NoMatch.tsx
+++ b/plugins/woocommerce-admin/client/layout/NoMatch.tsx
@@ -1,11 +1,48 @@
 /**
  * External dependencies
  */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody } from '@wordpress/components';
+import { Spinner } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';
+import { WooHeaderPageTitle } from '@woocommerce/admin-layout';
 
 const NoMatch: React.FC = () => {
+	const [ isDelaying, setIsDelaying ] = useState( true );
+
+	/*
+	 * Delay for 3 seconds to wait if there are routing pages added after the
+	 * initial routing pages to reduce the chance of flashing the error message
+	 * on this page.
+	 */
+	useEffect( () => {
+		const timerId = setTimeout( () => {
+			setIsDelaying( false );
+		}, 3000 );
+
+		return () => {
+			clearTimeout( timerId );
+		};
+	}, [] );
+
+	if ( isDelaying ) {
+		return (
+			<>
+				<WooHeaderPageTitle>
+					{ __( 'Loading…', 'woocommerce' ) }
+				</WooHeaderPageTitle>
+				<div className="woocommerce-layout__loading">
+					<Spinner />
+				</div>
+			</>
+		);
+	}
+
 	return (
 		<div className="woocommerce-layout__no-match">
 			<Card>

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -39,7 +39,7 @@ import {
  * Internal dependencies
  */
 import './style.scss';
-import { Controller, getPages } from './controller';
+import { Controller, usePages } from './controller';
 import { Header } from '../header';
 import { Footer } from './footer';
 import Notices from './notices';
@@ -313,6 +313,7 @@ const Layout = compose(
 
 const _PageLayout = () => {
 	const { currentUserCan } = useUser();
+	const pages = usePages();
 
 	// get the basename, usually 'wp-admin/' but can be something else if the site installation changed it
 	const path = document.location.pathname;
@@ -321,7 +322,7 @@ const _PageLayout = () => {
 	return (
 		<HistoryRouter history={ getHistory() }>
 			<Routes basename={ basename }>
-				{ getPages()
+				{ pages
 					.filter(
 						( page ) =>
 							! page.capability ||

--- a/plugins/woocommerce-admin/client/layout/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/test/index.js
@@ -1,21 +1,60 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import { addFilter, removeFilter } from '@wordpress/hooks';
 import { recordPageView } from '@woocommerce/tracks';
+import * as navigation from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
-import { updateLinkHref } from '../controller';
-import { EmbedLayout } from '../index';
+import { updateLinkHref, PAGES_FILTER } from '../controller';
+import { EmbedLayout, PageLayout } from '../index';
 
-jest.mock( '@woocommerce/admin-layout', () => {
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn().mockReturnValue( {} ),
+} ) );
+
+jest.mock( '@woocommerce/data', () => ( {
+	...jest.requireActual( '@woocommerce/data' ),
+	useUser: jest.fn().mockReturnValue( { currentUserCan: () => true } ),
+} ) );
+
+jest.mock( '@woocommerce/customer-effort-score', () => ( {
+	CustomerEffortScoreModalContainer: () => null,
+	triggerExitPageCesSurvey: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/components', () => ( {
+	...jest.requireActual( '@woocommerce/components' ),
+	Spinner: jest.fn( () => <div>spinner</div> ),
+} ) );
+
+jest.mock( '~/activity-panel', () => null );
+
+jest.mock( '../navigation', () => null );
+
+jest.mock( '~/utils/admin-settings', () => {
+	const adminSetting = jest.requireActual( '~/utils/admin-settings' );
 	return {
-		LayoutContextProvider: () => null,
-		getLayoutContextValue: () => null,
+		...adminSetting,
+		getAdminSetting: jest.fn().mockImplementation( ( name, ...args ) => {
+			if ( name === 'woocommerceTranslation' ) {
+				return 'WooCommerce';
+			}
+			return adminSetting.getAdminSetting( name, ...args );
+		} ),
 	};
 } );
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	...jest.requireActual( '@woocommerce/navigation' ),
+	getHistory: jest.fn(),
+} ) );
+
+const mockedGetHistory = navigation.getHistory;
 
 describe( 'updateLinkHref', () => {
 	const timeExcludedScreens = [ 'stock', 'settings', 'customers' ];
@@ -99,6 +138,83 @@ describe( 'Layout', () => {
 		expect( recordPageView ).toHaveBeenCalledWith( '/url?search', {
 			has_navigation: true,
 			is_embedded: true,
+		} );
+	} );
+} );
+
+describe( 'PageLayout', () => {
+	beforeEach( () => {
+		jest.spyOn( window, 'wpNavMenuClassChange' ).mockImplementation(
+			jest.fn()
+		);
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		jest.clearAllTimers();
+	} );
+
+	function mockPath( pathname ) {
+		const historyMock = {
+			listen: jest.fn().mockImplementation( () => jest.fn() ),
+			location: { pathname },
+		};
+		mockedGetHistory.mockReturnValue( historyMock );
+	}
+
+	describe( 'NoMatch', () => {
+		const message = 'Sorry, you are not allowed to access this page.';
+
+		it( 'should render a loading spinner first and then the error message after the delay', () => {
+			mockPath( '/incorrect-path' );
+			render( <PageLayout /> );
+
+			expect( screen.getByText( 'spinner' ) ).toBeInTheDocument();
+			expect( screen.queryByText( message ) ).not.toBeInTheDocument();
+
+			act( () => {
+				jest.runOnlyPendingTimers();
+			} );
+
+			expect( screen.queryByText( 'spinner' ) ).not.toBeInTheDocument();
+			expect( screen.getByText( message ) ).toBeInTheDocument();
+		} );
+
+		it( 'should render the page added after the initial filter has been run, not show the error message', () => {
+			const namespace = `woocommerce/woocommerce/test_${ PAGES_FILTER }`;
+			const path = '/test/greeting';
+
+			mockPath( path );
+			render( <PageLayout /> );
+
+			expect( screen.getByText( 'spinner' ) ).toBeInTheDocument();
+			expect( screen.queryByText( message ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: 'Greet' } )
+			).not.toBeInTheDocument();
+
+			act( () => {
+				addFilter( PAGES_FILTER, namespace, ( pages ) => {
+					return [
+						...pages,
+						{
+							breadcrumbs: [ 'Greeting' ],
+							container: () => <button>Greet</button>,
+							path,
+						},
+					];
+				} );
+			} );
+
+			expect( screen.queryByText( 'spinner' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( message ) ).not.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'Greet' } )
+			).toBeInTheDocument();
+
+			// Clean up the filter as filters are working globally.
+			removeFilter( PAGES_FILTER, namespace );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/fix-subsequent-admin-routing
+++ b/plugins/woocommerce/changelog/fix-subsequent-admin-routing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the issue that the React-powered admin routing pages added after the filter initialization could not be displayed.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR addresses the routing issue that the React-powered admin pages added after the initial filter had been run could not be displayed. Reference: https://github.com/woocommerce/google-listings-and-ads/issues/2147

- Make the `'woocommerce_admin_pages_list'` filter also include pages added after initialization.
- Delay showing `NoMatch` to reduce the chance of flashing error message when route page is added after initialization.

💡 The solution basically adopts solution 3 in https://github.com/woocommerce/google-listings-and-ads/issues/2147#issuecomment-2109910082, and the relevant discussion and consensus are also below the comment.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### 📌 Reproduce the issue

1. Use a revision without this fix
   1. Checkout the current `trunk` f57de6456083a4035dcc2fa470363d4358df655b
   2. Run `pnpm install` and `pnpm build`
2. Install and activate [WooCommerce Beta Tester](https://woo.com/products/woocommerce-beta-tester/) and [Google Listings & Ads](https://github.com/woocommerce/google-listings-and-ads)
3. Go to the admin page: `Marketing > Google Listings & Ads`
4. The page shows "Sorry, you are not allowed to access this page", which is not the expected result.

![image](https://github.com/woocommerce/woocommerce/assets/17420811/6bbb879e-4f76-437f-9146-9ff6c163a610)

#### 📌 Test the fixed routing issue with an extension

1. Use the revision of this PR
   1. Checkout the `fix/subsequent-admin-routing` branch
   2. Run `pnpm install` and `pnpm build`
2. Install and activate [WooCommerce Beta Tester](https://woo.com/products/woocommerce-beta-tester/) and [Google Listings & Ads](https://github.com/woocommerce/google-listings-and-ads)
3. Go to the admin page: `Marketing > Google Listings & Ads`
4. Check if the extension's admin page can be displayed

https://github.com/woocommerce/woocommerce/assets/17420811/434ad9c4-f0c1-486b-b5ac-12c94fb79059

#### 📌 Test the `NoMatch` page with an actual incorrect path

1. Continue the settings from the previous test
2. Go to an incorrect path, e.g. `/wp-admin/admin.php?page=wc-admin&path=%2Ffoobar`
3. Check if it displays a loading spinner first, and then the "Sorry, you are not allowed to access this page" after 3 seconds

https://github.com/woocommerce/woocommerce/assets/17420811/2fc0993a-c1e7-4919-b346-831958425a27

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
