### PR TITLE
Product Editor: Move variation pricing fields to General tab

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-variation-move-pricing-fields
+++ b/plugins/woocommerce/changelog/update-product-editor-variation-move-pricing-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Product Editor: Move variation pricing fields to General tab.

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -35,7 +35,6 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	public function __construct() {
 		$this->add_group_blocks();
 		$this->add_general_group_blocks();
-		$this->add_pricing_group_blocks();
 		$this->add_inventory_group_blocks();
 		$this->add_shipping_group_blocks();
 	}
@@ -76,15 +75,6 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 		);
 		$this->add_group(
 			array(
-				'id'         => $this::GROUP_IDS['PRICING'],
-				'order'      => 20,
-				'attributes' => array(
-					'title' => __( 'Pricing', 'woocommerce' ),
-				),
-			)
-		);
-		$this->add_group(
-			array(
 				'id'         => $this::GROUP_IDS['INVENTORY'],
 				'order'      => 30,
 				'attributes' => array(
@@ -107,6 +97,8 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	 * Adds the general group blocks to the template.
 	 */
 	protected function add_general_group_blocks() {
+		$is_calc_taxes_enabled = wc_tax_enabled();
+
 		$general_group = $this->get_group_by_id( $this::GROUP_IDS['GENERAL'] );
 		$general_group->add_block(
 			array(
@@ -132,6 +124,92 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				),
 			)
 		);
+
+		// Product Pricing columns.
+		$pricing_columns  = $basic_details->add_block(
+			array(
+				'id'        => 'product-pricing-group-pricing-columns',
+				'blockName' => 'core/columns',
+				'order'     => 10,
+			)
+		);
+		$pricing_column_1 = $pricing_columns->add_block(
+			array(
+				'id'         => 'product-pricing-group-pricing-column-1',
+				'blockName'  => 'core/column',
+				'order'      => 10,
+				'attributes' => array(
+					'templateLock' => 'all',
+				),
+			)
+		);
+		$pricing_column_1->add_block(
+			array(
+				'id'         => 'product-pricing-regular-price',
+				'blockName'  => 'woocommerce/product-regular-price-field',
+				'order'      => 10,
+				'attributes' => array(
+					'name'       => 'regular_price',
+					'label'      => __( 'Regular price', 'woocommerce' ),
+					'isRequired' => true,
+					'help'       => $is_calc_taxes_enabled ? null : sprintf(
+					/* translators: %1$s: store settings link opening tag. %2$s: store settings link closing tag.*/
+						__( 'Per your %1$sstore settings%2$s, taxes are not enabled.', 'woocommerce' ),
+						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=general' ) . '" target="_blank" rel="noreferrer">',
+						'</a>'
+					),
+				),
+			)
+		);
+		$pricing_column_2 = $pricing_columns->add_block(
+			array(
+				'id'         => 'product-pricing-group-pricing-column-2',
+				'blockName'  => 'core/column',
+				'order'      => 20,
+				'attributes' => array(
+					'templateLock' => 'all',
+				),
+			)
+		);
+		$pricing_column_2->add_block(
+			array(
+				'id'         => 'product-pricing-sale-price',
+				'blockName'  => 'woocommerce/product-sale-price-field',
+				'order'      => 10,
+				'attributes' => array(
+					'label' => __( 'Sale price', 'woocommerce' ),
+				),
+			)
+		);
+		$basic_details->add_block(
+			array(
+				'id'        => 'product-pricing-schedule-sale-fields',
+				'blockName' => 'woocommerce/product-schedule-sale-fields',
+				'order'     => 20,
+			)
+		);
+
+		if ( $is_calc_taxes_enabled ) {
+			$basic_details->add_block(
+				array(
+					'id'         => 'product-tax-class',
+					'blockName'  => 'woocommerce/product-select-field',
+					'order'      => 40,
+					'attributes' => array(
+						'label'    => __( 'Tax class', 'woocommerce' ),
+						'help'     => sprintf(
+						/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
+							__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s', 'woocommerce' ),
+							'<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class" target="_blank" rel="noreferrer">',
+							'</a>'
+						),
+						'property' => 'tax_class',
+						'options'  => SimpleProductTemplate::get_tax_classes( 'product_variation' ),
+					),
+				)
+			);
+		}
+
 		$basic_details->add_block(
 			array(
 				'id'         => 'product-variation-note',
@@ -188,128 +266,6 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 
 		// Downloads section.
 		$this->add_downloadable_product_blocks( $general_group );
-	}
-
-	/**
-	 * Adds the pricing group blocks to the template.
-	 */
-	protected function add_pricing_group_blocks() {
-		$is_calc_taxes_enabled = wc_tax_enabled();
-
-		$pricing_group = $this->get_group_by_id( $this::GROUP_IDS['PRICING'] );
-		$pricing_group->add_block(
-			array(
-				'id'         => 'pricing-single-variation-notice',
-				'blockName'  => 'woocommerce/product-single-variation-notice',
-				'order'      => 10,
-				'attributes' => array(
-					'content'       => __( '<strong>You’re editing details specific to this variation.</strong> Some information, like description and images, will be inherited from the main product, <noticeLink><parentProductName/></noticeLink>.', 'woocommerce' ),
-					'type'          => 'info',
-					'isDismissible' => true,
-					'name'          => $this::SINGLE_VARIATION_NOTICE_DISMISSED_OPTION,
-				),
-			)
-		);
-		// Product Pricing Section.
-		$product_pricing_section = $pricing_group->add_section(
-			array(
-				'id'         => 'product-pricing-section',
-				'order'      => 20,
-				'attributes' => array(
-					'title'       => __( 'Pricing', 'woocommerce' ),
-					'description' => sprintf(
-					/* translators: %1$s: Images guide link opening tag. %2$s: Images guide link closing tag.*/
-						__( 'Set a competitive price, put the product on sale, and manage tax calculations. %1$sHow to price your product?%2$s', 'woocommerce' ),
-						'<a href="https://woocommerce.com/posts/how-to-price-products-strategies-expert-tips/" target="_blank" rel="noreferrer">',
-						'</a>'
-					),
-					'blockGap'    => 'unit-40',
-				),
-			)
-		);
-		$pricing_columns         = $product_pricing_section->add_block(
-			array(
-				'id'        => 'product-pricing-group-pricing-columns',
-				'blockName' => 'core/columns',
-				'order'     => 10,
-			)
-		);
-		$pricing_column_1        = $pricing_columns->add_block(
-			array(
-				'id'         => 'product-pricing-group-pricing-column-1',
-				'blockName'  => 'core/column',
-				'order'      => 10,
-				'attributes' => array(
-					'templateLock' => 'all',
-				),
-			)
-		);
-		$pricing_column_1->add_block(
-			array(
-				'id'         => 'product-pricing-regular-price',
-				'blockName'  => 'woocommerce/product-regular-price-field',
-				'order'      => 10,
-				'attributes' => array(
-					'name'       => 'regular_price',
-					'label'      => __( 'Regular price', 'woocommerce' ),
-					'isRequired' => true,
-					'help'       => $is_calc_taxes_enabled ? null : sprintf(
-					/* translators: %1$s: store settings link opening tag. %2$s: store settings link closing tag.*/
-						__( 'Per your %1$sstore settings%2$s, taxes are not enabled.', 'woocommerce' ),
-						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=general' ) . '" target="_blank" rel="noreferrer">',
-						'</a>'
-					),
-				),
-			)
-		);
-		$pricing_column_2 = $pricing_columns->add_block(
-			array(
-				'id'         => 'product-pricing-group-pricing-column-2',
-				'blockName'  => 'core/column',
-				'order'      => 20,
-				'attributes' => array(
-					'templateLock' => 'all',
-				),
-			)
-		);
-		$pricing_column_2->add_block(
-			array(
-				'id'         => 'product-pricing-sale-price',
-				'blockName'  => 'woocommerce/product-sale-price-field',
-				'order'      => 10,
-				'attributes' => array(
-					'label' => __( 'Sale price', 'woocommerce' ),
-				),
-			)
-		);
-		$product_pricing_section->add_block(
-			array(
-				'id'        => 'product-pricing-schedule-sale-fields',
-				'blockName' => 'woocommerce/product-schedule-sale-fields',
-				'order'     => 20,
-			)
-		);
-
-		if ( $is_calc_taxes_enabled ) {
-			$product_pricing_section->add_block(
-				array(
-					'id'         => 'product-tax-class',
-					'blockName'  => 'woocommerce/product-select-field',
-					'order'      => 40,
-					'attributes' => array(
-						'label'    => __( 'Tax class', 'woocommerce' ),
-						'help'     => sprintf(
-						/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
-							__( 'Apply a tax rate if this product qualifies for tax reduction or exemption. %1$sLearn more%2$s', 'woocommerce' ),
-							'<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#shipping-tax-class" target="_blank" rel="noreferrer">',
-							'</a>'
-						),
-						'property' => 'tax_class',
-						'options'  => SimpleProductTemplate::get_tax_classes( 'product_variation' ),
-					),
-				)
-			);
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -229,7 +229,7 @@ test.describe( 'Variations tab', () => {
 
 			await page
 				.locator( '.woocommerce-product-tabs' )
-				.getByRole( 'tab', { name: 'Pricing' } )
+				.getByRole( 'tab', { name: 'General' } )
 				.click();
 
 			await page


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR moves the pricing fields for variations to the `General` tab:

<img width="1115" alt="Screenshot 2024-06-06 at 14 03 01" src="https://github.com/woocommerce/woocommerce/assets/2098816/d1abb8cd-b277-4541-97c4-60e62592771f">

Closes #48116.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**), and the Gutenberg plugin installed...

1. Go to **Products** > **Add New**
2. Go to the **Variations** tab
3. Click the **Add Options** button to add some variation options.
4. Once variations are generated, edit one by clicking the **Edit** link in the variations list.
5. Verify that the pricing fields are now under the `General` tab for the variation.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
