### PR TITLE
Fix an e2e test that was merged incorrectly in #47526

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { test, expect } from '@woocommerce/e2e-utils';
 
 const filterBlocks = [
 	{

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
 
 const filterBlocks = [
 	{
@@ -32,39 +32,23 @@ const filterBlocks = [
 ];
 
 test.describe( 'Filter blocks registration', () => {
-	test.beforeEach( async ( { admin, requestUtils } ) => {
-		await requestUtils.activatePlugin(
-			'woocommerce-blocks-test-enable-experimental-features'
-		);
+	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
 
-	test( 'Variations can be inserted through the inserter.', async ( {
+	test( 'Variations cannot be inserted through the inserter.', async ( {
 		page,
-		editor,
+		editorUtils,
 	} ) => {
 		for ( const block of filterBlocks ) {
-			await editor.insertBlockUsingGlobalInserter( block.title );
+			await editorUtils.openGlobalBlockInserter();
+			await page.getByPlaceholder( 'Search' ).fill( block.title );
+			const filterBlock = page.getByRole( 'option', {
+				name: block.title,
+				exact: true,
+			} );
 
-			await expect(
-				page.getByLabel( `Block: ${ block.title }` )
-			).toBeVisible();
-		}
-	} );
-
-	test( 'Each filter block comes with a default title', async ( {
-		editor,
-		page,
-	} ) => {
-		for ( const block of filterBlocks ) {
-			await editor.insertBlockUsingGlobalInserter( block.title );
-
-			await expect(
-				page
-					.getByLabel( `Block: Product Filter` )
-					.getByLabel( 'Block: Heading' )
-					.and( page.getByText( block.heading ) )
-			).toBeVisible();
+			await expect( filterBlock ).toBeHidden();
 		}
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/basic.block_theme.spec.ts
@@ -38,10 +38,10 @@ test.describe( 'Filter blocks registration', () => {
 
 	test( 'Variations cannot be inserted through the inserter.', async ( {
 		page,
-		editorUtils,
+		editor,
 	} ) => {
 		for ( const block of filterBlocks ) {
-			await editorUtils.openGlobalBlockInserter();
+			await editor.openGlobalBlockInserter();
 			await page.getByPlaceholder( 'Search' ).fill( block.title );
 			const filterBlock = page.getByRole( 'option', {
 				name: block.title,

--- a/plugins/woocommerce/changelog/48122-dev-fix-e2e-test
+++ b/plugins/woocommerce/changelog/48122-dev-fix-e2e-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix a filters block e2e test that was mistakenly merged incorrectly.  </details>  <details>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/47526 the file conflicts were accidentally merged the wrong way, undoing @thealexandrelara 's adjustments to the e2e tests because filter blocks are no longer visible in the inserter. This fixes that merge issue to allow Blocks PlayWright tests to pass.

You can see the original commit here: https://github.com/woocommerce/woocommerce/pull/47526/commits/969697625bf599dd84d3607e8a7d9f5ec50608ed

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

See the CI pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix a filters block e2e test that was mistakenly merged incorrectly.

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
