### PR TITLE
PFT: introduce controller and initialize it

### DIFF
--- a/plugins/woocommerce/changelog/update-pft-save-template-into-db
+++ b/plugins/woocommerce/changelog/update-pft-save-template-into-db
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+PFT: introduce controller and initialize it

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -385,7 +385,8 @@ class WC_Post_Types {
 				apply_filters(
 					'woocommerce_register_post_type_product_form',
 					array(
-						'labels'             => array(
+						'labels'
+						=> array(
 							'name'                  => __( 'Product Forms', 'woocommerce' ),
 							'singular_name'         => __( 'Product Form', 'woocommerce' ),
 							'all_items'             => __( 'All Product Form', 'woocommerce' ),
@@ -413,22 +414,22 @@ class WC_Post_Types {
 							'item_link'             => __( 'Product form Link', 'woocommerce' ),
 							'item_link_description' => __( 'A link to a product form.', 'woocommerce' ),
 						),
-						'description'        => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
-						'public'             => true,
-						'menu_icon'          => 'dashicons-forms',
-						'capability_type'    => 'product',
-						'map_meta_cap'       => true,
-						'publicly_queryable' => true,
-						'hierarchical'       => false, // Hierarchical causes memory issues - WP loads all records!
-						'rewrite'            => $permalinks['product_rewrite_slug'] ? array(
+						'description'         => __( 'This is where you can set up product forms for various product types in your dashboard.', 'woocommerce' ),
+						'public'              => true,
+						'menu_icon'           => 'dashicons-forms',
+						'capability_type'     => 'product',
+						'map_meta_cap'        => true,
+						'publicly_queryable'  => true,
+						'hierarchical'        => false, // Hierarchical causes memory issues - WP loads all records!
+						'rewrite'             => $permalinks['product_rewrite_slug'] ? array(
 							'slug'       => $permalinks['product_rewrite_slug'],
 							'with_front' => false,
 							'feeds'      => true,
 						) : false,
-						'query_var'          => true,
-						'supports'           => $supports,
-						'has_archive'        => $has_archive,
-						'show_in_rest'       => true,
+						'query_var'           => true,
+						'supports'            => $supports,
+						'has_archive'         => $has_archive,
+						'show_in_rest'        => true,
 						'show_ui'             => true,
 						'show_in_menu'        => true,
 						'exclude_from_search' => true,

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -429,7 +429,10 @@ class WC_Post_Types {
 						'supports'           => $supports,
 						'has_archive'        => $has_archive,
 						'show_in_rest'       => true,
-						'show_ui'            => false,
+						'show_ui'             => true,
+						'show_in_menu'        => true,
+						'exclude_from_search' => true,
+						'show_in_nav_menus'   => false,
 					)
 				)
 			);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
+
+class BlockTemplateUtils {
+	/**
+	 * Directory which contains all templates
+	 *
+	 * @var string
+	 */
+	const TEMPLATES_ROOT_DIR = 'templates';
+
+	/**
+     * Directory names.
+     *
+     * @var array
+     */
+	const DIRECTORY_NAMES = array(
+    	'TEMPLATES'      => 'product-form',
+    	'TEMPLATE_PARTS' => 'product-form/parts'
+	);
+
+	/**
+	 * Gets the directory where templates of a specific template type can be found.
+	 *
+	 * @param string $template_type wp_template or wp_template_part.
+	 * @return string
+	 */
+	private static function get_templates_directory( $template_type = 'wp_template' ) {
+    	$root_path                = dirname( __DIR__, 4 ) . '/' . self::TEMPLATES_ROOT_DIR . DIRECTORY_SEPARATOR;
+    	$templates_directory      = $root_path . self::DIRECTORY_NAMES['TEMPLATES'];
+    	$template_parts_directory = $root_path . self::DIRECTORY_NAMES['TEMPLATE_PARTS'];
+
+    	if ( 'wp_template_part' === $template_type ) {
+    		return $template_parts_directory;
+    	}
+
+    	return $templates_directory;
+	}
+
+
+	/**
+     * Return the path to a block template file.
+	 * Otherwise, False.
+	 *
+	 * @param string $slug - Template slug.
+	 * @return string|bool   Path to the template file or false.
+     */
+	public static function get_block_template_path( $slug ) {
+    	$directory = self::get_templates_directory();
+		$path      = trailingslashit( $directory ) . $slug . '.php';
+
+		if ( ! file_exists( $path ) ) {
+			return false;
+		}
+
+		return $path;
+	}
+
+	/**
+ 	 * Get the template data from the headers.
+ 	 *
+ 	 * @param string $file_path File path.
+ 	 * @return array Template data.
+ 	 */
+	public static function get_template_file_data( $file_path ) {
+		if ( ! file_exists( $file_path ) ) {
+			return array();
+		}
+
+    	$file_data = get_file_data(
+			$file_path,
+			array(
+				'title'         => 'Title',
+				'slug'          => 'Slug',
+				'description'   => 'Description',
+				'product_types' => 'Product Types'
+			)
+		);
+
+    	$file_data['product_types'] = explode( ',', trim( $file_data['product_types'] ) );
+
+    	return $file_data;
+	}
+
+	/**
+     * Get the template content from the file.
+     *
+     * @param $file_path File path.
+     * @return string Content.
+     */
+	public static function get_template_content( $file_path ) {
+		if ( ! file_exists( $file_path ) ) {
+			return '';
+		}
+
+    	ob_start();
+    	include( $file_path );
+    	$content = ob_get_contents(); 
+    	ob_end_clean();
+
+    	return $content;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockTemplateUtils.php
@@ -4,6 +4,9 @@ namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
 use Automattic\WooCommerce\LayoutTemplates\LayoutTemplateRegistry;
 
+/**
+ * Utils for block templates.
+ */
 class BlockTemplateUtils {
 	/**
 	 * Directory which contains all templates
@@ -13,13 +16,13 @@ class BlockTemplateUtils {
 	const TEMPLATES_ROOT_DIR = 'templates';
 
 	/**
-     * Directory names.
-     *
-     * @var array
-     */
+	 * Directory names.
+	 *
+	 * @var array
+	 */
 	const DIRECTORY_NAMES = array(
-    	'TEMPLATES'      => 'product-form',
-    	'TEMPLATE_PARTS' => 'product-form/parts'
+		'TEMPLATES'      => 'product-form',
+		'TEMPLATE_PARTS' => 'product-form/parts',
 	);
 
 	/**
@@ -29,27 +32,26 @@ class BlockTemplateUtils {
 	 * @return string
 	 */
 	private static function get_templates_directory( $template_type = 'wp_template' ) {
-    	$root_path                = dirname( __DIR__, 4 ) . '/' . self::TEMPLATES_ROOT_DIR . DIRECTORY_SEPARATOR;
-    	$templates_directory      = $root_path . self::DIRECTORY_NAMES['TEMPLATES'];
-    	$template_parts_directory = $root_path . self::DIRECTORY_NAMES['TEMPLATE_PARTS'];
+		$root_path                = dirname( __DIR__, 4 ) . '/' . self::TEMPLATES_ROOT_DIR . DIRECTORY_SEPARATOR;
+		$templates_directory      = $root_path . self::DIRECTORY_NAMES['TEMPLATES'];
+		$template_parts_directory = $root_path . self::DIRECTORY_NAMES['TEMPLATE_PARTS'];
 
-    	if ( 'wp_template_part' === $template_type ) {
-    		return $template_parts_directory;
-    	}
+		if ( 'wp_template_part' === $template_type ) {
+			return $template_parts_directory;
+		}
 
-    	return $templates_directory;
+		return $templates_directory;
 	}
 
-
 	/**
-     * Return the path to a block template file.
+	 * Return the path to a block template file.
 	 * Otherwise, False.
 	 *
 	 * @param string $slug - Template slug.
 	 * @return string|bool   Path to the template file or false.
-     */
+	 */
 	public static function get_block_template_path( $slug ) {
-    	$directory = self::get_templates_directory();
+		$directory = self::get_templates_directory();
 		$path      = trailingslashit( $directory ) . $slug . '.php';
 
 		if ( ! file_exists( $path ) ) {
@@ -60,47 +62,47 @@ class BlockTemplateUtils {
 	}
 
 	/**
- 	 * Get the template data from the headers.
- 	 *
- 	 * @param string $file_path File path.
- 	 * @return array Template data.
- 	 */
+	 * Get the template data from the headers.
+	 *
+	 * @param string $file_path - File path.
+	 * @return array              Template data.
+	 */
 	public static function get_template_file_data( $file_path ) {
 		if ( ! file_exists( $file_path ) ) {
 			return array();
 		}
 
-    	$file_data = get_file_data(
+		$file_data = get_file_data(
 			$file_path,
 			array(
 				'title'         => 'Title',
 				'slug'          => 'Slug',
 				'description'   => 'Description',
-				'product_types' => 'Product Types'
-			)
+				'product_types' => 'Product Types',
+			),
 		);
 
-    	$file_data['product_types'] = explode( ',', trim( $file_data['product_types'] ) );
+		$file_data['product_types'] = explode( ',', trim( $file_data['product_types'] ) );
 
-    	return $file_data;
+		return $file_data;
 	}
 
 	/**
-     * Get the template content from the file.
-     *
-     * @param $file_path File path.
-     * @return string Content.
-     */
+	 * Get the template content from the file.
+	 *
+	 * @param string $file_path - File path.
+	 * @return string Content.
+	 */
 	public static function get_template_content( $file_path ) {
 		if ( ! file_exists( $file_path ) ) {
 			return '';
 		}
 
-    	ob_start();
-    	include( $file_path );
-    	$content = ob_get_contents(); 
-    	ob_end_clean();
+		ob_start();
+		include $file_path;
+		$content = ob_get_contents();
+		ob_end_clean();
 
-    	return $content;
+		return $content;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -46,6 +46,13 @@ class Init {
 	private $redirection_controller;
 
 	/**
+	 * Product form controller.
+	 *
+	 * @var ProductFormsController
+	 */ 
+	private $product_form_controller;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -376,6 +383,12 @@ class Init {
 		);
 
 		$this->redirection_controller->set_product_templates( $this->product_templates );
+
+		// PFT: Initialize the product form controller.
+		if ( Features::is_enabled( 'product-editor-template-system' ) ) {
+			$this->product_form_controller = new ProductFormsController;
+			$this->product_form_controller->init();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -46,13 +46,6 @@ class Init {
 	private $redirection_controller;
 
 	/**
-	 * Product form controller.
-	 *
-	 * @var ProductFormsController
-	 */ 
-	private $product_form_controller;
-
-	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -386,8 +379,8 @@ class Init {
 
 		// PFT: Initialize the product form controller.
 		if ( Features::is_enabled( 'product-editor-template-system' ) ) {
-			$this->product_form_controller = new ProductFormsController;
-			$this->product_form_controller->init();
+			$product_form_controller = new ProductFormsController;
+			$product_form_controller->init();
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -379,7 +379,7 @@ class Init {
 
 		// PFT: Initialize the product form controller.
 		if ( Features::is_enabled( 'product-editor-template-system' ) ) {
-			$product_form_controller = new ProductFormsController;
+			$product_form_controller = new ProductFormsController();
 			$product_form_controller->init();
 		}
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -14,18 +14,17 @@ class ProductFormsController {
 	 * Set up the product forms controller.
 	 */
 	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingFinal, WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag -- Not an injection.
-		// Migrate form templates after WooCommerce plugin update.
-		add_action( 'upgrader_process_complete', array( $this, 'migrate_form_templates' ), 10, 2 );
+		add_action( 'upgrader_process_complete', array( $this, 'migrate_templates_when_plugin_updated' ), 10, 2 );
 	}
 
 	/**
-	 * Migrate form templates.
+	 * Migrate form templates after WooCommerce plugin update.
 	 *
 	 * @param \WP_Upgrader $upgrader The WP_Upgrader instance.
 	 * @param array        $hook_extra Extra arguments passed to hooked filters.
 	 * @return void
 	 */
-	public function migrate_form_templates( \WP_Upgrader $upgrader, array $hook_extra ) {
+	public function migrate_templates_when_plugin_updated( \WP_Upgrader $upgrader, array $hook_extra ) {
 		// Check if the action is an `update` or `install` action for a plugin.
 		if (
 			'install' !== $hook_extra['action'] &&
@@ -42,6 +41,15 @@ class ProductFormsController {
 			return;
 		}
 
+		$this->insert_post_form_posts();
+	}
+
+	/**
+	 * Insert post form posts for each form template file.
+	 *
+	 * @return void
+	 */
+	public function insert_post_form_posts() {
 		/**
 		 * Allow extend the list of templates that should be auto-generated.
 		 *
@@ -78,7 +86,6 @@ class ProductFormsController {
 				continue;
 			}
 
-			// Insert the post.
 			$post = wp_insert_post(
 				array(
 					'post_title'   => $file_data['title'],
@@ -86,7 +93,7 @@ class ProductFormsController {
 					'post_status'  => 'publish',
 					'post_type'    => 'product_form',
 					'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
-					'post_excerpt' => __( 'Template auto-generated for the Product Form Template system', 'woocommerce' ),
+					'post_excerpt' => __( 'Template auto-generated for the (PFT) Product Form Template system', 'woocommerce' ),
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -75,7 +75,8 @@ class ProductFormsController {
 		 * @param array $templates List of templates to auto-generate.
 		 */
 		$templates = apply_filters(
-			'woocommerce_product_form_templates', $this->product_form_templates
+			'woocommerce_product_form_templates',
+			$this->product_form_templates
 		);
 
 		foreach ( $templates as $slug ) {

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -34,10 +34,19 @@ class ProductFormsController {
 			return;
 		}
 
-		$updated_plugins = $hook_extra['plugins'];
+		/*
+		 * Check whether $hook_extra['plugins'] contains the WooCommerce plugin.
+		 * It seems that $hook_extra may be `null` in some cases.
+		 * @see https://github.com/woocommerce/woocommerce/pull/48221#pullrequestreview-2102772713
+		 */
+		if ( ! isset( $hook_extra['plugins'] ) || ! is_array( $hook_extra['plugins'] ) ) {
+			return;
+		}
 
 		// Check if WooCommerce plugin was updated.
-		if ( ! in_array( 'woocommerce/woocommerce.php', $updated_plugins, true ) ) {
+		if (
+			! in_array( 'woocommerce/woocommerce.php', $hook_extra['plugins'], true )
+		) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -13,21 +13,24 @@ class ProductFormsController {
 	/**
 	 * Set up the product forms controller.
 	 */
-	public function init() {
-
+	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingFinal, WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag -- Not an injection.
 		// Migrate form templates after WooCommerce plugin update.
 		add_action( 'upgrader_process_complete', array( $this, 'migrate_form_templates' ), 10, 2 );
 	}
 
 	/**
 	 * Migrate form templates.
+	 *
+	 * @param \WP_Upgrader $upgrader The WP_Upgrader instance.
+	 * @param array        $hook_extra Extra arguments passed to hooked filters.
+	 * @return void
 	 */
 	public function migrate_form_templates( \WP_Upgrader $upgrader, array $hook_extra ) {
 		// Check if the action is an `update` or `install` action for a plugin.
 		if (
-			$hook_extra['action'] !== 'install' &&
-			$hook_extra['action'] !== 'update' ||
-			$hook_extra['type'] !== 'plugin'
+			'install' !== $hook_extra['action'] &&
+			'update' !== $hook_extra['action'] ||
+			'plugin' !== $hook_extra['type']
 		) {
 			return;
 		}
@@ -35,7 +38,7 @@ class ProductFormsController {
 		$updated_plugins = $hook_extra['plugins'];
 
 		// Check if WooCommerce plugin was updated.
-		if ( ! in_array( 'woocommerce/woocommerce.php', $updated_plugins ) ) {
+		if ( ! in_array( 'woocommerce/woocommerce.php', $updated_plugins, true ) ) {
 			return;
 		}
 
@@ -48,13 +51,12 @@ class ProductFormsController {
 		$templates = apply_filters(
 			'woocommerce_product_form_templates',
 			array(
-				'simple'
+				'simple',
 			)
 		);
 
 		foreach ( $templates as $slug ) {
 			$file_path = BlockTemplateUtils::get_block_template_path( $slug );
-			error_log( $file_path );
 
 			if ( ! $file_path ) {
 				continue;
@@ -67,7 +69,7 @@ class ProductFormsController {
 					'name'           => $slug,
 					'post_type'      => 'product_form',
 					'post_status'    => 'any',
-					'posts_per_page' => 1
+					'posts_per_page' => 1,
 				)
 			);
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -34,15 +34,6 @@ class ProductFormsController {
 	 * @return void
 	 */
 	public function migrate_templates_when_plugin_updated( \WP_Upgrader $upgrader, array $hook_extra ) {
-		// Check if the action is an `update` or `install` action for a plugin.
-		if (
-			'install' !== $hook_extra['action'] &&
-			'update' !== $hook_extra['action'] ||
-			'plugin' !== $hook_extra['type']
-		) {
-			return;
-		}
-
 		/*
 		 * Check whether $hook_extra['plugins'] contains the WooCommerce plugin.
 		 * It seems that $hook_extra may be `null` in some cases.
@@ -55,6 +46,16 @@ class ProductFormsController {
 		// Check if WooCommerce plugin was updated.
 		if (
 			! in_array( 'woocommerce/woocommerce.php', $hook_extra['plugins'], true )
+		) {
+			return;
+		}
+
+		// Check if the action is an `update` or `install` action for a plugin.
+		$action = isset( $hook_extra['action'] ) ? $hook_extra['action'] : '';
+
+		if (
+			'install' !== $action && 'update' !== $action ||
+			'plugin' !== $hook_extra['type']
 		) {
 			return;
 		}
@@ -97,7 +98,9 @@ class ProductFormsController {
 				)
 			);
 
-			// If the post already exists, skip.
+			/*
+			 * Skip the post creation if the post already exists.
+			 */
 			if ( ! empty( $posts ) ) {
 				continue;
 			}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * WooCommerce Product Forms Controller
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+/**
+ * Handle retrieval of product forms.
+ */
+class ProductFormsController {
+
+	/**
+	 * Set up the product forms controller.
+	 */
+	public function init() {
+
+		// Migrate form templates after WooCommerce plugin update.
+		add_action( 'upgrader_process_complete', array( $this, 'migrate_form_templates' ), 10, 2 );
+	}
+
+	/**
+	 * Migrate form templates.
+	 */
+	public function migrate_form_templates( \WP_Upgrader $upgrader, array $hook_extra ) {
+		// Check if the action is an update and the type is a plugin.
+		if ( $hook_extra['action'] !== 'update' || $hook_extra['type'] !== 'plugin') {
+			return;
+		}
+
+		$updated_plugins = $hook_extra['plugins'];
+
+		// Check if WooCommerce plugin was updated.
+		if ( ! in_array( 'woocommerce/woocommerce.php', $updated_plugins ) ) {
+			return;
+		}
+
+		/**
+		 * Allow extend the list of templates that should be auto-generated.
+		 *
+		 * @since 9.1.0
+		 * @param array $templates List of templates to auto-generate.
+		 */
+		$templates = apply_filters(
+			'woocommerce_product_form_templates',
+			array(
+				'simple'
+			)
+		);
+
+		foreach ( $templates as $slug ) {
+			$file_path = BlockTemplateUtils::get_block_template_path( $slug );
+			error_log( $file_path );
+
+			if ( ! $file_path ) {
+				continue;
+			}
+
+			$file_data = BlockTemplateUtils::get_template_file_data( $file_path );
+
+			$posts = get_posts(
+				array(
+					'name'           => $slug,
+					'post_type'      => 'product_form',
+					'post_status'    => 'any',
+					'posts_per_page' => 1
+				)
+			);
+
+			// If the post already exists, skip.
+			if ( ! empty( $posts ) ) {
+				continue;
+			}
+
+			// Insert the post.
+			$post = wp_insert_post(
+				array(
+					'post_title'   => $file_data['title'],
+					'post_name'    => $slug,
+					'post_status'  => 'publish',
+					'post_type'    => 'product_form',
+					'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
+					'post_excerpt' => __( 'Template auto-generated for the Product Form Template system', 'woocommerce' ),
+				)
+			);
+		}
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -59,7 +59,7 @@ class ProductFormsController {
 			return;
 		}
 
-		$this->insert_post_form_posts();
+		$this->migrate_product_form_posts();
 	}
 
 	/**
@@ -67,7 +67,7 @@ class ProductFormsController {
 	 *
 	 * @return void
 	 */
-	public function insert_post_form_posts() {
+	public function migrate_product_form_posts() {
 		/**
 		 * Allow extend the list of templates that should be auto-generated.
 		 *

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -23,8 +23,12 @@ class ProductFormsController {
 	 * Migrate form templates.
 	 */
 	public function migrate_form_templates( \WP_Upgrader $upgrader, array $hook_extra ) {
-		// Check if the action is an update and the type is a plugin.
-		if ( $hook_extra['action'] !== 'update' || $hook_extra['type'] !== 'plugin') {
+		// Check if the action is an `update` or `install` action for a plugin.
+		if (
+			$hook_extra['action'] !== 'install' &&
+			$hook_extra['action'] !== 'update' ||
+			$hook_extra['type'] !== 'plugin'
+		) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -11,6 +11,15 @@ namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 class ProductFormsController {
 
 	/**
+	 * Product form templates.
+	 *
+	 * @var array
+	 */
+	private $product_form_templates = array(
+		'simple',
+	);
+
+	/**
 	 * Set up the product forms controller.
 	 */
 	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingFinal, WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag -- Not an injection.
@@ -66,10 +75,7 @@ class ProductFormsController {
 		 * @param array $templates List of templates to auto-generate.
 		 */
 		$templates = apply_filters(
-			'woocommerce_product_form_templates',
-			array(
-				'simple',
-			)
+			'woocommerce_product_form_templates', $this->product_form_templates
 		);
 
 		foreach ( $templates as $slug ) {

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -6,6 +6,9 @@
  * Slug: simple
  * Description: This is the template description.
  * Product Types: simple, variable
+ *
+ * @package WooCommerce\Templates
+ * @version 3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,16 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:woocommerce/product-section {"title":"<?php _e( 'Basic details', 'woocommerce' ); ?>"} -->
-<div data-block-name="woocommerce/product-section" class="wp-block-woocommerce-product-section" data-title="<?php _e( 'Basic details', 'woocommerce' ); ?>">
-    <div>
-        <!-- wp:woocommerce/product-regular-price-field -->
-        <div data-block-name="woocommerce/product-regular-price-field" class="wp-block-woocommerce-product-regular-price-field"></div>
-        <!-- /wp:woocommerce/product-regular-price-field -->
+<!-- wp:woocommerce/product-section {"title":"<?php esc_attr_e( 'Basic details', 'woocommerce' ); ?>"} -->
+<div data-block-name="woocommerce/product-section" class="wp-block-woocommerce-product-section" data-title="<?php esc_attr_e( 'Basic details', 'woocommerce' ); ?>">
+	<div>
+		<!-- wp:woocommerce/product-regular-price-field -->
+		<div data-block-name="woocommerce/product-regular-price-field" class="wp-block-woocommerce-product-regular-price-field"></div>
+		<!-- /wp:woocommerce/product-regular-price-field -->
 
-        <!-- wp:woocommerce/product-checkbox-field {"label":"<?php _e( 'Translatable Label', 'woocommerce' ); ?>","property":"testproperty"} -->
-        <div data-block-name="woocommerce/product-checkbox-field" class="wp-block-woocommerce-product-checkbox-field" data-label="<?php _e( 'Translatable Label', 'woocommerce' ); ?>"></div>
-        <!-- /wp:woocommerce/product-checkbox-field -->
-    </div>
+		<!-- wp:woocommerce/product-checkbox-field {"label":"<?php esc_attr_e( 'Translatable Label', 'woocommerce' ); ?>","property":"testproperty"} -->
+		<div data-block-name="woocommerce/product-checkbox-field" class="wp-block-woocommerce-product-checkbox-field" data-label="<?php esc_attr_e( 'Translatable Label', 'woocommerce' ); ?>"></div>
+		<!-- /wp:woocommerce/product-checkbox-field -->
+	</div>
 </div>
 <!-- /wp:woocommerce/product-section -->

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Simple Product Form
+ *
+ * Title: Simple
+ * Slug: simple
+ * Description: This is the template description.
+ * Product Types: simple, variable
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<!-- wp:woocommerce/product-section {"title":"<?php _e( 'Basic details', 'woocommerce' ); ?>"} -->
+<div data-block-name="woocommerce/product-section" class="wp-block-woocommerce-product-section" data-title="<?php _e( 'Basic details', 'woocommerce' ); ?>">
+    <div>
+        <!-- wp:woocommerce/product-regular-price-field -->
+        <div data-block-name="woocommerce/product-regular-price-field" class="wp-block-woocommerce-product-regular-price-field"></div>
+        <!-- /wp:woocommerce/product-regular-price-field -->
+
+        <!-- wp:woocommerce/product-checkbox-field {"label":"<?php _e( 'Translatable Label', 'woocommerce' ); ?>","property":"testproperty"} -->
+        <div data-block-name="woocommerce/product-checkbox-field" class="wp-block-woocommerce-product-checkbox-field" data-label="<?php _e( 'Translatable Label', 'woocommerce' ); ?>"></div>
+        <!-- /wp:woocommerce/product-checkbox-field -->
+    </div>
+</div>
+<!-- /wp:woocommerce/product-section -->

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -8,7 +8,7 @@
  * Product Types: simple, variable
  *
  * @package WooCommerce\Templates
- * @version 3.0.0
+ * @version 9.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the mechanism to migrate the representation of a Product Form Template file from its content to the dB.

* This process runs when the WooCommerce plugin is installed or updated.
* The PR introduces a super `simple` product template. It will be addressed in a follow-up 48000
* It shows the Product Form CPT in the UI only for testing/developing process

Closes #48000
Closes #48203

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Since the process triggers when the plugin installs/updates, I've created a plugin that registers a WP CLI command.

1. Install the plugin

[pft-dev-tools](https://github.com/woocommerce/pft-dev-tools/archive/refs/heads/trunk.zip)

2. Active the plugin
3. Enable the `product-editor-template-system` feature flag
  a. Install the WooCommerce Beta Tester plugin
  b. Go to the Settings -> WCA Test Helper -> Features
  c. Enable the `product-editor-template-system` feature flag

4. Go to the Product Forms page `wp-admin/edit.php?post_type=product_form`
5. Confirm the `Simple` form post isn't there
<img width="701" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/10a1efbd-6d51-4114-ab44-00dc7a1c22d1">
6. Run the following WP CLI command to migrate the template definition to the dB

```sh
wp trigger upgrader_process_complete
```
7. Hard refresh
8. Confirm the Simple form post is there

<img width="661" alt="Screenshot 2024-06-06 at 1 05 27 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/7c115882-d41f-4f2e-8844-3355deac921d">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
