### PR TITLE
Optimize text wrapping prevent orphans

### DIFF
--- a/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
+++ b/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
@@ -4,12 +4,12 @@
 	--large-gap: 40px;
 	--main-gap: 24px;
 }
-@media ( max-width: 960px ) {
+@media (max-width: 960px) {
 	:root {
 		--large-gap: 24px;
 	}
 }
-@media ( max-width: 782px ) {
+@media (max-width: 782px) {
 	:root {
 		--large-gap: 16px;
 		--main-gap: 16px;
@@ -60,6 +60,25 @@
 }
 
 body.woocommerce-admin-page {
+	// Prevent orphans
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	caption,
+	figcaption {
+		text-wrap: balance;
+	}
+
+	p,
+	ul,
+	ol,
+	blockquote {
+		text-wrap: pretty;
+	}
+
 	.components-button.is-primary {
 		&:not(:disabled):not([aria-disabled="true"]):hover {
 			color: $studio-white;

--- a/plugins/woocommerce/changelog/enhance-optimize-text-wrapping-prevent-orphans
+++ b/plugins/woocommerce/changelog/enhance-optimize-text-wrapping-prevent-orphans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Optimize text wrapping for wc admin pages


### PR DESCRIPTION

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Optimize text wrapping for wc admin pages to prevent widows and orphans.

I noticed that when using other languages such as Spanish, the text wrapping was not optimal and it was causing widows and orphans. I think the best way to fix this is to add some global CSS to prevent this from happening.

These CSS has been used in WordPress.com (p7H4VZ-4Hm-p2#comment-11820 ) and [WP Core](https://github.com/WordPress/wordpress.org/blob/e5c90eb041694162fba3492832baa7ca528dd6dc/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/styles/base/_headings.scss#L7-L26), and it has been working well so I think it's a good idea to add it to WooCommerce.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Go to /wp-admin/options-general.php
3. Choose `Español` as the site language
4. Go to `/wp-admin/update-core.php` and update the language pack
5. Go to WooCommerce onboarding wizard
6. Observe the text wrapping properly

Before:

![Screenshot 2024-06-04 at 14 42 26](https://github.com/woocommerce/woocommerce/assets/4344253/023bfad8-9db7-4533-89d7-4bb34ac59b74)

After:

![Screenshot 2024-06-04 at 16 15 05](https://github.com/woocommerce/woocommerce/assets/4344253/8f17f58d-9489-41d8-9ab8-965c8c5ad5b7)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>