### PR TITLE
Test to initiate connection to WooCommerce.com

### DIFF
--- a/plugins/woocommerce/changelog/e2e-add-wc_com-connection
+++ b/plugins/woocommerce/changelog/e2e-add-wc_com-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Added e2e test to check ability to connect to woocommerce.com

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -393,4 +393,43 @@ test.describe( 'Store owner can skip the core profiler', () => {
 			} )
 		).toBeVisible();
 	} );
+
+	test( 'Can connect to WooCommerce.com', async ( { page } ) => {
+		await test.step( 'Go to WC Home and make sure the connect button is visible', async () => {
+			await page.goto( 'wp-admin/admin.php?page=wc-admin' );
+
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Connect to WooCommerce.com',
+				} )
+			).toBeVisible();
+			await page
+				.getByRole( 'link', { name: 'Connect', exact: true } )
+				.click();
+		} );
+
+		await test.step( 'Ensure we are redirected to the correct URL and connect store', async () => {
+			await expect( page.url() ).toContain(
+				'?page=wc-admin&tab=my-subscriptions&path=%2Fextensions'
+			);
+			await expect(
+				page.getByRole( 'button', { name: 'My Subscriptions' } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', { name: 'Connect your store' } )
+			).toBeVisible();
+			await page
+				.getByRole( 'link', { name: 'Connect your store' } )
+				.click();
+		} );
+
+		await test.step( 'Check that we are sent to wp.com', async () => {
+			await expect( page.url() ).toContain( 'wordpress.com/log-in' );
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Log in to your account',
+				} )
+			).toBeVisible();
+		} );
+	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/39473

Connecting to WooCommerce.com was identified as a Critical Flow, but we missed a test for it.  It isn't possible to test the entire flow as it requires signing in with WordPress.com account, and installing the extension manager plugin -- but we can at least get as far as confirming that the connection can be initiated and that it leads to the right place.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Confirm CI passes
2. `pnpm env:restart && pnpm test:e2e-pw activate-and-setup/core-profiler`
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
