### PR TITLE
Move archive product title update logic outside BlockTemplatesController

### DIFF
--- a/plugins/woocommerce/changelog/48255-refactor-update-product-archive-title
+++ b/plugins/woocommerce/changelog/48255-refactor-update-product-archive-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Move the archive product update logic from BlockTemplatesController to wc-template-functions.php since it applies to block and classic themes.

--- a/plugins/woocommerce/changelog/48255-refactor-update-product-archive-title
+++ b/plugins/woocommerce/changelog/48255-refactor-update-product-archive-title
@@ -1,4 +1,5 @@
-Significance: patch
-Type: tweak
+Significance: major
+Type: update
 
-Move the archive product update logic from BlockTemplatesController to wc-template-functions.php since it applies to block and classic themes.
+The archive product title will now be updated to the title of the current shop
+page. If the page does not exist, it will fall back to "Shop.

--- a/plugins/woocommerce/changelog/48255-refactor-update-product-archive-title
+++ b/plugins/woocommerce/changelog/48255-refactor-update-product-archive-title
@@ -2,4 +2,4 @@ Significance: major
 Type: update
 
 The archive product title will now be updated to the title of the current shop
-page. If the page does not exist, it will fall back to "Shop.
+page. If the page does not exist, it will fall back to "Shop".

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3994,4 +3994,21 @@ function wc_get_pay_buttons() {
 	echo '</div>';
 }
 
+/**
+ * Update the product archive title to the title of the shop page.
+ *
+ * @param string $post_type_name Post type 'name' label.
+ * @param string $post_type      Post type.
+ *
+ * @return string
+ */
+function wc_update_product_archive_title( $post_type_name, $post_type ) {
+	if ( is_shop() && 'product' === $post_type ) {
+		return get_the_title( wc_get_page_id('shop') );
+	}
+
+	return $post_type_name;
+}
+add_filter( 'post_type_archive_title', 'wc_update_product_archive_title', 10, 2 );
+
 // phpcs:enable Generic.Commenting.Todo.TaskFound

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4004,7 +4004,12 @@ function wc_get_pay_buttons() {
  */
 function wc_update_product_archive_title( $post_type_name, $post_type ) {
 	if ( is_shop() && 'product' === $post_type ) {
-		return get_the_title( wc_get_page_id('shop') );
+		$shop_page_title = get_the_title( wc_get_page_id( 'shop' ) );
+		if ( $shop_page_title ) {
+			return $shop_page_title;
+		}
+		 
+		return __( 'Shop', 'woocommerce' );
 	}
 
 	return $post_type_name;

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3995,7 +3995,8 @@ function wc_get_pay_buttons() {
 }
 
 /**
- * Update the product archive title to the title of the shop page.
+ * Update the product archive title to the title of the shop page. Fallback to
+ * 'Shop' if the shop page doesn't exist.
  *
  * @param string $post_type_name Post type 'name' label.
  * @param string $post_type      Post type.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4009,7 +4009,7 @@ function wc_update_product_archive_title( $post_type_name, $post_type ) {
 		if ( $shop_page_title ) {
 			return $shop_page_title;
 		}
-		 
+
 		return __( 'Shop', 'woocommerce' );
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -29,7 +29,6 @@ class BlockTemplatesController {
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'taxonomy_template_hierarchy', array( $this, 'add_archive_product_to_eligible_for_fallback_templates' ), 10, 1 );
 		add_action( 'after_switch_theme', array( $this, 'check_should_use_blockified_product_grid_templates' ), 10, 2 );
-		add_filter( 'post_type_archive_title', array( $this, 'update_product_archive_title' ), 10, 2 );
 
 		if ( wc_current_theme_is_fse_theme() ) {
 			// By default, the Template Part Block only supports template parts that are in the current theme directory.
@@ -530,29 +529,5 @@ class BlockTemplatesController {
 		return is_readable(
 			$directory
 		) || $this->get_block_templates( array( $template_name ), $template_type );
-	}
-
-	/**
-	 * Update the product archive title to "Shop".
-	 *
-	 * Attention: this method is run in classic themes as well, so it
-	 * can't be moved to the ProductCatalogTemplate class. See:
-	 * https://github.com/woocommerce/woocommerce/pull/46429
-	 *
-	 * @param string $post_type_name Post type 'name' label.
-	 * @param string $post_type      Post type.
-	 *
-	 * @return string
-	 */
-	public function update_product_archive_title( $post_type_name, $post_type ) {
-		if (
-			function_exists( 'is_shop' ) &&
-			is_shop() &&
-			'product' === $post_type
-		) {
-			return __( 'Shop', 'woocommerce' );
-		}
-
-		return $post_type_name;
 	}
 }


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce/issues/46464

### What?

- Move the archive product update logic from `BlockTemplatesController` to `wc-template-functions.php` since it applies to block and classic themes.
- Previously, the title was hardcoded to `Shop`, but now it will respect whatever is set on the actual `Shop` page. If the page does not exist, the archive product title will default to `Shop`.

### How to test

- Edit the `Shop` page and change its title. Go to `/shop` and ensure the title is updated there.
- Delete the `shop` page permanently (remove from trash as well). Go to `/shop` and ensure the title returns to `Shop`.