### PR TITLE
Add a step to install patterns when during the CYS flow

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -23,6 +23,7 @@ import { updateTemplate } from '../data/actions';
 import { installAndActivateTheme as setTheme } from '../data/service';
 import { THEME_SLUG } from '../data/constants';
 import { trackEvent } from '../tracking';
+import { installPatterns } from '../design-without-ai/services';
 
 const { escalate } = actions;
 
@@ -464,4 +465,5 @@ export const services = {
 	saveAiResponseToOption,
 	installAndActivateTheme,
 	resetPatternsAndProducts,
+	installPatterns,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -450,6 +450,25 @@ export const designWithAiStateMachineDefinition = createMachine(
 									},
 								},
 							},
+							installPatterns: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'installPatterns',
+											onDone: {
+												target: 'success',
+											},
+											onError: {
+												target: 'success',
+											},
+										},
+									},
+									success: {
+										type: 'final',
+									},
+								},
+							},
 						},
 						onDone: {
 							target: '#designWithAi.showAssembleHub',

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -147,6 +147,10 @@ const installAndActivateTheme = async (
 };
 
 export const installPatterns = async () => {
+	if ( ! window.wcAdminFeatures[ 'pattern-toolkit-full-composability' ] ) {
+		return;
+	}
+
 	const isTrackingEnabled = window.wcTracks?.isEnabled || false;
 	if ( ! isTrackingEnabled ) {
 		return;

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -146,7 +146,7 @@ const installAndActivateTheme = async (
 	}
 };
 
-const installPatterns = async () => {
+export const installPatterns = async () => {
 	const isTrackingEnabled = window.wcTracks?.isEnabled || false;
 	if ( ! isTrackingEnabled ) {
 		return;

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -264,6 +264,25 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 									},
 								},
 							},
+							installPatterns: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'installPatterns',
+											onDone: {
+												target: 'success',
+											},
+											onError: {
+												target: 'success',
+											},
+										},
+									},
+									success: {
+										type: 'final',
+									},
+								},
+							},
 						},
 						onDone: {
 							target: 'assembleSite',

--- a/plugins/woocommerce/changelog/48274-48181-install-patterns-in-cys-flow
+++ b/plugins/woocommerce/changelog/48274-48181-install-patterns-in-cys-flow
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-CYS - Install the patterns during the CYS flow if the transient is not set. </details>  <details>  <summary>Changelog Entry Comment</summary>
+CYS - Install the patterns during the CYS flow if the transient is not set.

--- a/plugins/woocommerce/changelog/48274-48181-install-patterns-in-cys-flow
+++ b/plugins/woocommerce/changelog/48274-48181-install-patterns-in-cys-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Install the patterns during the CYS flow if the transient is not set. </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -5,7 +5,6 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\AIContent\PatternsHelper;
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Patterns\PatternRegistry;
-use Automattic\WooCommerce\Blocks\Patterns\PTKClient;
 use Automattic\WooCommerce\Blocks\Patterns\PTKPatternsStore;
 use WP_Error;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48181

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

⚠️ To test only by devs ⚠️

1. Enable the `pattern-toolkit-full-composability` feature flag.
2. Comment [this line](https://github.com/woocommerce/woocommerce/blob/bff253d6dc822f8051be440e585b4856f857f8e2/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php#L112) to avoid scheduling the action to fetch patterns.
3. In [this line](https://github.com/woocommerce/woocommerce/blob/7a3cbcded381dba0261ab86b32532c72d2ac97bb/plugins/woocommerce/src/Blocks/Patterns/PTKClient.php#L26), add this code: `$ptk_url = add_query_arg( 'site', 'wooblockpatterns.wordpress.com', $ptk_url );`
4. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and uncheck `Allow usage of WooCommerce to be tracked` and save.
5. Create a new page or post and try to insert a pattern called `test`. Make sure you cannot find it.
6. Go through the CYS flow.
7. Create a new page or post and make sure **you can** now insert the pattern called `test`.
8. Repeat the test on a WooExpress site.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Install the patterns during the CYS flow if the transient is not set.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>