### PR TITLE
Product Rating: Hide rating stars and counter from the inserter

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-counter/support.ts
@@ -1,4 +1,5 @@
 export const supports = {
+	inserter: false,
 	color: {
 		text: false,
 		background: false,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/support.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/rating-stars/support.ts
@@ -1,4 +1,5 @@
 export const supports = {
+	inserter: false,
 	color: {
 		text: true,
 		background: false,

--- a/plugins/woocommerce/changelog/48229-update-product-rating-stars-counter-hidden-from-inserter
+++ b/plugins/woocommerce/changelog/48229-update-product-rating-stars-counter-hidden-from-inserter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Product Rating Stars and Product Rating Counter from the inserter </details>  <details>  <summary>Changelog Entry Comment</summary>
+Product Rating Stars and Product Rating Counter from the inserter

--- a/plugins/woocommerce/changelog/48229-update-product-rating-stars-counter-hidden-from-inserter
+++ b/plugins/woocommerce/changelog/48229-update-product-rating-stars-counter-hidden-from-inserter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Rating Stars and Product Rating Counter from the inserter </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48229-update-product-rating-stars-counter-hidden-from-inserter
+++ b/plugins/woocommerce/changelog/48229-update-product-rating-stars-counter-hidden-from-inserter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Product Rating Stars and Product Rating Counter from the inserter
+Product Rating Stars and Product Rating Counter from the inserter </details>  <details>  <summary>Changelog Entry Comment</summary>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We have various product rating blocks, some of which were created for the purpose of patterns as far as I can tell. However because these are all available in the inserter it can make it confusing to differentiate between all of them with the overwhelming amount of options.

In this PR I've hidden Product Rating Stars and Product Rating Counter from the inserter, meaning they should still work with patterns.

As a follow up PR we should refactor the Product Rating block to be composed of these two hidden blocks.

![Screenshot 2024-06-06 at 14 25 05](https://github.com/woocommerce/woocommerce/assets/8639742/80bb7784-3773-49f4-b37e-0ac1874a8c7e)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check that Product Rating Stars and Product Rating Counter blocks are not available within the inserter both globally and as descendants of the Single Product Block / Single Product template.
2. Check any relevant patterns aren't impacted. They shouldn't be since we've just hidden the block from inserter.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Rating Stars and Product Rating Counter from the inserter
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
