### PR TITLE
[php tests] Skip test_order_updated_webhook_delivered_once

### DIFF
--- a/plugins/woocommerce/changelog/test-skip-test_order_updated_webhook_delivered_once
+++ b/plugins/woocommerce/changelog/test-skip-test_order_updated_webhook_delivered_once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: test_order_updated_webhook_delivered_once

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3222,6 +3222,8 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 * @testDox Test webhooks are not fired multiple times on order save.
 	 */
 	public function test_order_updated_webhook_delivered_once() {
+		$this->markTestSkipped( 'Skipped temporarily due to increased flakiness.' );
+
 		$this->toggle_cot_authoritative( true );
 		$this->enable_cot_sync();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Skipped `test_order_updated_webhook_delivered_once` PHP unit test as it has been too flaky 
lately.
More context: p1717161876001979-slack-C03CPM3UXDJ

Opened https://github.com/woocommerce/woocommerce/issues/48065 to track a possible fix.

### How to test the changes in this Pull Request:

Make sure CI is green. Check the `Test - @woocommerce/plugin-woocommerce - PHP` job log and make sure that `test_order_updated_webhook_delivered_once` test is skipped 