### PR TITLE
Revert some changes around class loading

### DIFF
--- a/plugins/woocommerce/changelog/update-wc-site-tracking-script
+++ b/plugins/woocommerce/changelog/update-wc-site-tracking-script
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: These changes revert some previous changes, no need for a changelog.
+
+

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -647,6 +647,15 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-register-wp-admin-settings.php';
 
 		/**
+		 * Tracks.
+		 */
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
+
+		/**
 		 * WCCOM Site.
 		 */
 		include_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php';
@@ -658,15 +667,10 @@ final class WooCommerce {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';
-
-			$this->tracks_includes();
 		}
 
 		if ( $this->is_request( 'admin' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
-
-			// Include tracking classes for use in admin.
-			$this->tracks_includes();
 		}
 
 		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.
@@ -674,11 +678,6 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'frontend' ) || $this->is_rest_api_request() || $in_post_editor ) {
 			$this->frontend_includes();
-		}
-
-		if ( $this->is_rest_api_request() && ! $this->is_store_api_request() ) {
-			// Include tracks classes for use in REST API.
-			$this->tracks_includes();
 		}
 
 		if ( $this->is_request( 'cron' ) && 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
@@ -758,17 +757,6 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-customer.php';
 		include_once WC_ABSPATH . 'includes/class-wc-embed.php';
 		include_once WC_ABSPATH . 'includes/class-wc-session-handler.php';
-	}
-
-	/**
-	 * Include Tracks classes.
-	 */
-	public function tracks_includes() {
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As part of https://github.com/woocommerce/woocommerce/pull/47938 we included some tracking classes conditionally. Turns out that some plugins are already expecting this to be available on `init`, so I am reverting the conditional part.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have opted into tracks under `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Install and enable AutomateWoo ( they rely on the `WC_Site_Tracking` class )
3. Install and enable the WooCommerce Beta Tester plugin
4. Enable the new product editor via `WooCommerce` -> `Settings` -> `Advanced` -> `Features` -> `Try the new product editor (Beta)`
5. Navigate to Products -> Add new
6. Publish a product
7. Navigate to `wp-admin/admin.php?page=wc-status&tab=logs`
8. Look for the latest tracks log in the dropdown
9. See the `wcadmin_product_add_publish` event was triggered
10. Visit your site ( front end ) and open your console
11. Look in the network request tab and make sure the `w.js` file is not being loaded.
12. Open the CLI and update a **draft** product using...

```
wp --user=demo wc product update <product id> --status=publish
```
... and see if the `wcadmin_product_add_publish` is triggered.


13. _(8.5 and above)_ Create an order from the frontend (cart). Any product should be fine.
14. A `wcadmin_order_attribution` track should be triggered correctly without errors (there were never any errors with this prior to #47938)
15. Check the logs and make sure no fatals happened ( in relation to AutomateWoo ).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
