### PR TITLE
Initial work to constrain when the `tk_ai` (anon ID tracking cookie) is set

### DIFF
--- a/plugins/woocommerce/changelog/fix-40688-control-tk_ai-cookie
+++ b/plugins/woocommerce/changelog/fix-40688-control-tk_ai-cookie
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not set the `tk_ai` tracking cookie if tracking is disabled.

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -245,7 +245,7 @@ class WC_Site_Tracking {
 	 * @param bool   $secure       Whether the cookie should be served only over https.
 	 * @param bool   $http_only    Whether the cookie is only accessible over HTTP.
 	 *
-	 * @return bool If setting the cookie was attempted (will be false if tracking is not allowed).)
+	 * @return bool If setting the cookie was attempted (will be false if tracking is not allowed).
 	 */
 	public static function set_tracking_cookie( string $cookie_key, string $cookie_value, int $expire = 0, bool $secure = false, bool $http_only = false ): bool {
 		if ( self::is_tracking_enabled() ) {

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -249,7 +249,7 @@ class WC_Site_Tracking {
 	 */
 	public static function set_tracking_cookie( string $cookie_key, string $cookie_value, int $expire = 0, bool $secure = false, bool $http_only = false ): bool {
 		if ( self::is_tracking_enabled() ) {
-			wc_setcookie( $cookie_key, $cookie_value, $expire, $secure, $http_only);
+			wc_setcookie( $cookie_key, $cookie_value, $expire, $secure, $http_only );
 			return true;
 		}
 

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -237,7 +237,7 @@ class WC_Site_Tracking {
 	 * Sets a cookie for tracking purposes, but only if tracking is enabled/allowed.
 	 *
 	 * @internal
-	 * @since 9.1.0
+	 * @since 9.2.0
 	 *
 	 * @param string $cookie_key   The key of the cookie.
 	 * @param string $cookie_value The value of the cookie.

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -233,5 +233,26 @@ class WC_Site_Tracking {
 		}
 	}
 
+	/**
+	 * Sets a cookie for tracking purposes, but only if tracking is enabled/allowed.
+	 *
+	 * @internal
+	 * @since 9.1.0
+	 *
+	 * @param string $cookie_key   The key of the cookie.
+	 * @param string $cookie_value The value of the cookie.
+	 * @param int    $expire       Expiry of the cookie.
+	 * @param bool   $secure       Whether the cookie should be served only over https.
+	 * @param bool   $http_only    Whether the cookie is only accessible over HTTP.
+	 *
+	 * @return bool If setting the cookie was attempted (will be false if tracking is not allowed).)
+	 */
+	public static function set_tracking_cookie( string $cookie_key, string $cookie_value, int $expire = 0, bool $secure = false, bool $http_only = false ): bool {
+		if ( self::is_tracking_enabled() ) {
+			wc_setcookie( $cookie_key, $cookie_value, $expire, $secure, $http_only);
+			return true;
+		}
 
+		return false;
+	}
 }

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php
@@ -73,7 +73,7 @@ class WC_Tracks_Client {
 
 		// Don't set cookie on API requests.
 		if ( ! Constants::is_true( 'REST_REQUEST' ) && ! Constants::is_true( 'XMLRPC_REQUEST' ) ) {
-			wc_setcookie( 'tk_ai', $anon_id );
+			WC_Site_Tracking::set_tracking_cookie( 'tk_ai', $anon_id );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -423,7 +423,7 @@ class Notes {
 		unset( $_COOKIE['tk_ai'] );
 		wc_admin_record_tracks_event( $event_name, $params );
 		if ( isset( $anon_id ) ) {
-			setcookie( 'tk_ai', $anon_id );
+			WC_Site_Tracking::set_tracking_cookie( 'tk_ai', $anon_id );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/tracks/class-wc-site-tracking-tests.php
+++ b/plugins/woocommerce/tests/php/includes/tracks/class-wc-site-tracking-tests.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Tests for site tracking.
+ */
+class WC_Site_Tracking_Tests extends WC_Unit_Test_Case {
+	/**
+	 * Describes when tracking cookies should and should not be set, in relation to
+	 * the 'tracking enabled' setting.
+	 *
+	 * @return void
+	 */
+	public function test_set_tracking_cookie(): void {
+		$last_cookie_key = '';
+
+		/**
+		 * Monitor and record when a new cookie is set. Do not actually allow it to be set,
+		 * however, as headers will already have been sent (during test suite bootstrap), and
+		 * we don't want the noise.
+		 *
+		 * @param bool   $should_set If wc_setcookie should set the cookie.
+		 * @param string $cookie_key The cookie key being set.
+		 *
+		 * @return false
+		 */
+		$watch_wc_cookie = function ( $should_set, $cookie_key ) use ( &$last_cookie_key ) {
+			$last_cookie_key = $cookie_key;
+			return false;
+		};
+
+		add_filter( 'woocommerce_set_cookie_enabled', $watch_wc_cookie, 10, 2 );
+
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		WC_Site_Tracking::set_tracking_cookie( 'foo', 'bar' );
+		$this->assertEquals( 'foo', $last_cookie_key, 'When tracking is enabled, a tracking cookie can successfully be set.' );
+
+		update_option( 'woocommerce_allow_tracking', 'no' );
+		WC_Site_Tracking::set_tracking_cookie( 'bar', 'baz' );
+		$this->assertNotEquals( 'bar', $last_cookie_key, 'When tracking is disabled, a tracking cookie cannot be set.' );
+
+		remove_filter( 'woocommerce_set_cookie_enabled', $watch_wc_cookie );
+	}
+}


### PR DESCRIPTION
Addresses concerns that the `tk_ai` (anonymous identifier tracking cookie) is being set, even when tracking has been disabled.

Closes #40688.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<div align="center"><img src="https://github.com/woocommerce/woocommerce/assets/3594411/0e8024bd-60d0-47c8-9175-fe747608e7dc" alt="Setting to enable or disable tracking" width="600"/></div>

1. Visit **WooCommerce ‣ Settings ‣ Advanced ‣ WooCommerce.com** and enable tracking (remember to save your changes each time you modify this!).
2. Use your browser's dev tools to ensure that a cookie named `tk_ai` has been set.
3. Delete the cookie and reload the page, or navigate to any other settings page. The cookie should have been restored.
4. Now disable tracking, and repeat the above test (delete the cookie, and reload the page or navigate to another admin page). This time, the cookie should *not* be restored.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
