### PR TITLE
Fix tax table ajax save

### DIFF
--- a/plugins/woocommerce/changelog/48201-fix-48189-tax-table-save
+++ b/plugins/woocommerce/changelog/48201-fix-48189-tax-table-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix - Tax table ajax save  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48201-fix-48189-tax-table-save
+++ b/plugins/woocommerce/changelog/48201-fix-48189-tax-table-save
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix - Tax table ajax save  </details>  <details>  <summary>Changelog Entry Comment</summary>
+Fix tax table ajax save

--- a/plugins/woocommerce/changelog/48201-fix-48189-tax-table-save
+++ b/plugins/woocommerce/changelog/48201-fix-48189-tax-table-save
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix tax table ajax save
+#47626 changed the classes on the legacy admin settings save button and broke saving standard tax rates

--- a/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
@@ -20,7 +20,7 @@
 			$save_button       = $( ':input[name="save"]' ),
 			$pagination        = $( '#rates-pagination, #rates-bottom-pagination' ),
 			$search_field      = $( '#rates-search .wc-tax-rates-search-field' ),
-			$submit            = $( '.submit .button-primary[type=submit]' ),
+			$submit            = $( '.woocommerce-save-button[type=submit]' ),
 			WCTaxTableModelConstructor = Backbone.Model.extend({
 				changes: {},
 				setRateAttribute: function( rateID, attribute, value ) {
@@ -72,9 +72,13 @@
 							opacity: 0.6
 						}
 					});
+					if ( ! $submit.attr( 'disabled' ) ) {
+						$submit.addClass( 'is-busy' );
+					}
 				},
 				unblock: function() {
 					$( '.wc_tax_rates' ).unblock();
+					$submit.removeClass( 'is-busy' );
 				},
 				save: function() {
 					var self = this;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The save button on the tax table was not firing correctly causing the ajax save not to work and displaying a browser modal of unsaved changes.

Closes #48189

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

- Check out this branch
- Build the plugin file `pnpm build`
- Head to WooCommerce -> Settings -> Tax -> Standard Rates
- Make some changes to the tax tables, like adding and removing rates
- Click the `Save changes` button and verify you do not get any browser modal notifying you that you have unsaved changes.
- Verify the table is blocked out while saving and then unblocked again
- Verify the rates actually saved by reloading the page and checking the rates is displaying that was saved.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

#47626 changed the classes on the legacy admin settings save button and broke saving standard tax rates.

The referenced PR is part of [the 9.0.0 milestone](https://github.com/woocommerce/woocommerce/milestone/231), so no users have experienced the issues, so we can exclude it from the changelog if we want to.

</details>
