### PR TITLE
Fix product tracks when importing

### DIFF
--- a/plugins/woocommerce/changelog/fix-47107_prevent_wrong_tracks_when_importing
+++ b/plugins/woocommerce/changelog/fix-47107_prevent_wrong_tracks_when_importing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix product tracks when importing #47857

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -548,16 +548,17 @@ class WC_Products_Tracking {
 	}
 
 	/**
-     * Check if the current process is importing products.
-     *
-     * @return bool True if importing, false otherwise.
-     */
+	 * Check if the current process is importing products.
+	 *
+	 * @return bool True if importing, false otherwise.
+	 */
     private function is_importing() {
-        // Check if the current request is a product import.
-        if ( isset( $_POST['action'] ) && 'woocommerce_do_ajax_product_import' === $_POST['action'] ) {
-            return true;
-        }
-        return false;
-    }
-
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// Check if the current request is a product import.
+		if ( isset( $_POST['action'] ) && 'woocommerce_do_ajax_product_import' === $_POST['action'] ) {
+			return true;
+		}
+		return false;
+		// phpcs:enable
+	}
 }

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -125,7 +125,7 @@ class WC_Products_Tracking {
 		}
 
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
-		$source     = apply_filters( 'woocommerce_product_source', self::is_importing() ? 'bulk-import' : self::TRACKS_SOURCE );
+		$source     = apply_filters( 'woocommerce_product_source', self::is_importing() ? 'import' : self::TRACKS_SOURCE );
 		$properties = array(
 			'product_id' => $product_id,
 			'source'     => $source,
@@ -341,7 +341,7 @@ class WC_Products_Tracking {
 			'product_type_options' => $product_type_options_string,
 			'purchase_note'        => $product->get_purchase_note() ? 'yes' : 'no',
 			'sale_price'           => $product->get_sale_price() ? 'yes' : 'no',
-			'source'               => apply_filters( 'woocommerce_product_source', self::is_importing() ? 'bulk-import' : self::TRACKS_SOURCE ),
+			'source'               => apply_filters( 'woocommerce_product_source', self::is_importing() ? 'import' : self::TRACKS_SOURCE ),
 			'short_description'    => $product->get_short_description() ? 'yes' : 'no',
 			'tags'                 => count( $product->get_tag_ids() ),
 			'upsells'              => ! empty( $product->get_upsell_ids() ) ? 'yes' : 'no',

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -125,7 +125,7 @@ class WC_Products_Tracking {
 		}
 
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
-		$source     = apply_filters( 'woocommerce_product_source', self::TRACKS_SOURCE );
+		$source     = apply_filters( 'woocommerce_product_source', self::is_importing() ? 'bulk-import' : self::TRACKS_SOURCE );
 		$properties = array(
 			'product_id' => $product_id,
 			'source'     => $source,
@@ -341,7 +341,7 @@ class WC_Products_Tracking {
 			'product_type_options' => $product_type_options_string,
 			'purchase_note'        => $product->get_purchase_note() ? 'yes' : 'no',
 			'sale_price'           => $product->get_sale_price() ? 'yes' : 'no',
-			'source'               => apply_filters( 'woocommerce_product_source', self::TRACKS_SOURCE ),
+			'source'               => apply_filters( 'woocommerce_product_source', self::is_importing() ? 'bulk-import' : self::TRACKS_SOURCE ),
 			'short_description'    => $product->get_short_description() ? 'yes' : 'no',
 			'tags'                 => count( $product->get_tag_ids() ),
 			'upsells'              => ! empty( $product->get_upsell_ids() ) ? 'yes' : 'no',
@@ -546,4 +546,18 @@ class WC_Products_Tracking {
 		}
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'add-term-tracking', false );
 	}
+
+	/**
+     * Check if the current process is importing products.
+     *
+     * @return bool True if importing, false otherwise.
+     */
+    private function is_importing() {
+        // Check if the current request is a product import.
+        if ( isset( $_POST['action'] ) && 'woocommerce_do_ajax_product_import' === $_POST['action'] ) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -552,7 +552,7 @@ class WC_Products_Tracking {
 	 *
 	 * @return bool True if importing, false otherwise.
 	 */
-    private function is_importing() {
+	private function is_importing() {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		// Check if the current request is a product import.
 		if ( isset( $_POST['action'] ) && 'woocommerce_do_ajax_product_import' === $_POST['action'] ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We trigger the `product_edit` and `product_add_publish` when a product published. This also happens when products are imported, generating a weird spike of edit/publish events that makes the data more difficult to analyze.

This PR modifies the events' source prop to set it as `bulk-import` to filter those products from the analysis results.

From @nathanss [suggestion](https://github.com/woocommerce/woocommerce/issues/47107#issuecomment-2102782465).


Closes #47107.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce store and install the WooCommerce Beta Tester from the mono repo
2. Make sure you have tracking enabled under **WooCommerce > Settings > Advanced > WooCommerce.com > Enable tracking**
3. Go to **Products > All products** and click **Import**
4. Import the CSV available within the mono repo: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/sample-data/sample_products.csv
5. Finish the importing
6. Go to **WooCommerce > Status > Logs** and open the tracks log ( only created if the beta tester is enabled )
7. Notice the events `product_edit` and `product_add_publish` for each imported product have the source prop set as `bulk-import`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
