### PR TITLE
CYS > Patterns Migration: Ensure a message is displayed if the user did not allow fetching patterns via API and/or they are unavailable

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -50,6 +50,7 @@ import {
 import { isEqual } from 'lodash';
 import { COLOR_PALETTES } from './global-styles/color-palette-variations/constants';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useNetworkStatus } from '~/utils/react-hooks/use-network-status';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
@@ -226,12 +227,17 @@ export const SidebarNavigationScreenHomepage = () => {
 				'woocommerce'
 		  );
 
+	const isNetworkOffline = useNetworkStatus();
+
 	const trackingAllowed = useSelect( ( select ) =>
 		select( OPTIONS_STORE_NAME ).getOption( 'woocommerce_allow_tracking' )
 	);
 	let notice;
 
 	const isTrackingDisallowed = trackingAllowed === 'no' || ! trackingAllowed;
+	if ( isNetworkOffline ) {
+		notice = __( "Looks like we can't detect your network. Please double-check your internet connection and refresh the page.", 'woocommerce' );
+	}
 	if ( isTrackingDisallowed ) {
 		notice = __(
 			'Opt in to <OptInModal>usage tracking</OptInModal> to get access to more patterns.',

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -258,7 +258,7 @@ export const SidebarNavigationScreenHomepage = () => {
 	const openModal = () => setIsModalOpen( true );
 	const closeModal = () => setIsModalOpen( false );
 
-	const [ OptInDataSharing, setIsOptInDataSharing ] =
+	const [ optInDataSharing, setIsOptInDataSharing ] =
 		useState< boolean >( true );
 
 	const optIn = () => {
@@ -368,7 +368,7 @@ export const SidebarNavigationScreenHomepage = () => {
 													),
 												},
 											} ) }
-											checked={ OptInDataSharing }
+											checked={ optInDataSharing }
 											onChange={ setIsOptInDataSharing }
 										/>
 										<div className="woocommerce-customize-store__design-change-warning-modal-footer">
@@ -398,7 +398,7 @@ export const SidebarNavigationScreenHomepage = () => {
 													}
 												} }
 												variant="primary"
-												disabled={ ! OptInDataSharing }
+												disabled={ ! optInDataSharing }
 											>
 												{ __(
 													'Opt in',

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -230,8 +230,8 @@ export const SidebarNavigationScreenHomepage = () => {
 
 	const isNetworkOffline = useNetworkStatus();
 	const isPTKPatternsAPIAvailable = context.isPTKPatternsAPIAvailable;
-	const trackingAllowed = useSelect( ( select ) =>
-		select( OPTIONS_STORE_NAME ).getOption( 'woocommerce_allow_tracking' )
+	const trackingAllowed = useSelect( ( sel ) =>
+		sel( OPTIONS_STORE_NAME ).getOption( 'woocommerce_allow_tracking' )
 	);
 	const isTrackingDisallowed = trackingAllowed === 'no' || ! trackingAllowed;
 
@@ -379,7 +379,10 @@ export const SidebarNavigationScreenHomepage = () => {
 												} }
 												variant="link"
 											>
-												{ __( 'Cancel', 'woocommerce' ) }
+												{ __(
+													'Cancel',
+													'woocommerce'
+												) }
 											</Button>
 											<Button
 												onClick={ () => {
@@ -397,7 +400,10 @@ export const SidebarNavigationScreenHomepage = () => {
 												variant="primary"
 												disabled={ ! OptInDataSharing }
 											>
-												{ __( 'Opt in', 'woocommerce' ) }
+												{ __(
+													'Opt in',
+													'woocommerce'
+												) }
 											</Button>
 										</div>
 									</Modal>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -51,6 +51,7 @@ import { isEqual } from 'lodash';
 import { COLOR_PALETTES } from './global-styles/color-palette-variations/constants';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useNetworkStatus } from '~/utils/react-hooks/use-network-status';
+import { isIframe, sendMessageToParent } from '~/customize-store/utils';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
@@ -211,7 +212,7 @@ export const SidebarNavigationScreenHomepage = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to re-run this effect when currentSelectedPattern changes
 	}, [ blocks, homePatterns, isLoading, isEditorLoading ] );
 
-	const { context } = useContext( CustomizeStoreContext );
+	const { context, sendEvent } = useContext( CustomizeStoreContext );
 	const aiOnline = context.flowType === FlowType.AIOnline;
 
 	const title = aiOnline
@@ -376,6 +377,15 @@ export const SidebarNavigationScreenHomepage = () => {
 											<Button
 												onClick={ () => {
 													optIn();
+													if ( isIframe( window ) ) {
+														sendMessageToParent( {
+															type: 'INSTALL_PATTERNS',
+														} );
+													} else {
+														sendEvent(
+															'INSTALL_PATTERNS'
+														);
+													}
 												} }
 												variant="primary"
 												disabled={ ! OptInDataSharing }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -229,17 +229,24 @@ export const SidebarNavigationScreenHomepage = () => {
 		  );
 
 	const isNetworkOffline = useNetworkStatus();
-
+	const isPTKPatternsAPIAvailable = context.isPTKPatternsAPIAvailable;
 	const trackingAllowed = useSelect( ( select ) =>
 		select( OPTIONS_STORE_NAME ).getOption( 'woocommerce_allow_tracking' )
 	);
-	let notice;
-
 	const isTrackingDisallowed = trackingAllowed === 'no' || ! trackingAllowed;
+
+	let notice;
 	if ( isNetworkOffline ) {
-		notice = __( "Looks like we can't detect your network. Please double-check your internet connection and refresh the page.", 'woocommerce' );
-	}
-	if ( isTrackingDisallowed ) {
+		notice = __(
+			"Looks like we can't detect your network. Please double-check your internet connection and refresh the page.",
+			'woocommerce'
+		);
+	} else if ( ! isPTKPatternsAPIAvailable ) {
+		notice = __(
+			"Unfortunately, we're experiencing some technical issues — please come back later to access more patterns.",
+			'woocommerce'
+		);
+	} else if ( isTrackingDisallowed ) {
 		notice = __(
 			'Opt in to <OptInModal>usage tracking</OptInModal> to get access to more patterns.',
 			'woocommerce'

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -480,6 +480,24 @@ body.woocommerce-assembler {
 		}
 	}
 
+	.woocommerce-customize-store_sidebar-patterns-upgrade-notice {
+		color: #1e1e1e;
+		padding: 0 0 40px;
+
+		h4 {
+			text-transform: uppercase;
+			margin-bottom: 4px;
+		}
+		p {
+			margin: 0;
+		}
+
+		a,
+		button {
+			text-decoration: none;
+		}
+	}
+
 	.woocommerce-customize-store_sidebar-typography-upgrade-notice {
 		margin-top: 48px;
 		color: #1e1e1e;

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/index.tsx
@@ -41,6 +41,8 @@ export const DesignWithNoAiController = ( {
 				...designWithNoAiStateMachineDefinition.context,
 				isFontLibraryAvailable:
 					parentContext?.isFontLibraryAvailable ?? false,
+				isPTKPatternsAPIAvailable:
+					parentContext?.isPTKPatternsAPIAvailable ?? false,
 			},
 		}
 	);

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/pages/ApiCallLoader.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/pages/ApiCallLoader.tsx
@@ -116,6 +116,10 @@ const AssemblerHub = ( { sendEvent }: { sendEvent: SendEventFn } ) => {
 			if ( event.data?.type === 'INSTALL_FONTS' ) {
 				sendEvent( { type: 'INSTALL_FONTS' } );
 			}
+
+			if ( event.data?.type === 'INSTALL_PATTERNS' ) {
+				sendEvent( { type: 'INSTALL_PATTERNS' } );
+			}
 		} );
 	}, [ sendEvent ] );
 

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -146,6 +146,28 @@ const installAndActivateTheme = async (
 	}
 };
 
+const installPatterns = async () => {
+	const isTrackingEnabled = window.wcTracks?.isEnabled || false;
+	if ( ! isTrackingEnabled ) {
+		return;
+	}
+
+	try {
+		const { success } = await apiFetch< {
+			success: boolean;
+		} >( {
+			path: '/wc/private/patterns',
+			method: 'POST',
+		} );
+
+		if ( ! success ) {
+			throw new Error( 'Fetching patterns failed' );
+		}
+	} catch ( error ) {
+		throw error;
+	}
+};
+
 const installFontFamilies = async () => {
 	const isTrackingEnabled = window.wcTracks?.isEnabled || false;
 	if ( ! isTrackingEnabled ) {
@@ -252,6 +274,7 @@ export const services = {
 	installAndActivateTheme,
 	createProducts,
 	installFontFamilies,
+	installPatterns,
 	updateGlobalStylesWithDefaultValues,
 	enableTracking,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -114,6 +114,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 				hasErrors: false,
 			},
 			isFontLibraryAvailable: false,
+			isPTKPatternsAPIAvailable: false,
 		},
 		initial: 'navigate',
 		states: {

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -38,6 +38,15 @@ export const hasFontInstallInUrl = () => {
 	);
 };
 
+export const hasPatternInstallInUrl = () => {
+	const { path = '' } = getQuery() as { path: string };
+	const pathFragments = path.split( '/' );
+	return (
+		pathFragments[ 2 ] === 'design' &&
+		pathFragments[ 3 ] === 'install-patterns'
+	);
+};
+
 const installFontFamiliesState = {
 	initial: 'checkFontLibrary',
 	states: {
@@ -72,6 +81,7 @@ const installFontFamiliesState = {
 export type DesignWithoutAIStateMachineEvents =
 	| { type: 'EXTERNAL_URL_UPDATE' }
 	| { type: 'INSTALL_FONTS' }
+	| { type: 'INSTALL_PATTERNS' }
 	| { type: 'NO_AI_FLOW_ERROR'; payload: { hasError: boolean } };
 
 export const designWithNoAiStateMachineDefinition = createMachine(
@@ -93,6 +103,9 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 			INSTALL_FONTS: {
 				target: 'installFontFamilies',
 			},
+			INSTALL_PATTERNS: {
+				target: 'installPatterns',
+			},
 		},
 		context: {
 			startLoadingTime: null,
@@ -112,6 +125,13 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 							step: 'design',
 						},
 						target: 'installFontFamilies',
+					},
+					{
+						cond: {
+							type: 'hasPatternInstallInUrl',
+							step: 'design',
+						},
+						target: 'installPatterns',
 					},
 					{
 						cond: {
@@ -139,6 +159,39 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 					checkFontLibrary:
 						installFontFamiliesState.states.checkFontLibrary,
 					pending: installFontFamiliesState.states.pending,
+					success: {
+						type: 'final',
+					},
+				},
+				onDone: {
+					target: '#designWithoutAI.showAssembleHub',
+				},
+			},
+			installPatterns: {
+				meta: {
+					component: ApiCallLoader,
+				},
+				initial: 'enableTracking',
+				states: {
+					enableTracking: {
+						invoke: {
+							src: 'enableTracking',
+							onDone: {
+								target: 'fetchPatterns',
+							},
+						},
+					},
+					fetchPatterns: {
+						invoke: {
+							src: 'installPatterns',
+							onDone: {
+								target: 'success',
+							},
+							onError: {
+								actions: 'redirectToIntroWithError',
+							},
+						},
+					},
 					success: {
 						type: 'final',
 					},
@@ -254,6 +307,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 			hasStepInUrl,
 			isFontLibraryAvailable,
 			hasFontInstallInUrl,
+			hasPatternInstallInUrl,
 		},
 	}
 );

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/types.ts
@@ -10,6 +10,7 @@ export type DesignWithoutAIStateMachineContext = {
 	};
 	flowType: FlowType.noAI;
 	isFontLibraryAvailable: boolean;
+	isPTKPatternsAPIAvailable: boolean;
 };
 
 export interface Theme {

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -62,6 +62,7 @@ export type customizeStoreStateMachineEvents =
 	| { type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION'; payload: { step: string } }
 	| { type: 'EXTERNAL_URL_UPDATE' }
 	| { type: 'INSTALL_FONTS' }
+	| { type: 'INSTALL_PATTERNS' }
 	| { type: 'NO_AI_FLOW_ERROR'; payload: { hasError: boolean } }
 	| { type: 'IS_FONT_LIBRARY_AVAILABLE'; payload: boolean };
 
@@ -240,6 +241,9 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 		INSTALL_FONTS: {
 			target: 'designWithoutAi.installFonts',
 		},
+		INSTALL_PATTERNS: {
+			target: 'designWithoutAi.installPatterns',
+		},
 	},
 	states: {
 		setFlags: {
@@ -376,6 +380,18 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 						{
 							type: 'updateQueryStep',
 							step: 'design/install-fonts',
+						},
+					],
+					meta: {
+						component: DesignWithoutAi,
+					},
+				},
+				// This state is used to install patterns and then redirect to the assembler hub.
+				installPatterns: {
+					entry: [
+						{
+							type: 'updateQueryStep',
+							step: 'design/install-patterns',
 						},
 					],
 					meta: {

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -210,6 +210,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 		},
 		flowType: FlowType.noAI,
 		isFontLibraryAvailable: null,
+		isPTKPatternsAPIAvailable: null,
 		activeThemeHasMods: undefined,
 	} as customizeStoreStateMachineContext,
 	invoke: {
@@ -559,6 +560,7 @@ declare global {
 	interface Window {
 		__wcCustomizeStore: {
 			isFontLibraryAvailable: boolean | null;
+			isPTKPatternsAPIAvailable: boolean | null;
 			activeThemeHasMods: boolean | undefined;
 			sendEventToIntroMachine: (
 				typeEvent: customizeStoreStateMachineEvents

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -148,6 +148,20 @@ export const assignIsFontLibraryAvailable = assign<
 	},
 } );
 
+export const assignIsPTKPatternsAPIAvailable = assign<
+	customizeStoreStateMachineContext,
+	customizeStoreStateMachineEvents
+>( {
+	isPTKPatternsAPIAvailable: ( context, event: unknown ) => {
+		console.log({event});
+		return (
+			event as {
+				payload: boolean;
+			}
+		).payload;
+	},
+} );
+
 export const assignActiveThemeHasMods = assign<
 	customizeStoreStateMachineContext,
 	customizeStoreStateMachineEvents
@@ -179,6 +193,14 @@ export const assignFlags = assign<
 		const isFontLibraryAvailable =
 			window.parent.__wcCustomizeStore.isFontLibraryAvailable || false;
 		return isFontLibraryAvailable;
+	},
+	isPTKPatternsAPIAvailable: () => {
+		if ( ! isIframe( window ) ) {
+			return window.__wcCustomizeStore.isPTKPatternsAPIAvailable;
+		}
+		const isPTKPatternsAPIAvailable =
+			window.parent.__wcCustomizeStore.isPTKPatternsAPIAvailable || false;
+		return isPTKPatternsAPIAvailable;
 	},
 	flowType: ( _context, event ) => {
 		const flowTypeData = event as DoneInvokeEvent< FlowType >;

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -153,12 +153,11 @@ export const assignIsPTKPatternsAPIAvailable = assign<
 	customizeStoreStateMachineEvents
 >( {
 	isPTKPatternsAPIAvailable: ( context, event: unknown ) => {
-		console.log({event});
 		return (
 			event as {
 				payload: boolean;
 			}
-		).payload;
+		 ).payload;
 	},
 } );
 

--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -144,6 +144,19 @@ const fetchIsFontLibraryAvailable = async () => {
 	}
 };
 
+const fetchIsPTKPatternsAPIAvailable = async () => {
+	try {
+		await apiFetch( {
+			path: '/wc/private/patterns',
+			method: 'GET',
+		} );
+
+		return true;
+	} catch ( err ) {
+		return false;
+	}
+};
+
 export const setFlags = async () => {
 	if ( ! isIframe( window ) ) {
 		// To improve the readability of the code, we want to use a dictionary
@@ -158,6 +171,14 @@ export const setFlags = async () => {
 				window.__wcCustomizeStore = {
 					...window.__wcCustomizeStore,
 					isFontLibraryAvailable,
+				};
+			} )(),
+			PTK_PATTERNS_API_AVAILABLE: ( async () => {
+				const isPTKPatternsAPIAvailable =
+					await fetchIsPTKPatternsAPIAvailable();
+				window.__wcCustomizeStore = {
+					...window.__wcCustomizeStore,
+					isPTKPatternsAPIAvailable,
 				};
 			} )(),
 		};

--- a/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
@@ -46,6 +46,7 @@ describe( 'Intro Banners', () => {
 					},
 					flowType: FlowType.AIOnline,
 					isFontLibraryAvailable: false,
+					isPTKPatternsAPIAvailable: false,
 					activeThemeHasMods: false,
 				} }
 				currentState={ 'intro' }
@@ -85,6 +86,7 @@ describe( 'Intro Banners', () => {
 					},
 					flowType: FlowType.AIOnline,
 					isFontLibraryAvailable: false,
+					isPTKPatternsAPIAvailable: false,
 					activeThemeHasMods: false,
 				} }
 				currentState={ 'intro' }
@@ -130,6 +132,7 @@ describe( 'Intro Banners', () => {
 					},
 					flowType: FlowType.AIOnline,
 					isFontLibraryAvailable: false,
+					isPTKPatternsAPIAvailable: false,
 					activeThemeHasMods: false,
 				} }
 				currentState={ 'intro' }

--- a/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-modal.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-modal.test.tsx
@@ -44,6 +44,7 @@ describe( 'Intro Modals', () => {
 					},
 					flowType: FlowType.AIOnline,
 					isFontLibraryAvailable: false,
+					isPTKPatternsAPIAvailable: false,
 					activeThemeHasMods: true,
 				} }
 				currentState={ 'intro' }
@@ -100,6 +101,7 @@ describe( 'Intro Modals', () => {
 					},
 					flowType: FlowType.AIOnline,
 					isFontLibraryAvailable: false,
+					isPTKPatternsAPIAvailable: false,
 					activeThemeHasMods: false,
 				} }
 				currentState={ 'intro' }
@@ -154,6 +156,7 @@ describe( 'Intro Modals', () => {
 					},
 					flowType: FlowType.AIOnline,
 					isFontLibraryAvailable: false,
+					isPTKPatternsAPIAvailable: false,
 					activeThemeHasMods: false,
 				} }
 				currentState={ 'intro' }

--- a/plugins/woocommerce-admin/client/customize-store/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/types.ts
@@ -58,5 +58,6 @@ export type customizeStoreStateMachineContext = {
 	};
 	flowType: FlowType;
 	isFontLibraryAvailable: boolean | null;
+	isPTKPatternsAPIAvailable: boolean | null;
 	activeThemeHasMods: boolean | undefined;
 };

--- a/plugins/woocommerce/changelog/48095-47395-patterns-allow-tracking-modal
+++ b/plugins/woocommerce/changelog/48095-47395-patterns-allow-tracking-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+[CYS] Show a message when tracking is not allowed in patterns and add the ability for users to opt-in and fetch patterns.  </details>  <details>

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -138,8 +138,6 @@ class BlockPatterns {
 			return;
 		}
 
-		$this->ptk_patterns_store = new PTKPatternsStore( new PTKClient() );
-
 		$patterns = $this->ptk_patterns_store->get_patterns();
 		if ( empty( $patterns ) ) {
 			wc_get_logger()->warning(

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -380,9 +380,15 @@ class Bootstrap {
 			}
 		);
 		$this->container->register(
+			PTKClient::class,
+			function () {
+				return new PTKClient();
+			}
+		);
+		$this->container->register(
 			PTKPatternsStore::class,
 			function () {
-				return new PTKPatternsStore( new PTKClient() );
+				return new PTKPatternsStore( $this->container->get( PTKClient::class ) );
 			}
 		);
 		$this->container->register(

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKClient.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKClient.php
@@ -32,6 +32,10 @@ class PTKClient {
 			$ptk_url = add_query_arg( 'categories', implode( ',', $options['categories'] ), $ptk_url );
 		}
 
+		if ( isset( $options['per_page'] ) ) {
+			$ptk_url = add_query_arg( 'per_page', $options['per_page'], $ptk_url );
+		}
+
 		$patterns = wp_safe_remote_get( $ptk_url );
 		if ( is_wp_error( $patterns ) || 200 !== wp_remote_retrieve_response_code( $patterns ) ) {
 			return new WP_Error(

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -173,6 +173,10 @@ class PTKPatternsStore {
 	 * @return void
 	 */
 	public function fetch_patterns() {
+		if ( ! $this->allowed_tracking_is_enabled() ) {
+			return;
+		}
+
 		$this->flush_cached_patterns();
 
 		$patterns = $this->ptk_client->fetch_patterns(

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Patterns.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Patterns.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Patterns\PTKPatternsStore;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Exception;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Patterns class.
+ */
+class Patterns extends AbstractRoute {
+	/**
+	 * The route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'patterns';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'patterns';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return self::get_path_regex();
+	}
+
+	/**
+	 * Get the path of this rest route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/patterns';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
+			],
+			'schema' => [ $this->schema, 'get_public_item_schema' ],
+		];
+	}
+
+	/**
+	 * Fetch the patterns from the PTK and update the transient.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response
+	 * @throws Exception If the patterns cannot be fetched.
+	 */
+	protected function get_route_post_response( WP_REST_Request $request ) {
+		$ptk_patterns_store = Package::container()->get( PTKPatternsStore::class );
+
+		$ptk_patterns_store->fetch_patterns();
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Patterns.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Patterns.php
@@ -90,7 +90,10 @@ class Patterns extends AbstractRoute {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			throw new RouteException( $response->get_error_message(), $response->get_error_code() );
+			throw new RouteException(
+				wp_kses( $response->get_error_message(), array() ),
+				wp_kses( $response->get_error_code(), array() )
+			);
 		}
 
 		return rest_ensure_response(

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -75,6 +75,7 @@ class RoutesController {
 				Routes\V1\AI\Products::IDENTIFIER   => Routes\V1\AI\Products::class,
 				Routes\V1\AI\BusinessDescription::IDENTIFIER => Routes\V1\AI\BusinessDescription::class,
 				Routes\V1\AI\StoreInfo::IDENTIFIER  => Routes\V1\AI\StoreInfo::class,
+				Routes\V1\Patterns::IDENTIFIER      => Routes\V1\Patterns::class,
 			],
 		];
 	}

--- a/plugins/woocommerce/src/StoreApi/SchemaController.php
+++ b/plugins/woocommerce/src/StoreApi/SchemaController.php
@@ -61,6 +61,7 @@ class SchemaController {
 				Schemas\V1\AI\ProductsSchema::IDENTIFIER   => Schemas\V1\AI\ProductsSchema::class,
 				Schemas\V1\AI\BusinessDescriptionSchema::IDENTIFIER => Schemas\V1\AI\BusinessDescriptionSchema::class,
 				Schemas\V1\AI\StoreInfoSchema::IDENTIFIER  => Schemas\V1\AI\StoreInfoSchema::class,
+				Schemas\V1\PatternsSchema::IDENTIFIER      => Schemas\V1\PatternsSchema::class,
 			],
 		];
 	}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/PatternsSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/PatternsSchema.php
@@ -1,0 +1,43 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+/**
+ * OrderSchema class.
+ */
+class PatternsSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'patterns';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'patterns';
+
+	/**
+	 * Patterns schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [];
+	}
+
+	/**
+	 * Get the Patterns response.
+	 *
+	 * @param array $item Item to get response for.
+	 *
+	 * @return array
+	 */
+	public function get_item_response( $item ) {
+		return [
+			'success' => true,
+		];
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
@@ -132,6 +132,7 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 	 * Test fetch patterns should not set the patterns cache when fetching patterns fails.
 	 */
 	public function test_fetch_patterns_should_not_set_the_patterns_cache_when_fetching_patterns_fails() {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
 		$this->ptk_client
 			->expects( $this->once() )
 			->method( 'fetch_patterns' )
@@ -144,9 +145,10 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test fetch patterns should set the patterns cache after fetching patterns.
+	 * Test fetch patterns should set the patterns cache after fetching patterns if tracking is allowed.
 	 */
 	public function test_fetch_patterns_should_set_the_patterns_cache_after_fetching_patterns() {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
 		$expected_patterns = array(
 			array(
 				'title' => 'My pattern',
@@ -168,6 +170,7 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 	 * Test fetch_patterns should filter out the excluded patterns.
 	 */
 	public function test_fetch_patterns_should_filter_out_the_excluded_patterns() {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
 		$expected_patterns = array(
 			array(
 				'title' => 'My pattern',

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Patterns.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Patterns.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Blocks\Patterns\PTKPatternsStore;
+
+/**
+ * Patterns Controller Tests.
+ */
+class Patterns extends ControllerTestCase {
+	/**
+	 * Set up user for tests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$user = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user );
+	}
+
+	/**
+	 * Test the post endpoint when tracking is not allowed.
+	 *
+	 * @return void
+	 */
+	public function test_post_endpoint_when_tracking_is_not_allowed() {
+		update_option( 'woocommerce_allow_tracking', 'no' );
+
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'POST', '/wc/private/patterns' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( true, $data['success'] );
+
+		$patterns = get_transient( PTKPatternsStore::TRANSIENT_NAME );
+		$this->assertFalse( $patterns );
+	}
+
+	/**
+	 * Test the post endpoint when tracking is allowed.
+	 *
+	 * @return void
+	 */
+	public function test_post_endpoint_when_tracking_is_allowed() {
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'POST', '/wc/private/patterns' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( true, $data['success'] );
+
+		$patterns = get_transient( PTKPatternsStore::TRANSIENT_NAME );
+		$this->assertNotFalse( $patterns );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR shows a message on the assembler homepage section depending on the allow tracking option status.
It also adds a new private endpoint `wp-json/wc/private/patterns` that is used from the assembler state machine to trigger a fetch of patterns from the PTK API when the user opts-in on tracking.

Closes #47395 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and make sure `Allow usage of WooCommerce to be tracked` is **unchecked**.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to `Tools > WCA Test Helper > Features`.
4. Make sure you see the `pattern-toolkit-full-composability` on the list and enable it.
5. Head over to `WooCommerce > Home > Customize your store`.
6. Click on `Design your homepage`.
7. Scroll to the bottom of the sidebar and make sure you see:
<img width="260" alt="Screenshot 2024-06-04 at 11 45 53" src="https://github.com/woocommerce/woocommerce/assets/186112/dc2d1da6-f8e2-4cac-8ab0-cac91e8a78ba">

8. Open the Chrome developer tools and on `Network` select `Offline`.
9. Make sure you now see:
<img width="291" alt="Screenshot 2024-06-04 at 11 49 23" src="https://github.com/woocommerce/woocommerce/assets/186112/c01c25e9-7f40-468a-8191-2b0372e205c8">

10. On the list of request search for `wp-json/wc/private/patterns?_locale=user`, right-click on it, and select `Block request URL`.
11. Refresh the page and make sure you now see:
<img width="287" alt="Screenshot 2024-06-04 at 11 52 18" src="https://github.com/woocommerce/woocommerce/assets/186112/cec4810c-e010-4124-8662-475a3e1ddb52">

12. Unblock the request and refresh the page.
13. Scroll down and click on `usage tracking`, then `Opt-in`.
14. Wait for the process to return to the assembler, and click on `Design your homepage`.
15. Scroll to the bottom and make sure you don't see any of the messages above anymore.
16. Exit the assembler and create a new post or page.
17. Make sure you can insert the `Services: Three column pricing table` pattern..

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
[CYS] Show a message when tracking is not allowed in patterns and add the ability for users to opt-in and fetch patterns.

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
