### PR TITLE
Only load 'productCount' and 'experimentalBlocksEnabled' settings in admin

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
@@ -11,11 +11,11 @@ export type WordCountType =
 
 export interface WcBlocksConfig {
 	pluginUrl: string;
-	productCount: number;
+	productCount?: number;
 	defaultAvatar: string;
 	restApiRoutes: Record< string, string[] >;
 	wordCountType: WordCountType;
-	experimentalBlocksEnabled: boolean;
+	experimentalBlocksEnabled?: boolean;
 }
 
 export const blocksConfig = getSetting( 'wcBlocksConfig', {

--- a/plugins/woocommerce/changelog/fix-46990-wcBlocksConfig-productCount
+++ b/plugins/woocommerce/changelog/fix-46990-wcBlocksConfig-productCount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Only load 'productCount' and 'experimentalBlocksEnabled' settings in admin

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -435,27 +435,35 @@ abstract class AbstractBlock {
 		}
 
 		if ( ! $this->asset_data_registry->exists( 'wcBlocksConfig' ) ) {
+			$wc_blocks_config = [
+				// Note that while we don't have a consolidated way of doing feature-flagging
+				// we are borrowing from the WC Admin Features implementation. Also note we cannot
+				// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
+				'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
+				'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
+				'restApiRoutes'             => [
+					'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
+				],
+				'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
+
+				/*
+				 * translators: If your word count is based on single characters (e.g. East Asian characters),
+				 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+				 * Do not translate into your own language.
+				 */
+				'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
+			];
+			if ( is_admin() && ! WC()->is_rest_api_request() ) {
+				$wc_blocks_config = array_merge(
+					$wc_blocks_config,
+					[
+						'productCount' => array_sum( (array) wp_count_posts( 'product' ) ),
+					]
+				);
+			}
 			$this->asset_data_registry->add(
 				'wcBlocksConfig',
-				[
-					// Note that while we don't have a consolidated way of doing feature-flagging
-					// we are borrowing from the WC Admin Features implementation. Also note we cannot
-					// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
-					'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
-					'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
-					'productCount'              => array_sum( (array) wp_count_posts( 'product' ) ),
-					'restApiRoutes'             => [
-						'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
-					],
-					'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
-
-					/*
-					 * translators: If your word count is based on single characters (e.g. East Asian characters),
-					 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-					 * Do not translate into your own language.
-					 */
-					'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
-				]
+				$wc_blocks_config
 			);
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -436,28 +436,28 @@ abstract class AbstractBlock {
 
 		if ( ! $this->asset_data_registry->exists( 'wcBlocksConfig' ) ) {
 			$wc_blocks_config = [
-				// Note that while we don't have a consolidated way of doing feature-flagging
-				// we are borrowing from the WC Admin Features implementation. Also note we cannot
-				// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
-				'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
-				'pluginUrl'                 => plugins_url( '/', dirname( __DIR__, 2 ) ),
-				'restApiRoutes'             => [
+				'pluginUrl'     => plugins_url( '/', dirname( __DIR__, 2 ) ),
+				'restApiRoutes' => [
 					'/wc/store/v1' => array_keys( $this->get_routes_from_namespace( 'wc/store/v1' ) ),
 				],
-				'defaultAvatar'             => get_avatar_url( 0, [ 'force_default' => true ] ),
+				'defaultAvatar' => get_avatar_url( 0, [ 'force_default' => true ] ),
 
 				/*
 				 * translators: If your word count is based on single characters (e.g. East Asian characters),
 				 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 				 * Do not translate into your own language.
 				 */
-				'wordCountType'             => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
+				'wordCountType' => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
 			];
 			if ( is_admin() && ! WC()->is_rest_api_request() ) {
 				$wc_blocks_config = array_merge(
 					$wc_blocks_config,
 					[
-						'productCount' => array_sum( (array) wp_count_posts( 'product' ) ),
+						// Note that while we don't have a consolidated way of doing feature-flagging
+						// we are borrowing from the WC Admin Features implementation. Also note we cannot
+						// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
+						'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
+						'productCount'              => array_sum( (array) wp_count_posts( 'product' ) ),
 					]
 				);
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Alternative to https://github.com/woocommerce/woocommerce/pull/47850.

This PR makes it so the `experimentalBlocksEnabled` and `productCount` variables from `wcBlocksConfig` are only loaded in the admin. The reason we want to do this is because `productCount` is causing a slow query that affects performance (see https://github.com/woocommerce/woocommerce/issues/46990) and because `experimentalBlocksEnabled` was introduced recently, so it's safe to move it to the admin only (https://github.com/woocommerce/woocommerce/pull/47701).

Closes #46990.

### How to test the changes in this Pull Request:

1. Remove all products from your store and add the All Products block to a post or page. Verify the 'no products' message is displayed in the editor (note, the UI might be different in your case because of https://github.com/woocommerce/woocommerce/issues/48380):
![image](https://github.com/woocommerce/woocommerce/assets/3616980/8eca0a14-9c5f-433d-af31-ce3df3ab156b)
2. Open the inserter and search for _Price Filter_. Verify there is only one block available, a block named _Product Filter: Price (Beta)_ shouldn't appear.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
