### PR TITLE
Replace truthy check with isset when setting default checkout field value

### DIFF
--- a/plugins/woocommerce/changelog/pr-48031
+++ b/plugins/woocommerce/changelog/pr-48031
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug with the woocommerce_get_default_value_for_{key} filter that was preventing setting a falsey value on a checkbox (i.e. to uncheck it dynamically)

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -1187,7 +1187,7 @@ class CheckoutFields {
 				 */
 				$value = apply_filters( "woocommerce_get_default_value_for_{$missing_field}", null, $group, $wc_object );
 
-			if ( $value ) {
+			if ( isset($value) ) {
 				$meta_data[ $missing_field ] = $value;
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -1187,7 +1187,7 @@ class CheckoutFields {
 				 */
 				$value = apply_filters( "woocommerce_get_default_value_for_{$missing_field}", null, $group, $wc_object );
 
-			if ( isset($value) ) {
+			if ( isset( $value ) ) {
 				$meta_data[ $missing_field ] = $value;
 			}
 		}


### PR DESCRIPTION
<details>
<summary>### Submission Review Guidelines:</summary>

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

</details>

### Changes proposed in this Pull Request:

This allows a falsey checkout field value to be set. Without this change, you aren't able to use the `woocommerce_get_default_value_for_{key}` filter to set a falsey value on a checkbox (i.e. to uncheck it dynamically) 

Fixes the issue i reported in https://github.com/woocommerce/woocommerce/issues/48030

### How to test the changes in this Pull Request:

Here's the simplest replication scenario:

Add the following code snippet to your site

```php
add_action( 'woocommerce_blocks_loaded', function(){
	woocommerce_register_additional_checkout_field( [  
	    'id'       => 'my_namespace/my_field',  
	    'label'    => 'Custom Checkbox',  
	    'location' => 'contact',  
	    'type'     => 'checkbox',  
	] );  
  
	// get the value from cart data  
	add_filter("woocommerce_get_default_value_for_my_namespace/my_field",  
    function ( $value ) {  
		return rand(0,1); // simulate a dynamic truthy/falsey value
    } );
} );
```

Then load your checkout page and see the "custom checkbox". Refresh several times, ensure you see the checkbox both checked and unchecked.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Fix a bug with the `woocommerce_get_default_value_for_{key}` filter that was preventing setting a falsey value on a checkbox (i.e. to uncheck it dynamically) 

</details>



</details>
