### PR TITLE
Fix incompability of Query Pagination block with Product Collection

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/index.tsx
@@ -13,7 +13,7 @@ import icon from './icon';
 import registerProductSummaryVariation from './variations/elements/product-summary';
 import registerProductTitleVariation from './variations/elements/product-title';
 import registerCollections from './collections';
-import { addProductCollectionBlockToParentOfPaginationBlock } from './utils';
+import { addProductCollectionToQueryPaginationParentOrAncestor } from './utils';
 
 registerBlockType( metadata, {
 	icon,
@@ -23,4 +23,4 @@ registerBlockType( metadata, {
 registerProductSummaryVariation();
 registerProductTitleVariation();
 registerCollections();
-addProductCollectionBlockToParentOfPaginationBlock();
+addProductCollectionToQueryPaginationParentOrAncestor();

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -96,10 +96,10 @@ export function getDefaultValueOfInheritQueryFromTemplate() {
 }
 
 /**
- * Add Product Collection block to the parent array of the Core Pagination block.
+ * Add Product Collection block to the parent or ancestor array of the Core Pagination block.
  * This enhancement allows the Core Pagination block to be available for the Product Collection block.
  */
-export const addProductCollectionBlockToParentOfPaginationBlock = () => {
+export const addProductCollectionToQueryPaginationParentOrAncestor = () => {
 	if ( isWpVersion( '6.1', '>=' ) ) {
 		addFilter(
 			'blocks.registerBlockType',

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -119,7 +119,7 @@ export const addProductCollectionToQueryPaginationParentOrAncestor = () => {
 				if ( blockSettings?.parent ) {
 					return {
 						...blockSettings,
-						ancestor: [ ...blockSettings.parent, blockJson.name ],
+						parent: [ ...blockSettings.parent, blockJson.name ],
 					};
 				}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -105,17 +105,25 @@ export const addProductCollectionBlockToParentOfPaginationBlock = () => {
 			'blocks.registerBlockType',
 			'woocommerce/add-product-collection-block-to-parent-array-of-pagination-block',
 			( blockSettings: Block, blockName: string ) => {
-				if (
-					blockName !== coreQueryPaginationBlockName ||
-					! blockSettings?.parent
-				) {
+				if ( blockName !== coreQueryPaginationBlockName ) {
 					return blockSettings;
 				}
 
-				return {
-					...blockSettings,
-					parent: [ ...blockSettings.parent, blockJson.name ],
-				};
+				if ( blockSettings?.ancestor ) {
+					return {
+						...blockSettings,
+						ancestor: [ ...blockSettings.ancestor, blockJson.name ],
+					};
+				}
+
+				if ( blockSettings?.parent ) {
+					return {
+						...blockSettings,
+						ancestor: [ ...blockSettings.parent, blockJson.name ],
+					};
+				}
+
+				return blockSettings;
 			}
 		);
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -116,6 +116,8 @@ export const addProductCollectionToQueryPaginationParentOrAncestor = () => {
 					};
 				}
 
+				// Below condition is to support WP >=6.4 where Pagination specifies the parent.
+				// Can be removed when minimum WP version is set to 6.5 and higher.
 				if ( blockSettings?.parent ) {
 					return {
 						...blockSettings,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -10,15 +10,11 @@ import type { Request } from '@playwright/test';
 import ProductCollectionPage, { SELECTORS } from './product-collection.page';
 
 const test = base.extend< { pageObject: ProductCollectionPage } >( {
-	pageObject: async (
-		{ page, admin, editor, templateApiUtils, editorUtils },
-		use
-	) => {
+	pageObject: async ( { page, admin, editor, editorUtils }, use ) => {
 		const pageObject = new ProductCollectionPage( {
 			page,
 			admin,
 			editor,
-			templateApiUtils,
 			editorUtils,
 		} );
 		await use( pageObject );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -876,6 +876,29 @@ test.describe( 'Product Collection', () => {
 				featuredProductsPrices
 			);
 		} );
+
+		test( 'With multiple Pagination blocks', async ( {
+			page,
+			admin,
+			editor,
+			editorUtils,
+			pageObject,
+		} ) => {
+			await admin.createNewPost();
+			await pageObject.insertProductCollection();
+			await pageObject.chooseCollectionInPost( 'productCatalog' );
+			const paginations = page.getByLabel( 'Block: Pagination' );
+
+			expect( paginations ).toHaveCount( 1 );
+
+			const siblingBlock = await editorUtils.getBlockByName(
+				'woocommerce/product-template'
+			);
+			await editor.selectBlocks( siblingBlock );
+			await editorUtils.insertBlockUsingGlobalInserter( 'Pagination' );
+
+			expect( paginations ).toHaveCount( 2 );
+		} );
 	} );
 
 	test.describe( 'Location is recognised', () => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -889,7 +889,7 @@ test.describe( 'Product Collection', () => {
 			await pageObject.chooseCollectionInPost( 'productCatalog' );
 			const paginations = page.getByLabel( 'Block: Pagination' );
 
-			expect( paginations ).toHaveCount( 1 );
+			await expect( paginations ).toHaveCount( 1 );
 
 			const siblingBlock = await editorUtils.getBlockByName(
 				'woocommerce/product-template'
@@ -897,7 +897,7 @@ test.describe( 'Product Collection', () => {
 			await editor.selectBlocks( siblingBlock );
 			await editorUtils.insertBlockUsingGlobalInserter( 'Pagination' );
 
-			expect( paginations ).toHaveCount( 2 );
+			await expect( paginations ).toHaveCount( 2 );
 		} );
 	} );
 

--- a/plugins/woocommerce/changelog/47717-incompability-with-blocks-from-builders-at-pagination-to-top-and-cannot-duplicate-the-pagiantion-block-at-the-recent-updates
+++ b/plugins/woocommerce/changelog/47717-incompability-with-blocks-from-builders-at-pagination-to-top-and-cannot-duplicate-the-pagiantion-block-at-the-recent-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: fix the incompatibility of Query Pagination block with Product Collection


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/WordPress/gutenberg/pull/58602, the `parent` property was replaced with `ancestor` in Query Pagination block which influenced the ability to insert Query Pagination in Product Collection block.

This PR amends the logic that edits Query Pagination metadata to recognise if `parent` is defined in older WordPress versions of `ancestor` in newer and extends these.

Closes https://github.com/woocommerce/woocommerce/issues/47717

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Insert Product Collection block
3. Choose Product Catalog collection
4. Try inserting second Pagination block inside Product Collection
5. **Expected:** you can find Pagination block and insert it:

<img width="355" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/262a51bc-849e-4653-a33a-64706d704a46">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
