### PR TITLE
Remove the potential for product attribute updates to unintentionally reset

### DIFF
--- a/plugins/woocommerce/changelog/fix-30659-rest-api-attribute-updates
+++ b/plugins/woocommerce/changelog/fix-30659-rest-api-attribute-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When a product attribute is updated, unchanged values should not be reset to their defaults.

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -633,6 +633,16 @@ function wc_update_attribute( $id, $args ) {
 
 	$args['id'] = $attribute ? $attribute->id : 0;
 
+	// When updating an existing attribute, populate any undefined args with the existing value.
+	// This prevents those values from being reset to their respective defaults.
+	if ( $args['id'] ) {
+		$args['has_archives'] = $args['has_archives'] ?? $attribute->has_archives;
+		$args['name']         = $args['name'] ?? $attribute->name;
+		$args['order_by']     = $args['order_by'] ?? $attribute->order_by;
+		$args['slug']         = $args['slug'] ?? $attribute->slug;
+		$args['type']         = $args['type'] ?? $attribute->type;
+	}
+
 	if ( $args['id'] && empty( $args['name'] ) ) {
 		$args['name'] = $attribute->name;
 	}

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -167,6 +167,54 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 		}
 	}
 
+	/**
+	 * Describes the behavior of the wc_update_attribute() function.
+	 *
+	 * @return void
+	 */
+	public function test_wc_update_attribute(): void {
+		$attribute_id = wc_create_attribute(
+			array(
+				'name'         => 'Whipuptitude',
+				'order_by'     => 'name_num',
+				'has_archives' => true,
+			)
+		);
+
+		$this->assertIsInt( $attribute_id, 'New product attribute was successfully created.' );
+
+		$update = wc_update_attribute(
+			$attribute_id,
+			array(
+				'name' => 'Assemblebility',
+			)
+		);
+
+		// Grab the updated attribute.
+		$attribute = wc_get_attribute( $attribute_id );
+
+		// If we change the title, then only the title is changed. Other properties remain unmodified.
+		$this->assertIsInt( $update, 'The product attribute was successfully updated.' );
+		$this->assertEquals( 'Assemblebility', $attribute->name, 'The product attribute name was updated.' );
+		$this->assertEquals( 'name_num', $attribute->order_by, 'The "order_by" property remained unchanged.' );
+		$this->assertTrue( $attribute->has_archives, 'The "has_archives" property remained unchanged.' );
+
+		$update = wc_update_attribute(
+			$attribute_id,
+			array(
+				'name'     => 'Ready-to-go-ness',
+				'order_by' => 'invalid_value',
+			)
+		);
+
+		// Grab the updated attribute.
+		$attribute = wc_get_attribute( $attribute_id );
+
+		$this->assertIsInt( $update, 'The product attribute was successfully updated, even if some non-essential parameters were invalid.' );
+		$this->assertEquals( 'Ready-to-go-ness', $attribute->name, 'The product attribute name was updated.' );
+		$this->assertEquals( 'menu_order', $attribute->order_by, 'Any invalid property changes will be reset to their defaults.' );
+	}
+
 	public function get_attribute_names_and_slugs() {
 		return [
 			[ 'Dash Me', 'dash-me' ],


### PR DESCRIPTION
If you take an existing product attribute and try to change one of its properties *without also specifying all of the other property values,* then some of those other properties could be reset to their defaults. For example, consider this existing attribute (simplified just a little):

```json
{
	"id":       100,
	"name":     "Shoo width",
	"order_by": "name_num"    # ← Take note!
}
```

Updating it to correct the name (let's say, to `Shoe width`), and *only* passing the updated name, would cause other properties like `menu_order` to unexpectedly reset to their defaults. We'd end up with:

```json
{
	"id":       100,
	"name":     "Shoe width",  # ← Expected/successful change
	"order_by": "menu_order"   # ← Unexpected!
}
```

Though the linked issue frames this in the context of REST API requests, it's also true at the programmatic level, which is where the fix is applied. However, I'll still write the manual testing instructions in a way that shows the fix working at REST API-level.

Closes #30659.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product attribute, or edit an existing one, and set the default ordering to `Name (numeric)`. For convenience, you may wish to do this via the admin UI:

![edit-attr-name-num](https://github.com/woocommerce/woocommerce/assets/3594411/b3a08f18-65a0-419d-9a39-c5ca5b84a98e)

2. Via the REST API, try changing the attribute name. The endpoint to use here is `PATCH /wp-json/wc/v3/products/attributes/<ATTRIBUTE_ID>`. Your payload should look something like this (we are only specifying the new name):

```json
{
  "name": "My new name"
}
```

3. Inspect the response:
    - Without this branch, you should see the problem (`order_by` will have changed back to `menu_order`).
    - With this branch, you should see that fields like `order_by` stay at their expected value (in this case, `name_num`).
    - It probably goes without saying ... but if you do switch between branches when testing, remember to reset the ordering field each time 🙃 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
