### PR TITLE
Do not dismiss the error snackbar automatically

### DIFF
--- a/packages/js/product-editor/changelog/dev-46765_modify_product_editor_error_snackbar
+++ b/packages/js/product-editor/changelog/dev-46765_modify_product_editor_error_snackbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Do not dismiss the error snackbar automatically #48192

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
@@ -22,5 +22,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
+	"usesContext": [ "selectedTab" ],
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
@@ -22,6 +22,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"usesContext": [ "postType", "selectedTab" ],
+	"usesContext": [ "selectedTab" ],
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
@@ -22,6 +22,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"usesContext": [ "selectedTab" ],
+	"usesContext": [ "postType", "selectedTab" ],
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -189,11 +189,7 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 				} );
 			} catch ( error ) {
 				const { message, errorProps } = getProductErrorMessageAndProps(
-					errorHandler(
-						error as WPError,
-						productStatus,
-						postType
-					) as WPError,
+					errorHandler( error as WPError, productStatus ) as WPError,
 					selectedTab
 				);
 				createErrorNotice( message, errorProps );
@@ -311,11 +307,7 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 			window.location.href = getNewPath( {}, `/product/${ productId }` );
 		} catch ( error ) {
 			const { message, errorProps } = getProductErrorMessageAndProps(
-				errorHandler(
-					error as WPError,
-					productStatus,
-					postType
-				) as WPError,
+				errorHandler( error as WPError, productStatus ) as WPError,
 				selectedTab
 			);
 			createErrorNotice( message, errorProps );

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -36,7 +36,7 @@ import { TRACKS_SOURCE } from '../../../constants';
 import {
 	WPError,
 	getProductErrorMessageAndProps,
-} from '../../../utils/get-product-error-message';
+} from '../../../utils/get-product-error-message-and-props';
 import type {
 	ProductEditorBlockEditProps,
 	ProductFormPostProps,

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -50,7 +50,7 @@ import { errorHandler } from '../../../hooks/use-product-manager';
 export function ProductDetailsSectionDescriptionBlockEdit( {
 	attributes,
 	clientId,
-	context: { selectedTab },
+	context: { postType, selectedTab },
 }: ProductEditorBlockEditProps< ProductDetailsSectionDescriptionBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 
@@ -189,7 +189,11 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 				} );
 			} catch ( error ) {
 				const { message, errorProps } = getProductErrorMessageAndProps(
-					errorHandler( error as WPError, productStatus ) as WPError,
+					errorHandler(
+						error as WPError,
+						productStatus,
+						postType
+					) as WPError,
 					selectedTab
 				);
 				createErrorNotice( message, errorProps );
@@ -307,7 +311,11 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 			window.location.href = getNewPath( {}, `/product/${ productId }` );
 		} catch ( error ) {
 			const { message, errorProps } = getProductErrorMessageAndProps(
-				errorHandler( error as WPError, productStatus ) as WPError,
+				errorHandler(
+					error as WPError,
+					productStatus,
+					postType
+				) as WPError,
 				selectedTab
 			);
 			createErrorNotice( message, errorProps );

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -18,13 +18,13 @@ import {
 import { __ } from '@wordpress/i18n';
 import * as icons from '@wordpress/icons';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { Product } from '@woocommerce/data';
+import type { ProductStatus, Product } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
-import { useEntityId } from '@wordpress/core-data';
+import { useEntityId, useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -35,7 +35,7 @@ import { useValidations } from '../../../contexts/validation-context';
 import { TRACKS_SOURCE } from '../../../constants';
 import {
 	WPError,
-	getProductErrorMessage,
+	getProductErrorMessageAndProps,
 } from '../../../utils/get-product-error-message';
 import type {
 	ProductEditorBlockEditProps,
@@ -45,10 +45,12 @@ import type {
 import { ProductDetailsSectionDescriptionBlockAttributes } from './types';
 import * as wooIcons from '../../../icons';
 import isProductFormTemplateSystemEnabled from '../../../utils/is-product-form-template-system-enabled';
+import { errorHandler } from '../../../hooks/use-product-manager';
 
 export function ProductDetailsSectionDescriptionBlockEdit( {
 	attributes,
 	clientId,
+	context: { selectedTab },
 }: ProductEditorBlockEditProps< ProductDetailsSectionDescriptionBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 
@@ -75,6 +77,12 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 		);
 
 	const productId = useEntityId( 'postType', 'product' );
+
+	const [ productStatus ] = useEntityProp< ProductStatus >(
+		'postType',
+		'product',
+		'status'
+	);
 
 	const { validate } = useValidations< Product >();
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -180,8 +188,11 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 					template: productTemplate.id,
 				} );
 			} catch ( error ) {
-				const message = getProductErrorMessage( error as WPError );
-				createErrorNotice( message );
+				const { message, errorProps } = getProductErrorMessageAndProps(
+					errorHandler( error as WPError, productStatus ) as WPError,
+					selectedTab
+				);
+				createErrorNotice( message, errorProps );
 			}
 
 			onClose();
@@ -295,8 +306,11 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 			// by the product editor.
 			window.location.href = getNewPath( {}, `/product/${ productId }` );
 		} catch ( error ) {
-			const message = getProductErrorMessage( error as WPError );
-			createErrorNotice( message );
+			const { message, errorProps } = getProductErrorMessageAndProps(
+				errorHandler( error as WPError, productStatus ) as WPError,
+				selectedTab
+			);
+			createErrorNotice( message, errorProps );
 		}
 	}
 

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -50,7 +50,7 @@ import { errorHandler } from '../../../hooks/use-product-manager';
 export function ProductDetailsSectionDescriptionBlockEdit( {
 	attributes,
 	clientId,
-	context: { postType, selectedTab },
+	context: { selectedTab },
 }: ProductEditorBlockEditProps< ProductDetailsSectionDescriptionBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -69,6 +69,7 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 										<Header
 											onTabSelect={ setSelectedTab }
 											productType={ postType }
+											selectedTab={ selectedTab }
 										/>
 									}
 									content={

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -253,6 +253,7 @@ export function Header( {
 					{ ! isVariation && (
 						<SaveDraftButton
 							productType={ productType }
+							visibleTab={ visibleTab }
 							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 							// @ts-ignore - Prop is not typed correctly.
 							productStatus={ lastPersistedProduct?.status }

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -8,6 +8,7 @@ import {
 	createElement,
 	useContext,
 	useEffect,
+	useState,
 	Fragment,
 	lazy,
 	Suspense,
@@ -75,6 +76,10 @@ export function Header( {
 				: null;
 		},
 		[ productType, productId ]
+	);
+
+	const [ visibleTab, setVisibleTab ] = useState< string | null >(
+		'general'
 	);
 
 	const editedProductName = product?.name;
@@ -266,6 +271,7 @@ export function Header( {
 							productType={ productType }
 							isPrePublishPanelVisible={ showPrepublishChecks }
 							isMenuButton
+							visibleTab={ visibleTab }
 						/>
 					</Suspense>
 
@@ -274,7 +280,12 @@ export function Header( {
 					<MoreMenu />
 				</div>
 			</div>
-			<Tabs onChange={ onTabSelect } />
+			<Tabs
+				onChange={ ( tab ) => {
+					setVisibleTab( tab );
+					onTabSelect( tab );
+				} }
+			/>
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -261,6 +261,7 @@ export function Header( {
 
 					<PreviewButton
 						productType={ productType }
+						visibleTab={ visibleTab }
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						// @ts-ignore - Prop is not typed correctly.
 						productStatus={ lastPersistedProduct?.status }

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -8,7 +8,6 @@ import {
 	createElement,
 	useContext,
 	useEffect,
-	useState,
 	Fragment,
 	lazy,
 	Suspense,
@@ -54,6 +53,7 @@ const RETURN_TO_MAIN_PRODUCT = __(
 export function Header( {
 	onTabSelect,
 	productType = 'product',
+	selectedTab,
 }: HeaderProps ) {
 	const isEditorLoading = useContext( EditorLoadingContext );
 
@@ -76,10 +76,6 @@ export function Header( {
 				: null;
 		},
 		[ productType, productId ]
-	);
-
-	const [ visibleTab, setVisibleTab ] = useState< string | null >(
-		'general'
 	);
 
 	const editedProductName = product?.name;
@@ -253,7 +249,7 @@ export function Header( {
 					{ ! isVariation && (
 						<SaveDraftButton
 							productType={ productType }
-							visibleTab={ visibleTab }
+							visibleTab={ selectedTab }
 							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 							// @ts-ignore - Prop is not typed correctly.
 							productStatus={ lastPersistedProduct?.status }
@@ -262,7 +258,7 @@ export function Header( {
 
 					<PreviewButton
 						productType={ productType }
-						visibleTab={ visibleTab }
+						visibleTab={ selectedTab }
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						// @ts-ignore - Prop is not typed correctly.
 						productStatus={ lastPersistedProduct?.status }
@@ -273,7 +269,7 @@ export function Header( {
 							productType={ productType }
 							isPrePublishPanelVisible={ showPrepublishChecks }
 							isMenuButton
-							visibleTab={ visibleTab }
+							visibleTab={ selectedTab }
 						/>
 					</Suspense>
 
@@ -282,12 +278,7 @@ export function Header( {
 					<MoreMenu />
 				</div>
 			</div>
-			<Tabs
-				onChange={ ( tab ) => {
-					setVisibleTab( tab );
-					onTabSelect( tab );
-				} }
-			/>
+			<Tabs onChange={ onTabSelect } />
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -129,7 +129,11 @@ export function usePreview( {
 		} catch ( error ) {
 			if ( onSaveError ) {
 				onSaveError(
-					errorHandler( error as WPError, productStatus ) as WPError
+					errorHandler(
+						error as WPError,
+						productStatus,
+						productType
+					) as WPError
 				);
 			}
 		}

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -16,6 +16,7 @@ import { useValidations } from '../../../../contexts/validation-context';
 import { WPError } from '../../../../utils/get-product-error-message';
 import { useProductURL } from '../../../../hooks/use-product-url';
 import { PreviewButtonProps } from '../../preview-button';
+import { errorHandler } from '../../../../hooks/use-product-manager';
 
 export function usePreview( {
 	productStatus,
@@ -127,13 +128,9 @@ export function usePreview( {
 			}
 		} catch ( error ) {
 			if ( onSaveError ) {
-				let wpError = error as WPError;
-				if ( ! wpError.code ) {
-					wpError = {
-						code: 'product_preview_error',
-					} as WPError;
-				}
-				onSaveError( wpError );
+				onSaveError(
+					errorHandler( error as WPError, productStatus ) as WPError
+				);
 			}
 		}
 	}

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -13,7 +13,7 @@ import { MouseEvent } from 'react';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
-import { WPError } from '../../../../utils/get-product-error-message';
+import { WPError } from '../../../../utils/get-product-error-message-and-props';
 import { useProductURL } from '../../../../hooks/use-product-url';
 import { PreviewButtonProps } from '../../preview-button';
 import { errorHandler } from '../../../../hooks/use-product-manager';

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -129,11 +129,7 @@ export function usePreview( {
 		} catch ( error ) {
 			if ( onSaveError ) {
 				onSaveError(
-					errorHandler(
-						error as WPError,
-						productStatus,
-						productType
-					) as WPError
+					errorHandler( error as WPError, productStatus ) as WPError
 				);
 			}
 		}

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -13,7 +13,7 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
  */
 import { useProductManager } from '../../../../hooks/use-product-manager';
 import { useProductScheduled } from '../../../../hooks/use-product-scheduled';
-import type { WPError } from '../../../../utils/get-product-error-message';
+import type { WPError } from '../../../../utils/get-product-error-message-and-props';
 import type { PublishButtonProps } from '../../publish-button';
 
 export function usePublish< T = Product >( {

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -15,7 +15,7 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
-import { WPError } from '../../../../utils/get-product-error-message';
+import { WPError } from '../../../../utils/get-product-error-message-and-props';
 import { SaveDraftButtonProps } from '../../save-draft-button';
 import { recordProductEvent } from '../../../../utils/record-product-event';
 import { errorHandler } from '../../../../hooks/use-product-manager';

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -108,7 +108,11 @@ export function useSaveDraft( {
 		} catch ( error ) {
 			if ( onSaveError ) {
 				onSaveError(
-					errorHandler( error as WPError, productStatus ) as WPError
+					errorHandler(
+						error as WPError,
+						productStatus,
+						productType
+					) as WPError
 				);
 			}
 		}

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -18,6 +18,7 @@ import { useValidations } from '../../../../contexts/validation-context';
 import { WPError } from '../../../../utils/get-product-error-message';
 import { SaveDraftButtonProps } from '../../save-draft-button';
 import { recordProductEvent } from '../../../../utils/record-product-event';
+import { errorHandler } from '../../../../hooks/use-product-manager';
 
 export function useSaveDraft( {
 	productStatus,
@@ -106,7 +107,9 @@ export function useSaveDraft( {
 			}
 		} catch ( error ) {
 			if ( onSaveError ) {
-				onSaveError( error as WPError );
+				onSaveError(
+					errorHandler( error as WPError, productStatus ) as WPError
+				);
 			}
 		}
 	}

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -108,11 +108,7 @@ export function useSaveDraft( {
 		} catch ( error ) {
 			if ( onSaveError ) {
 				onSaveError(
-					errorHandler(
-						error as WPError,
-						productStatus,
-						productType
-					) as WPError
+					errorHandler( error as WPError, productStatus ) as WPError
 				);
 			}
 		}

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -11,7 +11,7 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message-and-props';
 import { usePreview } from '../hooks/use-preview';
 import { PreviewButtonProps } from './types';
 import { TRACKS_SOURCE } from '../../../constants';

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -11,13 +11,14 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getProductErrorMessage } from '../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message';
 import { usePreview } from '../hooks/use-preview';
 import { PreviewButtonProps } from './types';
 import { TRACKS_SOURCE } from '../../../constants';
 
 export function PreviewButton( {
 	productStatus,
+	visibleTab = 'general',
 	...props
 }: PreviewButtonProps ) {
 	const { createErrorNotice } = useDispatch( 'core/notices' );
@@ -35,8 +36,11 @@ export function PreviewButton( {
 			}
 		},
 		onSaveError( error ) {
-			const message = getProductErrorMessage( error );
-			createErrorNotice( message );
+			const { message, errorProps } = getProductErrorMessageAndProps(
+				error,
+				visibleTab
+			);
+			createErrorNotice( message, errorProps );
 		},
 	} );
 

--- a/packages/js/product-editor/src/components/header/preview-button/types.ts
+++ b/packages/js/product-editor/src/components/header/preview-button/types.ts
@@ -10,4 +10,5 @@ export type PreviewButtonProps = Omit<
 > & {
 	productStatus: Product[ 'status' ];
 	productType: string;
+	visibleTab?: string | null;
 };

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
@@ -17,7 +17,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useProductManager } from '../../../../hooks/use-product-manager';
 import { useProductScheduled } from '../../../../hooks/use-product-scheduled';
 import { recordProductEvent } from '../../../../utils/record-product-event';
-import { getProductErrorMessageAndProps } from '../../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../../utils/get-product-error-message-and-props';
 import { ButtonWithDropdownMenu } from '../../../button-with-dropdown-menu';
 import { SchedulePublishModal } from '../../../schedule-publish-modal';
 import { showSuccessNotice } from '../utils';

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
@@ -17,7 +17,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useProductManager } from '../../../../hooks/use-product-manager';
 import { useProductScheduled } from '../../../../hooks/use-product-scheduled';
 import { recordProductEvent } from '../../../../utils/record-product-event';
-import { getProductErrorMessage } from '../../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../../utils/get-product-error-message';
 import { ButtonWithDropdownMenu } from '../../../button-with-dropdown-menu';
 import { SchedulePublishModal } from '../../../schedule-publish-modal';
 import { showSuccessNotice } from '../utils';
@@ -26,6 +26,7 @@ import { TRACKS_SOURCE } from '../../../../constants';
 
 export function PublishButtonMenu( {
 	postType,
+	visibleTab = 'general',
 	...props
 }: PublishButtonMenuProps ) {
 	const { isScheduling, isScheduled, schedule, date, formattedDate } =
@@ -50,8 +51,11 @@ export function PublishButtonMenu( {
 				showSuccessNotice( scheduledProduct );
 			} )
 			.catch( ( error ) => {
-				const message = getProductErrorMessage( error );
-				createErrorNotice( message );
+				const { message, errorProps } = getProductErrorMessageAndProps(
+					error,
+					visibleTab
+				);
+				createErrorNotice( message, errorProps );
 			} )
 			.finally( () => {
 				setShowScheduleModal( undefined );
@@ -134,9 +138,15 @@ export function PublishButtonMenu( {
 										navigateTo( { url } );
 									} )
 									.catch( ( error ) => {
-										const message =
-											getProductErrorMessage( error );
-										createErrorNotice( message );
+										const { message, errorProps } =
+											getProductErrorMessageAndProps(
+												error,
+												visibleTab
+											);
+										createErrorNotice(
+											message,
+											errorProps
+										);
 									} );
 								onClose();
 							} }
@@ -166,9 +176,15 @@ export function PublishButtonMenu( {
 										} );
 									} )
 									.catch( ( error ) => {
-										const message =
-											getProductErrorMessage( error );
-										createErrorNotice( message );
+										const { message, errorProps } =
+											getProductErrorMessageAndProps(
+												error,
+												visibleTab
+											);
+										createErrorNotice(
+											message,
+											errorProps
+										);
 									} );
 								onClose();
 							} }

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/types.ts
@@ -5,4 +5,5 @@ import { ButtonWithDropdownMenuProps } from '../../../button-with-dropdown-menu'
 
 export type PublishButtonMenuProps = ButtonWithDropdownMenuProps & {
 	postType: string;
+	visibleTab: string | null;
 };

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -14,7 +14,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { store as productEditorUiStore } from '../../../store/product-editor-ui';
-import { getProductErrorMessage } from '../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useFeedbackBar } from '../../../hooks/use-feedback-bar';
 import { TRACKS_SOURCE } from '../../../constants';
@@ -27,6 +27,7 @@ export function PublishButton( {
 	productType = 'product',
 	isMenuButton,
 	isPrePublishPanelVisible = true,
+	visibleTab = 'general',
 	...props
 }: PublishButtonProps ) {
 	const { createErrorNotice } = useDispatch( 'core/notices' );
@@ -61,8 +62,11 @@ export function PublishButton( {
 			}
 		},
 		onPublishError( error ) {
-			const message = getProductErrorMessage( error );
-			createErrorNotice( message );
+			const { message, errorProps } = getProductErrorMessageAndProps(
+				error,
+				visibleTab
+			);
+			createErrorNotice( message, errorProps );
 		},
 	} );
 

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -75,7 +75,11 @@ export function PublishButton( {
 			menuProps: Dropdown.RenderProps
 		): React.ReactElement {
 			return (
-				<PublishButtonMenu { ...menuProps } postType={ productType } />
+				<PublishButtonMenu
+					{ ...menuProps }
+					postType={ productType }
+					visibleTab={ visibleTab }
+				/>
 			);
 		}
 
@@ -107,6 +111,7 @@ export function PublishButton( {
 					controls={ undefined }
 					onClick={ handlePrePublishButtonClick }
 					renderMenu={ renderPublishButtonMenu }
+					visibleTab={ visibleTab }
 				/>
 			);
 		}
@@ -117,6 +122,7 @@ export function PublishButton( {
 				postType={ productType }
 				controls={ undefined }
 				renderMenu={ renderPublishButtonMenu }
+				visibleTab={ visibleTab }
 			/>
 		);
 	}

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -14,7 +14,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { store as productEditorUiStore } from '../../../store/product-editor-ui';
-import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message-and-props';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useFeedbackBar } from '../../../hooks/use-feedback-bar';
 import { TRACKS_SOURCE } from '../../../constants';

--- a/packages/js/product-editor/src/components/header/publish-button/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/types.ts
@@ -10,4 +10,5 @@ export type PublishButtonProps = Omit<
 	productType?: string;
 	isMenuButton?: boolean;
 	isPrePublishPanelVisible?: boolean;
+	visibleTab?: string | null;
 };

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -11,7 +11,7 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getProductErrorMessage } from '../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useSaveDraft } from '../hooks/use-save-draft';
 import { SaveDraftButtonProps } from './types';
@@ -20,6 +20,7 @@ import { useFeedbackBar } from '../../../hooks/use-feedback-bar';
 export function SaveDraftButton( {
 	productStatus,
 	productType = 'product',
+	visibleTab = 'general',
 	...props
 }: SaveDraftButtonProps ) {
 	const { createSuccessNotice, createErrorNotice } =
@@ -46,8 +47,11 @@ export function SaveDraftButton( {
 			}
 		},
 		onSaveError( error ) {
-			const message = getProductErrorMessage( error );
-			createErrorNotice( message );
+			const { message, errorProps } = getProductErrorMessageAndProps(
+				error,
+				visibleTab
+			);
+			createErrorNotice( message, errorProps );
 		},
 	} );
 

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -11,7 +11,7 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message';
+import { getProductErrorMessageAndProps } from '../../../utils/get-product-error-message-and-props';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useSaveDraft } from '../hooks/use-save-draft';
 import { SaveDraftButtonProps } from './types';

--- a/packages/js/product-editor/src/components/header/save-draft-button/types.ts
+++ b/packages/js/product-editor/src/components/header/save-draft-button/types.ts
@@ -10,4 +10,5 @@ export type SaveDraftButtonProps = Omit<
 > & {
 	productStatus: Product[ 'status' ];
 	productType?: string;
+	visibleTab?: string | null;
 };

--- a/packages/js/product-editor/src/components/header/types.ts
+++ b/packages/js/product-editor/src/components/header/types.ts
@@ -1,6 +1,7 @@
 export type HeaderProps = {
 	onTabSelect: ( tabId: string | null ) => void;
 	productType?: string;
+	selectedTab?: string | null;
 };
 
 export interface Image {

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -107,7 +107,6 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return savedProduct as T;
 		} catch ( error ) {
-			console.log( '----> save', error );
 			throw errorHandler( error as WPError, status );
 		} finally {
 			setIsSaving( false );

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -10,7 +10,7 @@ import { Product, ProductStatus, PRODUCTS_STORE_NAME } from '@woocommerce/data';
  * Internal dependencies
  */
 import { useValidations } from '../../contexts/validation-context';
-import type { WPError } from '../../utils/get-product-error-message';
+import type { WPError } from '../../utils/get-product-error-message-and-props';
 import { AUTO_DRAFT_NAME } from '../../utils/constants';
 
 export function errorHandler( error: WPError, productStatus: ProductStatus ) {

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -13,7 +13,11 @@ import { useValidations } from '../../contexts/validation-context';
 import type { WPError } from '../../utils/get-product-error-message-and-props';
 import { AUTO_DRAFT_NAME } from '../../utils/constants';
 
-export function errorHandler( error: WPError, productStatus: ProductStatus ) {
+export function errorHandler(
+	error: WPError,
+	productStatus: ProductStatus,
+	productType: string
+) {
 	if ( error.code ) {
 		return error;
 	}
@@ -33,6 +37,7 @@ export function errorHandler( error: WPError, productStatus: ProductStatus ) {
 		return {
 			code: 'product_form_field_error',
 			message: errorMessage,
+			productType,
 		};
 	}
 
@@ -41,6 +46,7 @@ export function errorHandler( error: WPError, productStatus: ProductStatus ) {
 			productStatus === 'publish' || productStatus === 'future'
 				? 'product_publish_error'
 				: 'product_create_error',
+		productType,
 	};
 }
 
@@ -107,7 +113,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return savedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status );
+			throw errorHandler( error as WPError, status, postType );
 		} finally {
 			setIsSaving( false );
 		}
@@ -128,7 +134,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return duplicatedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status );
+			throw errorHandler( error as WPError, status, postType );
 		} finally {
 			setIsSaving( false );
 		}
@@ -174,7 +180,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return deletedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status );
+			throw errorHandler( error as WPError, status, postType );
 		} finally {
 			setTrashing( false );
 		}

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -13,11 +13,7 @@ import { useValidations } from '../../contexts/validation-context';
 import type { WPError } from '../../utils/get-product-error-message-and-props';
 import { AUTO_DRAFT_NAME } from '../../utils/constants';
 
-export function errorHandler(
-	error: WPError,
-	productStatus: ProductStatus,
-	productType: string
-) {
+export function errorHandler( error: WPError, productStatus: ProductStatus ) {
 	if ( error.code ) {
 		return error;
 	}
@@ -37,7 +33,6 @@ export function errorHandler(
 		return {
 			code: 'product_form_field_error',
 			message: errorMessage,
-			productType,
 		};
 	}
 
@@ -46,7 +41,6 @@ export function errorHandler(
 			productStatus === 'publish' || productStatus === 'future'
 				? 'product_publish_error'
 				: 'product_create_error',
-		productType,
 	};
 }
 
@@ -113,7 +107,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return savedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status, postType );
+			throw errorHandler( error as WPError, status );
 		} finally {
 			setIsSaving( false );
 		}
@@ -134,7 +128,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return duplicatedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status, postType );
+			throw errorHandler( error as WPError, status );
 		} finally {
 			setIsSaving( false );
 		}

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -174,7 +174,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return deletedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status, postType );
+			throw errorHandler( error as WPError, status );
 		} finally {
 			setTrashing( false );
 		}

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -13,7 +13,7 @@ import { useValidations } from '../../contexts/validation-context';
 import type { WPError } from '../../utils/get-product-error-message';
 import { AUTO_DRAFT_NAME } from '../../utils/constants';
 
-function errorHandler( error: WPError, productStatus: ProductStatus ) {
+export function errorHandler( error: WPError, productStatus: ProductStatus ) {
 	if ( error.code ) {
 		return error;
 	}
@@ -107,6 +107,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return savedProduct as T;
 		} catch ( error ) {
+			console.log( '----> save', error );
 			throw errorHandler( error as WPError, status );
 		} finally {
 			setIsSaving( false );

--- a/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
@@ -50,25 +50,21 @@ export function getProductErrorMessageAndProps(
 			break;
 		case 'product_create_error':
 			response.message = __( 'Failed to create product.', 'woocommerce' );
-			response.errorProps.explicitDismiss = false;
 			break;
 		case 'product_publish_error':
 			response.message = __(
 				'Failed to publish product.',
 				'woocommerce'
 			);
-			response.errorProps.explicitDismiss = false;
 			break;
 		case 'product_preview_error':
 			response.message = __(
 				'Failed to preview product.',
 				'woocommerce'
 			);
-			response.errorProps.explicitDismiss = false;
 			break;
 		default:
 			response.message = __( 'Failed to save product.', 'woocommerce' );
-			response.errorProps.explicitDismiss = false;
 			break;
 	}
 	return response;

--- a/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
@@ -17,7 +17,6 @@ export type WPError = {
 	data: {
 		[ key: string ]: unknown;
 	};
-	productType?: string;
 };
 
 type ErrorProps = {
@@ -44,15 +43,7 @@ export function getProductErrorMessageAndProps(
 			break;
 		case 'product_form_field_error':
 			response.message = error.message;
-			if (
-				error.productType === 'product_variation' &&
-				visibleTab !== 'pricing'
-			) {
-				response.errorProps = { explicitDismiss: true };
-			} else if (
-				visibleTab !== 'general' &&
-				error.productType !== 'product_variation'
-			) {
+			if ( visibleTab !== 'general' ) {
 				response.errorProps = { explicitDismiss: true };
 			}
 			break;

--- a/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
@@ -35,18 +35,24 @@ export function getProductErrorMessageAndProps(
 	switch ( error.code ) {
 		case 'variable_product_no_variation_prices':
 			response.message = error.message;
-			response.errorProps.explicitDismiss = visibleTab !== 'variations';
+			if ( visibleTab !== 'variations' ) {
+				response.errorProps.explicitDismiss = true;
+			}
 			break;
 		case 'product_form_field_error':
 			response.message = error.message;
-			response.errorProps.explicitDismiss = visibleTab !== 'general';
+			if ( visibleTab !== 'general' ) {
+				response.errorProps.explicitDismiss = true;
+			}
 			break;
 		case 'product_invalid_sku':
 			response.message = __(
 				'Invalid or duplicated SKU.',
 				'woocommerce'
 			);
-			response.errorProps.explicitDismiss = visibleTab !== 'inventory';
+			if ( visibleTab !== 'inventory' ) {
+				response.errorProps.explicitDismiss = true;
+			}
 			break;
 		case 'product_create_error':
 			response.message = __( 'Failed to create product.', 'woocommerce' );

--- a/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message-and-props.ts
@@ -17,6 +17,11 @@ export type WPError = {
 	data: {
 		[ key: string ]: unknown;
 	};
+	productType?: string;
+};
+
+type ErrorProps = {
+	explicitDismiss: boolean;
 };
 
 export function getProductErrorMessageAndProps(
@@ -24,25 +29,31 @@ export function getProductErrorMessageAndProps(
 	visibleTab: string | null
 ): {
 	message: string;
-	errorProps: { explicitDismiss: boolean };
+	errorProps: ErrorProps;
 } {
 	const response = {
 		message: '',
-		errorProps: {
-			explicitDismiss: false,
-		},
+		errorProps: {} as ErrorProps,
 	};
 	switch ( error.code ) {
 		case 'variable_product_no_variation_prices':
 			response.message = error.message;
 			if ( visibleTab !== 'variations' ) {
-				response.errorProps.explicitDismiss = true;
+				response.errorProps = { explicitDismiss: true };
 			}
 			break;
 		case 'product_form_field_error':
 			response.message = error.message;
-			if ( visibleTab !== 'general' ) {
-				response.errorProps.explicitDismiss = true;
+			if (
+				error.productType === 'product_variation' &&
+				visibleTab !== 'pricing'
+			) {
+				response.errorProps = { explicitDismiss: true };
+			} else if (
+				visibleTab !== 'general' &&
+				error.productType !== 'product_variation'
+			) {
+				response.errorProps = { explicitDismiss: true };
 			}
 			break;
 		case 'product_invalid_sku':
@@ -51,7 +62,7 @@ export function getProductErrorMessageAndProps(
 				'woocommerce'
 			);
 			if ( visibleTab !== 'inventory' ) {
-				response.errorProps.explicitDismiss = true;
+				response.errorProps = { explicitDismiss: true };
 			}
 			break;
 		case 'product_create_error':

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -44,7 +44,6 @@ export function getProductErrorMessageAndProps(
 ): {
 	message: string;
 	errorProps: { explicitDismiss: boolean };
-	isDismissible?: boolean;
 } {
 	const response = {
 		message: '',

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -19,25 +19,6 @@ export type WPError = {
 	};
 };
 
-export function getProductErrorMessage( error: WPError ) {
-	switch ( error.code ) {
-		case 'variable_product_no_variation_prices':
-			return error.message;
-		case 'product_form_field_error':
-			return error.message;
-		case 'product_invalid_sku':
-			return __( 'Invalid or duplicated SKU.', 'woocommerce' );
-		case 'product_create_error':
-			return __( 'Failed to create product.', 'woocommerce' );
-		case 'product_publish_error':
-			return __( 'Failed to publish product.', 'woocommerce' );
-		case 'product_preview_error':
-			return __( 'Failed to preview product.', 'woocommerce' );
-		default:
-			return __( 'Failed to save product.', 'woocommerce' );
-	}
-}
-
 export function getProductErrorMessageAndProps(
 	error: WPError,
 	visibleTab: string | null

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -37,3 +37,59 @@ export function getProductErrorMessage( error: WPError ) {
 			return __( 'Failed to save product.', 'woocommerce' );
 	}
 }
+
+export function getProductErrorMessageAndProps(
+	error: WPError,
+	visibleTab: string | null
+): {
+	message: string;
+	errorProps: { explicitDismiss: boolean };
+	isDismissible?: boolean;
+} {
+	const response = {
+		message: '',
+		errorProps: {
+			explicitDismiss: false,
+		},
+	};
+	switch ( error.code ) {
+		case 'variable_product_no_variation_prices':
+			response.message = error.message;
+			response.errorProps.explicitDismiss = visibleTab !== 'variations';
+			break;
+		case 'product_form_field_error':
+			response.message = error.message;
+			response.errorProps.explicitDismiss = visibleTab !== 'general';
+			break;
+		case 'product_invalid_sku':
+			response.message = __(
+				'Invalid or duplicated SKU.',
+				'woocommerce'
+			);
+			response.errorProps.explicitDismiss = visibleTab !== 'inventory';
+			break;
+		case 'product_create_error':
+			response.message = __( 'Failed to create product.', 'woocommerce' );
+			response.errorProps.explicitDismiss = false;
+			break;
+		case 'product_publish_error':
+			response.message = __(
+				'Failed to publish product.',
+				'woocommerce'
+			);
+			response.errorProps.explicitDismiss = false;
+			break;
+		case 'product_preview_error':
+			response.message = __(
+				'Failed to preview product.',
+				'woocommerce'
+			);
+			response.errorProps.explicitDismiss = false;
+			break;
+		default:
+			response.message = __( 'Failed to save product.', 'woocommerce' );
+			response.errorProps.explicitDismiss = false;
+			break;
+	}
+	return response;
+}

--- a/packages/js/product-editor/src/utils/test/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/test/get-product-error-message.ts
@@ -1,20 +1,46 @@
 /**
  * Internal dependencies
  */
-import { getProductErrorMessage, WPError } from '../get-product-error-message';
+import {
+	getProductErrorMessageAndProps,
+	WPError,
+} from '../get-product-error-message-and-props';
 
-describe( 'getProductErrorMessage', () => {
-	it( 'should return the correct error message when one exists', () => {
+describe( 'getProductErrorMessageAndProps.message', () => {
+	it( 'should return the correct error message and props when exists and the field is visible', () => {
 		const error = {
 			code: 'product_invalid_sku',
 		} as WPError;
-		const message = getProductErrorMessage( error );
+		const visibleTab = 'inventory';
+		const { message, errorProps } = getProductErrorMessageAndProps(
+			error,
+			visibleTab
+		);
 		expect( message ).toBe( 'Invalid or duplicated SKU.' );
+		expect( errorProps.explicitDismiss ).toBeFalsy();
 	} );
 
-	it( 'should return a default message when the error code is not mapped', () => {
+	it( 'should return the correct error message and props when exists and the field is not visible', () => {
+		const error = {
+			code: 'product_invalid_sku',
+		} as WPError;
+		const visibleTab = 'general';
+		const { message, errorProps } = getProductErrorMessageAndProps(
+			error,
+			visibleTab
+		);
+		expect( message ).toBe( 'Invalid or duplicated SKU.' );
+		expect( errorProps.explicitDismiss ).toBeTruthy();
+	} );
+
+	it( 'should return a default message and props when the error code is not mapped', () => {
 		const error = {} as WPError;
-		const message = getProductErrorMessage( error );
+		const visibleTab = 'general';
+		const { message, errorProps } = getProductErrorMessageAndProps(
+			error,
+			visibleTab
+		);
 		expect( message ).toBe( 'Failed to save product.' );
+		expect( errorProps.explicitDismiss ).toBeFalsy();
 	} );
 } );

--- a/plugins/woocommerce/changelog/dev-46765_modify_product_editor_error_snackbar
+++ b/plugins/woocommerce/changelog/dev-46765_modify_product_editor_error_snackbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Do not dismiss the error snackbar automatically, fix E2E test #48192

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -116,7 +116,7 @@ test.describe( 'General tab', () => {
 				.click();
 
 			await expect(
-				page.getByLabel( 'Dismiss this notice' )
+				page.locator( '.components-snackbar__content' )
 			).toContainText( 'Invalid or duplicated SKU.' );
 		} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to don't dismiss the error snackbar automatically.

When the user creates a product and clicks `Publish`, `Preview` and `Save draft`, a snackbar will be shown if the form has errors.

![Screenshot 2024-06-06 at 3 24 41 PM](https://github.com/woocommerce/woocommerce/assets/1314156/552deca3-1f3c-4cc4-b187-d2a25fb85412)

Closes #46765.

A few considerations about the ACs:
- Now it's not possible to add a non-dismissible snackbar (it's [a known thing](https://github.com/WordPress/gutenberg/issues/45824), probably on purpose). This is why we use the prop `explicitDismiss` that also adds an `X` to close the snackbar.
- One of the original ACs mentioned that if the user was viewing the tab with the error, the snackbar would be shown for one second. However we show the snackbar longer by default. I modified that AC to show the snackbar for the period shown by default. 

```[tasklist]
### ACs
- [ ] Don't dismiss the error snackbar automatically.
- [ ] Dismiss the snackbar if the user is seeing the tab. The error will disappear automatically after a few seconds.
- [ ] If there are more error messages, we'd stack them.
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products > Add new` and add a Summary text.
3. Press `Save draft`, `Preview` and `Publish`. After pressing these buttons you will see 3 snackbars with the message `Product name is required.`.
4. Since you are in the `General` tab and the pricing is visible, the snackbar will disappear automatically.
5. Go to the `Shipping` tab.
6. Repeat step 3. The same snackbar will be shown and only will be dismissed after pressing the `X` next to the test.
7. Go to the `Variations` tab and create some.
8. Edit a single variation.
9. Add a `Note` and try to `Update` the variation.
10. You will see a snackbar with the message `Regular price is required.`, it will dismiss automatically. 
11. Go to the `Inventory` tab and press `Update`.
12. The same snackbar will be shown with an `X` at the end to dismiss it.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
