### PR TITLE
Add global ErrorBoundary component for handling errors in react admin

### DIFF
--- a/plugins/woocommerce-admin/client/error-boundary/index.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/index.tsx
@@ -115,7 +115,9 @@ Add any other context about the problem here.
 						</Button>
 					</div>
 					<details className="woocommerce-error-boundary__details">
-						<summary>Click for error details</summary>
+						<summary>
+							{ __( 'Click for error details', 'woocommerce' ) }
+						</summary>
 						<div className="woocommerce-error-boundary__details-content">
 							<strong className="woocommerce-error-boundary__error">
 								{ this.state.error &&

--- a/plugins/woocommerce-admin/client/error-boundary/index.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/index.tsx
@@ -87,7 +87,7 @@ Add any other context about the problem here.
 			return (
 				<div className="woocommerce-error-boundary">
 					<h1 className="woocommerce-error-boundary__heading">
-						{ __( 'Oops, Something went wrong', 'woocommerce' ) }
+						{ __( 'Oops, something went wrong', 'woocommerce' ) }
 					</h1>
 					<p className="woocommerce-error-boundary__subheading">
 						{ __(

--- a/plugins/woocommerce-admin/client/error-boundary/index.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/index.tsx
@@ -74,7 +74,7 @@ export class ErrorBoundary extends Component<
 							variant="primary"
 							onClick={ this.handleRefresh }
 						>
-							{ __( 'Reload', 'woocommerce' ) }
+							{ __( 'Reload Page', 'woocommerce' ) }
 						</Button>
 					</div>
 					<details className="woocommerce-error-boundary__details">

--- a/plugins/woocommerce-admin/client/error-boundary/index.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/index.tsx
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import { Component, ReactNode, ErrorInfo } from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+type ErrorBoundaryProps = {
+	children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+	hasError: boolean;
+	error: Error | null;
+	errorInfo: ErrorInfo | null;
+};
+
+export class ErrorBoundary extends Component<
+	ErrorBoundaryProps,
+	ErrorBoundaryState
+> {
+	constructor( props: ErrorBoundaryProps ) {
+		super( props );
+		this.state = { hasError: false, error: null, errorInfo: null };
+	}
+
+	static getDerivedStateFromError(
+		error: Error
+	): Partial< ErrorBoundaryState > {
+		return { hasError: true, error };
+	}
+
+	componentDidCatch( _error: Error, errorInfo: ErrorInfo ) {
+		this.setState( { errorInfo } );
+		// TODO: Log error to error tracking service
+	}
+
+	handleRefresh = () => {
+		window.location.reload();
+	};
+
+	handleOpenIssue = () => {
+		const { error, errorInfo } = this.state;
+		const issueBody = `
+### Describe the bug
+A clear and concise description of what the bug is.
+
+**Error Details**
+\`\`\`
+Error: ${ error?.toString() }
+Stack: ${ errorInfo?.componentStack }
+\`\`\`
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Actual behavior
+
+Fatal error occurred and error page was shown.
+
+### Steps to reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### WordPress Environment
+The System Status Report is found in your WordPress admin under **WooCommerce > Status**.
+Please select “Get system report”, then “Copy for support”, and then paste it here.
+
+### Additional context
+Add any other context about the problem here.
+        `;
+		const issueUrl = `https://github.com/woocommerce/woocommerce/issues/new?body=${ encodeURIComponent(
+			issueBody
+		) }`;
+		window.open( issueUrl, '_blank' );
+	};
+
+	render() {
+		if ( this.state.hasError ) {
+			return (
+				<div className="woocommerce-error-boundary">
+					<h1 className="woocommerce-error-boundary__heading">
+						{ __( 'Oops, Something went wrong', 'woocommerce' ) }
+					</h1>
+					<p className="woocommerce-error-boundary__subheading">
+						{ __(
+							"We're sorry for the inconvenience. Please try refreshing the page, or you can report the issue on GitHub.",
+							'woocommerce'
+						) }
+					</p>
+					<div className="woocommerce-error-boundary__actions">
+						<Button
+							variant="secondary"
+							onClick={ this.handleOpenIssue }
+							style={ { margin: '10px', padding: '10px 20px' } }
+						>
+							{ __( 'Report Issue on Github', 'woocommerce' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ this.handleRefresh }
+							style={ { margin: '10px', padding: '10px 20px' } }
+						>
+							{ __(
+								'Refresh Page and Try Again',
+								'woocommerce'
+							) }
+						</Button>
+					</div>
+					<details className="woocommerce-error-boundary__details">
+						<summary>Click for error details</summary>
+						<div className="woocommerce-error-boundary__details-content">
+							<strong className="woocommerce-error-boundary__error">
+								{ this.state.error &&
+									this.state.error.toString() }
+							</strong>
+							<p>
+								{ this.state.errorInfo &&
+									this.state.errorInfo.componentStack }
+							</p>
+						</div>
+					</details>
+				</div>
+			);
+		}
+
+		return this.props.children;
+	}
+}

--- a/plugins/woocommerce-admin/client/error-boundary/index.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/index.tsx
@@ -43,43 +43,11 @@ export class ErrorBoundary extends Component<
 		window.location.reload();
 	};
 
-	handleOpenIssue = () => {
-		const { error, errorInfo } = this.state;
-		const issueBody = `
-### Describe the bug
-A clear and concise description of what the bug is.
-
-**Error Details**
-\`\`\`
-Error: ${ error?.toString() }
-Stack: ${ errorInfo?.componentStack }
-\`\`\`
-
-### Expected behavior
-A clear and concise description of what you expected to happen.
-
-### Actual behavior
-
-Fatal error occurred and error page was shown.
-
-### Steps to reproduce
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-### WordPress Environment
-The System Status Report is found in your WordPress admin under **WooCommerce > Status**.
-Please select “Get system report”, then “Copy for support”, and then paste it here.
-
-### Additional context
-Add any other context about the problem here.
-        `;
-		const issueUrl = `https://github.com/woocommerce/woocommerce/issues/new?body=${ encodeURIComponent(
-			issueBody
-		) }`;
-		window.open( issueUrl, '_blank' );
+	handleOpenSupport = () => {
+		window.open(
+			'https://wordpress.org/support/plugin/woocommerce/',
+			'_blank'
+		);
 	};
 
 	render() {
@@ -91,27 +59,22 @@ Add any other context about the problem here.
 					</h1>
 					<p className="woocommerce-error-boundary__subheading">
 						{ __(
-							"We're sorry for the inconvenience. Please try refreshing the page, or you can report the issue on GitHub.",
+							"We're sorry for the inconvenience. Please try reloading the page, or you can get support from the community forums.",
 							'woocommerce'
 						) }
 					</p>
 					<div className="woocommerce-error-boundary__actions">
 						<Button
 							variant="secondary"
-							onClick={ this.handleOpenIssue }
-							style={ { margin: '10px', padding: '10px 20px' } }
+							onClick={ this.handleOpenSupport }
 						>
-							{ __( 'Report Issue on Github', 'woocommerce' ) }
+							{ __( 'Get Support', 'woocommerce' ) }
 						</Button>
 						<Button
 							variant="primary"
 							onClick={ this.handleRefresh }
-							style={ { margin: '10px', padding: '10px 20px' } }
 						>
-							{ __(
-								'Refresh Page and Try Again',
-								'woocommerce'
-							) }
+							{ __( 'Reload', 'woocommerce' ) }
 						</Button>
 					</div>
 					<details className="woocommerce-error-boundary__details">

--- a/plugins/woocommerce-admin/client/error-boundary/style.scss
+++ b/plugins/woocommerce-admin/client/error-boundary/style.scss
@@ -15,6 +15,7 @@
 		line-height: 46px;
 		color: $gray-900;
 		padding: 0;
+		text-align: center;
 	}
 
 	.woocommerce-error-boundary__subheading {
@@ -36,6 +37,10 @@
 		text-align: left;
 		margin: 32px auto;
 		max-width: 600px;
+
+		@media screen and (max-width: 600px) {
+			max-width: 100%;
+		}
 
 		summary {
 			text-align: center;

--- a/plugins/woocommerce-admin/client/error-boundary/style.scss
+++ b/plugins/woocommerce-admin/client/error-boundary/style.scss
@@ -34,7 +34,7 @@
 	.woocommerce-error-boundary__details {
 		white-space: pre-wrap;
 		text-align: left;
-		margin: 20px auto;
+		margin: 32px auto;
 		max-width: 600px;
 
 		summary {
@@ -47,7 +47,9 @@
 
 		p {
 			padding: 0;
-			margin: 0;
+			margin: 12px 0 0;
+			max-height: 400px;
+			overflow: auto;
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/error-boundary/style.scss
+++ b/plugins/woocommerce-admin/client/error-boundary/style.scss
@@ -1,0 +1,53 @@
+.woocommerce-error-boundary {
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+	padding: 70px 20px 0;
+	box-sizing: border-box;
+
+	.woocommerce-error-boundary__heading {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		margin-bottom: 48px;
+		font-size: 40px;
+		line-height: 46px;
+		color: $gray-900;
+		padding: 0;
+	}
+
+	.woocommerce-error-boundary__subheading {
+		text-align: center;
+	}
+
+	.woocommerce-error-boundary__actions {
+		display: flex;
+		justify-content: center;
+		margin-top: 48px;
+
+		button {
+			margin-left: 16px;
+		}
+	}
+
+	.woocommerce-error-boundary__details {
+		white-space: pre-wrap;
+		text-align: left;
+		margin: 20px auto;
+		max-width: 600px;
+
+		summary {
+			text-align: center;
+		}
+
+		.woocommerce-error-boundary__details-content {
+			padding: 16px 24px;
+		}
+
+		p {
+			padding: 0;
+			margin: 0;
+		}
+	}
+}

--- a/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { ErrorBoundary } from '../';
+
+const ThrowError = () => {
+	throw new Error( 'Test error' );
+	return null;
+};
+
+describe( 'ErrorBoundary', () => {
+	function onError( event: Event ) {
+		// Note: this will swallow reports about unhandled errors!
+		// Use with extreme caution.
+		event.preventDefault();
+	}
+
+	// Mock window.location.reload by using a global variable
+	const originalLocation = window.location;
+
+	beforeAll( () => {
+		// Opt Out of the jsdom error messages
+		window.addEventListener( 'error', onError );
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore - Ignore TS error for deleting window.location
+		delete window.location;
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore - Ignore TS error for assigning window.location
+		window.location = { reload: jest.fn() };
+	} );
+
+	afterAll( () => {
+		window.location = originalLocation;
+		window.removeEventListener( 'error', onError );
+	} );
+
+	it( 'catches errors and displays an error message', () => {
+		render(
+			<ErrorBoundary>
+				<ThrowError />
+			</ErrorBoundary>
+		);
+
+		expect(
+			screen.getByText( 'Oops, Something went wrong' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows refresh and report issue buttons', () => {
+		render(
+			<ErrorBoundary>
+				<ThrowError />
+			</ErrorBoundary>
+		);
+
+		expect(
+			screen.getByText( 'Refresh Page and Try Again' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Report Issue on Github' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'refreshes the page when Refresh Page button is clicked', () => {
+		const reloadMock = jest.fn();
+		Object.defineProperty( window.location, 'reload', {
+			configurable: true,
+			value: reloadMock,
+		} );
+
+		render(
+			<ErrorBoundary>
+				<ThrowError />
+			</ErrorBoundary>
+		);
+
+		fireEvent.click( screen.getByText( 'Refresh Page and Try Again' ) );
+
+		expect( reloadMock ).toHaveBeenCalled();
+	} );
+
+	it( 'opens a new issue when Report Issue button is clicked', () => {
+		const openSpy = jest
+			.spyOn( window, 'open' )
+			.mockImplementation( () => null );
+
+		render(
+			<ErrorBoundary>
+				<ThrowError />
+			</ErrorBoundary>
+		);
+
+		fireEvent.click( screen.getByText( 'Report Issue on Github' ) );
+
+		expect( openSpy ).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'https://github.com/woocommerce/woocommerce/issues/new?body='
+			),
+			'_blank'
+		);
+
+		openSpy.mockRestore();
+	} );
+} );

--- a/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
@@ -57,7 +57,7 @@ describe( 'ErrorBoundary', () => {
 			</ErrorBoundary>
 		);
 
-		expect( screen.getByText( 'Reload' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Reload Page' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Get Support' ) ).toBeInTheDocument();
 	} );
 
@@ -74,7 +74,7 @@ describe( 'ErrorBoundary', () => {
 			</ErrorBoundary>
 		);
 
-		fireEvent.click( screen.getByText( 'Reload' ) );
+		fireEvent.click( screen.getByText( 'Reload Page' ) );
 
 		expect( reloadMock ).toHaveBeenCalled();
 	} );

--- a/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
@@ -57,12 +57,8 @@ describe( 'ErrorBoundary', () => {
 			</ErrorBoundary>
 		);
 
-		expect(
-			screen.getByText( 'Refresh Page and Try Again' )
-		).toBeInTheDocument();
-		expect(
-			screen.getByText( 'Report Issue on Github' )
-		).toBeInTheDocument();
+		expect( screen.getByText( 'Reload' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Get Support' ) ).toBeInTheDocument();
 	} );
 
 	it( 'refreshes the page when Refresh Page button is clicked', () => {
@@ -78,7 +74,7 @@ describe( 'ErrorBoundary', () => {
 			</ErrorBoundary>
 		);
 
-		fireEvent.click( screen.getByText( 'Refresh Page and Try Again' ) );
+		fireEvent.click( screen.getByText( 'Reload' ) );
 
 		expect( reloadMock ).toHaveBeenCalled();
 	} );
@@ -94,7 +90,7 @@ describe( 'ErrorBoundary', () => {
 			</ErrorBoundary>
 		);
 
-		fireEvent.click( screen.getByText( 'Report Issue on Github' ) );
+		fireEvent.click( screen.getByText( 'Get Support' ) );
 
 		expect( openSpy ).toHaveBeenCalledWith(
 			expect.stringContaining(

--- a/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
+++ b/plugins/woocommerce-admin/client/error-boundary/test/index.test.tsx
@@ -46,7 +46,7 @@ describe( 'ErrorBoundary', () => {
 		);
 
 		expect(
-			screen.getByText( 'Oops, Something went wrong' )
+			screen.getByText( 'Oops, something went wrong' )
 		).toBeInTheDocument();
 	} );
 
@@ -93,9 +93,7 @@ describe( 'ErrorBoundary', () => {
 		fireEvent.click( screen.getByText( 'Get Support' ) );
 
 		expect( openSpy ).toHaveBeenCalledWith(
-			expect.stringContaining(
-				'https://github.com/woocommerce/woocommerce/issues/new?body='
-			),
+			'https://wordpress.org/support/plugin/woocommerce/',
 			'_blank'
 		);
 

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -22,6 +22,7 @@ import { possiblyRenderSettingsSlots } from './settings/settings-slots';
 import { registerTaxSettingsConflictErrorFill } from './settings/conflict-error-slotfill';
 import { registerPaymentsSettingsBannerFill } from './payments/payments-settings-banner-slotfill';
 import { registerSiteVisibilitySlotFill } from './launch-your-store';
+import { ErrorBoundary } from './error-boundary';
 
 const appRoot = document.getElementById( 'root' );
 const embeddedRoot = document.getElementById( 'woocommerce-embedded-root' );
@@ -49,7 +50,12 @@ if ( appRoot ) {
 		HydratedPageLayout =
 			withCurrentUserHydration( hydrateUser )( HydratedPageLayout );
 	}
-	render( <HydratedPageLayout />, appRoot );
+	render(
+		<ErrorBoundary>
+			<HydratedPageLayout />
+		</ErrorBoundary>,
+		appRoot
+	);
 } else if ( embeddedRoot ) {
 	let HydratedEmbedLayout = withSettingsHydration(
 		settingsGroup,

--- a/plugins/woocommerce-admin/client/layout/style.scss
+++ b/plugins/woocommerce-admin/client/layout/style.scss
@@ -124,7 +124,8 @@
 	}
 }
 
-.wp-toolbar .is-wp-toolbar-disabled {
+.wp-toolbar .is-wp-toolbar-disabled,
+.wp-toolbar:has(> .woocommerce-admin-full-screen .woocommerce-error-boundary) {
 	margin-top: -$adminbar-height;
 	@include breakpoint("<600px") {
 		margin-top: -$adminbar-height-mobile;

--- a/plugins/woocommerce/changelog/add-global-error-boundary
+++ b/plugins/woocommerce/changelog/add-global-error-boundary
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add ErrorBoundary component for handling unexpect errors


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Implement a global `ErrorBoundary` component to handle uncaught errors in react admin.

This component will catch any uncaught/unexpected errors during rendering in the React admin app and display a generic error message to the user. This will prevent the app from crashing and provide a better user experience. The error message will show a link to the community forum where users can report the error.

I have added a basic design and copy for the error message. I think we will also need to get some design & copy feedback (cc @verofasulo). Just wanted to get the basic functionality in place and get code review feedback first.

An uncaught error happens in a full-screen page such as core profiler:

Before (white screen):

<img width="1351" alt="Screenshot 2024-06-07 at 15 40 18" src="https://github.com/woocommerce/woocommerce/assets/4344253/47a7fad1-a210-475e-a697-e60fba3ebe64">

After:
![Screenshot 2024-06-10 at 15 49 44](https://github.com/woocommerce/woocommerce/assets/4344253/d1c68fa7-9145-4cd7-8e8b-449fbc7b0208)



An uncaught error happens on home screen:

Before:

<img width="1352" alt="Screenshot 2024-06-07 at 15 43 01" src="https://github.com/woocommerce/woocommerce/assets/4344253/e4664054-f374-46aa-9f90-66774718a3c8">


After:

![Screenshot 2024-06-10 at 15 51 18](https://github.com/woocommerce/woocommerce/assets/4344253/4dcb57c2-c53b-4e1c-b7b8-d17182cf6dab)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

We need to modify the code to throw an error to test the ErrorBoundary component.

1. Add the following code to the `plugins/woocommerce-admin/client/core-profiler/index.tsx` in the CoreProfilerController component to throw an error:

```js
throw new Error( 'test' );
```

2. Go to the Core Profiler and you should see the error message displayed.
3. Click on the link to community forums and verify that it opens the correct URL
4. Click the reload page button and confirm the page reloads
5. Add the exception code `plugins/woocommerce-admin/client/homescreen/index.tsx`
6. Go to the Home Screen and you should see the error message displayed.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
