### PR TITLE
Try: Improve product editor performance by bypassing the block editor

### DIFF
--- a/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
+++ b/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
@@ -18,6 +18,7 @@ import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
  * Internal dependencies
  */
 import { EditorWritingFlow } from './editor-writing-flow';
+import { registerBlocks } from './utils/register-blocks';
 
 type RichTextEditorProps = {
 	blocks: BlockInstance[];
@@ -26,6 +27,8 @@ type RichTextEditorProps = {
 	entryId?: string;
 	placeholder?: string;
 };
+
+registerBlocks();
 
 export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 	blocks,

--- a/packages/js/product-editor/src/blocks/generic/radio/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/radio/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { createElement } from '@wordpress/element';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ export function Edit( {
 	attributes,
 	context: { postType },
 }: ProductEditorBlockEditProps< RadioBlockAttributes > ) {
-	const blockProps = useWooBlockProps( attributes );
 	const { description, options, property, title, disabled } = attributes;
 	const [ value, setValue ] = useProductEntityProp< string >( property, {
 		postType,
@@ -24,7 +22,7 @@ export function Edit( {
 	} );
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			<RadioField
 				title={ title }
 				description={ description }

--- a/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
@@ -2,12 +2,10 @@
  * External dependencies
  */
 import { createElement } from '@wordpress/element';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { BlockFill } from '../../../components/block-slot-fill';
 import { ProductEditorBlockEditProps } from '../../../types';
 import { SectionDescriptionBlockAttributes } from './types';
 
@@ -15,15 +13,10 @@ export function SectionDescriptionBlockEdit( {
 	attributes,
 }: ProductEditorBlockEditProps< SectionDescriptionBlockAttributes > ) {
 	const { content } = attributes;
-	const blockProps = useWooBlockProps( attributes );
 
 	return (
-		<BlockFill
-			{ ...blockProps }
-			name="section-description"
-			slotContainerBlockName="woocommerce/product-section"
-		>
+		<div>
 			<div>{ content }</div>
-		</BlockFill>
+		</div>
 	);
 }

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -3,7 +3,6 @@
  */
 import classNames from 'classnames';
 import { createElement } from '@wordpress/element';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	// @ts-expect-error no exported member.
 	useInnerBlocksProps,
@@ -21,22 +20,12 @@ export function SectionBlockEdit( {
 	// @ts-ignore
 	children,
 }: ProductEditorBlockEditProps< SectionBlockAttributes > ) {
-	const { description, title, blockGap } = attributes;
+	const { description, title } = attributes;
 
-	const blockProps = useWooBlockProps( attributes );
-	const innerBlockProps = useInnerBlocksProps(
-		{
-			className: classNames(
-				'wp-block-woocommerce-product-section-header__content',
-				`wp-block-woocommerce-product-section-header__content--block-gap-${ blockGap }`
-			),
-		},
-		{ templateLock: 'all' }
-	);
 	const SectionTagName = title ? 'fieldset' : 'div';
 
 	return (
-		<SectionTagName { ...blockProps }>
+		<SectionTagName>
 			{ title && (
 				<SectionHeader
 					description={ description }

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -18,6 +18,8 @@ import { SectionHeader } from '../../../components/section-header';
 
 export function SectionBlockEdit( {
 	attributes,
+	// @ts-ignore
+	children,
 }: ProductEditorBlockEditProps< SectionBlockAttributes > ) {
 	const { description, title, blockGap } = attributes;
 
@@ -42,8 +44,7 @@ export function SectionBlockEdit( {
 					title={ title }
 				/>
 			) }
-
-			<div { ...innerBlockProps } />
+			{ children }
 		</SectionTagName>
 	);
 }

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -47,14 +47,16 @@ export function TabBlockEdit( {
 			<TabButton id={ id } selected={ isSelected } order={ order }>
 				{ title }
 			</TabButton>
-			<div
-				id={ `woocommerce-product-tab__${ id }-content` }
-				aria-labelledby={ `woocommerce-product-tab__${ id }` }
-				role="tabpanel"
-				className={ classes }
-			>
-				{ children }
-			</div>
+			{ isSelected && (
+				<div
+					id={ `woocommerce-product-tab__${ id }-content` }
+					aria-labelledby={ `woocommerce-product-tab__${ id }` }
+					role="tabpanel"
+					className={ classes }
+				>
+					{ children }
+				</div>
+			) }
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import { createElement } from '@wordpress/element';
 import type { BlockAttributes } from '@wordpress/blocks';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
@@ -26,7 +24,6 @@ export function TabBlockEdit( {
 	// @ts-ignore
 	children,
 }: ProductEditorBlockEditProps< TabBlockAttributes > ) {
-	const blockProps = useWooBlockProps( attributes );
 	const {
 		id,
 		title,
@@ -43,7 +40,7 @@ export function TabBlockEdit( {
 	} );
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			<TabButton id={ id } selected={ isSelected } order={ order }>
 				{ title }
 			</TabButton>

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -23,6 +23,8 @@ export function TabBlockEdit( {
 	setAttributes,
 	attributes,
 	context,
+	// @ts-ignore
+	children,
 }: ProductEditorBlockEditProps< TabBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 	const {
@@ -51,9 +53,7 @@ export function TabBlockEdit( {
 				role="tabpanel"
 				className={ classes }
 			>
-				{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-				{ /* @ts-ignore Content only template locking does exist for this property. */ }
-				<InnerBlocks templateLock="contentOnly" />
+				{ children }
 			</div>
 		</div>
 	);

--- a/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/description/edit.tsx
@@ -9,8 +9,6 @@ import {
 } from '@wordpress/element';
 import { BlockInstance, parse, serialize } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import classNames from 'classnames';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -138,11 +136,6 @@ export function DescriptionBlockEdit( {
 		setDescription( html );
 	}, [ modalEditorBlocks, setDescription, hasChanged ] );
 
-	const blockProps = useWooBlockProps( attributes, {
-		className: classNames( { 'has-blocks': !! description.length } ),
-		tabIndex: 0,
-	} );
-
 	const innerBlockProps = useInnerBlocksProps(
 		{},
 		{
@@ -152,7 +145,7 @@ export function DescriptionBlockEdit( {
 	);
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			{ !! descriptionBlocks?.length ? (
 				<>
 					<BlockControls>

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -12,7 +12,6 @@ import {
 } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { MediaItem } from '@wordpress/media-utils';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import { ListItem, MediaUploader, Sortable } from '@woocommerce/components';
 import { Product, ProductDownload } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -51,7 +50,6 @@ export function DownloadBlockEdit( {
 	attributes,
 	context: { postType },
 }: ProductEditorBlockEditProps< UploadsBlockAttributes > ) {
-	const blockProps = useWooBlockProps( attributes );
 	const [ downloads, setDownloads ] = useEntityProp< Product[ 'downloads' ] >(
 		'postType',
 		postType,
@@ -215,7 +213,7 @@ export function DownloadBlockEdit( {
 	}
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			<SectionActions>
 				{ Boolean( downloads.length ) && (
 					<Button

--- a/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
@@ -5,11 +5,9 @@ import { DragEvent } from 'react';
 import { __ } from '@wordpress/i18n';
 import { BlockAttributes } from '@wordpress/blocks';
 import { DropZone } from '@wordpress/components';
-import classnames from 'classnames';
 import { createElement, useState } from '@wordpress/element';
 import { Icon, trash } from '@wordpress/icons';
 import { MediaItem } from '@wordpress/media-utils';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	MediaUploader,
 	ImageGallery,
@@ -54,14 +52,6 @@ export function ImageBlockEdit( {
 	const [ draggedImageId, setDraggedImageId ] = useState< number | null >(
 		null
 	);
-
-	const blockProps = useWooBlockProps( attributes, {
-		className: classnames( {
-			'has-images': Array.isArray( propertyValue )
-				? propertyValue.length > 0
-				: Boolean( propertyValue ),
-		} ),
-	} );
 
 	function orderImages( newOrder: JSX.Element[] ) {
 		if ( Array.isArray( propertyValue ) ) {
@@ -191,7 +181,7 @@ export function ImageBlockEdit( {
 		( ! Array.isArray( propertyValue ) || propertyValue.length > 0 );
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			<div className="woocommerce-product-form__image-drop-zone">
 				{ isRemovingZoneVisible ? (
 					<div className="woocommerce-product-form__remove-image-drop-zone">

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
@@ -29,7 +29,6 @@ export function Edit( {
 	clientId,
 	context,
 }: ProductEditorBlockEditProps< SalePriceBlockAttributes > ) {
-	const blockProps = useWooBlockProps( attributes );
 	const { label, help, isRequired, tooltip, disabled } = attributes;
 	const [ regularPrice, setRegularPrice ] = useEntityProp< string >(
 		'postType',
@@ -96,7 +95,7 @@ export function Edit( {
 	}, [] );
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			<BaseControl
 				id={ regularPriceId }
 				help={

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
@@ -28,7 +27,6 @@ export function Edit( {
 	clientId,
 	context,
 }: ProductEditorBlockEditProps< SalePriceBlockAttributes > ) {
-	const blockProps = useWooBlockProps( attributes );
 	const { label, help, tooltip, disabled } = attributes;
 	const [ regularPrice ] = useEntityProp< string >(
 		'postType',
@@ -80,7 +78,7 @@ export function Edit( {
 	);
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			<BaseControl
 				id={ salePriceId }
 				help={

--- a/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import { DateTimePickerControl } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -24,11 +23,9 @@ import { useValidation } from '../../../contexts/validation-context';
 import { ProductEditorBlockEditProps } from '../../../types';
 
 export function Edit( {
-	attributes,
 	clientId,
 	context,
 }: ProductEditorBlockEditProps< ScheduleSalePricingBlockAttributes > ) {
-	const blockProps = useWooBlockProps( attributes );
 	const { hasEdit } = useProductEdits();
 
 	const dateTimeFormat = getSettings().formats.datetime;
@@ -138,7 +135,7 @@ export function Edit( {
 	);
 
 	return (
-		<div { ...blockProps }>
+		<div>
 			<ToggleControl
 				label={ __( 'Schedule sale', 'woocommerce' ) }
 				checked={ showScheduleSale }

--- a/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	createElement,
 	createInterpolateElement,
@@ -35,9 +34,6 @@ export function SummaryBlockEdit( {
 	context,
 }: ProductEditorBlockEditProps< SummaryAttributes > ) {
 	const { align, direction, label, helpText } = attributes;
-	const blockProps = useWooBlockProps( attributes, {
-		style: { direction },
-	} );
 	const contentId = useInstanceId(
 		SummaryBlockEdit,
 		'wp-block-woocommerce-product-summary-field__content'
@@ -50,11 +46,6 @@ export function SummaryBlockEdit( {
 	const [ summaryBlocks, setSummaryBlocks ] = useState< BlockInstance[] >(
 		parse( summary )
 	);
-
-	// This is a workaround to hide the toolbar when the block is blurred.
-	// This is a temporary solution until using Gutenberg 18 with the
-	// fix from https://github.com/WordPress/gutenberg/pull/59800
-	const { handleBlur: hideToolbar } = useClearSelectedBlockOnBlur();
 
 	function handleAlignmentChange( value: SummaryAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );
@@ -113,7 +104,7 @@ export function SummaryBlockEdit( {
 						: helpText
 				}
 			>
-				<div { ...blockProps }>
+				<div>
 					<RichTextEditor
 						label={ __( 'Summary', 'woocommerce' ) }
 						blocks={ summaryBlocks }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -223,6 +223,26 @@ export function BlockEditor( {
 		'<div data-block-name="woocommerce/product-radio-field" data-title="Charge sales tax on" data-property="stock_status"></div>' +
 		'<div data-block-name="woocommerce/product-summary-field" data-property="description"></div>' +
 		'</div>' +
+		'</div>' +
+		'<div data-block-name="woocommerce/product-tab" data-id="pricing" data-title="Pricing">' +
+		'<div data-block-name="woocommerce/product-section" data-id="basic-details" data-title="Basic Details" data-description="">' +
+		'<div data-block-name="woocommerce/product-name-field"></div>' +
+		'<div data-block-name="woocommerce/product-regular-price-field" data-label="Regular price"></div>' +
+		'<div data-block-name="woocommerce/product-sale-price-field" data-label="Sale price"></div>' +
+		'<div data-block-name="woocommerce/product-schedule-sale-fields" data-label="Sale price"></div>' +
+		'<div data-block-name="woocommerce/product-radio-field" data-title="Charge sales tax on" data-property="stock_status"></div>' +
+		'<div data-block-name="woocommerce/product-summary-field" data-property="description"></div>' +
+		'</div>' +
+		'</div>' +
+		'<div data-block-name="woocommerce/product-tab" data-id="third" data-title="Third">' +
+		'<div data-block-name="woocommerce/product-section" data-id="basic-details" data-title="Basic Details" data-description="">' +
+		'<div data-block-name="woocommerce/product-name-field"></div>' +
+		'<div data-block-name="woocommerce/product-regular-price-field" data-label="Regular price"></div>' +
+		'<div data-block-name="woocommerce/product-sale-price-field" data-label="Sale price"></div>' +
+		'<div data-block-name="woocommerce/product-schedule-sale-fields" data-label="Sale price"></div>' +
+		'<div data-block-name="woocommerce/product-radio-field" data-title="Charge sales tax on" data-property="stock_status"></div>' +
+		'<div data-block-name="woocommerce/product-summary-field" data-property="description"></div>' +
+		'</div>' +
 		'</div>';
 
 	const ProductForm = useCallback( () => {

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -222,6 +222,9 @@ export function BlockEditor( {
 		'<div data-block-name="woocommerce/product-schedule-sale-fields" data-label="Sale price"></div>' +
 		'<div data-block-name="woocommerce/product-radio-field" data-title="Charge sales tax on" data-property="stock_status"></div>' +
 		'<div data-block-name="woocommerce/product-summary-field" data-property="description"></div>' +
+		'<div data-block-name="woocommerce/product-description-field" data-property="description"></div>' +
+		'<div data-block-name="woocommerce/product-images-field" data-property="description"></div>' +
+		'<div data-block-name="woocommerce/product-downloads-field" data-property="description"></div>' +
 		'</div>' +
 		'</div>' +
 		'<div data-block-name="woocommerce/product-tab" data-id="pricing" data-title="Pricing">' +

--- a/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
+++ b/packages/js/product-editor/src/components/block-slot-fill/section-actions/index.tsx
@@ -6,7 +6,6 @@ import { createElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { BlockFill } from '../block-fill';
 import { BlockFillProps } from '../types';
 
 export type SectionActionsProps = Omit<
@@ -16,20 +15,6 @@ export type SectionActionsProps = Omit<
 	containerBlockName?: string | string[];
 };
 
-const DEFAULT_SECTION_BLOCKS = [
-	'woocommerce/product-section',
-	'woocommerce/product-subsection',
-];
-
-export function SectionActions( {
-	containerBlockName = DEFAULT_SECTION_BLOCKS,
-	...restProps
-}: SectionActionsProps ) {
-	return (
-		<BlockFill
-			{ ...restProps }
-			name="section-actions"
-			slotContainerBlockName={ containerBlockName }
-		/>
-	);
+export function SectionActions( {}: SectionActionsProps ) {
+	return <div></div>;
 }

--- a/packages/js/product-editor/src/utils/get-rendered-block-view.ts
+++ b/packages/js/product-editor/src/utils/get-rendered-block-view.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { ComponentType, ReactElement } from 'react';
+import { createElement } from '@wordpress/element';
+import { Block, getBlockType } from '@wordpress/blocks';
+// import { v4 as uuid } from 'uuid';
+
+export function getRenderedBlockView(
+	domElement: Element,
+	context: unknown
+): ReactElement[] {
+	const rendered: ReactElement[] = [];
+
+	for ( let i = 0; i < domElement.children.length; i++ ) {
+		const child = domElement.children[ i ];
+		const blockName = child.getAttribute( 'data-block-name' );
+		const children = getRenderedBlockView( child, context );
+
+		if ( blockName ) {
+			const blockType = getBlockType( blockName ) as Block & {
+				view: ComponentType;
+			};
+			if ( blockType?.edit ) {
+				rendered.push(
+					createElement(
+						blockType.edit,
+						{
+							// @ts-ignore No types for dataset yet.
+							attributes: child.dataset,
+							// @ts-ignore
+							context,
+							clientId: '@ptodo',
+							setAttributes: () => {},
+							// clientId: uuid(),
+						},
+						children
+					)
+				);
+			}
+		} else {
+			rendered.push(
+				createElement( child.tagName, child.attributes, children )
+			);
+		}
+	}
+
+	return rendered;
+}

--- a/packages/js/product-editor/src/utils/get-rendered-block-view.ts
+++ b/packages/js/product-editor/src/utils/get-rendered-block-view.ts
@@ -16,6 +16,9 @@ import { Edit as SalePriceBlockEdit } from '../blocks/product-fields/sale-price/
 import { Edit as ScheduleSaleBlockEdit } from '../blocks/product-fields/schedule-sale/edit';
 import { Edit as RadioBlockEdit } from '../blocks/generic/radio/edit';
 import { SummaryBlockEdit } from '../blocks/product-fields/summary/edit';
+import { DescriptionBlockEdit } from '../blocks/product-fields/description/edit';
+import { ImageBlockEdit } from '../blocks/product-fields/images/edit';
+import { DownloadBlockEdit } from '../blocks/product-fields/downloads/edit';
 
 type ComponentMap = {
 	[ key: string ]: unknown;
@@ -30,6 +33,9 @@ const componentMap: ComponentMap = {
 	'woocommerce/product-schedule-sale-fields': ScheduleSaleBlockEdit,
 	'woocommerce/product-radio-field': RadioBlockEdit,
 	'woocommerce/product-summary-field': SummaryBlockEdit,
+	'woocommerce/product-description-field': DescriptionBlockEdit,
+	'woocommerce/product-images-field': ImageBlockEdit,
+	'woocommerce/product-downloads-field': DownloadBlockEdit,
 };
 
 function getComponentName( blockName: string | null ) {

--- a/packages/js/product-editor/src/utils/get-rendered-block-view.ts
+++ b/packages/js/product-editor/src/utils/get-rendered-block-view.ts
@@ -1,10 +1,43 @@
 /**
  * External dependencies
  */
-import { ComponentType, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { createElement } from '@wordpress/element';
-import { Block, getBlockType } from '@wordpress/blocks';
 // import { v4 as uuid } from 'uuid';
+
+/**
+ * Internal dependencies
+ */
+import { TabBlockEdit } from '../blocks/generic/tab/edit';
+import { SectionBlockEdit } from '../blocks/generic/section/edit';
+import { NameBlockEdit } from '../blocks/product-fields/name/edit';
+import { Edit as RegularPriceBlockEdit } from '../blocks/product-fields/regular-price/edit';
+import { Edit as SalePriceBlockEdit } from '../blocks/product-fields/sale-price/edit';
+import { Edit as ScheduleSaleBlockEdit } from '../blocks/product-fields/schedule-sale/edit';
+import { Edit as RadioBlockEdit } from '../blocks/generic/radio/edit';
+import { SummaryBlockEdit } from '../blocks/product-fields/summary/edit';
+
+type ComponentMap = {
+	[ key: string ]: unknown;
+};
+
+const componentMap: ComponentMap = {
+	'woocommerce/product-tab': TabBlockEdit,
+	'woocommerce/product-section': SectionBlockEdit,
+	'woocommerce/product-name-field': NameBlockEdit,
+	'woocommerce/product-regular-price-field': RegularPriceBlockEdit,
+	'woocommerce/product-sale-price-field': SalePriceBlockEdit,
+	'woocommerce/product-schedule-sale-fields': ScheduleSaleBlockEdit,
+	'woocommerce/product-radio-field': RadioBlockEdit,
+	'woocommerce/product-summary-field': SummaryBlockEdit,
+};
+
+function getComponentName( blockName: string | null ) {
+	if ( ! blockName ) {
+		return null;
+	}
+	return componentMap[ blockName ];
+}
 
 export function getRenderedBlockView(
 	domElement: Element,
@@ -16,28 +49,25 @@ export function getRenderedBlockView(
 		const child = domElement.children[ i ];
 		const blockName = child.getAttribute( 'data-block-name' );
 		const children = getRenderedBlockView( child, context );
+		const componentName = getComponentName( blockName );
 
-		if ( blockName ) {
-			const blockType = getBlockType( blockName ) as Block & {
-				view: ComponentType;
-			};
-			if ( blockType?.edit ) {
-				rendered.push(
-					createElement(
-						blockType.edit,
-						{
-							// @ts-ignore No types for dataset yet.
-							attributes: child.dataset,
-							// @ts-ignore
-							context,
-							clientId: '@ptodo',
-							setAttributes: () => {},
-							// clientId: uuid(),
-						},
-						children
-					)
-				);
-			}
+		if ( componentName ) {
+			rendered.push(
+				createElement(
+					// @ts-ignore
+					componentName,
+					{
+						// @ts-ignore No types for dataset yet.
+						attributes: child.dataset,
+						// @ts-ignore
+						context,
+						clientId: '@ptodo',
+						setAttributes: () => {},
+						// clientId: uuid(),
+					},
+					children
+				)
+			);
 		} else {
 			rendered.push(
 				createElement( child.tagName, child.attributes, children )

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -87,12 +87,9 @@ export default function ProductPage() {
 			},
 		} );
 
-		const unregisterBlocks = initBlocks();
-
 		return () => {
 			document.body.classList.remove( 'is-product-editor' );
 			unregisterPlugin( 'wc-admin-more-menu' );
-			unregisterBlocks();
 		};
 	}, [ productId ] );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR shows how we can make some performance gains in the product editor by treating the product form as the "view" instead of an "editor."  Despite this PR using `edit` components, it's probably a good idea to separate the concept of editing these blocks vs rendering these blocks for use.  We're really doing the latter in the product form.  [This PR](https://github.com/woocommerce/woocommerce/pull/46135) shows better seperation of `view` and `edit` components.

As you can see below, we shaved about 1200ms off the scripting time alone.  ~400ms of those gains can be attributed to not rendering inactive product tabs, but the remainder centers around performance issues faced while editing a form nested within an editor.

**Key takeaways**

* Rendering our product fields via the block editor seems to add a significant amount of scripting time, probably exacerbated by our large number of re-renders as product info and context is passed down.
* Re-rerenders still needs to be addressed as this is the next largest performance issue.
* Avoiding rendering the entire form at once gives us a boost in performance, but this means we need to be careful going forward to decouple data and validations from the UI
* The use of functions like `getBlockParentsByBlockName` come with performance concerns, especially as we re-render.  We might need to reconsider how we use `BlockFill`.
* Using the block editor scripts for summary/description and continuing to register core blocks does still add ~100ms to scripting time, but this may be inevitable if we plan to keep these features.  It also may become less of an issue as WP moves towards a more seamless SPA where block editor scripts may have already been loaded
* Date components coming from `@woocommerce/components` are not insignificant in size and are the largest contributors to execution time in components

**Current Editor**

<img width="1100" alt="Screenshot 2024-05-23 at 1 45 12 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/4f0e2be7-e17d-4715-9d25-132392c21c75">

**View concept without BlockList or provider**

<img width="1136" alt="Screenshot 2024-05-23 at 5 36 14 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/e8496b6f-3c35-4845-9a1b-1b959dff28d1">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to the new product editor
2. Open the "Performance" tab of dev tools
3. Click "Start profiling and reload page"
4. Stop profiling when the page has loaded or optionally make some edits in the form and profile further to other perforance changes
5. Compare results to those on `trunk`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
