### PR TITLE
Product Block Editor: populate shipping class slug automatically

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-handle-shipping-classes-slug
+++ b/packages/js/product-editor/changelog/update-product-editor-handle-shipping-classes-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Product Block Editor: populate shipping class slug automatically

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -59,7 +59,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 	 * Pull the slug suggestion from the server,
 	 * and update the slug input field.
 	 */
-	async function pullAndupdateSlugInputField() {
+	async function pullAndUpdateSlugInputField() {
 		setIsRequestingSlug( true );
 
 		// Avoid making the request if the name has not changed.
@@ -94,7 +94,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 			return;
 		}
 
-		pullAndupdateSlugInputField();
+		pullAndUpdateSlugInputField();
 	}
 
 	return (
@@ -132,7 +132,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 						<Button
 							disabled={ isGenerateButtonDisabled }
 							variant="secondary"
-							onClick={ pullAndupdateSlugInputField }
+							onClick={ pullAndUpdateSlugInputField }
 							isBusy={ isRequestingSlug }
 							isSmall
 						>

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { BaseControl, Button, Modal, TextControl } from '@wordpress/components';
 import {
 	useState,
 	createElement,
@@ -12,6 +11,17 @@ import { Form, FormErrors, useFormContext } from '@woocommerce/components';
 import { ProductShippingClass } from '@woocommerce/data';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	Modal,
+	TextControl,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore We need this to import the block modules for registration.
+	__experimentalInputControl as InputControl,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore We need this to import the block modules for registration.
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+} from '@wordpress/components';
 
 export type ShippingClassFormProps = {
 	onAdd: () => Promise< ProductShippingClass >;
@@ -105,37 +115,32 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 				onBlur={ getSlugSuggestion }
 			/>
 
-			<div className="woocommerce-add-new-shipping-class-modal__slug-section">
-				<TextControl
-					{ ...getInputProps( 'slug' ) }
-					className="woocommerce-add-new-shipping-class-modal__slug-input"
-					label={ __( 'Slug', 'woocommerce' ) }
-					onChange={ ( value ) => {
-						setPrevNameValue( '' ); // clean the previous name value.
-						getInputProps( 'slug' ).onChange( value );
-					} }
-					disabled={ isRequestingSlug }
-					help={ __(
-						'Set a custom slug or generate it by clicking the button.',
-						'woocommerce'
-					) }
-				/>
-
-				<BaseControl
-					id="automatic-slug"
-					label={ __( 'Automatic', 'woocommerce' ) }
-					className="woocommerce-add-new-shipping-class-modal__slug-button"
-				>
-					<Button
-						disabled={ isGenerateButtonDisabled }
-						variant="secondary"
-						onClick={ pullAndupdateSlugInputField }
-						isBusy={ isRequestingSlug }
-					>
-						{ __( 'Generate', 'woocommerce' ) }
-					</Button>
-				</BaseControl>
-			</div>
+			<InputControl
+				{ ...getInputProps( 'slug' ) }
+				label={ __( 'Slug', 'woocommerce' ) }
+				onChange={ ( value: string ) => {
+					setPrevNameValue( '' ); // clean the previous name value.
+					getInputProps( 'slug' ).onChange( value );
+				} }
+				disabled={ isRequestingSlug }
+				help={ __(
+					'Set a custom slug or generate it by clicking the button.',
+					'woocommerce'
+				) }
+				prefix={
+					<InputControlPrefixWrapper>
+						<Button
+							disabled={ isGenerateButtonDisabled }
+							variant="secondary"
+							onClick={ pullAndupdateSlugInputField }
+							isBusy={ isRequestingSlug }
+							isSmall
+						>
+							{ __( 'Generate', 'woocommerce' ) }
+						</Button>
+					</InputControlPrefixWrapper>
+				}
+			/>
 
 			<TextControl
 				{ ...getInputProps( 'description' ) }

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -159,7 +159,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>
 				<Button
-					isPrimary
+					variant="primary"
 					isBusy={ isLoading }
 					disabled={ ! isValidForm || isLoading }
 					onClick={ handleAdd }

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -115,6 +115,10 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 						getInputProps( 'slug' ).onChange( value );
 					} }
 					disabled={ isRequestingSlug }
+					help={ __(
+						'Set a custom slug or generate it by clicking the button.',
+						'woocommerce'
+					) }
 				/>
 
 				<BaseControl

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -109,7 +109,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 				<TextControl
 					{ ...getInputProps( 'slug' ) }
 					className="woocommerce-add-new-shipping-class-modal__slug-input"
-					label={ __( 'Custom', 'woocommerce' ) }
+					label={ __( 'Slug', 'woocommerce' ) }
 					onChange={ ( value ) => {
 						setPrevNameValue( '' ); // clean the previous name value.
 						getInputProps( 'slug' ).onChange( value );

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/style.scss
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/style.scss
@@ -16,9 +16,22 @@
 		}
 	}
 
-	.woocommerce-add-new-shipping-class-modal__automatic-slug {
-		font-size: 11px;
-		font-weight: 500;
-		text-transform: uppercase;
+	.woocommerce-add-new-shipping-class-modal__slug-section {
+		display: flex;
+		flex-direction: row;
+		gap: 8px;
+	}
+
+	.woocommerce-add-new-shipping-class-modal__slug-input {
+		flex-grow: 2;
+	}
+
+	.woocommerce-add-new-shipping-class-modal__slug-button .components-base-control__field {
+		display: flex;
+		flex-direction: column;
+
+		.components-base-control__label {
+			visibility: hidden;
+		}
 	}
 }

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/style.scss
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/style.scss
@@ -10,28 +10,14 @@
 		gap: 8px;
 		justify-content: flex-end;
 	}
+
 	.has-error {
 		.components-base-control__help {
 			color: $studio-red-50;
 		}
 	}
 
-	.woocommerce-add-new-shipping-class-modal__slug-section {
-		display: flex;
-		flex-direction: row;
-		gap: 8px;
-	}
-
-	.woocommerce-add-new-shipping-class-modal__slug-input {
-		flex-grow: 2;
-	}
-
-	.woocommerce-add-new-shipping-class-modal__slug-button .components-base-control__field {
-		display: flex;
-		flex-direction: column;
-
-		.components-base-control__label {
-			visibility: hidden;
-		}
+	.components-input-control__container {
+		min-height: 36px;
 	}
 }

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/style.scss
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/style.scss
@@ -15,4 +15,10 @@
 			color: $studio-red-50;
 		}
 	}
+
+	.woocommerce-add-new-shipping-class-modal__automatic-slug {
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+	}
 }

--- a/plugins/woocommerce/changelog/update-product-editor-handle-shipping-classes-slug
+++ b/plugins/woocommerce/changelog/update-product-editor-handle-shipping-classes-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+REST API: extened shipping_classes namespace with the /suggest-slug endpoint

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-shipping-classes-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-shipping-classes-controller.php
@@ -52,6 +52,12 @@ class WC_REST_Product_Shipping_Classes_Controller extends WC_REST_Product_Shippi
 		);
 	}
 
+	/**
+	 * Callback fuction for the slug-suggestion endpoint.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return string          The suggested slug.
+	 */
 	public function suggest_slug( $request ) {
 		$name = $request['name'];
 		$slug = sanitize_title( $name ); // potential slug.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-shipping-classes-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-shipping-classes-controller.php
@@ -24,4 +24,55 @@ class WC_REST_Product_Shipping_Classes_Controller extends WC_REST_Product_Shippi
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Register the routes for product reviews.
+	 */
+	public function register_routes() {
+		parent::register_routes();
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/slug-suggestion',
+			array(
+				'args'   => array(
+					'name' => array(
+						'description' => __( 'Suggest a slug for the term.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'suggest_slug' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	public function suggest_slug( $request ) {
+		$name = $request['name'];
+		$slug = sanitize_title( $name ); // potential slug.
+		$term = get_term_by( 'slug', $slug, $this->taxonomy );
+
+		/*
+		 * If the term exists, creates a unique slug
+		 * based on the name provided.
+		 * Otherwise, returns the sanitized name.
+		 */
+		if ( isset( $term->slug ) ) {
+			/*
+			 * Pass a Term object that has only the taxonomy property,
+			 * to induce the wp_unique_term_slug() function to generate a unique slug.
+			 * Otherwise, the function will return the same slug.
+			 * @see https://core.trac.wordpress.org/browser/tags/6.5/src/wp-includes/taxonomy.php#L3130
+			 * @see https://github.com/WordPress/wordpress-develop/blob/a1b1e0339eb6dfa72a30933cac2a1c6ad2bbfe96/src/wp-includes/taxonomy.php#L3078-L3156
+			 */
+			$slug = wp_unique_term_slug( $slug, (object) array( 'taxonomy' => $this->taxonomy ) );
+		}
+
+		return rest_ensure_response( $slug );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR allows the user to get a Shipping Class slug based on the class name. The slug checks the existence of other slugs in the dB, avoiding name values.

Closes #35569

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Enable the new Product Editor
2. Go to the Shipping section
3. Create a new shipping class
4. Add a name
5. Confirm it's possible to request a slug by clicking on the `Generate` button


### First version

https://github.com/woocommerce/woocommerce/assets/77539/8a0ca9b8-1c61-48cf-b150-5ec2502a2c02

### Second version

https://github.com/woocommerce/woocommerce/assets/77539/104cfbfa-ade8-411c-8806-566f2fb57c68


### Third version:

https://github.com/woocommerce/woocommerce/assets/77539/ede7e2a7-b818-4f39-a81b-042a271ac6c6




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
