### PR TITLE
Product Editor: Set description properly if description consists only of a single non-paragraph block

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-modal-block-editor-1st-block
+++ b/packages/js/product-editor/changelog/fix-product-editor-modal-block-editor-1st-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Handle description properly when it contains a single non-paragraph block

--- a/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
@@ -55,11 +55,8 @@ export function getContentFromFreeform(
  * be empty. This function removes the default block to keep
  * the description empty.
  *
- * todo: this is not optimal. We cannot rely on the content attribute to
- * determine whether the description is empty or not
- *
  * @param blocks The block list
- * @return Empty array if there is only one block with empty content
+ * @return Empty array if there is only one paragraph block with empty content
  * in the list. The same block list otherwise.
  */
 function clearDescriptionIfEmpty( blocks: BlockInstance[] ) {
@@ -147,6 +144,8 @@ export function DescriptionBlockEdit( {
 		if ( ! hasChanged ) {
 			return;
 		}
+
+		console.log( 'modalEditorBlocks', modalEditorBlocks );
 
 		if ( ! modalEditorBlocks?.length ) {
 			setDescription( '' );

--- a/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
@@ -59,7 +59,11 @@ export function getContentFromFreeform(
  * @return Empty array if there is only one paragraph block with empty content
  * in the list. The same block list otherwise.
  */
-function clearDescriptionIfEmpty( blocks: BlockInstance[] ) {
+function clearDescriptionIfEmpty( blocks?: BlockInstance[] | null ) {
+	if ( ! blocks?.length ) {
+		return [];
+	}
+
 	if ( blocks.length === 1 ) {
 		const block = blocks[ 0 ];
 		const isParagraph = block.name === 'core/paragraph';
@@ -84,6 +88,7 @@ function clearDescriptionIfEmpty( blocks: BlockInstance[] ) {
 			}
 		}
 	}
+
 	return blocks;
 }
 
@@ -143,12 +148,6 @@ export function DescriptionBlockEdit( {
 	useEffect( () => {
 		if ( ! hasChanged ) {
 			return;
-		}
-
-		console.log( 'modalEditorBlocks', modalEditorBlocks );
-
-		if ( ! modalEditorBlocks?.length ) {
-			setDescription( '' );
 		}
 
 		const html = serialize( clearDescriptionIfEmpty( modalEditorBlocks ) );

--- a/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
@@ -49,49 +49,6 @@ export function getContentFromFreeform(
 	return false;
 }
 
-/**
- * By default the blocks variable always contains one paragraph
- * block with empty content, that causes the description to never
- * be empty. This function removes the default block to keep
- * the description empty.
- *
- * @param blocks The block list
- * @return Empty array if there is only one paragraph block with empty content
- * in the list. The same block list otherwise.
- */
-function clearDescriptionIfEmpty( blocks?: BlockInstance[] | null ) {
-	if ( ! blocks?.length ) {
-		return [];
-	}
-
-	if ( blocks.length === 1 ) {
-		const block = blocks[ 0 ];
-		const isParagraph = block.name === 'core/paragraph';
-
-		if ( isParagraph ) {
-			// dropCap is set to false by default; we don't care what it is set to
-			// when determining if a paragraph block is empty
-			const { content, dropCap, backgroundColor, ...attributes } =
-				block.attributes;
-			const isContentEmpty = ! content || ! content.trim();
-			// When the background is cleared, the backgroundColor is set to undefined,
-			// so we need to check if it is actually set to a value
-			const isBackgroundColorSet = !! backgroundColor;
-			const isAttributesSet = Object.keys( attributes ).length > 0;
-
-			if (
-				isContentEmpty &&
-				! isBackgroundColorSet &&
-				! isAttributesSet
-			) {
-				return [];
-			}
-		}
-	}
-
-	return blocks;
-}
-
 export function DescriptionBlockEdit( {
 	attributes,
 }: DescriptionBlockEditComponent ) {
@@ -150,7 +107,7 @@ export function DescriptionBlockEdit( {
 			return;
 		}
 
-		const html = serialize( clearDescriptionIfEmpty( modalEditorBlocks ) );
+		const html = serialize( modalEditorBlocks );
 		setDescription( html );
 	}, [ modalEditorBlocks, setDescription, hasChanged ] );
 

--- a/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
@@ -64,9 +64,27 @@ export function getContentFromFreeform(
  */
 function clearDescriptionIfEmpty( blocks: BlockInstance[] ) {
 	if ( blocks.length === 1 ) {
-		const { content } = blocks[ 0 ].attributes;
-		if ( ! content || ! content.trim() ) {
-			return [];
+		const block = blocks[ 0 ];
+		const isParagraph = block.name === 'core/paragraph';
+
+		if ( isParagraph ) {
+			// dropCap is set to false by default; we don't care what it is set to
+			// when determining if a paragraph block is empty
+			const { content, dropCap, backgroundColor, ...attributes } =
+				block.attributes;
+			const isContentEmpty = ! content || ! content.trim();
+			// When the background is cleared, the backgroundColor is set to undefined,
+			// so we need to check if it is actually set to a value
+			const isBackgroundColorSet = !! backgroundColor;
+			const isAttributesSet = Object.keys( attributes ).length > 0;
+
+			if (
+				isContentEmpty &&
+				! isBackgroundColorSet &&
+				! isAttributesSet
+			) {
+				return [];
+			}
 		}
 	}
 	return blocks;

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -53,6 +53,7 @@ import {
 	KeyboardShortcuts,
 	RegisterKeyboardShortcuts,
 } from './keyboard-shortcuts';
+import { areBlocksEmpty } from './utils/are-blocks-empty';
 
 type IframeEditorProps = {
 	initialBlocks?: BlockInstance[];
@@ -191,7 +192,11 @@ export function IframeEditor( {
 
 					<HeaderToolbar
 						onSave={ () => {
-							setBlocks( temporalBlocks );
+							setBlocks(
+								areBlocksEmpty( temporalBlocks )
+									? []
+									: temporalBlocks
+							);
 							setModalEditorContentHasChanged( true );
 							onChange( temporalBlocks );
 							onClose?.();

--- a/packages/js/product-editor/src/components/iframe-editor/utils/are-blocks-empty.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/utils/are-blocks-empty.ts
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { BlockInstance } from '@wordpress/blocks';
+
+/**
+ * By default the blocks returned by the editor contains one paragraph
+ * block with empty content. This function checks to see if the blocks
+ * consists of a single paragraph block with empty content.
+ *
+ * @param blocks The block list
+ * @return true if the blocks consists of a single paragraph block with empty content; false otherwise
+ */
+export function areBlocksEmpty( blocks?: BlockInstance[] | null ) {
+	if ( ! blocks?.length ) {
+		return true;
+	}
+
+	if ( blocks.length === 1 ) {
+		const block = blocks[ 0 ];
+		const isParagraph = block.name === 'core/paragraph';
+
+		if ( isParagraph ) {
+			// dropCap is set to false by default; we don't care what it is set to
+			// when determining if a paragraph block is empty
+			const { content, dropCap, backgroundColor, ...attributes } =
+				block.attributes;
+			const isContentEmpty = ! content || ! content.trim();
+			// When the background is cleared, the backgroundColor is set to undefined,
+			// so we need to check if it is actually set to a value
+			const isBackgroundColorSet = !! backgroundColor;
+			const isAttributesSet = Object.keys( attributes ).length > 0;
+
+			if (
+				isContentEmpty &&
+				! isBackgroundColorSet &&
+				! isAttributesSet
+			) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/packages/js/product-editor/src/components/iframe-editor/utils/are-blocks-empty.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/utils/are-blocks-empty.ts
@@ -6,10 +6,10 @@ import { BlockInstance } from '@wordpress/blocks';
 /**
  * By default the blocks returned by the editor contains one paragraph
  * block with empty content. This function checks to see if the blocks
- * consists of a single paragraph block with empty content.
+ * consists of a single paragraph block with empty content or no blocks.
  *
  * @param blocks The block list
- * @return true if the blocks consists of a single paragraph block with empty content; false otherwise
+ * @return true if the blocks consists of a single paragraph block with empty content or no blocks; false otherwise
  */
 export function areBlocksEmpty( blocks?: BlockInstance[] | null ) {
 	if ( ! blocks?.length ) {

--- a/packages/js/product-editor/src/components/iframe-editor/utils/tests/are-blocks-empty.test.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/utils/tests/are-blocks-empty.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Internal dependencies
+ */
+import { areBlocksEmpty } from '../are-blocks-empty';
+
+describe( 'areBlocksEmpty', () => {
+	it( 'should return false if there is more than one block', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: [],
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+			{
+				name: 'core/paragraph',
+				attributes: [],
+				innerBlocks: [],
+				isValid: true,
+				clientId: '2',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( false );
+	} );
+
+	it( 'should return false if there is one block that is not a paragraph block', () => {
+		const blocks = [
+			{
+				name: 'core/heading',
+				attributes: [],
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( false );
+	} );
+
+	it( 'should return false if the paragraph block has content', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Some content',
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( false );
+	} );
+
+	it( 'should return false if the paragraph block has no content but a backgroundColor', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					backgroundColor: 'red',
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( false );
+	} );
+
+	it( 'should return false if the paragraph block has no content but any attribute', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					foo: 'bar',
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( false );
+	} );
+
+	it( 'should return true if an empty block list is passed', () => {
+		expect( areBlocksEmpty( [] ) ).toBe( true );
+	} );
+
+	it( 'should return true if a null block list is passed', () => {
+		expect( areBlocksEmpty( null ) ).toBe( true );
+	} );
+
+	it( 'should return true if an undefined block list is passed', () => {
+		expect( areBlocksEmpty( undefined ) ).toBe( true );
+	} );
+
+	it( 'should return true if the paragraph block has no content or attributes', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: [],
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( true );
+	} );
+
+	it( 'should return true if the paragraph block has empty content', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( true );
+	} );
+
+	it( 'should return true if the paragraph block has empty content (after trimming)', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '     ',
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( true );
+	} );
+
+	it( 'should return true if the paragraph block has no content and an undefined backgroundColor', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					backgroundColor: undefined,
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( true );
+	} );
+
+	it( 'should return true if the paragraph block has no content and dropCap set true', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: true,
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( true );
+	} );
+
+	it( 'should return true if the paragraph block has no content and dropCap set false', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+				isValid: true,
+				clientId: '1',
+			},
+		];
+
+		expect( areBlocksEmpty( blocks ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the blank description detection logic to account for the case where the description consists of a single non-paragraph block.

Closes #45740.

#### Before (description does not get set)

https://github.com/woocommerce/woocommerce/assets/2098816/e6e6f84f-e353-4777-a81f-a2625cf2c2c7

#### After (description gets set)

https://github.com/woocommerce/woocommerce/assets/2098816/c71601cf-9f5c-4f26-95d7-113f190f5f26

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Automated testing

1. Run unit tests and verify they pass (you can just look at the results on this PR):

```
pnpm --filter=./packages/js/product-editor run test:js ./packages/js/product-editor/src/components/iframe-editor/utils/tests/are-blocks-empty.test.ts
```
#### Manual testing

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Clear dev console in browser
3. Click on **Description** > **Full Editor** to bring up the modal block editor
4. Click **Done**
5. Verify the description is blank and can still be edited in the description field (not in the modal block editor)
6. Click on **Description** > **Full Editor** to bring up the modal block editor
7. Add a quote block
8. Click **Done**
9. Verify the description is set correctly (it should not be blank)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
