### PR TITLE
Product Form Template: update CPT product_form posts when plugin updates

### DIFF
--- a/plugins/woocommerce/changelog/update-ptf-update-cpts-when-plugin-update
+++ b/plugins/woocommerce/changelog/update-ptf-update-cpts-when-plugin-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+WooCommerce: update CPT product_form posts when plugin updates

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -64,7 +64,9 @@ class ProductFormsController {
 	}
 
 	/**
-	 * Insert post form posts for each form template file.
+	 * Create ot update a product_form post for each product form template.
+	 * If the post already exists, it will be updated.
+	 * If the post does not exist, it will be created even if the action is `update`.
 	 *
 	 * @param string $action - The action to perform. `insert` | `update`.
 	 * @return void

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -60,15 +60,16 @@ class ProductFormsController {
 			return;
 		}
 
-		$this->migrate_product_form_posts();
+		$this->migrate_product_form_posts( $action );
 	}
 
 	/**
 	 * Insert post form posts for each form template file.
 	 *
+	 * @param string $action - The action to perform. `insert` | `update`.
 	 * @return void
 	 */
-	public function migrate_product_form_posts() {
+	public function migrate_product_form_posts( $action ) {
 		/**
 		 * Allow extend the list of templates that should be auto-generated.
 		 *
@@ -99,6 +100,25 @@ class ProductFormsController {
 			);
 
 			/*
+			 * Update the the CPT post if it already exists,
+			 * and the action is `update`.
+			 */
+			if ( 'update' === $action ) {
+				$post = $posts[0] ?? null;
+
+				if ( ! empty( $post ) ) {
+					wp_update_post(
+						array(
+							'ID'           => $post->ID,
+							'post_title'   => $file_data['title'],
+							'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
+							'post_excerpt' => __( 'Template updated by the (PFT) Product Form Template system', 'woocommerce' ),
+						)
+					);
+				}
+			}
+
+			/*
 			 * Skip the post creation if the post already exists.
 			 */
 			if ( ! empty( $posts ) ) {
@@ -112,7 +132,7 @@ class ProductFormsController {
 					'post_status'  => 'publish',
 					'post_type'    => 'product_form',
 					'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
-					'post_excerpt' => __( 'Template auto-generated for the (PFT) Product Form Template system', 'woocommerce' ),
+					'post_excerpt' => __( 'Template created by the (PFT) Product Form Template system', 'woocommerce' ),
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


This PR addresses the case when the CPT posts need to be updated when the WooCoommerce plugin updates.

Follow-up of https://github.com/woocommerce/woocommerce/pull/48221

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the plugin [pft-dev-tools](https://github.com/woocommerce/pft-dev-tools/archive/refs/heads/trunk.zip)
2. Go to the `Product Forms` post type
3. If there isn't any post, generate the `Simple` form template by running the following `wp-cli` command:

```sh
wp trigger upgrader_process_complete --action=install
```

_The command above will trigger the action when the plugin **installs**_

4. Confirm it creates a new post
5. Go to edit the post. Confirm the post excerpt:

<img width="289" alt="Screenshot 2024-06-07 at 12 47 03 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/cda64055-a89d-4004-b300-da1c6e689a67">

6. Run the following command that will trigger the action when the plugin is updated:

```sh
wp trigger upgrader_process_complete --action=update
```

_The command above will trigger the action when the plugin **updates**_

7. Confirm the post excerpt changed

<img width="291" alt="Screenshot 2024-06-07 at 12 47 37 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/985a2473-487e-49a0-b89e-57d7c7bfe461">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
