### PR TITLE
Do not update the `last_access` field unnecessarily.

### DIFF
--- a/plugins/woocommerce/changelog/fix-31511-rest-api-last-access
+++ b/plugins/woocommerce/changelog/fix-31511-rest-api-last-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+In general, the `last_access` field of a REST API key should only be updated once-per-request.

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -603,7 +603,7 @@ class WC_REST_Authentication {
 	 * This method tries to disambiguate 'primary' API requests from any programmatic REST
 	 * API requests made internally.
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request currently being processed.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -597,6 +597,16 @@ class WC_REST_Authentication {
 		return true;
 	}
 
+	/**
+	 * Updates the `last_access` field for the API key associated with the current request.
+	 *
+	 * This method tries to disambiguate 'primary' API requests from any programmatic REST
+	 * API requests made internally.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return void
+	 */
 	private function update_last_access( $request ) {
 		global $wp;
 		global $wpdb;

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -601,7 +601,7 @@ class WC_REST_Authentication {
 		global $wp;
 		global $wpdb;
 
-		// Lots of (programmatically) created REST API requests may be processed within the same process.
+		// Lots of (programmatically) created REST API requests may be handled within the same process.
 		// In most cases, however, we do not want to record the last access time for each of these.
 		$do_not_record = true;
 

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -35,6 +35,22 @@ class WC_REST_Authentication {
 	protected $auth_method = '';
 
 	/**
+	 * Provides access to the global WC_REST_Authentication instance.
+	 *
+	 * @internal
+	 * @return self
+	 */
+	public static function instance(): self {
+		static $instance;
+
+		if ( ! isset( $instance ) ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/**
 	 * Initialize authentication actions.
 	 */
 	public function __construct() {
@@ -581,12 +597,30 @@ class WC_REST_Authentication {
 		return true;
 	}
 
-	/**
-	 * Updated API Key last access datetime.
-	 */
-	private function update_last_access() {
+	private function update_last_access( $request ) {
+		global $wp;
 		global $wpdb;
 
+		// Lots of (programmatically) created REST API requests may be processed within the same process.
+		// In most cases, however, we do not want to record the last access time for each of these.
+		$do_not_record = true;
+
+		// Try to detect if the REST API request actively being processed matches the current WP request.
+		if ( is_a( $wp, WP::class ) && is_a( $request, WP_REST_Request::class ) ) {
+			$actual_http_request     = trim( $wp->request, '/' );
+			$api_request_in_progress = trim( $request->get_route(), '/' );
+
+			// Remove the REST API route prefix (normally 'wp-json') for easier comparison.
+			$rest_prefix = trailingslashit( rest_get_url_prefix() );
+
+			if ( str_starts_with( $actual_http_request, $rest_prefix ) ) {
+				$actual_http_request = substr( $actual_http_request, strlen( $rest_prefix ) );
+			}
+
+			// Recommend recording the last access time only if the actual WP request and the current
+			// API request being processed are a match.
+			$do_not_record = $actual_http_request !== $api_request_in_progress;
+		}
 		/**
 		 * This filter enables the exclusion of the most recent access time from being logged for REST API calls.
 		 *
@@ -596,7 +630,7 @@ class WC_REST_Authentication {
 		 *
 		 * @since 7.7.0
 		 */
-		if ( apply_filters( 'woocommerce_disable_rest_api_access_log', false, $this->user->key_id, $this->user->user_id ) ) {
+		if ( apply_filters( 'woocommerce_disable_rest_api_access_log', $do_not_record, $this->user->key_id, $this->user->user_id ) ) {
 			return;
 		}
 
@@ -643,11 +677,11 @@ class WC_REST_Authentication {
 			}
 
 			// Register last access.
-			$this->update_last_access();
+			$this->update_last_access( $request );
 		}
 
 		return $result;
 	}
 }
 
-new WC_REST_Authentication();
+WC_REST_Authentication::instance();

--- a/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Tests relating to our REST authentication logic.
+ */
+class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
+	/**
+	 * The default behaviour is to record a last_access datetime only once per request.
+	 *
+	 * This should only be for the 'primary' REST API request, and not programmatically
+	 * generated REST API requests used for internal purposes.
+	 *
+	 * @return void
+	 */
+	public function test_last_access(): void {
+		global $wp;
+		$original_request = $wp->request;
+
+		// Prepare the WC_Rest_Authentication instance for testing.
+		$wc_rest_authentication      = WC_REST_Authentication::instance();
+		$update_last_access          = new ReflectionMethod( $wc_rest_authentication, 'update_last_access' );
+		$authenticated_user          = new ReflectionProperty( $wc_rest_authentication, 'user' );
+		$original_authenticated_user = $authenticated_user->getValue( $wc_rest_authentication );
+		$update_last_access->setAccessible( true );
+		$authenticated_user->setValue(
+			$wc_rest_authentication,
+			(object) array(
+				'key_id'      => 1,
+				'user_id'     => 1,
+				'permissions' => 'read_write',
+			)
+		);
+
+		// Spy on decisions to log REST API access.
+		$last_access_updated = false;
+		$last_access_spy     = function ( $do_not_record ) use ( &$last_access_updated ) {
+			$last_access_updated = ! $do_not_record;
+		};
+		add_filter( 'woocommerce_disable_rest_api_access_log', $last_access_spy );
+
+		// Test if last_access is updated for programmatic API requests.
+		$update_last_access->invoke( $wc_rest_authentication, new WP_REST_Request( 'GET', '/wc/v3/products' ) );
+		$this->assertFalse(
+			$last_access_updated,
+			'If a REST API request is created programmatically, the default is to not update the corresponding last_access time.'
+		);
+
+		// Test if last_access is updated for 'real' API requests.
+		$wp->request = '/wp-json/wc/v3/products';
+		$update_last_access->invoke( $wc_rest_authentication, new WP_REST_Request( 'GET', '/wc/v3/products' ) );
+		$this->assertTrue(
+			$last_access_updated,
+			'If a REST API request is received over HTTP, then by default the corresponding last_access time should be updated.'
+		);
+
+		// Clean-up.
+		$wp->request = $original_request;
+		$update_last_access->setAccessible( false );
+		$authenticated_user->setValue( $wc_rest_authentication, $original_authenticated_user );
+		add_filter( 'woocommerce_disable_rest_api_access_log', $last_access_spy );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
@@ -17,9 +17,9 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$original_request = $wp->request;
 
 		// Prepare the WC_Rest_Authentication instance for testing.
-		$wc_rest_authentication  = WC_REST_Authentication::instance();
-		$update_last_access      = new ReflectionMethod( $wc_rest_authentication, 'update_last_access' );
-		$authenticated_user      = new ReflectionProperty( $wc_rest_authentication, 'user' );
+		$wc_rest_authentication = WC_REST_Authentication::instance();
+		$update_last_access     = new ReflectionMethod( $wc_rest_authentication, 'update_last_access' );
+		$authenticated_user     = new ReflectionProperty( $wc_rest_authentication, 'user' );
 
 		$update_last_access->setAccessible( true );
 		$authenticated_user->setAccessible( true );

--- a/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
@@ -22,6 +22,7 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$authenticated_user          = new ReflectionProperty( $wc_rest_authentication, 'user' );
 		$original_authenticated_user = $authenticated_user->getValue( $wc_rest_authentication );
 		$update_last_access->setAccessible( true );
+		$authenticated_user->setAccessible( true );
 		$authenticated_user->setValue(
 			$wc_rest_authentication,
 			(object) array(
@@ -55,8 +56,9 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 
 		// Clean-up.
 		$wp->request = $original_request;
-		$update_last_access->setAccessible( false );
 		$authenticated_user->setValue( $wc_rest_authentication, $original_authenticated_user );
+		$authenticated_user->setAccessible( false );
+		$update_last_access->setAccessible( false );
 		add_filter( 'woocommerce_disable_rest_api_access_log', $last_access_spy );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
@@ -17,12 +17,13 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$original_request = $wp->request;
 
 		// Prepare the WC_Rest_Authentication instance for testing.
-		$wc_rest_authentication      = WC_REST_Authentication::instance();
-		$update_last_access          = new ReflectionMethod( $wc_rest_authentication, 'update_last_access' );
-		$authenticated_user          = new ReflectionProperty( $wc_rest_authentication, 'user' );
-		$original_authenticated_user = $authenticated_user->getValue( $wc_rest_authentication );
+		$wc_rest_authentication  = WC_REST_Authentication::instance();
+		$update_last_access      = new ReflectionMethod( $wc_rest_authentication, 'update_last_access' );
+		$authenticated_user      = new ReflectionProperty( $wc_rest_authentication, 'user' );
+
 		$update_last_access->setAccessible( true );
 		$authenticated_user->setAccessible( true );
+		$original_authenticated_user = $authenticated_user->getValue( $wc_rest_authentication );
 		$authenticated_user->setValue(
 			$wc_rest_authentication,
 			(object) array(


### PR DESCRIPTION
When a REST API request is received, we try to update the `last_access` datetime of the corresponding API key. However, this is also happening for programmatic REST API requests (of which there are typically several-per-request).

Generally this is unwanted and undesirable, so this change attempts to limit things so that `last_access` is only updated once per (API) request. For edge cases where this is not desirable, existing filter hooks allow the possibility of undoing this new default.

Closes #31511.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. To test this, you will need to set up an API key via **WooCommerce ‣ Settings ‣ Advanced ‣ REST API** and use it in your test requests. 
2. Add the following snippet to a suitable location, such as `wp-content/mu-plugins/test-47912.php`:

```php
<?php

add_filter( 'woocommerce_disable_rest_api_access_log', function ( $track ) {
	if ( $track === false ) {
		wc_get_logger()->debug( 'PR 31511 → Last access field updated.' );
	}

	return $track;
} );
```

3. Now, using *trunk* (without this change), send a single REST API request. This could be something simple, like a request to fetch a list of products: `GET https://example.wp/wp-json/wc/v3/products`.
4. Visit **WooCommerce ‣ Status ‣ Logs** and identify the relevant log file (its name will match the location where you saved the earlier snippet). You should see something similar to the following screenshot, in which 10 attempts to update the `last_access` field were logged:

<div align="center"><img src="https://github.com/woocommerce/woocommerce/assets/3594411/05f10d4c-6bbb-45a5-b12e-6c0adbc0bb99" alt="WooCommerce logs screen, showing attempts to update the last access field of an API key" /></div>

5. The exact number of logged entries may be different to the screenshot. However, take note of the number.
6. Now switch to this branch, and *then* clear/delete the logs.
7. Trigger a new REST API request (it can be the same as earlier, or you can use a fresh endpoint).
8. Refresh the logs, and you should see only one log entry relating to last_access updates.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
