### PR TITLE
FlexSlider: Trigger custom manual event

### DIFF
--- a/plugins/woocommerce/changelog/48137-fix-flexslider-gallery-thumbs-not-responding
+++ b/plugins/woocommerce/changelog/48137-fix-flexslider-gallery-thumbs-not-responding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix FlexSlider thumbnail animation for variable products with default form values on small devices.  </details>  <details>

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -65,8 +65,8 @@
 
     var namespace = slider.vars.namespace,
         touch = (( "ontouchstart" in window ) || window.DocumentTouch && document instanceof DocumentTouch) && slider.vars.touch,
-        // deprecating this idea, as devices are being released with both of these events
-        eventType = "click touchend keyup",
+        // we add a custom event so we can differentiate manually triggering events when needed.
+        eventType = "click touchend keyup flexslider-click",
         watchedEvent = "",
         watchedEventClearTimer,
         easing = easings[slider.vars.easing] || "ease",
@@ -289,7 +289,8 @@
 
           slider.controlNavScaffold.on(eventType, 'a, img', function(event) {
             event.preventDefault();
-            if (watchedEvent === "" || eventType.includes( watchedEvent ) ) {
+
+            if (watchedEvent === "" || watchedEvent === event.type) {
               var $this = $(this),
                   target = slider.controlNav.index($this);
 
@@ -300,7 +301,7 @@
             }
 
             // setup flags to prevent event duplication
-            if (watchedEvent === "") {
+            if (watchedEvent === "" && event.type !== "flexslider-click") {
               watchedEvent = event.type;
             }
             methods.setToClearWatchedEvent();
@@ -325,7 +326,7 @@
             }
 
             // setup flags to prevent event duplication
-            if (watchedEvent === "") {
+            if (watchedEvent === "" && event.type !== "flexslider-click") {
               watchedEvent = event.type;
             }
             methods.setToClearWatchedEvent();
@@ -378,7 +379,7 @@
             }
 
             // setup flags to prevent event duplication
-            if (watchedEvent === "") {
+            if (watchedEvent === "" && event.type !== "flexslider-click") {
               watchedEvent = event.type;
             }
             methods.setToClearWatchedEvent();
@@ -432,7 +433,7 @@
             }
 
             // setup flags to prevent event duplication
-            if (watchedEvent === "") {
+            if (watchedEvent === "" && event.type !== "flexslider-click") {
               watchedEvent = event.type;
             }
             methods.setToClearWatchedEvent();

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -289,8 +289,7 @@
 
           slider.controlNavScaffold.on(eventType, 'a, img', function(event) {
             event.preventDefault();
-
-            if (watchedEvent === "" || watchedEvent === event.type) {
+            if (watchedEvent === "" || eventType.includes( watchedEvent ) ) {
               var $this = $(this),
                   target = slider.controlNav.index($this);
 

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -668,7 +668,7 @@
 			var slideToImage = $gallery_nav.find( 'li img[src="' + variation.image.gallery_thumbnail_src + '"]' );
 
 			if ( slideToImage.length > 0 ) {
-				slideToImage.trigger( 'click' );
+				slideToImage.trigger( 'flexslider-click' );
 				$form.attr( 'current-image', variation.image_id );
 				window.setTimeout( function() {
 					$( window ).trigger( 'resize' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Create a custom event to differentiate between manually triggered events.

This code is pretty legacy and complex so there may be unintended side effects. Because of this I'd love extensive testing and a second opinion on this change.

Closes https://github.com/woocommerce/woocommerce/issues/27327

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**To reproduce bug**:

1. Ensure your product page is using the classic gallery.
2. Setup a variable product with default values. Using this attached test data ([sample_products.csv](https://github.com/user-attachments/files/15546320/sample_products.csv)) I updated the V-Neck T-Shirt product to have Default Form Values: Blue & Large.
3. Save product and go to the frontend on a mobile device.
4. Click one of the inactive thumbnails.
5. Nothing should happen

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**To test fix**:

1. Ensure your product page is using the classic gallery.
2. Setup a variable product with default values. Using this attached test data ([sample_products.csv](https://github.com/user-attachments/files/15546320/sample_products.csv)) I updated the V-Neck T-Shirt product to have Default Form Values: Blue & Large.
3. Save product and go to the frontend on a mobile device.
4. Try clicking other thumbnails. Attempt this multiple times after various refreshes to ensure its working as expected.
6. Try various regression tests with different products at different screen sizes to ensure no other bugs have been reintroduced.

![Screenshot 2024-06-04 at 11 01 33](https://github.com/woocommerce/woocommerce/assets/8639742/3b2b8e81-fa01-4624-a72b-b5eb39201555)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix FlexSlider thumbnail animation for variable products with default form values on small devices.

</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
