### PR TITLE
[CYS - Full Composability] Select the next block after deleting the selected one

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
@@ -28,7 +28,9 @@ export default function Delete( {
 					icon={ trash }
 					onClick={ () => {
 						removeBlock( clientId );
-						selectBlock( nextBlockClientId );
+						if ( nextBlockClientId ) {
+							selectBlock( nextBlockClientId );
+						}
 					} }
 				/>
 			</ToolbarButton>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
@@ -15,7 +15,7 @@ export default function Delete( {
 	nextBlockClientId,
 }: {
 	clientId: string;
-	nextBlockClientId: string;
+	nextBlockClientId: string | undefined;
 } ) {
 	// @ts-expect-error missing type
 	const { removeBlock, selectBlock } = useDispatch( blockEditorStore );

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
@@ -10,9 +10,15 @@ import {
 	// @ts-expect-error missing type
 } from '@wordpress/block-editor';
 
-export default function Delete( { clientId }: { clientId: string } ) {
+export default function Delete( {
+	clientId,
+	nextBlockClientId,
+}: {
+	clientId: string;
+	nextBlockClientId: string;
+} ) {
 	// @ts-expect-error missing type
-	const { removeBlock } = useDispatch( blockEditorStore );
+	const { removeBlock, selectBlock } = useDispatch( blockEditorStore );
 
 	return (
 		<ToolbarGroup>
@@ -22,6 +28,7 @@ export default function Delete( { clientId }: { clientId: string } ) {
 					icon={ trash }
 					onClick={ () => {
 						removeBlock( clientId );
+						selectBlock( nextBlockClientId );
 					} }
 				/>
 			</ToolbarButton>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
@@ -37,13 +37,11 @@ export const Toolbar = () => {
 		nextBlock,
 		previousBlock,
 		allBlocks,
-		nextBlockClientId,
 	}: {
 		currentBlock: BlockInstance | undefined;
 		nextBlock: BlockInstance | undefined;
 		previousBlock: BlockInstance | undefined;
 		allBlocks: BlockInstance[];
-		nextBlockClientId: string;
 	} = useSelect( ( select ) => {
 		const selectedBlockId =
 			// @ts-expect-error missing type
@@ -80,7 +78,6 @@ export const Toolbar = () => {
 			nextBlock: next,
 			previousBlock: previous,
 			allBlocks: blocks,
-			nextBlockClientId,
 		};
 	}, [] );
 
@@ -149,7 +146,7 @@ export const Toolbar = () => {
 						<Shuffle clientId={ selectedBlockClientId } />
 						<Delete
 							clientId={ selectedBlockClientId }
-							nextBlockClientId={ nextBlockClientId }
+							nextBlockClientId={ nextBlock?.clientId }
 						/>
 					</>
 				</WPToolbar>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
@@ -37,11 +37,13 @@ export const Toolbar = () => {
 		nextBlock,
 		previousBlock,
 		allBlocks,
+		nextBlockClientId,
 	}: {
 		currentBlock: BlockInstance | undefined;
 		nextBlock: BlockInstance | undefined;
 		previousBlock: BlockInstance | undefined;
 		allBlocks: BlockInstance[];
+		nextBlockClientId: string;
 	} = useSelect( ( select ) => {
 		const selectedBlockId =
 			// @ts-expect-error missing type
@@ -78,6 +80,7 @@ export const Toolbar = () => {
 			nextBlock: next,
 			previousBlock: previous,
 			allBlocks: blocks,
+			nextBlockClientId,
 		};
 	}, [] );
 
@@ -144,7 +147,10 @@ export const Toolbar = () => {
 							/>
 						</ToolbarGroup>
 						<Shuffle clientId={ selectedBlockClientId } />
-						<Delete clientId={ selectedBlockClientId } />
+						<Delete
+							clientId={ selectedBlockClientId }
+							nextBlockClientId={ nextBlockClientId }
+						/>
 					</>
 				</WPToolbar>
 			</div>

--- a/plugins/woocommerce/changelog/48316-48251-select-next-block-after-delete
+++ b/plugins/woocommerce/changelog/48316-48251-select-next-block-after-delete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Select the next block after deleting the selected one (instead of the header).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48251 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to `Tools > WCA Test Helper > Features`.
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to `WooCommerce > Home > Customize your store`.
7. Click on `Design Your Homepage`.
8. Select a pattern, and click on the `Delete` button on the toolbar.
9. Make sure after deletion, the next pattern is selected.
10. Repeat deleting a few more patterns and make sure always the selected one is the next available block.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Select the next block after deleting the selected one (instead of the header).
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
