### PR TITLE
Move registration of block categories on the server side

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/index.js
+++ b/plugins/woocommerce-blocks/assets/js/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { getCategories, setCategories } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { updateCategory } from '@wordpress/blocks';
 import { woo } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 
@@ -16,24 +15,12 @@ import './filters/get-block-attributes';
 import './base/components/notice-banner/style.scss';
 import './atomic/utils/blocks-registration-manager';
 
-setCategories( [
-	...getCategories().filter(
-		( { slug } ) =>
-			slug !== 'woocommerce' && slug !== 'woocommerce-product-elements'
+// Icons are set on the front-end to make use of WordPress SVG primitive,
+// See: https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#wp-blocks-updatecategory
+
+updateCategory( 'woocommerce', { icon: <Icon icon={ woo } /> } );
+updateCategory( 'woocommerce-product-elements', {
+	icon: (
+		<Icon icon={ woo } className="wc-block-editor-components-block-icon" />
 	),
-	{
-		slug: 'woocommerce',
-		title: __( 'WooCommerce', 'woocommerce' ),
-		icon: <Icon icon={ woo } />,
-	},
-	{
-		slug: 'woocommerce-product-elements',
-		title: __( 'WooCommerce Product Elements', 'woocommerce' ),
-		icon: (
-			<Icon
-				icon={ woo }
-				className="wc-block-editor-components-block-icon"
-			/>
-		),
-	},
-] );
+} );

--- a/plugins/woocommerce/changelog/47836-fix-42927-registering-blocks-in-categories-warning
+++ b/plugins/woocommerce/changelog/47836-fix-42927-registering-blocks-in-categories-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Moved WooCommerce block categories registration on the server-side, fixing a bug that would show warnings to developers trying to hook new blocks in such categories.

--- a/plugins/woocommerce/changelog/fix-42927-registering-blocks-in-categories-warning
+++ b/plugins/woocommerce/changelog/fix-42927-registering-blocks-in-categories-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Moved WooCommerce block categories registration on the server-side, fixing a bug that would show warnings to developers trying to hook new blocks in such categories.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -48,6 +48,7 @@ final class BlockTypesController {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
+		add_filter( 'block_categories_all', array( $this, 'register_block_categories' ), 10, 2 );
 		add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
@@ -105,6 +106,29 @@ final class BlockTypesController {
 
 			new $block_type_class( $this->asset_api, $this->asset_data_registry, new IntegrationRegistry() );
 		}
+	}
+
+	/**
+	 * Register block categories
+	 *
+	 * Used in combination with the `block_categories_all` filter, to append
+	 * WooCommerce Blocks related categories to the Gutenberg editor.
+	 *
+	 * @param array $categories The array of already registered categories.
+	 */
+	public function register_block_categories( $categories ) {
+		$woocommerce_block_categories = array(
+			array(
+				'slug'  => 'woocommerce',
+				'title' => __( 'WooCommerce', 'woocommerce' ),
+			),
+			array(
+				'slug'  => 'woocommerce-product-elements',
+				'title' => __( 'WooCommerce Product Elements', 'woocommerce' ),
+			)
+		);
+
+		return array_merge( $categories, $woocommerce_block_categories );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -125,7 +125,7 @@ final class BlockTypesController {
 			array(
 				'slug'  => 'woocommerce-product-elements',
 				'title' => __( 'WooCommerce Product Elements', 'woocommerce' ),
-			)
+			),
 		);
 
 		return array_merge( $categories, $woocommerce_block_categories );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, we registered block categories on the client-side, leading to them not being available until client initialization. This meant, for example, that hooking external blocks to our categories would result in a warning.

With this change, we register the categories server-side, and only update them on the client-side to attach the SVG icon. This is the recommended approach in the Gutenberg docs, to make sure we use the SVG primitive, which affords some accessibility features.

See: https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#wp-blocks-updatecategory

For reference, client-side registration was introduced in this PR (2019): https://github.com/woocommerce/woocommerce-blocks/pull/581/

Closes #42927 (discussion).

> [!NOTE]
> This PR is not necessarily an endorsement for 3PDs to register custom blocks under WooCommerce categories. This might be the topic of another discussion, or the one linked above.
> However, server-side registration is nevertheless the best way to go in this case.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### WooCommerce Blocks categories should be available on the editor

1. Go to any screen which uses the Gutenberg editor (post editor, page editor or site editor).
2. Toggle the “Block Inserter”.
3. Ensure that the “WooCommerce“ and “WooCommerce Product Elements” categories are available and they show the “Woo” brand icon.

#### Registering third-party blocks in WooCommerce categories should work without warnings

1. Scaffold a new block plugin using `npx @wordpress/create-block example-plugin`.
2. Edit `example-plugin/build/block.json` and set the `'category'` to `'woocommerce-product-elements'`.
3. Activate the newly-created “Example plugin” plugin.
4. Create a new page, and browse the available blocks.
5. Ensure the “Example Plugin” block is available in the inserter under the `'woocommerce-product-elements'` category.
6. Ensure no warnings related to block registration are output in the console.
7. Repeat steps 2-6 for the '`woocommerce`' category.

A ready [example-plugin.zip](https://github.com/woocommerce/woocommerce/files/15448240/example-plugin.zip) is provided here for convenience.

The warning we are looking for would read:

> The block "create-block/example-plugin" is registered with an invalid category "woocommerce-product-elements".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Moved WooCommerce block categories registration on the server-side, fixing a bug that would show warnings to developers trying to hook new blocks in such categories.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
