### PR TITLE
Fix two products being added to cart when Geolocate (with page caching support) was enabled and AJAX add to cart buttons disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-33077-fix-2-products-added-to-cart-geolocate-with-caching
+++ b/plugins/woocommerce/changelog/fix-33077-fix-2-products-added-to-cart-geolocate-with-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix two products being added to cart when Geolocate (with page caching support) was enabled and AJAX add to cart buttons disabled

--- a/plugins/woocommerce/includes/class-wc-cache-helper.php
+++ b/plugins/woocommerce/includes/class-wc-cache-helper.php
@@ -169,8 +169,7 @@ class WC_Cache_Helper {
 					$redirect_url = add_query_arg( $wp->query_string, '', $redirect_url );
 				}
 
-				$redirect_url = add_query_arg( 'v', $location_hash, remove_query_arg( 'v', $redirect_url ) );
-
+				$redirect_url = add_query_arg( 'v', $location_hash, remove_query_arg( array( 'v', 'add-to-cart' ), $redirect_url ) );
 				wp_safe_redirect( esc_url_raw( $redirect_url ), 307 );
 				exit;
 			}

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
@@ -80,7 +80,7 @@ test.describe( 'Add to Cart behavior', () => {
 		await api.put(
 			'settings/general/woocommerce_default_customer_address',
 			{
-				value: '',
+				value: 'base',
 			}
 		);
 		await api.put(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
@@ -1,0 +1,93 @@
+const { test, expect } = require( '@playwright/test' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { addAProductToCart } = require( '../../utils/cart' );
+
+const productName = `Cart product test ${ Date.now() }`;
+const productPrice = '13.99';
+
+test.describe( 'Add to Cart behavior', () => {
+	let productId;
+
+	test.beforeAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api
+			.post( 'products', {
+				name: productName,
+				type: 'simple',
+				regular_price: productPrice,
+			} )
+			.then( ( response ) => {
+				productId = response.data.id;
+			} );
+	} );
+
+	test.beforeEach( async ( { context } ) => {
+		// Shopping cart is very sensitive to cookies, so be explicit
+		await context.clearCookies();
+	} );
+
+	test.afterAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api.post( 'products/batch', {
+			delete: [ productId ],
+		} );
+	} );
+
+	test( 'should add only one product to the cart with AJAX add to cart buttons disabled and "Geolocate (with page caching support)" as the default customer location', async ( {
+		page,
+		baseURL,
+	} ) => {
+		// Set settings combination that allowed reproducing the bug.
+		// @see https://github.com/woocommerce/woocommerce/issues/33077
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api.put(
+			'settings/general/woocommerce_default_customer_address',
+			{
+				value: 'geolocation_ajax',
+			}
+		);
+		await api.put(
+			'settings/products/woocommerce_enable_ajax_add_to_cart',
+			{
+				value: 'no',
+			}
+		);
+		await addAProductToCart( page, productId );
+		await page.goto( '/cart/' );
+		await expect( page.locator( 'td.product-name' ) ).toContainText(
+			productName
+		);
+		await expect( page.getByLabel( 'Product quantity' ) ).toHaveValue(
+			'1'
+		);
+
+		// Reset settings.
+		await api.put(
+			'settings/general/woocommerce_default_customer_address',
+			{
+				value: '',
+			}
+		);
+		await api.put(
+			'settings/products/woocommerce_enable_ajax_add_to_cart',
+			{
+				value: 'yes',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { addAProductToCart } = require( '../../utils/cart' );
 
 const productName = `Cart product test ${ Date.now() }`;
 const productPrice = '13.99';
@@ -96,6 +97,54 @@ test.describe( 'Cart page', () => {
 		await page.goto( '/cart/' );
 		await expect( page.locator( 'td.product-name' ) ).toContainText(
 			productName
+		);
+	} );
+
+	test( 'should add only one product to the cart with AJAX add to cart buttons disabled and "Geolocate (with page caching support)" as the default customer location', async ( {
+		page,
+		baseURL,
+	} ) => {
+		// Set settings combination that allowed reproducing the bug.
+		// @see https://github.com/woocommerce/woocommerce/issues/33077
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api.put(
+			'settings/general/woocommerce_default_customer_address',
+			{
+				value: 'geolocation_ajax',
+			}
+		);
+		await api.put(
+			'settings/products/woocommerce_enable_ajax_add_to_cart',
+			{
+				value: 'no',
+			}
+		);
+		await addAProductToCart( page, productId );
+		await page.goto( '/cart/' );
+		await expect( page.locator( 'td.product-name' ) ).toContainText(
+			productName
+		);
+		await expect( page.getByLabel( 'Product quantity' ) ).toHaveValue(
+			'1'
+		);
+
+		// Reset settings.
+		await api.put(
+			'settings/general/woocommerce_default_customer_address',
+			{
+				value: '',
+			}
+		);
+		await api.put(
+			'settings/products/woocommerce_enable_ajax_add_to_cart',
+			{
+				value: 'yes',
+			}
 		);
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -1,6 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-const { addAProductToCart } = require( '../../utils/cart' );
 
 const productName = `Cart product test ${ Date.now() }`;
 const productPrice = '13.99';
@@ -97,54 +96,6 @@ test.describe( 'Cart page', () => {
 		await page.goto( '/cart/' );
 		await expect( page.locator( 'td.product-name' ) ).toContainText(
 			productName
-		);
-	} );
-
-	test( 'should add only one product to the cart with AJAX add to cart buttons disabled and "Geolocate (with page caching support)" as the default customer location', async ( {
-		page,
-		baseURL,
-	} ) => {
-		// Set settings combination that allowed reproducing the bug.
-		// @see https://github.com/woocommerce/woocommerce/issues/33077
-		const api = new wcApi( {
-			url: baseURL,
-			consumerKey: process.env.CONSUMER_KEY,
-			consumerSecret: process.env.CONSUMER_SECRET,
-			version: 'wc/v3',
-		} );
-		await api.put(
-			'settings/general/woocommerce_default_customer_address',
-			{
-				value: 'geolocation_ajax',
-			}
-		);
-		await api.put(
-			'settings/products/woocommerce_enable_ajax_add_to_cart',
-			{
-				value: 'no',
-			}
-		);
-		await addAProductToCart( page, productId );
-		await page.goto( '/cart/' );
-		await expect( page.locator( 'td.product-name' ) ).toContainText(
-			productName
-		);
-		await expect( page.getByLabel( 'Product quantity' ) ).toHaveValue(
-			'1'
-		);
-
-		// Reset settings.
-		await api.put(
-			'settings/general/woocommerce_default_customer_address',
-			{
-				value: '',
-			}
-		);
-		await api.put(
-			'settings/products/woocommerce_enable_ajax_add_to_cart',
-			{
-				value: 'yes',
-			}
 		);
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue that was only reproducible with a certain combination of settings that caused two products to be added to the cart instead of one. I think the issue is that the  _Geolocate (with page caching support)_ option causes an extra redirect, which was triggering the `add_to_cart` behavior twice.

Closes #33077.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > General and set _Default customer location_ to _Geolocate (with page caching support)_.
2. Go to WooCommerce > Settings > Products and uncheck _Enable AJAX add to cart buttons on archives_.
3. Go to the Shop page.
4. Add a product to the cart.
5. Verify only one item was added, instead of two.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
