### PR TITLE
Run possibly_add_template_id function in woocommerce_rest_prepare_product_variation_object hook

### DIFF
--- a/plugins/woocommerce/changelog/48325-fix-prepare-variation-boejct
+++ b/plugins/woocommerce/changelog/48325-fix-prepare-variation-boejct
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Run possibly_add_template_id function in woocommerce_rest_prepare_product_variation_object hook  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48325-fix-prepare-variation-boejct
+++ b/plugins/woocommerce/changelog/48325-fix-prepare-variation-boejct
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Run possibly_add_template_id function in woocommerce_rest_prepare_product_variation_object hook  </details>  <details>  <summary>Changelog Entry Comment</summary>
+Run possibly_add_template_id function in woocommerce_rest_prepare_product_variation_object hook

--- a/plugins/woocommerce/changelog/48325-fix-prepare-variation-boejct
+++ b/plugins/woocommerce/changelog/48325-fix-prepare-variation-boejct
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Run possibly_add_template_id function in woocommerce_rest_prepare_product_variation_object hook
+Run possibly_add_template_id function in woocommerce_rest_prepare_product_variation_object hook  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -73,6 +73,7 @@ class Init {
 			add_filter( 'woocommerce_get_block_types', array( $this, 'get_block_types' ), 999, 1 );
 
 			add_filter( 'woocommerce_rest_prepare_product_object', array( $this, 'possibly_add_template_id' ), 10, 2 );
+			add_filter( 'woocommerce_rest_prepare_product_variation_object', array( $this, 'possibly_add_template_id' ), 10, 2 );
 
 			// Make sure the block registry is initialized so that core blocks are registered.
 			BlockRegistry::get_instance();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/47762, I started calling the `possibly_add_template_id` for products, and missed out that it needs to run for variations as well. So I'm adding a filter to also have it called to variations.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the following plugin: [test-match-product-template.zip](https://github.com/user-attachments/files/15660578/test-match-product-template.zip)
2. DISABLE the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
3. Go to Products > Add
4. Create a variable product and add "15" to regular price to one (or all) the variations, publish it
5. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
6. Open the product with the new product editor
7. Open one of the variations you edited before
8. It should load the simple product template and you should see 'This is a test specific product.' below the basic details section. (Some blocks will present errors since they are not made to work with variations, but that's fine to ignore)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Run possibly_add_template_id function in woocommerce_rest_prepare_product_variation_object hook

