### PR TITLE
Fix flaky e2e publishing created pages and posts

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-merchant-tests-create-page-post
+++ b/plugins/woocommerce/changelog/e2e-fix-merchant-tests-create-page-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: improve existing merchant e2e tests for creating page and post

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
@@ -73,6 +73,35 @@ exports.test = base.test.extend( {
 			} );
 		}
 	},
+
+	testPostTitlePrefix: [ '', { option: true } ],
+
+	testPost: async ( { wpApi, testPostTitlePrefix }, use ) => {
+		const postTitle = `${ testPostTitlePrefix } Post ${ random() }`;
+		const postSlug = postTitle.replace( / /gi, '-' ).toLowerCase();
+
+		await use( { title: postTitle, slug: postSlug } );
+
+		// Cleanup
+		const posts = await wpApi.get(
+			`/wp-json/wp/v2/posts?slug=${ postSlug }`,
+			{
+				data: {
+					_fields: [ 'id' ],
+				},
+				failOnStatusCode: false,
+			}
+		);
+
+		for ( const post of await posts.json() ) {
+			console.log( `Deleting post ${ post.id }` );
+			await wpApi.delete( `/wp-json/wp/v2/posts/${ post.id }`, {
+				data: {
+					force: true,
+				},
+			} );
+		}
+	},
 } );
 
 exports.expect = base.expect;

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
@@ -1,46 +1,21 @@
-const { test, expect, request } = require( '@playwright/test' );
-const { admin } = require( '../../test-data/data' );
+const { test: baseTest } = require( '../../fixtures/fixtures' );
 const {
 	goToPostEditor,
 	fillPageTitle,
 	getCanvas,
+	publishPage,
 } = require( '../../utils/editor' );
 
-const postTitle = `Post-${ new Date().getTime().toString() }`;
-
-test.describe( 'Can create a new post', () => {
-	test.use( { storageState: process.env.ADMINSTATE } );
-
-	test.afterAll( async ( { baseURL } ) => {
-		const base64auth = Buffer.from(
-			`${ admin.username }:${ admin.password }`
-		).toString( 'base64' );
-		const wpApi = await request.newContext( {
-			baseURL: `${ baseURL }/wp-json/wp/v2/`,
-			extraHTTPHeaders: {
-				Authorization: `Basic ${ base64auth }`,
-			},
-		} );
-
-		let response = await wpApi.get( `posts` );
-		const allPosts = await response.json();
-
-		await allPosts.forEach( async ( post ) => {
-			if ( post.title.rendered === postTitle ) {
-				response = await wpApi.delete( `posts/${ post.id }`, {
-					data: {
-						force: true,
-					},
-				} );
-				//				expect( response.ok() ).toBeTruthy();
-			}
-		} );
+baseTest.describe( 'Can create a new post', () => {
+	const test = baseTest.extend( {
+		storageState: process.env.ADMINSTATE,
 	} );
 
-	test( 'can create new post', async ( { page } ) => {
+	// eslint-disable-next-line playwright/expect-expect
+	test( 'can create new post', async ( { page, testPost } ) => {
 		await goToPostEditor( { page } );
 
-		await fillPageTitle( page, postTitle );
+		await fillPageTitle( page, testPost.title );
 
 		const canvas = await getCanvas( page );
 
@@ -54,17 +29,6 @@ test.describe( 'Can create a new post', () => {
 			} )
 			.fill( 'Test Post' );
 
-		await page
-			.getByRole( 'button', { name: 'Publish', exact: true } )
-			.click();
-
-		await page
-			.getByRole( 'region', { name: 'Editor publish' } )
-			.getByRole( 'button', { name: 'Publish', exact: true } )
-			.click();
-
-		await expect(
-			page.getByText( `${ postTitle } is now live.` )
-		).toBeVisible();
+		await publishPage( page, testPost.title );
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -85,7 +85,9 @@ const transformIntoBlocks = async ( page ) => {
 };
 
 const publishPage = async ( page, pageTitle ) => {
-	await page.getByRole( 'button', { name: 'Publish', exact: true } ).click();
+	await page
+		.getByRole( 'button', { name: 'Publish', exact: true } )
+		.dispatchEvent( 'click' );
 	await page
 		.getByRole( 'region', { name: 'Editor publish' } )
 		.getByRole( 'button', { name: 'Publish', exact: true } )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48096 #48098 #47585 #48097 #48039

According to the investigation, creation posts and pages flaked due to the distraction-free mode being turned on for unknown reasons. To avoid this in the future, I updated the editor util for publishing posts/pages to click on the Publish button in all modes - full screen, distraction-free, or normal mode.

This applies to 5 e2e tests that flaked for the same reason.

Additionally, unified create a post with create a page to have the same style.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/create-post.spec.js --headed`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
