### PR TITLE
Enable image inline actions in the variations table

### DIFF
--- a/packages/js/product-editor/changelog/add-40351-image
+++ b/packages/js/product-editor/changelog/add-40351-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable image inline actions in the variations table

--- a/packages/js/product-editor/src/components/menu-items/media-library-menu-item/index.ts
+++ b/packages/js/product-editor/src/components/menu-items/media-library-menu-item/index.ts
@@ -1,0 +1,2 @@
+export * from './media-library-menu-item';
+export * from './types';

--- a/packages/js/product-editor/src/components/menu-items/media-library-menu-item/media-library-menu-item.tsx
+++ b/packages/js/product-editor/src/components/menu-items/media-library-menu-item/media-library-menu-item.tsx
@@ -1,12 +1,11 @@
 /**
  * External dependencies
  */
-import type { ChangeEvent } from 'react';
-import { FormFileUpload, MenuItem } from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { media } from '@wordpress/icons';
-import { MediaUpload, uploadMedia } from '@wordpress/media-utils';
+import { MediaUpload } from '@wordpress/media-utils';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/menu-items/media-library-menu-item/media-library-menu-item.tsx
+++ b/packages/js/product-editor/src/components/menu-items/media-library-menu-item/media-library-menu-item.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import type { ChangeEvent } from 'react';
+import { FormFileUpload, MenuItem } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { media } from '@wordpress/icons';
+import { MediaUpload, uploadMedia } from '@wordpress/media-utils';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaLibraryMenuItemProps } from './types';
+
+export function MediaLibraryMenuItem( {
+	// MenuItem.Props
+	icon,
+	iconPosition,
+	text,
+	info,
+	// MediaUpload.Props
+	...props
+}: MediaLibraryMenuItemProps ) {
+	return (
+		<MediaUpload
+			{ ...props }
+			render={ ( { open } ) => (
+				<MenuItem
+					icon={ icon ?? media }
+					iconPosition={ iconPosition ?? 'left' }
+					onClick={ open }
+					info={
+						info ??
+						__( 'Choose from uploaded media', 'woocommerce' )
+					}
+				>
+					{ text ?? __( 'Media Library', 'woocommerce' ) }
+				</MenuItem>
+			) }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/components/menu-items/media-library-menu-item/types.ts
+++ b/packages/js/product-editor/src/components/menu-items/media-library-menu-item/types.ts
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { MenuItem as DropdownMenuItem } from '@wordpress/components';
+import { MediaUpload } from '@wordpress/media-utils';
+
+export type MediaLibraryMenuItemProps = Omit<
+	MediaUpload.Props< boolean >,
+	'children' | 'render' | 'onChange'
+> &
+	Pick< DropdownMenuItem.Props, 'icon' | 'iconPosition' | 'text' | 'info' >;

--- a/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/index.ts
+++ b/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/index.ts
@@ -1,0 +1,2 @@
+export * from './upload-files-menu-item';
+export * from './types';

--- a/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/types.ts
+++ b/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/types.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import {
+	FormFileUpload,
+	MenuItem as DropdownMenuItem,
+} from '@wordpress/components';
+import { MediaItem, UploadMediaOptions } from '@wordpress/media-utils';
+
+export type UploadFilesMenuItemProps = Omit<
+	FormFileUpload.Props,
+	'children' | 'render' | 'onChange'
+> &
+	Pick< DropdownMenuItem.Props, 'icon' | 'iconPosition' | 'text' | 'info' > &
+	Partial<
+		Pick<
+			UploadMediaOptions,
+			| 'additionalData'
+			| 'allowedTypes'
+			| 'maxUploadFileSize'
+			| 'wpAllowedMimeTypes'
+		>
+	> & {
+		onUploadProgress?( files: MediaItem[] ): void;
+		onUploadSuccess( files: MediaItem[] ): void;
+		onUploadError( error: unknown ): void;
+	};

--- a/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/upload-files-menu-item.tsx
+++ b/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/upload-files-menu-item.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import type { ChangeEvent } from 'react';
+import { FormFileUpload, MenuItem } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { upload } from '@wordpress/icons';
+import { uploadMedia } from '@wordpress/media-utils';
+
+/**
+ * Internal dependencies
+ */
+import type { UploadFilesMenuItemProps } from './types';
+
+export function UploadFilesMenuItem( {
+	// UploadMediaOptions
+	allowedTypes,
+	maxUploadFileSize = 10000000,
+	wpAllowedMimeTypes,
+	additionalData,
+	// MenuItem.Props
+	icon,
+	iconPosition,
+	text,
+	info,
+	// Handlers
+	onUploadProgress,
+	onUploadSuccess,
+	onUploadError,
+	// FormFileUpload.Props
+	...props
+}: UploadFilesMenuItemProps ) {
+	function handleFormFileUploadChange(
+		event: ChangeEvent< HTMLInputElement >
+	) {
+		const filesList = event.currentTarget.files as FileList;
+
+		uploadMedia( {
+			allowedTypes,
+			filesList,
+			maxUploadFileSize,
+			additionalData,
+			wpAllowedMimeTypes,
+			onFileChange( files ) {
+				const isUploading = files.some( ( file ) => ! file.id );
+
+				if ( isUploading ) {
+					onUploadProgress?.( files );
+					return;
+				}
+
+				onUploadSuccess( files );
+			},
+			onError: onUploadError,
+		} );
+	}
+
+	return (
+		<FormFileUpload
+			{ ...props }
+			onChange={ handleFormFileUploadChange }
+			render={ ( { openFileDialog } ) => (
+				<MenuItem
+					icon={ icon ?? upload }
+					iconPosition={ iconPosition ?? 'left' }
+					onClick={ openFileDialog }
+					info={
+						info ??
+						__( 'Select files from your device', 'woocommerce' )
+					}
+				>
+					{ text ?? __( 'Upload', 'woocommerce' ) }
+				</MenuItem>
+			) }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
@@ -12,6 +12,7 @@ import { MediaItem } from '@wordpress/media-utils';
 import { MediaLibraryMenuItem } from '../../menu-items/media-library-menu-item';
 import { UploadFilesMenuItem } from '../../menu-items/upload-files-menu-item';
 import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
+import { VariationQuickUpdateMenuItem } from '../variation-actions-menus';
 import type { ImageActionsMenuProps } from './types';
 
 export function ImageActionsMenu( {
@@ -91,6 +92,14 @@ export function ImageActionsMenu( {
 							) }
 						/>
 					</MenuGroup>
+
+					<VariationQuickUpdateMenuItem.Slot
+						group={ 'image-actions-menu' }
+						onChange={ onChange }
+						onClose={ onClose }
+						selection={ selection }
+						supportsMultipleSelection={ false }
+					/>
 				</div>
 			) }
 		/>

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { Dropdown, MenuGroup } from '@wordpress/components';
+import { createElement, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { MediaItem } from '@wordpress/media-utils';
+
+/**
+ * Internal dependencies
+ */
+import { MediaLibraryMenuItem } from '../../menu-items/media-library-menu-item';
+import { UploadFilesMenuItem } from '../../menu-items/upload-files-menu-item';
+import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
+import type { ImageActionsMenuProps } from './types';
+
+export function ImageActionsMenu( {
+	selection,
+	onChange,
+	onDelete,
+	...props
+}: ImageActionsMenuProps ) {
+	const [ isUploading, setIsUploading ] = useState( false );
+
+	function uploadSuccessHandler( onClose: () => void ) {
+		return function handleUploadSuccess( files: MediaItem[] ) {
+			const image =
+				( files.length && mapUploadImageToImage( files[ 0 ] ) ) ||
+				undefined;
+			const variation = {
+				id: selection[ 0 ].id,
+				image,
+			};
+
+			setIsUploading( false );
+
+			onChange( [ variation ], false );
+			onClose();
+		};
+	}
+
+	function mediaLibraryMenuItemSelectHandler( onClose: () => void ) {
+		return function handleMediaLibraryMenuItemSelect( media: never ) {
+			const variation = {
+				id: selection[ 0 ].id,
+				image: mapUploadImageToImage( media ) || undefined,
+			};
+			onChange( [ variation ], false );
+			onClose();
+		};
+	}
+
+	return (
+		<Dropdown
+			{ ...props }
+			// @ts-expect-error missing prop in types.
+			popoverProps={ {
+				placement: 'bottom-end',
+			} }
+			renderToggle={ ( toggleProps ) =>
+				props.renderToggle( { ...toggleProps, isBusy: isUploading } )
+			}
+			contentClassName="woocommerce-image-actions-menu__menu-content"
+			renderContent={ ( { onClose } ) => (
+				<div className="components-dropdown-menu__menu">
+					<MenuGroup>
+						<UploadFilesMenuItem
+							allowedTypes={ [ 'image' ] }
+							multiple={ false }
+							info={ __(
+								'1000 pixels wide or larger',
+								'woocommerce'
+							) }
+							onUploadProgress={ () => {
+								setIsUploading( true );
+								onClose();
+							} }
+							onUploadSuccess={ uploadSuccessHandler( onClose ) }
+							onUploadError={ () => {
+								setIsUploading( false );
+								onClose();
+							} }
+						/>
+
+						<MediaLibraryMenuItem
+							allowedTypes={ [ 'image' ] }
+							multiple={ false }
+							value={ selection[ 0 ].id }
+							onSelect={ mediaLibraryMenuItemSelectHandler(
+								onClose
+							) }
+						/>
+					</MenuGroup>
+				</div>
+			) }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
@@ -61,6 +61,7 @@ export function ImageActionsMenu( {
 			renderToggle={ ( toggleProps ) =>
 				props.renderToggle( { ...toggleProps, isBusy: isUploading } )
 			}
+			className="woocommerce-image-actions-menu"
 			contentClassName="woocommerce-image-actions-menu__menu-content"
 			renderContent={ ( { onClose } ) => (
 				<div className="components-dropdown-menu__menu">

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
@@ -67,6 +67,7 @@ export function ImageActionsMenu( {
 					<MenuGroup>
 						<UploadFilesMenuItem
 							allowedTypes={ [ 'image' ] }
+							accept="image/*"
 							multiple={ false }
 							info={ __(
 								'1000 pixels wide or larger',

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/index.ts
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/index.ts
@@ -1,0 +1,2 @@
+export * from './image-actions-menu';
+export * from './types';

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/style.scss
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/style.scss
@@ -1,0 +1,10 @@
+.woocommerce-image-actions-menu {
+	&__menu-content {
+		// To be rendered below the MediaLibrary modal.
+		z-index: 100000;
+
+		.components-menu-item__item {
+			min-width: 172px;
+		}
+	}
+}

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/style.scss
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/style.scss
@@ -1,4 +1,6 @@
 .woocommerce-image-actions-menu {
+	display: inline-flex;
+
 	&__menu-content {
 		// To be rendered below the MediaLibrary modal.
 		z-index: 100000;

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/types.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { Dropdown } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { VariationActionsMenuProps } from '../variation-actions-menus';
+
+export type ImageActionsMenuProps = Omit<
+	Dropdown.Props,
+	'renderToggle' | 'renderContent'
+> &
+	VariationActionsMenuProps & {
+		renderToggle(
+			props: Dropdown.RenderProps & { isBusy?: boolean }
+		): JSX.Element;
+	};

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -5,7 +5,7 @@
 @import "./variations-filter/styles.scss";
 @import "./table-row-skeleton/styles.scss";
 @import "./add-image-menu-item/style.scss";
-@import "./variations-table-row/image-actions-menu/style.scss";
+@import "./image-actions-menu/style.scss";
 
 .woocommerce-product-variations {
 	display: flex;

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -5,6 +5,7 @@
 @import "./variations-filter/styles.scss";
 @import "./table-row-skeleton/styles.scss";
 @import "./add-image-menu-item/style.scss";
+@import "./variations-table-row/image-actions-menu/style.scss";
 
 .woocommerce-product-variations {
 	display: flex;
@@ -190,17 +191,24 @@
 		border-radius: 2px;
 		border: 1px dashed $gray-400;
 		margin-right: $gap-small;
-		width: 32px;
+		width: $grid-unit-40;
+		height: $grid-unit-40;
 		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		.components-spinner {
+			margin: 0;
+		}
 	}
 	&__image-button {
 		margin-right: $gap-small;
-		width: 32px;
-		max-height: 32px;
+		width: $grid-unit-40;
+		height: $grid-unit-40;
 		padding: 0;
 	}
 	&__image {
-		width: 32px;
-		max-height: 32px;
+		width: 100%;
 	}
 }

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -210,5 +210,9 @@
 	}
 	&__image {
 		width: 100%;
+		height: 100%;
+		background-position: center center;
+		background-size: contain;
+		background-repeat: no-repeat;
 	}
 }

--- a/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
@@ -269,6 +269,18 @@ export function useVariations( { productId }: UseVariationsProps ) {
 	}: PartialProductVariation ) {
 		if ( isUpdating[ variationId ] ) return;
 
+		setVariations( ( current ) =>
+			current.map( ( currentVariation ) => {
+				if ( currentVariation.id === variationId ) {
+					return {
+						...currentVariation,
+						...variation,
+					};
+				}
+				return currentVariation;
+			} )
+		);
+
 		const { updateProductVariation } = dispatch(
 			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
 		);

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menus/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menus/types.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { PartialProductVariation, ProductVariation } from '@woocommerce/data';
+import { MenuItem } from '@wordpress/components';
 
 export type VariationActionsMenuProps = {
 	disabled?: boolean;
@@ -18,8 +19,7 @@ export type VariationQuickUpdateSlotProps = {
 	onClose: () => void;
 };
 
-export type MenuItemProps = {
-	children?: React.ReactNode;
+export type MenuItemProps = Omit< MenuItem.Props, 'onClick' > & {
 	order?: number;
 	group?: string;
 	supportsMultipleSelection?: boolean;

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menus/variation-quick-update-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menus/variation-quick-update-menu-item.tsx
@@ -41,6 +41,7 @@ export const VariationQuickUpdateMenuItem: React.FC< MenuItemProps > & {
 	group = TOP_LEVEL_MENU,
 	supportsMultipleSelection,
 	onClick = () => {},
+	...props
 } ) => {
 	const handleClick =
 		( fillProps: Fill.Props & VariationQuickUpdateSlotProps ) => () => {
@@ -61,7 +62,7 @@ export const VariationQuickUpdateMenuItem: React.FC< MenuItemProps > & {
 		>
 			{ ( fillProps: Fill.Props & VariationQuickUpdateSlotProps ) =>
 				createOrderedChildren(
-					<MenuItem onClick={ handleClick( fillProps ) }>
+					<MenuItem { ...props } onClick={ handleClick( fillProps ) }>
 						{ children }
 					</MenuItem>,
 					order,

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
@@ -16,7 +16,6 @@ import {
 import { plus, info, Icon } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
-import { MediaUpload } from '@wordpress/media-utils';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ import {
 } from '../../../utils';
 import { SingleUpdateMenu } from '../variation-actions-menus';
 import { VariationsTableRowProps } from './types';
-import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
+import { ImageActionsMenu } from '../image-actions-menu';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 
@@ -142,46 +141,44 @@ export function VariationsTableRow( {
 				className="woocommerce-product-variations__attributes-cell"
 				role="cell"
 			>
-				<MediaUpload
-					value={ variation.id }
-					onSelect={ ( image ) =>
-						handleChange(
-							[
-								{
-									id: variation.id,
-									image:
-										mapUploadImageToImage( image ) ||
-										undefined,
-								},
-							],
-							false
+				<ImageActionsMenu
+					selection={ [ variation ] }
+					onChange={ handleChange }
+					onDelete={ handleDelete }
+					renderToggle={ ( { onToggle, isBusy } ) =>
+						isBusy ? (
+							<div className="woocommerce-product-variations__add-image-button">
+								<Spinner
+									aria-label={ __(
+										'Loading image',
+										'woocommerce'
+									) }
+								/>
+							</div>
+						) : (
+							<Button
+								className={ classNames(
+									variation.image
+										? 'woocommerce-product-variations__image-button'
+										: 'woocommerce-product-variations__add-image-button'
+								) }
+								icon={ variation.image ? undefined : plus }
+								iconSize={ variation.image ? undefined : 16 }
+								// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+								// @ts-ignore this exists in the props but is not typed
+								size="compact"
+								onClick={ onToggle }
+							>
+								{ variation.image && (
+									<img
+										className="woocommerce-product-variations__image"
+										src={ variation.image.src }
+										alt={ variation.image.alt }
+									/>
+								) }
+							</Button>
 						)
 					}
-					allowedTypes={ [ 'image' ] }
-					multiple={ false }
-					render={ ( { open } ) => (
-						<Button
-							className={ classNames(
-								variation.image
-									? 'woocommerce-product-variations__image-button'
-									: 'woocommerce-product-variations__add-image-button'
-							) }
-							icon={ variation.image ? undefined : plus }
-							iconSize={ variation.image ? undefined : 16 }
-							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-							// @ts-ignore this exists in the props but is not typed
-							size="compact"
-							onClick={ open }
-						>
-							{ variation.image && (
-								<img
-									className="woocommerce-product-variations__image"
-									src={ variation.image.src }
-									alt={ variation.image.alt }
-								/>
-							) }
-						</Button>
-					) }
 				/>
 
 				<div className="woocommerce-product-variations__attributes">

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
@@ -170,10 +170,11 @@ export function VariationsTableRow( {
 								onClick={ onToggle }
 							>
 								{ variation.image && (
-									<img
+									<div
 										className="woocommerce-product-variations__image"
-										src={ variation.image.src }
-										alt={ variation.image.alt }
+										style={ {
+											backgroundImage: `url('${ variation.image.src }')`,
+										} }
 									/>
 								) }
 							</Button>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #40351

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products > Add new` and generate some variations from the `Variations` tab
3. Click on the `+` button at the beginning of the table row <img width="688" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/9549f968-65c7-4b05-a8b9-f53d7d9f938b">
4. A new quick actions menu should be shown like below <img width="676" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/742d9d68-4348-434f-9aa2-d3b5b3eb41fb">
5. Clicking the `Upload` item should let you pick an image directly from the computer and save it as the variation image
6. Clicking the `Media Library` item should let you pick an image from the WP Gallery and save it as the variation image

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
