### PR TITLE
Add zoom and flex slider functionatility gallery images for variable products with missing Product Image

### DIFF
--- a/plugins/woocommerce/changelog/fix-27247-missing-zoom-in-variable-products-with-no-cover
+++ b/plugins/woocommerce/changelog/fix-27247-missing-zoom-in-variable-products-with-no-cover
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+If a variable product doesn't have a Product Image but variations do have images, the zoom and flex slider will be initiated as expected

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1607,37 +1607,31 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
 	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $main_image ? 'woocommerce_single' : $thumbnail_size );
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
-	$thumbnail_src     = ! empty( $attachment_id ) ? wp_get_attachment_image_src( $attachment_id, $thumbnail_size ) : array( wc_placeholder_img_src( $thumbnail_size ) );
-	$full_src          = ! empty( $attachment_id ) ? wp_get_attachment_image_src( $attachment_id, $full_size ) : array( wc_placeholder_img_src( $full_size ) );
-	$alt_text          = ! empty( $attachment_id ) ? trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) ) : esc_html__( 'Awaiting product image', 'woocommerce' );
-	$image_classname   = $main_image ? 'wp-post-image' : '';
-	$wrapper_classname = ! empty( $attachment_id ) ? 'woocommerce-product-gallery__image' : 'woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder';
-	if ( ! empty( $attachment_id ) ) {
-		$image = wp_get_attachment_image(
+	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
+	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
+	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
+	$image             = wp_get_attachment_image(
+		$attachment_id,
+		$image_size,
+		false,
+		apply_filters(
+			'woocommerce_gallery_image_html_attachment_image_params',
+			array(
+				'title'                   => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+				'data-caption'            => _wp_specialchars( get_post_field( 'post_excerpt', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+				'data-src'                => esc_url( $full_src[0] ),
+				'data-large_image'        => esc_url( $full_src[0] ),
+				'data-large_image_width'  => esc_attr( $full_src[1] ),
+				'data-large_image_height' => esc_attr( $full_src[2] ),
+				'class'                   => esc_attr( $main_image ? 'wp-post-image' : '' ),
+			),
 			$attachment_id,
 			$image_size,
-			false,
-			apply_filters(
-				'woocommerce_gallery_image_html_attachment_image_params',
-				array(
-					'title'                   => isset( $attachment_id ) ? _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ) : '',
-					'data-caption'            => isset( $attachment_id ) ? _wp_specialchars( get_post_field( 'post_excerpt', $attachment_id ), ENT_QUOTES, 'UTF-8', true ) : '',
-					'data-src'                => esc_url( $full_src[0] ),
-					'data-large_image'        => esc_url( $full_src[0] ),
-					'data-large_image_width'  => esc_attr( $full_src[1] ),
-					'data-large_image_height' => esc_attr( $full_src[2] ),
-					'class'                   => esc_attr( $image_classname ),
-				),
-				$attachment_id,
-				$image_size,
-				$main_image
-			)
-		);
-	} else {
-		$image = sprintf( '<img src="%s" alt="%s" class="%s" />', esc_url( wc_placeholder_img_src( $image_size ) ), esc_attr( $alt_text ), esc_attr( $image_classname ) );
-	}
+			$main_image
+		)
+	);
 
-	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="' . esc_attr( $wrapper_classname ) . '"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 }
 
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1597,8 +1597,8 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
  * Hooks: woocommerce_gallery_thumbnail_size, woocommerce_gallery_image_size and woocommerce_gallery_full_size accept name based image sizes, or an array of width/height values.
  *
  * @since 3.3.2
- * @param string $attachment_id Attachment ID.
- * @param bool   $main_image Is this the main image or a thumbnail?.
+ * @param int  $attachment_id Attachment ID.
+ * @param bool $main_image Is this the main image or a thumbnail?.
  * @return string
  */
 function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -43,7 +43,7 @@ $wrapper_classes   = apply_filters(
 		if ( $post_thumbnail_id ) {
 			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
-			$wrapper_classname = $has_images ? 'woocommerce-product-gallery__image' : 'woocommerce-product-gallery__image--placeholder';
+			$wrapper_classname = $has_images ? 'woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder' : 'woocommerce-product-gallery__image--placeholder';
 			$html              = sprintf( '<div class="%s">', esc_attr( $wrapper_classname ) );
 			$html             .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woocommerce_single' ) ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
 			$html             .= '</div>';

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -26,12 +26,11 @@ global $product;
 
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
 $post_thumbnail_id = $product->get_image_id();
-$has_images        = $post_thumbnail_id || ( $product->is_type( 'variable' ) && ! empty( $product->get_available_variations( 'image' ) ) );
 $wrapper_classes   = apply_filters(
 	'woocommerce_single_product_image_gallery_classes',
 	array(
 		'woocommerce-product-gallery',
-		'woocommerce-product-gallery--' . ( $has_images ? 'with-images' : 'without-images' ),
+		'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
 		'woocommerce-product-gallery--columns-' . absint( $columns ),
 		'images',
 	)
@@ -43,7 +42,9 @@ $wrapper_classes   = apply_filters(
 		if ( $post_thumbnail_id ) {
 			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
-			$wrapper_classname = $has_images ? 'woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder' : 'woocommerce-product-gallery__image--placeholder';
+			$wrapper_classname = $product->is_type( 'variable' ) && ! empty( $product->get_available_variations( 'image' ) ) ?
+				'woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder' :
+				'woocommerce-product-gallery__image--placeholder';
 			$html              = sprintf( '<div class="%s">', esc_attr( $wrapper_classname ) );
 			$html             .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woocommerce_single' ) ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
 			$html             .= '</div>';

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -26,11 +26,12 @@ global $product;
 
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
 $post_thumbnail_id = $product->get_image_id();
+$has_images        = $post_thumbnail_id || ( $product->is_type( 'variable' ) && ! empty( $product->get_available_variations( 'image' ) ) );
 $wrapper_classes   = apply_filters(
 	'woocommerce_single_product_image_gallery_classes',
 	array(
 		'woocommerce-product-gallery',
-		'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
+		'woocommerce-product-gallery--' . ( $has_images ? 'with-images' : 'without-images' ),
 		'woocommerce-product-gallery--columns-' . absint( $columns ),
 		'images',
 	)
@@ -39,7 +40,14 @@ $wrapper_classes   = apply_filters(
 <div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
 	<div class="woocommerce-product-gallery__wrapper">
 		<?php
-		$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
+		if ( $post_thumbnail_id ) {
+			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
+		} else {
+			$wrapper_classname = $has_images ? 'woocommerce-product-gallery__image' : 'woocommerce-product-gallery__image--placeholder';
+			$html              = sprintf( '<div class="%s">', esc_attr( $wrapper_classname ) );
+			$html             .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woocommerce_single' ) ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
+			$html             .= '</div>';
+		}
 
 		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $post_thumbnail_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 9.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -39,13 +39,7 @@ $wrapper_classes   = apply_filters(
 <div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
 	<div class="woocommerce-product-gallery__wrapper">
 		<?php
-		if ( $post_thumbnail_id ) {
-			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
-		} else {
-			$html  = '<div class="woocommerce-product-gallery__image--placeholder">';
-			$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woocommerce_single' ) ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
-			$html .= '</div>';
-		}
+		$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 
 		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $post_thumbnail_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/27247.

This PR makes it so even if a variable product's main _Product Image_ is missing but variation images exist, the zoom/flex slider functionalities are initialized.

### How to test the changes in this Pull Request:

1. Create a new Variable product.
2. Don't add a _Product image_.
3. Add some images to some of the variations you created.
4. In the frontend, verify you can zoom in and expand the variation images:

https://github.com/woocommerce/woocommerce/assets/3616980/c8566a25-41c6-4521-a7a8-0ece615d4f0c

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
