### PR TITLE
PFT: retrieve and render the product form templates

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-retrieves-templates-from-cpt
+++ b/packages/js/product-editor/changelog/update-product-editor-retrieves-templates-from-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+PFT: retrieve and render the product form templates

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -226,7 +226,7 @@ export function BlockEditor( {
 		);
 	}, [] ) as ProductFormTemplateProps[];
 
-	// Set the defailt product form template ID.
+	// Set the default product form template ID.
 	useEffect( () => {
 		if ( ! productForms.length ) {
 			return;

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { useLayoutTemplate } from '@woocommerce/block-templates';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { Product } from '@woocommerce/data';
+import { SelectControl } from '@wordpress/components';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
@@ -252,7 +253,7 @@ export function BlockEditor( {
 		);
 
 		let productFormTemplate;
-		if ( productFormPost && isProductEditorTemplateSystemEnabled ) {
+		if ( isProductEditorTemplateSystemEnabled && productFormPost ) {
 			productFormTemplate = parse( productFormPost.content.raw );
 		}
 
@@ -284,7 +285,7 @@ export function BlockEditor( {
 		// the blocks by calling onChange.
 		//
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isEditorLoading, productId, productForms ] );
+	}, [ isEditorLoading, productId, productForms, selectedProductFormId ] );
 
 	// Check if the Modal editor is open from the store.
 	const isModalEditorOpen = useSelect( ( selectCore ) => {
@@ -312,8 +313,34 @@ export function BlockEditor( {
 		);
 	}
 
+	const formTemplateSelectValues = productForms?.map( ( form ) => ( {
+		label: form.title.raw,
+		value: String( form.id ),
+	} ) );
+
 	return (
 		<div className="woocommerce-product-block-editor">
+			{ isProductEditorTemplateSystemEnabled && (
+				<div style={ { margin: '32px', width: '250px' } }>
+					<SelectControl
+						label={ __(
+							'Choose form template type',
+							'woocommerce'
+						) }
+						options={ formTemplateSelectValues }
+						onChange={ ( value: string ) =>
+							setSelectedProductFormId( parseInt( value, 10 ) )
+						}
+						disabled={ ! productForms }
+						className="woocommerce-product-block-editor__product-type-selector"
+						help={ __(
+							'This is a temporary setting.',
+							'woocommerce'
+						) }
+					/>
+				</div>
+			) }
+
 			<BlockContextProvider value={ context }>
 				<BlockEditorProvider
 					value={ blocks }

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -49,3 +49,43 @@ export interface Taxonomy {
 export interface TaxonomyMetadata {
 	hierarchical: boolean;
 }
+
+export type ProductFormTemplateProps = {
+	id: number;
+	date: string;
+	date_gmt: string;
+	guid: {
+		rendered: string;
+		raw: string;
+	};
+	modified: string;
+	modified_gmt: string;
+	password: string;
+	slug: string;
+	status: 'publish' | 'future' | 'draft' | 'pending' | 'private';
+	type: 'product_form';
+	link: string;
+	title: {
+		raw: string;
+		rendered: string;
+	};
+	content: {
+		raw: string;
+		rendered: string;
+		protected: false;
+		block_version: number;
+	};
+	excerpt: {
+		raw: string;
+		rendered: string;
+		protected: boolean;
+	};
+	featured_media: number;
+	comment_status: 'open' | 'closed';
+	ping_status: 'closed' | 'open';
+	template: '';
+	meta: [];
+	permalink_template: string;
+	generated_slug: string;
+	class_list: string[];
+};

--- a/packages/js/product-editor/typings/global.d.ts
+++ b/packages/js/product-editor/typings/global.d.ts
@@ -1,42 +1,6 @@
 declare global {
 	interface Window {
-		wcAdminFeatures: {
-			'activity-panels': boolean;
-			analytics: boolean;
-			'product-block-editor': boolean;
-			'experimental-blocks': boolean;
-			coupons: boolean;
-			'core-profiler': boolean;
-			'customize-store': boolean;
-			'import-products-task': boolean;
-			'experimental-fashion-sample-products': boolean;
-			'shipping-smart-defaults': boolean;
-			'shipping-setting-tour': boolean;
-			homescreen: boolean;
-			marketing: boolean;
-			'minified-js': boolean;
-			'mobile-app-banner': boolean;
-			navigation: boolean;
-			onboarding: boolean;
-			'onboarding-tasks': boolean;
-			'pattern-toolkit-full-composability': boolean;
-			'product-pre-publish-modal': boolean;
-			'product-custom-fields': boolean;
-			'remote-inbox-notifications': boolean;
-			'remote-free-extensions': boolean;
-			'payment-gateway-suggestions': boolean;
-			settings: boolean;
-			'shipping-label-banner': boolean;
-			subscriptions: boolean;
-			'store-alerts': boolean;
-			'transient-notices': boolean;
-			'woo-mobile-welcome': boolean;
-			'wc-pay-promotion': boolean;
-			'wc-pay-welcome-page': boolean;
-			'async-product-editor-category-field': boolean;
-			'launch-your-store': boolean;
-			'product-editor-template-system': boolean;
-		};
+		wcAdminFeatures: Record< string, boolean >;
 		wcTracks: {
 			isEnabled: boolean;
 			validateEvent: (

--- a/packages/js/product-editor/typings/global.d.ts
+++ b/packages/js/product-editor/typings/global.d.ts
@@ -1,6 +1,42 @@
 declare global {
 	interface Window {
-		wcAdminFeatures: Record< string, boolean >;
+		wcAdminFeatures: {
+			'activity-panels': boolean;
+			analytics: boolean;
+			'product-block-editor': boolean;
+			'experimental-blocks': boolean;
+			coupons: boolean;
+			'core-profiler': boolean;
+			'customize-store': boolean;
+			'import-products-task': boolean;
+			'experimental-fashion-sample-products': boolean;
+			'shipping-smart-defaults': boolean;
+			'shipping-setting-tour': boolean;
+			homescreen: boolean;
+			marketing: boolean;
+			'minified-js': boolean;
+			'mobile-app-banner': boolean;
+			navigation: boolean;
+			onboarding: boolean;
+			'onboarding-tasks': boolean;
+			'pattern-toolkit-full-composability': boolean;
+			'product-pre-publish-modal': boolean;
+			'product-custom-fields': boolean;
+			'remote-inbox-notifications': boolean;
+			'remote-free-extensions': boolean;
+			'payment-gateway-suggestions': boolean;
+			settings: boolean;
+			'shipping-label-banner': boolean;
+			subscriptions: boolean;
+			'store-alerts': boolean;
+			'transient-notices': boolean;
+			'woo-mobile-welcome': boolean;
+			'wc-pay-promotion': boolean;
+			'wc-pay-welcome-page': boolean;
+			'async-product-editor-category-field': boolean;
+			'launch-your-store': boolean;
+			'product-editor-template-system': boolean;
+		};
 		wcTracks: {
 			isEnabled: boolean;
 			validateEvent: (


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR pulls and shows the Product Form Templates in the UI, showing a temporary selector whose purpose is purely for the testing/development process. It's safe, considering the changes are hidden behind the `product-editor-template-system` feature flag.

Closes #48174

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Enable the `product-editor-template-system` feature flag
  a. Install the WooCommerce Beta Tester plugin
  b. Go to the Settings -> WCA Test Helper -> Features
  c. Enable the `product-editor-template-system` feature flag

![image](https://github.com/woocommerce/woocommerce/assets/77539/4fbfeeae-3ed2-417f-8419-ef813d3a0e0a)

3. Ensure there are a few Product Form Templates
4. Go to "Products > Add New"
5. Confirm the UI shows the `CHOOSE FORM TEMPLATE TYPE` selector:

<img width="350" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/f3580387-cb12-4bfe-9132-d8d92b293005">
6. Confirm the app switches the templates when selecting a template

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
