### PR TITLE
Fix redundant confetti on LYS task congrats page

### DIFF
--- a/packages/js/components/changelog/fix-47791-confetti-pop-every-render
+++ b/packages/js/components/changelog/fix-47791-confetti-pop-every-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added useRef to ensure confetti animation is only run once

--- a/packages/js/components/src/confetti-animation/index.ts
+++ b/packages/js/components/src/confetti-animation/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import confetti from 'canvas-confetti';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Note: This was copied over from https://github.com/Automattic/wp-calypso/blob/a39539547780871d0371a20fcf21c767a86a1010/packages/components/src/confetti/index.ts
@@ -83,9 +83,12 @@ export const ConfettiAnimation = ( {
 	delay = 0,
 	colors = COLORS,
 } ) => {
+	const hasRun = useRef( false );
+
 	useEffect( () => {
-		if ( trigger ) {
+		if ( ! hasRun.current && trigger ) {
 			setTimeout( () => fireConfetti( colors ), delay );
+			hasRun.current = true;
 		}
 	}, [ trigger, delay, colors ] );
 

--- a/plugins/woocommerce/changelog/fix-47791-confetti-pop-every-render
+++ b/plugins/woocommerce/changelog/fix-47791-confetti-pop-every-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added useRef to ensure confetti animation is only run once


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/47791.

Adds `useRef` to ensure confetti is triggered only once.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set up a fresh store and ensure to go through or skip setup wizard
2. When redirected to homescreen, ensure the site visibility badge on top left is showing `Site coming soon`
3. Click on `Launch your store` task
4. Click on `Launch your store` button
5. Observe confetti shoots out on page
6. Click on any of the emojis in survey
7. Ensure the confetti is not shown again

https://github.com/woocommerce/woocommerce/assets/3747241/94829bc9-9355-4f81-8ed7-95d312baf7c7


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>