### PR TITLE
REST API: Update schema for rate_id property

### DIFF
--- a/plugins/woocommerce/changelog/fix-32037
+++ b/plugins/woocommerce/changelog/fix-32037
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change the item schemas for Orders and Order Refunds API endpoints to correctly specify that the rate_id property in a tax_line object is an integer, not a string

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -586,7 +586,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 							),
 							'rate_id'            => array(
 								'description' => __( 'Tax rate ID.', 'woocommerce' ),
-								'type'        => 'string',
+								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1619,7 +1619,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'rate_id'            => array(
 								'description' => __( 'Tax rate ID.', 'woocommerce' ),
-								'type'        => 'string',
+								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This changes the item schemas for Orders and Order Refunds API endpoints to correctly specify that the `rate_id` property in a `tax_line` object is an integer, not a string.

Note that these endpoints are already returning an integer for `rate_id` in the response. This only changes what the schema _says_ the data type is.

Fixes #32037

### How to test the changes in this Pull Request:

1. Make an OPTIONS request to `wc/v3/orders`. In the response data, under `schema`, look for `tax_lines` and then `rate_id` (If you can filter with JSONPath use `$.schema.properties.tax_lines.items.properties.rate_id`). It should be listed as an integer.
2. Do the same for `wc/v3/orders/0/refunds`.