### PR TITLE
Fix accessibility issues when using the keyboard to navigate/select tabs in the new product editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-36773
+++ b/packages/js/product-editor/changelog/fix-36773
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix accessibility issues when using the keyboard to navigate/select tabs in the new product editor

--- a/packages/js/product-editor/src/blocks/generic/tab/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/tab/editor.scss
@@ -1,12 +1,6 @@
 .wp-block-woocommerce-product-tab__content {
-    &:not(.is-selected) {
+	&:not(.is-selected) {
 		display: none;
-	}
-}
-
-.woocommerce-product-tabs {
-	.wp-block-woocommerce-product-tab__button:focus:not( :disabled ) {
-		box-shadow: none;
 	}
 }
 

--- a/packages/js/product-editor/src/blocks/generic/tab/tab-button.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/tab-button.tsx
@@ -52,6 +52,8 @@ export function TabButton( {
 							id={ `woocommerce-product-tab__${ id }` }
 							aria-controls={ `woocommerce-product-tab__${ id }-content` }
 							aria-selected={ selected }
+							tabIndex={ selected ? undefined : -1 }
+							role="tab"
 						>
 							{ children }
 						</Button>

--- a/packages/js/product-editor/src/components/tabs/tabs.tsx
+++ b/packages/js/product-editor/src/components/tabs/tabs.tsx
@@ -105,7 +105,7 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 				event.preventDefault();
 				event.stopPropagation();
 
-				const [ lastTab ] = [ ...tabs ].reverse();
+				const lastTab = tabs[ tabs.length - 1 ];
 				lastTab?.focus();
 				break;
 		}

--- a/packages/js/product-editor/src/components/tabs/tabs.tsx
+++ b/packages/js/product-editor/src/components/tabs/tabs.tsx
@@ -84,7 +84,7 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 		_childIndex: number,
 		child: HTMLButtonElement
 	) {
-		child.click();
+		child.focus();
 	}
 
 	function renderFills( fills: readonly ( readonly ReactElement[] )[] ) {

--- a/packages/js/product-editor/src/components/tabs/tabs.tsx
+++ b/packages/js/product-editor/src/components/tabs/tabs.tsx
@@ -7,7 +7,7 @@ import {
 	useState,
 	Fragment,
 } from '@wordpress/element';
-import { ReactElement, useMemo } from 'react';
+import { KeyboardEvent, ReactElement, useMemo } from 'react';
 import { NavigableMenu, Slot } from '@wordpress/components';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -87,6 +87,30 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 		child.focus();
 	}
 
+	function handleKeyDown( event: KeyboardEvent< HTMLDivElement > ) {
+		const tabs =
+			event.currentTarget.querySelectorAll< HTMLButtonElement >(
+				'[role="tab"]'
+			);
+
+		switch ( event.key ) {
+			case 'Home':
+				event.preventDefault();
+				event.stopPropagation();
+
+				const [ firstTab ] = tabs;
+				firstTab?.focus();
+				break;
+			case 'End':
+				event.preventDefault();
+				event.stopPropagation();
+
+				const [ lastTab ] = [ ...tabs ].reverse();
+				lastTab?.focus();
+				break;
+		}
+	}
+
 	function renderFills( fills: readonly ( readonly ReactElement[] )[] ) {
 		return (
 			<TabFills
@@ -106,6 +130,7 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 		<NavigableMenu
 			role="tablist"
 			onNavigate={ selectTabOnNavigate }
+			onKeyDown={ handleKeyDown }
 			className="woocommerce-product-tabs"
 			orientation="horizontal"
 		>

--- a/plugins/woocommerce/changelog/fix-36773
+++ b/plugins/woocommerce/changelog/fix-36773
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix e2e tests about the tabs selection during the product creation experience

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -225,7 +225,7 @@ test.describe( 'Variations tab', () => {
 
 			await page
 				.locator( '.woocommerce-product-tabs' )
-				.getByRole( 'button', { name: 'Pricing' } )
+				.getByRole( 'tab', { name: 'Pricing' } )
 				.click();
 
 			await page
@@ -234,7 +234,7 @@ test.describe( 'Variations tab', () => {
 
 			await page
 				.locator( '.woocommerce-product-tabs' )
-				.getByRole( 'button', { name: 'Inventory' } )
+				.getByRole( 'tab', { name: 'Inventory' } )
 				.click();
 
 			await page

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -108,7 +108,7 @@ test.skip( 'can create and add attributes', async ( { page, product } ) => {
 
 	await test.step( 'go to product editor, Organization tab', async () => {
 		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
-		await page.getByRole( 'button', { name: 'Organization' } ).click();
+		await page.getByRole( 'tab', { name: 'Organization' } ).click();
 	} );
 
 	await test.step( 'add new attributes', async () => {
@@ -215,7 +215,7 @@ test.skip( 'can add existing attributes', async ( {
 				response.url().includes( '/terms?attribute_id=' ) &&
 				response.status() === 200
 		);
-		await page.getByRole( 'button', { name: 'Organization' } ).click();
+		await page.getByRole( 'tab', { name: 'Organization' } ).click();
 		await getAttributesResponsePromise;
 	} );
 
@@ -297,7 +297,7 @@ test.skip( 'can update product attributes', async ( {
 		await page.goto(
 			`wp-admin/post.php?post=${ productWithAttributes.id }&action=edit`
 		);
-		await page.getByRole( 'button', { name: 'Organization' } ).click();
+		await page.getByRole( 'tab', { name: 'Organization' } ).click();
 
 		// Sometimes the attribute's terms take a while to load, and we need to reload and retry.
 		// See https://github.com/woocommerce/woocommerce/issues/44925
@@ -393,7 +393,7 @@ test( 'can remove product attributes', async ( {
 				response.url().includes( '/terms?attribute_id=' ) &&
 				response.status() === 200
 		);
-		await page.getByRole( 'button', { name: 'Organization' } ).click();
+		await page.getByRole( 'tab', { name: 'Organization' } ).click();
 		await getAttributesResponsePromise;
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-inventory-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-inventory-block-editor.spec.js
@@ -28,7 +28,7 @@ const test = baseTest.extend( {
 			await page.goto(
 				`wp-admin/post.php?post=${ product.id }&action=edit`
 			);
-			await page.getByRole( 'button', { name: 'Inventory' } ).click();
+			await page.getByRole( 'tab', { name: 'Inventory' } ).click();
 		} );
 
 		await use( page );
@@ -132,7 +132,7 @@ test( 'can track stock quantity', async ( { page, product } ) => {
 
 	await test.step( 'return to product editor', async () => {
 		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
-		await page.getByRole( 'button', { name: 'Inventory' } ).click();
+		await page.getByRole( 'tab', { name: 'Inventory' } ).click();
 	} );
 
 	await test.step( 'update available quantity', async () => {
@@ -185,7 +185,7 @@ test( 'can limit purchases', async ( { page, product } ) => {
 
 	await test.step( 'return to product editor', async () => {
 		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
-		await page.getByRole( 'button', { name: 'Inventory' } ).click();
+		await page.getByRole( 'tab', { name: 'Inventory' } ).click();
 	} );
 
 	await test.step( 'enable limit purchases', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/utils/simple-products.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/simple-products.js
@@ -8,9 +8,9 @@ const SETTINGS_URL =
  *
  * Navigates to the block product editor and verifies it's enabled.
  *
- * @param {Page} page
+ * @param {import('@playwright/test').Page} page
  *
- * @returns {Promise<boolean>} Boolean value based on the visibility of the element.
+ * @return {Promise<boolean>} Boolean value based on the visibility of the element.
  */
 async function isBlockProductEditorEnabled( page ) {
 	await page.goto( SETTINGS_URL );
@@ -23,7 +23,7 @@ async function isBlockProductEditorEnabled( page ) {
  * This function is typically used for enabling/disabling the block product editor in settings page.
  *
  * @param {string} action The action that will be performed.
- * @param {Page} page
+ * @param {import('@playwright/test').Page}   page
  */
 async function toggleBlockProductEditor( action = 'enable', page ) {
 	await page.goto( SETTINGS_URL );
@@ -47,7 +47,7 @@ async function toggleBlockProductEditor( action = 'enable', page ) {
 /**
  * This function simulates the clicking of the "Add New" link under the "product" section in the menu.
  *
- * @param {Page} page
+ * @param {import('@playwright/test').Page} page
  */
 async function clickAddNewMenuItem( page ) {
 	await page
@@ -59,7 +59,7 @@ async function clickAddNewMenuItem( page ) {
 /**
  * This function checks if the old product editor is visible.
  *
- * @param {Page} page
+ * @param {import('@playwright/test').Page} page
  */
 async function expectOldProductEditor( page ) {
 	await expect(
@@ -70,7 +70,7 @@ async function expectOldProductEditor( page ) {
 /**
  * This function checks if the block product editor is visible.
  *
- * @param {Page} page
+ * @param {import('@playwright/test').Page} page
  */
 async function expectBlockProductEditor( page ) {
 	await expect(
@@ -81,8 +81,8 @@ async function expectBlockProductEditor( page ) {
 /**
  * Click on a block editor tab.
  *
- * @param {Page} page
- * @param {string} tabName
+ * @param {string}													tabName
+ * @param {import('@playwright/test').Page} page
  */
 async function clickOnTab( tabName, page ) {
 	await page

--- a/plugins/woocommerce/tests/e2e-pw/utils/simple-products.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/simple-products.js
@@ -87,7 +87,7 @@ async function expectBlockProductEditor( page ) {
 async function clickOnTab( tabName, page ) {
 	await page
 		.locator( '.woocommerce-product-tabs' )
-		.getByRole( 'button', { name: tabName } )
+		.getByRole( 'tab', { name: tabName } )
 		.click();
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36773

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Then go to Products > Add new
3. Pressing the `Tab` key should let you navigate from outside of the tab list to inside it focusing the current selected tab. If the `Tab` key is pressed again the focus will be moved to the first focusable element inside the tabpanel.
4. When the focus is in a specific tab (within the tablist), pressing `Right Array` should move the focus to the next right tab of the list. When at the end of the list the first tab should receive the focus. (Note that this do not select the tab)
5. When the focus is in a specific tab (within the tablist), pressing `Left Array` should move the focus to the previous left tab of the list. When at the beginning of the list the last tab should receive the focus. (Note that this do not select the tab)
6. When focusing a specific tab (within the tablist) that is not selected, it is possible to select it by pressing `Space` or `Enter` keys.
7. When the focus is in a specific tab (within the tablist), pressing the `Home` key should move the focus to the first tab of the list.
8. When the focus is in a specific tab (within the tablist), pressing the `End` key should move the focus to the last tab of the list.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
