### PR TITLE
Honor blank "additional content" in e-mails (vs using default text)

### DIFF
--- a/plugins/woocommerce/changelog/fix-41462
+++ b/plugins/woocommerce/changelog/fix-41462
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honor empty "additional content" setting in e-mails.

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -167,23 +167,6 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		}
 
 		/**
-		 * Return content from the additional_content field.
-		 *
-		 * Displayed above the footer.
-		 *
-		 * @since 3.7.0
-		 * @return string
-		 */
-		public function get_additional_content() {
-			/**
-			 * This filter is documented in ./class-wc-email.php
-			 *
-			 * @since 7.8.0
-			 */
-			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
-		}
-
-		/**
 		 * Initialise settings form fields.
 		 */
 		public function init_form_fields() {

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -407,11 +407,6 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_additional_content() {
-		$additional_content = $this->get_option( 'additional_content' );
-		if ( ! is_string( $additional_content ) ) {
-			$additional_content = $this->get_default_additional_content();
-		}
-
 		/**
 		 * Provides an opportunity to inspect and modify additional content for the email.
 		 *
@@ -421,7 +416,7 @@ class WC_Email extends WC_Settings_API {
 		 * @param object|bool $object             The object (ie, product or order) this email relates to, if any.
 		 * @param WC_Email    $email              WC_Email instance managing the email.
 		 */
-		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $additional_content ), $this->object, $this );
+		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -407,6 +407,11 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_additional_content() {
+		$additional_content = $this->get_option( 'additional_content' );
+		if ( ! is_string( $additional_content ) ) {
+			$additional_content = $this->get_default_additional_content();
+		}
+
 		/**
 		 * Provides an opportunity to inspect and modify additional content for the email.
 		 *
@@ -416,7 +421,7 @@ class WC_Email extends WC_Settings_API {
 		 * @param object|bool $object             The object (ie, product or order) this email relates to, if any.
 		 * @param WC_Email    $email              WC_Email instance managing the email.
 		 */
-		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content', $this->get_default_additional_content() ) ), $this->object, $this );
+		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $additional_content ), $this->object, $this );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, e-mails that have "additional content" (most do) will use the default value set in the e-mail class even when that additional content setting has been modified by the merchant to be empty. This means there's currently no way to have no additional content in those e-mails.

It seems to me we should honor what the merchant has configured and the default value should only be used when the merchant hasn't customized the e-mail at all.

Closes #41462.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Have a way to "catch" e-mails sent by your WP instance. I recommend MailHog or the WP Mail Logging plugin.
2. Either manually create an order in WC > Orders or make a purchase through the frontend.
3. Go to WC > Settings > E-mails and choose **Order details**.
4. Modify **Additional content** to anything of your liking and save.
5. Go to WC > Orders and choose the order created in step 2.
6. Choose **Send order details to customer** and click the action button **`>`**.
7. Using your mail catcher, confirm that the e-mail is sent and contains the additional content you've specified.
8. Repeat 3-4 but this time remove all content from **Additional content**.
9. Repeat steps 5-7 and confirm no additional content is sent.
   **Optional:** Contrast this with `trunk`, where despite this customization, the e-mail will contain the default text of "Thank you for using [site URL]!".
11. Run `wp option patch delete woocommerce_customer_invoice_settings additional_content` to simulate the e-mail not having been customized by the merchant.
12. Repeat steps 5-7 and confirm that the e-mail contains the default message of "Thank you for using [site URL]!".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
