### PR TITLE
Remove isFeaturePlugin and flag code from FeatureGating class

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/average-rating/support.ts
@@ -1,26 +1,18 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-/**
- * External dependencies
- */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-
 export const supports = {
-	...( isFeaturePluginBuild() && {
-		color: {
-			text: true,
-			background: true,
-			__experimentalSkipSerialization: true,
-		},
-		spacing: {
-			margin: true,
-			padding: true,
-			__experimentalSkipSerialization: true,
-		},
-		typography: {
-			fontSize: true,
-			__experimentalFontWeight: true,
-			__experimentalSkipSerialization: true,
-		},
-		__experimentalSelector: '.wc-block-components-product-average-rating',
-	} ),
+	color: {
+		text: true,
+		background: true,
+		__experimentalSkipSerialization: true,
+	},
+	spacing: {
+		margin: true,
+		padding: true,
+		__experimentalSkipSerialization: true,
+	},
+	typography: {
+		fontSize: true,
+		__experimentalFontWeight: true,
+		__experimentalSkipSerialization: true,
+	},
+	__experimentalSelector: '.wc-block-components-product-average-rating',
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/index.tsx
@@ -3,7 +3,6 @@
  */
 import { Icon, button } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 /**
  * Internal dependencies
@@ -14,24 +13,23 @@ import metadata from './block.json';
 
 const featurePluginSupport = {
 	...metadata.supports,
-	...( isFeaturePluginBuild() && {
-		color: {
-			text: true,
-			background: true,
-			link: false,
+
+	color: {
+		text: true,
+		background: true,
+		link: false,
+		__experimentalSkipSerialization: true,
+	},
+	__experimentalBorder: {
+		radius: true,
+		__experimentalSkipSerialization: true,
+	},
+	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+		spacing: {
+			margin: true,
+			padding: true,
 			__experimentalSkipSerialization: true,
 		},
-		__experimentalBorder: {
-			radius: true,
-			__experimentalSkipSerialization: true,
-		},
-		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
-			spacing: {
-				margin: true,
-				padding: true,
-				__experimentalSkipSerialization: true,
-			},
-		} ),
 		typography: {
 			fontSize: true,
 			lineHeight: true,
@@ -48,12 +46,11 @@ const featurePluginSupport = {
 		__experimentalSelector:
 			'.wp-block-button.wc-block-components-product-button .wc-block-components-product-button__button',
 	} ),
-	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' &&
-		! isFeaturePluginBuild() && {
-			spacing: {
-				margin: true,
-			},
-		} ),
+	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+		spacing: {
+			margin: true,
+		},
+	} ),
 };
 // @ts-expect-error: `metadata` currently does not have a type definition in WordPress core
 registerBlockType( metadata, {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
@@ -11,21 +10,19 @@ import { __experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles 
 
 export const supports = {
 	html: false,
-	...( isFeaturePluginBuild() && {
-		__experimentalBorder: {
-			radius: true,
-			__experimentalSkipSerialization: true,
+	__experimentalBorder: {
+		radius: true,
+		__experimentalSkipSerialization: true,
+	},
+	typography: {
+		fontSize: true,
+		__experimentalSkipSerialization: true,
+	},
+	...( typeof getSpacingClassesAndStyles === 'function' && {
+		spacing: {
+			margin: true,
+			padding: true,
 		},
-		typography: {
-			fontSize: true,
-			__experimentalSkipSerialization: true,
-		},
-		...( typeof getSpacingClassesAndStyles === 'function' && {
-			spacing: {
-				margin: true,
-				padding: true,
-			},
-		} ),
-		__experimentalSelector: '.wc-block-components-product-image',
 	} ),
+	__experimentalSelector: '.wc-block-components-product-image',
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/supports.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
@@ -11,25 +10,23 @@ import sharedConfig from '../shared/config';
 
 export const supports = {
 	...sharedConfig.supports,
-	...( isFeaturePluginBuild() && {
-		color: {
-			text: true,
-			background: true,
-			link: false,
-			__experimentalSkipSerialization: true,
-		},
-		typography: {
-			fontSize: true,
-			lineHeight: true,
-			__experimentalFontFamily: true,
-			__experimentalFontWeight: true,
-			__experimentalFontStyle: true,
-			__experimentalSkipSerialization: true,
-			__experimentalLetterSpacing: true,
-		},
-		__experimentalSelector:
-			'.wp-block-woocommerce-product-price .wc-block-components-product-price',
-	} ),
+	color: {
+		text: true,
+		background: true,
+		link: false,
+		__experimentalSkipSerialization: true,
+	},
+	typography: {
+		fontSize: true,
+		lineHeight: true,
+		__experimentalFontFamily: true,
+		__experimentalFontWeight: true,
+		__experimentalFontStyle: true,
+		__experimentalSkipSerialization: true,
+		__experimentalLetterSpacing: true,
+	},
+	__experimentalSelector:
+		'.wp-block-woocommerce-product-price .wc-block-components-product-price',
 	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 		spacing: {
 			margin: true,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/support.ts
@@ -1,24 +1,16 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-/**
- * External dependencies
- */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-
 export const supports = {
-	...( isFeaturePluginBuild() && {
-		color: {
-			text: false,
-			background: false,
-			link: true,
-		},
-		spacing: {
-			margin: true,
-			padding: true,
-		},
-		typography: {
-			fontSize: true,
-			__experimentalSkipSerialization: true,
-		},
-		__experimentalSelector: '.wc-block-components-product-rating-counter',
-	} ),
+	color: {
+		text: false,
+		background: false,
+		link: true,
+	},
+	spacing: {
+		margin: true,
+		padding: true,
+	},
+	typography: {
+		fontSize: true,
+		__experimentalSkipSerialization: true,
+	},
+	__experimentalSelector: '.wc-block-components-product-rating-counter',
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/support.ts
@@ -1,25 +1,17 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-/**
- * External dependencies
- */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-
 export const supports = {
-	...( isFeaturePluginBuild() && {
-		color: {
-			text: true,
-			background: false,
-			link: false,
-			__experimentalSkipSerialization: true,
-		},
-		spacing: {
-			margin: true,
-			padding: true,
-		},
-		typography: {
-			fontSize: true,
-			__experimentalSkipSerialization: true,
-		},
-		__experimentalSelector: '.wc-block-components-product-rating',
-	} ),
+	color: {
+		text: true,
+		background: false,
+		link: false,
+		__experimentalSkipSerialization: true,
+	},
+	spacing: {
+		margin: true,
+		padding: true,
+	},
+	typography: {
+		fontSize: true,
+		__experimentalSkipSerialization: true,
+	},
+	__experimentalSelector: '.wc-block-components-product-rating',
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating/support.ts
@@ -2,31 +2,27 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 export const supports = {
-	...( isFeaturePluginBuild() && {
-		color: {
-			text: true,
-			background: false,
-			link: false,
-			__experimentalSkipSerialization: true,
-		},
+	color: {
+		text: true,
+		background: false,
+		link: false,
+		__experimentalSkipSerialization: true,
+	},
+	spacing: {
+		margin: true,
+		padding: true,
+	},
+	typography: {
+		fontSize: true,
+		__experimentalSkipSerialization: true,
+	},
+	__experimentalSelector: '.wc-block-components-product-rating',
+	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 		spacing: {
 			margin: true,
-			padding: true,
 		},
-		typography: {
-			fontSize: true,
-			__experimentalSkipSerialization: true,
-		},
-		__experimentalSelector: '.wc-block-components-product-rating',
 	} ),
-	...( ! isFeaturePluginBuild() &&
-		typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
-			spacing: {
-				margin: true,
-			},
-		} ),
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
@@ -2,49 +2,46 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 export const supports = {
 	html: false,
 	align: true,
-	...( isFeaturePluginBuild() && {
-		color: {
-			gradients: true,
-			background: true,
-			link: false,
-			__experimentalSkipSerialization: true,
+	color: {
+		gradients: true,
+		background: true,
+		link: false,
+		__experimentalSkipSerialization: true,
+	},
+	typography: {
+		fontSize: true,
+		lineHeight: true,
+		__experimentalFontFamily: true,
+		__experimentalFontWeight: true,
+		__experimentalFontStyle: true,
+		__experimentalSkipSerialization: true,
+		__experimentalLetterSpacing: true,
+		__experimentalTextTransform: true,
+		__experimentalTextDecoration: true,
+	},
+	__experimentalBorder: {
+		color: true,
+		radius: true,
+		width: true,
+		__experimentalSkipSerialization: true,
+	},
+	// @todo: Improve styles support when WordPress 6.4 is released. https://make.wordpress.org/core/2023/07/17/introducing-the-block-selectors-api/
+	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+		spacing: {
+			margin: true,
+			padding: true,
 		},
-		typography: {
-			fontSize: true,
-			lineHeight: true,
-			__experimentalFontFamily: true,
-			__experimentalFontWeight: true,
-			__experimentalFontStyle: true,
-			__experimentalSkipSerialization: true,
-			__experimentalLetterSpacing: true,
-			__experimentalTextTransform: true,
-			__experimentalTextDecoration: true,
-		},
-		__experimentalBorder: {
-			color: true,
-			radius: true,
-			width: true,
-			__experimentalSkipSerialization: true,
-		},
-		// @todo: Improve styles support when WordPress 6.4 is released. https://make.wordpress.org/core/2023/07/17/introducing-the-block-selectors-api/
-		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
-			spacing: {
-				margin: true,
-				padding: true,
-			},
-		} ),
-		__experimentalSelector: '.wc-block-components-product-sale-badge',
 	} ),
-	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' &&
-		! isFeaturePluginBuild() && {
-			spacing: {
-				margin: true,
-			},
-		} ),
+	__experimentalSelector: '.wc-block-components-product-sale-badge',
+
+	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+		spacing: {
+			margin: true,
+		},
+	} ),
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/supports.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import {
 	// @ts-expect-error We check if this exists before using it.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -22,14 +21,12 @@ export const supports = {
 	typography: {
 		fontSize: true,
 		lineHeight: true,
-		...( isFeaturePluginBuild() && {
-			__experimentalFontWeight: true,
-			__experimentalFontFamily: true,
-			__experimentalFontStyle: true,
-			__experimentalTextTransform: true,
-			__experimentalTextDecoration: true,
-			__experimentalLetterSpacing: true,
-		} ),
+		__experimentalFontWeight: true,
+		__experimentalFontFamily: true,
+		__experimentalFontStyle: true,
+		__experimentalTextTransform: true,
+		__experimentalTextDecoration: true,
+		__experimentalLetterSpacing: true,
 	},
 	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 		spacing: {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/supports.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import {
 	// @ts-expect-error We check if this exists before using it.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -22,14 +21,12 @@ export const supports = {
 	typography: {
 		fontSize: true,
 		lineHeight: true,
-		...( isFeaturePluginBuild() && {
-			__experimentalFontWeight: true,
-			__experimentalFontFamily: true,
-			__experimentalFontStyle: true,
-			__experimentalTextTransform: true,
-			__experimentalTextDecoration: true,
-			__experimentalLetterSpacing: true,
-		} ),
+		__experimentalFontWeight: true,
+		__experimentalFontFamily: true,
+		__experimentalFontStyle: true,
+		__experimentalTextTransform: true,
+		__experimentalTextDecoration: true,
+		__experimentalLetterSpacing: true,
 	},
 	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 		spacing: {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/supports.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/supports.ts
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-
 export const supports = {
-	...( isFeaturePluginBuild() && {
-		color: {
-			background: false,
-		},
-		typography: {
-			fontSize: true,
-		},
-		__experimentalSelector: '.wc-block-components-product-summary',
-	} ),
+	color: {
+		background: false,
+	},
+	typography: {
+		fontSize: true,
+	},
+	__experimentalSelector: '.wc-block-components-product-summary',
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/attributes.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import type { BlockAttributes } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
 let blockAttributes: BlockAttributes = {
 	headingLevel: {
@@ -22,12 +21,11 @@ let blockAttributes: BlockAttributes = {
 	},
 };
 
-if ( isFeaturePluginBuild() ) {
-	blockAttributes = {
-		...blockAttributes,
-		align: {
-			type: 'string',
-		},
-	};
-}
+blockAttributes = {
+	...blockAttributes,
+	align: {
+		type: 'string',
+	},
+};
+
 export default blockAttributes;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -6,7 +6,6 @@ import {
 	useInnerBlockLayoutContext,
 	useProductDataContext,
 } from '@woocommerce/shared-context';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
 import ProductName from '@woocommerce/base-components/product-name';
 import { useStoreEvents } from '@woocommerce/base-context/hooks';
@@ -73,10 +72,10 @@ export const Block = ( props: Props ): JSX.Element => {
 						[ `${ parentClassName }__product-title` ]:
 							parentClassName,
 						[ `wc-block-components-product-title--align-${ align }` ]:
-							align && isFeaturePluginBuild(),
+							align,
 					}
 				) }
-				style={ isFeaturePluginBuild() ? styleProps.style : {} }
+				style={ styleProps.style }
 			/>
 		);
 	}
@@ -91,10 +90,10 @@ export const Block = ( props: Props ): JSX.Element => {
 				{
 					[ `${ parentClassName }__product-title` ]: parentClassName,
 					[ `wc-block-components-product-title--align-${ align }` ]:
-						align && isFeaturePluginBuild(),
+						align,
 				}
 			) }
-			style={ isFeaturePluginBuild() ? styleProps.style : {} }
+			style={ styleProps.style }
 		>
 			<ProductName
 				disabled={ ! showProductLink }

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -10,7 +10,6 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import HeadingToolbar from '@woocommerce/editor-components/heading-toolbar';
 
 /**
@@ -42,14 +41,12 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 						setAttributes( { headingLevel: newLevel } )
 					}
 				/>
-				{ isFeaturePluginBuild() && (
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( newAlign ) => {
-							setAttributes( { align: newAlign } );
-						} }
-					/>
-				) }
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( newAlign ) => {
+						setAttributes( { align: newAlign } );
+					} }
+				/>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings', 'woocommerce' ) }>
@@ -84,17 +81,15 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 	);
 };
 
-const Title = isFeaturePluginBuild()
-	? compose( [
-			withProductSelector( {
-				icon: BLOCK_ICON,
-				label: BLOCK_TITLE,
-				description: __(
-					'Choose a product to display its title.',
-					'woocommerce'
-				),
-			} ),
-	  ] )( TitleEdit )
-	: TitleEdit;
+const Title = compose( [
+	withProductSelector( {
+		icon: BLOCK_ICON,
+		label: BLOCK_TITLE,
+		description: __(
+			'Choose a product to display its title.',
+			'woocommerce'
+		),
+	} ),
+] )( TitleEdit );
 
 export default Title;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -4,7 +4,6 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
@@ -34,30 +33,27 @@ const blockConfig: BlockConfiguration = {
 	save: Save,
 	supports: {
 		...sharedConfig.supports,
-		...( isFeaturePluginBuild() && {
-			typography: {
-				fontSize: true,
-				lineHeight: true,
-				__experimentalFontWeight: true,
-				__experimentalTextTransform: true,
-				__experimentalFontFamily: true,
-			},
-			color: {
-				text: true,
-				background: true,
-				link: false,
-				gradients: true,
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontWeight: true,
+			__experimentalTextTransform: true,
+			__experimentalFontFamily: true,
+		},
+		color: {
+			text: true,
+			background: true,
+			link: false,
+			gradients: true,
+			__experimentalSkipSerialization: true,
+		},
+		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+			spacing: {
+				margin: true,
 				__experimentalSkipSerialization: true,
 			},
-			...( typeof __experimentalGetSpacingClassesAndStyles ===
-				'function' && {
-				spacing: {
-					margin: true,
-					__experimentalSkipSerialization: true,
-				},
-			} ),
-			__experimentalSelector: '.wc-block-components-product-title',
 		} ),
+		__experimentalSelector: '.wc-block-components-product-title',
 	},
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/deprecated.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/deprecated.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import classNames from 'classnames';
 
 /**
@@ -15,13 +14,11 @@ import metadata from './block.json';
 const v1 = {
 	supports: {
 		...metadata.supports,
-		...( isFeaturePluginBuild() && {
-			__experimentalBorder: {
-				radius: false,
-				color: true,
-				width: false,
-			},
-		} ),
+		__experimentalBorder: {
+			radius: false,
+			color: true,
+			width: false,
+		},
 	},
 	attributes: {
 		...metadata.attributes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/breadcrumbs/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/breadcrumbs/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { Icon } from '@wordpress/icons';
 
 /**
@@ -15,18 +14,17 @@ import './style.scss';
 
 const featurePluginSupport = {
 	...metadata.supports,
-	...( isFeaturePluginBuild() && {
-		typography: {
-			...metadata.supports.typography,
-			__experimentalFontFamily: true,
-			__experimentalFontStyle: true,
-			__experimentalFontWeight: true,
-			__experimentalTextTransform: true,
-			__experimentalDefaultControls: {
-				fontSize: true,
-			},
+
+	typography: {
+		...metadata.supports.typography,
+		__experimentalFontFamily: true,
+		__experimentalFontStyle: true,
+		__experimentalFontWeight: true,
+		__experimentalTextTransform: true,
+		__experimentalDefaultControls: {
+			fontSize: true,
 		},
-	} ),
+	},
 };
 
 registerBlockType( metadata, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/featured-items/register.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/featured-items/register.tsx
@@ -7,7 +7,6 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { getSetting } from '@woocommerce/settings';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import type { FunctionComponent } from 'react';
 import type { BlockConfiguration } from '@wordpress/blocks';
 
@@ -75,20 +74,16 @@ export function register(
 			},
 			spacing: {
 				padding: metadata.supports?.spacing?.padding,
-				...( isFeaturePluginBuild() && {
-					__experimentalDefaultControls: {
-						padding:
-							metadata.supports?.spacing
-								?.__experimentalDefaultControls,
-					},
-					__experimentalSkipSerialization:
+
+				__experimentalDefaultControls: {
+					padding:
 						metadata.supports?.spacing
-							?.__experimentalSkipSerialization,
-				} ),
+							?.__experimentalDefaultControls,
+				},
+				__experimentalSkipSerialization:
+					metadata.supports?.spacing?.__experimentalSkipSerialization,
 			},
-			...( isFeaturePluginBuild() && {
-				__experimentalBorder: metadata?.supports?.__experimentalBorder,
-			} ),
+			__experimentalBorder: metadata?.supports?.__experimentalBorder,
 		},
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/index.tsx
@@ -4,7 +4,6 @@
 import { miniCartAlt } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
@@ -15,13 +14,11 @@ import './style.scss';
 
 const featurePluginSupport = {
 	...metadata.supports,
-	...( isFeaturePluginBuild() && {
-		typography: {
-			...metadata.supports.typography,
-			__experimentalFontFamily: true,
-			__experimentalFontWeight: true,
-		},
-	} ),
+	typography: {
+		...metadata.supports.typography,
+		__experimentalFontFamily: true,
+		__experimentalFontWeight: true,
+	},
 };
 
 registerBlockType( metadata, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -8,7 +8,6 @@ import {
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { EditorProvider } from '@woocommerce/base-context';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import type { TemplateArray } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import type { FocusEvent, ReactElement } from 'react';
@@ -115,41 +114,38 @@ const Edit = ( {
 
 	return (
 		<>
-			{ isFeaturePluginBuild() && (
-				<InspectorControls key="inspector">
-					<PanelBody
-						title={ __( 'Dimensions', 'woocommerce' ) }
-						initialOpen
-					>
-						<UnitControl
-							onChange={ ( value ) => {
-								setAttributes( { width: value } );
-							} }
-							onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
-								if ( e.target.value === '' ) {
-									setAttributes( {
-										width: defaultAttributes.width.default,
-									} );
-								} else if (
-									Number( e.target.value ) < MIN_WIDTH
-								) {
-									setAttributes( {
-										width: MIN_WIDTH + 'px',
-									} );
-								}
-							} }
-							value={ width }
-							units={ [
-								{
-									value: 'px',
-									label: 'px',
-									default: defaultAttributes.width.default,
-								},
-							] }
-						/>
-					</PanelBody>
-				</InspectorControls>
-			) }
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Dimensions', 'woocommerce' ) }
+					initialOpen
+				>
+					<UnitControl
+						onChange={ ( value ) => {
+							setAttributes( { width: value } );
+						} }
+						onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
+							if ( e.target.value === '' ) {
+								setAttributes( {
+									width: defaultAttributes.width.default,
+								} );
+							} else if ( Number( e.target.value ) < MIN_WIDTH ) {
+								setAttributes( {
+									width: MIN_WIDTH + 'px',
+								} );
+							}
+						} }
+						value={ width }
+						units={ [
+							{
+								value: 'px',
+								label: 'px',
+								default: defaultAttributes.width.default,
+							},
+						] }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
 			<div
 				className="wc-block-components-drawer__screen-overlay"
 				aria-hidden="true"

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
@@ -6,7 +6,6 @@ import { cart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -39,12 +38,10 @@ const settings: BlockConfiguration = {
 			link: true,
 		},
 		lock: false,
-		...( isFeaturePluginBuild() && {
-			__experimentalBorder: {
-				color: true,
-				width: true,
-			},
-		} ),
+		__experimentalBorder: {
+			color: true,
+			width: true,
+		},
 	},
 	attributes,
 	example: {

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
@@ -10,7 +10,6 @@ export type WordCountType =
 	| 'characters_including_spaces';
 
 export interface WcBlocksConfig {
-	buildPhase: number;
 	pluginUrl: string;
 	productCount: number;
 	defaultAvatar: string;
@@ -20,7 +19,6 @@ export interface WcBlocksConfig {
 }
 
 export const blocksConfig = getSetting( 'wcBlocksConfig', {
-	buildPhase: 1,
 	pluginUrl: '',
 	productCount: 0,
 	defaultAvatar: '',
@@ -31,7 +29,6 @@ export const blocksConfig = getSetting( 'wcBlocksConfig', {
 export const WC_BLOCKS_IMAGE_URL = blocksConfig.pluginUrl + 'assets/images/';
 export const WC_BLOCKS_BUILD_URL =
 	blocksConfig.pluginUrl + 'assets/client/blocks/';
-export const WC_BLOCKS_PHASE = blocksConfig.buildPhase;
 export const SHOP_URL = STORE_PAGES.shop?.permalink;
 export const CHECKOUT_PAGE_ID = STORE_PAGES.checkout?.id;
 export const CHECKOUT_URL = STORE_PAGES.checkout?.permalink;

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/feature-flags.ts
@@ -6,7 +6,7 @@ import { getSetting } from '@woocommerce/settings';
 /**
  * Internal dependencies
  */
-import { WC_BLOCKS_PHASE, WcBlocksConfig } from './constants';
+import { WcBlocksConfig } from './constants';
 
 /**
  * Checks if experimental blocks are enabled.
@@ -20,10 +20,3 @@ export const isExperimentalBlocksEnabled = (): boolean => {
 
 	return experimentalBlocksEnabled;
 };
-
-/**
- * Checks if we're executing the code in an feature plugin or experimental build mode.
- *
- * @return {boolean} True if this is an experimental or feature plugin build, false otherwise.
- */
-export const isFeaturePluginBuild = (): boolean => WC_BLOCKS_PHASE > 1;

--- a/plugins/woocommerce/changelog/47866-dev-remove-feature-plugin-and-flags
+++ b/plugins/woocommerce/changelog/47866-dev-remove-feature-plugin-and-flags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove the isFeaturePlugin function, which was used to turn off experimental block styling (but was non functional). Also remove associated code in FeatureGating class.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -438,7 +438,6 @@ abstract class AbstractBlock {
 			$this->asset_data_registry->add(
 				'wcBlocksConfig',
 				[
-					'buildPhase'                => Package::feature()->get_flag(),
 					// Note that while we don't have a consolidated way of doing feature-flagging
 					// we are borrowing from the WC Admin Features implementation. Also note we cannot
 					// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -123,13 +123,4 @@ class Package {
 	public function feature() {
 		return $this->feature_gating;
 	}
-
-	/**
-	 * Checks if we're executing the code in an feature plugin or experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public function is_feature_plugin_build() {
-		return $this->feature()->is_feature_plugin_build();
-	}
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
@@ -2,23 +2,12 @@
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 /**
- * Service class that handles the feature flags.
+ * Service class that used to handle feature flags. That functionality
+ * is removed now and it is only used to determine "environment".
  *
  * @internal
  */
 class FeatureGating {
-
-	/**
-	 * Current flag value.
-	 *
-	 * @var int
-	 */
-	private $flag;
-
-	const EXPERIMENTAL_FLAG   = 3;
-	const FEATURE_PLUGIN_FLAG = 2;
-	const CORE_FLAG           = 1;
-
 	/**
 	 * Current environment
 	 *
@@ -33,35 +22,16 @@ class FeatureGating {
 	/**
 	 * Constructor
 	 *
-	 * @param int    $flag        Hardcoded flag value. Useful for tests.
 	 * @param string $environment Hardcoded environment value. Useful for tests.
 	 */
-	public function __construct( $flag = 0, $environment = 'unset' ) {
-		$this->flag        = $flag;
+	public function __construct( $environment = 'unset' ) {
 		$this->environment = $environment;
-		$this->load_flag();
 		$this->load_environment();
 	}
 
 	/**
-	 * Set correct flag.
+	 * Set correct environment.
 	 */
-	public function load_flag() {
-		if ( 0 === $this->flag ) {
-			$default_flag = defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ? self::FEATURE_PLUGIN_FLAG : self::CORE_FLAG;
-			if ( file_exists( __DIR__ . '/../../../../blocks.ini' ) ) {
-				$allowed_flags = [ self::EXPERIMENTAL_FLAG, self::FEATURE_PLUGIN_FLAG, self::CORE_FLAG ];
-				$woo_options   = parse_ini_file( __DIR__ . '/../../../../blocks.ini' );
-				$this->flag    = is_array( $woo_options ) && in_array( intval( $woo_options['woocommerce_blocks_phase'] ), $allowed_flags, true ) ? $woo_options['woocommerce_blocks_phase'] : $default_flag;
-			} else {
-				$this->flag = $default_flag;
-			}
-		}
-	}
-
-		/**
-		 * Set correct environment.
-		 */
 	public function load_environment() {
 		if ( 'unset' === $this->environment ) {
 			if ( file_exists( __DIR__ . '/../../../../blocks.ini' ) ) {
@@ -72,24 +42,6 @@ class FeatureGating {
 				$this->environment = self::PRODUCTION_ENVIRONMENT;
 			}
 		}
-	}
-
-	/**
-	 * Returns the current flag value.
-	 *
-	 * @return int
-	 */
-	public function get_flag() {
-		return $this->flag;
-	}
-
-	/**
-	 * Checks if we're executing the code in an feature plugin or experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public function is_feature_plugin_build() {
-		return $this->flag >= self::FEATURE_PLUGIN_FLAG;
 	}
 
 	/**
@@ -126,46 +78,5 @@ class FeatureGating {
 	 */
 	public function is_test_environment() {
 		return self::TEST_ENVIRONMENT === $this->environment;
-	}
-
-	/**
-	 * Returns core flag value.
-	 *
-	 * @return number
-	 */
-	public static function get_core_flag() {
-		return self::CORE_FLAG;
-	}
-
-	/**
-	 * Returns feature plugin flag value.
-	 *
-	 * @return number
-	 */
-	public static function get_feature_plugin_flag() {
-		return self::FEATURE_PLUGIN_FLAG;
-	}
-
-	/**
-	 * Returns experimental flag value.
-	 *
-	 * @return number
-	 */
-	public static function get_experimental_flag() {
-		return self::EXPERIMENTAL_FLAG;
-	}
-
-
-	/**
-	 * Check if the block templates controller refactor should be used to display blocks.
-	 *
-	 * @return boolean
-	 */
-	public function is_block_templates_controller_refactor_enabled() {
-		if ( file_exists( __DIR__ . '/../../../../blocks.ini' ) ) {
-			$conf = parse_ini_file( __DIR__ . '/../../../../blocks.ini' );
-			return $this->is_development_environment() && isset( $conf['use_block_templates_controller_refactor'] ) && true === (bool) $conf['use_block_templates_controller_refactor'];
-		}
-		return false;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Package.php
+++ b/plugins/woocommerce/src/Blocks/Package.php
@@ -72,16 +72,6 @@ class Package {
 	}
 
 	/**
-	 * Checks if we're executing the code in a feature plugin or experimental build mode.
-	 *
-	 * @return boolean
-	 */
-	public static function is_feature_plugin_build() {
-		return self::get_package()->is_feature_plugin_build();
-	}
-
-
-	/**
 	 * Loads the dependency injection container for woocommerce blocks.
 	 *
 	 * @param boolean $reset Used to reset the container to a fresh instance.

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -20,10 +20,6 @@ if ( ! defined( 'WC_PLUGIN_FILE' ) ) {
 	define( 'WC_PLUGIN_FILE', __FILE__ );
 }
 
-if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
-	define( 'WC_BLOCKS_IS_FEATURE_PLUGIN', true );
-}
-
 // Load core packages and the autoloader.
 require __DIR__ . '/src/Autoloader.php';
 require __DIR__ . '/src/Packages.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The overall goal of https://github.com/woocommerce/woocommerce/issues/43073 is to remove the concept of WOOCOMMERCE_BLOCKS_PHASE which has never really worked properly since the merge to the monorepo.

In the spirit of keeping PRs small and isolated this PR achieves https://github.com/woocommerce/woocommerce/issues/47693 which removes`isFeaturePlugin`. You can read the issue description for more detail but I'll also post this from the issue here:

After some investigation @gigitux found that the experimental styling properties we're using either:

* Have a stable version we can migrate to
* Will be made stable very soon
* Are used already in blocks shipped with Gutenberg so can be considered stable enough anyway

On the basis of that, and also because we discovered these features had already been inadvertently enabled in production for a while now, we decided a better approach would be to remove `isFeaturePlugin` altogether because it is not actually doing anything (it's always true) and because we don't need to gate these features any more anyway.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You can test that the block styling features are still available:

1. Choose a block that was edited in this PR, for example I chose mini-cart and mini-cart-contents
2. In any block editor add the block (or in case of mini-cart-contents edit template)
3. Open the block settings and go to the styles tab (icon of a half filled circle)
4. See that the "experimental" options are available for that block.

e.g for mini-cart typography is available:


<img width="283" alt="Screenshot 2024-05-29 at 1 36 08 PM" src="https://github.com/woocommerce/woocommerce/assets/1281828/f6e07395-7c96-4b8a-adc6-db96d567a6f8">

and mini-cart-contents has dimensions available:


<img width="150" alt="Screenshot 2024-05-29 at 1 41 46 PM" src="https://github.com/woocommerce/woocommerce/assets/1281828/ee9e3cca-ddcf-45ce-8955-b9c277ea0977">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Remove the isFeaturePlugin function, which was used to turn off experimental block styling (but was non functional).
Also remove associated code in FeatureGating class.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
