### PR TITLE
Blocks E2E: Cancel running jobs on new commits

### DIFF
--- a/.github/workflows/blocks-playwright.yml
+++ b/.github/workflows/blocks-playwright.yml
@@ -11,6 +11,10 @@ on:
     # Allow manually triggering the workflow.
     workflow_dispatch:
 
+concurrency:
+    group: '${{ github.workflow }}-${{ github.ref }}'
+    cancel-in-progress: true
+
 env:
     FORCE_COLOR: 1
 


### PR DESCRIPTION
### What?

Let's save some time & resources by canceling running Blocks E2E jobs when new commits are pushed to a PR. 

### How to test

Feel free to push to this PR a couple of times to check if it cancels the previous job :)