### PR TITLE
Add product id to product_edit_view track in classic product edit screen

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
@@ -6,10 +6,16 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { addExitPageListener, initProductScreenTracks } from './shared';
+import {
+	addExitPageListener,
+	getProductData,
+	initProductScreenTracks,
+} from './shared';
 
 const initTracks = () => {
-	recordEvent( 'product_edit_view' );
+	const productData = getProductData();
+
+	recordEvent( 'product_edit_view', { product_id: productData?.product_id } );
 	initProductScreenTracks();
 };
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -57,7 +57,7 @@ function getProductTypeOptionsString(
 		.join( ', ' );
 }
 
-const getProductData = () => {
+export const getProductData = () => {
 	const isBlockEditor =
 		document.querySelectorAll( '.block-editor' ).length > 0;
 

--- a/plugins/woocommerce/changelog/fix-47108
+++ b/plugins/woocommerce/changelog/fix-47108
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add product id to product_edit_view track in classic product edit screen


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47108

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure to enable `Enable WooCommerce Analytics` under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. When editing a product in the classic experience the tracking event `wcadmin_product_edit_view` should now send the product id as the event data. 
<img width="943" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/447772e6-4f9f-4fd4-8666-1dcfa1aec260">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
