### PR TITLE
Hide Products (Beta) from inserter

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
@@ -6,7 +6,7 @@
 	"title": "Product Collection",
 	"description": "Display a collection of products from your store.",
 	"category": "woocommerce",
-	"keywords": [ "WooCommerce", "Products (Beta)" ],
+	"keywords": [ "WooCommerce", "Products (Beta)", "products" ],
 	"textdomain": "woocommerce",
 	"attributes": {
 		"queryId": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/product-query.tsx
@@ -63,7 +63,7 @@ const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
 		// @ts-ignore
 		allowedControls: DEFAULT_ALLOWED_CONTROLS,
 		innerBlocks: INNER_BLOCKS_TEMPLATE,
-		scope: [ 'inserter' ],
+		scope: [],
 	} );
 };
 

--- a/plugins/woocommerce/changelog/43414-product-collection-hide-products-beta-from-inserter
+++ b/plugins/woocommerce/changelog/43414-product-collection-hide-products-beta-from-inserter
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Products (Beta): hide block from inserter. Use Product Collection instead

--- a/plugins/woocommerce/changelog/43414-product-collection-hide-products-beta-from-inserter
+++ b/plugins/woocommerce/changelog/43414-product-collection-hide-products-beta-from-inserter
@@ -1,4 +1,4 @@
 Significance: major
 Type: update
 
-Products (Beta): hide block from inserter. Use Product Collection instead
+Products (Beta): hide block from inserter in favor of Product Collection block

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
@@ -261,7 +261,7 @@ test.describe( 'Browse product tags and attributes from the product page', () =>
 	} );
 
 	test( 'can see products showcase', async ( { page } ) => {
-		// create as a merchant a new page with Products block
+		// create as a merchant a new page with Product Collection block
 		await goToPageEditor( { page } );
 
 		await page
@@ -274,7 +274,7 @@ test.describe( 'Browse product tags and attributes from the product page', () =>
 			.getByRole( 'document', {
 				name: 'Empty block; start writing or type forward slash to choose a block',
 			} )
-			.fill( '/products' );
+			.fill( '/product collection' );
 		await page.keyboard.press( 'Enter' );
 
 		await page

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
@@ -277,6 +277,13 @@ test.describe( 'Browse product tags and attributes from the product page', () =>
 			.fill( '/product collection' );
 		await page.keyboard.press( 'Enter' );
 
+		// Product Collection requires choosing some collection.
+		await page
+			.getByRole( 'button', {
+				name: 'Product Catalog Display all products in your catalog. Results can (change to) match the current template, page, or search term.',
+			} )
+			.click();
+
 		await page
 			.getByRole( 'button', { name: 'Publish', exact: true } )
 			.click();

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
@@ -274,7 +274,7 @@ test.describe( 'Browse product tags and attributes from the product page', () =>
 			.getByRole( 'document', {
 				name: 'Empty block; start writing or type forward slash to choose a block',
 			} )
-			.fill( '/product collection' );
+			.pressSequentially( '/product collection' );
 		await page.keyboard.press( 'Enter' );
 
 		// Product Collection requires choosing some collection.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR hides Products (Beta) from inserter.

This PR will be merged with https://github.com/woocommerce/woocommerce/pull/48112 that replaces Products (Beta) with Product Collection in product archive templates.

Closes https://github.com/woocommerce/woocommerce/issues/43414

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Try adding "Products (Beta)" block by typing:
   - `/products`
   - `/products (beta)`
   - `/products beta`
4. **Expected:** It doesn't appear in the inserter but `Product Collection` does. Order of blocks may differ from the screenshots below

`/products` | `/products (beta)` | `/products beta`
-- | -- | --
<img width="501" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/4db964f3-c416-4123-89c8-1d18d777c1de"> | <img width="423" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/331359f0-cc59-4d96-a66f-d6072fa5efbe"> | <img width="396" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/fcb3bd23-cfa5-4e8b-85ec-cfa619864db2">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
