### PR TITLE
Specify Product Price ancestor and simplify Product Elements ancestors

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/index.ts
@@ -27,12 +27,6 @@ const blockConfig: BlockConfiguration = {
 	keywords: [ 'WooCommerce' ],
 	description,
 	usesContext: [ 'query', 'queryId', 'postId' ],
-	ancestor: [
-		'woocommerce/all-products',
-		'woocommerce/single-product',
-		'core/post-template',
-		'woocommerce/product-template',
-	],
 	textdomain: 'woocommerce',
 	attributes,
 	supports,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
@@ -16,10 +16,8 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-const { ancestor, ...configuration } = sharedConfig;
-
 const blockConfig = {
-	...configuration,
+	...sharedConfig,
 	apiVersion: 2,
 	title,
 	description,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/index.ts
@@ -15,12 +15,6 @@ import { supports } from './support';
 
 const blockConfig: BlockConfiguration = {
 	...sharedConfig,
-	ancestor: [
-		'woocommerce/all-products',
-		'woocommerce/single-product',
-		'core/post-template',
-		'woocommerce/product-template',
-	],
 	icon: { src: icon },
 	supports,
 	edit,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
@@ -28,10 +28,7 @@ const blockConfig: BlockConfiguration = {
 	edit,
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	ancestor: [
-		'woocommerce/all-products',
-		'woocommerce/single-product',
-		'core/post-template',
-		'woocommerce/product-template',
+		...( sharedConfig.ancestor || [] ),
 		'woocommerce/product-gallery',
 	],
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -28,7 +28,14 @@ const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	supports: {
 		html: false,
 	},
-	ancestor: [ 'woocommerce/all-products', 'woocommerce/single-product' ],
+	ancestor: [
+		'woocommerce/all-products',
+		'woocommerce/single-product',
+		// Product Collection product template
+		'woocommerce/product-template',
+		// Products (Beta) product template
+		'core/post-template',
+	],
 	save,
 	deprecated: [
 		{

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/index.tsx
@@ -17,10 +17,8 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-const { ancestor, ...configuration } = sharedConfig;
-
 const blockConfig: BlockConfiguration = {
-	...configuration,
+	...sharedConfig,
 	apiVersion: 2,
 	title,
 	description,
@@ -28,10 +26,7 @@ const blockConfig: BlockConfiguration = {
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	attributes,
 	ancestor: [
-		'woocommerce/all-products',
-		'woocommerce/single-product',
-		'core/post-template',
-		'woocommerce/product-template',
+		...( sharedConfig.ancestor || [] ),
 		'woocommerce/product-meta',
 	],
 	edit,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
@@ -28,12 +28,6 @@ const blockConfig: BlockConfiguration = {
 	supports,
 	edit,
 	usesContext: [ 'query', 'queryId', 'postId' ],
-	ancestor: [
-		'woocommerce/all-products',
-		'woocommerce/single-product',
-		'core/post-template',
-		'woocommerce/product-template',
-	],
 };
 
 registerBlockType( 'woocommerce/product-stock-indicator', {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/index.ts
@@ -20,6 +20,9 @@ import { Save } from './save';
 
 const blockConfig: BlockConfiguration = {
 	...sharedConfig,
+	// Product Summary is not expected to be available in Product Collection
+	// nor Products (Beta). They use core/post-summary variation.
+	ancestor: [ 'woocommerce/all-products', 'woocommerce/single-product' ],
 	apiVersion: 2,
 	title,
 	description,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -22,6 +22,9 @@ import { Save } from './save';
 
 const blockConfig: BlockConfiguration = {
 	...sharedConfig,
+	// Product Title is not expected to be available in Product Collection
+	// nor Products (Beta). They use core/post-title variation.
+	ancestor: [ 'woocommerce/all-products', 'woocommerce/single-product' ],
 	apiVersion: 2,
 	title,
 	description,

--- a/plugins/woocommerce/changelog/fix-product-price-ancestors
+++ b/plugins/woocommerce/changelog/fix-product-price-ancestors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Price: Narrow down the ancestors of the block so it's available in inserter only in places where block makes sense

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -14,9 +14,6 @@ const singleProductPrice = '555.00';
 // default cart and checkout blocks, mini-cart, product collection
 const blocks = [
 	{
-		name: 'Product Price',
-	},
-	{
 		name: 'Product Search',
 	},
 	{


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Product Price block had no ancestor set and hence was available everywhere in the Editor even though it doesn't make much sense without necessary context.

This PR fixes that problem by adding `ancestor` field from `sharedConfig` in Product Price block.
In addition:
- `ancestor` in `sharedConfig` was extended with Product Template (used in Product Collection) and Post Template (used in Products (Beta)). Anyway both of them were specified in some of the Product Elements
- I went through the Product Elements and utilized the `ancestor` from `sharedConfig` where applicable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Editor -> Product Catalog template
2. Insert Product Collection block
3. Choose Product Catalog
4. Try adding Product Price block inside Product Collection
5. **Expected:** Product Price should be available in inserter
<img width="470" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/b182f422-e92a-4d99-835c-d9ca79d9236c">

6. Focus OUTSIDE of Product Collection and try adding Product Price block
7. **Expected:** It should not be available in inserter
<img width="437" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/5025cdb9-a1c3-4cc6-9284-0130b40c0a7b">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
