### PR TITLE
Enable manage stock inline actions in the variations table

### DIFF
--- a/packages/js/product-editor/changelog/add-40351-stock
+++ b/packages/js/product-editor/changelog/add-40351-stock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable manage stock inline actions in the variations table

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -6,6 +6,7 @@
 @import "./table-row-skeleton/styles.scss";
 @import "./add-image-menu-item/style.scss";
 @import "./image-actions-menu/style.scss";
+@import "./variation-stock-status-form/styles.scss";
 
 .woocommerce-product-variations {
 	display: flex;

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -216,4 +216,10 @@
 		background-size: contain;
 		background-repeat: no-repeat;
 	}
+
+	&__stock-status-actions-menu {
+		.components-popover__content {
+			padding: 0;
+		}
+	}
 }

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/index.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/index.ts
@@ -1,0 +1,2 @@
+export * from './variation-stock-status-form';
+export * from './types';

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
@@ -5,18 +5,12 @@
 
 	&__controls,
 	&__actions {
+		display: flex;
 		gap: $grid-unit-20;
 		padding: $grid-unit-20;
 	}
 
-	&__controls {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		justify-content: stretch;
-	}
-
 	&__actions {
-		display: flex;
 		justify-content: flex-end;
 	}
 }

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
@@ -10,6 +10,18 @@
 		padding: $grid-unit-20;
 	}
 
+	&__controls {
+		&:first-child {
+			padding-top: $grid-unit-20;
+		}
+
+		padding-top: 0;
+
+		.components-base-control.components-toggle-control {
+			margin: 0;
+		}
+	}
+
 	&__actions {
 		justify-content: flex-end;
 	}

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
@@ -20,6 +20,20 @@
 		.components-base-control.components-toggle-control {
 			margin: 0;
 		}
+
+		.components-base-control {
+			width: 100%;
+
+			&.has-error {
+				.components-input-control__backdrop {
+					border-color: $studio-red-50;
+				}
+
+				.components-base-control__help {
+					color: $studio-red-50;
+				}
+			}
+		}
 	}
 
 	&__actions {

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/styles.scss
@@ -1,0 +1,22 @@
+.woocommerce-variation-stock-status-form {
+	display: flex;
+	flex-direction: column;
+	min-width: 345px;
+
+	&__controls,
+	&__actions {
+		gap: $grid-unit-20;
+		padding: $grid-unit-20;
+	}
+
+	&__controls {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		justify-content: stretch;
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+	}
+}

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/types.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { ProductVariation } from '@woocommerce/data';
+
+export type VariationStockStatusFormProps = {
+	initialValue?: Partial< ProductVariation >;
+	onSubmit?( value: Pick< ProductVariation, 'manage_stock' > ): void;
+	onCancel?(): void;
+};

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/types.ts
@@ -5,6 +5,8 @@ import { ProductVariation } from '@woocommerce/data';
 
 export type VariationStockStatusFormProps = {
 	initialValue?: Partial< ProductVariation >;
-	onSubmit?( value: Pick< ProductVariation, 'manage_stock' > ): void;
+	onSubmit?(
+		value: Pick< ProductVariation, 'manage_stock' | 'stock_status' >
+	): void;
 	onCancel?(): void;
 };

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/types.ts
@@ -6,7 +6,10 @@ import { ProductVariation } from '@woocommerce/data';
 export type VariationStockStatusFormProps = {
 	initialValue?: Partial< ProductVariation >;
 	onSubmit?(
-		value: Pick< ProductVariation, 'manage_stock' | 'stock_status' >
+		value: Pick<
+			ProductVariation,
+			'manage_stock' | 'stock_status' | 'stock_quantity'
+		>
 	): void;
 	onCancel?(): void;
 };

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
@@ -11,13 +11,13 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import {
 	Button,
 	ToggleControl,
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -69,7 +69,7 @@ export function VariationStockStatusForm( {
 	);
 
 	function validateStockQuantity() {
-		let error: string | undefined = undefined;
+		let error: string | undefined;
 
 		if (
 			value.manage_stock &&
@@ -109,6 +109,7 @@ export function VariationStockStatusForm( {
 			),
 			{
 				Link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a
 						href={ getAdminLink(
 							'admin.php?page=wc-settings&tab=products&section=inventory'

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
@@ -17,8 +17,23 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { VariationStockStatusFormProps } from './types';
+import { RadioField } from '../../radio-field';
 
 const MANAGE_STOCK_OPTION = 'woocommerce_manage_stock';
+const STOCK_STATUS_OPTIONS = [
+	{
+		label: __( 'In stock', 'woocommerce' ),
+		value: 'instock',
+	},
+	{
+		label: __( 'Out of stock', 'woocommerce' ),
+		value: 'outofstock',
+	},
+	{
+		label: __( 'On backorder', 'woocommerce' ),
+		value: 'onbackorder',
+	},
+];
 
 export function VariationStockStatusForm( {
 	initialValue,
@@ -27,6 +42,7 @@ export function VariationStockStatusForm( {
 }: VariationStockStatusFormProps ) {
 	const [ value, setValue ] = useState( {
 		manage_stock: Boolean( initialValue?.manage_stock ),
+		stock_status: initialValue?.stock_status,
 	} );
 
 	const { canManageStock, isLoadingManageStockOption } = useSelect(
@@ -76,6 +92,10 @@ export function VariationStockStatusForm( {
 		);
 	}
 
+	function handleStockStatusRadioFieldChange( selected: string ) {
+		setValue( ( current ) => ( { ...current, stock_status: selected } ) );
+	}
+
 	return (
 		<form
 			onSubmit={ handleSubmit }
@@ -91,6 +111,17 @@ export function VariationStockStatusForm( {
 					help={ renderTrackInventoryToggleHelp() }
 				/>
 			</div>
+
+			{ ! value.manage_stock && (
+				<div className="woocommerce-variation-stock-status-form__controls">
+					<RadioField
+						title={ __( 'Stock status', 'woocommerce' ) }
+						selected={ value.stock_status }
+						options={ STOCK_STATUS_OPTIONS }
+						onChange={ handleStockStatusRadioFieldChange }
+					/>
+				</div>
+			) }
 
 			<div className="woocommerce-variation-stock-status-form__actions">
 				<Button variant="tertiary" onClick={ onCancel }>

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import type { FormEvent } from 'react';
+import { Button, ToggleControl } from '@wordpress/components';
+import { createElement, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { VariationStockStatusFormProps } from './types';
+
+export function VariationStockStatusForm( {
+	initialValue,
+	onSubmit,
+	onCancel,
+}: VariationStockStatusFormProps ) {
+	const [ value, setValue ] = useState( {
+		manage_stock: Boolean( initialValue?.manage_stock ),
+	} );
+
+	function handleSubmit( event: FormEvent< HTMLFormElement > ) {
+		event.preventDefault();
+
+		onSubmit?.( value );
+	}
+
+	function handleTrackInventoryToggleChange( isChecked: boolean ) {
+		setValue( ( current ) => ( { ...current, manage_stock: isChecked } ) );
+	}
+
+	return (
+		<form
+			onSubmit={ handleSubmit }
+			className="woocommerce-variation-stock-status-form"
+			aria-label={ __( 'Variation stock status form', 'woocommerce' ) }
+		>
+			<div className="woocommerce-variation-stock-status-form__controls">
+				<ToggleControl
+					label={ __( 'Track inventory', 'woocommerce' ) }
+					checked={ value.manage_stock }
+					onChange={ handleTrackInventoryToggleChange }
+				/>
+			</div>
+
+			<div className="woocommerce-variation-stock-status-form__actions">
+				<Button variant="tertiary" onClick={ onCancel }>
+					Cancel
+				</Button>
+
+				<Button variant="primary" type="submit">
+					Save
+				</Button>
+			</div>
+		</form>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
@@ -6,7 +6,12 @@ import { Tag, __experimentalTooltip as Tooltip } from '@woocommerce/components';
 import { CurrencyContext } from '@woocommerce/currency';
 import { PartialProductVariation, ProductVariation } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
-import { Button, CheckboxControl, Spinner } from '@wordpress/components';
+import {
+	Button,
+	CheckboxControl,
+	Dropdown,
+	Spinner,
+} from '@wordpress/components';
 import {
 	createElement,
 	Fragment,
@@ -28,8 +33,9 @@ import {
 	truncate,
 } from '../../../utils';
 import { SingleUpdateMenu } from '../variation-actions-menus';
-import { VariationsTableRowProps } from './types';
 import { ImageActionsMenu } from '../image-actions-menu';
+import { VariationStockStatusForm } from '../variation-stock-status-form/variation-stock-status-form';
+import { VariationsTableRowProps } from './types';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 
@@ -100,6 +106,56 @@ export function VariationsTableRow( {
 
 	function handleDelete( values: PartialProductVariation[] ) {
 		onDelete( values[ 0 ] );
+	}
+
+	function renderStockStatus() {
+		return (
+			<>
+				<span
+					className={ classNames(
+						'woocommerce-product-variations__status-dot',
+						getProductStockStatusClass( variation )
+					) }
+				>
+					●
+				</span>
+				{ getProductStockStatus( variation ) }
+			</>
+		);
+	}
+
+	function renderStockStatusForm( onClose: () => void ) {
+		return (
+			<VariationStockStatusForm
+				initialValue={ variation }
+				onSubmit={ ( editedVariation ) => {
+					onChange( { ...editedVariation, id: variation.id }, true );
+					onClose();
+				} }
+				onCancel={ onClose }
+			/>
+		);
+	}
+
+	function renderStockCellContent() {
+		if ( ! variation.regular_price ) return null;
+
+		return (
+			<Dropdown
+				// @ts-expect-error missing prop in types.
+				popoverProps={ {
+					placement: 'bottom',
+				} }
+				renderToggle={ ( { onToggle } ) => (
+					<Button onClick={ onToggle } variant="tertiary">
+						{ renderStockStatus() }
+					</Button>
+				) }
+				renderContent={ ( { onClose } ) =>
+					renderStockStatusForm( onClose )
+				}
+			/>
+		);
 	}
 
 	return (
@@ -248,19 +304,7 @@ export function VariationsTableRow( {
 				) }
 				role="cell"
 			>
-				{ variation.regular_price && (
-					<>
-						<span
-							className={ classNames(
-								'woocommerce-product-variations__status-dot',
-								getProductStockStatusClass( variation )
-							) }
-						>
-							●
-						</span>
-						{ getProductStockStatus( variation ) }
-					</>
-				) }
+				{ renderStockCellContent() }
 			</div>
 			<div
 				className="woocommerce-product-variations__actions"

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
@@ -142,6 +142,7 @@ export function VariationsTableRow( {
 
 		return (
 			<Dropdown
+				contentClassName="woocommerce-product-variations__stock-status-actions-menu"
 				// @ts-expect-error missing prop in types.
 				popoverProps={ {
 					placement: 'bottom',

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -9,7 +9,6 @@ import {
 	ProductVariation,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { ListItem, Sortable } from '@woocommerce/components';
 import {
 	createElement,
 	Fragment,
@@ -304,12 +303,12 @@ export const VariationsTable = forwardRef<
 
 	function renderTableBody() {
 		return totalCount > 0 ? (
-			<Sortable
+			<div
 				className="woocommerce-product-variations__table-body"
 				role="rowgroup"
 			>
 				{ variations.map( ( variation ) => (
-					<ListItem
+					<div
 						key={ `${ variation.id }` }
 						className="woocommerce-product-variations__table-row"
 						role="row"
@@ -326,9 +325,9 @@ export const VariationsTable = forwardRef<
 							onEdit={ editVariationClickHandler( variation ) }
 							onSelect={ onSelect( variation ) }
 						/>
-					</ListItem>
+					</div>
 				) ) }
-			</Sortable>
+			</div>
 		) : (
 			<EmptyOrErrorTableState
 				isError={ false }

--- a/plugins/woocommerce/changelog/add-40351-stock
+++ b/plugins/woocommerce/changelog/add-40351-stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add woocommerce_manage_stock option to the default_option_permissions list in the Options rest controller

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -194,6 +194,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_admin_reviewed_store_location_settings',
 			'woocommerce_ces_product_feedback_shown',
 			'woocommerce_marketing_overview_multichannel_banner_dismissed',
+			'woocommerce_manage_stock',
 			'woocommerce_dimension_unit',
 			'woocommerce_weight_unit',
 			'woocommerce_product_editor_show_feedback_bar',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40351

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `Products > Add new` and generate some variations from the `Variations` tab
3. Then click `Set prices` from the button inside the alert <img width="739" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/e1c1b9bb-7036-4e5f-adb6-f6a938f74f1b">
4. Once the prices are set to the variations, clicking on the stock cell of an specific variation should show a quick update form to manage the stock like follow <img width="658" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c27fd0af-0a0a-47e4-810c-496cfbd08cbf">
5. If `Enable stock management` is disabled form `/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory` the action form should looks like follow <img width="660" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/febf8e41-0b07-4046-9d46-5cc4401edb18">
6. When `Track inventory` is toggled on the form should looks like follow <img width="657" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/bffa086e-fc54-4117-b853-0e3328220792">
7. Validations should behave as in the product inventory tab <img width="657" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/b055f73a-5002-4674-9c11-1082175004e5">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
