### PR TITLE
WooCommerce: collect taxonomies before to record the `product_add_publish` event

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-fix-tracking-taxonomies
+++ b/plugins/woocommerce/changelog/update-woocommerce-fix-tracking-taxonomies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooCommerce: collect taxonomies before to record the `product_add_publish` event


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR ensures that product terms (attributes, category_ids, and tag_ids) are correctly collected and processed after they have been fully updated. The following changes have been made:

* Term Collection: Added a function to collect terms during the set_object_terms hook.
* Term Processing: Moved the term processing logic to the `shutdown` hook to ensure it occurs after all term updates are completed.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48094

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Follow the instructions described in #48094

1. Enable the new product editor
2. Create a new product
3. Edit the product data
4. Assign categories, tags, and or attributes 
5. Save the product, always keeping the draft state
6. Edit other product attributes.
7. Confirm there is not a new `wcadmin_product_add_publish` event in the events `Tracks` event for this product yet.
(`/wp-admin/admin.php?page=wc-status&tab=logs`)
8. Publish the product
9. Confirm now there is a new `wcadmin_product_add_publish` for your current product
10. Confirm the attributes, categories, and tag numbers are correct in the event data

<img src="https://github.com/woocommerce/woocommerce/assets/77539/26fe5fae-b73c-4584-a5e6-0ae559e94a5a" width="600px" />

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
