### PR TITLE
Cleanup wcBlocksConfig

### DIFF
--- a/plugins/woocommerce/changelog/update-46990-wcBlocksConfig-cleanup
+++ b/plugins/woocommerce/changelog/update-46990-wcBlocksConfig-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce the amount of queries needed to define WC Blocks settings

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -445,7 +445,6 @@ abstract class AbstractBlock {
 				'restApiRoutes'             => [
 					'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
 				],
-				'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
 
 				/*
 				 * translators: If your word count is based on single characters (e.g. East Asian characters),
@@ -458,7 +457,8 @@ abstract class AbstractBlock {
 				$wc_blocks_config = array_merge(
 					$wc_blocks_config,
 					[
-						'productCount' => array_sum( (array) wp_count_posts( 'product' ) ),
+						'productCount'  => array_sum( (array) wp_count_posts( 'product' ) ),
+						'defaultAvatar' => get_avatar_url( 0, [ 'force_default' => true ] ),
 					]
 				);
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -436,7 +436,6 @@ abstract class AbstractBlock {
 
 		if ( ! $this->asset_data_registry->exists( 'wcBlocksConfig' ) ) {
 			$wc_blocks_config = [
-				'buildPhase'                => Package::feature()->get_flag(),
 				// Note that while we don't have a consolidated way of doing feature-flagging
 				// we are borrowing from the WC Admin Features implementation. Also note we cannot
 				// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
@@ -457,6 +456,7 @@ abstract class AbstractBlock {
 				$wc_blocks_config = array_merge(
 					$wc_blocks_config,
 					[
+						'buildPhase'    => Package::feature()->get_flag(),
 						'productCount'  => array_sum( (array) wp_count_posts( 'product' ) ),
 						'defaultAvatar' => get_avatar_url( 0, [ 'force_default' => true ] ),
 					]

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -449,7 +449,6 @@ abstract class AbstractBlock {
 				$wc_blocks_config = array_merge(
 					$wc_blocks_config,
 					[
-						'buildPhase'                => Package::feature()->get_flag(),
 						// Note that while we don't have a consolidated way of doing feature-flagging
 						// we are borrowing from the WC Admin Features implementation. Also note we cannot
 						// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -436,26 +436,26 @@ abstract class AbstractBlock {
 
 		if ( ! $this->asset_data_registry->exists( 'wcBlocksConfig' ) ) {
 			$wc_blocks_config = [
-				// Note that while we don't have a consolidated way of doing feature-flagging
-				// we are borrowing from the WC Admin Features implementation. Also note we cannot
-				// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
-				'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
-				'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
+				'pluginUrl'     => plugins_url( '/', dirname( __DIR__, 2 ) ),
 
 				/*
 				 * translators: If your word count is based on single characters (e.g. East Asian characters),
 				 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 				 * Do not translate into your own language.
 				 */
-				'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
+				'wordCountType' => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
 			];
 			if ( is_admin() && ! WC()->is_rest_api_request() ) {
 				$wc_blocks_config = array_merge(
 					$wc_blocks_config,
 					[
-						'buildPhase'    => Package::feature()->get_flag(),
-						'productCount'  => array_sum( (array) wp_count_posts( 'product' ) ),
-						'defaultAvatar' => get_avatar_url( 0, [ 'force_default' => true ] ),
+						'buildPhase'                => Package::feature()->get_flag(),
+						// Note that while we don't have a consolidated way of doing feature-flagging
+						// we are borrowing from the WC Admin Features implementation. Also note we cannot
+						// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
+						'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
+						'productCount'              => array_sum( (array) wp_count_posts( 'product' ) ),
+						'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
 					]
 				);
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -441,9 +441,6 @@ abstract class AbstractBlock {
 				// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
 				'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
 				'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
-				'restApiRoutes'             => [
-					'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
-				],
 
 				/*
 				 * translators: If your word count is based on single characters (e.g. East Asian characters),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -435,27 +435,36 @@ abstract class AbstractBlock {
 		}
 
 		if ( ! $this->asset_data_registry->exists( 'wcBlocksConfig' ) ) {
+			$wc_blocks_config = [
+				'buildPhase'                => Package::feature()->get_flag(),
+				// Note that while we don't have a consolidated way of doing feature-flagging
+				// we are borrowing from the WC Admin Features implementation. Also note we cannot
+				// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
+				'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
+				'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
+				'restApiRoutes'             => [
+					'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
+				],
+				'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
+
+				/*
+				 * translators: If your word count is based on single characters (e.g. East Asian characters),
+				 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+				 * Do not translate into your own language.
+				 */
+				'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
+			];
+			if ( is_admin() && ! WC()->is_rest_api_request() ) {
+				$wc_blocks_config = array_merge(
+					$wc_blocks_config,
+					[
+						'productCount' => array_sum( (array) wp_count_posts( 'product' ) ),
+					]
+				);
+			}
 			$this->asset_data_registry->add(
 				'wcBlocksConfig',
-				[
-					// Note that while we don't have a consolidated way of doing feature-flagging
-					// we are borrowing from the WC Admin Features implementation. Also note we cannot
-					// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
-					'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
-					'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
-					'productCount'              => array_sum( (array) wp_count_posts( 'product' ) ),
-					'restApiRoutes'             => [
-						'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
-					],
-					'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
-
-					/*
-					 * translators: If your word count is based on single characters (e.g. East Asian characters),
-					 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-					 * Do not translate into your own language.
-					 */
-					'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
-				]
+				$wc_blocks_config
 			);
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR cleanups `wcBlocksConfig` making the following changes:

* `buildPhase`, `experimentalBlocksEnabled`, `productCount` and `defaultAvatar` are now only defined in the admin site, so we don't create them in the frontend. That's specially beneficial for `productCount`, as it was doing an expensive query (closes https://github.com/woocommerce/woocommerce/issues/46990).
* `restApiRoutes` has been removed altogether. I think it wasn't used anywhere.

### How to test the changes in this Pull Request:

1. Go to the post or page editor and search for a reviews block, verify that when hovering it the default user avatar is visible in the preview:
![image](https://github.com/woocommerce/woocommerce/assets/3616980/68593a36-881e-4018-b86c-ba9c15bde732)
2. Remove all products of your store and add the All Products block to a post or page. Verify the 'no products' message is displayed in the editor:
![image](https://github.com/woocommerce/woocommerce/assets/3616980/8eca0a14-9c5f-433d-af31-ce3df3ab156b)
3. Open the inserter and search for _Price Filter_. Verify there is only one block available, a block named _Product Filter: Price (Beta)_ shouldn't appear.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
