### PR TITLE
Fix typo in some tests and comments: 'blockbased' > 'block-based'

### DIFF
--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/stock-reservation.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/stock-reservation.md
@@ -95,7 +95,7 @@ In the above code snippet:
 
 ## How this all fits into Checkout Block vs Traditional Checkout
 
-The point of which stock is reserved differs between the new Block based checkout and the traditional checkout, the main difference being that the Block based checkout reserves stock on entry so the customer isn't forced to fill out the entire checkout form unnecessarily.
+The point of which stock is reserved differs between the new block-based checkout and the traditional checkout, the main difference being that the block-based checkout reserves stock on entry so the customer isn't forced to fill out the entire checkout form unnecessarily.
 
 ![Checkout Processes](checkout.jpg)
 

--- a/plugins/woocommerce/changelog/fix-blockbased-typo-tests
+++ b/plugins/woocommerce/changelog/fix-blockbased-typo-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Fix typo in some tests and comments: 'blockbased' > 'block-based'
+
+

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -597,7 +597,7 @@ class WC_Emails {
 	}
 
 	/**
-	 * Renders any additional fields captured during block based checkout.
+	 * Renders any additional fields captured during block-based checkout.
 	 *
 	 * @param WC_Order $order         Order instance.
 	 * @param bool     $sent_to_admin If email is sent to admin.
@@ -634,7 +634,7 @@ class WC_Emails {
 	}
 
 	/**
-	 * Renders any additional address fields captured during block based checkout.
+	 * Renders any additional address fields captured during block-based checkout.
 	 *
 	 * @param string   $address_type Address type.
 	 * @param WC_Order $order         Order instance.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -460,7 +460,7 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	 * If the customer has selected local pickup, keep it selected if it's still in the package. We don't want to auto
 	 * toggle between shipping and pickup even if available shipping methods are changed.
 	 *
-	 * This is important for block based checkout where there is an explicit toggle between shipping and pickup.
+	 * This is important for block-based checkout where there is an explicit toggle between shipping and pickup.
 	 */
 	$local_pickup_method_ids = LocalPickupUtils::get_local_pickup_method_ids();
 	$is_local_pickup_chosen  = in_array( $chosen_method_id, $local_pickup_method_ids, true );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Notices.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Notices.php
@@ -119,7 +119,7 @@ class Notices {
 	}
 
 	/**
-	 * Replaces all notices with the new block based notices.
+	 * Replaces all notices with the new block-based notices.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Blocks/Installer.php
+++ b/plugins/woocommerce/src/Blocks/Installer.php
@@ -25,7 +25,7 @@ class Installer {
 
 	/**
 	 * Modifies default page content replacing it with classic shortcode block.
-	 * We check for shortcode as default because after WooCommerce 8.3, block based checkout is used by default.
+	 * We check for shortcode as default because after WooCommerce 8.3, block-based checkout is used by default.
 	 * This only runs on Tools > Create Pages as the filter is not applied on WooCommerce plugin activation.
 	 *
 	 * @param array $pages Default pages.

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
@@ -121,7 +121,7 @@ test.describe( 'Shopper Cart & Checkout Block Tax Display', () => {
 		await publishPage( page, checkoutBlockPageTitle );
 	} );
 
-	test( 'that inclusive tax is displayed properly in blockbased Cart & Checkout pages', async ( {
+	test( 'that inclusive tax is displayed properly in block-based Cart & Checkout pages', async ( {
 		page,
 		context,
 	} ) => {
@@ -168,7 +168,7 @@ test.describe( 'Shopper Cart & Checkout Block Tax Display', () => {
 		} );
 	} );
 
-	test( 'that exclusive tax is displayed properly in blockbased Cart & Checkout pages', async ( {
+	test( 'that exclusive tax is displayed properly in block-based Cart & Checkout pages', async ( {
 		page,
 		baseURL,
 		context,
@@ -330,7 +330,7 @@ test.describe( 'Shopper Cart & Checkout Block Tax Rounding', () => {
 		} );
 	} );
 
-	test( 'that tax rounding is present at subtotal level in blockbased Cart & Checkout pages', async ( {
+	test( 'that tax rounding is present at subtotal level in block-based Cart & Checkout pages', async ( {
 		page,
 		baseURL,
 	} ) => {
@@ -389,7 +389,7 @@ test.describe( 'Shopper Cart & Checkout Block Tax Rounding', () => {
 		} );
 	} );
 
-	test( 'that tax rounding is off at subtotal level in blockbased Cart & Checkout pages', async ( {
+	test( 'that tax rounding is off at subtotal level in block-based Cart & Checkout pages', async ( {
 		page,
 		baseURL,
 	} ) => {
@@ -714,7 +714,7 @@ test.describe( 'Shopper Cart & Checkout Block Tax Levels', () => {
 		} );
 	} );
 
-	test( 'that applying taxes in blockbased Cart & Checkout of 2 different levels (2 excluded) calculates properly', async ( {
+	test( 'that applying taxes in block-based Cart & Checkout of 2 different levels (2 excluded) calculates properly', async ( {
 		page,
 		baseURL,
 	} ) => {

--- a/plugins/woocommerce/tests/e2e-pw/utils/checkout.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/checkout.js
@@ -1,5 +1,5 @@
 /**
- * Util helper made for filling shipping details in the blockbased checkout
+ * Util helper made for filling shipping details in the block-based checkout
  *
  * @param page
  * @param firstName
@@ -39,7 +39,7 @@ export async function fillShippingCheckoutBlocks(
 }
 
 /**
- * Util helper made for filling billing details in the blockbased checkout
+ * Util helper made for filling billing details in the block-based checkout
  *
  * @param page
  * @param firstName

--- a/plugins/woocommerce/tests/e2e-pw/utils/checkout.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/checkout.js
@@ -1,12 +1,12 @@
 /**
  * Util helper made for filling shipping details in the block-based checkout
  *
- * @param page
- * @param firstName
- * @param lastName
- * @param address
- * @param city
- * @param zip
+ * @param {Object} page
+ * @param {string} firstName
+ * @param {string} lastName
+ * @param {string} address
+ * @param {string} city
+ * @param {string} zip
  */
 export async function fillShippingCheckoutBlocks(
 	page,
@@ -41,12 +41,12 @@ export async function fillShippingCheckoutBlocks(
 /**
  * Util helper made for filling billing details in the block-based checkout
  *
- * @param page
- * @param firstName
- * @param lastName
- * @param address
- * @param city
- * @param zip
+ * @param {Object} page
+ * @param {string} firstName
+ * @param {string} lastName
+ * @param {string} address
+ * @param {string} city
+ * @param {string} zip
  */
 export async function fillBillingCheckoutBlocks(
 	page,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Small PR fixing a typo in some tests and comments, from `blockbased` to `block-based`. I also took the chance to unify all other tests and comments to `block-based` with a hyphen.

### How to test the changes in this Pull Request:

This PR only modifies test titles and comments, so there is no need to test anything.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
