### PR TITLE
Update: Order Status badge tooltip shows static description  

### DIFF
--- a/plugins/woocommerce/changelog/2024-06-11-14-30-36-229170
+++ b/plugins/woocommerce/changelog/2024-06-11-14-30-36-229170
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Modified order status tooltip labels

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -236,7 +236,7 @@ class ListTable extends WP_List_Table {
 		if ( ! empty( $this->order_query_args['s'] ) ) {
 			$search_label  = '<span class="subtitle">';
 			$search_label .= sprintf(
-				/* translators: %s: Search query. */
+			/* translators: %s: Search query. */
 				__( 'Search results for: %s', 'woocommerce' ),
 				'<strong>' . esc_html( $this->order_query_args['s'] ) . '</strong>'
 			);
@@ -275,15 +275,15 @@ class ListTable extends WP_List_Table {
 	 */
 	public function render_blank_state(): void {
 		?>
-			<div class="woocommerce-BlankState">
+		<div class="woocommerce-BlankState">
 
-				<h2 class="woocommerce-BlankState-message">
-					<?php esc_html_e( 'When you receive a new order, it will appear here.', 'woocommerce' ); ?>
-				</h2>
+			<h2 class="woocommerce-BlankState-message">
+				<?php esc_html_e( 'When you receive a new order, it will appear here.', 'woocommerce' ); ?>
+			</h2>
 
-				<div class="woocommerce-BlankState-buttons">
-					<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://woocommerce.com/document/managing-orders/?utm_source=blankslate&utm_medium=product&utm_content=ordersdoc&utm_campaign=woocommerceplugin"><?php esc_html_e( 'Learn more about orders', 'woocommerce' ); ?></a>
-				</div>
+			<div class="woocommerce-BlankState-buttons">
+				<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://woocommerce.com/document/managing-orders/?utm_source=blankslate&utm_medium=product&utm_content=ordersdoc&utm_campaign=woocommerceplugin"><?php esc_html_e( 'Learn more about orders', 'woocommerce' ); ?></a>
+			</div>
 
 			<?php
 			/**
@@ -294,7 +294,7 @@ class ListTable extends WP_List_Table {
 			do_action( 'wc_marketplace_suggestions_orders_empty_state' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 			?>
 
-			</div>
+		</div>
 		<?php
 	}
 
@@ -611,8 +611,8 @@ class ListTable extends WP_List_Table {
 
 			$this->status_count_cache =
 				$res
-				? array_combine( array_column( $res, 'status' ), array_map( 'absint', array_column( $res, 'cnt' ) ) )
-				: array();
+					? array_combine( array_column( $res, 'status' ), array_map( 'absint', array_column( $res, 'cnt' ) ) )
+					: array();
 		}
 
 		$status = (array) $status;
@@ -646,7 +646,7 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @param null           $should_render_blank_state `null` will use the built-in counts. Sending a boolean will short-circuit that path.
 		 * @param object         ListTable The current instance of the class.
-		*/
+		 */
 		$should_render_blank_state = apply_filters(
 			'woocommerce_' . $this->order_type . '_list_table_should_render_blank_state',
 			null,
@@ -793,7 +793,7 @@ class ListTable extends WP_List_Table {
 		foreach ( $order_dates as $date ) {
 			$month           = zeroise( $date->month, 2 );
 			$month_year_text = sprintf(
-				/* translators: 1: Month name, 2: 4-digit year. */
+			/* translators: 1: Month name, 2: 4-digit year. */
 				esc_html_x( '%1$s %2$d', 'order dates dropdown', 'woocommerce' ),
 				$wp_locale->get_month( $month ),
 				$date->year
@@ -825,7 +825,7 @@ class ListTable extends WP_List_Table {
 			$user    = get_user_by( 'id', $user_id );
 
 			$user_string = sprintf(
-				/* translators: 1: user display name 2: user ID 3: user email */
+			/* translators: 1: user display name 2: user ID 3: user email */
 				esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
 				$user->display_name,
 				absint( $user->ID ),
@@ -1031,30 +1031,43 @@ class ListTable extends WP_List_Table {
 	 */
 	public function render_order_status_column( WC_Order $order ): void {
 		$tooltip = '';
-		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
-		$comment_count = get_comment_count( $order->get_id() );
-		add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
-		$approved_comments_count = absint( $comment_count['approved'] );
 
-		if ( $approved_comments_count ) {
-			$latest_notes = wc_get_order_notes(
-				array(
-					'order_id' => $order->get_id(),
-					'limit'    => 1,
-					'orderby'  => 'date_created_gmt',
-				)
-			);
+		/**
+		 * Provides an opportunity to toggle showing tooltips
+		 * when hovering over an order status badge in the dashboard.
+		 *
+		 * @param bool $use_tooltip 'true' will enable the tooltips over status badges.
+		 *
+		 * @since 6.7.0
+		 */
+		$use_tooltip = apply_filters( 'woocommerce_enable_order_status_tooltips_on_hover', true);
 
-			$latest_note = current( $latest_notes );
+		if ( $use_tooltip ){
+			remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
+			$comment_count = get_comment_count( $order->get_id() );
+			add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
+			$approved_comments_count = absint( $comment_count['approved'] );
 
-			if ( isset( $latest_note->content ) && 1 === $approved_comments_count ) {
-				$tooltip = wc_sanitize_tooltip( $latest_note->content );
-			} elseif ( isset( $latest_note->content ) ) {
-				/* translators: %d: notes count */
-				$tooltip = wc_sanitize_tooltip( $latest_note->content . '<br/><small style="display:block">' . sprintf( _n( 'Plus %d other note', 'Plus %d other notes', ( $approved_comments_count - 1 ), 'woocommerce' ), $approved_comments_count - 1 ) . '</small>' );
-			} else {
-				/* translators: %d: notes count */
-				$tooltip = wc_sanitize_tooltip( sprintf( _n( '%d note', '%d notes', $approved_comments_count, 'woocommerce' ), $approved_comments_count ) );
+			if ( $approved_comments_count ) {
+				$latest_notes = wc_get_order_notes(
+					array(
+						'order_id' => $order->get_id(),
+						'limit'    => 1,
+						'orderby'  => 'date_created_gmt',
+					)
+				);
+
+				$latest_note = current( $latest_notes );
+
+				if ( isset( $latest_note->content ) && 1 === $approved_comments_count ) {
+					$tooltip = wc_sanitize_tooltip( $latest_note->content );
+				} elseif ( isset( $latest_note->content ) ) {
+					/* translators: %d: notes count */
+					$tooltip = wc_sanitize_tooltip( $latest_note->content . '<br/><small style="display:block">' . sprintf( _n( 'Plus %d other note', 'Plus %d other notes', ( $approved_comments_count - 1 ), 'woocommerce' ), $approved_comments_count - 1 ) . '</small>' );
+				} else {
+					/* translators: %d: notes count */
+					$tooltip = wc_sanitize_tooltip( sprintf( _n( '%d note', '%d notes', $approved_comments_count, 'woocommerce' ), $approved_comments_count ) );
+				}
 			}
 		}
 
@@ -1501,8 +1514,8 @@ class ListTable extends WP_List_Table {
 	public function get_order_preview_template(): string {
 		$order_edit_url_placeholder =
 			wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
-			? esc_url( admin_url( 'admin.php?page=wc-orders&action=edit' ) ) . '&id={{ data.data.id }}'
-			: esc_url( admin_url( 'post.php?action=edit' ) ) . '&post={{ data.data.id }}';
+				? esc_url( admin_url( 'admin.php?page=wc-orders&action=edit' ) ) . '&id={{ data.data.id }}'
+				: esc_url( admin_url( 'post.php?action=edit' ) ) . '&post={{ data.data.id }}';
 
 		ob_start();
 		?>
@@ -1527,46 +1540,46 @@ class ListTable extends WP_List_Table {
 									{{{ data.formatted_billing_address }}}
 
 									<# if ( data.data.billing.email ) { #>
-										<strong><?php esc_html_e( 'Email', 'woocommerce' ); ?></strong>
-										<a href="mailto:{{ data.data.billing.email }}">{{ data.data.billing.email }}</a>
+									<strong><?php esc_html_e( 'Email', 'woocommerce' ); ?></strong>
+									<a href="mailto:{{ data.data.billing.email }}">{{ data.data.billing.email }}</a>
 									<# } #>
 
 									<# if ( data.data.billing.phone ) { #>
-										<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
-										<a href="tel:{{ data.data.billing.phone }}">{{ data.data.billing.phone }}</a>
+									<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
+									<a href="tel:{{ data.data.billing.phone }}">{{ data.data.billing.phone }}</a>
 									<# } #>
 
 									<# if ( data.payment_via ) { #>
-										<strong><?php esc_html_e( 'Payment via', 'woocommerce' ); ?></strong>
-										{{{ data.payment_via }}}
+									<strong><?php esc_html_e( 'Payment via', 'woocommerce' ); ?></strong>
+									{{{ data.payment_via }}}
 									<# } #>
 								</div>
 								<# if ( data.needs_shipping ) { #>
-									<div class="wc-order-preview-address">
-										<h2><?php esc_html_e( 'Shipping details', 'woocommerce' ); ?></h2>
-										<# if ( data.ship_to_billing ) { #>
-											{{{ data.formatted_billing_address }}}
-										<# } else { #>
-											<a href="{{ data.shipping_address_map_url }}" target="_blank">{{{ data.formatted_shipping_address }}}</a>
-										<# } #>
+								<div class="wc-order-preview-address">
+									<h2><?php esc_html_e( 'Shipping details', 'woocommerce' ); ?></h2>
+									<# if ( data.ship_to_billing ) { #>
+									{{{ data.formatted_billing_address }}}
+									<# } else { #>
+									<a href="{{ data.shipping_address_map_url }}" target="_blank">{{{ data.formatted_shipping_address }}}</a>
+									<# } #>
 
-										<# if ( data.data.shipping.phone ) { #>
-											<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
-											<a href="tel:{{ data.data.shipping.phone }}">{{ data.data.shipping.phone }}</a>
-										<# } #>
+									<# if ( data.data.shipping.phone ) { #>
+									<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
+									<a href="tel:{{ data.data.shipping.phone }}">{{ data.data.shipping.phone }}</a>
+									<# } #>
 
-										<# if ( data.shipping_via ) { #>
-											<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
-											{{ data.shipping_via }}
-										<# } #>
-									</div>
+									<# if ( data.shipping_via ) { #>
+									<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
+									{{ data.shipping_via }}
+									<# } #>
+								</div>
 								<# } #>
 
 								<# if ( data.data.customer_note ) { #>
-									<div class="wc-order-preview-note">
-										<strong><?php esc_html_e( 'Note', 'woocommerce' ); ?></strong>
-										{{ data.data.customer_note }}
-									</div>
+								<div class="wc-order-preview-note">
+									<strong><?php esc_html_e( 'Note', 'woocommerce' ); ?></strong>
+									{{ data.data.customer_note }}
+								</div>
 								<# } #>
 							</div>
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1056,14 +1056,14 @@ class ListTable extends WP_List_Table {
 	 */
 	private function get_order_status_label( WC_Order $order ): string {
 		$status_names = array(
-			"Pending payment" => "The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.",
-			"On hold" => "The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.",
-			"Processing" => "Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.",
-			"Completed" => "Order fulfilled and complete.",
-			"Failed" => "The customer’s payment failed or was declined, and no payment has been successfully made.",
-			"Draft" => "Draft orders are created when customers start the checkout process while the block version of the checkout is in place.",
-			"Canceled" => "The order was canceled by an admin or the customer.",
-			"Refunded" => "Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment."
+			'Pending payment' => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
+			'On hold'		  => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
+			'Processing' 	  => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
+			'Completed' 	  => __( 'Order fulfilled and complete.', 'woocommerce' ),
+			'Failed' 		  => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
+			'Draft' 		  => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
+			'Canceled' 		  => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
+			'Refunded' 		  => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
 		);
 
 		/**
@@ -1071,7 +1071,7 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @param array    $action Order actions.
 		 * @param WC_Order $order  Current order object.
-		 * @since 6.7.0
+		 * @since 9.1.0
 		 */
 		$status_names = apply_filters( 'woocommerce_get_order_status_labels', $status_names );
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -285,14 +285,14 @@ class ListTable extends WP_List_Table {
 					<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://woocommerce.com/document/managing-orders/?utm_source=blankslate&utm_medium=product&utm_content=ordersdoc&utm_campaign=woocommerceplugin"><?php esc_html_e( 'Learn more about orders', 'woocommerce' ); ?></a>
 				</div>
 
-				<?php
-				/**
-				 * Renders after the 'blank state' message for the order list table has rendered.
-				 *
-				 * @since 6.6.1
-				 */
-				do_action( 'wc_marketplace_suggestions_orders_empty_state' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
-				?>
+			<?php
+			/**
+			 * Renders after the 'blank state' message for the order list table has rendered.
+			 *
+			 * @since 6.6.1
+			 */
+			do_action( 'wc_marketplace_suggestions_orders_empty_state' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			?>
 
 			</div>
 		<?php
@@ -1553,19 +1553,19 @@ class ListTable extends WP_List_Table {
 									<div class="wc-order-preview-address">
 										<h2><?php esc_html_e( 'Shipping details', 'woocommerce' ); ?></h2>
 										<# if ( data.ship_to_billing ) { #>
-										{{{ data.formatted_billing_address }}}
+											{{{ data.formatted_billing_address }}}
 										<# } else { #>
-										<a href="{{ data.shipping_address_map_url }}" target="_blank">{{{ data.formatted_shipping_address }}}</a>
+											<a href="{{ data.shipping_address_map_url }}" target="_blank">{{{ data.formatted_shipping_address }}}</a>
 										<# } #>
 
 										<# if ( data.data.shipping.phone ) { #>
-										<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
-										<a href="tel:{{ data.data.shipping.phone }}">{{ data.data.shipping.phone }}</a>
+											<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
+											<a href="tel:{{ data.data.shipping.phone }}">{{ data.data.shipping.phone }}</a>
 										<# } #>
 
 										<# if ( data.shipping_via ) { #>
-										<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
-										{{ data.shipping_via }}
+											<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
+											{{ data.shipping_via }}
 										<# } #>
 									</div>
 								<# } #>

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1050,20 +1050,20 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Gets the order status label for an order.
 	 *
-	 * @param WC_Order $order The order object
+	 * @param WC_Order $order The order object.
 	 *
-	 * @return void
+	 * @return string
 	 */
 	private function get_order_status_label( WC_Order $order ): string {
 		$status_names = array(
 			'Pending payment' => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
-			'On hold'		  => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
-			'Processing' 	  => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
-			'Completed' 	  => __( 'Order fulfilled and complete.', 'woocommerce' ),
-			'Failed' 		  => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
-			'Draft' 		  => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
-			'Canceled' 		  => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
-			'Refunded' 		  => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
+			'On hold'         => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
+			'Processing'      => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
+			'Completed'       => __( 'Order fulfilled and complete.', 'woocommerce' ),
+			'Failed'          => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
+			'Draft'           => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
+			'Canceled'        => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
+			'Refunded'        => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
 		);
 
 		/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -236,7 +236,7 @@ class ListTable extends WP_List_Table {
 		if ( ! empty( $this->order_query_args['s'] ) ) {
 			$search_label  = '<span class="subtitle">';
 			$search_label .= sprintf(
-			/* translators: %s: Search query. */
+				/* translators: %s: Search query. */
 				__( 'Search results for: %s', 'woocommerce' ),
 				'<strong>' . esc_html( $this->order_query_args['s'] ) . '</strong>'
 			);
@@ -275,26 +275,26 @@ class ListTable extends WP_List_Table {
 	 */
 	public function render_blank_state(): void {
 		?>
-		<div class="woocommerce-BlankState">
+			<div class="woocommerce-BlankState">
 
-			<h2 class="woocommerce-BlankState-message">
-				<?php esc_html_e( 'When you receive a new order, it will appear here.', 'woocommerce' ); ?>
-			</h2>
+				<h2 class="woocommerce-BlankState-message">
+					<?php esc_html_e( 'When you receive a new order, it will appear here.', 'woocommerce' ); ?>
+				</h2>
 
-			<div class="woocommerce-BlankState-buttons">
-				<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://woocommerce.com/document/managing-orders/?utm_source=blankslate&utm_medium=product&utm_content=ordersdoc&utm_campaign=woocommerceplugin"><?php esc_html_e( 'Learn more about orders', 'woocommerce' ); ?></a>
+				<div class="woocommerce-BlankState-buttons">
+					<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://woocommerce.com/document/managing-orders/?utm_source=blankslate&utm_medium=product&utm_content=ordersdoc&utm_campaign=woocommerceplugin"><?php esc_html_e( 'Learn more about orders', 'woocommerce' ); ?></a>
+				</div>
+
+				<?php
+				/**
+				 * Renders after the 'blank state' message for the order list table has rendered.
+				 *
+				 * @since 6.6.1
+				 */
+				do_action( 'wc_marketplace_suggestions_orders_empty_state' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+				?>
+
 			</div>
-
-			<?php
-			/**
-			 * Renders after the 'blank state' message for the order list table has rendered.
-			 *
-			 * @since 6.6.1
-			 */
-			do_action( 'wc_marketplace_suggestions_orders_empty_state' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
-			?>
-
-		</div>
 		<?php
 	}
 
@@ -611,8 +611,8 @@ class ListTable extends WP_List_Table {
 
 			$this->status_count_cache =
 				$res
-					? array_combine( array_column( $res, 'status' ), array_map( 'absint', array_column( $res, 'cnt' ) ) )
-					: array();
+				? array_combine( array_column( $res, 'status' ), array_map( 'absint', array_column( $res, 'cnt' ) ) )
+				: array();
 		}
 
 		$status = (array) $status;
@@ -646,7 +646,7 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @param null           $should_render_blank_state `null` will use the built-in counts. Sending a boolean will short-circuit that path.
 		 * @param object         ListTable The current instance of the class.
-		 */
+		*/
 		$should_render_blank_state = apply_filters(
 			'woocommerce_' . $this->order_type . '_list_table_should_render_blank_state',
 			null,
@@ -793,7 +793,7 @@ class ListTable extends WP_List_Table {
 		foreach ( $order_dates as $date ) {
 			$month           = zeroise( $date->month, 2 );
 			$month_year_text = sprintf(
-			/* translators: 1: Month name, 2: 4-digit year. */
+				/* translators: 1: Month name, 2: 4-digit year. */
 				esc_html_x( '%1$s %2$d', 'order dates dropdown', 'woocommerce' ),
 				$wp_locale->get_month( $month ),
 				$date->year
@@ -825,7 +825,7 @@ class ListTable extends WP_List_Table {
 			$user    = get_user_by( 'id', $user_id );
 
 			$user_string = sprintf(
-			/* translators: 1: user display name 2: user ID 3: user email */
+				/* translators: 1: user display name 2: user ID 3: user email */
 				esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
 				$user->display_name,
 				absint( $user->ID ),
@@ -1509,8 +1509,8 @@ class ListTable extends WP_List_Table {
 	public function get_order_preview_template(): string {
 		$order_edit_url_placeholder =
 			wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
-				? esc_url( admin_url( 'admin.php?page=wc-orders&action=edit' ) ) . '&id={{ data.data.id }}'
-				: esc_url( admin_url( 'post.php?action=edit' ) ) . '&post={{ data.data.id }}';
+			? esc_url( admin_url( 'admin.php?page=wc-orders&action=edit' ) ) . '&id={{ data.data.id }}'
+			: esc_url( admin_url( 'post.php?action=edit' ) ) . '&post={{ data.data.id }}';
 
 		ob_start();
 		?>
@@ -1535,46 +1535,46 @@ class ListTable extends WP_List_Table {
 									{{{ data.formatted_billing_address }}}
 
 									<# if ( data.data.billing.email ) { #>
-									<strong><?php esc_html_e( 'Email', 'woocommerce' ); ?></strong>
-									<a href="mailto:{{ data.data.billing.email }}">{{ data.data.billing.email }}</a>
+										<strong><?php esc_html_e( 'Email', 'woocommerce' ); ?></strong>
+										<a href="mailto:{{ data.data.billing.email }}">{{ data.data.billing.email }}</a>
 									<# } #>
 
 									<# if ( data.data.billing.phone ) { #>
-									<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
-									<a href="tel:{{ data.data.billing.phone }}">{{ data.data.billing.phone }}</a>
+										<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
+										<a href="tel:{{ data.data.billing.phone }}">{{ data.data.billing.phone }}</a>
 									<# } #>
 
 									<# if ( data.payment_via ) { #>
-									<strong><?php esc_html_e( 'Payment via', 'woocommerce' ); ?></strong>
-									{{{ data.payment_via }}}
+										<strong><?php esc_html_e( 'Payment via', 'woocommerce' ); ?></strong>
+										{{{ data.payment_via }}}
 									<# } #>
 								</div>
 								<# if ( data.needs_shipping ) { #>
-								<div class="wc-order-preview-address">
-									<h2><?php esc_html_e( 'Shipping details', 'woocommerce' ); ?></h2>
-									<# if ( data.ship_to_billing ) { #>
-									{{{ data.formatted_billing_address }}}
-									<# } else { #>
-									<a href="{{ data.shipping_address_map_url }}" target="_blank">{{{ data.formatted_shipping_address }}}</a>
-									<# } #>
+									<div class="wc-order-preview-address">
+										<h2><?php esc_html_e( 'Shipping details', 'woocommerce' ); ?></h2>
+										<# if ( data.ship_to_billing ) { #>
+										{{{ data.formatted_billing_address }}}
+										<# } else { #>
+										<a href="{{ data.shipping_address_map_url }}" target="_blank">{{{ data.formatted_shipping_address }}}</a>
+										<# } #>
 
-									<# if ( data.data.shipping.phone ) { #>
-									<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
-									<a href="tel:{{ data.data.shipping.phone }}">{{ data.data.shipping.phone }}</a>
-									<# } #>
+										<# if ( data.data.shipping.phone ) { #>
+										<strong><?php esc_html_e( 'Phone', 'woocommerce' ); ?></strong>
+										<a href="tel:{{ data.data.shipping.phone }}">{{ data.data.shipping.phone }}</a>
+										<# } #>
 
-									<# if ( data.shipping_via ) { #>
-									<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
-									{{ data.shipping_via }}
-									<# } #>
-								</div>
+										<# if ( data.shipping_via ) { #>
+										<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
+										{{ data.shipping_via }}
+										<# } #>
+									</div>
 								<# } #>
 
 								<# if ( data.data.customer_note ) { #>
-								<div class="wc-order-preview-note">
-									<strong><?php esc_html_e( 'Note', 'woocommerce' ); ?></strong>
-									{{ data.data.customer_note }}
-								</div>
+									<div class="wc-order-preview-note">
+										<strong><?php esc_html_e( 'Note', 'woocommerce' ); ?></strong>
+										{{ data.data.customer_note }}
+									</div>
 								<# } #>
 							</div>
 


### PR DESCRIPTION
This PR updates the tooltip text over the order status badges in the dashboard. The amount of notes information ("plus 8  other notes" text from the screenshot bellow this paragraph) inside the tooltip is now replaced with static description for the actual order status.

<img width="607" alt="image" src="https://github.com/woocommerce/woocommerce/assets/34198639/1fa62715-8275-4658-bca2-db0a2c8dabbf">


Why are we implementing this feature? 
- We noticed that this functionality triggers a noticeable amount of queries (at least X, where X is the amount of posts per page), and there is no way to disable it. In our case, the count of notes and the tooltip itself, was not useful at all, therefore we don't see a reason to have extra queries that slow our site. 
- The company I work at is a huge eCommerce business, that has thousands of orders per day, thus every single millisecond is precious to our team.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
 
1. [Current behaviour] Go to WP Dashboard -> WooCommerce -> Orders. Find an order, and hover over it's status. A tooltip should appear, showing the amount of notes that specific order has.
2. [The PR's changes] Go back again to WP Dashboard -> WooCommerce -> Orders. Find an order, and hover it's status. This time a tooltip should appear, but it should show a static description for the orders' status. The status description is derived from [these](https://woocommerce.com/document/managing-orders/order-statuses/) docs.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [X] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
