### PR TITLE
Filter by Attribute: fix potential reading property of undefined error

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
@@ -130,7 +130,7 @@ const AttributeFilterBlock = ( {
 			resourceName: 'products/attributes/terms',
 			resourceValues: [ attributeObject?.id || 0 ],
 			shouldSelect: blockAttributes.attributeId > 0,
-			query: { orderby: attributeObject.orderby },
+			query: { orderby: attributeObject?.orderby || 'menu_order' },
 		} );
 
 	const { results: filteredCounts, isLoading: filteredCountsLoading } =

--- a/plugins/woocommerce-blocks/assets/js/types/type-defs/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/types/type-defs/attributes.ts
@@ -13,7 +13,7 @@ export interface AttributeObject {
 	id: number;
 	label: string;
 	name: string;
-	order: 'menu_order' | 'name' | 'name_num' | 'id';
+	orderby: 'menu_order' | 'name' | 'name_num' | 'id';
 	parent: number;
 	taxonomy: string;
 	type: string;

--- a/plugins/woocommerce/changelog/fix-attribute-filter-reading-property-of-undefined
+++ b/plugins/woocommerce/changelog/fix-attribute-filter-reading-property-of-undefined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Filter by Attribute: fix potential reading from undefined error


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I spotted this error in tests:

```
TypeError: Cannot read properties of undefined (reading 'orderby')
    at Block (http://localhost:8889/wp-content/plugins/woocommerce/assets/client/blocks/attribute-filter-frontend.js?ver=623afdc5d704efe19bc8:6:5179)
```

[Example run](https://github.com/woocommerce/woocommerce/actions/runs/9187467555/job/25265216162?pr=44931).

This is based on a recent change: https://github.com/woocommerce/woocommerce/pull/47616. As we can see all of the properties from `attributeObject` in the `plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx` are read with optional chaining. This PR adds optional chaining and updates the type in which there was `order` property but it's never used. Instead, I put `orderby`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Only to be tested by devs:**

1. Go to `Blocks Playwright Tests / Shard 1 of 10 (pull_request)` job
2. Find `attributes-filter/attribute-filter.block_theme.spec.ts:190:6 › Filter by Attribute Block - with Product Collection › should show all products` test
3. Verify there's no `TypeError: Cannot read properties of undefined (reading 'orderby')` error

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
