### PR TITLE
Make the plugin autoinstall process more robust

### DIFF
--- a/plugins/woocommerce/changelog/pr-47798
+++ b/plugins/woocommerce/changelog/pr-47798
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the plugin autoinstall process more robust

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -447,32 +447,11 @@ class WC_Install {
 		set_transient( 'wc_installing', 'yes', MINUTE_IN_SECONDS * 10 );
 		wc_maybe_define_constant( 'WC_INSTALLING', true );
 
-		if ( self::is_new_install() && ! get_option( self::NEWLY_INSTALLED_OPTION, false ) ) {
-			update_option( self::NEWLY_INSTALLED_OPTION, 'yes' );
+		try {
+			self::install_core();
+		} finally {
+			delete_transient( 'wc_installing' );
 		}
-
-		WC()->wpdb_table_fix();
-		self::remove_admin_notices();
-		self::create_tables();
-		self::verify_base_tables();
-		self::create_options();
-		self::migrate_options();
-		self::create_roles();
-		self::setup_environment();
-		self::create_terms();
-		self::create_cron_jobs();
-		self::delete_obsolete_notes();
-		self::create_files();
-		self::maybe_create_pages();
-		self::maybe_set_activation_transients();
-		self::set_paypal_standard_load_eligibility();
-		self::update_wc_version();
-		self::maybe_update_db_version();
-		self::maybe_set_store_id();
-		self::maybe_install_legacy_api_plugin();
-		self::maybe_activate_legacy_api_enabled_option();
-
-		delete_transient( 'wc_installing' );
 
 		// Use add_option() here to avoid overwriting this value with each
 		// plugin version update. We base plugin age off of this value.
@@ -501,6 +480,36 @@ class WC_Install {
 		 * @since 6.5.0
 		 */
 		do_action( 'woocommerce_admin_installed' );
+	}
+
+	/**
+	 * Core function that performs the WooCommerce install.
+	 */
+	private static function install_core() {
+		if ( self::is_new_install() && ! get_option( self::NEWLY_INSTALLED_OPTION, false ) ) {
+			update_option( self::NEWLY_INSTALLED_OPTION, 'yes' );
+		}
+
+		WC()->wpdb_table_fix();
+		self::remove_admin_notices();
+		self::create_tables();
+		self::verify_base_tables();
+		self::create_options();
+		self::migrate_options();
+		self::create_roles();
+		self::setup_environment();
+		self::create_terms();
+		self::create_cron_jobs();
+		self::delete_obsolete_notes();
+		self::create_files();
+		self::maybe_create_pages();
+		self::maybe_set_activation_transients();
+		self::set_paypal_standard_load_eligibility();
+		self::update_wc_version();
+		self::maybe_update_db_version();
+		self::maybe_set_store_id();
+		self::maybe_install_legacy_api_plugin();
+		self::maybe_activate_legacy_api_enabled_option();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
@@ -114,8 +114,8 @@ class PluginInstaller implements RegisterHooksInterface {
 		$installed_by = $metadata['installed_by'] ?? 'WooCommerce';
 		if ( 0 === strcasecmp( 'WooCommerce', $installed_by ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
-			$calling_file = debug_backtrace()[1]['file'] ?? null; // [1], not [0], because the immediate caller is the install_plugin method.
-			if ( ! StringUtil::starts_with( $calling_file, WC_ABSPATH . 'includes/' ) && ! StringUtil::starts_with( $calling_file, WC_ABSPATH . 'src/' ) ) {
+			$calling_file = StringUtil::normalize_local_path_slashes( debug_backtrace()[1]['file'] ?? '' ); // [1], not [0], because the immediate caller is the install_plugin method.
+			if ( ! StringUtil::starts_with( $calling_file, StringUtil::normalize_local_path_slashes( WC_ABSPATH . 'includes/' ) ) && ! StringUtil::starts_with( $calling_file, StringUtil::normalize_local_path_slashes( WC_ABSPATH . 'src/' ) ) ) {
 				throw new \InvalidArgumentException( "If the value of 'installed_by' is 'WooCommerce', the caller of the method must be a WooCommerce core class or function." );
 			}
 		}

--- a/plugins/woocommerce/src/Utilities/StringUtil.php
+++ b/plugins/woocommerce/src/Utilities/StringUtil.php
@@ -116,6 +116,7 @@ final class StringUtil {
 	 */
 	public static function to_sql_list( array $values ) {
 		if ( empty( $values ) ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \InvalidArgumentException( self::class_name_without_namespace( __CLASS__ ) . '::' . __FUNCTION__ . ': the values array is empty' );
 		}
 
@@ -132,5 +133,15 @@ final class StringUtil {
 		// A '?:' would convert this to a one-liner, but WP coding standards disallow these :shrug:.
 		$result = substr( strrchr( $class_name, '\\' ), 1 );
 		return $result ? $result : $class_name;
+	}
+
+	/**
+	 * Normalize the slashes (/ and \) of a local filesystem path by converting them to DIRECTORY_SEPARATOR.
+	 *
+	 * @param string|null $path Path to normalize.
+	 * @return string|null Normalized path, or null if the input was null.
+	 */
+	public static function normalize_local_path_slashes( ?string $path ) {
+		return is_null( $path ) ? null : str_replace( array( '\\', '/' ), DIRECTORY_SEPARATOR, $path );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Utilities/StringUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/StringUtilTest.php
@@ -146,4 +146,20 @@ class StringUtilTest extends \WC_Unit_Test_Case {
 		$actual_output = StringUtil::class_name_without_namespace( $input );
 		$this->assertEquals( $expected_output, $actual_output );
 	}
+
+	/**
+	 * @testdox 'normalize_local_path_slashes' replaces all the input slashes with DIRECTORY_SEPARATOR.
+	 */
+	public function test_normalize_local_path_slashes() {
+		$actual_output   = StringUtil::normalize_local_path_slashes( "one/two\\three" );
+		$expected_output = 'one' . DIRECTORY_SEPARATOR . 'two' . DIRECTORY_SEPARATOR . 'three';
+		$this->assertEquals( $expected_output, $actual_output );
+	}
+
+	/**
+	 * @testdox 'normalize_local_path_slashes' returns null when it gets null.
+	 */
+	public function test_normalize_local_path_slashes_passing_null() {
+		$this->assertNull( StringUtil::normalize_local_path_slashes( null ) );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

1. Fix a bug in `PluginInstaller::install_plugin` that caused a false "caller is not WooCommerce" exception in Windows, due to this OS using backslashes as the local directory separator.
2. Catch any exception thrown by `PluginInstaller::install_plugin` during the install of the Legacy REST API plugin on WooCommerce update, and write an error log entry.
3. Make sure that the `wc_installing` transient is deleted even if the install/update process throws an exception.

To reproduce 1, you'll need to use WordPress hosted in Windows (for example using [XAMPP](https://www.apachefriends.org/)). Alternatively, you can do the following (make the file changes in the contents of a WooCommerce zip file not containing the changes of this pull request):

1. Add the following line at the end of `WooCommerce::define_constants`:

```php
$this->define('WIN_WC_ABSPATH', str_replace('/', '\\', WC_ABSPATH));
```

2. Modify `PluginInstaller::install_plugin_core` replacing the instances of `WC_ABSPATH` with `WIN_WC_ABSPATH`.

3. Now you can go and try to update WooCommerce using the modified zip file and making sure that the legacy API plugin autoinstall will be attempted (see below), it will fail.


### How to test the changes in this Pull Request:

General testing note: when updating WooCommerce, to ensure that the legacy API plugin autoinstall will be attempted you should delete the plugin if it's installed and run the following in command line:

```bash
wp option delete woocommerce_history_of_autoinstalled_plugins
wp option delete woocommerce_autoinstalled_plugins
wp option set woocommerce_api_enabled yes
wp transient delete wc_installing
# Any version number lower than the one currently installed is fine
wp option set woocommerce_version 8.0.0
``` 

#### Installing on Windows

Ideally, simply use a zip file generated from the branch of this pull request to update WooCommerce in a Windows hosted WordPress, making sure that the legacy API plugin autoinstall will be attempted as outlined above. Alternatively, update WooCommerce after making the outlined code changes, but this time using the said zip file generated from the branch of this pull request. This time the legacy REST API plugin should be automatically installed without issues.

#### Autoinstall exception

To simulate the autoinstall process throwing an exception, add the following line at the beginning of `PluginInstaller::install_plugin` in a zip file generated from the branch of this pull request:

```php
throw new \Exception( 'Oh no, something went wrong when installing a plugin!!' );
```

Now ensure that the legacy API plugin autoinstall will be attempted and try to update WooCommerce from the modified zip file, you'll see an admin notice saying that the autoinstall of the legacy API plugin failed, and you'll see an error log entry under the `plugin_auto_installs` source in WooCommerce - Status - Logs.

#### Proper cleanup of `wc_installing`

Modify again the original zip file generated from the branch of this pull request, now throwing an exception in the first line of `WC_Install::install_core`. Trying to update WooCommerce will fail, but after that `wp transient get wc_installing` should yield nothing.

Zip file for testing (updated 2024-05-24 10:30 UTC):

[woocommerce-47798.zip](https://github.com/woocommerce/woocommerce/files/15432150/woocommerce-47798.zip)


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
