### PR TITLE
Add a higher priority z-index to coming soon banner

### DIFF
--- a/plugins/woocommerce/changelog/48082-comming-soon-banner
+++ b/plugins/woocommerce/changelog/48082-comming-soon-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent on-sale badge from showing on top of the coming soon banner  </details>  <details>

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -2391,6 +2391,7 @@ body:not(.search-results) .twentysixteen .entry-summary {
 	border-top: 1px solid #dcdcdc;
 	padding: 16px;
 	box-sizing: border-box;
+	z-index: 100;
 
 	.coming-soon-footer-banner__content {
 		text-align: center;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/46758

This PR adds an arbitrary z-index of `100` to ensure the coming soon banner shows on top of the `on sale` badge.

| Before | After |
|--------|--------|
| ![Google Chrome - Shop – woo-blocks-dev 2024-05-31 at 11 50 50 AM](https://github.com/woocommerce/woocommerce/assets/2132595/7169da99-1594-4367-92d1-67685c3b1b0e) | ![Google Chrome - Shop – woo-blocks-dev 2024-05-31 at 11 50 20 AM](https://github.com/woocommerce/woocommerce/assets/2132595/d4a9a2a1-c2cd-4c7e-af43-6660c0b94244) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to admin Setting->WooCommerce->Settings->Site visibility and turn on `Coming soon`.
2. Go to the store page and ensure you see the `Coming soon` banner at the footer.
3. On the store page assuming you have product list with an `on sale item with the badge`, scroll the page until the `Coming soon` banner is on top of the `on sale badge` and ensure it covers it.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent on-sale badge from showing on top of the coming soon banner

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
