### PR TITLE
Loop through each package to check if the chosen rate for it is valid

### DIFF
--- a/plugins/woocommerce/changelog/fix-check-valid-shipping-rates
+++ b/plugins/woocommerce/changelog/fix-check-valid-shipping-rates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check each pacakge's chosen shipping rate against each valid rate for that package

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -556,14 +556,20 @@ class OrderController {
 			throw $exception;
 		}
 
-		$valid_methods = array_keys( WC()->shipping()->get_shipping_methods() );
+		$packages = WC()->shipping()->get_packages();
+		foreach ( $packages as $package_id => $package ) {
+			$chosen_rate_for_package    = wc_get_chosen_shipping_method_for_package( $package_id, $package );
+			$valid_rate_ids_for_package = array_map(
+				function ( $rate ) {
+					return $rate->id;
+				},
+				$package['rates']
+			);
 
-		foreach ( $chosen_shipping_methods as $chosen_shipping_method ) {
 			if (
-				false === $chosen_shipping_method ||
-				! is_string( $chosen_shipping_method ) ||
-				! ArrayUtils::string_contains_array( $chosen_shipping_method, $valid_methods )
-			) {
+				false === $chosen_rate_for_package ||
+				! is_string( $chosen_rate_for_package ) ||
+				! ArrayUtils::string_contains_array( $chosen_rate_for_package, $valid_rate_ids_for_package ) ) {
 				throw $exception;
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes issues added by checking for the _method_ id when validating shipping _rate_ ID's.

The code now loops over every package in the order and verifies that the chosen rate for that package is in the package's rates array.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Developer testing

Install a shipping method whose rate IDs are different to the method ID. You can use this code snippet and add it to the code snippets plugin. There have been reports of this bug happening with UPS, so if that is set up on your store you can  also use that.

<details>
<summary>Expand to get testing code</summary>

```php
if ( ! class_exists( 'WC_Custom_Shipping_Method' ) ) {
	class WC_Custom_Shipping_Method extends WC_Shipping_Method {

		public function __construct() {
			$this->id                 = 'custom_shipping_method-with-some-random-text';
			$this->method_title       = __( 'Custom Shipping Method', 'custom-shipping-method' );
			$this->method_description = __( 'Description of your custom shipping method', 'custom-shipping-method' );

			$this->enabled = "yes";
			$this->title   = "Custom Shipping";

			$this->init();
		}

		function init() {
			// Load the settings API
			$this->init_form_fields();
			$this->init_settings();

			// Save settings in admin if you have any defined
			add_action( 'woocommerce_update_options_shipping_' . $this->id, array(
				$this,
				'process_admin_options'
			) );
		}

		// Define settings field for this shipping
		function init_form_fields() {
			$this->form_fields = array(
				'enabled' => array(
					'title'       => __( 'Enable', 'custom-shipping-method' ),
					'type'        => 'checkbox',
					'description' => __( 'Enable this shipping.', 'custom-shipping-method' ),
					'default'     => 'yes'
				),
				'title'   => array(
					'title'       => __( 'Title', 'custom-shipping-method' ),
					'type'        => 'text',
					'description' => __( 'Title to be displayed on site', 'custom-shipping-method' ),
					'default'     => __( 'Custom Shipping', 'custom-shipping-method' )
				),
				'cost'    => array(
					'title'       => __( 'Cost', 'custom-shipping-method' ),
					'type'        => 'text',
					'description' => __( 'Cost for this shipping method', 'custom-shipping-method' ),
					'default'     => '10'
				)
			);
		}

		// Calculate the shipping costs
		public function calculate_shipping( $package = array() ) {
			$rate = array(
				'label'    => $this->title,
				'cost'     => $this->settings['cost'],
				'calc_tax' => 'per_item',
				'id' => 'completely-unrelated-rate-id'
			);

			// Register the rate
			$this->add_rate( $rate );
		}
	}
}

// Add the custom shipping method to WooCommerce
function add_custom_shipping_method( $methods ) {
	$methods['custom_shipping_method'] = 'WC_Custom_Shipping_Method';

	return $methods;
}

add_filter( 'woocommerce_shipping_methods', 'add_custom_shipping_method' );

function custom_shipping_method_init() {
	if ( ! class_exists( 'WC_Custom_Shipping_Method' ) ) {
		require_once( plugin_basename( __FILE__ ) );
	}
}

add_action( 'woocommerce_shipping_init', 'custom_shipping_method_init' );
```

1. Place an order using this shipping method and ensure it's successful.
2. Install [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/) and go to its settings, set it to "Individual" mode.
3. Add two other shipping rates, e.g. flat rate and free shipping.
4. Add 3 items to your cart and go to the Checkout block.
5. For each package choose a different shipping method (The custom method above should be chosen for one of them)
6. Ensure you can check out successfully.

</details>

#### User testing

1. Add two shipping methods to your site, Free Shipping and Flat rate will be fine.
2. Add items to your cart and ensure you can check out successfully.
3. Install [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/) and go to its settings, set it to "Individual" mode.
4. Add multiple items to your cart and ensure you can check out using different shipping methods for each product.

#### Regression testing

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Have a shipping zone with at least one shipping method, but **do not enable it**.  (If there are no shipping zones/methods at all, Woo will not include a shipping section at all on the checkout page.)
7. Make sure that the checkout page is built with the Checkout Block.
8. As a customer, buy a product and go to the checkout page.
9. Eenter an address that does not support shipping. You'll want to see the message "_There are no shipping options available. Please check your shipping address._"
10. Select the **Place Order** button.
11. Ensure the order does not place.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
