### PR TITLE
Use LYS API endpoint for woocommerce_admin_launch_your_store_survey_completed option

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/transitional/services.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/services.tsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
-import { resolveSelect } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
 
 export const fetchSurveyCompletedOption = async () =>
-	resolveSelect( OPTIONS_STORE_NAME ).getOption(
-		'woocommerce_admin_customize_store_survey_completed'
-	);
+	await apiFetch( {
+		path: `/wc-admin/launch-your-store/survey-completed`,
+	} );

--- a/plugins/woocommerce-admin/client/customize-store/transitional/services.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/services.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { resolveSelect } from '@wordpress/data';
 
 export const fetchSurveyCompletedOption = async () =>
-	await apiFetch( {
-		path: `/wc-admin/launch-your-store/survey-completed`,
-	} );
+	resolveSelect( OPTIONS_STORE_NAME ).getOption(
+		'woocommerce_admin_customize_store_survey_completed'
+	);

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/services.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/services.tsx
@@ -1,19 +1,17 @@
 /**
  * External dependencies
  */
-import {
-	ONBOARDING_STORE_NAME,
-	OPTIONS_STORE_NAME,
-	PLUGINS_STORE_NAME,
-} from '@woocommerce/data';
+import { ONBOARDING_STORE_NAME, PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { resolveSelect } from '@wordpress/data';
 import { fromPromise } from 'xstate5';
+import apiFetch from '@wordpress/api-fetch';
 
 export const fetchCongratsData = fromPromise( async () => {
 	const [ surveyCompleted, tasklists, activePlugins ] = await Promise.all( [
-		resolveSelect( OPTIONS_STORE_NAME ).getOption(
-			'woocommerce_admin_launch_your_store_survey_completed'
-		),
+		await apiFetch( {
+			path: `/wc-admin/launch-your-store/survey-completed`,
+		} ),
+
 		resolveSelect( ONBOARDING_STORE_NAME ).getTaskListsByIds( [
 			'setup',
 			'extended',

--- a/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/services.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/hub/main-content/pages/launch-store-success/services.tsx
@@ -6,12 +6,23 @@ import { resolveSelect } from '@wordpress/data';
 import { fromPromise } from 'xstate5';
 import apiFetch from '@wordpress/api-fetch';
 
+type SurveyCompletedResponse = string | null;
+let cachedSurveyCompleted: SurveyCompletedResponse = null;
+const fetchSurveyCompletedOption =
+	async (): Promise< SurveyCompletedResponse > => {
+		if ( cachedSurveyCompleted !== null ) {
+			return cachedSurveyCompleted;
+		}
+		const response = await apiFetch( {
+			path: `/wc-admin/launch-your-store/survey-completed`,
+		} );
+		cachedSurveyCompleted = response as SurveyCompletedResponse;
+		return cachedSurveyCompleted;
+	};
+
 export const fetchCongratsData = fromPromise( async () => {
 	const [ surveyCompleted, tasklists, activePlugins ] = await Promise.all( [
-		await apiFetch( {
-			path: `/wc-admin/launch-your-store/survey-completed`,
-		} ),
-
+		fetchSurveyCompletedOption(),
 		resolveSelect( ONBOARDING_STORE_NAME ).getTaskListsByIds( [
 			'setup',
 			'extended',

--- a/plugins/woocommerce/changelog/47915-update-47800-use-dedicated-api-endpoint-for-lys-survey-status
+++ b/plugins/woocommerce/changelog/47915-update-47800-use-dedicated-api-endpoint-for-lys-survey-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Replace the use of options endpoint with the LYS API endpoint to query woocommerce_admin_launch_your_store_survey_completed option.

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -65,6 +65,18 @@ class LaunchYourStore {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/survey-completed',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'has_survey_completed' ),
+					'permission_callback' => array( $this, 'must_be_shop_manager_or_admin' ),
+				),
+			)
+		);
 	}
 
 	/**
@@ -124,5 +136,14 @@ class LaunchYourStore {
 	public function update_survey_status( \WP_REST_Request $request ) {
 		update_option( 'woocommerce_admin_launch_your_store_survey_completed', $request->get_param( 'status' ) );
 		return new \WP_REST_Response();
+	}
+
+	/**
+	 * Return woocommerce_admin_launch_your_store_survey_completed option.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function has_survey_completed() {
+		return new \WP_REST_Response( get_option( 'woocommerce_admin_launch_your_store_survey_completed', 'no' ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47800 

This PR replaces the use of options endpoint with the LYS API endpoint to query woocommerce_admin_launch_your_store_survey_completed option, as the options endpoint is deprecated.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch. 
2. SSH into the JN site.
3. cd into `wp-content` and run `tail -f debug.log`
4. Go to `WooCommerce -> Home`
5. Click on `Launch your store` task
6. Click on `Launch your store` button.
7. Confirm there is no warning notice from the log.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Replace the use of options endpoint with the LYS API endpoint to query woocommerce_admin_launch_your_store_survey_completed option.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
