### PR TITLE
Add unit tests for some tracks in product editor

### DIFF
--- a/packages/js/internal-js-tests/changelog/add-tracks-unit-tests-improvements-product-editor
+++ b/packages/js/internal-js-tests/changelog/add-tracks-unit-tests-improvements-product-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add tests for some product editor tracks

--- a/packages/js/internal-js-tests/jest-preset.js
+++ b/packages/js/internal-js-tests/jest-preset.js
@@ -51,6 +51,9 @@ module.exports = {
 		'**/test/*.[jt]s?(x)',
 		'**/?(*.)test.[jt]s?(x)',
 	],
+	testPathIgnorePatterns: [
+		'\\.d\\.ts$', // This regex pattern matches any file that ends with .d.ts
+	],
 	// The keys for the transformed modules contains the name of the packages that should be transformed.
 	transformIgnorePatterns: [
 		'node_modules/(?!(?:\\.pnpm|' + Object.keys( transformModules ).join( '|' ) + ')/)',

--- a/packages/js/product-editor/changelog/add-tracks-unit-tests-improvements-product-editor
+++ b/packages/js/product-editor/changelog/add-tracks-unit-tests-improvements-product-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add tests for some product editor tracks

--- a/packages/js/product-editor/src/components/feedback-bar/test/feedback-bar.test.tsx
+++ b/packages/js/product-editor/src/components/feedback-bar/test/feedback-bar.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { createElement } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { FeedbackBar } from '../feedback-bar';
+import { useFeedbackBar } from '../../../hooks/use-feedback-bar';
+
+jest.mock( '../../../hooks/use-feedback-bar', () => ( {
+	...jest.requireActual( '../../../hooks/use-feedback-bar' ),
+	useFeedbackBar: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	...jest.requireActual( '@woocommerce/tracks' ),
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'FeedbackBar', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+	it( 'should render empty name rows when names are empty', () => {
+		( useFeedbackBar as jest.Mock ).mockImplementation( () => ( {
+			hideFeedbackBar: () => {},
+			shouldShowFeedbackBar: true,
+		} ) );
+		render( <FeedbackBar productType={ 'testing' } /> );
+
+		act( () => {
+			fireEvent.click( screen.getByText( 'turn it off' ) );
+		} );
+		expect( recordEvent ).toBeCalledWith(
+			'product_editor_feedback_bar_turnoff_editor_click',
+			{ product_type: 'testing' }
+		);
+	} );
+} );

--- a/packages/js/product-editor/src/components/feedback-bar/test/feedback-bar.test.tsx
+++ b/packages/js/product-editor/src/components/feedback-bar/test/feedback-bar.test.tsx
@@ -26,7 +26,7 @@ describe( 'FeedbackBar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
-	it( 'should render empty name rows when names are empty', () => {
+	it( 'should trigger product_editor_feedback_bar_turnoff_editor_click event when clicking turn off editor', () => {
 		( useFeedbackBar as jest.Mock ).mockImplementation( () => ( {
 			hideFeedbackBar: () => {},
 			shouldShowFeedbackBar: true,

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/test/delete-variation-menu-item.test.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/test/delete-variation-menu-item.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
+import { useParams } from 'react-router-dom';
+
+/**
+ * Internal dependencies
+ */
+import { DeleteVariationMenuItem } from '../delete-variation-menu-item';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
+
+jest.mock( 'react-router-dom', () => ( { useParams: jest.fn() } ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityId: jest.fn().mockReturnValue( 'variation_1' ),
+	useEntityProp: jest
+		.fn()
+		.mockImplementation( ( _1, _2, propType ) => [ propType ] ),
+} ) );
+
+describe( 'DeleteVariationMenuItem', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+	it( 'should trigger product_dropdown_option_click track event when clicking the menu', async () => {
+		( useDispatch as jest.Mock ).mockReturnValue( {
+			deleteProductVariation: () => {},
+		} );
+		( useSelect as jest.Mock ).mockReturnValue( {
+			type: 'simple',
+			status: 'publish',
+		} );
+		( useParams as jest.Mock ).mockReturnValue( { productId: 1 } );
+		const { getByText } = render(
+			<DeleteVariationMenuItem onClose={ () => {} } />
+		);
+		fireEvent.click( getByText( 'Delete variation' ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'product_dropdown_option_click',
+			{
+				product_id: 1,
+				product_status: 'status',
+				selected_option: 'delete_variation',
+				variation_id: 'variation_1',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce-admin/client/products/fills/test/product-block-editor-fills.test.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/test/product-block-editor-fills.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { MoreMenuFill } from '../product-block-editor-fills';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+} ) );
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
+jest.mock( '../more-menu-items', () => ( {
+	...jest.requireActual( '../more-menu-items' ),
+	ClassicEditorMenuItem: jest.fn().mockImplementation( () => <div></div> ),
+	FeedbackMenuItem: jest.fn().mockImplementation( ( { onClick } ) => (
+		<div>
+			<button onClick={ onClick }>Feedback button</button>
+		</div>
+	) ),
+} ) );
+
+describe( 'MoreMenuFill', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+	it( 'should trigger product_dropdown_option_click track event when clicking the menu', async () => {
+		( useSelect as jest.Mock ).mockReturnValue( {
+			type: 'simple',
+			status: 'publish',
+		} );
+		const { getByText } = render( <MoreMenuFill onClose={ () => {} } /> );
+		fireEvent.click( getByText( 'Feedback button' ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'product_dropdown_option_click',
+			{
+				product_status: 'publish',
+				product_type: 'simple',
+				selected_option: 'feedback',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
@@ -10,6 +10,8 @@ import { useParams } from 'react-router-dom';
  * Internal dependencies
  */
 import ProductPage from '../product-page';
+import ProductVariationPage from '../product-variation-page';
+
 
 jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
@@ -25,6 +27,9 @@ jest.mock( '@wordpress/core-data', () => ( {
 } ) );
 jest.mock( '../hooks/use-product-entity-record', () => ( {
 	useProductEntityRecord: jest.fn(),
+} ) );
+jest.mock( '../hooks/use-product-variation-entity-record', () => ( {
+	useProductVariationEntityRecord: jest.fn(),
 } ) );
 jest.mock( '@woocommerce/product-editor', () => ( {
 	...jest.requireActual( '@woocommerce/product-editor' ),
@@ -47,6 +52,27 @@ describe( 'ProductPage', () => {
 	it( 'should trigger product_edit_view on render with product_id defined', () => {
 		( useParams as jest.Mock ).mockReturnValue( { productId: 1 } );
 		render( <ProductPage /> );
+		expect( recordEvent ).toBeCalledWith( 'product_edit_view', {
+			source: TRACKS_SOURCE,
+			product_id: 1,
+		} );
+	} );
+} );
+
+describe( 'ProductVariationPage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+	it( 'should trigger product_add_view on render without product_id defined', () => {
+		( useParams as jest.Mock ).mockReturnValue( { productId: null } );
+		render( <ProductVariationPage /> );
+		expect( recordEvent ).toBeCalledWith( 'product_add_view', {
+			source: TRACKS_SOURCE,
+		} );
+	} );
+	it( 'should trigger product_edit_view on render with product_id defined', () => {
+		( useParams as jest.Mock ).mockReturnValue( { productId: 1 } );
+		render( <ProductVariationPage /> );
 		expect( recordEvent ).toBeCalledWith( 'product_edit_view', {
 			source: TRACKS_SOURCE,
 			product_id: 1,

--- a/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
@@ -12,7 +12,6 @@ import { useParams } from 'react-router-dom';
 import ProductPage from '../product-page';
 import ProductVariationPage from '../product-variation-page';
 
-
 jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
 } ) );

--- a/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
@@ -63,14 +63,14 @@ describe( 'ProductVariationPage', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
-	it( 'should trigger product_add_view on render without product_id defined', () => {
+	it( 'should trigger product_add_view track event on render without product_id defined', () => {
 		( useParams as jest.Mock ).mockReturnValue( { productId: null } );
 		render( <ProductVariationPage /> );
 		expect( recordEvent ).toBeCalledWith( 'product_add_view', {
 			source: TRACKS_SOURCE,
 		} );
 	} );
-	it( 'should trigger product_edit_view on render with product_id defined', () => {
+	it( 'should trigger product_edit_view track event on render with product_id defined', () => {
 		( useParams as jest.Mock ).mockReturnValue( { productId: 1 } );
 		render( <ProductVariationPage /> );
 		expect( recordEvent ).toBeCalledWith( 'product_edit_view', {

--- a/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-page.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { recordEvent } from '@woocommerce/tracks';
+import { TRACKS_SOURCE } from '@woocommerce/product-editor';
+import { useParams } from 'react-router-dom';
+
+/**
+ * Internal dependencies
+ */
+import ProductPage from '../product-page';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+jest.mock( 'react-router-dom', () => ( { useParams: jest.fn() } ) );
+
+// Mocks to prevent crashes.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	apiFetch: jest.fn(),
+} ) );
+jest.mock( '@wordpress/core-data', () => ( {
+	apiFetch: jest.fn(),
+} ) );
+jest.mock( '../hooks/use-product-entity-record', () => ( {
+	useProductEntityRecord: jest.fn(),
+} ) );
+jest.mock( '@woocommerce/product-editor', () => ( {
+	...jest.requireActual( '@woocommerce/product-editor' ),
+	productEditorHeaderApiFetchMiddleware: jest.fn(),
+	productApiFetchMiddleware: jest.fn(),
+	__experimentalInitBlocks: jest.fn().mockImplementation( () => () => {} ),
+} ) );
+
+describe( 'ProductPage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+	it( 'should trigger product_add_view on render without product_id defined', () => {
+		( useParams as jest.Mock ).mockReturnValue( { productId: null } );
+		render( <ProductPage /> );
+		expect( recordEvent ).toBeCalledWith( 'product_add_view', {
+			source: TRACKS_SOURCE,
+		} );
+	} );
+	it( 'should trigger product_edit_view on render with product_id defined', () => {
+		( useParams as jest.Mock ).mockReturnValue( { productId: 1 } );
+		render( <ProductPage /> );
+		expect( recordEvent ).toBeCalledWith( 'product_edit_view', {
+			source: TRACKS_SOURCE,
+			product_id: 1,
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/test/global.d.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/test/global.d.ts
@@ -1,0 +1,4 @@
+declare const productScreen: { name: string };
+declare const global: typeof globalThis & {
+  productScreen: typeof productScreen;
+};

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/test/product-edit.test.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/test/product-edit.test.tsx
@@ -13,21 +13,24 @@ jest.mock( '@woocommerce/tracks', () => ( {
 jest.mock( '../shared', () => ( {
 	addExitPageListener: jest.fn().mockImplementation( () => {} ),
 	initProductScreenTracks: jest.fn().mockImplementation( () => {} ),
+	getProductData: jest.fn().mockImplementation( () => ( { product_id: 1 } ) ),
 } ) );
 
 describe( 'Product Screen Tracking', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
-	it( 'should trigger product_add_view event when productScreen.name is "new"', () => {
-		global.productScreen = { name: 'new' };
-		require( '../product-new' );
-		expect( recordEvent ).toHaveBeenCalledWith( 'product_add_view' );
+	it( 'should trigger product_edit_view event when productScreen.name is "edit"', () => {
+		global.productScreen = { name: 'edit' };
+		require( '../product-edit' );
+		expect( recordEvent ).toHaveBeenCalledWith( 'product_edit_view', {
+			product_id: 1,
+		} );
 	} );
 
-	it( 'should not trigger product_add_view event when productScreen.name is not "new"', () => {
+	it( 'should not trigger product_edit_view event when productScreen.name is not "edit"', () => {
 		global.productScreen = { name: '' };
-		require( '../product-new' );
+		require( '../product-edit' );
 		expect( recordEvent ).not.toHaveBeenCalled();
 	} );
 } );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/test/product-new.test.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/test/product-new.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+jest.mock( '../shared', () => ( {
+	addExitPageListener: jest.fn().mockImplementation( () => {} ),
+	initProductScreenTracks: jest.fn().mockImplementation( () => {} ),
+} ) );
+
+describe( 'Product Screen Tracking', () => {
+	it( 'should trigger product_add_view event when productScreen.name is "new"', () => {
+		global.productScreen = { name: 'new' };
+		require( '../product-new' );
+		expect( recordEvent ).toHaveBeenCalledWith( 'product_add_view' );
+	} );
+
+	it( 'should not trigger product_add_view event when productScreen.name is not "new"', () => {
+		global.productScreen = { name: '' };
+		require( '../product-new' );
+		expect( recordEvent ).toHaveBeenCalledWith( 'product_add_view' );
+	} );
+} );

--- a/plugins/woocommerce/changelog/add-tracks-unit-tests-improvements-product-editor
+++ b/plugins/woocommerce/changelog/add-tracks-unit-tests-improvements-product-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add tests for some product editor tracks


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partially addresses https://github.com/woocommerce/woocommerce/issues/48142 for the following tracks:

1. wcadmin_product_add_view
2. wcadmin_product_edit_view
1. wcadmin_product_add_publish
1. wcadmin_product_tab_click
1. wcadmin_product_editor_feedback_bar_turnoff_editor_click
1. wcadmin_product_dropdown_option_click

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check test codes
3. Ensure tests passes

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
