### PR TITLE
scroll to view the templates section on the status page.

### DIFF
--- a/plugins/woocommerce/changelog/pr-48125
+++ b/plugins/woocommerce/changelog/pr-48125
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Scroll to view the templates section on the status page when clicking View affected templates
+Scroll to view the templates section on the status page

--- a/plugins/woocommerce/changelog/pr-48125
+++ b/plugins/woocommerce/changelog/pr-48125
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Scroll to view the templates section on the status page when clicking View affected templates

--- a/plugins/woocommerce/changelog/pr-48125
+++ b/plugins/woocommerce/changelog/pr-48125
@@ -1,4 +1,4 @@
 Significance: patch
-Type: update
+Type: fix
 
 Scroll to view the templates section on the status page

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8712,3 +8712,7 @@ table.bar_chart {
 		}
 	}
 }
+
+html:has(#status-table-templates){
+	scroll-padding-top: 80px;
+}

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -969,7 +969,7 @@ if ( 0 < $mu_plugins_count ) :
 		</tr>
 	</tbody>
 </table>
-<table class="wc_status_table widefat" cellspacing="0">
+<table class="wc_status_table widefat" id="status-table-templates" cellspacing="0">
 	<thead>
 		<tr>
 			<th colspan="3" data-export-label="Templates"><h2><?php esc_html_e( 'Templates', 'woocommerce' ); ?><?php echo wc_help_tip( esc_html__( 'This section shows any files that are overriding the default WooCommerce template pages.', 'woocommerce' ) ); ?></h2></th>

--- a/plugins/woocommerce/includes/admin/views/html-notice-template-check.php
+++ b/plugins/woocommerce/includes/admin/views/html-notice-template-check.php
@@ -24,6 +24,6 @@ $theme = wp_get_theme();
 	</p>
 	<p class="submit">
 		<a class="button-primary" href="https://woocommerce.com/document/template-structure/" target="_blank"><?php esc_html_e( 'Learn more about templates', 'woocommerce' ); ?></a>
-		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>" target="_blank"><?php esc_html_e( 'View affected templates', 'woocommerce' ); ?></a>
+		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status#status-table-templates' ) ); ?>" target="_blank"><?php esc_html_e( 'View affected templates', 'woocommerce' ); ?></a>
 	</p>
 </div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47142 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Use a theme with outdated WooCommerce templates (like [picostrap](https://picostrap.com/))
2. In the wp-admin Dashboard an alert message and a button is shown to help the user: "View affected templates".

![image](https://github.com/woocommerce/woocommerce/assets/937723/5a5c2cf6-f64a-4da3-987d-9c4702d718cb)

3. Clicking this button brings to the WooCommerce Status view and scrolls to the right section.

![image](https://github.com/woocommerce/woocommerce/assets/937723/b249501d-0741-4155-8844-6330b5092493)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Added an ID to the Templates on the status page. Appended the ID to the link **View affected templates** button so that it scrolls to the appropriate section when the status page is opened.

</details>
