### PR TITLE
[testing workflows] Replace push to tags trigger with release published and updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
         branches:
             - 'trunk'
             - 'release/*'
-        tags:
-          - '*'
+    release:
+      types: [ published, edited ]
     workflow_call:
         inputs:
             trigger:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After some testing it doesn't look like updates to tags are triggering the workflow for `release-checks` as expected.
Using the release event looks like a better fit for what we need. 

### How to test the changes in this Pull Request:

YAML review.

