### PR TITLE
Fix tabs overflowing when viewport is small

### DIFF
--- a/packages/js/product-editor/changelog/fix-responsive-tabs
+++ b/packages/js/product-editor/changelog/fix-responsive-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tabs overflowing when viewport is small

--- a/packages/js/product-editor/src/components/tabs/style.scss
+++ b/packages/js/product-editor/src/components/tabs/style.scss
@@ -1,6 +1,9 @@
 .woocommerce-product-tabs {
     display: flex;
-    justify-content: center;
+    justify-content: safe center;
+	@media only screen and (max-width: 500px) {
+		overflow: auto;
+	}
 
     .components-button {
         padding: $gap-smaller 0 20px 0;
@@ -9,6 +12,10 @@
         border-bottom: 3.5px solid transparent;
         border-radius: 0;
         height: auto;
+
+		@media only screen and (max-width: 500px) {
+			margin-top: 2px;
+		}
 
         &.is-selected {
             border-color: var(--wp-admin-theme-color);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix tabs overflowing when viewport is small

<img width="536" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13437655/8d13bf53-9c90-4e4f-908b-6b7778c1ae34">

I had to use media-query only to add the CSS when the viewport was small because currently, the button outline is overflowing vertically, and it's not possible to set only `overflow-x` to auto and keep `overflow-y` as visible. That's why I also had to add a margin to the top.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Open the browser's developer tools and simulate a small device (e.g. iPhone SE)
4. Check that it's possible to use the tabs, scrolling them horizontally.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
