### PR TITLE
Revert removal of product descriptions in the Order summary

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -41,6 +41,8 @@ const OrderSummaryItem = ( { cartItem }: OrderSummaryProps ): JSX.Element => {
 		permalink,
 		prices,
 		quantity,
+		short_description: shortDescription,
+		description: fullDescription,
 		item_data: itemData,
 		variation,
 		totals,
@@ -173,6 +175,8 @@ const OrderSummaryItem = ( { cartItem }: OrderSummaryProps ): JSX.Element => {
 					)
 				) }
 				<ProductMetadata
+					shortDescription={ shortDescription }
+					fullDescription={ fullDescription }
 					itemData={ itemData }
 					variation={ variation }
 				/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/block.js
@@ -210,6 +210,12 @@ describe( 'Checkout Order Summary', () => {
 
 	it( 'Renders the standard preview items in the sidebar', async () => {
 		const { container } = render( <Block showRateAfterTaxName={ true } /> );
+		expect(
+			await findByText( container, 'Warm hat for winter' )
+		).toBeInTheDocument();
+		expect(
+			await findByText( container, 'Lightweight baseball cap' )
+		).toBeInTheDocument();
 
 		// Checking if variable product is rendered.
 		expect(

--- a/plugins/woocommerce/changelog/47867-revert-45767
+++ b/plugins/woocommerce/changelog/47867-revert-45767
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Partially revert #45767, ensuring the product description remains visible within the order summary section on the Checkout block.
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -288,6 +288,9 @@ baseTest.describe( 'Checkout Block page', () => {
 			)
 		).toContainText( `$${ singleProductSalePrice }` );
 		await expect(
+			page.locator( '.wc-block-components-product-metadata__description' )
+		).toContainText( simpleProductDesc );
+		await expect(
 			page.locator(
 				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
 			)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In PR #45767, we removed the product description from the order summary section on the Checkout block. However, as discussed [here](https://woocommercecommunity.slack.com/archives/C03MCL9RTAR/p1716568343190219), we discovered that some developers use the product description to display custom product data. Removing this section disrupts backward compatibility. This PR partially reverts #45767, ensuring the product description remains visible within the order summary section on the Checkout block.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have a test product with a product short description.
2. Add that product to the cart.
3. Go to the checkout page.
4. Verify that the product (short) description is visible within the order summary section.

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="383" alt="Screenshot 2024-05-28 at 14 24 30" src="https://github.com/woocommerce/woocommerce/assets/3323310/7e7e68af-741f-4e0e-8b66-cfcc33f5b805">
</td>
<td valign="top">After:
<br><br>
<img width="389" alt="Screenshot 2024-05-28 at 14 25 35" src="https://github.com/woocommerce/woocommerce/assets/3323310/731396bb-16b2-4a29-9866-c153c8da2bca">
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Partially revert #45767, ensuring the product description remains visible within the order summary section on the Checkout block.

</details>
