### PR TITLE
CYS > Ensure that after installing fonts or patterns the user lands back in the same CYS section

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -73,7 +73,7 @@ export const SidebarNavigationScreenHomepage = () => {
 
 	const [ blocks, , onChange ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate.id ?? ''
+		currentTemplate?.id ?? ''
 	);
 
 	// @ts-expect-error No types for this exist yet.

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/actions.ts
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import { sendParent } from 'xstate';
+import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
 import { DesignWithoutAIStateMachineContext } from './types';
 import { DesignWithoutAIStateMachineEvents } from './state-machine';
+import { navigateOrParent } from '../utils';
 
 const redirectToAssemblerHub = async () => {
 	// This is a workaround to update the "activeThemeHasMods" in the parent's machine
@@ -29,7 +31,25 @@ const redirectToIntroWithError = sendParent<
 	type: 'NO_AI_FLOW_ERROR',
 } );
 
+const redirectToAssemblerHubSection = (
+	_context: unknown,
+	_evt: unknown,
+	{ action }: { action: unknown }
+) => {
+	const { section } = action as { section: string };
+
+	navigateOrParent(
+		window,
+		getNewPath(
+			{ customizing: true },
+			`/customize-store/assembler-hub/${ section }`,
+			{}
+		)
+	);
+};
+
 export const actions = {
 	redirectToAssemblerHub,
 	redirectToIntroWithError,
+	redirectToAssemblerHubSection,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -166,7 +166,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 					},
 				},
 				onDone: {
-					target: '#designWithoutAI.showAssembleHub',
+					target: '#designWithoutAI.showAssembleHubTypography',
 				},
 			},
 			installPatterns: {
@@ -199,7 +199,7 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 					},
 				},
 				onDone: {
-					target: '#designWithoutAI.showAssembleHub',
+					target: '#designWithoutAI.showAssembleHubHomepage',
 				},
 			},
 			preAssembleSite: {
@@ -299,6 +299,22 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 					component: AssembleHubLoader,
 				},
 				entry: [ 'redirectToAssemblerHub' ],
+			},
+			showAssembleHubHomepage: {
+				entry: [
+					{
+						type: 'redirectToAssemblerHubSection',
+						section: 'homepage',
+					},
+				],
+			},
+			showAssembleHubTypography: {
+				entry: [
+					{
+						type: 'redirectToAssemblerHubSection',
+						section: 'typography',
+					},
+				],
 			},
 		},
 	},

--- a/plugins/woocommerce/changelog/48227-48179-tracking-redirect-same-section
+++ b/plugins/woocommerce/changelog/48227-48179-tracking-redirect-same-section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Redirect to the same section after installing fonts or patterns on the assembler.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/48179

Note: it includes a fix https://github.com/woocommerce/woocommerce/pull/48227/commits/e0f0202c183bc9cdd49a846b9b3bd86ce859d1ca to avoid the page crashing if `currentTemplate` is null.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Redirect to homepage**
1. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and disable the `Allow usage of WooCommerce to be tracked` option.
2. Go to `WooCommerce > Home > Customize your store` and click `Start designing`.
3. On the assembler, click on `Design your homepage`.
4. Scroll to the bottom and click on `usage tracking`, then on the modal click on `Opt-in`.
5. Make sure you are redirected to the assembler with the `Choose your homepage` section open.

**Redirect to fonts**
1. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and disable the `Allow usage of WooCommerce to be tracked` option.
2. Go to `WooCommerce > Home > Customize your store` and click `Start designing`.
3. On the assembler, click on `Choose fonts`.
4. Scroll to the bottom and click on `usage tracking`, then on the modal click on `Opt-in`.
5. Make sure you are redirected to the assembler with the `Choose fonts` section open.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Redirect to the same section after installing fonts or patterns on the assembler.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
