### PR TITLE
Product Gallery: Prevent block from being registered on the post editor

### DIFF
--- a/plugins/woocommerce/changelog/48228-fix-product-gallery-beta-appearing-in-post-editor
+++ b/plugins/woocommerce/changelog/48228-fix-product-gallery-beta-appearing-in-post-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent Product Gallery from being inserted on Posts and Pages.  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48228-fix-product-gallery-beta-appearing-in-post-editor
+++ b/plugins/woocommerce/changelog/48228-fix-product-gallery-beta-appearing-in-post-editor
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent Product Gallery from being inserted on Posts and Pages.
+Prevent Product Gallery from being inserted on Posts and Pages.  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48228-fix-product-gallery-beta-appearing-in-post-editor
+++ b/plugins/woocommerce/changelog/48228-fix-product-gallery-beta-appearing-in-post-editor
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent Product Gallery from being inserted on Posts and Pages.  </details>  <details>  <summary>Changelog Entry Comment</summary>
+Prevent Product Gallery from being inserted on Posts and Pages.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -342,6 +342,7 @@ final class BlockTypesController {
 					'AllProducts',
 					'Cart',
 					'Checkout',
+					'ProductGallery',
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -371,6 +371,7 @@ final class BlockTypesController {
 					'OrderConfirmation\AdditionalInformation',
 					'OrderConfirmation\AdditionalFieldsWrapper',
 					'OrderConfirmation\AdditionalFields',
+					'ProductGallery',
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixed https://github.com/woocommerce/woocommerce/issues/46782

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Add `ProductGallery` to the list of blocks that aren't allowed to be registered to the editor in a post or page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Post or Page and check the `Product Gallery (Beta)` block isn't available in the inserter.
2. Go to a Site Editor > Template and check you're able to insert it into the `Single Product` template
3. Check other templates to ensure you're not able to insert it there to confirm its restricted only to the `Single Product` template.
4. Check widget areas to ensure you're unable to insert the block there also.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent Product Gallery from being inserted on Posts and Pages.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
