### PR TITLE
Handle `screen-reader-text` on e-mails

### DIFF
--- a/plugins/woocommerce/changelog/fix-46997
+++ b/plugins/woocommerce/changelog/fix-46997
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add screen-reader-text styles to e-mails.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -616,6 +616,16 @@ class WC_Email extends WC_Settings_API {
 
 					$dom_document = $css_inliner->getDomDocument();
 
+					// Remove `.screen-reader-text` elements until there's better support in e-mail clients for the
+					// necessary styles. See https://github.com/woocommerce/woocommerce/pull/47738.
+					foreach ( ( new \DOMXPath( $dom_document ) )->query( "//*[contains(concat(' ', @class, ' '), ' screen-reader-text ')]" ) as $element ) {
+						// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						if ( null !== $element->parentNode ) {
+							$element->parentNode->removeChild( $element );
+						}
+						// phpcs:enable
+					}
+
 					HtmlPruner::fromDomDocument( $dom_document )->removeElementsWithDisplayNone();
 					$content = CssToAttributeConverter::fromDomDocument( $dom_document )
 						->convertCssToVisualAttributes()

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -610,6 +610,14 @@ class WC_Email extends WC_Settings_API {
 			wc_get_template( 'emails/email-styles.php' );
 			$css .= ob_get_clean();
 
+			/**
+			 * Provides an opportunity to filter the CSS styles included in e-mails.
+			 *
+			 * @since 2.3.0
+			 *
+			 * @param string    $css   CSS code.
+			 * @param \WC_Email $email E-mail instance.
+			 */
 			$css = apply_filters( 'woocommerce_email_styles', $css, $this );
 
 			$css_inliner_class = CssInliner::class;

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -602,9 +602,15 @@ class WC_Email extends WC_Settings_API {
 	 */
 	public function style_inline( $content ) {
 		if ( in_array( $this->get_content_type(), array( 'text/html', 'multipart/alternative' ), true ) ) {
+			$css  = '';
+			$css .= $this->get_must_use_css_styles();
+			$css .= "\n";
+
 			ob_start();
 			wc_get_template( 'emails/email-styles.php' );
-			$css = apply_filters( 'woocommerce_email_styles', ob_get_clean(), $this );
+			$css .= ob_get_clean();
+
+			$css = apply_filters( 'woocommerce_email_styles', $css, $this );
 
 			$css_inliner_class = CssInliner::class;
 
@@ -630,6 +636,29 @@ class WC_Email extends WC_Settings_API {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Returns CSS styles that should be included with all HTML e-mails, regardless of theme specific customizations.
+	 *
+	 * @since 9.1.0
+	 *
+	 * @return string
+	 */
+	protected function get_must_use_css_styles(): string {
+		$css = <<<'EOF'
+
+		/*
+		* Temporary measure until e-mail clients more properly support the correct styles.
+		* See https://github.com/woocommerce/woocommerce/pull/47738.
+		*/
+		.screen-reader-text {
+			display: none;
+		}
+
+		EOF;
+
+		return $css;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -616,16 +616,6 @@ class WC_Email extends WC_Settings_API {
 
 					$dom_document = $css_inliner->getDomDocument();
 
-					// Remove `.screen-reader-text` elements until there's better support in e-mail clients for the
-					// necessary styles. See https://github.com/woocommerce/woocommerce/pull/47738.
-					foreach ( ( new \DOMXPath( $dom_document ) )->query( "//*[contains(concat(' ', @class, ' '), ' screen-reader-text ')]" ) as $element ) {
-						// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						if ( null !== $element->parentNode ) {
-							$element->parentNode->removeChild( $element );
-						}
-						// phpcs:enable
-					}
-
 					HtmlPruner::fromDomDocument( $dom_document )->removeElementsWithDisplayNone();
 					$content = CssToAttributeConverter::fromDomDocument( $dom_document )
 						->convertCssToVisualAttributes()

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 8.6.0
+ * @version 9.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -241,6 +241,14 @@ img {
 	vertical-align: middle;
 	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 10px;
 	max-width: 100%;
+}
+
+/*
+ * Temporary measure until e-mail clients more properly support the correct styles.
+ * See https://github.com/woocommerce/woocommerce/pull/47738.
+ */
+.screen-reader-text {
+	display: none;
 }
 
 /**

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.1.0
+ * @version 8.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -241,14 +241,6 @@ img {
 	vertical-align: middle;
 	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 10px;
 	max-width: 100%;
-}
-
-/*
- * Temporary measure until e-mail clients more properly support the correct styles.
- * See https://github.com/woocommerce/woocommerce/pull/47738.
- */
-.screen-reader-text {
-	display: none;
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In #44413 we introduced some markup changes to the way we format sale prices on the frontend to include screen reader text, which is identified by the `screen-reader-text` CSS class. This class results in the text being visually hidden but available to screen reader tools (like macOS VoiceOver), but in https://github.com/woocommerce/woocommerce/issues/46997#issuecomment-2120670671, we were notified that in e-mail templates with calls to `wc_format_sale_price()`, the screen reader text was visible, resulting in a less than ideal experience:

<img width="637" alt="Screenshot 2024-05-22 at 14 34 18" src="https://github.com/woocommerce/woocommerce/assets/184724/8abf308f-7b1a-459c-9ed4-4924f390b345">

This happens because our e-mail styles don't have anything in place for this `screen-reader-text` CSS class that the function uses, and we can't just borrow the styles that apply to this class on the frontend and backend because those don't play nicely with most e-mail clients (including Gmail), and so the text remains visible.

A simpler approach would be to use `display: none;`, which our e-mail code then [removes from the resulting e-mail](https://github.com/woocommerce/woocommerce/blob/f1489892aa97bb38cbf0288ad7829c122a598288/plugins/woocommerce/includes/emails/class-wc-email.php#L619).

This might seem like a regression as the accessible text is no longer in the e-mail, but, once again, testing revealed that eve if we didn't do this in our code, Gmail (for example) would still remove from markup those non-visible elements.
Because of that, it seems like removing those elements from the e-mail is the way to go. To do this we can either rely on the automatic removal of `display: none;` elements or, manually remove `screen-reader-text` elements from the markup before the e-mail is sent.

This PR showcases both approaches, hoping we can discuss which one to keep:

- In 61575b38283ce2e580d201c6b4cec8da4fd89c91, `screen-reader-text` are removed from the markup using XPath. This has the advantage of not requiring updates to the style template, in case it's been overridden in a theme, but it's a bit more convoluted.
- 6d5de7486ad5705064cabf2c5a905f5e7618de62, on the other hand, just adds `visiblity: none;` to the `.screen-reader-text`, which is a much simpler approach. This, however, involves a version bump in our styles template, and thus might affect those themes overriding the template.

⚠️ **Note:** If we want to go with the XPath approach, I'd need to reorganize the commits, so don't merge immediately.

Related to #46997.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

You'll need to be able to receive e-mails from your test site, so either make sure your WP instance is able to send e-mails or use software like MailHog or a plugin like [WP Mail Logging](https://wordpress.org/plugins/wp-mail-logging/).

1. Drop the following snippet as a .php file in `wp-content/mu-plugins/` or activate as a snippet using plugins like [Code Snippet](https://wordpress.org/plugins/code-snippets/):
   ```php
   <?php
   add_action(
	   'woocommerce_email_order_details',
	   function( $order ) {
		   echo '<ul>';
			   foreach ( $order->get_items() as $item ):
				   printf( '<li>%s - %s</li>', $item->get_name(), $item->get_product()->get_price_html() );
			   endforeach;
		   echo '</ul>';
	   }
   );
   ```
   This snippet adds a list to the "order details" e-mail that uses the sale price formatting.
2. Go to WC > Products and create a product that is on sale (i.e. specify both its regular and sale price).
3. Go to WC > Orders > Add Order and add this item to the order. Choose a customer and click **Create**.
4. In the **Order actions** metabox, select **Send order details to customer** and click the action button (`>`).
5. Check your e-mail (or MailHog or WP Mail Logging's e-mail log) and confirm that the message has been received and the "sale" price information looks correct with no screen reader text:
   <img width="547" alt="Screenshot 2024-05-23 at 10 15 53" src="https://github.com/woocommerce/woocommerce/assets/184724/06de42ca-d43a-441f-aa2d-853f58a40cb3">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
