### PR TITLE
Fix terms counts in wcadmin_product_add_publish Tracks event

### DIFF
--- a/plugins/woocommerce/changelog/fix-wcadmin_product_add_publish_terms_count
+++ b/plugins/woocommerce/changelog/fix-wcadmin_product_add_publish_terms_count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the terms counts in wcadmin_product_add_publish event.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -278,6 +278,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$product->apply_changes();
 
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_update_product', $product->get_id(), $product, $changes );
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -278,7 +278,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$product->apply_changes();
 
-		do_action( 'woocommerce_update_product', $product->get_id(), $product );
+		do_action( 'woocommerce_update_product', $product->get_id(), $product, $changes );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -29,7 +29,7 @@ class WC_Products_Tracking {
 		add_action( 'load-edit.php', array( $this, 'track_products_view' ), 10 );
 		add_action( 'load-edit-tags.php', array( $this, 'track_categories_and_tags_view' ), 10, 2 );
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
-		add_action( 'wp_after_insert_post', array( $this, 'track_product_published' ), 10, 4 );
+		add_action( 'woocommerce_update_product', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
 		add_action( 'edited_product_cat', array( $this, 'track_product_category_updated' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10 );
@@ -303,24 +303,21 @@ class WC_Products_Tracking {
 	/**
 	 * Send a Tracks event when a product is published.
 	 *
-	 * @param int          $post_id     Post ID.
-	 * @param WP_Post      $post        Post object.
-	 * @param bool         $update      Whether this is an existing post being updated.
-	 * @param null|WP_Post $post_before Null for new posts, the WP_Post object prior
-	 *                                  to the update for updated posts.
+	 * @param int        $product_id  Product ID.
+	 * @param WC_Product $product     Product object.
+	 * @param array      $changes     Product changes.
 	 */
-	public function track_product_published( $post_id, $post, $update, $post_before ) {
+	public function track_product_published( $product_id, $product, $changes ) {
 		if (
-			'product' !== $post->post_type ||
-			'publish' !== $post->post_status ||
-			( $post_before && 'publish' === $post_before->post_status )
+			! isset( $product ) ||
+			'product' !== $product->post_type ||
+			'publish' !== $product->get_status( 'edit' ) ||
+			( $changes && ! isset( $changes['status'] ) )
 		) {
 			return;
 		}
 
-		$product = wc_get_product( $post_id );
-
-		$product_type_options        = self::get_product_type_options( $post_id );
+		$product_type_options        = self::get_product_type_options( $product_id );
 		$product_type_options_string = self::get_product_type_options_string( $product_type_options );
 
 		$properties = array(
@@ -334,7 +331,7 @@ class WC_Products_Tracking {
 			'is_virtual'           => $product->is_virtual() ? 'yes' : 'no',
 			'manage_stock'         => $product->get_manage_stock() ? 'yes' : 'no',
 			'menu_order'           => $product->get_menu_order() ? 'yes' : 'no',
-			'product_id'           => $post_id,
+			'product_id'           => $product_id,
 			'product_gallery'      => count( $product->get_gallery_image_ids() ),
 			'product_image'        => $product->get_image_id() ? 'yes' : 'no',
 			'product_type'         => $product->get_type(),

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -308,7 +308,7 @@ class WC_Products_Tracking {
 	 * @param WC_Product $product     Product object.
 	 * @param array      $changes     Product changes.
 	 */
-	public function track_product_published( $product_id, $product, $changes ) {
+	public function track_product_published( $product_id, $product, $changes = null ) {
 		if (
 			! isset( $product ) ||
 			'product' !== $product->post_type ||

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -29,6 +29,7 @@ class WC_Products_Tracking {
 		add_action( 'load-edit.php', array( $this, 'track_products_view' ), 10 );
 		add_action( 'load-edit-tags.php', array( $this, 'track_categories_and_tags_view' ), 10, 2 );
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
+		add_action( 'woocommerce_new_product', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'woocommerce_update_product', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
 		add_action( 'edited_product_cat', array( $this, 'track_product_category_updated' ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR provides an alternate implementation to #48111 to fix the terms counts in the `wcadmin_product_add_publish` Tracks events. Since the implementation is quite different and avoids most of the changes in #48111, it seemed easiest to share this as a new PR.

The following changes were made:

* Pass product changes to `woocommerce_update_product` action (since this is an additional parameter, existing hooks should continue to work fine by ignoring this)
* Use `woocommerce_new_product` and `woocommerce_update_product` action instead of `wp_after_insert_post` action to log Tracks event, since then all related data for product (including terms) have been updated.

Closes #48094.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

(Testing instructions shamelessly mostly copied from #48111)

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**), and the Gutenberg plugin installed...

1. Go to **Products** > **Add New**
2. Edit the product data
3. Assign categories, tags, and or attributes 
4. Save the product, always keeping the draft state
5. Edit other product attributes.
6. Confirm there is not a new `wcadmin_product_add_publish` event in the events `Tracks` event for this product yet.
(`/wp-admin/admin.php?page=wc-status&tab=logs`)
7. Publish the product
8. Confirm now there is a new `wcadmin_product_add_publish` for your current product
9. Confirm the attributes, categories, and tag counts are correct in the event data

<img src="https://github.com/woocommerce/woocommerce/assets/77539/26fe5fae-b73c-4584-a5e6-0ae559e94a5a" width="600px" />

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
