### PR TITLE
Fix: "On Sale" collection isn't displaying on Editor side

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
@@ -100,9 +100,10 @@ const ProductCollectionContent = ( {
 		...( attributes as Partial< ProductCollectionAttributes > ),
 		queryId,
 		// If initialPreviewState is provided, set it as previewState.
-		...( !! attributes.collection && {
-			__privatePreviewState: initialPreviewState,
-		} ),
+		...( !! attributes.collection &&
+			initialPreviewState && {
+				__privatePreviewState: initialPreviewState,
+			} ),
 	};
 
 	/**

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
@@ -112,6 +112,7 @@ const ProductCollectionContent = ( {
 	useEffect(
 		() => {
 			setAttributes( defaultAttributesValue );
+			isInitialAttributesSet.current = true;
 		},
 		// This hook is only needed on initialization and sets default attributes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -1164,7 +1164,7 @@ test.describe( 'Product Collection', () => {
 	} );
 
 	test.describe( 'Product Collection should be visible after Refresh', () => {
-		test( 'In a Product Archive (Product Catalog)', async ( {
+		test( 'Product Collection should be visible after Refresh in a Template', async ( {
 			page,
 			editor,
 			pageObject,
@@ -1182,7 +1182,11 @@ test.describe( 'Product Collection', () => {
 			await expect( productTemplate ).toBeVisible();
 		} );
 
-		test( 'In a Post', async ( { page, pageObject, editor } ) => {
+		test( 'Product Collection should be visible after Refresh in a Post', async ( {
+			page,
+			pageObject,
+			editor,
+		} ) => {
 			await pageObject.createNewPostAndInsertBlock();
 			const productTemplate = page.getByLabel(
 				BLOCK_LABELS.productTemplate
@@ -1190,9 +1194,28 @@ test.describe( 'Product Collection', () => {
 			await expect( productTemplate ).toBeVisible();
 
 			// Refresh the post and verify the block is still visible
-			await editor.saveDraft();
+			await editor.publishPost();
 			await page.reload();
 			await expect( productTemplate ).toBeVisible();
+		} );
+
+		test( 'On Sale collection should be visible after Refresh', async ( {
+			page,
+			pageObject,
+			editor,
+		} ) => {
+			await pageObject.goToProductCatalogAndInsertCollection( 'onSale' );
+
+			const productTemplate = editor.canvas.getByLabel(
+				BLOCK_LABELS.productTemplate
+			);
+
+			await expect( productTemplate ).toHaveCount( 2 );
+
+			// Refresh the template and verify "On Sale" collection is still visible
+			await editor.saveSiteEditorEntities();
+			await page.reload();
+			await expect( productTemplate ).toHaveCount( 2 );
 		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -1217,5 +1217,22 @@ test.describe( 'Product Collection', () => {
 			await page.reload();
 			await expect( productTemplate ).toHaveCount( 2 );
 		} );
+
+		test( 'On Sale collection should be visible after Refresh in a Post', async ( {
+			page,
+			pageObject,
+			editor,
+		} ) => {
+			await pageObject.createNewPostAndInsertBlock( 'onSale' );
+			const productTemplate = page.getByLabel(
+				BLOCK_LABELS.productTemplate
+			);
+			await expect( productTemplate ).toBeVisible();
+
+			// Refresh the post and verify "On Sale" collection is still visible
+			await editor.saveDraft();
+			await page.reload();
+			await expect( productTemplate ).toBeVisible();
+		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/47994-fix-47868-product-collection-block-does-not-display-properly-when-editing-template-2
+++ b/plugins/woocommerce/changelog/47994-fix-47868-product-collection-block-does-not-display-properly-when-editing-template-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: "On Sale" collection isn't displaying on Editor side  </details>  <details>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Because of regression in #47871 PR, Collections are not showing on the Editor side. This PR fixes this issue. Here is a video of the issue:

https://github.com/woocommerce/woocommerce/assets/16707866/4ba1c4b0-7283-4a70-9f1c-f1f7a2f022d9

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47996

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->
1. Create a new post
2. Add Product Collection block to it & choose "On Sale" collection. Verify that "On Sale" collection is rendering as expected. 
3. Save the draft
4. Refresh the post and verify that the Product Collection block displays the products in the Editor. 
5. Perform steps 2 to 4 for other Collections too. Verify that all the collections are rendering as expected after adding them to a post. 

<!-- End testing instructions -->

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: "On Sale" collection isn't displaying on Editor side

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
