### PR TITLE
[ci] Fetch all pages when evaluating jobs conclusions

### DIFF
--- a/.github/workflows/scripts/evaluate-jobs-conclusions.js
+++ b/.github/workflows/scripts/evaluate-jobs-conclusions.js
@@ -16,23 +16,38 @@ const isJobRequired = ( job ) => {
 };
 
 const fetchJobs = async () => {
-	try {
-		const response = await fetch(
-			`https://api.github.com/repos/${ REPOSITORY }/actions/runs/${ RUN_ID }/jobs`,
-			{
+	let url = `https://api.github.com/repos/${ REPOSITORY }/actions/runs/${ RUN_ID }/jobs`;
+	const nextPattern = /(?<=<)([\S]*)(?=>; rel="Next")/i;
+	let pagesRemaining = true;
+	const jobs = [];
+
+	while ( pagesRemaining ) {
+		console.log( 'Fetching:', url );
+		try {
+			const response = await fetch( url, {
 				headers: {
 					'User-Agent': 'node.js',
 					Authorization: `Bearer ${ GITHUB_TOKEN }`,
 				},
+			} );
+			const data = await response.json();
+			jobs.push( ...data.jobs );
+
+			const linkHeader = response.headers.get( 'link' );
+			pagesRemaining =
+				linkHeader && linkHeader.includes( `rel=\"next\"` );
+
+			if ( pagesRemaining ) {
+				url = linkHeader.match( nextPattern )[ 0 ];
 			}
-		);
-		const data = await response.json();
-		return data.jobs;
-	} catch ( error ) {
-		console.error( 'Error:', error );
-		// We want to fail if there is an error getting the jobs conclusions
-		process.exit( 1 );
+		} catch ( error ) {
+			console.error( 'Error:', error );
+			// We want to fail if there is an error getting the jobs conclusions
+			process.exit( 1 );
+		}
 	}
+
+	return jobs;
 };
 
 const evaluateJobs = async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

By default the Github api only returns 30 jobs per page in the actions/runs/{run_id}/jobs endpoint response. Some PRs have more jobs than that so not all required jobs are evaluated. This can lead to PRs not getting the merge action blocked even with failing checks.

See this run as example: https://github.com/woocommerce/woocommerce/actions/runs/9423048317/job/25961714654?pr=48291 
There were 5 failing jobs, but only 3 detected by the evaluation script. Only 30 of the jobs are being fetched, instead of 76. Fortunately some of the failed ones are in the first page.

### How to test the changes in this Pull Request:

Tested with the above run and all jobs were evaluated correctly.
You can test locally by running `REPOSITORY=woocommerce/woocommerce GITHUB_TOKEN=<token> RUN_ID=<runID> node .github/workflows/scripts/evaluate-jobs-conclusions.js`
