### PR TITLE
Update `@woocommerce/extend-cart-checkout-block` package to add Additional Checkout Fields examples

### DIFF
--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -18,34 +18,36 @@
  *
  * @package         {{namespace}}
  */
-add_action('woocommerce_blocks_loaded', function() {
-    require_once __DIR__ . '/{{slug}}-blocks-integration.php';
-	add_action(
-		'woocommerce_blocks_cart_block_registration',
-		function( $integration_registry ) {
-			$integration_registry->register( new {{slugPascalCase}}_Blocks_Integration() );
-		}
-	);
-	add_action(
-		'woocommerce_blocks_checkout_block_registration',
-		function( $integration_registry ) {
-			$integration_registry->register( new {{slugPascalCase}}_Blocks_Integration() );
-		}
-	);
-});
+add_action( 'woocommerce_blocks_loaded',
+	function() {
+		require_once __DIR__ . '/{{slug}}-blocks-integration.php';
+		add_action(
+			'woocommerce_blocks_cart_block_registration',
+			function ( $integration_registry ) {
+				$integration_registry->register( new {{slugPascalCase}}_Blocks_Integration() );
+			}
+		);
+		add_action(
+			'woocommerce_blocks_checkout_block_registration',
+			function ( $integration_registry ) {
+				$integration_registry->register( new {{slugPascalCase}}_Blocks_Integration() );
+			}
+		);
+	}
+);
 
 /**
  * Registers the slug as a block category with WordPress.
  */
 function register_{{slugPascalCase}}_block_category( $categories ) {
-    return array_merge(
-        $categories,
-        [
-            [
-                'slug'  => '{{slug}}',
-                'title' => __( '{{slugPascalCase}} Blocks', '{{slug}}' ),
-            ],
-        ]
-    );
+	return array_merge(
+		$categories,
+		[
+			[
+				'slug'  => '{{slug}}',
+				'title' => __( '{{slugPascalCase}} Blocks', '{{slug}}' ),
+			],
+		]
+	);
 }
 add_action( 'block_categories_all', 'register_{{slugPascalCase}}_block_category', 10, 2 );

--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -19,7 +19,7 @@
  * @package         {{namespace}}
  */
 add_action( 'woocommerce_blocks_loaded',
-	function() {
+	function () {
 		require_once __DIR__ . '/{{slug}}-blocks-integration.php';
 		add_action(
 			'woocommerce_blocks_cart_block_registration',
@@ -50,4 +50,87 @@ function register_{{slugPascalCase}}_block_category( $categories ) {
 		]
 	);
 }
+
 add_action( 'block_categories_all', 'register_{{slugPascalCase}}_block_category', 10, 2 );
+
+
+add_action( 'woocommerce_loaded', '{{slug}}_register_custom_checkout_fields' );
+
+/**
+ * Registers custom checkout fields for the WooCommerce checkout form.
+ *
+ * @return void
+ * @throws Exception If there is an error during the registration of the checkout fields.
+ */
+function {{slug}}_register_custom_checkout_fields() {
+
+	if ( ! function_exists( 'woocommerce_register_additional_checkout_field' ) ) {
+		return;
+	}
+
+	woocommerce_register_additional_checkout_field(
+		array(
+			'id'       => '{{slug}}/custom-checkbox',
+			'label'    => 'Check this box to see a custom field on the order.',
+			'location' => 'contact',
+			'type'     => 'checkbox',
+		)
+	);
+
+	woocommerce_register_additional_checkout_field(
+		array(
+			'id'       => '{{slug}}/custom-text-input',
+			'label'    => "{{slugPascalCase}}'s example text input",
+			'location' => 'address',
+			'type'     => 'text',
+		)
+	);
+
+	/**
+	 * Sanitizes the value of the custom text input field. For demo purposes we will just turn it to all caps.
+	 */
+	add_action(
+		'woocommerce_sanitize_additional_field',
+		function ( $value, $key, $group ) {
+			if ( '{{slug}}/custom-text-input' === $key ) {
+				return strtoupper( $value );
+			}
+			return $value;
+		},
+		10,
+		3
+	);
+
+	/**
+	 * Validates the custom text input field. For demo purposes we will not accept the string 'INVALID'.
+	 */
+	add_action(
+		'woocommerce_blocks_validate_location_address_fields',
+		function ( \WP_Error $errors, $fields, $group ) {
+			if ( 'INVALID' === $fields['{{slug}}/custom-text-input'] ) {
+				$errors->add( 'invalid_text_detected', 'Please ensure your custom text input is not "invalid".' );
+			}
+		},
+		10,
+		3
+	);
+
+	woocommerce_register_additional_checkout_field(
+		array(
+			'id'       => '{{slug}}/custom-select-input',
+			'label'    => "{{slugPascalCase}}'s example select input",
+			'location' => 'order',
+			'type'     => 'select',
+			'options'  => [
+				[
+					'label' => 'Option 1',
+					'value' => 'option1',
+				],
+				[
+					'label' => 'Option 2',
+					'value' => 'option2',
+				],
+			],
+		)
+	);
+}

--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -54,7 +54,7 @@ function register_{{slugPascalCase}}_block_category( $categories ) {
 add_action( 'block_categories_all', 'register_{{slugPascalCase}}_block_category', 10, 2 );
 
 
-add_action( 'woocommerce_loaded', '{{slug}}_register_custom_checkout_fields' );
+add_action( 'woocommerce_loaded', '{{slugPascalCase}}_register_custom_checkout_fields' );
 
 /**
  * Registers custom checkout fields for the WooCommerce checkout form.
@@ -62,7 +62,7 @@ add_action( 'woocommerce_loaded', '{{slug}}_register_custom_checkout_fields' );
  * @return void
  * @throws Exception If there is an error during the registration of the checkout fields.
  */
-function {{slug}}_register_custom_checkout_fields() {
+function {{slugPascalCase}}_register_custom_checkout_fields() {
 
 	if ( ! function_exists( 'woocommerce_register_additional_checkout_field' ) ) {
 		return;

--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -108,7 +108,7 @@ function {{slugPascalCase}}_register_custom_checkout_fields() {
 		'woocommerce_blocks_validate_location_address_fields',
 		function ( \WP_Error $errors, $fields, $group ) {
 			if ( 'INVALID' === $fields['{{slug}}/custom-text-input'] ) {
-				$errors->add( 'invalid_text_detected', 'Please ensure your custom text input is not "invalid".' );
+				$errors->add( 'invalid_text_detected', 'Please ensure your custom text input is not "INVALID".' );
 			}
 		},
 		10,

--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -54,7 +54,7 @@ function register_{{slugPascalCase}}_block_category( $categories ) {
 add_action( 'block_categories_all', 'register_{{slugPascalCase}}_block_category', 10, 2 );
 
 
-add_action( 'woocommerce_loaded', '{{slugPascalCase}}_register_custom_checkout_fields' );
+add_action( 'woocommerce_init', '{{slugPascalCase}}_register_custom_checkout_fields' );
 
 /**
  * Registers custom checkout fields for the WooCommerce checkout form.

--- a/packages/js/extend-cart-checkout-block/changelog/update-extend-cart-checkout-template
+++ b/packages/js/extend-cart-checkout-block/changelog/update-extend-cart-checkout-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Adds an example of using the Additional Checkout Fields API


### PR DESCRIPTION
### Submission Review Guidelines:

### Changes proposed in this Pull Request:

This PR adds a checkbox, select, and text field to the checkout using the Additional Checkout Fields API.

It also fixes some lint issues in the mustache templates

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the `wp-content/plugins` directory and type `npx @wordpress/create-block -t woocommerce-monorepo/packages/js/extend-cart-checkout-block your-plugin-name` **(Update the monorepo path to match what you have!)
2. Go to the WP Dashboard -> Plugins and enable "Your plugin name"
3. Add an item to your cart and go to the Checkout block. Ensure it loads correctly and there are no PHP/JS errors.
4. You should see two checkboxes in the "Contact" area: 

<img width="673" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/86ea5f11-7da0-4e52-ad9c-891967d8a886">

The first is using Additional Checkout Fields API and the second is an inner block. **Note, the second checkbox is required to please check this**.
6. Check them both.
7. Go to the address section, ensure you see "YourPluginName's example text input". Enter `INVALID` into this for now.
<img width="627" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/d7fbd746-9d24-4e3b-be3d-86d9fd072ab0">

8. Fill in the rest of the form.
9. In the additional information section ensure you see a "YourPluginName's example select input" - select an option in this.
<img width="685" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/61b2999b-0918-4455-b21a-6e6891052220">

11. Try to check out.
12. Ensure an error about the "INVALID" text in the text input appears.
13. Fix this and enter a lowercase string.
14. Check out and ensure the details you entered show up on the order confirmation screen, and order admin page.
15. Ensure the text in the text input is in upper case on these screens.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
