### PR TITLE
[WIP] Remove isFeaturePlugin, add experimental setting to enable "experimental block styling"

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/support.ts
@@ -2,10 +2,10 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 
 export const supports = {
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			text: true,
 			background: true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/index.tsx
@@ -3,7 +3,7 @@
  */
 import { Icon, button } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ import metadata from './block.json';
 
 const featurePluginSupport = {
 	...metadata.supports,
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			text: true,
 			background: true,
@@ -49,7 +49,7 @@ const featurePluginSupport = {
 			'.wp-block-button.wc-block-components-product-button .wc-block-components-product-button__button',
 	} ),
 	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' &&
-		! isFeaturePluginBuild() && {
+		! isExperimentalBlockStylingEnabled() && {
 			spacing: {
 				margin: true,
 			},

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
@@ -11,7 +11,7 @@ import { __experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles 
 
 export const supports = {
 	html: false,
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		__experimentalBorder: {
 			radius: true,
 			__experimentalSkipSerialization: true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/supports.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
@@ -11,7 +11,7 @@ import sharedConfig from '../shared/config';
 
 export const supports = {
 	...sharedConfig.supports,
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			text: true,
 			background: true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/support.ts
@@ -2,10 +2,10 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 
 export const supports = {
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			text: false,
 			background: false,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/support.ts
@@ -2,10 +2,10 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 
 export const supports = {
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			text: true,
 			background: false,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/support.ts
@@ -2,11 +2,11 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 export const supports = {
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			text: true,
 			background: false,
@@ -23,7 +23,7 @@ export const supports = {
 		},
 		__experimentalSelector: '.wc-block-components-product-rating',
 	} ),
-	...( ! isFeaturePluginBuild() &&
+	...( ! isExperimentalBlockStylingEnabled() &&
 		typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
@@ -2,13 +2,13 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 export const supports = {
 	html: false,
 	align: true,
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			gradients: true,
 			background: true,
@@ -42,7 +42,7 @@ export const supports = {
 		__experimentalSelector: '.wc-block-components-product-sale-badge',
 	} ),
 	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' &&
-		! isFeaturePluginBuild() && {
+		! isExperimentalBlockStylingEnabled() && {
 			spacing: {
 				margin: true,
 			},

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/supports.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import {
 	// @ts-expect-error We check if this exists before using it.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -22,7 +22,7 @@ export const supports = {
 	typography: {
 		fontSize: true,
 		lineHeight: true,
-		...( isFeaturePluginBuild() && {
+		...( isExperimentalBlockStylingEnabled() && {
 			__experimentalFontWeight: true,
 			__experimentalFontFamily: true,
 			__experimentalFontStyle: true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/supports.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import {
 	// @ts-expect-error We check if this exists before using it.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -22,7 +22,7 @@ export const supports = {
 	typography: {
 		fontSize: true,
 		lineHeight: true,
-		...( isFeaturePluginBuild() && {
+		...( isExperimentalBlockStylingEnabled() && {
 			__experimentalFontWeight: true,
 			__experimentalFontFamily: true,
 			__experimentalFontStyle: true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/supports.ts
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 
 export const supports = {
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		color: {
 			background: false,
 		},

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/attributes.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import type { BlockAttributes } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 
 let blockAttributes: BlockAttributes = {
 	headingLevel: {
@@ -22,7 +22,7 @@ let blockAttributes: BlockAttributes = {
 	},
 };
 
-if ( isFeaturePluginBuild() ) {
+if ( isExperimentalBlockStylingEnabled() ) {
 	blockAttributes = {
 		...blockAttributes,
 		align: {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -6,7 +6,7 @@ import {
 	useInnerBlockLayoutContext,
 	useProductDataContext,
 } from '@woocommerce/shared-context';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
 import ProductName from '@woocommerce/base-components/product-name';
 import { useStoreEvents } from '@woocommerce/base-context/hooks';
@@ -73,10 +73,12 @@ export const Block = ( props: Props ): JSX.Element => {
 						[ `${ parentClassName }__product-title` ]:
 							parentClassName,
 						[ `wc-block-components-product-title--align-${ align }` ]:
-							align && isFeaturePluginBuild(),
+							align && isExperimentalBlockStylingEnabled(),
 					}
 				) }
-				style={ isFeaturePluginBuild() ? styleProps.style : {} }
+				style={
+					isExperimentalBlockStylingEnabled() ? styleProps.style : {}
+				}
 			/>
 		);
 	}
@@ -91,10 +93,12 @@ export const Block = ( props: Props ): JSX.Element => {
 				{
 					[ `${ parentClassName }__product-title` ]: parentClassName,
 					[ `wc-block-components-product-title--align-${ align }` ]:
-						align && isFeaturePluginBuild(),
+						align && isExperimentalBlockStylingEnabled(),
 				}
 			) }
-			style={ isFeaturePluginBuild() ? styleProps.style : {} }
+			style={
+				isExperimentalBlockStylingEnabled() ? styleProps.style : {}
+			}
 		>
 			<ProductName
 				disabled={ ! showProductLink }

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -10,7 +10,7 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import HeadingToolbar from '@woocommerce/editor-components/heading-toolbar';
 
 /**
@@ -42,7 +42,7 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 						setAttributes( { headingLevel: newLevel } )
 					}
 				/>
-				{ isFeaturePluginBuild() && (
+				{ isExperimentalBlockStylingEnabled() && (
 					<AlignmentToolbar
 						value={ align }
 						onChange={ ( newAlign ) => {
@@ -84,7 +84,7 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 	);
 };
 
-const Title = isFeaturePluginBuild()
+const Title = isExperimentalBlockStylingEnabled()
 	? compose( [
 			withProductSelector( {
 				icon: BLOCK_ICON,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -4,7 +4,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
@@ -31,7 +31,7 @@ const blockConfig: BlockConfiguration = {
 	save: Save,
 	supports: {
 		...sharedConfig.supports,
-		...( isFeaturePluginBuild() && {
+		...( isExperimentalBlockStylingEnabled() && {
 			typography: {
 				fontSize: true,
 				lineHeight: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/deprecated.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/deprecated.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import classNames from 'classnames';
 
 /**
@@ -15,7 +15,7 @@ import metadata from './block.json';
 const v1 = {
 	supports: {
 		...metadata.supports,
-		...( isFeaturePluginBuild() && {
+		...( isExperimentalBlockStylingEnabled() && {
 			__experimentalBorder: {
 				radius: false,
 				color: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/breadcrumbs/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/breadcrumbs/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { Icon } from '@wordpress/icons';
 
 /**
@@ -15,7 +15,7 @@ import './style.scss';
 
 const featurePluginSupport = {
 	...metadata.supports,
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		typography: {
 			...metadata.supports.typography,
 			__experimentalFontFamily: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/register.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/register.tsx
@@ -7,7 +7,7 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { getSetting } from '@woocommerce/settings';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import type { FunctionComponent } from 'react';
 import type { BlockConfiguration } from '@wordpress/blocks';
 
@@ -75,7 +75,7 @@ export function register(
 			},
 			spacing: {
 				padding: metadata.supports?.spacing?.padding,
-				...( isFeaturePluginBuild() && {
+				...( isExperimentalBlockStylingEnabled() && {
 					__experimentalDefaultControls: {
 						padding:
 							metadata.supports?.spacing
@@ -86,7 +86,7 @@ export function register(
 							?.__experimentalSkipSerialization,
 				} ),
 			},
-			...( isFeaturePluginBuild() && {
+			...( isExperimentalBlockStylingEnabled() && {
 				__experimentalBorder: metadata?.supports?.__experimentalBorder,
 			} ),
 		},

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/index.tsx
@@ -4,7 +4,7 @@
 import { miniCartAlt } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ import './style.scss';
 
 const featurePluginSupport = {
 	...metadata.supports,
-	...( isFeaturePluginBuild() && {
+	...( isExperimentalBlockStylingEnabled() && {
 		typography: {
 			...metadata.supports.typography,
 			__experimentalFontFamily: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -8,7 +8,7 @@ import {
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { EditorProvider } from '@woocommerce/base-context';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 import type { TemplateArray } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import type { FocusEvent, ReactElement } from 'react';
@@ -115,7 +115,7 @@ const Edit = ( {
 
 	return (
 		<>
-			{ isFeaturePluginBuild() && (
+			{ isExperimentalBlockStylingEnabled() && (
 				<InspectorControls key="inspector">
 					<PanelBody
 						title={ __( 'Dimensions', 'woocommerce' ) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
@@ -6,7 +6,7 @@ import { cart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlockStylingEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ const settings: BlockConfiguration = {
 			link: true,
 		},
 		lock: false,
-		...( isFeaturePluginBuild() && {
+		...( isExperimentalBlockStylingEnabled() && {
 			__experimentalBorder: {
 				color: true,
 				width: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/index.tsx
@@ -14,7 +14,7 @@ import {
 	more,
 	starEmpty,
 } from '@wordpress/icons';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { __ } from '@wordpress/i18n';
 import { toggle } from '@woocommerce/icons';
 
@@ -27,7 +27,7 @@ import save from './save';
 import { BLOCK_NAME_MAP } from './constants';
 import { BlockAttributes } from './types';
 
-if ( isExperimentalBuild() ) {
+if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, {
 		icon: {
 			src: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/index.tsx
@@ -4,7 +4,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon } from '@wordpress/icons';
 import { toggle } from '@woocommerce/icons';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import metadata from './block.json';
 import Edit from './edit';
 import './style.scss';
 
-if ( isExperimentalBuild() ) {
+if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, {
 		icon: {
 			src: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/attribute-filter/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import './style.scss';
 import metadata from './block.json';
 import Edit from './edit';
 
-if ( isExperimentalBuild() ) {
+if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, {
 		edit: Edit,
 	} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/clear-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/clear-button/index.tsx
@@ -3,7 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { button as icon } from '@wordpress/icons';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import metadata from './block.json';
 import Edit from './edit';
 import save from './save';
 
-if ( isExperimentalBuild() ) {
+if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, {
 		icon,
 		edit: Edit,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/index.tsx
@@ -3,7 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, currencyDollar } from '@wordpress/icons';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import './style.scss';
 import metadata from './block.json';
 import Edit from './edit';
 
-if ( isExperimentalBuild() ) {
+if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, {
 		icon: {
 			src: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/stock-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/stock-filter/index.tsx
@@ -3,7 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, box } from '@wordpress/icons';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import './style.scss';
 import edit from './edit';
 import metadata from './block.json';
 
-if ( isExperimentalBuild() ) {
+if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, {
 		icon: {
 			src: (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -10,6 +10,6 @@ import { isExperimentalBuild } from '@woocommerce/block-settings';
 import metadata from './block.json';
 import { ProductFiltersBlockSettings } from './settings';
 
-if ( isExperimentalBuild() ) {
+if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, ProductFiltersBlockSettings );
 }

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
@@ -9,13 +9,14 @@ export type WordCountType =
 	| 'characters_excluding_spaces'
 	| 'characters_including_spaces';
 
-interface WcBlocksConfig {
+export interface WcBlocksConfig {
 	buildPhase: number;
 	pluginUrl: string;
 	productCount: number;
 	defaultAvatar: string;
 	restApiRoutes: Record< string, string[] >;
 	wordCountType: WordCountType;
+	experimentalBlocksEnabled: boolean;
 }
 
 export const blocksConfig = getSetting( 'wcBlocksConfig', {

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
@@ -10,17 +10,16 @@ export type WordCountType =
 	| 'characters_including_spaces';
 
 export interface WcBlocksConfig {
-	buildPhase: number;
 	pluginUrl: string;
 	productCount: number;
 	defaultAvatar: string;
 	restApiRoutes: Record< string, string[] >;
 	wordCountType: WordCountType;
 	experimentalBlocksEnabled: boolean;
+	experimentalBlockStylingEnabled: boolean;
 }
 
 export const blocksConfig = getSetting( 'wcBlocksConfig', {
-	buildPhase: 1,
 	pluginUrl: '',
 	productCount: 0,
 	defaultAvatar: '',
@@ -31,7 +30,6 @@ export const blocksConfig = getSetting( 'wcBlocksConfig', {
 export const WC_BLOCKS_IMAGE_URL = blocksConfig.pluginUrl + 'assets/images/';
 export const WC_BLOCKS_BUILD_URL =
 	blocksConfig.pluginUrl + 'assets/client/blocks/';
-export const WC_BLOCKS_PHASE = blocksConfig.buildPhase;
 export const SHOP_URL = STORE_PAGES.shop?.permalink;
 export const CHECKOUT_PAGE_ID = STORE_PAGES.checkout?.id;
 export const CHECKOUT_URL = STORE_PAGES.checkout?.permalink;

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
@@ -6,7 +6,7 @@ import { getSetting } from '@woocommerce/settings';
 /**
  * Internal dependencies
  */
-import { WC_BLOCKS_PHASE, WcBlocksConfig } from './constants';
+import { WcBlocksConfig } from './constants';
 
 /**
  * Checks if experimental blocks are enabled.
@@ -22,8 +22,14 @@ export const isExperimentalBlocksEnabled = (): boolean => {
 };
 
 /**
- * Checks if we're executing the code in an feature plugin or experimental build mode.
+ * Checks if experimental block styling is enabled.
  *
- * @return {boolean} True if this is an experimental or feature plugin build, false otherwise.
+ * @return {boolean} True if experimental block styling is enabled.
  */
-export const isFeaturePluginBuild = (): boolean => WC_BLOCKS_PHASE > 1;
+export const isExperimentalBlockStylingEnabled = (): boolean => {
+	const { experimentalBlockStylingEnabled } = getSetting( 'wcBlocksConfig', {
+		experimentalBlockStylingEnabled: false,
+	} ) as WcBlocksConfig;
+
+	return experimentalBlockStylingEnabled;
+};

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
@@ -1,48 +1,25 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
-import type { Block, BlockConfiguration } from '@wordpress/blocks';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { WC_BLOCKS_PHASE } from './constants';
+import { WC_BLOCKS_PHASE, WcBlocksConfig } from './constants';
 
 /**
- * Registers a new experimental block provided a unique name and an object defining its
- * behavior. Once registered, the block is made available as an option to any
- * editor interface where blocks are implemented.
- */
-export const registerExperimentalBlockType = (
-	blockNameOrMetadata: string | BlockConfiguration,
-	settings: Record< string, unknown >
-): Block | undefined => {
-	if ( WC_BLOCKS_PHASE > 2 ) {
-		return registerBlockType( blockNameOrMetadata, settings );
-	}
-};
-
-/**
- * Registers a new feature plugin block provided a unique name and an object
- * defining its behavior. Once registered, the block is made available as an
- * option to any editor interface where blocks are implemented.
- */
-export const registerFeaturePluginBlockType = (
-	blockNameOrMetadata: string | BlockConfiguration,
-	settings: Record< string, unknown >
-): Block | undefined => {
-	if ( WC_BLOCKS_PHASE > 1 ) {
-		return registerBlockType( blockNameOrMetadata, settings );
-	}
-};
-
-/**
- * Checks if we're executing the code in an experimental build mode.
+ * Checks if experimental blocks are enabled.
  *
- * @return {boolean} True if this is an experimental build, false otherwise.
+ * @return {boolean} True if this experimental blocks are enabled.
  */
-export const isExperimentalBuild = (): boolean => WC_BLOCKS_PHASE > 2;
+export const isExperimentalBuild = (): boolean => {
+	const { experimentalBlocksEnabled } = getSetting( 'wcBlocksConfig', {
+		experimentalBlocksEnabled: false,
+	} ) as WcBlocksConfig;
+
+	return experimentalBlocksEnabled;
+};
 
 /**
  * Checks if we're executing the code in an feature plugin or experimental build mode.

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
@@ -13,7 +13,7 @@ import { WC_BLOCKS_PHASE, WcBlocksConfig } from './constants';
  *
  * @return {boolean} True if this experimental blocks are enabled.
  */
-export const isExperimentalBuild = (): boolean => {
+export const isExperimentalBlocksEnabled = (): boolean => {
 	const { experimentalBlocksEnabled } = getSetting( 'wcBlocksConfig', {
 		experimentalBlocksEnabled: false,
 	} ) as WcBlocksConfig;

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/active-filters.block_theme.spec.ts
@@ -8,12 +8,17 @@ import path from 'path';
  * Internal dependencies
  */
 import { PRODUCT_CATALOG_LINK, PRODUCT_CATALOG_TEMPLATE_ID } from './constants';
+import { cli } from '../../utils';
 
 const TEMPLATE_PATH = path.join( __dirname, './active-filters.handlebars' );
 
 test.describe( 'Product Filter: Active Filters Block', () => {
 	test.describe( 'frontend', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
+
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/attribute-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/attribute-filter.block_theme.spec.ts
@@ -144,6 +144,9 @@ test.describe( 'Product Filter: Attribute Block', () => {
 
 	test.describe( 'With show counts enabled', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,
@@ -177,6 +180,9 @@ test.describe( 'Product Filter: Attribute Block', () => {
 
 	test.describe( "With display style 'dropdown'", () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/attribute-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/attribute-filter.block_theme.spec.ts
@@ -8,6 +8,7 @@ import path from 'path';
  * Internal dependencies
  */
 import { PRODUCT_CATALOG_LINK, PRODUCT_CATALOG_TEMPLATE_ID } from './constants';
+import { cli } from '../../utils';
 
 const TEMPLATE_PATH = path.join( __dirname, './attribute-filter.handlebars' );
 
@@ -24,6 +25,9 @@ const COLOR_ATTRIBUTES_WITH_COUNTS = [
 test.describe( 'Product Filter: Attribute Block', () => {
 	test.describe( 'With default display style', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { cli } from '../../utils';
 
 const filterBlocks = [
 	{
@@ -33,6 +34,10 @@ const filterBlocks = [
 
 test.describe( 'Filter blocks registration', () => {
 	test.beforeEach( async ( { admin } ) => {
+		await cli(
+			'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+		);
+
 		await admin.createNewPost();
 	} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+/**
+ * Internal dependencies
+ */
 import { cli } from '../../utils';
 
 const filterBlocks = [

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/price-filter.block_theme.spec.ts
@@ -8,12 +8,16 @@ import path from 'path';
  * Internal dependencies
  */
 import { PRODUCT_CATALOG_LINK, PRODUCT_CATALOG_TEMPLATE_ID } from './constants';
+import { cli } from '../../utils';
 
 const TEMPLATE_PATH = path.join( __dirname, './price-filter.handlebars' );
 
 test.describe( 'Product Filter: Price Filter Block', () => {
 	test.describe( 'frontend', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/rating-filter.block_theme.spec.ts
@@ -8,12 +8,16 @@ import path from 'path';
  * Internal dependencies
  */
 import { PRODUCT_CATALOG_LINK, PRODUCT_CATALOG_TEMPLATE_ID } from './constants';
+import { cli } from '../../utils';
 
 const TEMPLATE_PATH = path.join( __dirname, './rating-filter.handlebars' );
 
 test.describe( 'Product Filter: Rating Filter Block', () => {
 	test.describe( 'frontend', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
@@ -117,6 +117,9 @@ test.describe( 'Product Filter: Stock Status Block', () => {
 
 	test.describe( 'With dropdown display style', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/stock-status.block_theme.spec.ts
@@ -8,12 +8,16 @@ import path from 'path';
  * Internal dependencies
  */
 import { PRODUCT_CATALOG_LINK, PRODUCT_CATALOG_TEMPLATE_ID } from './constants';
+import { cli } from '../../utils';
 
 const TEMPLATE_PATH = path.join( __dirname, './stock-status.handlebars' );
 
 test.describe( 'Product Filter: Stock Status Block', () => {
 	test.describe( 'With default display style', () => {
 		test.beforeEach( async ( { requestUtils } ) => {
+			await cli(
+				'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+			);
 			await requestUtils.updateTemplateContents(
 				PRODUCT_CATALOG_TEMPLATE_ID,
 				TEMPLATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
@@ -26,9 +26,6 @@ export const blockData = {
 
 test.describe( `${ blockData.name } Block - editor side`, () => {
 	test.beforeEach( async ( { admin, editor } ) => {
-		await cli(
-			'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
-		);
 		await admin.createNewPost();
 		await editor.insertBlock( {
 			name: 'woocommerce/filter-wrapper',
@@ -224,6 +221,10 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 } );
 test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 	test.beforeEach( async ( { admin, page, editor, editorUtils } ) => {
+		await cli(
+			'npm run wp-env run tests-cli -- wp option update wc_blocks_use_blockified_product_grid_block_as_template false'
+		);
+
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
@@ -26,6 +26,9 @@ export const blockData = {
 
 test.describe( `${ blockData.name } Block - editor side`, () => {
 	test.beforeEach( async ( { admin, editor } ) => {
+		await cli(
+			'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+		);
 		await admin.createNewPost();
 		await editor.insertBlock( {
 			name: 'woocommerce/filter-wrapper',
@@ -221,10 +224,6 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 } );
 test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 	test.beforeEach( async ( { admin, page, editor, editorUtils } ) => {
-		await cli(
-			'npm run wp-env run tests-cli -- wp option update wc_blocks_use_blockified_product_grid_block_as_template false'
-		);
-
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -7,6 +7,7 @@ import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
  * Internal dependencies
  */
 import { ProductFiltersPage } from './product-filters.page';
+import { cli } from '../../utils';
 
 const blockData = {
 	name: 'woocommerce/product-filters',
@@ -35,6 +36,10 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editorUtils } ) => {
+		await cli(
+			'npm run wp-env run tests-cli -- wp option update woocommerce_feature_experimental_blocks_enabled yes'
+		);
+
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//${ blockData.slug }`,
 			postType: 'wp_template',

--- a/plugins/woocommerce/changelog/47701-dev-remove-block-phase-experimental
+++ b/plugins/woocommerce/changelog/47701-dev-remove-block-phase-experimental
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the ability to test experimental blocks via the Advanced > Features menu of WooCommerce settings.

--- a/plugins/woocommerce/changelog/47745-dev-remove-feature-plugin-flag
+++ b/plugins/woocommerce/changelog/47745-dev-remove-feature-plugin-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a setting to enable "experimental block styling" in the WooCommerce > Settings > Advanced > Features menu

--- a/plugins/woocommerce/changelog/47746-dev-remove-feature-plugin-flag
+++ b/plugins/woocommerce/changelog/47746-dev-remove-feature-plugin-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a setting to enable "experimental block styling" in the WooCommerce > Settings > Advanced > Features menu

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * AbstractBlock class.
@@ -239,7 +240,7 @@ abstract class AbstractBlock {
 			$block_settings['style'] = null;
 			add_filter(
 				'render_block',
-				function( $html, $block ) use ( $style_handles ) {
+				function ( $html, $block ) use ( $style_handles ) {
 					if ( $block['blockName'] === $this->get_block_type() ) {
 						array_map( 'wp_enqueue_style', $style_handles );
 					}
@@ -437,20 +438,21 @@ abstract class AbstractBlock {
 			$this->asset_data_registry->add(
 				'wcBlocksConfig',
 				[
-					'buildPhase'    => Package::feature()->get_flag(),
-					'pluginUrl'     => plugins_url( '/', dirname( __DIR__, 2 ) ),
-					'productCount'  => array_sum( (array) wp_count_posts( 'product' ) ),
-					'restApiRoutes' => [
+					'buildPhase'                => Package::feature()->get_flag(),
+					'experimentalBlocksEnabled' => FeaturesUtil::feature_is_enabled( 'experimental_blocks' ),
+					'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
+					'productCount'              => array_sum( (array) wp_count_posts( 'product' ) ),
+					'restApiRoutes'             => [
 						'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
 					],
-					'defaultAvatar' => get_avatar_url( 0, [ 'force_default' => true ] ),
+					'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
 
 					/*
 					 * translators: If your word count is based on single characters (e.g. East Asian characters),
 					 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 					 * Do not translate into your own language.
 					 */
-					'wordCountType' => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
+					'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
 				]
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -438,21 +438,21 @@ abstract class AbstractBlock {
 			$this->asset_data_registry->add(
 				'wcBlocksConfig',
 				[
-					'buildPhase'                => Package::feature()->get_flag(),
-					'experimentalBlocksEnabled' => FeaturesUtil::feature_is_enabled( 'experimental_blocks' ),
-					'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
-					'productCount'              => array_sum( (array) wp_count_posts( 'product' ) ),
-					'restApiRoutes'             => [
+					'experimentalBlockStylingEnabled' => FeaturesUtil::feature_is_enabled( 'experimental_block_styling' ),
+					'experimentalBlocksEnabled'       => FeaturesUtil::feature_is_enabled( 'experimental_blocks' ),
+					'pluginUrl'                       => plugins_url( '/', dirname( __DIR__, 2 ) ),
+					'productCount'                    => array_sum( (array) wp_count_posts( 'product' ) ),
+					'restApiRoutes'                   => [
 						'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
 					],
-					'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
+					'defaultAvatar'                   => get_avatar_url( 0, [ 'force_default' => true ] ),
 
 					/*
 					 * translators: If your word count is based on single characters (e.g. East Asian characters),
 					 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 					 * Do not translate into your own language.
 					 */
-					'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
+					'wordCountType'                   => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
 				]
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
 use Automattic\WooCommerce\Blocks\BlockTypes\Checkout;
 use Automattic\WooCommerce\Blocks\BlockTypes\MiniCartContents;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * BlockTypesController class.
@@ -297,7 +298,7 @@ final class BlockTypesController {
 			MiniCartContents::get_mini_cart_block_types()
 		);
 
-		if ( Package::feature()->is_experimental_build() ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental_blocks' ) ) {
 			$block_types[] = 'ProductFilter';
 			$block_types[] = 'ProductFilters';
 			$block_types[] = 'ProductFilterStockStatus';

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -125,15 +125,6 @@ class Package {
 	}
 
 	/**
-	 * Checks if we're executing the code in an experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public function is_experimental_build() {
-		return $this->feature()->is_experimental_build();
-	}
-
-	/**
 	 * Checks if we're executing the code in an feature plugin or experimental build mode.
 	 *
 	 * @return boolean

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -123,13 +123,4 @@ class Package {
 	public function feature() {
 		return $this->feature_gating;
 	}
-
-	/**
-	 * Checks if we're executing the code in an feature plugin or experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public function is_feature_plugin_build() {
-		return $this->feature()->is_feature_plugin_build();
-	}
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
@@ -2,23 +2,12 @@
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 /**
- * Service class that handles the feature flags.
+ * Service class that used to handle feature flags in blocks.
+ * Now the remaining code is only used to determine the environment.
  *
  * @internal
  */
 class FeatureGating {
-
-	/**
-	 * Current flag value.
-	 *
-	 * @var int
-	 */
-	private $flag;
-
-	const EXPERIMENTAL_FLAG   = 3;
-	const FEATURE_PLUGIN_FLAG = 2;
-	const CORE_FLAG           = 1;
-
 	/**
 	 * Current environment
 	 *
@@ -33,30 +22,11 @@ class FeatureGating {
 	/**
 	 * Constructor
 	 *
-	 * @param int    $flag        Hardcoded flag value. Useful for tests.
 	 * @param string $environment Hardcoded environment value. Useful for tests.
 	 */
-	public function __construct( $flag = 0, $environment = 'unset' ) {
-		$this->flag        = $flag;
+	public function __construct( $environment = 'unset' ) {
 		$this->environment = $environment;
-		$this->load_flag();
 		$this->load_environment();
-	}
-
-	/**
-	 * Set correct flag.
-	 */
-	public function load_flag() {
-		if ( 0 === $this->flag ) {
-			$default_flag = defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ? self::FEATURE_PLUGIN_FLAG : self::CORE_FLAG;
-			if ( file_exists( __DIR__ . '/../../../../blocks.ini' ) ) {
-				$allowed_flags = [ self::EXPERIMENTAL_FLAG, self::FEATURE_PLUGIN_FLAG, self::CORE_FLAG ];
-				$woo_options   = parse_ini_file( __DIR__ . '/../../../../blocks.ini' );
-				$this->flag    = is_array( $woo_options ) && in_array( intval( $woo_options['woocommerce_blocks_phase'] ), $allowed_flags, true ) ? $woo_options['woocommerce_blocks_phase'] : $default_flag;
-			} else {
-				$this->flag = $default_flag;
-			}
-		}
 	}
 
 		/**
@@ -75,33 +45,6 @@ class FeatureGating {
 	}
 
 	/**
-	 * Returns the current flag value.
-	 *
-	 * @return int
-	 */
-	public function get_flag() {
-		return $this->flag;
-	}
-
-	/**
-	 * Checks if we're executing the code in an feature plugin or experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public function is_feature_plugin_build() {
-		return $this->flag >= self::FEATURE_PLUGIN_FLAG;
-	}
-
-	/**
-	 * Returns the current environment value.
-	 *
-	 * @return string
-	 */
-	public function get_environment() {
-		return $this->environment;
-	}
-
-	/**
 	 * Checks if we're executing the code in an development environment.
 	 *
 	 * @return boolean
@@ -117,55 +60,5 @@ class FeatureGating {
 	 */
 	public function is_production_environment() {
 		return self::PRODUCTION_ENVIRONMENT === $this->environment;
-	}
-
-	/**
-	 * Checks if we're executing the code in a test environment.
-	 *
-	 * @return boolean
-	 */
-	public function is_test_environment() {
-		return self::TEST_ENVIRONMENT === $this->environment;
-	}
-
-	/**
-	 * Returns core flag value.
-	 *
-	 * @return number
-	 */
-	public static function get_core_flag() {
-		return self::CORE_FLAG;
-	}
-
-	/**
-	 * Returns feature plugin flag value.
-	 *
-	 * @return number
-	 */
-	public static function get_feature_plugin_flag() {
-		return self::FEATURE_PLUGIN_FLAG;
-	}
-
-	/**
-	 * Returns experimental flag value.
-	 *
-	 * @return number
-	 */
-	public static function get_experimental_flag() {
-		return self::EXPERIMENTAL_FLAG;
-	}
-
-
-	/**
-	 * Check if the block templates controller refactor should be used to display blocks.
-	 *
-	 * @return boolean
-	 */
-	public function is_block_templates_controller_refactor_enabled() {
-		if ( file_exists( __DIR__ . '/../../../../blocks.ini' ) ) {
-			$conf = parse_ini_file( __DIR__ . '/../../../../blocks.ini' );
-			return $this->is_development_environment() && isset( $conf['use_block_templates_controller_refactor'] ) && true === (bool) $conf['use_block_templates_controller_refactor'];
-		}
-		return false;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
@@ -84,15 +84,6 @@ class FeatureGating {
 	}
 
 	/**
-	 * Checks if we're executing the code in an experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public function is_experimental_build() {
-		return $this->flag >= self::EXPERIMENTAL_FLAG;
-	}
-
-	/**
 	 * Checks if we're executing the code in an feature plugin or experimental build mode.
 	 *
 	 * @return boolean
@@ -177,5 +168,4 @@ class FeatureGating {
 		}
 		return false;
 	}
-
 }

--- a/plugins/woocommerce/src/Blocks/Package.php
+++ b/plugins/woocommerce/src/Blocks/Package.php
@@ -72,15 +72,6 @@ class Package {
 	}
 
 	/**
-	 * Checks if we're executing the code in an experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public static function is_experimental_build() {
-		return self::get_package()->is_experimental_build();
-	}
-
-	/**
 	 * Checks if we're executing the code in a feature plugin or experimental build mode.
 	 *
 	 * @return boolean

--- a/plugins/woocommerce/src/Blocks/Package.php
+++ b/plugins/woocommerce/src/Blocks/Package.php
@@ -71,15 +71,6 @@ class Package {
 		return self::get_package()->feature();
 	}
 
-	/**
-	 * Checks if we're executing the code in a feature plugin or experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public static function is_feature_plugin_build() {
-		return self::get_package()->is_feature_plugin_build();
-	}
-
 
 	/**
 	 * Loads the dependency injection container for woocommerce blocks.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -162,7 +162,7 @@ class FeaturesController {
 	private function get_feature_definitions() {
 		if ( empty( $this->features ) ) {
 			$legacy_features = array(
-				'analytics'            => array(
+				'analytics'                  => array(
 					'name'               => __( 'Analytics', 'woocommerce' ),
 					'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
 					'option_key'         => Analytics::TOGGLE_OPTION_NAME,
@@ -171,7 +171,7 @@ class FeaturesController {
 					'disable_ui'         => false,
 					'is_legacy'          => true,
 				),
-				'new_navigation'       => array(
+				'new_navigation'             => array(
 					'name'            => __( 'Navigation', 'woocommerce' ),
 					'description'     => __(
 						'Add the new WooCommerce navigation experience to the dashboard',
@@ -182,7 +182,7 @@ class FeaturesController {
 					'disable_ui'      => false,
 					'is_legacy'       => true,
 				),
-				'product_block_editor' => array(
+				'product_block_editor'       => array(
 					'name'            => __( 'New product editor', 'woocommerce' ),
 					'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
 					'is_experimental' => true,
@@ -203,7 +203,7 @@ class FeaturesController {
 						return $string;
 					},
 				),
-				'experimental_blocks'  => array(
+				'experimental_blocks'        => array(
 					'name'            => __( 'Experimental blocks', 'woocommerce' ),
 					'description'     => __( 'Try blocks that are in an experimental state', 'woocommerce' ),
 					'is_experimental' => true,
@@ -224,13 +224,34 @@ class FeaturesController {
 						return $string;
 					},
 				),
-				'cart_checkout_blocks' => array(
+				'experimental_block_styling' => array(
+					'name'            => __( 'Experimental block styling', 'woocommerce' ),
+					'description'     => __( 'Enable additional experimental styling features for blocks that support it', 'woocommerce' ),
+					'is_experimental' => true,
+					'disable_ui'      => false,
+					'is_legacy'       => true,
+					'disabled'        => function () {
+						return version_compare( get_bloginfo( 'version' ), '6.2', '<' );
+					},
+					'desc_tip'        => function () {
+						$string = '';
+						if ( version_compare( get_bloginfo( 'version' ), '6.2', '<' ) ) {
+							$string = __(
+								'⚠ This feature is compatible with WordPress version 6.2 or higher.',
+								'woocommerce'
+							);
+						}
+
+						return $string;
+					},
+				),
+				'cart_checkout_blocks'       => array(
 					'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 					'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
 					'is_experimental' => false,
 					'disable_ui'      => true,
 				),
-				'marketplace'          => array(
+				'marketplace'                => array(
 					'name'               => __( 'Marketplace', 'woocommerce' ),
 					'description'        => __(
 						'New, faster way to find extensions and themes for your WooCommerce store',
@@ -243,7 +264,7 @@ class FeaturesController {
 				),
 				// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 				// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
-				'order_attribution'    => array(
+				'order_attribution'          => array(
 					'name'               => __( 'Order Attribution', 'woocommerce' ),
 					'description'        => __(
 						'Enable this feature to track and credit channels and campaigns that contribute to orders on your site',
@@ -254,7 +275,7 @@ class FeaturesController {
 					'is_legacy'          => true,
 					'is_experimental'    => false,
 				),
-				'hpos_fts_indexes'     => array(
+				'hpos_fts_indexes'           => array(
 					'name'               => __( 'HPOS Full text search indexes', 'woocommerce' ),
 					'description'        => __(
 						'Create and use full text search indexes for orders. This feature only works with high-performance order storage.',

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -203,6 +203,27 @@ class FeaturesController {
 						return $string;
 					},
 				),
+				'experimental_blocks'  => array(
+					'name'            => __( 'Experimental blocks', 'woocommerce' ),
+					'description'     => __( 'Try blocks that are in an experimental state', 'woocommerce' ),
+					'is_experimental' => true,
+					'disable_ui'      => false,
+					'is_legacy'       => true,
+					'disabled'        => function () {
+						return version_compare( get_bloginfo( 'version' ), '6.2', '<' );
+					},
+					'desc_tip'        => function () {
+						$string = '';
+						if ( version_compare( get_bloginfo( 'version' ), '6.2', '<' ) ) {
+							$string = __(
+								'⚠ This feature is compatible with WordPress version 6.2 or higher.',
+								'woocommerce'
+							);
+						}
+
+						return $string;
+					},
+				),
 				'cart_checkout_blocks' => array(
 					'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 					'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
@@ -27,7 +27,7 @@ class DeleteDraftOrders extends TestCase {
 	protected function setUp(): void {
 		global $wpdb;
 
-		$this->draft_orders_instance = new DraftOrders( new Package( 'test', './', new FeatureGating( 2 ) ) );
+		$this->draft_orders_instance = new DraftOrders( new Package( 'test', './', new FeatureGating() ) );
 
 		$order = new WC_Order();
 		$order->set_status( DraftOrders::STATUS );

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -20,10 +20,6 @@ if ( ! defined( 'WC_PLUGIN_FILE' ) ) {
 	define( 'WC_PLUGIN_FILE', __FILE__ );
 }
 
-if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
-	define( 'WC_BLOCKS_IS_FEATURE_PLUGIN', true );
-}
-
 // Load core packages and the autoloader.
 require __DIR__ . '/src/Autoloader.php';
 require __DIR__ . '/src/Packages.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The overall goal of https://github.com/woocommerce/woocommerce/issues/43073 is to remove the concept of WOOCOMMERCE_BLOCKS_PHASE which has never really worked properly since the merge to the monorepo.

In the spirit of keeping PRs small and isolated this PR achieves https://github.com/woocommerce/woocommerce/issues/47693 which removes`isFeaturePlugin`. You can read the issue description for more detail but I'll also post this from the issue here:

After some investigation @gigitux found that the experimental styling properties we're using either:

* Have a stable version we can migrate to
* Will be made stable very soon
* Are used already in blocks shipped with Gutenberg so can be considered stable enough anyway

On the basis of that, and also because we discovered these features had already been inadvertently enabled in production for a while now, we decided a better approach would be to remove `isFeaturePlugin` altogether because it is not actually doing anything (it's always true) and because we don't need to gate these features any more anyway.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

TBD

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a setting to enable "experimental block styling" in the WooCommerce > Settings > Advanced > Features menu

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
