### PR TITLE
Fix getPreviousDate default behaviour to compare previous year

### DIFF
--- a/packages/js/date/changelog/fix-47949-set-getPreviousDate-default-previous-year
+++ b/packages/js/date/changelog/fix-47949-set-getPreviousDate-default-previous-year
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure getPreviousDate default behaviour is comparing previous_year

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -600,7 +600,7 @@ export const getPreviousDate = (
 	date: string,
 	date1: string,
 	date2: string,
-	compare: string,
+	compare = 'previous_year',
 	interval: moment.unitOfTime.Diff | moment.DurationInputArg2
 ) => {
 	const dateMoment = moment( date );

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -990,6 +990,19 @@ describe( 'getPreviousDate', () => {
 		);
 		expect( previousDate.format( isoDateFormat ) ).toBe( '2017-08-21' );
 	} );
+	it( 'should default to previous_year when compare is undefined', () => {
+		const date = '2020-03-01 00:00:00';
+		const primaryStart = '2020-02-28';
+		const secondaryStart = '2020-02-28';
+		const previousDate = getPreviousDate(
+			date,
+			primaryStart,
+			secondaryStart,
+			undefined,
+			'day'
+		);
+		expect( previousDate.format( isoDateFormat ) ).toBe( '2019-03-01' );
+	} );
 } );
 
 describe( 'getChartTypeForQuery', () => {

--- a/plugins/woocommerce/changelog/fix-47949-set-getPreviousDate-default-previous-year
+++ b/plugins/woocommerce/changelog/fix-47949-set-getPreviousDate-default-previous-year
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure getPreviousDate default behaviour is comparing previous_year


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #47949.

This PR sets the default behaviour of `getPreviousDate` to compare with `previous_year`

### How to test the changes in this Pull Request:

1. Download and install [wc-smooth-generator](https://github.com/woocommerce/wc-smooth-generator/releases/tag/1.1.0) plugin
2. Run the following commands in wp-cli: <p>
```
wp wc generate orders 1 --date-start=2020-02-29 --date-end=2020-02-29 --status=completed &&
wp wc generate orders 1 --date-start=2019-02-28 --date-end=2019-02-28 --status=completed &&
wp wc generate orders 1 --date-start=2019-03-01 --date-end=2019-03-01 --status=completed
```

3. Go to `Analytics > Settings` and set the following:
    - `Date type` to `Date created`
    - `Date range` to custom tab, `02/01/2020` to `03/31/2020`
4. Save and go to `Analytics > Orders`
5. Observe `March 1, 2020` is compared with `March 1, 2019`

<img width="938" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/bd77c1bd-fb5f-404b-8d13-3c2e5203c7fe">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
