### PR TITLE
Prefer update URLs over PluginURI in My Subscriptions

### DIFF
--- a/plugins/woocommerce/changelog/47950-fix-20529-incorrect-product-urls-in-my-app-subscriptions
+++ b/plugins/woocommerce/changelog/47950-fix-20529-incorrect-product-urls-in-my-app-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prefer update URLs over PluginURI in My Subscriptions for plugins without a subscription.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1554,28 +1554,36 @@ class WC_Helper {
 	}
 
 	/**
-	 * Get the connected user's subscription list data.
-	 * This is used by the My Subscriptions page.
+	 * Get the connected user's subscription list data. Here, we merge connected
+	 * subscriptions with locally installed Woo plugins and themes. We also
+	 * add in information about available updates.
+	 *
+	 * Used by the My Subscriptions page.
 	 *
 	 * @return array
 	 */
 	public static function get_subscription_list_data() {
+		// First, connected subscriptions.
 		$subscriptions = self::get_subscriptions();
 
-		// Installed plugins and themes, with or without an active subscription.
+		// Then, installed plugins and themes, with or without an active subscription.
 		$woo_plugins = self::get_local_woo_plugins();
 		$woo_themes  = self::get_local_woo_themes();
 
+		// Get the product IDs of the subscriptions.
 		$subscriptions_product_ids = wp_list_pluck( $subscriptions, 'product_id' );
 
+		// Get the site ID.
 		$auth    = WC_Helper_Options::get( 'auth' );
 		$site_id = isset( $auth['site_id'] ) ? absint( $auth['site_id'] ) : 0;
 
-		// Installed products without a subscription.
+		// Now, merge installed products without a subscription.
 		foreach ( array_merge( $woo_plugins, $woo_themes ) as $filename => $data ) {
 			if ( in_array( $data['_product_id'], $subscriptions_product_ids, true ) ) {
 				continue;
 			}
+
+			// We add these as subscriptions to the previous connected subscriptions list.
 			$subscriptions[] = array(
 				'product_key'       => '',
 				'product_id'        => $data['_product_id'],
@@ -1587,6 +1595,7 @@ class WC_Helper {
 				'key_type_label'    => '',
 				'lifetime'          => false,
 				'product_status'    => 'publish',
+				// Connections is empty because this is not a connected subscription.
 				'connections'       => array(),
 				'expires'           => 0,
 				'expired'           => true,
@@ -1601,6 +1610,7 @@ class WC_Helper {
 		// Fetch updates so we can refine subscriptions with information about updates.
 		$updates = WC_Helper_Updater::get_update_data();
 
+		// Add local data to merged subscriptions list (both locally installed and purchased).
 		foreach ( $subscriptions as &$subscription ) {
 			$subscription['active'] = in_array( $site_id, $subscription['connections'], true );
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1598,10 +1598,11 @@ class WC_Helper {
 			);
 		}
 
+		// Fetch updates so we can refine subscriptions with information about updates.
+		$updates = WC_Helper_Updater::get_update_data();
+
 		foreach ( $subscriptions as &$subscription ) {
 			$subscription['active'] = in_array( $site_id, $subscription['connections'], true );
-
-			$updates = WC_Helper_Updater::get_update_data();
 
 			$subscription['local'] = self::get_subscription_local_data( $subscription );
 
@@ -1612,6 +1613,11 @@ class WC_Helper {
 
 			if ( ! empty( $updates[ $subscription['product_id'] ] ) ) {
 				$subscription['version'] = $updates[ $subscription['product_id'] ]['version'];
+			}
+
+			// If the update endpoint returns a URL, we prefer it over the default PluginURI.
+			if ( ! empty( $updates[ $subscription['product_id'] ]['url'] ) ) {
+				$subscription['product_url'] = $updates[ $subscription['product_id'] ]['url'];
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x]  I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x]  I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Plugins in My Subscriptions that don't have a linked subscription has a product URL that is currently populated using the plugin's `PluginURI` metadata. This however often results in outdated product URLs (especially if you haven't updated the plugin for a long time).

In this screenshot for example, WooCommerce Customer/Order/Coupon Export has an extra and unnecessary `www` in the URL that is fetched from the plugin's `PluginURI`.

![CleanShot 2024-05-29 at 16 28 22](https://github.com/woocommerce/woocommerce/assets/533/c689af33-5fc7-4e5d-a0db-eaf6ebfd207a)

This PR changes the `product_url` to the URL returned from woocommerce.com's `update-check` endpoint. If such a URL is unavailable, it always falls back to the existing `PluginURI` behaviour.

Related to 20529-gh-Automattic/woocommerce.com

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Let's first reproduce the bug:

1. Use a site [like JN](https://jurassic.ninja/) to create a Woo site with latest version.
2. Install and activate a plugin for which you don't have a purchase on woocommerce.com. Note that this plugin also needs an outdated `PluginURI` field in the ZIP. For A8C reviewers, you can download `Customer/Order/Coupon CSV Import Suite` from [here](https://woocommerce.com/my-account/downloads/).
3. Make sure you don't have a purchase for  `Customer/Order/Coupon CSV Import Suite` .
4. Connect the site to woocommerce.com from WooCommerce > Extensions > My Subscriptions (`/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions`).
5. Now, you should see the wrong plugin URL (with `www`) when hovering over the product listing.


Now, test the fix:
1. Use a site like JN to create a site.
2. Install [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/15484015/woocommerce.zip) from this branch.
3. Follow steps 2-4 above.
4. You should now see the correct URL:

![CleanShot 2024-05-29 at 17 15 06](https://github.com/woocommerce/woocommerce/assets/533/c2dc11d5-cdb9-4bae-9770-f253ab01480d)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prefer update URLs over PluginURI in My Subscriptions for plugins without a subscription.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
