### PR TITLE
Ensure attribute slugs are properly handled in the Products REST API controller

### DIFF
--- a/plugins/woocommerce/changelog/fix-36138-rest-attribute-name
+++ b/plugins/woocommerce/changelog/fix-36138-rest-attribute-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure attribute slugs with multibyte characters are handled property when outputting attributes in the REST API products endpoint

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1123,7 +1123,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		$attributes = array_fill_keys( array_keys( $this->get_attributes( 'edit' ) ), null );
 		foreach ( $raw_attributes as $attribute ) {
 			if ( is_a( $attribute, 'WC_Product_Attribute' ) ) {
-				$attributes[ wc_sanitize_taxonomy_name( $attribute->get_name() ) ] = $attribute;
+				$attributes[ sanitize_title( $attribute->get_name() ) ] = $attribute;
 			}
 		}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1123,7 +1123,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		$attributes = array_fill_keys( array_keys( $this->get_attributes( 'edit' ) ), null );
 		foreach ( $raw_attributes as $attribute ) {
 			if ( is_a( $attribute, 'WC_Product_Attribute' ) ) {
-				$attributes[ sanitize_title( $attribute->get_name() ) ] = $attribute;
+				$attributes[ wc_sanitize_taxonomy_name( $attribute->get_name() ) ] = $attribute;
 			}
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -462,8 +462,12 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	protected function get_attribute_taxonomy_name( $slug, $product ) {
 		// Format slug so it matches attributes of the product.
 		$slug       = wc_attribute_taxonomy_slug( $slug );
-		$attributes = $product->get_attributes();
-		$attribute  = false;
+		$attributes = array_combine(
+			array_map( 'wc_sanitize_taxonomy_name', array_keys( $product->get_attributes() ) ),
+			array_values( $product->get_attributes() )
+		);
+
+		$attribute = false;
 
 		// pa_ attributes.
 		if ( isset( $attributes[ wc_attribute_taxonomy_name( $slug ) ] ) ) {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
@@ -293,4 +293,24 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 
 		$this->assertIsArray( $decoded_data_object[0]->meta_data );
 	}
+
+	/**
+	 * @testdox Test that an attribute with a multibyte name includes that name correctly in the attributes
+	 *          property of the product object.
+	 */
+	public function test_product_with_multibyte_attribute() {
+		$product   = WC_Helper_Product::create_simple_product();
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'Сирене', array( 'asdf', 'fdsa' ) );
+
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals( 'Сирене', $data['attributes'][0]['name'] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When taxonomy terms are added that have multibyte characters (Cyrillic or others) in their name/title, those characters get converted to URL entities for the slug field. In the case of product attributes, this was causing a problem in the Products REST API controller because it was not decoding these entities before trying to match them up in the `get_attribute_taxonomy_label` method. This causes the behavior described in #36138.

Initially I tried adding extra sanitization in the `WC_Product::set_attributes` method, but this actually caused problems elsewhere in the codebase that was expecting the encoded entities. So instead, this PR simply does the decoding right before getting the attribute name within the REST API controller.

Fixes #36138

### How to test the changes in this Pull Request:

1. Create a global attribute. Give it a name that includes some Cyrillic characters, like Сирене (note that it is capitalized). Add some terms to the attribute.
2. Now create a product. Mark it as a Variable product. In the Product data > Attributes tab, add the attribute to the product and include the attributes values. Save attributes. Then go to the Variations tab. Click the button to generate variations. Save changes. Then refresh the screen and ensure the attributes and variations are still added to the product. Note the product's ID.
3. Now make a REST request to get the product's data:
    ```
    curl --request GET \
      --url http://localhost/wp-json/wc/v3/products/{product IC}
    ```
4. In the response look for the `attributes` property and make sure your Cyrillic attribute is there and that the `name` field has the capitalized name in it. Something like this:
    ```
    {
      "id": 3,
      "name": "Сирене",
      "slug": "pa_сирене",
      "position": 1,
      "visible": true,
      "variation": true,
      "options": [
        "A",
        "B"
      ]
    }
    ```