### PR TITLE
[ci] Evaluate jobs: update the ignore list with regex expressions

### DIFF
--- a/.github/workflows/scripts/evaluate-jobs-conclusions-test-data.json
+++ b/.github/workflows/scripts/evaluate-jobs-conclusions-test-data.json
@@ -78,5 +78,25 @@
 		"status": "completed",
 		"conclusion": "unknown_conclusion",
 		"name": "Job with unknown conclusion (optional)"
+	},
+	{
+		"status": "in_progress",
+		"conclusion": "",
+		"name": "Publish reports in_progress"
+	},
+	{
+		"status": "completed",
+		"conclusion": "",
+		"name": "Publish reports - failed"
+	},
+	{
+		"status": "completed",
+		"conclusion": "",
+		"name": "Another Publish reports that failed"
+	},
+	{
+		"status": "queued",
+		"conclusion": "",
+		"name": "Publish reports job queued"
 	}
 ]

--- a/.github/workflows/scripts/evaluate-jobs-conclusions.js
+++ b/.github/workflows/scripts/evaluate-jobs-conclusions.js
@@ -1,14 +1,17 @@
 /* eslint-disable no-console */
 const { REPOSITORY, RUN_ID, GITHUB_TOKEN, TEST_MODE } = process.env;
 const IGNORED_JOBS = [
-	'Evaluate Project Job Statuses',
-	'Report tests results',
+	/Evaluate Project Job Statuses/,
+	/Report results on Slack/,
+	/Publish reports/,
 ];
 
 const isJobRequired = ( job ) => {
 	return (
 		! job.name.endsWith( '(optional)' ) &&
-		! IGNORED_JOBS.includes( job.name )
+		! IGNORED_JOBS.some( ( ignoredJobRegex ) =>
+			ignoredJobRegex.test( job.name )
+		)
 	);
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:


The job names in CI updated with https://github.com/woocommerce/woocommerce/pull/48175 but the ignored jobs list in evaluation script remained outdated. 
If one of the Publish reports jobs would complete with failure before the Evaluation job the workflow will incorrectly fail.

More than that, we need to ignore jobs with dynamic name now (`'Publish reports - ${{ matrix.report }}'`) so I updated the script to list and test regex expressions instead.


### How to test the changes in this Pull Request:

You can test it locally against the test data file with `TEST_MODE=true node .github/workflows/scripts/evaluate-jobs-conclusions.js`

In CI, check that everything is green.
