### PR TITLE
CES: Move allow tracking option call into addCustomerEffortScoreExitPageListener

### DIFF
--- a/packages/js/customer-effort-score/changelog/improve-ces-allow-tracking-option
+++ b/packages/js/customer-effort-score/changelog/improve-ces-allow-tracking-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Move tracking option API call to listener function with caching

--- a/packages/js/customer-effort-score/src/utils/customer-effort-score-exit-page.ts
+++ b/packages/js/customer-effort-score/src/utils/customer-effort-score-exit-page.ts
@@ -36,23 +36,17 @@ export const getExitPageData = () => {
 	return arrayItems;
 };
 
-// Cache the value of whether tracking is allowed or not to avoid multiple calls.
-let _allowTracking: boolean | null = null;
-
 /**
  * Returns the value of whether tracking is allowed or not.
  *
  * @return boolean
  */
-const getAllowTracking = async () => {
-	if ( _allowTracking === null ) {
-		const trackingOption = await resolveSelect(
-			OPTIONS_STORE_NAME
-		).getOption( ALLOW_TRACKING_OPTION_NAME );
+const isTrackingAllowed = async () => {
+	const trackingOption = await resolveSelect( OPTIONS_STORE_NAME ).getOption(
+		ALLOW_TRACKING_OPTION_NAME
+	);
 
-		_allowTracking = trackingOption === 'yes';
-	}
-	return _allowTracking;
+	return trackingOption === 'yes';
 };
 
 /**
@@ -61,7 +55,7 @@ const getAllowTracking = async () => {
  * @param {string} pageId of page exited early.
  */
 export const addExitPage = async ( pageId: string ) => {
-	const allowTracking = await getAllowTracking();
+	const allowTracking = await isTrackingAllowed();
 
 	if ( ! ( window.localStorage && allowTracking ) ) {
 		return;
@@ -115,7 +109,7 @@ export const addCustomerEffortScoreExitPageListener = (
 	hasUnsavedChanges: () => boolean
 ) => {
 	// Pre-fetch the tracking option so that it is available before the unload event.
-	getAllowTracking();
+	isTrackingAllowed();
 
 	eventListeners[ pageId ] = () => {
 		if ( hasUnsavedChanges() ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `woocommerce_allow_tracking` option API is called on every WC admin page with the CES package loaded. This doesn't affect the page load time, but calling this API on every page is unnecessary.

Furthermore, when it fails, it throws an error that can cause the core profiler to break (https://github.com/woocommerce/woocommerce/pull/48246). This PR moves the `woocommerce_allow_tracking` option API call into the `addCustomerEffortScoreExitPageListener` function to ensure the option is fetched only when needed and uses cache to avoid multiple calls.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Go to the WooCommerce
3. Allow tracking
4. Go to **Product > Add New** and make some changes
5. Now go to another page like **WooCommerce > Home** and select **Leave** when it warns you about unsaved changes.
6. A notice should show on the new page that allows you to share feedback, something to the affect of `How is your experience with creating products?`
7. Open dev tools and check the network tab 
8. Go to WooCommerce > Home
9. Confirm the `woocommerce_allow_tracking` option API is not called


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
