### PR TITLE
Move the tracker init under defensive check

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracker-load
+++ b/plugins/woocommerce/changelog/fix-tracker-load
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: No functional change, moved a hook loading under defensive check to prevent accidental misuse in future.
+
+

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -1162,5 +1162,3 @@ class WC_Tracker {
 		return get_option( 'woocommerce_mobile_app_usage' );
 	}
 }
-
-WC_Tracker::init();

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -682,6 +682,7 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'cron' ) && 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
 			include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
+			WC_Tracker::init();
 		}
 
 		$this->theme_support_includes();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, we call the `init` method on WC_Tracker class in the file itself. Which means whenever the file is required, such as via the `use WC_Tracker` statement, this init will be called and we will add the hook which sends the tracker data. However, this should only happen if the check for `woocommerce_allow_tracking` is true. Right now this is not a problem because there are no usages of `use WC_Tracker` which happens in the context of the cron where we send the data, but an innocent-looking change in the future might change this.

As such, we are being defensive to make sure that just using `use WC_Tracker` won't hook any action.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Disable tracking by going to WooCommerce -> Setings -> Advanced -> WooCommerce.com and disable the opt-in tracking.
2. Add the following snippet:
```php
add_action( 'init', function () { Automattic\WooCommerce\Internal\Orders\MobileMessagingHandler::prepare_mobile_message( new WC_Order(), 1, new DateTime(), 'example.com' ); } );
add_action( 'init', function () {
	if ( has_filter( 'woocommerce_tracker_send_event', array( WC_Tracker::class, 'send_tracking_data') ) ) {
		$message = 'Error: Filter found, NOT expected';
	} else {
		$message = 'Success: Filter not found and it was not expected';
	}
	if( defined( 'DOING_CRON') ) {
		if( get_option('woocommerce_allow_tracking') ==='yes' && has_filter( 'woocommerce_tracker_send_event', array( WC_Tracker::class, 'send_tracking_data') )  ) {
			echo 'Filter found as expected, all good.';
		} elseif ( get_option('woocommerce_allow_tracking') === 'yes' && !has_filter( 'woocommerce_tracker_send_event', array( WC_Tracker::class, 'send_tracking_data') ) ) {
			echo 'Error: Tracking filter not found, but it was expected';
		}
		return;
	}
	echo "<script>alert('$message');</script>";
});
```
3. Refresh the page, you should see the message: `Success: Filter not found and it was not expected`
4. Now, re-enable the tracking option.
5. On the CLI run the following command to manually trigger tracking : ` wp  cron event run woocommerce_tracker_send_event`.  In the output, you should see `Filter found as expected, all good.`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
