### PR TITLE
Add path ignore to assess bundle action to reduce how often it runs

### DIFF
--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -12,7 +12,7 @@ on:
             - '**.prettier*'
             - '**.tsconfig*'
             - '**/webpack.config.js'
-            - '.github/workflows/pr-assess-bundle-size.yml'
+            - '!.github/**'
             - '!packages/js/*e2e*/**'
             - '!packages/js/*plugin*/**'
             - '!packages/js/*internal*/**'
@@ -23,6 +23,7 @@ on:
             - '!changelog/**'
             - '!docs/**'
             - '!bin/**'
+            - '.github/workflows/pr-assess-bundle-size.yml'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -20,6 +20,9 @@ on:
             - '!**/*.spec.*'
             - '!**/tests/**'
             - '!tools/**'
+            - '!changelog/**'
+            - '!docs/**'
+            - '!bin/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -19,6 +19,7 @@ on:
             - '!packages/js/*create*/**'
             - '!**/*.spec.*'
             - '!**/tests/**'
+            - '!tools/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -13,13 +13,12 @@ on:
             - '**.tsconfig*'
             - '**/webpack.config.js'
             - '.github/workflows/pr-assess-bundle-size.yml'
-        paths-ignore:
-            - 'packages/js/*e2e*/**'
-            - 'packages/js/*plugin*/**'
-            - 'packages/js/*internal*/**'
-            - 'packages/js/*create*/**'
-            - '**/*.spec.*'
-            - '**/tests/**'
+            - '!packages/js/*e2e*/**'
+            - '!packages/js/*plugin*/**'
+            - '!packages/js/*internal*/**'
+            - '!packages/js/*create*/**'
+            - '!**/*.spec.*'
+            - '!**/tests/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -19,6 +19,7 @@ on:
             - 'packages/js/*internal*/**'
             - 'packages/js/*create*/**'
             - '**/*.spec.*'
+            - '**/tests/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -14,7 +14,6 @@ on:
             - '**/webpack.config.js'
             - '.github/workflows/pr-assess-bundle-size.yml'
         paths-ignore:
-            - '**/*internal*/**'
             - 'packages/js/*e2e*/**'
             - 'packages/js/*plugin*/**'
             - 'packages/js/*internal*/**'

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -13,6 +13,13 @@ on:
             - '**.tsconfig*'
             - '**/webpack.config.js'
             - '.github/workflows/pr-assess-bundle-size.yml'
+        paths-ignore:
+            - '**/*internal*/**'
+            - 'packages/js/*e2e*/**'
+            - 'packages/js/*plugin*/**'
+            - 'packages/js/*internal*/**'
+            - 'packages/js/*create*/**'
+            - '**/*.spec.*'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The matching on the new assess bundle size action is a bit too broad and currently it will run on a PR that has changes to tests or internal plugins that we don't care about the size of. To remedy this I've tried to make the path ignore more closely match the paths we also ignore when doing the bundle size check.

### How to test the changes in this Pull Request:

TBD, I was thinking maybe just to add some manual file changes to some of the ignored paths and confirm the action does not run.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
