### PR TITLE
Fix the permissions check for customer downloads REST API endpoints.

### DIFF
--- a/plugins/woocommerce/changelog/fix-27109-customer-id
+++ b/plugins/woocommerce/changelog/fix-27109-customer-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure permission checks for the customer downloads REST API endpoint use the correct customer ID.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-customer-downloads-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-customer-downloads-v1-controller.php
@@ -64,13 +64,14 @@ class WC_REST_Customer_Downloads_V1_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_items_permissions_check( $request ) {
-		$customer = get_user_by( 'id', (int) $request['customer_id'] );
+		$customer    = new WC_Customer( (int) $request['customer_id'] );
+		$customer_id = $customer->get_id();
 
-		if ( ! $customer ) {
+		if ( ! $customer_id ) {
 			return new WP_Error( 'woocommerce_rest_customer_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		if ( ! wc_rest_check_user_permissions( 'read', $customer->get_id() ) ) {
+		if ( ! wc_rest_check_user_permissions( 'read', $customer_id ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-customer-downloads-v1-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-customer-downloads-v1-controller-tests.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Tests relating to WC_REST_Orders_V1_Controller.
+ */
+class WC_REST_Customer_Downloads_V1_Controller_Tests extends WC_Unit_Test_Case {
+	/**
+	 * Describes the basic expectations for permission checks, as implemented for the customer downloads endpoint.
+	 *
+	 * @return void
+	 */
+	public function test_get_items_permissions_check(): void {
+		$sut                 = new WC_REST_Customer_Downloads_V1_Controller();
+		$average_user_id     = $this->factory->user->create();
+		$shop_manager_id     = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
+		$valid_customer_id   = $this->factory->user->create();
+		$invalid_customer_id = $valid_customer_id + 100;
+
+		wp_set_current_user( $shop_manager_id );
+		$request = new WP_REST_Request( 'GET', '/wc/v1/orders' );
+		$request->set_query_params( array( 'customer_id' => $valid_customer_id ) );
+
+		$this->assertTrue(
+			$sut->get_items_permissions_check( $request ),
+			'Requests (here initiated by a shop manager) that specify an valid customer/user will be approved.'
+		);
+
+		$request->set_query_params( array() );
+		$this->assertWPError(
+			$sut->get_items_permissions_check( $request ),
+			'Requests that do not specify a customer/user will be rejected.'
+		);
+
+		$request->set_query_params( array( 'customer_id' => $invalid_customer_id ) );
+		$this->assertWPError(
+			$sut->get_items_permissions_check( $request ),
+			'Requests that specify an invalid customer/user will be rejected.'
+		);
+
+		wp_set_current_user( $average_user_id );
+		$this->assertWPError(
+			$sut->get_items_permissions_check( $request ),
+			'Valid requests specifying an valid customer/user will be rejected if the initiating user does not have the required permissions.'
+		);
+	}
+}


### PR DESCRIPTION
Within our permissions check for the `/customers/<ID>/downloads` route, we were trying to use a non-existent `WP_User` method to obtain the customer ID.

A little surprisingly, then, this still worked without triggering fatal errors, because of some fairly relaxed magic methods within `WP_User`. However, it did have consequences for any code hooking into `woocommerce_rest_check_permissions` since that would not receive the ID of the actual customer.

Closes #27109.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Let's firstly check that the happy path remains happy (ie, we aren't disrupting typical flows). You will need:

1. An API key for a shop manager or above.
1. A customer who has purchased one or more downloadable products.
2. A customer with no downloads.

From there:

1. Send a series of REST API requests to `/wp-json/wc/v3/customers/<ID>/downloads`.
2. First time, use the customer with the downloads (insert their user ID). These should be listed in the response data.
3. Second time, use the customer with no downloads. This time, no downloads should be listed in the response.

Now, add the following snippet to a suitable location (such as `wp-content/mu-plugins/pr-47854.php`):

```php
<?php

add_filter(
	'woocommerce_rest_check_permissions',
	function ( $permission, $context, $object_id, $type ) {
		if ( $type === 'user' && $object_id < 1 ) {
			throw new Exception( 'Where be the user ID?' );
		}

		return $permission;
	},
	10,
	4
);
```

1. Send another REST API request to `/wp-json/wc/v3/customers/<ID>/downloads` (supplying a valid user ID).
2. With this branch, you should get back the expected response.
3. Without this branch, a fatal error will occur (because of the exception thrown by the snippet, which is very crudely testing to see if it was passed a valid user ID).
4. A further variation of this can be found in the linked issue.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
