### PR TITLE
Fix missing "discover more" url in LYS tour

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/tour/index.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/tour/index.tsx
@@ -64,8 +64,14 @@ export const SiteVisibilityTour = ( { onClose }: { onClose: () => void } ) => {
 										'woocommerce'
 									),
 									{
-										// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
-										link: <a href="#" target="_blank" />,
+										link: (
+											// eslint-disable-next-line jsx-a11y/anchor-has-content
+											<a
+												href="https://woocommerce.com/document/configuring-woocommerce-settings/coming-soon-mode/"
+												target="_blank"
+												rel="noreferrer"
+											/>
+										),
 									}
 								),
 							},

--- a/plugins/woocommerce/changelog/fix-lys-add-discover-more-url
+++ b/plugins/woocommerce/changelog/fix-lys-add-discover-more-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add missing URL to discover more link in LYS tour


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses p1717409641645239/1717409221.031479-slack-C06DJHTE04U

Originally reported by @jamesckemp, we've missed adding URL in the link for "Discover more" in tour.

![image](https://github.com/woocommerce/woocommerce/assets/3747241/e4c7a64c-a717-4560-9a9e-de78bb2b2e50)

### How to test the changes in this Pull Request:

#### Test with WordPress Playground:

1. Create WordPress using [this blueprint](https://playground.wordpress.net/builder/builder.html#{%22landingPage%22:%22/wp-admin/admin.php?page=wc-admin%22,%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%22latest%22},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://downloads.wordpress.org/plugin/woocommerce.8.9.1.zip%22},%22options%22:{%22activate%22:true}},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/https://github.com/woocommerce/wc-smooth-generator/releases/download/1.1.0/wc-smooth-generator.zip%22},%22options%22:{%22activate%22:true}},{%22step%22:%22setSiteOptions%22,%22options%22:{%22woocommerce_onboarding_profile%22:{%22skipped%22:true}}},{%22step%22:%22wp-cli%22,%22command%22:%22wp%20wc%20generate%20orders%203%20--status=completed%22},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-2.3.1/woocommerce-beta-tester.zip%22},%22options%22:{%22activate%22:true}},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22url%22,%22url%22:%22https://playground.wordpress.net/plugin-proxy.php?org=woocommerce&repo=woocommerce&workflow=Build%20Live%20Branch&artifact=plugins-9351046469&pr=48109%22},%22options%22:{%22activate%22:true}},{%22step%22:%22wp-cli%22,%22command%22:%22wp%20wc%20update%22},{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22}],%22plugins%22:[]})
2. Observe coming soon tour is shown
3. Click on `Discover more`
4. Observe a new tab is opened with `https://woocommerce.com/document/configuring-woocommerce-settings/coming-soon-mode/`

#### (Alternative) Test without WordPress Playground:

1. Create a new JN site without WooCommerce.
2. Download the latest 8.6.x version [here](https://downloads.wordpress.org/plugin/woocommerce.8.6.1.zip)
3. Upload the zip file and activate it.
5. Checkout this branch locally and build a new zip file in `plugins/woocommerce` directory with `pnpm run build:zip` command
6. Upload the zip file and replace the current version with it.
7. A database update notice should show up. Click on update.
8. SSH into the server and run `wp option get woocommerce_show_lys_tour`
9. Confirm the option exists.
10. Go to `WooCommerce -> Home`
11. Confirm the tour shows up.
3. Click on `Discover more`
4. Observe a new tab is opened with `https://woocommerce.com/document/configuring-woocommerce-settings/coming-soon-mode/`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>