### PR TITLE
Re-enable variable product E2E test

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-tests-for-variations
+++ b/plugins/woocommerce/changelog/fix-e2e-tests-for-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Re-enable variable product E2E test #48294

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -136,8 +136,7 @@ test.describe( 'Variations tab', () => {
 					);
 
 					await inputLocator.fill( option );
-					await page.waitForTimeout( 100 ); // needs some time to be able to press Enter.
-					await expect( inputLocator ).toHaveValue( option );
+					await page.waitForTimeout( 500 ); // needs some time to be able to press Enter.
 					await inputLocator.press( 'Enter' );
 					await expect( container ).toContainText( option );
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After the changes added by PR https://github.com/woocommerce/woocommerce/pull/47093, some E2E tests for variable products started to fail, this is why [they were skipped](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js#L80). This PR adds a few changes to fix them.

![Screenshot 2024-06-10 at 10 16 00 AM](https://github.com/woocommerce/woocommerce/assets/1314156/d52cf1ee-efa7-4d6e-8a98-0705dc4e55cc)

Fixes partially https://github.com/woocommerce/woocommerce/issues/47858.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Run `cd plugins/woocommerce && pnpm env:start`
3. Then run `USE_WP_ENV=1 pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/basic-setup.spec.js` if you add the relative path behind it will run the file you want. I would also add `--headed` to see visually what's going on. In this case, the command should look like `USE_WP_ENV=1 pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/basic-setup.spec.js ./tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js --headed`
4. All the tests should pass.

More details [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e-pw/README.md).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
