### PR TITLE
Make `BatchProcessingController` a bit more robust

### DIFF
--- a/plugins/woocommerce/changelog/fix-44271
+++ b/plugins/woocommerce/changelog/fix-44271
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enhancements to background batch processing.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -170,7 +170,12 @@ class BatchProcessingController {
 			// The batch processing failed and no items were processed:
 			// reschedule the processing with a delay, unless this is a repeatead failure.
 			if ( $this->is_consistently_failing( $batch_processor ) ) {
-				$this->logger->error( "Batch processor {$batch_processor->get_name()} appears to be consistently failing. Execution won't be automatically re-attempted." );
+				$this->logger->error(
+					"Batch processor {$batch_processor->get_name()} appears to be consistently failing. Execution won't be automatically re-attempted.",
+					array(
+						'source' => 'batch-processing',
+					)
+				);
 			} else {
 				$this->schedule_batch_processing( $processor_class_name, true );
 			}
@@ -448,7 +453,7 @@ class BatchProcessingController {
 		 */
 		$error_message = apply_filters( 'wc_batch_processing_log_message', $error_message, $error, $batch_processor, $batch );
 
-		$this->logger->error( $error_message, array( 'exception' => $error ) );
+		$this->logger->error( $error_message, array( 'exception' => $error, 'source' => 'batch-processing' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -474,7 +474,7 @@ class BatchProcessingController {
 			 * @param array $process_details Array with batch processor state.
 			 */
 			apply_filters(
-				'wc_batch_processing_attempts_threshold',
+				'wc_batch_processing_max_attempts',
 				self::FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT,
 				$batch_processor,
 				$process_details

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -49,7 +49,7 @@ class BatchProcessingController {
 	/**
 	 * Maximum number of failures per processor before it gets dequeued.
 	 */
-	const FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT = 3;
+	const FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT = 5;
 
 	/**
 	 * Instance of WC_Logger class.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -496,16 +496,6 @@ class BatchProcessingController {
 			)
 		);
 
-		/**
-		 * Controls the failure threshold for recurring actions.
-		 *
-		 * Before rescheduling a recurring action, we look at its status. If it failed, we then check if all of the most
-		 * recent actions (upto the threshold set by this filter) sharing the same hook have also failed: if they have,
-		 * that is considered consistent failure and a new instance of the action will not be scheduled.
-		 *
-		 * @param int $failure_threshold Number of actions of the same hook to examine for failure. Defaults to 5.
-		 */
-
 		return absint( $process_details['recent_failures'] ?? 0 ) >= max( $max_attempts, 1 );
 	}
 

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -269,6 +269,8 @@ class BatchProcessingController {
 	/**
 	 * Removes the option where we store state for a given processor.
 	 *
+	 * @since 9.1.0
+	 *
 	 * @param string $processor_class_name Fully qualified class name of the processor.
 	 */
 	private function clear_processor_state( string $processor_class_name ): void {

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -82,7 +82,7 @@ class BatchProcessingController {
 
 		add_action(
 			'shutdown',
-			function() {
+			function () {
 				$this->remove_or_retry_failed_processors();
 			}
 		);
@@ -491,8 +491,6 @@ class BatchProcessingController {
 			} else {
 				$this->schedule_batch_processing( $processor, true );
 			}
-
 		}
 	}
-
 }

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -498,7 +498,7 @@ class BatchProcessingController {
 	 * This prevents stale states where Action Scheduler won't schedule any more attempts but we still report the
 	 * processor as enqueued.
 	 *
-	 * @return void
+	 * @since 9.1.0
 	 */
 	private function remove_or_retry_failed_processors(): void {
 		if ( as_has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -49,7 +49,7 @@ class BatchProcessingController {
 	/**
 	 * Maximum number of failures per processor before it gets dequeued.
 	 */
-	const FAILING_PROCESS_MAX_ATTEMPTS = 3;
+	const FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT = 3;
 
 	/**
 	 * Instance of WC_Logger class.
@@ -473,7 +473,7 @@ class BatchProcessingController {
 			 */
 			apply_filters(
 				'wc_batch_processing_attempts_threshold',
-				self::FAILING_PROCESS_MAX_ATTEMPTS,
+				self::FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT,
 				$batch_processor,
 				$process_details
 			)

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataCleanup.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataCleanup.php
@@ -171,18 +171,6 @@ class LegacyDataCleanup implements BatchProcessorInterface {
 	}
 
 	/**
-	 * Checks whether the cleanup process should run. That is, it must be activated and {@see can_run()} must return TRUE.
-	 *
-	 * @deprecated 9.1.0
-	 *
-	 * @return boolean TRUE if the cleanup process should be run, FALSE otherwise.
-	 */
-	public function should_run() {
-		wc_deprecated_function( __METHOD__, '9.1.0', __CLASS__ . '::can_run()' );
-		return $this->can_run();
-	}
-
-	/**
 	 * Whether the user has initiated the cleanup process.
 	 *
 	 * @return boolean TRUE if the user has initiated the cleanup process, FALSE otherwise.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataCleanup.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataCleanup.php
@@ -20,6 +20,8 @@ class LegacyDataCleanup implements BatchProcessorInterface {
 
 	/**
 	 * Option name for this feature.
+	 *
+	 * @deprecated 9.1.0
 	 */
 	public const OPTION_NAME = 'woocommerce_hpos_legacy_data_cleanup_in_progress';
 
@@ -193,16 +195,15 @@ class LegacyDataCleanup implements BatchProcessorInterface {
 	 * Sets the flag that indicates that the cleanup process should be initiated.
 	 *
 	 * @param boolean $enabled TRUE if the process should be initiated, FALSE if it should be canceled.
+	 * @return boolean Whether the legacy data cleanup was initiated or not.
 	 */
-	public function toggle_flag( bool $enabled ) {
-		if ( $enabled ) {
-			if ( ! $this->can_run() ) {
-				throw new \Exception( 'Can not start HPOS cleanup process.' );
-			}
-
+	public function toggle_flag( bool $enabled ): bool {
+		if ( $enabled && $this->can_run() ) {
 			$this->batch_processing->enqueue_processor( self::class );
+			return true;
 		} else {
 			$this->batch_processing->remove_processor( self::class );
+			return $enabled ? false : true;
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataCleanupTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataCleanupTests.php
@@ -57,8 +57,7 @@ class LegacyDataCleanupTests extends WC_Unit_Test_Case {
 			$this->disable_cot_sync();
 		}
 
-		update_option( $this->sut::OPTION_NAME, 'yes' );
-		$this->assertEquals( $expected_cleanup_option_value, get_option( $this->sut::OPTION_NAME ) );
+		$this->sut->toggle_flag( true );
 		$this->assertEquals( wc_string_to_bool( $expected_cleanup_option_value ), $this->sut->is_flag_set() );
 	}
 
@@ -70,11 +69,11 @@ class LegacyDataCleanupTests extends WC_Unit_Test_Case {
 
 		$this->toggle_cot_authoritative( true );
 		$this->disable_cot_sync();
-		update_option( $this->sut::OPTION_NAME, 'yes' );
+		$this->sut->toggle_flag( true );
 		$this->assertTrue( $batch_processing->is_enqueued( get_class( $this->sut ) ) );
 		$this->assertFalse( $batch_processing->is_enqueued( DataSynchronizer::class ) );
 
-		update_option( $this->sut::OPTION_NAME, 'no' );
+		$this->sut->toggle_flag( false );
 		$this->assertFalse( $batch_processing->is_enqueued( get_class( $this->sut ) ) );
 	}
 
@@ -86,7 +85,7 @@ class LegacyDataCleanupTests extends WC_Unit_Test_Case {
 		$order_ids        = $this->create_test_orders( 11 ); // 11 test orders.
 
 		$this->disable_cot_sync();
-		update_option( $this->sut::OPTION_NAME, 'yes' );
+		$this->sut->toggle_flag( true );
 
 		$this->assertEquals( count( $order_ids ), $this->sut->get_total_pending_count() );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a "retry" mechanism to our batch processing system and also better accounting for failures.

Currently, "recoverable" failures (exceptions, etc.) result in the batch processor [being re-scheduled indefinitely](https://github.com/woocommerce/woocommerce/blob/d2bde1368af18dc3489dcca96086f2986835ee1f/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php#L161), which isn't great as it's probably doomed to fail again.
On the other hand, other errors (such as fatal errors or timeouts) that can't be "captured" result in Action Scheduler marking the action as failed and never re-scheduled again. This is because Action Scheduler only retries recurring actions, which our batch processing doesn't use.

This PR tries to manage both types of failures identically: the failure will be logged into the processor's state and the processor itself re-scheduled. If subsequent batches can't be processed and the processor continues to fail, we remove the processor from the queue.

With this added stability, we can simplify the logic in one of our current batch processors (the one cleaning up data from legacy order tables).

Closes #44271.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### 0. Prereqs
We have a few batch processors but it's difficult to _introduce_ a failure that can be observed in a consistent way, and so I developed a small "plugin" that, via a few WP-CLI commands, can enqueue a processor that produces different types of failures while running.
As first step, unzip and drop [this snippet](https://github.com/user-attachments/files/15519316/batch-processing.php.zip) in a suitable location (such as `wp-content/mu-plugins/`).

#### Scenario 1: processor with no problems
1. Run `wp wc batch enqueue --fail-after=0` to enqueue a processor that will succeed after processing 10 batches.
1. Immediately, run `wp wc batch info` which should report the processor as _enqueued_ and the watchdog process as _scheduled_.
1. Initially (and if you're fast enough) a `wc_schedule_pending_batch_processes` action must be visible in Tools > Scheduled Actions > Pending.
1. Refresh periodically (if necessary) and confirm that after the previous action runs, one with name `wc_run_batch_process` and argument `X_BatchProcessor` appears. 
1. After a while (and a few refreshes) you should have 10  `wc_run_batch_process` with argument `X_BatchProcessor` in Tools > Scheduled Actions > Complete.
1. Run `wp wc batch info`. This time it'll report nothing as enqueued or scheduled, `process state` should be `false` and the `processor data` value should be empty.

**Note:** Please note that besides just waiting for AS to do its job, you can also manually run any of these actions from the Tools > Scheduled Actions screen by clicking the _Run_ link in the action's row.

#### Scenario 2: processor with a temporary failure that later succeeds
1. Run `wp wc batch enqueue --fail-after=3 --fail-for=2 --fail-with=exception` to enqueue a processor that will fail 2 times in a row after the 3rd batch.
1. Similarly to the above scenario, follow the progression on Tools > Scheduled Actions from `wc_schedule_pending_batch_processes` to the `wc_run_batch_process` action with argument `X_BatchProcessor`.
1. Concurrently, run `wp wc batch info` which will also indicate how the "processor data" is being consumed by the batch processor.
1. Eventually, the process will fail and `wp wc batch info` will indicate `recent_failures = 1` as part of `process_state`. You can also confirm that there's one entry in Tools > Scheduled Actions > Failed for this processor.
1. Continue waiting for AS to process its queues or manually run the relevant actions.
1. After 2 consecutive failures, the processor will succeed. Check that this is reflected in `wp wc batch info` (see previous scenario).
1. You should end up with 2 failures in Tools > Scheduled Actions > Failed associated to this run of the processor.
1. Similarly, the log in WC > Status > Logs should have 2 entries like this:
   > Error processing batch for Failing Batch Processor: Something's off...
1. Repeat the above but use `--fail-with=error` on the first step instead. Results should be identical (but the underlying error and A-S handling of it is different).

#### Scenario 3: processor with an indefinite failure
1. Run `wp wc batch enqueue --fail-after=3 --fail-for=ever --fail-with=exception` to enqueue a processor that will fail 2 times in a row after the 3rd batch.
1. In the same manner as before, follow the process using Tools > Scheduled Actions and also `wp wc batch info`. In particular, keep an eye for:
   - `wp wc batch info` reporting an increasing number of `recent_failures` (in the `process_state` row) until it hits 5.
   - The logs will show the _Error processing batch for Failing Batch Processor_ message for each failed attempt to process the batch.
1. After a while (specifically, after 5 failures), confirm with `wp wc batch info` that the processor is no longer enqueued nor scheduled.
1. Confirm that the logs show a message like the following:
   > Batch processor Failing Batch Processor appears to be consistently failing. Execution won't be automatically re-attempted.
1. Repeat the above but use `--fail-with=error` on the first step instead and `--fail-for=10`(or any value > 5). Results should be identical.

#### (Optional) Scenario 4: choose your own adventure
Try different combinations of `--fail-after`, `--fail-for` and `--fail-with`. In all cases, the system should re-attempt any failing processor until either it succeeds or for a maximum of 5 attempts.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
