### PR TITLE
Revert customer-effort-score-tracks feature flag removal

### DIFF
--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -97,11 +97,19 @@ if ( appRoot ) {
 	}
 }
 
-// Set up customer effort score survey.
-( function () {
-	const root = appRoot || embeddedRoot;
-	render(
-		<CustomerEffortScoreTracksContainer />,
-		root.insertBefore( document.createElement( 'div' ), null )
-	);
-} )();
+// Render the CustomerEffortScoreTracksContainer only if
+// the feature flag is enabled.
+if (
+	window.wcAdminFeatures &&
+	window.wcAdminFeatures[ 'customer-effort-score-tracks' ] === true
+) {
+	// Set up customer effort score survey.
+	( function () {
+		const root = appRoot || embeddedRoot;
+
+		render(
+			<CustomerEffortScoreTracksContainer />,
+			root.insertBefore( document.createElement( 'div' ), null )
+		);
+	} )();
+}

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -33,6 +33,7 @@ declare global {
 			'activity-panels': boolean;
 			analytics: boolean;
 			coupons: boolean;
+			'customer-effort-score-tracks': boolean;
 			homescreen: boolean;
 			marketing: boolean;
 			'minified-js': boolean;

--- a/plugins/woocommerce/changelog/fix-48213_add_ces_feature_flag
+++ b/plugins/woocommerce/changelog/fix-48213_add_ces_feature_flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "Remove customer-effort-score-tracks" feature flag #48235

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -7,6 +7,7 @@
 		"coupons": true,
 		"core-profiler": true,
 		"customize-store": true,
+		"customer-effort-score-tracks": true,
 		"import-products-task": true,
 		"experimental-fashion-sample-products": true,
 		"shipping-smart-defaults": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -7,6 +7,7 @@
 		"coupons": true,
 		"core-profiler": true,
 		"customize-store": true,
+		"customer-effort-score-tracks": true,
 		"import-products-task": true,
 		"experimental-fashion-sample-products": true,
 		"shipping-smart-defaults": true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request addresses an issue with the Customer Effort Score (CES) survey not being displayed on the `trunk` branch and the `9.0 Release Candidate (RC)`. By reverting the removal of the `customer-effort-score-tracks` feature flag, we ensure that the CES survey is properly shown as intended.

![Screenshot 2024-06-06 at 1 50 46 PM](https://github.com/woocommerce/woocommerce/assets/1314156/d950c81a-f98f-49fe-b7c3-ed359d2ed368)

**Explanation of the error:**
The [CES relies on the feature](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php#L5) class file, since the class only gets instantiated from the feature list, the CES survey wasn't visible anymore after removing the feature flag.

Closes #48213.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch.
2. After completing the onboarding wizard.
3. Go to Product > Add New.
4. Create a product
5. Observe that the `How easy was it to add a product?` survey is shown after the product is published

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
