### PR TITLE
PFT: create a new `product_form` CPT

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-introduce-product-form-post-type
+++ b/plugins/woocommerce/changelog/update-product-editor-introduce-product-form-post-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+WooCommerce: create a new product_form CPT

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -406,7 +406,7 @@ class WC_Post_Types {
 					),
 					'description'         => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
 					'public'              => true,
-					'menu_icon'           => 'dashicons-archive',
+					'menu_icon'           => 'dashicons-forms',
 					'capability_type'     => 'product',
 					'map_meta_cap'        => true,
 					'publicly_queryable'  => true,

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -372,6 +372,63 @@ class WC_Post_Types {
 		);
 
 		register_post_type(
+			'product_form',
+			apply_filters(
+				'woocommerce_register_post_type_product_form',
+				array(
+					'labels'              => array(
+						'name'                  => __( 'Product Forms', 'woocommerce' ),
+						'singular_name'         => __( 'Product Form', 'woocommerce' ),
+						'all_items'             => __( 'All Product Form', 'woocommerce' ),
+						'menu_name'             => _x( 'Product Forms', 'Admin menu name', 'woocommerce' ),
+						'add_new'               => __( 'Add New', 'woocommerce' ),
+						'add_new_item'          => __( 'Add new product form', 'woocommerce' ),
+						'edit'                  => __( 'Edit', 'woocommerce' ),
+						'edit_item'             => __( 'Edit product form', 'woocommerce' ),
+						'new_item'              => __( 'New product form', 'woocommerce' ),
+						'view_item'             => __( 'View product form', 'woocommerce' ),
+						'view_items'            => __( 'View product forms', 'woocommerce' ),
+						'search_items'          => __( 'Search product forms', 'woocommerce' ),
+						'not_found'             => __( 'No product forms found', 'woocommerce' ),
+						'not_found_in_trash'    => __( 'No product forms found in trash', 'woocommerce' ),
+						'parent'                => __( 'Parent product form', 'woocommerce' ),
+						'featured_image'        => __( 'Product form image', 'woocommerce' ),
+						'set_featured_image'    => __( 'Set product form image', 'woocommerce' ),
+						'remove_featured_image' => __( 'Remove product form image', 'woocommerce' ),
+						'use_featured_image'    => __( 'Use as product form image', 'woocommerce' ),
+						'insert_into_item'      => __( 'Insert into product form', 'woocommerce' ),
+						'uploaded_to_this_item' => __( 'Uploaded to this product form', 'woocommerce' ),
+						'filter_items_list'     => __( 'Filter product forms', 'woocommerce' ),
+						'items_list_navigation' => __( 'Product forms navigation', 'woocommerce' ),
+						'items_list'            => __( 'Product forms list', 'woocommerce' ),
+						'item_link'             => __( 'Product form Link', 'woocommerce' ),
+						'item_link_description' => __( 'A link to a product form.', 'woocommerce' ),
+					),
+					'description'         => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
+					'public'              => true,
+					'menu_icon'           => 'dashicons-archive',
+					'capability_type'     => 'product',
+					'map_meta_cap'        => true,
+					'publicly_queryable'  => true,
+					'hierarchical'        => false, // Hierarchical causes memory issues - WP loads all records!
+					'rewrite'             => $permalinks['product_rewrite_slug'] ? array(
+						'slug'       => $permalinks['product_rewrite_slug'],
+						'with_front' => false,
+						'feeds'      => true,
+					) : false,
+					'query_var'           => true,
+					'supports'            => $supports,
+					'has_archive'         => $has_archive,
+					'show_in_rest'        => true,
+					'show_ui'             => false,
+					// 'show_in_menu'        => true,  // inherit from `show_ui`
+					// 'exclude_from_search' => true,  // inherit from `public`
+					// 'show_in_nav_menus'   => false, // inherit from `public`
+				)
+			)
+		);
+
+		register_post_type(
 			'product_variation',
 			apply_filters(
 				'woocommerce_register_post_type_product_variation',

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -11,6 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * Post types Class.
@@ -371,62 +372,65 @@ class WC_Post_Types {
 			)
 		);
 
-		register_post_type(
-			'product_form',
-			apply_filters(
-				'woocommerce_register_post_type_product_form',
-				array(
-					'labels'              => array(
-						'name'                  => __( 'Product Forms', 'woocommerce' ),
-						'singular_name'         => __( 'Product Form', 'woocommerce' ),
-						'all_items'             => __( 'All Product Form', 'woocommerce' ),
-						'menu_name'             => _x( 'Product Forms', 'Admin menu name', 'woocommerce' ),
-						'add_new'               => __( 'Add New', 'woocommerce' ),
-						'add_new_item'          => __( 'Add new product form', 'woocommerce' ),
-						'edit'                  => __( 'Edit', 'woocommerce' ),
-						'edit_item'             => __( 'Edit product form', 'woocommerce' ),
-						'new_item'              => __( 'New product form', 'woocommerce' ),
-						'view_item'             => __( 'View product form', 'woocommerce' ),
-						'view_items'            => __( 'View product forms', 'woocommerce' ),
-						'search_items'          => __( 'Search product forms', 'woocommerce' ),
-						'not_found'             => __( 'No product forms found', 'woocommerce' ),
-						'not_found_in_trash'    => __( 'No product forms found in trash', 'woocommerce' ),
-						'parent'                => __( 'Parent product form', 'woocommerce' ),
-						'featured_image'        => __( 'Product form image', 'woocommerce' ),
-						'set_featured_image'    => __( 'Set product form image', 'woocommerce' ),
-						'remove_featured_image' => __( 'Remove product form image', 'woocommerce' ),
-						'use_featured_image'    => __( 'Use as product form image', 'woocommerce' ),
-						'insert_into_item'      => __( 'Insert into product form', 'woocommerce' ),
-						'uploaded_to_this_item' => __( 'Uploaded to this product form', 'woocommerce' ),
-						'filter_items_list'     => __( 'Filter product forms', 'woocommerce' ),
-						'items_list_navigation' => __( 'Product forms navigation', 'woocommerce' ),
-						'items_list'            => __( 'Product forms list', 'woocommerce' ),
-						'item_link'             => __( 'Product form Link', 'woocommerce' ),
-						'item_link_description' => __( 'A link to a product form.', 'woocommerce' ),
-					),
-					'description'         => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
-					'public'              => true,
-					'menu_icon'           => 'dashicons-forms',
-					'capability_type'     => 'product',
-					'map_meta_cap'        => true,
-					'publicly_queryable'  => true,
-					'hierarchical'        => false, // Hierarchical causes memory issues - WP loads all records!
-					'rewrite'             => $permalinks['product_rewrite_slug'] ? array(
-						'slug'       => $permalinks['product_rewrite_slug'],
-						'with_front' => false,
-						'feeds'      => true,
-					) : false,
-					'query_var'           => true,
-					'supports'            => $supports,
-					'has_archive'         => $has_archive,
-					'show_in_rest'        => true,
-					'show_ui'             => false,
-					// 'show_in_menu'        => true,  // inherit from `show_ui`
-					// 'exclude_from_search' => true,  // inherit from `public`
-					// 'show_in_nav_menus'   => false, // inherit from `public`
+		// Register the product form post type wne the feature is enabled.
+		if ( Features::is_enabled( 'product-editor-template-system' ) ) {
+			register_post_type(
+				'product_form',
+				apply_filters(
+					'woocommerce_register_post_type_product_form',
+					array(
+						'labels'              => array(
+							'name'                  => __( 'Product Forms', 'woocommerce' ),
+							'singular_name'         => __( 'Product Form', 'woocommerce' ),
+							'all_items'             => __( 'All Product Form', 'woocommerce' ),
+							'menu_name'             => _x( 'Product Forms', 'Admin menu name', 'woocommerce' ),
+							'add_new'               => __( 'Add New', 'woocommerce' ),
+							'add_new_item'          => __( 'Add new product form', 'woocommerce' ),
+							'edit'                  => __( 'Edit', 'woocommerce' ),
+							'edit_item'             => __( 'Edit product form', 'woocommerce' ),
+							'new_item'              => __( 'New product form', 'woocommerce' ),
+							'view_item'             => __( 'View product form', 'woocommerce' ),
+							'view_items'            => __( 'View product forms', 'woocommerce' ),
+							'search_items'          => __( 'Search product forms', 'woocommerce' ),
+							'not_found'             => __( 'No product forms found', 'woocommerce' ),
+							'not_found_in_trash'    => __( 'No product forms found in trash', 'woocommerce' ),
+							'parent'                => __( 'Parent product form', 'woocommerce' ),
+							'featured_image'        => __( 'Product form image', 'woocommerce' ),
+							'set_featured_image'    => __( 'Set product form image', 'woocommerce' ),
+							'remove_featured_image' => __( 'Remove product form image', 'woocommerce' ),
+							'use_featured_image'    => __( 'Use as product form image', 'woocommerce' ),
+							'insert_into_item'      => __( 'Insert into product form', 'woocommerce' ),
+							'uploaded_to_this_item' => __( 'Uploaded to this product form', 'woocommerce' ),
+							'filter_items_list'     => __( 'Filter product forms', 'woocommerce' ),
+							'items_list_navigation' => __( 'Product forms navigation', 'woocommerce' ),
+							'items_list'            => __( 'Product forms list', 'woocommerce' ),
+							'item_link'             => __( 'Product form Link', 'woocommerce' ),
+							'item_link_description' => __( 'A link to a product form.', 'woocommerce' ),
+						),
+						'description'         => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
+						'public'              => true,
+						'menu_icon'           => 'dashicons-forms',
+						'capability_type'     => 'product',
+						'map_meta_cap'        => true,
+						'publicly_queryable'  => true,
+						'hierarchical'        => false, // Hierarchical causes memory issues - WP loads all records!
+						'rewrite'             => $permalinks['product_rewrite_slug'] ? array(
+							'slug'       => $permalinks['product_rewrite_slug'],
+							'with_front' => false,
+							'feeds'      => true,
+						) : false,
+						'query_var'           => true,
+						'supports'            => $supports,
+						'has_archive'         => $has_archive,
+						'show_in_rest'        => true,
+						'show_ui'             => false,
+						// 'show_in_menu'        => true,  // inherit from `show_ui`
+						// 'exclude_from_search' => true,  // inherit from `public`
+						// 'show_in_nav_menus'   => false, // inherit from `public`
+					)
 				)
-			)
-		);
+			);
+		}
 
 		register_post_type(
 			'product_variation',

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -376,6 +376,12 @@ class WC_Post_Types {
 		if ( Features::is_enabled( 'product-editor-template-system' ) ) {
 			register_post_type(
 				'product_form',
+				/**
+				 * Allow developers to customize the product form post type registration arguments.
+				 *
+				 * @since 9.1.0
+				 * @param array $args The default post type registration arguments.
+				 */
 				apply_filters(
 					'woocommerce_register_post_type_product_form',
 					array(

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -385,7 +385,7 @@ class WC_Post_Types {
 				apply_filters(
 					'woocommerce_register_post_type_product_form',
 					array(
-						'labels'              => array(
+						'labels'             => array(
 							'name'                  => __( 'Product Forms', 'woocommerce' ),
 							'singular_name'         => __( 'Product Form', 'woocommerce' ),
 							'all_items'             => __( 'All Product Form', 'woocommerce' ),
@@ -413,26 +413,23 @@ class WC_Post_Types {
 							'item_link'             => __( 'Product form Link', 'woocommerce' ),
 							'item_link_description' => __( 'A link to a product form.', 'woocommerce' ),
 						),
-						'description'         => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
-						'public'              => true,
-						'menu_icon'           => 'dashicons-forms',
-						'capability_type'     => 'product',
-						'map_meta_cap'        => true,
-						'publicly_queryable'  => true,
-						'hierarchical'        => false, // Hierarchical causes memory issues - WP loads all records!
-						'rewrite'             => $permalinks['product_rewrite_slug'] ? array(
+						'description'        => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
+						'public'             => true,
+						'menu_icon'          => 'dashicons-forms',
+						'capability_type'    => 'product',
+						'map_meta_cap'       => true,
+						'publicly_queryable' => true,
+						'hierarchical'       => false, // Hierarchical causes memory issues - WP loads all records!
+						'rewrite'            => $permalinks['product_rewrite_slug'] ? array(
 							'slug'       => $permalinks['product_rewrite_slug'],
 							'with_front' => false,
 							'feeds'      => true,
 						) : false,
-						'query_var'           => true,
-						'supports'            => $supports,
-						'has_archive'         => $has_archive,
-						'show_in_rest'        => true,
-						'show_ui'             => false,
-						// 'show_in_menu'        => true,  // inherit from `show_ui`
-						// 'exclude_from_search' => true,  // inherit from `public`
-						// 'show_in_nav_menus'   => false, // inherit from `public`
+						'query_var'          => true,
+						'supports'           => $supports,
+						'has_archive'        => $has_archive,
+						'show_in_rest'       => true,
+						'show_ui'            => false,
 					)
 				)
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR registers the new `product_form` custom post type. Also, it introduces the `woocommerce_register_post_type_product_form` hook that allows developers to customize it.

Closes https://github.com/woocommerce/woocommerce/issues/47907

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the WooCommerce Beta Tester plugin

2. Using the `wp-cli` list the post-types

```cli
wp post-type list
```

<img width="1016" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/62ade78e-054a-4986-9962-f3a1cd00a439">

3. Confirm the `product_form` is NOT listed there.

4. List the REST API endpoint list by loading the `wp/v2` endpoint in your browser:

```
https://<hotsname>/wp-json/wp/v2
```

5. Confirm the `product_form` is NOT listed there.

6. Enable the `product-editor-template-system` feature flag
  a. Install the WooCommerce Beta Tester plugin
  b. Go to the Settings -> WCA Test Helper -> Features
  c. Enable the `product-editor-template-system` feature flag

![image](https://github.com/woocommerce/woocommerce/assets/77539/4fbfeeae-3ed2-417f-8419-ef813d3a0e0a)

7. Repeat step `(2)`
8. Confirm now you see the `product_form` CPT

<img width="1018" alt="Screenshot 2024-06-04 at 12 41 43 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/6caa73cf-241f-4758-b9c5-2152283a202e">

10. Repeat step `(4)`
11. Confirm the `product_form` CPT is there

<img width="962" alt="Screenshot 2024-06-04 at 12 42 13 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/f2dc1bf3-18ff-4d42-9f8b-2dc80af42b47">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
