### PR TITLE
Update product status after calling save() on a new product

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-save-status
+++ b/plugins/woocommerce/changelog/fix-product-save-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Calling $product->get_status() after $product->save() on a new product now returns correct status.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -138,6 +138,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( $id && ! is_wp_error( $id ) ) {
 			$product->set_id( $id );
 
+			// get the post object so that we can set the status
+			// to the correct value; it is possible that the status was
+			// changed by the woocommerce_new_product_data filter above.
+			$post_object = get_post( $product->get_id() );
+			$product->set_status( $post_object->post_status );
+
 			$this->update_post_meta( $product, true );
 			$this->update_terms( $product, true );
 			$this->update_visibility( $product, true );

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -24,7 +24,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test creating a new product.
+	 * Test creating a new product (published by default).
 	 *
 	 * @since 3.0.0
 	 */
@@ -40,6 +40,54 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 
 		$this->assertEquals( '42', $read_product->get_regular_price() );
 		$this->assertEquals( 'My Product', $read_product->get_name() );
+	}
+
+	/**
+	 * Test creating a new product (explicitly set to published).
+	 */
+	public function test_product_create_published() {
+		$product = new WC_Product();
+		$product->set_status( 'publish' );
+		$product->save();
+
+		$this->assertEquals( 'publish', $product->get_status() );
+	}
+
+	/**
+	 * Test creating a new draft product.
+	 */
+	public function test_product_create_draft() {
+		$product = new WC_Product();
+		$product->set_status( 'draft' );
+		$product->save();
+
+		$this->assertEquals( 'draft', $product->get_status() );
+	}
+
+	/**
+	 * Test creating a new product with woocommerce_new_product_data filter.
+	 */
+	public function test_product_create_with_woocommerce_new_product_data_filter() {
+		$force_draft_status_fn = function ( $data ) {
+			$data['post_status'] = 'draft';
+			return $data;
+		};
+
+		add_filter(
+			'woocommerce_new_product_data',
+			$force_draft_status_fn
+		);
+
+		$product = new WC_Product();
+		$product->set_status( 'pending' );
+		$product->save();
+
+		$this->assertEquals( 'draft', $product->get_status() );
+
+		remove_filter(
+			'woocommerce_new_product_data',
+			$force_draft_status_fn
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -34,6 +34,8 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$product->set_name( 'My Product' );
 		$product->save();
 
+		$this->assertEquals( 'publish', $product->get_status() );
+
 		$read_product = new WC_Product( $product->get_id() );
 
 		$this->assertEquals( '42', $read_product->get_regular_price() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the implementation of the `WC_Product_Data_Store_CPT::create()` method to update the product's status after the product has been saved, so that the `WC_Product::get_status()` method returns the correct status for a new product created without explicitly setting the status:

```php
$product = new WC_Product();
$product->save();
$status = $product->get_status();
// $status should be `"publish"`
```

Closes #48290.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Run the unit tests (or just look at the CI results on this PR) and verify they all pass (and make sense):

```
pnpm test:unit:env --filter 'WC_Tests_Product_Data_Store'
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
