### PR TITLE
Product Block Editor: load and create shipping classes optimistically 

### DIFF
--- a/packages/js/product-editor/changelog/update-create-shipping-classes-optimistically
+++ b/packages/js/product-editor/changelog/update-create-shipping-classes-optimistically
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Block Editor: load and create shipping classes optimistically

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
@@ -51,6 +51,11 @@ function mapShippingClassToSelectOption(
 	} ) );
 }
 
+/*
+ * Query to fetch shipping classes.
+ */
+const shippingClassRequestQuery = {};
+
 function extractDefaultShippingClassFromProduct(
 	categories?: PartialProduct[ 'categories' ],
 	shippingClasses?: ProductShippingClass[]
@@ -130,9 +135,9 @@ export function Edit( {
 			return {
 				shippingClasses:
 					( isInSelectedTab &&
-						getProductShippingClasses<
-							ProductShippingClass[]
-						>() ) ||
+						getProductShippingClasses< ProductShippingClass[] >(
+							shippingClassRequestQuery
+						) ) ||
 					[],
 			};
 		},
@@ -214,7 +219,9 @@ export function Edit( {
 					onAdd={ ( shippingClassValues ) =>
 						createProductShippingClass<
 							Promise< ProductShippingClass >
-						>( shippingClassValues )
+						>( shippingClassValues, {
+							optimisticQueryUpdate: shippingClassRequestQuery,
+						} )
 							.then( ( value ) => {
 								recordEvent(
 									'product_new_shipping_class_modal_add_button_click'

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
@@ -83,7 +83,7 @@ export function Edit( {
 
 	const blockProps = useWooBlockProps( attributes );
 
-	const { createProductShippingClass, invalidateResolution } = useDispatch(
+	const { createProductShippingClass } = useDispatch(
 		EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME
 	);
 
@@ -225,9 +225,6 @@ export function Edit( {
 							.then( ( value ) => {
 								recordEvent(
 									'product_new_shipping_class_modal_add_button_click'
-								);
-								invalidateResolution(
-									'getProductShippingClasses'
 								);
 								setShippingClass( value.slug );
 								return value;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR turns the optimistic mode of data handling in the section when the user can create Shipping classes, eliminating the invalidate resolution action in favor of a better UX.

Part of https://github.com/woocommerce/woocommerce/issues/47622

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new Product Editor
2. Create/edit a new Product
3. Go to the `Shipping` section/tab
4. Confirm it works as usual:
  * Create a new class
  * Try to create a new class with the same name produces an error
  * Hard refresh and confirm it loads the classes properly

Additionally, you can check how the data is propagated, populating the store, without the need to invalidate the selector's resolution.

### 🍿 Video:

https://github.com/woocommerce/woocommerce/assets/77539/36e31675-fb71-4715-9125-ac86839500fd

Snippet used to create a new Shipping class

```es6
wp.data.dispatch( 'experimental/wc/admin/products/shipping-classes' )
    .createProductShippingClass( { name: 'In the box' }, {
        optimisticQueryUpdate: {},
    } )
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
