### PR TITLE
Enable pricing inline actions in the variations table

### DIFF
--- a/packages/js/product-editor/changelog/add-40351-prices
+++ b/packages/js/product-editor/changelog/add-40351-prices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable pricing inline actions in the variations table

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -7,6 +7,7 @@
 @import "./add-image-menu-item/style.scss";
 @import "./image-actions-menu/style.scss";
 @import "./variation-stock-status-form/styles.scss";
+@import "./variation-pricing-form/styles.scss";
 
 .woocommerce-product-variations {
 	display: flex;
@@ -217,7 +218,8 @@
 		background-repeat: no-repeat;
 	}
 
-	&__stock-status-actions-menu {
+	&__stock-status-actions-menu,
+	&__pricing-actions-menu {
 		.components-popover__content {
 			padding: 0;
 		}

--- a/packages/js/product-editor/src/components/variations-table/variation-pricing-form/index.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-pricing-form/index.ts
@@ -1,0 +1,2 @@
+export * from './variation-pricing-form';
+export * from './types';

--- a/packages/js/product-editor/src/components/variations-table/variation-pricing-form/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/variation-pricing-form/styles.scss
@@ -1,0 +1,20 @@
+.woocommerce-variation-pricing-form {
+	display: flex;
+	flex-direction: column;
+	min-width: 345px;
+
+	&__controls,
+	&__actions {
+		display: flex;
+		gap: $grid-unit-20;
+		padding: $grid-unit-20;
+	}
+
+	&__controls {
+		justify-content: stretch;
+	}
+
+	&__actions {
+		justify-content: flex-end;
+	}
+}

--- a/packages/js/product-editor/src/components/variations-table/variation-pricing-form/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/variation-pricing-form/styles.scss
@@ -5,16 +5,36 @@
 
 	&__controls,
 	&__actions {
-		display: flex;
 		gap: $grid-unit-20;
 		padding: $grid-unit-20;
 	}
 
 	&__controls {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
 		justify-content: stretch;
+
+		.components-base-control {
+			&.has-error {
+				.components-input-control__backdrop {
+					border-color: $studio-red-50;
+				}
+
+				.components-base-control__help {
+					color: $studio-red-50;
+				}
+			}
+
+			&.components-currency-control {
+				.components-input-control__prefix {
+					margin-left: $grid-unit;
+				}
+			}
+		}
 	}
 
 	&__actions {
+		display: flex;
 		justify-content: flex-end;
 	}
 }

--- a/packages/js/product-editor/src/components/variations-table/variation-pricing-form/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-pricing-form/types.ts
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import type { ProductVariation } from '@woocommerce/data';
+
+export type VariationPricingFormProps = {
+	initialValue?: Partial< ProductVariation >;
+	onSubmit?(
+		value: Pick< ProductVariation, 'regular_price' | 'sale_price' >
+	): void;
+	onCancel?(): void;
+};

--- a/packages/js/product-editor/src/components/variations-table/variation-pricing-form/variation-pricing-form.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-pricing-form/variation-pricing-form.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import type { FormEvent } from 'react';
+import { createElement, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { VariationPricingFormProps } from './types';
+
+export function VariationPricingForm( {
+	initialValue,
+	onSubmit,
+	onCancel,
+}: VariationPricingFormProps ) {
+	const [ value, setValue ] = useState( {
+		regular_price: initialValue?.regular_price ?? '',
+		sale_price: initialValue?.sale_price ?? '',
+	} );
+
+	function handleSubmit( event: FormEvent< HTMLFormElement > ) {
+		event.preventDefault();
+
+		onSubmit?.( value );
+	}
+
+	return (
+		<form
+			onSubmit={ handleSubmit }
+			className="woocommerce-variation-pricing-form"
+			aria-label={ __( 'Variation pricing form', 'woocommerce' ) }
+		>
+			<div className="woocommerce-variation-pricing-form__controls">
+				<InputControl
+					name="regular_price"
+					label={ __( 'Regular price', 'woocommerce' ) }
+					value={ value.regular_price }
+					onChange={ ( regular_price: string ) =>
+						setValue( ( current ) => ( {
+							...current,
+							regular_price,
+						} ) )
+					}
+				/>
+
+				<InputControl
+					name="sale_price"
+					label={ __( 'Sale price', 'woocommerce' ) }
+					value={ value.sale_price }
+					onChange={ ( sale_price: string ) =>
+						setValue( ( current ) => ( {
+							...current,
+							sale_price,
+						} ) )
+					}
+				/>
+			</div>
+
+			<div className="woocommerce-variation-pricing-form__actions">
+				<Button variant="tertiary" onClick={ onCancel }>
+					Cancel
+				</Button>
+
+				<Button variant="primary" type="submit">
+					Save
+				</Button>
+			</div>
+		</form>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { Tag, __experimentalTooltip as Tooltip } from '@woocommerce/components';
 import { CurrencyContext } from '@woocommerce/currency';
 import { PartialProductVariation, ProductVariation } from '@woocommerce/data';
@@ -35,6 +34,7 @@ import {
 import { SingleUpdateMenu } from '../variation-actions-menus';
 import { ImageActionsMenu } from '../image-actions-menu';
 import { VariationStockStatusForm } from '../variation-stock-status-form/variation-stock-status-form';
+import { VariationPricingForm } from '../variation-pricing-form';
 import { VariationsTableRowProps } from './types';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
@@ -106,6 +106,59 @@ export function VariationsTableRow( {
 
 	function handleDelete( values: PartialProductVariation[] ) {
 		onDelete( values[ 0 ] );
+	}
+
+	function renderPrices() {
+		return (
+			<>
+				{ variation.on_sale && (
+					<span className="woocommerce-product-variations__sale-price">
+						{ formatAmount( variation.sale_price ) }
+					</span>
+				) }
+				<span
+					className={ classNames(
+						'woocommerce-product-variations__regular-price',
+						{
+							'woocommerce-product-variations__regular-price--on-sale':
+								variation.on_sale,
+						}
+					) }
+				>
+					{ formatAmount( variation.regular_price ) }
+				</span>
+			</>
+		);
+	}
+
+	function renderPriceForm( onClose: () => void ) {
+		return (
+			<VariationPricingForm
+				initialValue={ variation }
+				onSubmit={ ( editedVariation ) => {
+					onChange( { ...editedVariation, id: variation.id }, true );
+					onClose();
+				} }
+				onCancel={ onClose }
+			/>
+		);
+	}
+
+	function renderPriceCellContent() {
+		if ( ! variation.regular_price ) return null;
+		return (
+			<Dropdown
+				contentClassName="woocommerce-product-variations__pricing-actions-menu"
+				// @ts-expect-error missing prop in types.
+				popoverProps={ {
+					placement: 'bottom',
+				} }
+				renderToggle={ ( { onToggle } ) => (
+					<Button onClick={ onToggle }>{ renderPrices() }</Button>
+				) }
+				renderContent={ ( { onClose } ) => renderPriceForm( onClose ) }
+			/>
+		);
 	}
 
 	function renderStockStatus() {
@@ -278,22 +331,7 @@ export function VariationsTableRow( {
 				) }
 				role="cell"
 			>
-				{ variation.on_sale && (
-					<span className="woocommerce-product-variations__sale-price">
-						{ formatAmount( variation.sale_price ) }
-					</span>
-				) }
-				<span
-					className={ classNames(
-						'woocommerce-product-variations__regular-price',
-						{
-							'woocommerce-product-variations__regular-price--on-sale':
-								variation.on_sale,
-						}
-					) }
-				>
-					{ formatAmount( variation.regular_price ) }
-				</span>
+				{ renderPriceCellContent() }
 			</div>
 			<div
 				className={ classNames(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40351

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products > Add new` and generate some variations from the `Variations` tab
3. Then click `Set prices` from the button inside the alert <img width="739" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/e1c1b9bb-7036-4e5f-adb6-f6a938f74f1b">
4. Once the prices are set to the variations, clicking on the pricing cell of an specific variation should show a quick update form to modify the prices like so <img width="668" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c696928f-ad64-48ca-b305-0d4fc162a207">
5. The form validations should behave as if you are editing the variation in a full new page.
6. After saving the new changes the variation should be updated.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
