### PR TITLE
Fix payment task track only shown gateways

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
@@ -179,18 +179,13 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 					additionalGateways.map( ( g ) => g.id )
 				);
 			}
-			if ( offlineGateways.length ) {
-				shownGateways = shownGateways.concat(
-					offlineGateways.map( ( g ) => g.id )
-				);
-			}
 			if ( shownGateways.length ) {
 				recordEvent( 'tasklist_payments_options', {
 					options: shownGateways,
 				} );
 			}
 		}
-	}, [ additionalGateways, currentGateway, offlineGateways, wcPayGateway ] );
+	}, [ additionalGateways, currentGateway, wcPayGateway ] );
 
 	const trackSeeMore = () => {
 		recordEvent( 'tasklist_payment_see_more', {} );

--- a/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
@@ -71,16 +71,6 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		[ installedPaymentGateways, paymentGatewaySuggestions ]
 	);
 
-	useEffect( () => {
-		if ( paymentGateways.size ) {
-			recordEvent( 'tasklist_payments_options', {
-				options: Array.from( paymentGateways.values() ).map(
-					( gateway ) => gateway.id
-				),
-			} );
-		}
-	}, [ paymentGateways ] );
-
 	const enablePaymentGateway = ( id ) => {
 		if ( ! id ) {
 			return;
@@ -176,6 +166,31 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			isWCPayOrOtherCategoryDoneSetup,
 		]
 	);
+
+	useEffect( () => {
+		let shownGateways = [];
+
+		if ( ! currentGateway ) {
+			if ( wcPayGateway.length ) {
+				shownGateways.push( wcPayGateway[ 0 ].id );
+			}
+			if ( additionalGateways.length ) {
+				shownGateways = shownGateways.concat(
+					additionalGateways.map( ( g ) => g.id )
+				);
+			}
+			if ( offlineGateways.length ) {
+				shownGateways = shownGateways.concat(
+					offlineGateways.map( ( g ) => g.id )
+				);
+			}
+			if ( shownGateways.length ) {
+				recordEvent( 'tasklist_payments_options', {
+					options: shownGateways,
+				} );
+			}
+		}
+	}, [ additionalGateways, currentGateway, offlineGateways, wcPayGateway ] );
 
 	const trackSeeMore = () => {
 		recordEvent( 'tasklist_payment_see_more', {} );

--- a/plugins/woocommerce/changelog/fix-payments-shown-options-track
+++ b/plugins/woocommerce/changelog/fix-payments-shown-options-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tasklist_payments_options to record only shown payment gateways


### PR DESCRIPTION
### Changes proposed in this Pull Request:

p1716288836244759/1716288743.531139-slack-C01SFMVEYAK

Fixes tracks prop to use only shown payment gateways in payments task

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a fresh store in any US state
2. Open up browser console and run `localStorage.setItem('debug', 'wc-admin:*')`
3. Go to `WooCommerce > Home > Get paid`
4. Observe the track `wcadmin_tasklist_payments_options` with props `options: ['woocommerce_payments:with-in-person-payments', 'stripe', 'ppcp-gateway', 'square_credit_card']`
5. Change the store country to anywhere in `Mexico`
3. Go to `WooCommerce > Home > Get paid`
4. Observe the track `wcadmin_tasklist_payments_options` with props `options: ['stripe', 'woo-mercado-pago-custom', 'ppcp-gateway']` is fired

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>