### PR TITLE
Add CLI tool to toggle HPOS compatibility mode

### DIFF
--- a/plugins/woocommerce/changelog/fix-47078
+++ b/plugins/woocommerce/changelog/fix-47078
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add CLI tools to enable and disable HPOS compatibility mode.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -76,8 +76,8 @@ class CLIRunner {
 		WP_CLI::add_command( 'wc hpos status', array( $this, 'status' ) );
 		WP_CLI::add_command( 'wc hpos diff', array( $this, 'diff' ) );
 		WP_CLI::add_command( 'wc hpos backfill', array( $this, 'backfill' ) );
-		WP_CLI::add_command( 'wc hpos compat-mode enable', array( $this, 'enable_compat_mode' ) );
-		WP_CLI::add_command( 'wc hpos compat-mode disable', array( $this, 'disable_compat_mode' ) );
+		WP_CLI::add_command( 'wc hpos compatibility-mode enable', array( $this, 'enable_compat_mode' ) );
+		WP_CLI::add_command( 'wc hpos compatibility-mode disable', array( $this, 'disable_compat_mode' ) );
 
 		WP_CLI::add_command( 'wc cot migrate', array( $this, 'migrate' ) ); // Fully deprecated. No longer works.
 	}

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1263,5 +1263,4 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			WP_CLI::success( __( 'Compatibility mode disabled.', 'woocommerce' ) );
 		}
 	}
-
 }

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -76,6 +76,8 @@ class CLIRunner {
 		WP_CLI::add_command( 'wc hpos status', array( $this, 'status' ) );
 		WP_CLI::add_command( 'wc hpos diff', array( $this, 'diff' ) );
 		WP_CLI::add_command( 'wc hpos backfill', array( $this, 'backfill' ) );
+		WP_CLI::add_command( 'wc hpos compat-mode enable', array( $this, 'enable_compat_mode' ) );
+		WP_CLI::add_command( 'wc hpos compat-mode disable', array( $this, 'disable_compat_mode' ) );
 
 		WP_CLI::add_command( 'wc cot migrate', array( $this, 'migrate' ) ); // Fully deprecated. No longer works.
 	}
@@ -803,12 +805,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 		}
 
 		if ( $assoc_args['with-sync'] && $table_exists ) {
-			if ( $data_synchronizer->data_sync_is_enabled() ) {
-				WP_CLI::warning( __( 'Sync is already enabled.', 'woocommerce' ) );
-			} else {
-				$feature_controller->change_feature_enable( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, true );
-				WP_CLI::success( __( 'Sync enabled.', 'woocommerce' ) );
-			}
+			$this->toggle_compat_mode( true );
 		}
 
 		if ( ! $enable_hpos ) {
@@ -889,15 +886,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 		}
 
 		if ( $assoc_args['with-sync'] ) {
-			if ( ! $data_synchronizer->data_sync_is_enabled() ) {
-				return WP_CLI::warning( __( 'Sync is already disabled.', 'woocommerce' ) );
-			}
-			$feature_controller->change_feature_enable( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, false );
-			if ( $data_synchronizer->data_sync_is_enabled() ) {
-				return WP_CLI::warning( __( 'Sync could not be disabled.', 'woocommerce' ) );
-			} else {
-				WP_CLI::success( __( 'Sync disabled.', 'woocommerce' ) );
-			}
+			$this->toggle_compat_mode( false );
 		}
 	}
 
@@ -1223,4 +1212,56 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			)
 		);
 	}
+
+	/**
+	 * Enables compatibility mode, which keeps the HPOS and posts datastore in sync.
+	 *
+	 * @since 9.1.0
+	 */
+	public function enable_compat_mode(): void {
+		$this->toggle_compat_mode( true );
+	}
+
+	/**
+	 * Disables compatibility mode, which keeps the HPOS and posts datastore in sync.
+	 *
+	 * @since 9.1.0
+	 */
+	public function disable_compat_mode(): void {
+		$this->toggle_compat_mode( false );
+	}
+
+	/**
+	 * Toggles compatibility mode on or off.
+	 *
+	 * @since 9.1.0
+	 *
+	 * @param bool $enabled TRUE to enable compatibility mode, FALSE to disable.
+	 */
+	private function toggle_compat_mode( bool $enabled ): void {
+		if ( ! $this->synchronizer->check_orders_table_exists() ) {
+			WP_CLI::error( __( 'HPOS tables do not exist.', 'woocommerce' ) );
+		}
+
+		$currently_enabled = $this->synchronizer->data_sync_is_enabled();
+
+		if ( $currently_enabled === $enabled ) {
+			if ( $enabled ) {
+				WP_CLI::warning( __( 'Compatibility mode is already enabled.', 'woocommerce' ) );
+			} else {
+				WP_CLI::warning( __( 'Compatibility mode is already disabled.', 'woocommerce' ) );
+			}
+
+			return;
+		}
+
+		update_option( $this->synchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, wc_bool_to_string( $enabled ) );
+
+		if ( $enabled ) {
+			WP_CLI::success( __( 'Compatibility mode enabled.', 'woocommerce' ) );
+		} else {
+			WP_CLI::success( __( 'Compatibility mode disabled.', 'woocommerce' ) );
+		}
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR introduces CLI commands `wc hpos compatibility-mode enable` and `wc hpos compatibility-mode disable` which enable and disable the HPOS compatibility mode (respectively).

It also fixes an issue where using `--with-sync` in either `wc hpos enable` or `wc hpos disable` wouldn't actually do anything.

Closes #47078.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Settings > Advanced > Features and confirm that compatibility mode is disabled. Update settings as necessary.
1. Run `wp wc hpos sync` in the CLI to sync all orders so that the baseline for this test is everything synced up.
1. Run `wc hpos compatibility-mode enable` in the CLI and confirm that compatibility mode has been enabled in WC > Settings > Advanced > Features > Order data storage.
1. Run `wc hpos compatibility-mode disable` in the CLI and confirm that compatibility mode has been disabled in WC > Settings > Advanced > Features > Order data storage.
1. Run `wc hpos enable --with-sync` in the CLI and confirm that compatibility mode and 
HPOS are enabled in WC > Settings > Advanced > Features > Order data storage.
1. Run `wc hpos disable --with-sync` in the CLI and confirm that compatibility mode is disabled and "WordPress posts storage" is chosen in WC > Settings > Advanced > Features > Order data storage.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
