### PR TITLE
Load controllers only when needed for performance.

### DIFF
--- a/plugins/woocommerce/changelog/fix-44359
+++ b/plugins/woocommerce/changelog/fix-44359
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Load REST API namespaces only when needed.

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -28,7 +28,7 @@ class Server {
 	/**
 	 * Hook into WordPress ready to init the REST API as needed.
 	 */
-	public function init() {
+	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod -- Not an injection method.
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
 
 		\WC_REST_System_Status_V2_Controller::register_cache_clean();
@@ -57,13 +57,19 @@ class Server {
 	 * @return array List of Namespaces and Main controller classes.
 	 */
 	protected function get_rest_namespaces() {
+		/**
+		 * Filter the list of REST API controllers to load.
+		 *
+		 * @since 4.5.0
+		 * @param array $controllers List of $namespace => $controllers to load.
+		 */
 		return apply_filters(
 			'woocommerce_rest_api_get_rest_namespaces',
 			array(
-				'wc/v1'        => $this->get_v1_controllers(),
-				'wc/v2'        => $this->get_v2_controllers(),
-				'wc/v3'        => $this->get_v3_controllers(),
-				'wc-telemetry' => $this->get_telemetry_controllers(),
+				'wc/v1'        => wc_rest_should_load_namespace( 'wc/v1' ) ? $this->get_v1_controllers() : array(),
+				'wc/v2'        => wc_rest_should_load_namespace( 'wc/v2' ) ? $this->get_v2_controllers() : array(),
+				'wc/v3'        => wc_rest_should_load_namespace( 'wc/v3' ) ? $this->get_v3_controllers() : array(),
+				'wc-telemetry' => wc_rest_should_load_namespace( 'wc-telemetry' ) ? $this->get_telemetry_controllers() : array(),
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/wc-rest-functions.php
+++ b/plugins/woocommerce/includes/wc-rest-functions.php
@@ -405,7 +405,7 @@ function wc_rest_should_load_namespace( string $ns, string $rest_route = '' ): b
 		'wc-admin',
 		'wc-analytics',
 		'wc/store',
-		'wc/private'
+		'wc/private',
 	);
 
 	// We can consider allowing filtering this list in the future.

--- a/plugins/woocommerce/includes/wc-rest-functions.php
+++ b/plugins/woocommerce/includes/wc-rest-functions.php
@@ -377,6 +377,8 @@ function wc_rest_is_from_product_editor() {
 /**
  * Check if a REST namespace should be loaded. Useful to maintain site performance even when lots of REST namespaces are registered.
  *
+ * @since 9.2.0.
+ *
  * @param string $ns The namespace to check.
  * @param string $rest_route (Optional) The REST route being checked.
  *

--- a/plugins/woocommerce/includes/wc-rest-functions.php
+++ b/plugins/woocommerce/includes/wc-rest-functions.php
@@ -394,5 +394,33 @@ function wc_rest_should_load_namespace( string $ns, string $rest_route = '' ): b
 	$rest_route = trailingslashit( ltrim( $rest_route, '/' ) );
 	$ns         = trailingslashit( $ns );
 
+	/**
+	 * Known namespaces that we know are safe to not load if the request is not for them. Namespaces not in this namespace should always be loaded, because we don't know if they won't be making another internal REST request to an unloaded namespace.
+	 */
+	$known_namespaces = array(
+		'wc/v1',
+		'wc/v2',
+		'wc/v3',
+		'wc-telemetry',
+		'wc-admin',
+		'wc-analytics',
+		'wc/store',
+		'wc/private'
+	);
+
+	// We can consider allowing filtering this list in the future.
+
+	$known_namespace_request = false;
+	foreach ( $known_namespaces as $known_namespace ) {
+		if ( str_starts_with( $rest_route, $known_namespace ) ) {
+			$known_namespace_request = true;
+			break;
+		}
+	}
+
+	if ( ! $known_namespace_request ) {
+		return true;
+	}
+
 	return str_starts_with( $rest_route, $ns );
 }

--- a/plugins/woocommerce/includes/wc-rest-functions.php
+++ b/plugins/woocommerce/includes/wc-rest-functions.php
@@ -373,3 +373,26 @@ function wc_rest_check_product_reviews_permissions( $context = 'read', $object_i
 function wc_rest_is_from_product_editor() {
 	return isset( $_SERVER['HTTP_X_WC_FROM_PRODUCT_EDITOR'] ) && '1' === $_SERVER['HTTP_X_WC_FROM_PRODUCT_EDITOR'];
 }
+
+/**
+ * Check if a REST namespace should be loaded. Useful to maintain site performance even when lots of REST namespaces are registered.
+ *
+ * @param string $ns The namespace to check.
+ * @param string $rest_route (Optional) The REST route being checked.
+ *
+ * @return bool True if the namespace should be loaded, false otherwise.
+ */
+function wc_rest_should_load_namespace( string $ns, string $rest_route = '' ): bool {
+	if ( '' === $rest_route ) {
+		$rest_route = $GLOBALS['wp']->query_vars['rest_route'] ?? '';
+	}
+
+	if ( '' === $rest_route ) {
+		return true;
+	}
+
+	$rest_route = trailingslashit( ltrim( $rest_route, '/' ) );
+	$ns         = trailingslashit( $ns );
+
+	return str_starts_with( $rest_route, $ns );
+}

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -57,87 +57,102 @@ class Init {
 	 * Init REST API.
 	 */
 	public function rest_api_init() {
-		if ( ! wc_rest_should_load_namespace( 'wc-admin' ) ) {
-			return;
-		}
-
-		$controllers = array(
-			'Automattic\WooCommerce\Admin\API\Features',
-			'Automattic\WooCommerce\Admin\API\Notes',
-			'Automattic\WooCommerce\Admin\API\NoteActions',
-			'Automattic\WooCommerce\Admin\API\Coupons',
-			'Automattic\WooCommerce\Admin\API\Data',
-			'Automattic\WooCommerce\Admin\API\DataCountries',
-			'Automattic\WooCommerce\Admin\API\DataDownloadIPs',
-			'Automattic\WooCommerce\Admin\API\Experiments',
-			'Automattic\WooCommerce\Admin\API\Marketing',
-			'Automattic\WooCommerce\Admin\API\MarketingOverview',
-			'Automattic\WooCommerce\Admin\API\MarketingRecommendations',
-			'Automattic\WooCommerce\Admin\API\MarketingChannels',
-			'Automattic\WooCommerce\Admin\API\MarketingCampaigns',
-			'Automattic\WooCommerce\Admin\API\MarketingCampaignTypes',
-			'Automattic\WooCommerce\Admin\API\Notice',
-			'Automattic\WooCommerce\Admin\API\Options',
-			'Automattic\WooCommerce\Admin\API\Orders',
-			'Automattic\WooCommerce\Admin\API\PaymentGatewaySuggestions',
-			'Automattic\WooCommerce\Admin\API\Products',
-			'Automattic\WooCommerce\Admin\API\ProductAttributes',
-			'Automattic\WooCommerce\Admin\API\ProductAttributeTerms',
-			'Automattic\WooCommerce\Admin\API\ProductCategories',
-			'Automattic\WooCommerce\Admin\API\ProductVariations',
-			'Automattic\WooCommerce\Admin\API\ProductReviews',
-			'Automattic\WooCommerce\Admin\API\ProductVariations',
-			'Automattic\WooCommerce\Admin\API\ProductsLowInStock',
-			'Automattic\WooCommerce\Admin\API\SettingOptions',
-			'Automattic\WooCommerce\Admin\API\Themes',
-			'Automattic\WooCommerce\Admin\API\Plugins',
-			'Automattic\WooCommerce\Admin\API\OnboardingFreeExtensions',
-			'Automattic\WooCommerce\Admin\API\OnboardingProductTypes',
-			'Automattic\WooCommerce\Admin\API\OnboardingProfile',
-			'Automattic\WooCommerce\Admin\API\OnboardingTasks',
-			'Automattic\WooCommerce\Admin\API\OnboardingThemes',
-			'Automattic\WooCommerce\Admin\API\OnboardingPlugins',
-			'Automattic\WooCommerce\Admin\API\OnboardingProducts',
-			'Automattic\WooCommerce\Admin\API\NavigationFavorites',
-			'Automattic\WooCommerce\Admin\API\Taxes',
-			'Automattic\WooCommerce\Admin\API\MobileAppMagicLink',
-			'Automattic\WooCommerce\Admin\API\ShippingPartnerSuggestions',
-		);
+		$controllers              = array();
+		$analytics_controllers    = array();
 
 		if ( Features::is_enabled( 'launch-your-store' ) ) {
 			$controllers[] = 'Automattic\WooCommerce\Admin\API\LaunchYourStore';
 		}
 
-		if ( Features::is_enabled( 'analytics' ) ) {
-			$analytics_controllers = array(
-				'Automattic\WooCommerce\Admin\API\Customers',
-				'Automattic\WooCommerce\Admin\API\Leaderboards',
-				'Automattic\WooCommerce\Admin\API\Reports\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Import\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Export\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Products\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Variations\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Products\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Variations\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Revenue\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Orders\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Categories\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Taxes\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Coupons\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Coupons\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Stock\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Stock\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Downloads\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Downloads\Stats\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Customers\Controller',
-				'Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\Controller',
+		if ( wc_rest_should_load_namespace( 'wc-admin' ) ) {
+			// Controllers in the wc-admin namespace.
+			$controllers = array(
+				'Automattic\WooCommerce\Admin\API\Notice',
+				'Automattic\WooCommerce\Admin\API\Features',
+				'Automattic\WooCommerce\Admin\API\Experiments',
+				'Automattic\WooCommerce\Admin\API\Marketing',
+				'Automattic\WooCommerce\Admin\API\MarketingOverview',
+				'Automattic\WooCommerce\Admin\API\MarketingRecommendations',
+				'Automattic\WooCommerce\Admin\API\MarketingChannels',
+				'Automattic\WooCommerce\Admin\API\MarketingCampaigns',
+				'Automattic\WooCommerce\Admin\API\MarketingCampaignTypes',
+				'Automattic\WooCommerce\Admin\API\Options',
+				'Automattic\WooCommerce\Admin\API\PaymentGatewaySuggestions',
+				'Automattic\WooCommerce\Admin\API\Themes',
+				'Automattic\WooCommerce\Admin\API\Plugins',
+				'Automattic\WooCommerce\Admin\API\OnboardingFreeExtensions',
+				'Automattic\WooCommerce\Admin\API\OnboardingProductTypes',
+				'Automattic\WooCommerce\Admin\API\OnboardingProfile',
+				'Automattic\WooCommerce\Admin\API\OnboardingTasks',
+				'Automattic\WooCommerce\Admin\API\OnboardingThemes',
+				'Automattic\WooCommerce\Admin\API\OnboardingPlugins',
+				'Automattic\WooCommerce\Admin\API\OnboardingProducts',
+				'Automattic\WooCommerce\Admin\API\NavigationFavorites',
+				'Automattic\WooCommerce\Admin\API\MobileAppMagicLink',
+				'Automattic\WooCommerce\Admin\API\ShippingPartnerSuggestions',
 			);
 
-			// The performance indicators controller must be registered last, after other /stats endpoints have been registered.
-			$analytics_controllers[] = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
-			$controllers             = array_merge( $controllers, $analytics_controllers );
+			if ( Features::is_enabled( 'launch-your-store' ) ) {
+				$controllers[] = 'Automattic\WooCommerce\Admin\API\LaunchYourStore';
+			}
+		}
+
+		if ( wc_rest_should_load_namespace( 'wc-analytics' ) ) {
+			// Controllers in wc-analytics namespace, but loaded irrespective of analytics feature value.
+			$analytic_mu_controllers = array(
+				'Automattic\WooCommerce\Admin\API\Notes',
+				'Automattic\WooCommerce\Admin\API\NoteActions',
+				'Automattic\WooCommerce\Admin\API\Coupons',
+				'Automattic\WooCommerce\Admin\API\Data',
+				'Automattic\WooCommerce\Admin\API\DataCountries',
+				'Automattic\WooCommerce\Admin\API\DataDownloadIPs',
+				'Automattic\WooCommerce\Admin\API\Orders',
+				'Automattic\WooCommerce\Admin\API\Products',
+				'Automattic\WooCommerce\Admin\API\ProductAttributes',
+				'Automattic\WooCommerce\Admin\API\ProductAttributeTerms',
+				'Automattic\WooCommerce\Admin\API\ProductCategories',
+				'Automattic\WooCommerce\Admin\API\ProductVariations',
+				'Automattic\WooCommerce\Admin\API\ProductReviews',
+				'Automattic\WooCommerce\Admin\API\ProductVariations',
+				'Automattic\WooCommerce\Admin\API\ProductsLowInStock',
+				'Automattic\WooCommerce\Admin\API\SettingOptions',
+				'Automattic\WooCommerce\Admin\API\Taxes',
+			);
+
+			if ( Features::is_enabled( 'analytics' ) ) {
+				$analytics_controllers = array(
+					'Automattic\WooCommerce\Admin\API\Customers',
+					'Automattic\WooCommerce\Admin\API\Leaderboards',
+					'Automattic\WooCommerce\Admin\API\Reports\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Import\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Export\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Products\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Variations\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Products\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Variations\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Revenue\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Orders\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Categories\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Taxes\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Coupons\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Coupons\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Stock\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Stock\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Downloads\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Downloads\Stats\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Customers\Controller',
+					'Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\Controller',
+				);
+
+				// The performance indicators controllerq must be registered last, after other /stats endpoints have been registered.
+				$analytics_controllers[] = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
+
+				$analytics_controllers = array_merge( $analytics_controllers, $analytic_mu_controllers );
+			}
+
+			$controllers = array_merge( $controllers, $analytics_controllers, $analytic_mu_controllers );
 		}
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -91,10 +91,6 @@ class Init {
 				'Automattic\WooCommerce\Admin\API\MobileAppMagicLink',
 				'Automattic\WooCommerce\Admin\API\ShippingPartnerSuggestions',
 			);
-
-			if ( Features::is_enabled( 'launch-your-store' ) ) {
-				$controllers[] = 'Automattic\WooCommerce\Admin\API\LaunchYourStore';
-			}
 		}
 
 		if ( wc_rest_should_load_namespace( 'wc-analytics' ) ) {

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -60,10 +60,6 @@ class Init {
 		$controllers           = array();
 		$analytics_controllers = array();
 
-		if ( Features::is_enabled( 'launch-your-store' ) ) {
-			$controllers[] = 'Automattic\WooCommerce\Admin\API\LaunchYourStore';
-		}
-
 		if ( wc_rest_should_load_namespace( 'wc-admin' ) ) {
 			// Controllers in the wc-admin namespace.
 			$controllers = array(
@@ -91,6 +87,10 @@ class Init {
 				'Automattic\WooCommerce\Admin\API\MobileAppMagicLink',
 				'Automattic\WooCommerce\Admin\API\ShippingPartnerSuggestions',
 			);
+		}
+
+		if ( Features::is_enabled( 'launch-your-store' ) ) {
+			$controllers[] = 'Automattic\WooCommerce\Admin\API\LaunchYourStore';
 		}
 
 		if ( wc_rest_should_load_namespace( 'wc-analytics' ) ) {

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -57,8 +57,8 @@ class Init {
 	 * Init REST API.
 	 */
 	public function rest_api_init() {
-		$controllers              = array();
-		$analytics_controllers    = array();
+		$controllers           = array();
+		$analytics_controllers = array();
 
 		if ( Features::is_enabled( 'launch-your-store' ) ) {
 			$controllers[] = 'Automattic\WooCommerce\Admin\API\LaunchYourStore';

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -57,6 +57,10 @@ class Init {
 	 * Init REST API.
 	 */
 	public function rest_api_init() {
+		if ( ! wc_rest_should_load_namespace( 'wc-admin' ) ) {
+			return;
+		}
+
 		$controllers = array(
 			'Automattic\WooCommerce\Admin\API\Features',
 			'Automattic\WooCommerce\Admin\API\Notes',

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -23,6 +23,9 @@ final class StoreApi {
 		add_action(
 			'rest_api_init',
 			function () {
+				if ( ! wc_rest_should_load_namespace( 'wc/store' ) ) {
+					return;
+				}
 				self::container()->get( Legacy::class )->init();
 				self::container()->get( RoutesController::class )->register_all_routes();
 			}
@@ -31,6 +34,9 @@ final class StoreApi {
 		add_action(
 			'rest_api_init',
 			function () {
+				if ( ! wc_rest_should_load_namespace( 'wc/store' ) ) {
+					return;
+				}
 				self::container()->get( Authentication::class )->init();
 			},
 			11

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -23,7 +23,7 @@ final class StoreApi {
 		add_action(
 			'rest_api_init',
 			function () {
-				if ( ! wc_rest_should_load_namespace( 'wc/store' ) ) {
+				if ( ! wc_rest_should_load_namespace( 'wc/store' ) && ! wc_rest_should_load_namespace( 'wc/private' ) ) {
 					return;
 				}
 				self::container()->get( Legacy::class )->init();

--- a/plugins/woocommerce/tests/php/includes/wc-rest-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-rest-functions-test.php
@@ -1,0 +1,29 @@
+<?php
+
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch -- backcompat nomenclature.
+
+/**
+ * Tests for wc-rest-functions.php.
+ * Class WC_Rest_Functions_Test.
+ */
+class WCRestFunctionsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testDox All namespaces are loaded for unknown path.
+	 */
+	public function test_wc_rest_should_load_namespace_unknown() {
+		$this->assertTrue( wc_rest_should_load_namespace( 'wc/v1', 'wc/unknown' ) );
+		$this->assertTrue( wc_rest_should_load_namespace( 'wc-analytics', 'wc/unknown' ) );
+		$this->assertTrue( wc_rest_should_load_namespace( 'wc-telemetry', 'wc/unknown' ) );
+		$this->assertTrue( wc_rest_should_load_namespace( 'wc-random', 'wc/unknown' ) );
+	}
+
+	/**
+	 * @testDox Only required namespace is loaded for known path.
+	 */
+	public function test_wc_rest_should_load_namespace_known() {
+		$this->assertFalse( wc_rest_should_load_namespace( 'wc/v1', 'wc/v2' ) );
+		$this->assertFalse( wc_rest_should_load_namespace( 'wc-analytics', 'wc/v2' ) );
+		$this->assertTrue( wc_rest_should_load_namespace( 'wc/v2', 'wc/v2' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/wc-rest-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-rest-functions-test.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1);
 
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch -- backcompat nomenclature.
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves REST API performance by only loading the namespaces that are going to be needed. It's quite conservative, in the sense that it only works for a list of namespaces, otherwise it will load everything. 

I started with a more broader approach without having a predetermined list of namespaces that this patch would work for, and loading namespaces based on the request path. However, I ran into issues with this approach because sometimes a REST request will internally make another request to a different namespace, in which case it would encounter an error because we have not loaded that namespace.

Overall, we would eventually want to move to a selective loading of controllers itself, but that's a much more involved and invasive work that I wasn't able to justify based on anticipated performance benefits. This approach is a nice middle ground between loading everything, and granular controller based loading. 

On testing this on a stressed server, I found API calls to be up to 30% faster with this patch applied, basically we are optimizing away the time that would have been spend in loading and initializing API namespaces that are not needed:

*Side by side comparison of flamegraph of API requests with and without this patch on wc/settings endpoint*
<img width="1641" alt="Screenshot 2024-06-03 at 2 55 13 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/2e8d304e-c6d3-483a-99de-b169e9e4e7cf">

Closes #44539

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

There is no functional change, so we will do exploratory testing and try to break the API:

1. Complete a checkout using cart and checkout blocks to verify that store API is working as expected. 
2. Perform several REST API requests, including batch requests, create, delete, update (and not just read).
3. Try out above on different API namespaces.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
