### PR TITLE
Only accept return_url when do_update_woocommerce is present

### DIFF
--- a/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
+++ b/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix db update notice redirection bug where it redirects without checking for db update action.  </details>  <details>  <summary>Changelog Entry Comment</summary>
+Fix db update notice redirection bug where it redirects without checking for db update action. 

--- a/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
+++ b/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix db update notice redirection bug where it redirects without checking for db update action.
+Fix db update notice redirection bug where it redirects without checking for db update action.  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
+++ b/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix db update notice redirection bug where it redirects without checking for db update action. 
+Fix db update notice redirection bug where it redirects without checking for db update action.  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
+++ b/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix db update notice redirection bug where it redirects without checking for db update action.  </details>  <details>  <summary>Changelog Entry Comment</summary>
+Fix db update notice redirection bug where it redirects without checking for db update action.

--- a/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
+++ b/plugins/woocommerce/changelog/48163-fix-db-update-redirect-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix db update notice redirection bug where it redirects without checking for db update action.  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -423,10 +423,11 @@ class WC_Install {
 			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
 			self::update();
 			WC_Admin_Notices::add_notice( 'update', true );
-		}
-		if ( ! empty( $_GET['return_url'] ) ) { // WPCS: input var ok.
-			$return_url = esc_url_raw( wp_unslash( $_GET['return_url'] ) );
-			wp_safe_redirect( $return_url ); // WPCS: input var ok.
+
+			if ( ! empty( $_GET['return_url'] ) ) { // WPCS: input var ok.
+				$return_url = esc_url_raw( wp_unslash( $_GET['return_url'] ) );
+				wp_safe_redirect( $return_url ); // WPCS: input var ok.
+			}
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48154 .

We currently redirect users to `redirect_url` without checking for `do_update_woocommerce`. The redirection should only occur when both `do_update_woocommerce` and `redirect_url` params are present. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site WITHOUT WooCommerce.
2. Install and activate an [older version](https://downloads.wordpress.org/plugin/woocommerce.8.6.1.zip) of WooCommerce. 
3. Build this branch locally by running `pnpm run build:zip` in `plugins/woocommerce`
4. Upload the zip file and activate it.
5. Test the bug by visiting https://JN-SITE-URL/wp-admin/post.php?post=1&action=edit&return_url=https://JN-SITE-URL/wp-admin/admin.php?page=wc-admin
6. Redirection should not happen.
7. Go to `WooCommerce -> Home`
8. Confirm the D.B update notice.
9. Click on the update button.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix db update notice redirection bug where it redirects without checking for db update action.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
