### PR TITLE
Reduce potential for plugin conflict-driven fatal errors during (REST API-based) refund creation

### DIFF
--- a/plugins/woocommerce/changelog/fix-47601-rest-api-refunds
+++ b/plugins/woocommerce/changelog/fix-47601-rest-api-refunds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Provide more informative errors if a refund cannot be requested via the REST API, due to plugin conflicts.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -318,6 +318,8 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 		 * The dynamic portion of the hook name, `$this->post_type`,
 		 * refers to the object type slug.
 		 *
+		 * @since 4.5.0
+		 *
 		 * @param WC_Data         $coupon   Object object.
 		 * @param WP_REST_Request $request  Request object.
 		 * @param bool            $creating If is creating a new object.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -329,8 +329,8 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 		return Types::ensure_instance_of(
 			$refund,
 			WC_Data::class,
-			function () {
-				return new WP_Error(
+			function ( $thing ) {
+				return is_wp_error( $thing ) ?? new WP_Error(
 					'woocommerce_rest_cannot_verify_refund_created',
 					__( 'An unexpected error occurred while generating the refund.', 'woocommerce' )
 				);

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -320,7 +320,24 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 		 * @param WP_REST_Request $request  Request object.
 		 * @param bool            $creating If is creating a new object.
 		 */
-		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $refund, $request, $creating );
+		$refund = apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $refund, $request, $creating );
+
+		// If the filtered result is not a WC_Data instance and is not a WP_Error then something went wrong, but we
+		// still need to honor the declared return type.
+		if ( ! is_a( $refund, WC_Data::class ) && ! is_wp_error( $refund ) ) {
+			return new WP_Error(
+				'woocommerce-rest-api-cannot-write-refund',
+				sprintf(
+					/* translators: 1: REST API request route 2: filter hook name. */
+					__( 'Unable to prepare the refund for the database during REST API request "%1$s". There may be a problem with one or more functions hooked into "%2$s".', 'woocommerce' ),
+					$request->get_route(),
+					"woocommerce_rest_pre_insert_{$this->post_type}_object"
+				),
+				$refund
+			);
+		}
+
+		return $refund;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -332,10 +332,12 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 			$refund,
 			WC_Data::class,
 			function ( $thing ) {
-				return is_wp_error( $thing ) ?: new WP_Error(
-					'woocommerce_rest_cannot_verify_refund_created',
-					__( 'An unexpected error occurred while generating the refund.', 'woocommerce' )
-				);
+				return is_wp_error( $thing )
+					? $thing
+					: new WP_Error(
+						'woocommerce_rest_cannot_verify_refund_created',
+						__( 'An unexpected error occurred while generating the refund.', 'woocommerce' )
+					);
 			}
 		);
 	}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -10,6 +10,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\Utilities\Types;
+
 /**
  * REST API Order Refunds controller class.
  *
@@ -324,20 +326,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 
 		// If the filtered result is not a WC_Data instance and is not a WP_Error then something went wrong, but we
 		// still need to honor the declared return type.
-		if ( ! is_a( $refund, WC_Data::class ) && ! is_wp_error( $refund ) ) {
-			return new WP_Error(
-				'woocommerce-rest-api-cannot-write-refund',
-				sprintf(
-					/* translators: 1: REST API request route 2: filter hook name. */
-					__( 'Unable to prepare the refund for the database during REST API request "%1$s". There may be a problem with one or more functions hooked into "%2$s".', 'woocommerce' ),
-					$request->get_route(),
-					"woocommerce_rest_pre_insert_{$this->post_type}_object"
-				),
-				$refund
-			);
-		}
-
-		return $refund;
+		return Types::ensure_is_type_or_wp_error( $refund, WC_Data::class );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -330,7 +330,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 			$refund,
 			WC_Data::class,
 			function ( $thing ) {
-				return is_wp_error( $thing ) ?? new WP_Error(
+				return is_wp_error( $thing ) ?: new WP_Error(
 					'woocommerce_rest_cannot_verify_refund_created',
 					__( 'An unexpected error occurred while generating the refund.', 'woocommerce' )
 				);

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -326,7 +326,16 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 
 		// If the filtered result is not a WC_Data instance and is not a WP_Error then something went wrong, but we
 		// still need to honor the declared return type.
-		return Types::ensure_is_type_or_wp_error( $refund, WC_Data::class );
+		return Types::ensure_instance_of(
+			$refund,
+			WC_Data::class,
+			function () {
+				return new WP_Error(
+					'woocommerce_rest_cannot_verify_refund_created',
+					__( 'An unexpected error occurred while generating the refund.', 'woocommerce' )
+				);
+			}
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/src/Internal/Utilities/Types.php
@@ -2,67 +2,68 @@
 
 namespace Automattic\WooCommerce\Internal\Utilities;
 
-use WP_Error;
+use InvalidArgumentException;
 
 /**
  * Utilities to help ensure type safety.
  */
 class Types {
+	public const UNABLE_TO_ENSURE_INSTANCE_IS_OF_EXPECTED_TYPE = 'unable-to-ensure-instance-is-of-expected-type';
+
 	/**
-	 * Checks if the $thing is either the expected type, or a WP Error.
+	 * Checks if $thing is an instance of $desired_type.
 	 *
-	 * If it passes the test then $thing will be returned unmodified, otherwise a WP_Error is returned. This is helpful
-	 * for ensuring return types are honored, but where the return value is filterable.
+	 * If the check succeeds, $thing will be returned without further modification. If the check fails, then either
+	 * an exception will be thrown or, if an $on_failure callback was supplied, it will be invoked to either generate
+	 * an appropriate return value or to throw a more specific exception.
 	 *
-	 * Note that, in the context of REST API requests, the WP_Error may be exposed to the caller and therefore care
-	 * should be taken not to expose sensitive information.
+	 * Please note that the failure handler will be passed two arguments:
+	 *
+	 *     $on_failure( $object, $desired_type )
 	 *
 	 * @since 9.1.0
+	 * @throws InvalidArgumentException If $object does not match $desired_type, and an $on_failure callback was not supplied.
 	 *
-	 * @param mixed           $thing        The return value to be assessed.
-	 * @param string          $desired_type What we expect the return type to be, if it is not a WP_Error.
-	 * @param string|null     $message      Optional message used to form a WP_Error if the type checks fail.
-	 * @param int|string|null $code         Optional code used to form a WP_Error if the type checks fail.
-	 * @param bool            $data         If $thing should be supplied to the WP_Error. Defaults to false.
+	 * @param mixed     $thing        The value or reference to be assessed.
+	 * @param string    $desired_type What we expect the return type to be, if it is not a WP_Error.
+	 * @param ?callable $on_failure   If provided, and if evaluation fails, this will be invoked to generate a return value.
 	 *
-	 * @return mixed|WP_Error
+	 * @return mixed
 	 */
-	public static function ensure_is_type_or_wp_error( $thing, string $desired_type, string $message = null, $code = null, bool $data = false ) {
-		// Is the $thing of the expected type?
-		if ( $thing instanceof $desired_type || is_wp_error( $thing ) ) {
+	public static function ensure_instance_of( $thing, string $desired_type, callable $on_failure = null ) {
+		// If everything looks good, return early.
+		if ( $thing instanceof $desired_type ) {
 			return $thing;
 		}
 
-		// Log the problem, so the site operator has an opportunity to look at the source of the problem.
+		// Summarize the error for use in logging and in case we have to throw an exception.
+		$summary = sprintf(
+			/* translators: %1$s: name of the expected type */
+			__( 'Unable to ensure that an object was of expected type %1$s. This is not necessarily a problem within WooCommerce, and may indicate there is a problem with code from another plugin that has hooked into one or more WooCommerce filters (please refer to the backtrace).', 'woocommerce' ),
+			$desired_type
+		);
+
+		// Otherwise, let's log the problem so the site operator has a record of where things went wrong.
 		$logger = wc_get_logger();
-
-		// Where did the problem come from?
-		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
-		$file      = __( 'Unknown source file', 'woocommerce');
-		$line      = __( 'Unknown line', 'woocommerce' );
-
-		if ( count( $backtrace ) < 1 ) {
-			$file = $backtrace[0]['file'] ?? $file;
-			$line = $backtrace[0]['line'] ?? $line;
-		}
 
 		if ( $logger ) {
 			$logger->error(
-				sprintf(
-					/* translators: 1: file path 2: line number. */
-					__( 'Return type could not be ensured. This may be the result of problematic code using a hook provided close to %1$s:%2$d.', 'woocommerce' ),
-					$file,
-					$line
+				$summary,
+				array(
+					'source'    => 'wc-type-check-utility',
+					'backtrace' => true,
 				)
 			);
 		}
 
-		// Generate a WP_Error that can be returned in place of the misshapen $thing. Note that the code, message etc
-		// are deliberately vague by default, to avoid unintentional exposure of information to end users.
-		return new WP_Error(
-			$code ?? 'unexpected-error',
-			$message ?? __( 'There was an unexpected problem generating the return value.', 'woocommerce' ),
-			$data ? $thing : ''
+		// Invoke the $on_failure handler, if specified.
+		if ( null !== $on_failure ) {
+			return $on_failure( $thing, $desired_type );
+		}
+
+		throw new InvalidArgumentException(
+			esc_html( $summary ),
+			esc_html( self::UNABLE_TO_ENSURE_INSTANCE_IS_OF_EXPECTED_TYPE )
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/src/Internal/Utilities/Types.php
@@ -8,8 +8,6 @@ use InvalidArgumentException;
  * Utilities to help ensure type safety.
  */
 class Types {
-	public const UNABLE_TO_ENSURE_INSTANCE_IS_OF_EXPECTED_TYPE = 'unable-to-ensure-instance-is-of-expected-type';
-
 	/**
 	 * Checks if $thing is an instance of $desired_type.
 	 *
@@ -60,9 +58,6 @@ class Types {
 			return $on_failure( $thing, $desired_type );
 		}
 
-		throw new InvalidArgumentException(
-			esc_html( $summary ),
-			esc_html( self::UNABLE_TO_ENSURE_INSTANCE_IS_OF_EXPECTED_TYPE )
-		);
+		throw new InvalidArgumentException( esc_html( $summary ) );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/src/Internal/Utilities/Types.php
@@ -38,8 +38,7 @@ class Types {
 
 		// Summarize the error for use in logging and in case we have to throw an exception.
 		$summary = sprintf(
-			/* translators: %1$s: name of the expected type */
-			__( 'Unable to ensure that an object was of expected type %1$s. This is not necessarily a problem within WooCommerce, and may indicate there is a problem with code from another plugin that has hooked into one or more WooCommerce filters (please refer to the backtrace).', 'woocommerce' ),
+			'Object was not of expected type %1$s.',
 			$desired_type
 		);
 

--- a/plugins/woocommerce/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/src/Internal/Utilities/Types.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Internal\Utilities;
 
 use InvalidArgumentException;

--- a/plugins/woocommerce/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/src/Internal/Utilities/Types.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+use WP_Error;
+
+/**
+ * Utilities to help ensure type safety.
+ */
+class Types {
+	/**
+	 * Checks if the $thing is either the expected type, or a WP Error.
+	 *
+	 * If it passes the test then $thing will be returned unmodified, otherwise a WP_Error is returned. This is helpful
+	 * for ensuring return types are honored, but where the return value is filterable.
+	 *
+	 * Note that, in the context of REST API requests, the WP_Error may be exposed to the caller and therefore care
+	 * should be taken not to expose sensitive information.
+	 *
+	 * @since 9.1.0
+	 *
+	 * @param mixed           $thing        The return value to be assessed.
+	 * @param string          $desired_type What we expect the return type to be, if it is not a WP_Error.
+	 * @param string|null     $message      Optional message used to form a WP_Error if the type checks fail.
+	 * @param int|string|null $code         Optional code used to form a WP_Error if the type checks fail.
+	 * @param bool            $data         If $thing should be supplied to the WP_Error. Defaults to false.
+	 *
+	 * @return mixed|WP_Error
+	 */
+	public static function ensure_is_type_or_wp_error( $thing, string $desired_type, string $message = null, $code = null, bool $data = false ) {
+		// Is the $thing of the expected type?
+		if ( $thing instanceof $desired_type || is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		// Log the problem, so the site operator has an opportunity to look at the source of the problem.
+		$logger = wc_get_logger();
+
+		// Where did the problem come from?
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+		$file      = __( 'Unknown source file', 'woocommerce');
+		$line      = __( 'Unknown line', 'woocommerce' );
+
+		if ( count( $backtrace ) < 1 ) {
+			$file = $backtrace[0]['file'] ?? $file;
+			$line = $backtrace[0]['line'] ?? $line;
+		}
+
+		if ( $logger ) {
+			$logger->error(
+				sprintf(
+					/* translators: 1: file path 2: line number. */
+					__( 'Return type could not be ensured. This may be the result of problematic code using a hook provided close to %1$s:%2$d.', 'woocommerce' ),
+					$file,
+					$line
+				)
+			);
+		}
+
+		// Generate a WP_Error that can be returned in place of the misshapen $thing. Note that the code, message etc
+		// are deliberately vague by default, to avoid unintentional exposure of information to end users.
+		return new WP_Error(
+			$code ?? 'unexpected-error',
+			$message ?? __( 'There was an unexpected problem generating the return value.', 'woocommerce' ),
+			$data ? $thing : ''
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/Types.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Utilities\Types;
+use DateTime;
+use InvalidArgumentException;
+use WC_DateTime;
+use WC_Product;
+use WC_Unit_Test_Case;
+use WP_Error;
+
+/**
+ * A collection of tests for the types-handling utility class.
+ */
+class TypesTest extends WC_Unit_Test_Case {
+	/**
+	 * Describe basic behaviors of the `Types::ensure_instance_of()` utility method.
+	 *
+	 * @return void
+	 */
+	public function test_ensure_instance_of(): void {
+		$datetime = new WC_DateTime( 'now' );
+
+		$this->assertInstanceOf(
+			WC_DateTime::class,
+			Types::ensure_instance_of( $datetime, WC_DateTime::class ),
+			'We can validate that an object is of a specific type.'
+		);
+
+		$this->assertInstanceOf(
+			DateTime::class,
+			Types::ensure_instance_of( $datetime, DateTime::class ),
+			'We can validate that an object is descended from a specific type.'
+		);
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			Types::ensure_instance_of( $datetime, WC_Product::class, fn () => new WP_Error() ),
+			'Error handling callbacks can be specified to implement custom logic if an unexpected type is encountered.'
+		);
+
+		$this->expectException( InvalidArgumentException::class );
+		Types::ensure_instance_of( $datetime, WC_Product::class );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/Types.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Utilities;
 


### PR DESCRIPTION
In the linked issue, we identified the potential for methods to unexpectedly return the wrong type. The specific case we looked at involved the possibility of 'rogue code' hooking into `woocommerce_rest_pre_insert_shop_order_refund_object`, returning an unexpected type and, in doing so, breaking the V2 refunds endpoint.

In this change, we look at introducing a method for handling this sort of problem. *Later,* we can consider rolling it out more generally across other methods.

Closes #47601.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

When testing this, you will need to use a payment gateway that supports automated processing of refunds (COD, BACS, cheque etc **do not** support this). WooPayments, Stripe etc all **do** support this. Alternatively, you could try setting up the linked "Test Cash" gateway, which is based on the cheque gateway, but nominally supports automated refund processing:

🔌 [testcash.zip](https://github.com/user-attachments/files/16036817/testcash.zip)

If you use this, please note you will additionally need to use the **classic** checkout page when placing your test orders (unless you use some other means to create the test orders, like the REST API).

1. Place an order. It will *probably* make your life easier if you purchase a single item. Additionally, it will be a little easier if you disable taxes and shipping (or else purchase an item that is not subject to these extra charges).
2. Via the order editor, identify the order ID, line item ID, and line item cost.
    - To establish the line item ID, you can use your browser's developer tools to inspect the line item. Look for the value of the table row's `data-order_item_id` attribute.
    - If this is too clunky, you can also obtain the information you need via a REST API request: `GET /wp-json/wc/v3/orders/123`.
4. Execute a refund via the REST API (you must use V2). Supposing the order ID is `123` and the line item ID is `456`, and the cost was `10.00`:

```http
POST /wp-json/wc/v2/orders/123/refunds
Authorization: Basic <base64_encoded_key:secret>
Content-Type: application/json

{
  "amount": "10",
  "line_items": [
    {
      "id": "456",
      "refund_total": "10"
    }
  ]
}
```

5. The refund should succeed. 
6. Now add the following snippet, perhaps to a mu-plugin like `wp-content/mu-plugins/test-pr-47918.php`:

```php
add_filter(
	'woocommerce_rest_pre_insert_shop_order_refund_object',
	'__return_false'
);
```

7. Repeat the test with a fresh order.
8. This time, the API request to create the refund should fail, with a payload looking something like this (indicating something went wrong, and that the status of the refund isn't known, so should be verified manually or via a further API request, etc):

```json
{
  "code": "woocommerce_rest_cannot_verify_refund_created",
  "message": "An unexpected error occurred while generating the refund.",
  "data": null
}
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
