### PR TITLE
Prevent extensions to be listed as incompatible

### DIFF
--- a/plugins/woocommerce/changelog/fix-prevent-extensions-to-be-listed-as-incompatible
+++ b/plugins/woocommerce/changelog/fix-prevent-extensions-to-be-listed-as-incompatible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent compatible extensions, such as WooCommerce Stripe Gateway and WooPayments to be listed as incompatible.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -207,6 +207,7 @@ class FeaturesController {
 					'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 					'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
 					'is_experimental' => false,
+					'is_legacy'       => true,
 					'disable_ui'      => true,
 				),
 				'marketplace'          => array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In 2022, the `FeaturesController` was introduced to manage WooCommerce features. This controller checks if a feature existed before its implementation, allowing extensions to declare compatibility with specific features, such as `analytics` or `product_block_editor`. If an extension does not explicitly declare compatibility, the feature is listed as "uncertain".

Within the `FeaturesController`, features can mark themselves as legacy by adding `is_legacy => true`. Failing to do so results in certain extensions being listed as incompatible with these features.

This PR adds `is_legacy => true` to the `cart_checkout_blocks` feature to prevent extensions from being incorrectly listed as incompatible.

Closes #47920.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Before checking out this PR, install and activate [WooCommerce Stripe Payment Gateway](https://wordpress.org/plugins/woocommerce-gateway-stripe/), [WooCommerce.com Update Manager](https://woocommerce.com/posts/introducing-woo-com-update-manager/) and [WooPayments](https://wordpress.org/plugins/woocommerce-payments/).
2. Go to `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&feature_id=all`.
3. Verify that both `WooCommerce Stripe Gateway`, `WooCommerce.com Update Manager` and `WooPayments` are listed as incompatible.

<img width="1101" alt="Screenshot 2024-05-30 at 15 44 56" src="https://github.com/woocommerce/woocommerce/assets/3323310/6ea570c1-4b49-4c00-bf5f-3d75ee17e7c6">

5. Apply this PR.
6. Go to `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&feature_id=all` again.
7. Verify that both `WooCommerce Stripe Gateway`, `WooCommerce.com Update Manager` and `WooPayments` are no longer listed as incompatible.

<img width="1105" alt="Screenshot 2024-05-30 at 15 44 13" src="https://github.com/woocommerce/woocommerce/assets/3323310/2b4b6840-6d08-4377-aa3e-254449696c67">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent compatible extensions, such as `WooCommerce Stripe Gateway` and `WooPayments` to be listed as incompatible.

</details>