### PR TITLE
Add action `woocommerce_rest_delete_shipping_zone_method` 

### DIFF
--- a/plugins/woocommerce/changelog/fix-43346-rest-delete-zone-action
+++ b/plugins/woocommerce/changelog/fix-43346-rest-delete-zone-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adds new hook `woocommerce_rest_delete_shipping_zone_method` which will fire after a shipping zone method is deleted via the REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zone-methods-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zone-methods-v2-controller.php
@@ -231,13 +231,16 @@ class WC_REST_Shipping_Zone_Methods_V2_Controller extends WC_REST_Shipping_Zones
 		}
 
 		/**
-		 * Fires after a product review is deleted via the REST API.
+		 * Fires after a shipping zone is deleted via the REST API.
 		 *
-		 * @param object           $method
-		 * @param WP_REST_Response $response        The response data.
-		 * @param WP_REST_Request  $request         The request sent to the API.
+		 * @since 9.1.0
+		 *
+		 * @param WC_Shipping_Method $method   The shipping zone method being deleted.
+		 * @param WC_Shipping_Zone   $zone     The shipping zone the method belonged to.
+		 * @param WP_REST_Response   $response The response data.
+		 * @param WP_REST_Request    $request  The request sent to the API.
 		 */
-		do_action( 'rest_delete_product_review', $method, $response, $request );
+		do_action( 'woocommerce_rest_delete_shipping_zone_method', $method, $zone, $response, $request );
 
 		return $response;
 	}


### PR DESCRIPTION
Likely because of a historic copy-and-paste error, when a shipping zone method was deleted via the REST API we would trigger the following action:

`rest_delete_product_review`

Of course, this should only fire if a product review is deleted via the REST API. In this PR, we remove the above hook (from the shipping zone method code) and supply a replacement instead:

`woocommerce_rest_delete_shipping_zone_method`

There is perhaps some sort of back-compat issue with this change, but on the whole it seems unlikely that too many developers would have been relying on this anomaly.

Closes #43346.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a shipping zone, and add a shipping zone method. Identify the ID of both the zone and the method.
2. Add the following snippet to a suitable location:

```php
add_filter(
	'woocommerce_rest_delete_shipping_zone_method',
	function ( $method, $zone ) {
		wc_get_logger()->info(
			sprintf(
				'Shipping method %1$s from shipping zone %2$s has been deleted.',
				$method->get_method_title(),
				$zone->get_zone_name()
			)
		);
	},
	10,
	2
);
```

3. Now try deleting the method you just added, via the REST API: `DELETE https://example/wp-json/wc/v3/shipping/zones/<ZONE_ID>/methods/<METHOD_ID>?force=true` ... note, *force=true* is required.
4. Visit the logs at **WooCommerce ⏵ Status ⏵ Logs** and you should find an entry logged by the snippet, much like in the following screenshot:

<div align="center"><img src="https://github.com/woocommerce/woocommerce/assets/3594411/4dd7d4eb-0d27-4bf9-9b9b-d73c8f6fdc34" alt="Info-level logging message, indicating that the shipping zone method was deleted via the REST API."></div>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
