### PR TITLE
Prevent the possibility of unpublished coupons from being available

### DIFF
--- a/plugins/woocommerce/changelog/47739-fix-47720
+++ b/plugins/woocommerce/changelog/47739-fix-47720
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Possible availability of unpublished coupons on sites with an object cache has been addressed through improved cache management.

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -191,8 +191,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$coupon->apply_changes();
 		delete_transient( 'rest_api_coupons_type_count' );
 
-		// The cache must be cleared when the coupon's status transitions from 'publish' to 'future', otherwise the coupon will remain available for use.
-		if ( 'future' === $coupon->get_status() ) {
+		// The `coupon_id_from_code` entry in the object cache must not exist when the coupon is not published, otherwise the coupon will remain available for use.
+		if ( 'publish' !== $coupon->get_status() ) {
 			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code(), 'coupons' );
 		}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -190,6 +190,12 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$this->update_post_meta( $coupon );
 		$coupon->apply_changes();
 		delete_transient( 'rest_api_coupons_type_count' );
+
+		// The cache must be cleared when the coupon's status transitions from 'publish' to 'future', otherwise the coupon will remain available for use.
+		if ( 'future' === $coupon->get_status() ) {
+			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code(), 'coupons' );
+		}
+
 		do_action( 'woocommerce_update_coupon', $coupon->get_id(), $coupon );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #47720

Coupons which are now scheduled but were previously published may still be usable due to a stale object cache entry which should only exist if the coupon's status is `publish`. This pull request adds logic which checks the coupon's status, and deletes the offending object cache entry when a coupon is updated.

### How to test the changes in this Pull Request:

1. Enable an Object Cache on the WordPress installation.
2. Create a coupon and publish it.
3. Add one or more products to the cart.
4. Add the coupon created in the aforementioned step to the cart.
5. Schedule the coupon to be published in the future.
6. Reload the cart page.

Without the changes in this pull request, the steps above will result in the coupon remaining available for use even though it shouldn't be.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Possible availability of unpublished coupons on sites with an object cache has been addressed through improved cache management.


#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
