### PR TITLE
Defensive check to reduce error/warning noise when regenerating images.

### DIFF
--- a/plugins/woocommerce/changelog/fix-reduce-width-height-noise
+++ b/plugins/woocommerce/changelog/fix-reduce-width-height-noise
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Adds a defensive check to reduce error log noise when regenerating images.

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -273,7 +273,7 @@ class WC_Regenerate_Images {
 		}
 
 		// The result of the earlier wp_get_attachment_metadata call is filterable, so we may not have height or
-		// width data at this point. 
+		// width data at this point.
 		if ( ! isset( $imagedata['height'] ) || ! isset( $imagedata['width'] ) ) {
 			return array();
 		}

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -272,6 +272,12 @@ class WC_Regenerate_Images {
 			$imagedata['width']  = $imagedata['sizes']['full']['width'];
 		}
 
+		// The result of the earlier wp_get_attachment_metadata call is filterable, so we may not have height or
+		// width data at this point. 
+		if ( ! isset( $imagedata['height'] ) || ! isset( $imagedata['width'] ) ) {
+			return array();
+		}
+
 		return array(
 			'width'  => $imagedata['width'],
 			'height' => $imagedata['height'],


### PR DESCRIPTION
When monitoring error logs around release time, we see a *lot* of error noise as follows:

```
PHP Warning: Undefined array key "width" in /.../includes/class-wc-regenerate-images.php on line 276
```

This PR adds a defensive check to reduce or remove this noise, hopefully helping us as well as our merchants to monitor our sites more effectively.

In practice, if we ignore the warnings, what would otherwise happen is that private method `WC_Regenerate_Images::get_full_size_image_dimensions` would return:

```php
[
    'width'  => null,
    'height' => null,
]
```

The [calling code](https://github.com/woocommerce/woocommerce/blob/8.9.1/plugins/woocommerce/includes/class-wc-regenerate-images.php#L221-L223) will then simply 'bail out'. This change shouldn't change that process, but should remove the error noise.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

In this case, I think code review is sufficient. Though we could contrive a test scenario as follows.

1. In your `wp-config.php` file, set `WP_DEBUG` and `WP_DEBUG_DISPLAY` to `true`. Disable Query Monitor if it is enabled.
2. Identify an existing attachment from the media library, or upload something. Grab the ID.
3. Add the following snippet to `wp-content/mu-plugins/test-47785.php`:

```php
<?php

add_filter( 'wp_get_attachment_metadata', '__return_empty_array' );
```

4. Run the following via WP CLI:

```sh
# Replace $attachment_id with the actual attachment ID you captured.
wp eval "print_r( WC_Regenerate_Images::maybe_resize_image( [ 1, 2, 3 ], $attachment_id, 'woocommerce_single', false ) );"
```

5. With this change, you should get a representation of the `[ 1, 2, 3 ]` array we passed in. *Without* this change, you should still get that but you will also see essentially the same undefined array key errors (for image height and width) cited in the PR description.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
