### PR TITLE
CYS: Ensure that toolbar appears only when the homepage sidebar is open

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @woocommerce/dependency-group */
 /**
  * External dependencies
  */
@@ -17,12 +18,11 @@ import {
 /**
  * Internal dependencies
  */
+import { useQuery } from '@woocommerce/navigation';
 import Shuffle from './shuffle';
 import './style.scss';
 
-const isHomepageUrl = ( url: string ) => {
-	const path = new URLSearchParams( url ).get( 'path' );
-
+const isHomepageUrl = ( path: string ) => {
 	return path === '/customize-store/assembler-hub/homepage';
 };
 
@@ -85,34 +85,13 @@ export const Toolbar = () => {
 		);
 	}, [ allBlocks ] );
 
+	const query = useQuery();
+
 	useEffect( () => {
-		const initialUrl = window.parent.location.href;
+		const path = query.path;
 
-		setIsHomepageSidebarOpen( isHomepageUrl( initialUrl ) );
-
-		const navigateHandler = ( event: {
-			destination: {
-				url: string;
-			};
-		} ) => {
-			setIsHomepageSidebarOpen( isHomepageUrl( event.destination.url ) );
-		};
-
-		// @ts-expect-error missing type
-		window.parent.navigation.addEventListener(
-			'navigate',
-			navigateHandler
-		);
-
-		return () => {
-			// @ts-expect-error missing type
-			window.parent.navigation.removeEventListener(
-				'navigate',
-				navigateHandler
-			);
-		};
-	}, [] );
-
+		setIsHomepageSidebarOpen( isHomepageUrl( path ) );
+	}, [ query ] );
 	const { isPreviousBlockTemplatePart, isNextBlockTemplatePart } =
 		useMemo( () => {
 			return {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
@@ -2,32 +2,44 @@
  * External dependencies
  */
 
-import { useSelect } from '@wordpress/data';
 import { BlockInstance } from '@wordpress/blocks';
 import { ToolbarGroup, Toolbar as WPToolbar } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useMemo, useState } from '@wordpress/element';
+
 import {
 	BlockMover,
 	BlockPopover,
 	store as blockEditorStore,
-	// @ts-expect-error No types for this exist yet.
+	// @ts-expect-error missing type
 } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import './style.scss';
 import Shuffle from './shuffle';
+import './style.scss';
+
+const isHomepageUrl = ( url: string ) => {
+	const path = new URLSearchParams( url ).get( 'path' );
+
+	return path === '/customize-store/assembler-hub/homepage';
+};
 
 export const Toolbar = () => {
+	const [ isHomepageSidebarOpen, setIsHomepageSidebarOpen ] =
+		useState( false );
+
 	const {
 		currentBlock,
 		nextBlock,
 		previousBlock,
+		allBlocks,
 	}: {
 		currentBlock: BlockInstance | undefined;
 		nextBlock: BlockInstance | undefined;
 		previousBlock: BlockInstance | undefined;
+		allBlocks: BlockInstance[];
 	} = useSelect( ( select ) => {
 		const selectedBlockId =
 			// @ts-expect-error missing type
@@ -54,10 +66,50 @@ export const Toolbar = () => {
 			// @ts-expect-error missing type
 		).getBlocksByClientId( [ previousBlockClientId ] );
 
+		const blocks = select(
+			blockEditorStore
+			// @ts-expect-error missing type
+		).getBlocks();
+
 		return {
 			currentBlock: current,
 			nextBlock: next,
 			previousBlock: previous,
+			allBlocks: blocks,
+		};
+	}, [] );
+
+	const firstBlock = useMemo( () => {
+		return allBlocks.find(
+			( block: BlockInstance ) => block.name !== 'core/template-part'
+		);
+	}, [ allBlocks ] );
+
+	useEffect( () => {
+		const initialUrl = window.parent.location.href;
+
+		setIsHomepageSidebarOpen( isHomepageUrl( initialUrl ) );
+
+		const navigateHandler = ( event: {
+			destination: {
+				url: string;
+			};
+		} ) => {
+			setIsHomepageSidebarOpen( isHomepageUrl( event.destination.url ) );
+		};
+
+		// @ts-expect-error missing type
+		window.parent.navigation.addEventListener(
+			'navigate',
+			navigateHandler
+		);
+
+		return () => {
+			// @ts-expect-error missing type
+			window.parent.navigation.removeEventListener(
+				'navigate',
+				navigateHandler
+			);
 		};
 	}, [] );
 
@@ -71,14 +123,21 @@ export const Toolbar = () => {
 			};
 		}, [ nextBlock?.name, previousBlock?.name ] );
 
+	const selectedBlockClientId =
+		currentBlock?.clientId ?? firstBlock?.clientId;
+
+	if ( ! isHomepageSidebarOpen || ! selectedBlockClientId ) {
+		return null;
+	}
+
 	return (
-		<BlockPopover clientId={ currentBlock?.clientId }>
+		<BlockPopover clientId={ selectedBlockClientId }>
 			<div className="woocommerce-customize-store-block-toolbar">
 				<WPToolbar label="Options">
 					<>
 						<ToolbarGroup>
 							<BlockMover
-								clientIds={ [ currentBlock?.clientId ] }
+								clientIds={ [ selectedBlockClientId ] }
 								isBlockMoverUpButtonDisabled={
 									isPreviousBlockTemplatePart
 								}
@@ -88,7 +147,7 @@ export const Toolbar = () => {
 							/>
 						</ToolbarGroup>
 						{ currentBlock && (
-							<Shuffle clientId={ currentBlock?.clientId } />
+							<Shuffle clientId={ selectedBlockClientId } />
 						) }
 					</>
 				</WPToolbar>

--- a/plugins/woocommerce/changelog/48115-47751-cys-full-composability-ensure-that-the-block-toolbar-is-rendered-only-when-the-homepage-sidebar-is-open
+++ b/plugins/woocommerce/changelog/48115-47751-cys-full-composability-ensure-that-the-block-toolbar-is-rendered-only-when-the-homepage-sidebar-is-open
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+CYS: Ensure that toolbar appears only when the homepage sidebar is open  </details>  <details>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47751.

This PR ensures that the toolbar appears only when the homepage sidebar is open.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled
2. Make sure you have the WooCommerce beta tester plugin installed
3. Head over to Tools > WCA Test Helper > Features
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on blocks.
8. Ensure that no block toolbar appears
9. On the sidebar, click on "Design your homepage"
10. Ensure that the Block Toolbar appears. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS: Ensure that toolbar appears only when the homepage sidebar is open

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
