### PR TITLE
Fix WooPayments incentives allowed promo notes logic

### DIFF
--- a/plugins/woocommerce/changelog/fix-48102-wcpay-incentive-promo-notes
+++ b/plugins/woocommerce/changelog/fix-48102-wcpay-incentive-promo-notes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: We fix the WCPay incentives promo notes logic to avoid needless friction in the merchant UX.
+
+

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -52,11 +52,13 @@ class WcPayWelcomePage {
 	/**
 	 * Whether the WooPayments welcome page should be visible.
 	 *
+	 * @param bool $skip_wcpay_active Whether to skip the check for the WooPayments plugin being active.
+	 *
 	 * @return boolean
 	 */
-	public function must_be_visible(): bool {
+	public function must_be_visible( $skip_wcpay_active = false ): bool {
 		// The WooPayments plugin must not be active.
-		if ( $this->is_wcpay_active() ) {
+		if ( ! $skip_wcpay_active && $this->is_wcpay_active() ) {
 			return false;
 		}
 
@@ -174,18 +176,20 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Adds allowed promo notes from the WooPayments incentive.
+	 * Adds allowed promo notes for the WooPayments incentives.
 	 *
 	 * @param array $promo_notes Allowed promo notes.
 	 * @return array
 	 */
 	public function allowed_promo_notes( $promo_notes = [] ): array {
-		// Return early if the incentive must not be visible.
-		if ( ! $this->must_be_visible() ) {
+		// Note: We need to disregard if WooPayments is active when adding the promo note to the list of
+		// allowed promo notes. The AJAX call that adds the promo note happens after WooPayments is installed and activated.
+		// Return early if the incentive page must not be visible, without checking if WooPayments is active.
+		if ( ! $this->must_be_visible( true ) ) {
 			return $promo_notes;
 		}
 
-		// Add our incentive ID to the promo notes.
+		// Add our incentive ID to the allowed promo notes so it can be added to the store.
 		$promo_notes[] = $this->get_incentive()['id'];
 
 		return $promo_notes;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We add the active WooPayments incentive ID to the list of allowed promo notes, regardless if WooPayments is active or not, because the AJAX call to add the promo note happens _after_ the calls to install and/or activate WooPayments.

Because of the performance enhancements we made in https://github.com/woocommerce/woocommerce/pull/41466, this is safe to do.

Closes #48102 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JurassicNinja WP site with just WooCommerce using this PR's live branch (or use your preferred way to spin up a fresh Woo store with this PR's branch changes) - here is [a JN link for ease of use](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce=fix/48102-wcpay-incentive-promo-notes)
2. Once in the WP admin, skip the WooCommerce profiler and set your store's country to US.
3. Once in the WP admin, you should see a "Payments" menu item with a red notice badge.
4. Click on the "Payments" menu item and you should see a page looking like this:
![QO5Pnl.png](https://github.com/Automattic/woocommerce-payments-server/assets/8830539/13a4926a-e7a2-4247-9018-32cd81afc4ee)
5. Click on "Install WooPayments for free".
6. The button should switch to a progress animation and, after a couple of seconds, you should be redirected to the WooPayments WPCOM connection setup and then to the WooPayments onboarding wizard. If your store already has a WPCOM connection, you will be taken directly to the WooPayments onboarding wizard.

Here is a recording of the flow:

https://github.com/woocommerce/woocommerce/assets/8830539/917fb81e-05aa-443c-99fa-6cfbe9fc46a0


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>