### PR TITLE
Add `woocommerce_order_note_deleted` hook (redux)

### DIFF
--- a/plugins/woocommerce/changelog/redux-38498
+++ b/plugins/woocommerce/changelog/redux-38498
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add 'woocommerce_order_note_deleted' hook for order note deletions.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1063,6 +1063,7 @@ function wc_get_order_note( $data ) {
 			'content'       => $data->comment_content,
 			'customer_note' => (bool) get_comment_meta( $data->comment_ID, 'is_customer_note', true ),
 			'added_by'      => __( 'WooCommerce', 'woocommerce' ) === $data->comment_author ? 'system' : $data->comment_author,
+			'order_id'      => absint( $data->comment_post_ID ),
 		),
 		$data
 	);

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1184,18 +1184,20 @@ function wc_create_order_note( $order_id, $note, $is_customer_note = false, $add
  * @return bool         True on success, false on failure.
  */
 function wc_delete_order_note( $note_id ) {
-	$delete = wp_delete_comment( $note_id, true );
-
-	if ( $delete ) {
+	$note = wc_get_order_note( $note_id );
+	if ( $note && wp_delete_comment( $note_id, true ) ) {
 		/**
 		 * Action hook fired after an order note is deleted.
 		 *
 		 * @param int      $note_id	Order note ID.
+		 * @param stdClass $note    Object with the deleted order note details.
 		 *
-		 * @since 7.7.0
+		 * @since 9.1.0
 		 */
-		do_action( 'woocommerce_order_note_deleted', $note_id);
+		do_action( 'woocommerce_order_note_deleted', $note_id, $note );
+
+		return true;
 	}
 
-	return $delete;
+	return false;
 }

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1189,7 +1189,7 @@ function wc_delete_order_note( $note_id ) {
 		/**
 		 * Action hook fired after an order note is deleted.
 		 *
-		 * @param int      $note_id	Order note ID.
+		 * @param int      $note_id Order note ID.
 		 * @param stdClass $note    Object with the deleted order note details.
 		 *
 		 * @since 9.1.0

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1183,5 +1183,18 @@ function wc_create_order_note( $order_id, $note, $is_customer_note = false, $add
  * @return bool         True on success, false on failure.
  */
 function wc_delete_order_note( $note_id ) {
-	return wp_delete_comment( $note_id, true );
+	$delete = wp_delete_comment( $note_id, true );
+
+	if($delete) {
+		/**
+		 * Action hook fired after an order note is deleted.
+		 *
+		 * @param int      $note_id	Order note ID.
+		 *
+		 * @since 7.7.0
+		 */
+		do_action( 'woocommerce_order_note_deleted', $note_id);
+	}
+
+	return $delete;
 }

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1185,7 +1185,7 @@ function wc_create_order_note( $order_id, $note, $is_customer_note = false, $add
 function wc_delete_order_note( $note_id ) {
 	$delete = wp_delete_comment( $note_id, true );
 
-	if($delete) {
+	if ( $delete ) {
 		/**
 		 * Action hook fired after an order note is deleted.
 		 *

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1472,6 +1472,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 			'content'       => $note_content,
 			'customer_note' => false,
 			'added_by'      => 'system',
+			'order_id'      => absint( $order->get_id() ),
 		);
 		$note         = (array) wc_get_order_note( $note_id );
 		unset( $note['date_created'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This is pretty the same as #38498, with some added unit testing and a few code changes. I cherry picked the original commits from #38498 so that we can preserve (some?) attribution to the original author. I decided to take this across the finish line as to not let it linger forever, given the required changes were minimal.

This PR introduces the hook `woocommerce_order_note_deleted`, fired right after an order note is deleted.

It also adds an `order_id` property to order notes returned by `wc_get_order_note()`. This can be useful as we abstract the underlying `WP_Comment` implementation and do not surface the parent object for the comment/note.

Closes #38448.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Drop the following PHP snippet at a suitable location (such as wp-content/mu-plugins):
   ```php
   <?php
   add_action(
	   'woocommerce_order_note_deleted',
	   function( $note_id, $note ) {
		   error_log( sprintf( 'Order note %d deleted. Details: %s.', $note_id, print_r( $note, 1 ) ) );
	   },
	   10,
	   2
   );
   ```
1. Go to WC > Orders and manually create an order (if necessary) or choose any existing order.
1. Click "Delete note" for any order listed in the "Order notes" metabox.
   In the unlikely scenario that your order has no notes, add one first using the form in that same metabox.
1. Check the error log for your site and confirm you have an entry like this:

   > [28-May-2024 21:53:33 UTC] Order note 139246 deleted. Details: stdClass Object [...]

   Where `[...]` are the details of the order you just deleted.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
