### PR TITLE
REST API: Check if stock should be adjusted when updating order line items

### DIFF
--- a/plugins/woocommerce/changelog/fix-44085-on-hold-stock-api
+++ b/plugins/woocommerce/changelog/fix-44085-on-hold-stock-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure available stock is updated correctly when updating line items in orders via the REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -930,6 +930,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		$this->maybe_set_item_props( $item, array( 'name', 'quantity', 'total', 'subtotal', 'tax_class' ), $posted );
 		$this->maybe_set_item_meta_data( $item, $posted );
 
+		if ( 'update' === $action ) {
+			require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
+			wc_maybe_adjust_line_item_product_stock( $item );
+		}
+
 		return $item;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As described in #44085, changing the quantity of a line item in an on-hold order from WP Admin correctly adjusts the stock level of the product, but doing it via a REST API request does not. Unfortunately the process for updating line items via REST API is entirely separate from the process in the programmatic API used in WP Admin. This attempts to add in the missing stock adjustment without causing any undesirable side effects.

Fixes #44085

### How to test the changes in this Pull Request:

1. Create a product. Under Product Data > Inventory, check the box for Stock management and then set the Quantity to 50.
2. Create an order. Add the new product to the order with a quantity of 1. Set the order status to On Hold. Note the ID of the order.
3. Back on the Products list table view, note that the new product should now show as "In stock (49)" since 1 has now been reserved for the On Hold order.
4. Make a REST API request to get the data about the new order, so you can get the ID of the line item (which is different than the product ID):
    ```
    curl --request GET \
      --url http://localhost:8888/wp-json/wc/v3/orders/{order ID}
    ```
5. Now make another REST API request to update the order so that the quantity of the product is 2.
    ```
    POST /wp-json/wc/v3/orders/{order ID} HTTP/1.1
    Host: localhost:8888

    {
      "line_items": [
        {
          "id": {line item ID},
          "quantity": 2
        }
      ]
    }
    ```
6. Check back on the Products list table view. The product should now show 48 in stock instead of 49. If you view the order, the quantity should be updated to 2. **Note:** since you only updated the quantity, and not the total for the line item, the order total will not change, but instead the price per item will be recalculated.
7. If you try this on trunk rather than the branch for this PR, the number of in stock for the product will not be updated when you update the order via REST API.
