### PR TITLE
Fix tracking files being loaded on the front end

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracking_loaded_on_front_end
+++ b/plugins/woocommerce/changelog/fix-tracking_loaded_on_front_end
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent tracking files from being enqueued on the front end.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -254,7 +254,9 @@ final class WooCommerce {
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
 		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'init', array( $this, 'load_rest_api' ) );
-		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
+		if (  $this->is_request( 'admin' ) || ( $this->is_rest_api_request() && ! $this->is_store_api_request() ) ) {
+			add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
+		}
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'activated_plugin', array( $this, 'activated_plugin' ) );
 		add_action( 'deactivated_plugin', array( $this, 'deactivated_plugin' ) );
@@ -645,11 +647,6 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-register-wp-admin-settings.php';
 
 		/**
-		 * Tracks.
-		 */
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
-
-		/**
 		 * WCCOM Site.
 		 */
 		include_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php';
@@ -769,6 +766,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -478,11 +478,11 @@ final class WooCommerce {
 	 * @return bool
 	 */
 	public function is_store_api_request() {
-		if ( WC()->is_rest_api_request() ) {
-			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			return false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' );
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
 		}
-		return false;
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -254,7 +254,7 @@ final class WooCommerce {
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
 		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'init', array( $this, 'load_rest_api' ) );
-		if (  $this->is_request( 'admin' ) || ( $this->is_rest_api_request() && ! $this->is_store_api_request() ) ) {
+		if ( $this->is_request( 'admin' ) || ( $this->is_rest_api_request() && ! $this->is_store_api_request() ) ) {
 			add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
 		}
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
@@ -759,7 +759,7 @@ final class WooCommerce {
 	}
 
 	/**
-	 * Include Tracks classes.	 
+	 * Include Tracks classes.
 	 */
 	public function tracks_includes() {
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -254,7 +254,7 @@ final class WooCommerce {
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
 		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'init', array( $this, 'load_rest_api' ) );
-		if ( $this->is_request( 'admin' ) || ( $this->is_rest_api_request() && ! $this->is_store_api_request() ) ) {
+		if ( $this->is_request( 'admin' ) || ( $this->is_rest_api_request() && ! $this->is_store_api_request() ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
 		}
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
@@ -658,6 +658,8 @@ final class WooCommerce {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';
+
+			$this->tracks_includes();
 		}
 
 		if ( $this->is_request( 'admin' ) ) {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -634,10 +634,6 @@ final class WooCommerce {
 		/**
 		 * Tracks.
 		 */
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 
 		/**
@@ -656,6 +652,9 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'admin' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
+
+			// Include tracking classes for use in admin.
+			$this->tracks_includes();
 		}
 
 		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.
@@ -663,6 +662,11 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'frontend' ) || $this->is_rest_api_request() || $in_post_editor ) {
 			$this->frontend_includes();
+		}
+
+		if ( $this->is_rest_api_request() ) {
+			// Include tracks classes for use in REST API.
+			$this->tracks_includes();
 		}
 
 		if ( $this->is_request( 'cron' ) && 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
@@ -742,6 +746,16 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-customer.php';
 		include_once WC_ABSPATH . 'includes/class-wc-embed.php';
 		include_once WC_ABSPATH . 'includes/class-wc-session-handler.php';
+	}
+
+	/**
+	 * Include Tracks classes.	 
+	 */
+	public function tracks_includes() {
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -471,6 +471,19 @@ final class WooCommerce {
 	}
 
 	/**
+	 * Returns true if the request is a store REST API request.
+	 *
+	 * @return bool
+	 */
+	public function is_store_api_request() {
+		if ( WC()->is_rest_api_request() ) {
+			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' );
+		}
+		return false;
+	}
+
+	/**
 	 * Load REST API.
 	 */
 	public function load_rest_api() {
@@ -664,7 +677,7 @@ final class WooCommerce {
 			$this->frontend_includes();
 		}
 
-		if ( $this->is_rest_api_request() ) {
+		if ( $this->is_rest_api_request() && ! $this->is_store_api_request() ) {
 			// Include tracks classes for use in REST API.
 			$this->tracks_includes();
 		}

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -187,10 +187,15 @@ class WC_Site_Tracking {
 	 * Init tracking.
 	 */
 	public static function init() {
-		// Only run on admin or if it is a rest api request.
-		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
+		$is_rest = WC()->is_rest_api_request();
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$is_store_api_request = $is_rest && ! empty( $_SERVER['REQUEST_URI'] ) && ( false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' ) );
+		
+		// Only run tracking on admin or if it is admin API request.
+		if ( ! is_admin() && ! $is_rest && ! $is_store_api_request ) {
 			return;
 		}
+		
 		// Define window.wcTracks.recordEvent in case it is enabled client-side.
 		self::register_scripts();
 		add_filter( 'admin_footer', array( __CLASS__, 'add_tracking_function' ), 24 );

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -187,6 +187,10 @@ class WC_Site_Tracking {
 	 * Init tracking.
 	 */
 	public static function init() {
+		// Only run on admin or if it is a rest api request.
+		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
+			return;
+		}
 		// Define window.wcTracks.recordEvent in case it is enabled client-side.
 		self::register_scripts();
 		add_filter( 'admin_footer', array( __CLASS__, 'add_tracking_function' ), 24 );

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -187,11 +187,6 @@ class WC_Site_Tracking {
 	 * Init tracking.
 	 */
 	public static function init() {
-		// Only run tracking on admin and none store REST API requests .
-		if ( ! is_admin() && ( ! WC()->is_rest_api_request() || WC()->is_store_api_request() ) ) {
-			return;
-		}
-		
 		// Define window.wcTracks.recordEvent in case it is enabled client-side.
 		self::register_scripts();
 		add_filter( 'admin_footer', array( __CLASS__, 'add_tracking_function' ), 24 );

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -187,12 +187,8 @@ class WC_Site_Tracking {
 	 * Init tracking.
 	 */
 	public static function init() {
-		$is_rest = WC()->is_rest_api_request();
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$is_store_api_request = $is_rest && ! empty( $_SERVER['REQUEST_URI'] ) && ( false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' ) );
-		
-		// Only run tracking on admin or if it is admin API request.
-		if ( ! is_admin() && ! $is_rest && ! $is_store_api_request ) {
+		// Only run tracking on admin and none store REST API requests .
+		if ( ! is_admin() && ( ! WC()->is_rest_api_request() || WC()->is_store_api_request() ) ) {
 			return;
 		}
 		

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -491,12 +491,14 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'customer_registered' => $order->get_customer_id() ? 'yes' : 'no',
 		);
 
-		$this->proxy->call_static(
-			WC_Tracks::class,
-			'record_event',
-			'order_attribution',
-			$tracks_data
-		);
+		if ( class_exists( 'WC_Tracks' ) ) {
+			$this->proxy->call_static(
+				WC_Tracks::class,
+				'record_event',
+				'order_attribution',
+				$tracks_data
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -16,7 +16,6 @@ use WC_Customer;
 use WC_Log_Levels;
 use WC_Logger_Interface;
 use WC_Order;
-use WC_Tracks;
 
 /**
  * Class OrderAttributionController
@@ -491,13 +490,8 @@ class OrderAttributionController implements RegisterHooksInterface {
 			'customer_registered' => $order->get_customer_id() ? 'yes' : 'no',
 		);
 
-		if ( class_exists( 'WC_Tracks' ) ) {
-			$this->proxy->call_static(
-				WC_Tracks::class,
-				'record_event',
-				'order_attribution',
-				$tracks_data
-			);
+		if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+			wc_admin_record_tracks_event( 'order_attribution', $tracks_data );
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As part of https://github.com/woocommerce/woocommerce/pull/37796 we triggered the tracking file on `init`, which meant that the `w.js` file was being enqueued on the front end for sites that have tracking enabled.
This change addresses that, but keeps it working with the rest request.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have opted into tracks under `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Install and enable AutomateWoo ( they rely on the `WC_Site_Tracking` class )
3. Install and enable the WooCommerce Beta Tester plugin
4. Enable the new product editor via `WooCommerce` -> `Settings` -> `Advanced` -> `Features` -> `Try the new product editor (Beta)`
5. Navigate to Products -> Add new
6. Publish a product
7. Navigate to `wp-admin/admin.php?page=wc-status&tab=logs`
8. Look for the latest tracks log in the dropdown
9. See the `wcadmin_product_add_publish` event was triggered
10. Visit your site ( front end ) and open your console
11. Look in the network request tab and make sure the `w.js` file is not being loaded.
12. Open the CLI and update a **draft** product using...

```
wp --user=demo wc product update <product id> --status=publish
```
... and see if the `wcadmin_product_add_publish` is triggered.
13. Create an order from the frontend (cart). Any product should be fine.
14. A `wcadmin_order_attribution` track should be triggered correctly without errors (there were never any errors with this prior to this PR)
15. Check the logs and make sure no fatals happened ( in relation to AutomateWoo ).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
