### PR TITLE
Use github proxy to install WC beta tester in playground previews

### DIFF
--- a/.github/workflows/scripts/generate-playground-blueprint.js
+++ b/.github/workflows/scripts/generate-playground-blueprint.js
@@ -25,6 +25,16 @@ const generateWordpressPlaygroundBlueprint = ( runId, prNumber ) => {
 				},
 			},
 			{
+				step: 'installPlugin',
+				pluginZipFile: {
+					resource: 'url',
+					url: `https://github-proxy.com/https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-2.3.1/woocommerce-beta-tester.zip`,
+				},
+				options: {
+					activate: true,
+				},
+			},
+			{
 				step: 'login',
 				username: 'admin',
 				password: 'password',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is a proxy `github-proxy.com` that will allow us to serve Github hosted assets like release zips with `cors` headers, therefore enabling the use of them in Wordpress Playground environments.

This PR adds the WooCommerce Beta Tester to our Playground preview links in PRs. This is particularly useful for experimental features that can be enabled via the WCA Test Helper menu.

### How to test the changes in this Pull Request:

1. Click the Playground preview link generated in this PR
2. When it's finished setting up the Playground, confirm that WC Beta tester is installed
3. If you'd like to further confirm the usefulness of WC beta tester in this context, then open the Tools > WCA Test Helper menu from the admin
4. Open the Features menu
5. Enable "experimental blocks" toggle
6. Go to any block editor, and see you can find "Product Filters: Attribute Filter" (one of the experimental blocks) in the block inserter

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
