### PR TITLE
Add `original_post_status` to HPOS order edit screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-40871
+++ b/plugins/woocommerce/changelog/fix-40871
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Include 'original_post_status' in HPOS edit form.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -474,7 +474,12 @@ class Edit {
 		wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
 		?>
 		<input type="hidden" id="hiddenaction" name="action" value="<?php echo esc_attr( $form_action ); ?>"/>
-		<input type="hidden" id="original_order_status" name="original_order_status" value="<?php echo esc_attr( $this->order->get_status() ); ?>"/>
+
+		<?php
+		$order_status = $this->order->get_status( 'edit' );
+		?>
+		<input type="hidden" id="original_order_status" name="original_order_status" value="<?php echo esc_attr( $order_status ); ?>"/>
+		<input type="hidden" id="original_post_status" name="original_post_status" value="<?php echo wc_is_order_status( 'wc-' . $order_status ) ? 'wc-' . $order_status : $order_status; ?>"/>
 		<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>"/>
 		<input type="hidden" id="post_ID" name="post_ID" value="<?php echo esc_attr( $this->order->get_id() ); ?>"/>
 		<div id="poststuff">

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -479,7 +479,7 @@ class Edit {
 		$order_status = $this->order->get_status( 'edit' );
 		?>
 		<input type="hidden" id="original_order_status" name="original_order_status" value="<?php echo esc_attr( $order_status ); ?>"/>
-		<input type="hidden" id="original_post_status" name="original_post_status" value="<?php echo wc_is_order_status( 'wc-' . $order_status ) ? 'wc-' . $order_status : $order_status; ?>"/>
+		<input type="hidden" id="original_post_status" name="original_post_status" value="<?php echo esc_attr( wc_is_order_status( 'wc-' . $order_status ) ? 'wc-' . $order_status : $order_status ); ?>"/>
 		<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>"/>
 		<input type="hidden" id="post_ID" name="post_ID" value="<?php echo esc_attr( $this->order->get_id() ); ?>"/>
 		<div id="poststuff">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When the order datastore is set to "posts" (CPT), there's a field `original_post_status` in the order edit form which, when referring to a WC order status, has the `wc-` prefix (for example, `wc-pending`).

When using HPOS, this field no longer exists and we have a `original_order_status` field instead, which contains a non-prefixed version of the order status (for example, `pending`).

After a quick search on GH, it doesn't seem like either of these fields is used much. Only instances I found were a couple of tests and then there's WooCommerce Payments, which already includes a workaround that looks at both fields and also handles the prefix/non-prefix situation.

Adding the prefix to `original_order_status` is probably backwards incompatible, but adding a prefixed `original_post_status` (this being what this PR does) seems fine, and it's also compatible with CPT or admin code expecting this CPT field.

Alternatively, we could just do nothing as these fields don't seem to be widely used at all, but still the changes here could make things slightly easier for a few use cases.

Closes #40871.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Orders > Add order.
2. Use the devtools to look for the `original_post_status` and `original_order_status` fields: both should be set to `auto-draft`.
3. Choose "Processing" as order status and click "Create".
4. Use the devtools to look for the `original_post_status` and `original_order_status` fields again. This time, the former should be set to `wc-processing` while the latter is set to `processing`.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
