### PR TITLE
[e2e tests] Only run the default project in daily e2e runs

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -136,7 +136,7 @@ jobs:
                   BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_DAILY_E2E_TOKEN }}
                   BUILDKITE_ANALYTICS_MESSAGE: ${{ steps.set_buildkite_message.outputs.BUILDKITE_MESSAGE }}
               working-directory: plugins/woocommerce
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js --shard ${{ matrix.shard.name }}
+              run: pnpm test:e2e-pw --shard ${{ matrix.shard.name }}
 
             - name: Upload reports to GitHub Actions Artifacts
               if: always()
@@ -301,6 +301,7 @@ jobs:
               with:
                   playwright-config: ignore-plugin-tests.playwright.config.js
                   report-name: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
+                  tests: '--project=default'
               env:
                   E2E_MAX_FAILURES: 90
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

#47612 added a new Playwright project configuration (Gutenberg), requiring being explicit on which project to run on `playwright test` command, otherwise all projects will run. This happened with the daily e2e runs, which were using a different pnpm command to run the tests.
Update the workflow to only run the default project. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Tested with [this run](https://github.com/woocommerce/woocommerce/actions/runs/9211409504/job/25340716915). Check the tests that ran, there should be only [default] runs.
