### PR TITLE
Remove unused wp_upload_dir() var

### DIFF
--- a/plugins/woocommerce/changelog/default-constants-unused-var
+++ b/plugins/woocommerce/changelog/default-constants-unused-var
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove an unused variable from `WooCommerce::define_constants()` missing during an earlier piece of work.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -373,8 +373,6 @@ final class WooCommerce {
 	 * Define WC Constants.
 	 */
 	private function define_constants() {
-		$upload_dir = wp_upload_dir( null, false );
-
 		$this->define( 'WC_ABSPATH', dirname( WC_PLUGIN_FILE ) . '/' );
 		$this->define( 'WC_PLUGIN_BASENAME', plugin_basename( WC_PLUGIN_FILE ) );
 		$this->define( 'WC_VERSION', $this->version );


### PR DESCRIPTION
Since https://github.com/woocommerce/woocommerce/pull/44735/files#diff-97fb927371ee663e98afaf8b8134905a96d4b59c68f6a83c569ec42a6b468a08L369 this is no longer referenced.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
