### PR TITLE
Migrate simple product template to HTML

### DIFF
--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -84,6 +84,12 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 		'status'
 	);
 
+	const [ , setSelectedProductFormId ] = useEntityProp< number >(
+		'postType',
+		'product',
+		'__provisorySelectedProductFormId'
+	);
+
 	const { validate } = useValidations< Product >();
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
@@ -388,7 +394,11 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 											icon={ resolveIcon( 'external' ) }
 											info={ formPost.excerpt.raw }
 											iconPosition="left"
-											onClick={ onClose } // close the dropdown for now
+											onClick={ () =>
+												setSelectedProductFormId(
+													formPost.id
+												)
+											}
 										>
 											{ formPost.title.rendered }
 										</MenuItem>

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -35,6 +35,7 @@ import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore store should be included.
 	useEntityBlockEditor,
+	useEntityProp,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore store should be included.
 	useEntityRecord,
@@ -87,10 +88,6 @@ export function BlockEditor( {
 	productId,
 	setIsEditorLoading,
 }: BlockEditorProps ) {
-	const [ selectedProductFormId, setSelectedProductFormId ] = useState<
-		number | null
-	>( null );
-
 	useConfirmUnsavedProductChanges( postType );
 
 	/**
@@ -214,6 +211,12 @@ export function BlockEditor( {
 		{ id: productId !== -1 ? productId : 0 }
 	);
 
+	const [ selectedProductFormId ] = useEntityProp(
+		'postType',
+		postType,
+		'__provisorySelectedProductFormId'
+	);
+
 	// Pull the product templates from the store.
 	const productForms = useSelect( ( sel ) => {
 		return (
@@ -222,15 +225,6 @@ export function BlockEditor( {
 			} ) || []
 		);
 	}, [] ) as ProductFormPostProps[];
-
-	// Set the default product form template ID.
-	useEffect( () => {
-		if ( ! productForms.length ) {
-			return;
-		}
-
-		setSelectedProductFormId( productForms[ 0 ].id );
-	}, [ productForms ] );
 
 	const isEditorLoading =
 		! settings ||
@@ -261,7 +255,6 @@ export function BlockEditor( {
 		},
 		[ productForms, selectedProductFormId ]
 	);
-
 	useLayoutEffect(
 		function setupEditor() {
 			if ( isEditorLoading ) {
@@ -277,7 +270,7 @@ export function BlockEditor( {
 			 * If the product form template is not available, use the block instances.
 			 * ToDo: Remove this fallback once the product form template is stable/available.
 			 */
-			const editorTemplate = blockInstances ?? productFormTemplate;
+			const editorTemplate = productFormTemplate || blockInstances;
 
 			onChange( editorTemplate, {} );
 

--- a/plugins/woocommerce/changelog/add-pft-comment-delimited-conversion
+++ b/plugins/woocommerce/changelog/add-pft-comment-delimited-conversion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create 'get_comment_delimited_template' for the Template API and migrate simple product template to HTML

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -695,7 +695,6 @@
 				"node_modules/@woocommerce/e2e-core-tests/CHANGELOG.md",
 				"node_modules/@woocommerce/api/dist/",
 				"node_modules/@woocommerce/admin-e2e-tests/build",
-				"node_modules/@woocommerce/classic-assets/build",
 				"node_modules/@woocommerce/block-library/build",
 				"node_modules/@woocommerce/block-library/blocks.ini",
 				"node_modules/@woocommerce/admin-library/build",

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
@@ -152,4 +152,9 @@ interface BlockInterface {
 	 * @return array The block configuration as a formatted template.
 	 */
 	public function get_formatted_template(): array;
+
+	/**
+	 * TODO
+	 */
+	public function get_comment_delimited_template();
 }

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
@@ -152,5 +152,11 @@ interface BlockInterface {
 	 * @return array The block configuration as a formatted template.
 	 */
 	public function get_formatted_template(): array;
+	/**
+	 * Get the block configuration as a comment delimited template
+	 *
+	 * @return string The block configuration as a formatted string.
+	 */
+	public function get_comment_delimited_template(): string;
 
 }

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
@@ -153,8 +153,4 @@ interface BlockInterface {
 	 */
 	public function get_formatted_template(): array;
 
-	/**
-	 * TODO
-	 */
-	public function get_comment_delimited_template();
 }

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
@@ -158,5 +158,4 @@ interface BlockInterface {
 	 * @return string The block configuration as a formatted string.
 	 */
 	public function get_comment_delimited_template(): string;
-
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -26,26 +26,20 @@ class ProductFormsController {
 	 */
 	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingFinal, WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag -- Not an injection.
 		add_action( 'upgrader_process_complete', array( $this, 'migrate_templates_when_plugin_updated' ), 10, 2 );
-		add_action( 'rest_post_dispatch', array( $this, 'maybe_add_product_form_templates' ), 10, 3 );
+		add_action( 'the_content', array( $this, 'maybe_add_product_form_templates' ), 10, 2 );
 	}
 
 	/**
 	 * Maybe add product form templates to the posts array.
 	 */
-	public function maybe_add_product_form_templates( $response, $server, $request ) {
-		if ( $request->get_route() === '/wp/v2/product_form' ) {
-			$test             = new SimpleProductTemplate();
-			$response->data[] = array(
-				'content' => array( 'raw' => $test->get_comment_delimited_template() ),
-				'id'      => 9999,
-				'title'   => array(
-					'raw'      => 'simple_test',
-					'rendered' => 'simple_test',
-				),
-				'excerpt' => array( 'ray' => 'simple_test' ),
-			);
+	public function maybe_add_product_form_templates( $content ) {
+		$post = get_post();
+
+		if ( 'product_form' === $post->post_type && 'Simple' === $post->post_title ) {
+			$simple = new SimpleProductTemplate();
+			return $simple->get_comment_delimited_template();
 		}
-		return $response;
+		return $content;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
+use Automattic\WooCommerce\Internal\Features\ProductBlockEditor\ProductTemplates\SimpleProductTemplate;
+
 /**
  * Handle retrieval of product forms.
  */
@@ -24,6 +26,26 @@ class ProductFormsController {
 	 */
 	public function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingFinal, WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag -- Not an injection.
 		add_action( 'upgrader_process_complete', array( $this, 'migrate_templates_when_plugin_updated' ), 10, 2 );
+		add_action( 'rest_post_dispatch', array( $this, 'maybe_add_product_form_templates' ), 10, 3 );
+	}
+
+	/**
+	 * Maybe add product form templates to the posts array.
+	 */
+	public function maybe_add_product_form_templates( $response, $server, $request ) {
+		if ( $request->get_route() === '/wp/v2/product_form' ) {
+			$test             = new SimpleProductTemplate();
+			$response->data[] = array(
+				'content' => array( 'raw' => $test->get_comment_delimited_template() ),
+				'id'      => 9999,
+				'title'   => array(
+					'raw'      => 'simple_test',
+					'rendered' => 'simple_test',
+				),
+				'excerpt' => array( 'ray' => 'simple_test' ),
+			);
+		}
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -105,11 +105,13 @@ class ProductFormsController {
 
 				if ( ! empty( $post ) ) {
 					wp_update_post(
-						array(
-							'ID'           => $post->ID,
-							'post_title'   => $file_data['title'],
-							'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
-							'post_excerpt' => $file_data['description'],
+						wp_slash(
+							array(
+								'ID'           => $post->ID,
+								'post_title'   => $file_data['title'],
+								'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
+								'post_excerpt' => $file_data['description'],
+							)
 						)
 					);
 				}
@@ -123,13 +125,15 @@ class ProductFormsController {
 			}
 
 			$post = wp_insert_post(
-				array(
-					'post_title'   => $file_data['title'],
-					'post_name'    => $slug,
-					'post_status'  => 'publish',
-					'post_type'    => 'product_form',
-					'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
-					'post_excerpt' => $file_data['description'],
+				wp_slash(
+					array(
+						'post_title'   => $file_data['title'],
+						'post_name'    => $slug,
+						'post_status'  => 'publish',
+						'post_type'    => 'product_form',
+						'post_content' => BlockTemplateUtils::get_template_content( $file_path ),
+						'post_excerpt' => $file_data['description'],
+					)
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Admin\BlockTemplates\ContainerInterface;
 /**
  * Block configuration used to specify blocks in BlockTemplate.
  */
-class AbstractBlock implements BlockInterface {
+abstract class AbstractBlock implements BlockInterface {
 	use BlockFormattedTemplateTrait;
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
@@ -39,7 +39,7 @@ abstract class AbstractBlockTemplate implements BlockTemplateInterface {
 	 * Get the template attributes.
 	 */
 	public function get_attributes(): array {
-		return [];
+		return array();
 	}
 
 	/**
@@ -53,14 +53,14 @@ abstract class AbstractBlockTemplate implements BlockTemplateInterface {
 	 * Get the template hide conditions.
 	 */
 	public function get_hide_conditions() {
-		return [];
+		return array();
 	}
 
 	/**
 	 * Get the template disable conditions.
 	 */
 	public function get_disable_conditions() {
-		return [];
+		return array();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
@@ -177,7 +177,6 @@ abstract class AbstractBlockTemplate implements BlockTemplateInterface {
 			'description'    => $this->get_description(),
 			'area'           => $this->get_area(),
 			'blockTemplates' => $this->get_formatted_template(),
-			'comment'        => $this->get_comment_delimited_template(),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
@@ -30,6 +30,14 @@ abstract class AbstractBlockTemplate implements BlockTemplateInterface {
 		return '';
 	}
 
+	public function get_name(): string {
+		return '';
+	}
+
+	public function get_attributes(): array {
+		return [];
+	}
+
 	/**
 	 * Get the template area.
 	 */
@@ -144,6 +152,7 @@ abstract class AbstractBlockTemplate implements BlockTemplateInterface {
 			'description'    => $this->get_description(),
 			'area'           => $this->get_area(),
 			'blockTemplates' => $this->get_formatted_template(),
+			'comment'        => $this->get_comment_delimited_template(),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
@@ -29,12 +29,37 @@ abstract class AbstractBlockTemplate implements BlockTemplateInterface {
 	public function get_description(): string {
 		return '';
 	}
-
+	/**
+	 * Get the template name.
+	 */
 	public function get_name(): string {
 		return '';
 	}
-
+	/**
+	 * Get the template attributes.
+	 */
 	public function get_attributes(): array {
+		return [];
+	}
+
+	/**
+	 * Get the template order.
+	 */
+	public function get_order() {
+		return null;
+	}
+
+	/**
+	 * Get the template hide conditions.
+	 */
+	public function get_hide_conditions() {
+		return [];
+	}
+
+	/**
+	 * Get the template disable conditions.
+	 */
+	public function get_disable_conditions() {
 		return [];
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -205,11 +205,11 @@ trait BlockContainerTrait {
 	 */
 	public function get_comment_delimited_template(): string {
 
-		$arr          = [];
+		$arr          = array();
 		$inner_blocks = $this->get_inner_blocks_sorted_by_order();
 		if ( ! empty( $inner_blocks ) ) {
 			$arr = array_map(
-				function( BlockInterface $block ) {
+				function ( BlockInterface $block ) {
 					return $block->get_comment_delimited_template();
 				},
 				$inner_blocks
@@ -222,7 +222,6 @@ trait BlockContainerTrait {
 		$children = implode( "\n", $arr );
 
 		return '' !== $name ? get_comment_delimited_block_content( $name, $attributes, $children ) : $children;
-
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -201,6 +201,26 @@ trait BlockContainerTrait {
 	}
 
 	/**
+	 * TODO
+	 */
+	public function get_comment_delimited_template() {
+
+		$arr          = [];
+		$inner_blocks = $this->get_inner_blocks_sorted_by_order();
+		if ( ! empty( $inner_blocks ) ) {
+			$arr = array_map(
+				function( BlockInterface $block ) {
+					return $block->get_comment_delimited_template();
+				},
+				$inner_blocks
+			);
+		}
+
+		return get_comment_delimited_block_content( $this->get_name(), $this->get_attributes(), "\n<div>\n" . implode( "\n", $arr ) . "\n</div>\n" );
+
+	}
+
+	/**
 	 * Do the `woocommerce_block_template_after_add_block` action.
 	 * Handle exceptions thrown by the action.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -201,9 +201,9 @@ trait BlockContainerTrait {
 	}
 
 	/**
-	 * TODO
+	 * Get the inner blocks as a comment delimited template.
 	 */
-	public function get_comment_delimited_template() {
+	public function get_comment_delimited_template(): string {
 
 		$arr          = [];
 		$inner_blocks = $this->get_inner_blocks_sorted_by_order();
@@ -217,7 +217,7 @@ trait BlockContainerTrait {
 		}
 
 		$name       = $this->get_name();
-		$attributes = $this->get_attributes();
+		$attributes = $this->get_augmented_attributes();
 
 		$children = implode( "\n", $arr );
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -219,9 +219,16 @@ trait BlockContainerTrait {
 		$name       = $this->get_name();
 		$attributes = $this->get_augmented_attributes();
 
-		$children = implode( "\n", $arr );
+		$children = implode( '', $arr );
 
-		return '' !== $name ? get_comment_delimited_block_content( $name, $attributes, $children ) : $children;
+		$content = '';
+		if ( 'core/column' === $name ) {
+			$content = '<div class="wp-block-column" />';
+		} elseif ( 'core/columns' === $name ) {
+			$content = '<div class="wp-block-columns" />';
+		}
+
+		return '' !== $name ? get_comment_delimited_block_content( $name, $attributes, $content . $children ) : $children;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -216,7 +216,22 @@ trait BlockContainerTrait {
 			);
 		}
 
-		return get_comment_delimited_block_content( $this->get_name(), $this->get_attributes(), "\n<div>\n" . implode( "\n", $arr ) . "\n</div>\n" );
+		$name            = $this->get_name();
+		$attributes      = $this->get_attributes();
+		$attributes_html = implode(
+			' ',
+			array_map(
+				function( $key, $value ) {
+					return "data-$key=\"" . esc_attr( $value ) . '"';
+				},
+				array_keys( $attributes ),
+				$attributes
+			)
+		);
+
+		$children = $name && $attributes ? '<div data-block-name="' . esc_attr( $name ) . '"' . $attributes_html . ">\n" . implode( "\n", $arr ) . "\n</div>\n" : implode( "\n", $arr );
+
+		return $name !== '' && count( $attributes ) > 0 ? get_comment_delimited_block_content( $name, $attributes, $children ) : $children;
 
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -216,22 +216,12 @@ trait BlockContainerTrait {
 			);
 		}
 
-		$name            = $this->get_name();
-		$attributes      = $this->get_attributes();
-		$attributes_html = implode(
-			' ',
-			array_map(
-				function( $key, $value ) {
-					return "data-$key=\"" . esc_attr( $value ) . '"';
-				},
-				array_keys( $attributes ),
-				$attributes
-			)
-		);
+		$name       = $this->get_name();
+		$attributes = $this->get_attributes();
 
-		$children = $name && $attributes ? '<div data-block-name="' . esc_attr( $name ) . '"' . $attributes_html . ">\n" . implode( "\n", $arr ) . "\n</div>\n" : implode( "\n", $arr );
+		$children = implode( "\n", $arr );
 
-		return $name !== '' && count( $attributes ) > 0 ? get_comment_delimited_block_content( $name, $attributes, $children ) : $children;
+		return '' !== $name ? get_comment_delimited_block_content( $name, $attributes, $children ) : $children;
 
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
@@ -20,7 +20,7 @@ trait BlockFormattedTemplateTrait {
 		return $arr;
 	}
 	/**
-	 * Get the block attributes with block id, blkock order, hide and disable conditions.
+	 * Get the block attributes with block id, block order, hide and disable conditions.
 	 */
 	private function get_augmented_attributes() {
 		return array_merge(

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
@@ -31,6 +31,12 @@ trait BlockFormattedTemplateTrait {
 
 		return $arr;
 	}
+	/**
+	 * TODO
+	 */
+	public function get_comment_delimited_template() {
+		return get_comment_delimited_block_content( $this->get_name(), $this->get_attributes(), '' );
+	}
 
 	/**
 	 * Get the block hide conditions formatted for inclusion in a formatted template.

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
@@ -14,22 +14,28 @@ trait BlockFormattedTemplateTrait {
 	public function get_formatted_template(): array {
 		$arr = array(
 			$this->get_name(),
-			array_merge(
-				$this->get_attributes(),
-				array(
-					'_templateBlockId'    => $this->get_id(),
-					'_templateBlockOrder' => $this->get_order(),
-				),
-				! empty( $this->get_hide_conditions() ) ? array(
-					'_templateBlockHideConditions' => $this->get_formatted_hide_conditions(),
-				) : array(),
-				! empty( $this->get_disable_conditions() ) ? array(
-					'_templateBlockDisableConditions' => $this->get_formatted_disable_conditions(),
-				) : array(),
-			),
+			$this->get_augmented_attributes(),
 		);
 
 		return $arr;
+	}
+	/**
+	 * Get the block attributes with block id, blkock order, hide and disable conditions.
+	 */
+	private function get_augmented_attributes() {
+		return array_merge(
+			$this->get_attributes(),
+			array(
+				'_templateBlockId'    => $this->get_id(),
+				'_templateBlockOrder' => $this->get_order(),
+			),
+			! empty( $this->get_hide_conditions() ) ? array(
+				'_templateBlockHideConditions' => $this->get_formatted_hide_conditions(),
+			) : array(),
+			! empty( $this->get_disable_conditions() ) ? array(
+				'_templateBlockDisableConditions' => $this->get_formatted_disable_conditions(),
+			) : array(),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
@@ -31,12 +31,6 @@ trait BlockFormattedTemplateTrait {
 
 		return $arr;
 	}
-	/**
-	 * TODO
-	 */
-	public function get_comment_delimited_template() {
-		return get_comment_delimited_block_content( $this->get_name(), $this->get_attributes(), '' );
-	}
 
 	/**
 	 * Get the block hide conditions formatted for inclusion in a formatted template.

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -16,307 +16,44 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:woocommerce/product-tab {"title":"General","id":"general"} -->
-<div data-block-name="woocommerce/product-tab" data-title="General" data-id="general">
-	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.","buttonText":"Go to Variations","type":"info"} -->
-	<div data-block-name="woocommerce/product-has-variations-notice"
-	data-content="This product has options, such as size or color. You can manage each variation&#039;s images, downloads, and other details individually."
-	data-buttonText="Go to Variations" data-type="info">
 
-	</div>
-	<!-- /wp:woocommerce/product-has-variations-notice -->
-	<!-- wp:woocommerce/product-section {"title":"Basic details","description":"This info will be displayed on the product page, category pages, social media, and search results."} -->
-	<div data-block-name="woocommerce/product-section" data-title="Basic details"
-	data-description="This info will be displayed on the product page, category pages, social media, and search results.">
-
-	<!-- wp:woocommerce/product-name-field {"name":"Product name","autoFocus":true,"metadata":{"bindings":{"value":{"source":"woocommerce/entity-product","args":{"prop":"name"}}}}} -->
-	<div data-block-name="woocommerce/product-name-field" data-name="Product name" data-autoFocus="1"
-		data-metadata="Array">
-
-	</div>
-	<!-- /wp:woocommerce/product-name-field -->
-	<!-- wp:column {"templateLock":"all"} -->
-	<div data-block-name="core/column" data-templateLock="all">
-		<!-- wp:woocommerce/product-regular-price-field {"name":"regular_price","label":"Regular price","help":"Per your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=general\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003estore settings\u003c/a\u003e, taxes are not enabled."} -->
-		<div data-block-name="woocommerce/product-regular-price-field" data-name="regular_price"
-		data-label="Regular price"
-		data-help="Per your &lt;a href=&quot;https://test.local/wp-admin/admin.php?page=wc-settings&amp;tab=general&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;store settings&lt;/a&gt;, taxes are not enabled.">
-
-		</div>
-		<!-- /wp:woocommerce/product-regular-price-field -->
-	</div>
-	<!-- /wp:column -->
-	<!-- wp:column {"templateLock":"all"} -->
-	<div data-block-name="core/column" data-templateLock="all">
-		<!-- wp:woocommerce/product-sale-price-field {"label":"Sale price"} -->
-		<div data-block-name="woocommerce/product-sale-price-field" data-label="Sale price">
-
-		</div>
-		<!-- /wp:woocommerce/product-sale-price-field -->
-	</div>
-	<!-- /wp:column -->
-
-	<!-- wp:woocommerce/product-text-area-field {"label":"Summary","help":"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.","property":"short_description"} -->
-	<div data-block-name="woocommerce/product-text-area-field" data-label="Summary"
-		data-help="Summarize this product in 1-2 short sentences. We&#039;ll show it at the top of the page."
-		data-property="short_description">
-
-	</div>
-	<!-- /wp:woocommerce/product-text-area-field -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Description","description":"What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks."} -->
-	<div data-block-name="woocommerce/product-section" data-title="Description"
-	data-description="What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks.">
-	<!-- wp:woocommerce/product-summary-field {"helpText":null,"label":null,"property":"description"} -->
-	<div data-block-name="woocommerce/product-summary-field" data-helpText="" data-label="" data-property="description">
-
-	</div>
-	<!-- /wp:woocommerce/product-summary-field -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Buy button","description":"Add a link and choose a label for the button linked to a product sold elsewhere."} -->
-	<div data-block-name="woocommerce/product-section" data-title="Buy button"
-	data-description="Add a link and choose a label for the button linked to a product sold elsewhere.">
-	<!-- wp:woocommerce/product-text-field {"property":"external_url","label":"Link to the external product","placeholder":"Enter the external URL to the product","suffix":true,"type":{"value":"url","message":"Link to the external product is an invalid URL."}} -->
-	<div data-block-name="woocommerce/product-text-field" data-property="external_url"
-		data-label="Link to the external product" data-placeholder="Enter the external URL to the product" data-suffix="1"
-		data-type="Array">
-
-	</div>
-	<!-- /wp:woocommerce/product-text-field -->
-	<!-- wp:woocommerce/product-text-field {"property":"button_text","label":"Buy button text"} -->
-	<div data-block-name="woocommerce/product-text-field" data-property="button_text" data-label="Buy button text">
-
-	</div>
-	<!-- /wp:woocommerce/product-text-field -->
-
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Products in this group","description":"Make a collection of related products, enabling customers to purchase multiple items together."} -->
-	<div data-block-name="woocommerce/product-section" data-title="Products in this group"
-	data-description="Make a collection of related products, enabling customers to purchase multiple items together.">
-	<!-- wp:woocommerce/product-list-field {"property":"grouped_products"} -->
-	<div data-block-name="woocommerce/product-list-field" data-property="grouped_products">
-
-	</div>
-	<!-- /wp:woocommerce/product-list-field -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Images","description":"Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. \u003ca href=\u0022https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to prepare images?\u003c/a\u003e"} -->
-	<div data-block-name="woocommerce/product-section" data-title="Images"
-	data-description="Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. &lt;a href=&quot;https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;How to prepare images?&lt;/a&gt;">
-	<!-- wp:woocommerce/product-images-field {"images":[],"property":"images"} -->
-	<div data-block-name="woocommerce/product-images-field" data-images="Array" data-property="images">
-
-	</div>
-	<!-- /wp:woocommerce/product-images-field -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
-	<div data-block-name="woocommerce/product-section" data-blockGap="unit-40">
-	<!-- wp:woocommerce/product-toggle-field {"property":"downloadable","label":"Include downloads","checkedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","uncheckedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info."} -->
-	<div data-block-name="woocommerce/product-toggle-field" data-property="downloadable" data-label="Include downloads"
-		data-checkedHelp="Add any files you&#039;d like to make available for the customer to download after purchasing, such as instructions or warranty info."
-		data-uncheckedHelp="Add any files you&#039;d like to make available for the customer to download after purchasing, such as instructions or warranty info.">
-
-	</div>
-	<!-- /wp:woocommerce/product-toggle-field -->
-	<!-- wp:woocommerce/product-subsection {"title":"Downloads","description":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=downloadable\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eproduct settings\u003c/a\u003e."} -->
-	<div data-block-name="woocommerce/product-subsection" data-title="Downloads"
-		data-description="Add any files you&#039;d like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your &lt;a href=&quot;https://test.local/wp-admin/admin.php?page=wc-settings&amp;tab=products&amp;section=downloadable&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;product settings&lt;/a&gt;.">
-
-	</div>
-	<!-- /wp:woocommerce/product-subsection -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-</div>
-<!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Variations","id":"variations"} -->
-<div data-block-name="woocommerce/product-tab" data-title="Variations" data-id="variations">
-	<!-- wp:woocommerce/product-section {"title":"Variation options","description":"Add and manage attributes used for product options, such as size and color."} -->
-	<div data-block-name="woocommerce/product-section" data-title="Variation options"
-	data-description="Add and manage attributes used for product options, such as size and color.">
-
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Variations","description":"Manage individual product combinations created from options."} -->
-	<div data-block-name="woocommerce/product-section" data-title="Variations"
-	data-description="Manage individual product combinations created from options.">
-
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-</div>
-<!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Organization","id":"organization"} -->
-<div data-block-name="woocommerce/product-tab" data-title="Organization" data-id="organization">
-	<!-- wp:woocommerce/product-section {"title":"Product catalog","description":"Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels."} -->
-	<div data-block-name="woocommerce/product-section" data-title="Product catalog"
-	data-description="Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels.">
-	<!-- wp:woocommerce/product-taxonomy-field {"slug":"product_cat","property":"categories","label":"Categories","createTitle":"Create new category","dialogNameHelpText":"Shown to customers on the product page.","parentTaxonomyText":"Parent category","placeholder":"Search or create categories…"} -->
-	<div data-block-name="woocommerce/product-taxonomy-field" data-slug="product_cat" data-property="categories"
-		data-label="Categories" data-createTitle="Create new category"
-		data-dialogNameHelpText="Shown to customers on the product page." data-parentTaxonomyText="Parent category"
-		data-placeholder="Search or create categories…">
-
-	</div>
-	<!-- /wp:woocommerce/product-taxonomy-field -->
-	<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide in product catalog","visibility":"search"} -->
-	<div data-block-name="woocommerce/product-catalog-visibility-field" data-label="Hide in product catalog"
-		data-visibility="search">
-
-	</div>
-	<!-- /wp:woocommerce/product-catalog-visibility-field -->
-	<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide from search results","visibility":"catalog"} -->
-	<div data-block-name="woocommerce/product-catalog-visibility-field" data-label="Hide from search results"
-		data-visibility="catalog">
-
-	</div>
-	<!-- /wp:woocommerce/product-catalog-visibility-field -->
-	<!-- wp:woocommerce/product-checkbox-field {"label":"Enable product reviews","property":"reviews_allowed"} -->
-	<div data-block-name="woocommerce/product-checkbox-field" data-label="Enable product reviews"
-		data-property="reviews_allowed">
-
-	</div>
-	<!-- /wp:woocommerce/product-checkbox-field -->
-	<!-- wp:woocommerce/product-password-field {"label":"Require a password"} -->
-	<div data-block-name="woocommerce/product-password-field" data-label="Require a password">
-
-	</div>
-	<!-- /wp:woocommerce/product-password-field -->
-	<!-- wp:woocommerce/product-tag-field {"name":"tags"} -->
-	<div data-block-name="woocommerce/product-tag-field" data-name="tags">
-
-	</div>
-	<!-- /wp:woocommerce/product-tag-field -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Attributes","description":"Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information.","blockGap":"unit-40"} -->
-	<div data-block-name="woocommerce/product-section" data-title="Attributes"
-	data-description="Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information."
-	data-blockGap="unit-40">
-
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-custom-fields-toggle-field {"label":"Show custom fields"} -->
-	<div data-block-name="woocommerce/product-custom-fields-toggle-field" data-label="Show custom fields">
-	<!-- wp:woocommerce/product-section {"blockGap":"unit-30","title":"Custom fields","description":"Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. \u003ca href=\u0022https://woocommerce.com/document/custom-product-fields/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about custom fields\u003c/a\u003e"} -->
-	<div data-block-name="woocommerce/product-section" data-blockGap="unit-30" data-title="Custom fields"
-		data-description="Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. &lt;a href=&quot;https://woocommerce.com/document/custom-product-fields/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Read more about custom fields&lt;/a&gt;">
-
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	</div>
-	<!-- /wp:woocommerce/product-custom-fields-toggle-field -->
-</div>
-<!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Inventory","id":"inventory"} -->
-<div data-block-name="woocommerce/product-tab" data-title="Inventory" data-id="inventory">
-	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.","buttonText":"Go to Variations","type":"info"} -->
-	<div data-block-name="woocommerce/product-has-variations-notice"
-	data-content="This product has options, such as size or color. You can now manage each variation&#039;s inventory and other details individually."
-	data-buttonText="Go to Variations" data-type="info">
-
-	</div>
-	<!-- /wp:woocommerce/product-has-variations-notice -->
-	<!-- wp:woocommerce/product-section {"title":"Inventory","description":"Set up and manage inventory for this product, including status and available quantity. \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=inventory\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eManage store inventory settings\u003c/a\u003e","blockGap":"unit-40"} -->
-	<div data-block-name="woocommerce/product-section" data-title="Inventory"
-	data-description="Set up and manage inventory for this product, including status and available quantity. &lt;a href=&quot;https://test.local/wp-admin/admin.php?page=wc-settings&amp;tab=products&amp;section=inventory&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Manage store inventory settings&lt;/a&gt;"
-	data-blockGap="unit-40">
-
-	<!-- wp:woocommerce/product-toggle-field {"label":"Track inventory","property":"manage_stock","disabled":false,"disabledCopy":null} -->
-	<div data-block-name="woocommerce/product-toggle-field" data-label="Track inventory" data-property="manage_stock"
-		data-disabled="" data-disabledCopy="">
-
-	</div>
-	<!-- /wp:woocommerce/product-toggle-field -->
-
-	<!-- wp:woocommerce/product-radio-field {"title":"Stock status","property":"stock_status","options":[{"label":"In stock","value":"instock"},{"label":"Out of stock","value":"outofstock"},{"label":"On backorder","value":"onbackorder"}]} -->
-	<div data-block-name="woocommerce/product-radio-field" data-title="Stock status" data-property="stock_status"
-		data-options="Array">
-
-	</div>
-	<!-- /wp:woocommerce/product-radio-field -->
-	<!-- wp:woocommerce/product-text-area-field {"property":"purchase_note","label":"Post-purchase note","placeholder":"Enter an optional note attached to the order confirmation message sent to the shopper."} -->
-	<div data-block-name="woocommerce/product-text-area-field" data-property="purchase_note"
-		data-label="Post-purchase note"
-		data-placeholder="Enter an optional note attached to the order confirmation message sent to the shopper.">
-
-	</div>
-	<!-- /wp:woocommerce/product-text-area-field -->
-	<!-- wp:woocommerce/product-collapsible {"toggleText":"Advanced","initialCollapsed":true,"persistRender":true} -->
-	<div data-block-name="woocommerce/product-collapsible" data-toggleText="Advanced" data-initialCollapsed="1"
-		data-persistRender="1">
-		<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
-		<div data-block-name="woocommerce/product-section" data-blockGap="unit-40">
-		<!-- wp:woocommerce/product-radio-field {"title":"When out of stock","property":"backorders","options":[{"label":"Allow purchases","value":"yes"},{"label":"Allow purchases, but notify customers","value":"notify"},{"label":"Don't allow purchases","value":"no"}]} -->
-		<div data-block-name="woocommerce/product-radio-field" data-title="When out of stock" data-property="backorders"
-			data-options="Array">
-
-		</div>
-		<!-- /wp:woocommerce/product-radio-field -->
-
-		<!-- wp:woocommerce/product-checkbox-field {"title":"Restrictions","label":"Limit purchases to 1 item per order","property":"sold_individually","tooltip":"When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods."} -->
-		<div data-block-name="woocommerce/product-checkbox-field" data-title="Restrictions"
-			data-label="Limit purchases to 1 item per order" data-property="sold_individually"
-			data-tooltip="When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods.">
-
-		</div>
-		<!-- /wp:woocommerce/product-checkbox-field -->
-		</div>
-		<!-- /wp:woocommerce/product-section -->
-	</div>
-	<!-- /wp:woocommerce/product-collapsible -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-</div>
-<!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Shipping","id":"shipping"} -->
-<div data-block-name="woocommerce/product-tab" data-title="Shipping" data-id="shipping">
-	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.","buttonText":"Go to Variations","type":"info"} -->
-	<div data-block-name="woocommerce/product-has-variations-notice"
-	data-content="This product has options, such as size or color. You can now manage each variation&#039;s shipping settings and other details individually."
-	data-buttonText="Go to Variations" data-type="info">
-
-	</div>
-	<!-- /wp:woocommerce/product-has-variations-notice -->
-	<!-- wp:woocommerce/product-toggle-field {"property":"virtual","checkedValue":false,"uncheckedValue":true,"label":"This product requires shipping or pickup","uncheckedHelp":"This product will not trigger your customer's shipping calculator in cart or at checkout. This product also won't require your customers to enter their shipping details at checkout. \u003ca href=\u0022https://woocommerce.com/document/managing-products/#adding-a-virtual-product\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about virtual products\u003c/a\u003e."} -->
-	<div data-block-name="woocommerce/product-toggle-field" data-property="virtual" data-checkedValue=""
-	data-uncheckedValue="1" data-label="This product requires shipping or pickup"
-	data-uncheckedHelp="This product will not trigger your customer&#039;s shipping calculator in cart or at checkout. This product also won&#039;t require your customers to enter their shipping details at checkout. &lt;a href=&quot;https://woocommerce.com/document/managing-products/#adding-a-virtual-product&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Read more about virtual products&lt;/a&gt;.">
-
-	</div>
-	<!-- /wp:woocommerce/product-toggle-field -->
-	<!-- wp:woocommerce/product-section {"title":"Fees \u0026 dimensions","description":"Set up shipping costs and enter dimensions used for accurate rate calculations. \u003ca href=\u0022https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to get started?\u003c/a\u003e"} -->
-	<div data-block-name="woocommerce/product-section" data-title="Fees &amp; dimensions"
-	data-description="Set up shipping costs and enter dimensions used for accurate rate calculations. &lt;a href=&quot;https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;How to get started?&lt;/a&gt;">
-
-
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-</div>
-<!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Linked products","id":"linked-products"} -->
-<div data-block-name="woocommerce/product-tab" data-title="Linked products" data-id="linked-products">
-	<!-- wp:woocommerce/product-section {"title":"Upsells","description":"Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
-	<div data-block-name="woocommerce/product-section" data-title="Upsells"
-	data-description="Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. &lt;br /&gt;&lt;a href=&quot;https://woocommerce.com/document/related-products-up-sells-and-cross-sells/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Learn more about linked products&lt;/a&gt;">
-	<!-- wp:woocommerce/product-linked-list-field {"property":"upsell_ids","emptyState":{"image":"ShoppingBags","tip":"Tip: Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.","isDismissible":true}} -->
-	<div data-block-name="woocommerce/product-linked-list-field" data-property="upsell_ids" data-emptyState="Array">
-
-	</div>
-	<!-- /wp:woocommerce/product-linked-list-field -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Cross-sells","description":"By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
-	<div data-block-name="woocommerce/product-section" data-title="Cross-sells"
-	data-description="By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. &lt;br /&gt;&lt;a href=&quot;https://woocommerce.com/document/related-products-up-sells-and-cross-sells/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Learn more about linked products&lt;/a&gt;">
-	<!-- wp:woocommerce/product-linked-list-field {"property":"cross_sell_ids","emptyState":{"image":"CashRegister","tip":"Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.","isDismissible":true}} -->
-	<div data-block-name="woocommerce/product-linked-list-field" data-property="cross_sell_ids" data-emptyState="Array">
-
-	</div>
-	<!-- /wp:woocommerce/product-linked-list-field -->
-	</div>
-	<!-- /wp:woocommerce/product-section -->
-</div>
-<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"General","id":"general"} --><!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
+<!-- wp:woocommerce/product-section {"title":"Basic details","description":"This info will be displayed on the product page, category pages, social media, and search results."} --><!-- wp:woocommerce/product-details-section-description /-->
+<!-- wp:woocommerce/product-name-field {"name":"Product name","autoFocus":true,"metadata":{"bindings":{"value":{"source":"woocommerce/entity-product","args":{"prop":"name"}}}}} /-->
+<!-- wp:columns --><div class="wp-block-columns"></div><!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div><!-- wp:woocommerce/product-regular-price-field {"name":"regular_price","label":"Regular price","help":"Per your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=general\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003estore settings\u003c/a\u003e, taxes are not enabled."} /--><!-- /wp:column -->
+<!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div><!-- wp:woocommerce/product-sale-price-field {"label":"Sale price"} /--><!-- /wp:column --><!-- /wp:columns -->
+<!-- wp:woocommerce/product-schedule-sale-fields /-->
+<!-- wp:woocommerce/product-text-area-field {"label":"Summary","help":"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.","property":"short_description"} /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Description","description":"What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks."} --><!-- wp:woocommerce/product-description-field --><!-- wp:woocommerce/product-summary-field {"helpText":null,"label":null,"property":"description"} /--><!-- /wp:woocommerce/product-description-field --><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Buy button","description":"Add a link and choose a label for the button linked to a product sold elsewhere."} --><!-- wp:woocommerce/product-text-field {"property":"external_url","label":"Link to the external product","placeholder":"Enter the external URL to the product","suffix":true,"type":{"value":"url","message":"Link to the external product is an invalid URL."}} /-->
+<!-- wp:columns --><div class="wp-block-columns"></div><!-- wp:column --><div class="wp-block-column"></div><!-- wp:woocommerce/product-text-field {"property":"button_text","label":"Buy button text"} /--><!-- /wp:column -->
+<!-- /wp:columns --><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Products in this group","description":"Make a collection of related products, enabling customers to purchase multiple items together."} --><!-- wp:woocommerce/product-list-field {"property":"grouped_products"} /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Images","description":"Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. \u003ca href=\u0022https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to prepare images?\u003c/a\u003e"} --><!-- wp:woocommerce/product-images-field {"images":[],"property":"images"} /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} --><!-- wp:woocommerce/product-toggle-field {"property":"downloadable","label":"Include downloads","checkedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","uncheckedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info."} /-->
+<!-- wp:woocommerce/product-subsection {"title":"Downloads","description":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=downloadable\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eproduct settings\u003c/a\u003e."} --><!-- wp:woocommerce/product-downloads-field /--><!-- /wp:woocommerce/product-subsection --><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Variations","id":"variations"} --><!-- wp:woocommerce/product-section {"title":"Variation options","description":"Add and manage attributes used for product options, such as size and color."} --><!-- wp:woocommerce/product-variations-options-field /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Variations","description":"Manage individual product combinations created from options."} --><!-- wp:woocommerce/product-variation-items-field /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Organization","id":"organization"} --><!-- wp:woocommerce/product-section {"title":"Product catalog","description":"Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels."} --><!-- wp:woocommerce/product-taxonomy-field {"slug":"product_cat","property":"categories","label":"Categories","createTitle":"Create new category","dialogNameHelpText":"Shown to customers on the product page.","parentTaxonomyText":"Parent category","placeholder":"Search or create categories…"} /-->
+<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide in product catalog","visibility":"search"} /-->
+<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide from search results","visibility":"catalog"} /-->
+<!-- wp:woocommerce/product-checkbox-field {"label":"Enable product reviews","property":"reviews_allowed"} /-->
+<!-- wp:woocommerce/product-password-field {"label":"Require a password"} /-->
+<!-- wp:woocommerce/product-tag-field {"name":"tags"} /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Attributes","description":"Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information.","blockGap":"unit-40"} --><!-- wp:woocommerce/product-attributes-field /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section --><!-- wp:woocommerce/product-custom-fields-toggle-field {"label":"Show custom fields"} --><!-- wp:woocommerce/product-section {"blockGap":"unit-30","title":"Custom fields","description":"Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. \u003ca href=\u0022https://woocommerce.com/document/custom-product-fields/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about custom fields\u003c/a\u003e"} --><!-- wp:woocommerce/product-custom-fields /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-custom-fields-toggle-field --><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Inventory","id":"inventory"} --><!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
+<!-- wp:woocommerce/product-section {"title":"Inventory","description":"Set up and manage inventory for this product, including status and available quantity. \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=inventory\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eManage store inventory settings\u003c/a\u003e","blockGap":"unit-40"} --><!-- wp:woocommerce/product-subsection --><!-- wp:woocommerce/product-sku-field /-->
+<!-- wp:woocommerce/product-toggle-field {"label":"Track inventory","property":"manage_stock","disabled":false,"disabledCopy":null} /-->
+<!-- wp:woocommerce/product-inventory-quantity-field /--><!-- /wp:woocommerce/product-subsection -->
+<!-- wp:woocommerce/product-radio-field {"title":"Stock status","property":"stock_status","options":[{"label":"In stock","value":"instock"},{"label":"Out of stock","value":"outofstock"},{"label":"On backorder","value":"onbackorder"}]} /-->
+<!-- wp:woocommerce/product-text-area-field {"property":"purchase_note","label":"Post-purchase note","placeholder":"Enter an optional note attached to the order confirmation message sent to the shopper."} /-->
+<!-- wp:woocommerce/product-collapsible {"toggleText":"Advanced","initialCollapsed":true,"persistRender":true} --><!-- wp:woocommerce/product-section {"blockGap":"unit-40"} --><!-- wp:woocommerce/product-radio-field {"title":"When out of stock","property":"backorders","options":[{"label":"Allow purchases","value":"yes"},{"label":"Allow purchases, but notify customers","value":"notify"},{"label":"Don't allow purchases","value":"no"}]} /-->
+<!-- wp:woocommerce/product-inventory-email-field /-->
+<!-- wp:woocommerce/product-checkbox-field {"title":"Restrictions","label":"Limit purchases to 1 item per order","property":"sold_individually","tooltip":"When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods."} /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-collapsible --><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Shipping","id":"shipping"} --><!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
+<!-- wp:woocommerce/product-section --><!-- wp:woocommerce/product-toggle-field {"property":"virtual","checkedValue":false,"uncheckedValue":true,"label":"This product requires shipping or pickup","uncheckedHelp":"This product will not trigger your customer's shipping calculator in cart or at checkout. This product also won't require your customers to enter their shipping details at checkout. \u003ca href=\u0022https://woocommerce.com/document/managing-products/#adding-a-virtual-product\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about virtual products\u003c/a\u003e."} /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Fees \u0026 dimensions","description":"Set up shipping costs and enter dimensions used for accurate rate calculations. \u003ca href=\u0022https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to get started?\u003c/a\u003e"} --><!-- wp:woocommerce/product-shipping-class-field /-->
+<!-- wp:woocommerce/product-shipping-dimensions-fields /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Linked products","id":"linked-products"} --><!-- wp:woocommerce/product-section {"title":"Upsells","description":"Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} --><!-- wp:woocommerce/product-linked-list-field {"property":"upsell_ids","emptyState":{"image":"ShoppingBags","tip":"Tip: Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.","isDismissible":true}} /--><!-- /wp:woocommerce/product-section -->
+<!-- wp:woocommerce/product-section {"title":"Cross-sells","description":"By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} --><!-- wp:woocommerce/product-linked-list-field {"property":"cross_sell_ids","emptyState":{"image":"CashRegister","tip":"Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.","isDismissible":true}} /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -17,110 +17,108 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 
-<!-- wp:woocommerce/product-tab {"title":"General","id":"general"} -->
-	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
-	<!-- wp:woocommerce/product-section {"title":"Basic details","description":"This info will be displayed on the product page, category pages, social media, and search results."} -->
-		<!-- wp:woocommerce/product-details-section-description /-->
-		<!-- wp:woocommerce/product-name-field {"name":"Product name","autoFocus":true,"metadata":{"bindings":{"value":{"source":"woocommerce/entity-product","args":{"prop":"name"}}}}} /-->
-		<!-- wp:columns --><div class="wp-block-columns"></div>
-			<!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div>
-				<!-- wp:woocommerce/product-regular-price-field {"name":"regular_price","label":"Regular price","help":"Per your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=general\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003estore settings\u003c/a\u003e, taxes are not enabled."} /-->
+<!-- wp:woocommerce/product-tab {"title":"General","id":"general","_templateBlockId":"general","_templateBlockOrder":10} -->
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.","buttonText":"Go to Variations","type":"info","_templateBlockId":"product_variation_notice_general_tab","_templateBlockOrder":10} /-->
+	<!-- wp:woocommerce/product-section {"title":"Basic details","description":"This info will be displayed on the product page, category pages, social media, and search results.","_templateBlockId":"basic-details","_templateBlockOrder":10} -->
+		<!-- wp:woocommerce/product-details-section-description {"_templateBlockId":"product-details-section-description","_templateBlockOrder":10} /-->
+		<!-- wp:woocommerce/product-name-field {"name":"Product name","autoFocus":true,"metadata":{"bindings":{"value":{"source":"woocommerce/entity-product","args":{"prop":"name"}}}},"_templateBlockId":"product-name","_templateBlockOrder":10} /-->
+		<!-- wp:columns {"_templateBlockId":"product-pricing-group-pricing-columns","_templateBlockOrder":10} --><div class="wp-block-columns"></div>
+			<!-- wp:column {"templateLock":"all","_templateBlockId":"product-pricing-group-pricing-column-1","_templateBlockOrder":10} --><div class="wp-block-column"></div>
+				<!-- wp:woocommerce/product-regular-price-field {"name":"regular_price","label":"Regular price","help":"Per your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=general\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003estore settings\u003c/a\u003e, taxes are not enabled.","_templateBlockId":"product-pricing-regular-price","_templateBlockOrder":10,"_templateBlockDisableConditions":[{"expression":"editedProduct.type === \u0022variable\u0022"}]} /-->
 			<!-- /wp:column -->
-			<!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div>
-				<!-- wp:woocommerce/product-sale-price-field {"label":"Sale price"} /-->
-			<!-- /wp:column -->
-		<!-- /wp:columns -->
-		<!-- wp:woocommerce/product-schedule-sale-fields /-->
-		<!-- wp:woocommerce/product-text-area-field {"label":"Summary","help":"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.","property":"short_description"} /-->
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Description","description":"What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks."} -->
-		<!-- wp:woocommerce/product-description-field -->
-			<!-- wp:woocommerce/product-summary-field {"helpText":null,"label":null,"property":"description"} /-->
-		<!-- /wp:woocommerce/product-description-field -->
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Buy button","description":"Add a link and choose a label for the button linked to a product sold elsewhere."} -->
-		<!-- wp:woocommerce/product-text-field {"property":"external_url","label":"Link to the external product","placeholder":"Enter the external URL to the product","suffix":true,"type":{"value":"url","message":"Link to the external product is an invalid URL."}} /-->
-		<!-- wp:columns --><div class="wp-block-columns"></div>
-			<!-- wp:column --><div class="wp-block-column"></div>
-				<!-- wp:woocommerce/product-text-field {"property":"button_text","label":"Buy button text"} /-->
+			<!-- wp:column {"templateLock":"all","_templateBlockId":"product-pricing-group-pricing-column-2","_templateBlockOrder":20} --><div class="wp-block-column"></div>
+				<!-- wp:woocommerce/product-sale-price-field {"label":"Sale price","_templateBlockId":"product-pricing-sale-price","_templateBlockOrder":10,"_templateBlockDisableConditions":[{"expression":"editedProduct.type === \u0022variable\u0022"}]} /-->
 			<!-- /wp:column -->
 		<!-- /wp:columns -->
+		<!-- wp:woocommerce/product-schedule-sale-fields {"_templateBlockId":"product-pricing-schedule-sale-fields","_templateBlockOrder":20} /-->
+		<!-- wp:woocommerce/product-text-area-field {"label":"Summary","help":"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.","property":"short_description","_templateBlockId":"product-summary","_templateBlockOrder":50} /-->
 	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Products in this group","description":"Make a collection of related products, enabling customers to purchase multiple items together."} -->
-		<!-- wp:woocommerce/product-list-field {"property":"grouped_products"} /-->
+	<!-- wp:woocommerce/product-section {"title":"Description","description":"What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks.","_templateBlockId":"product-description-section","_templateBlockOrder":20} -->
+		<!-- wp:woocommerce/product-description-field {"_templateBlockId":"product-description","_templateBlockOrder":10} -->
+			<!-- wp:woocommerce/product-summary-field {"helpText":null,"label":null,"property":"description","_templateBlockId":"product-description__content","_templateBlockOrder":10} /--><!-- /wp:woocommerce/product-description-field -->
 	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Images","description":"Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. \u003ca href=\u0022https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to prepare images?\u003c/a\u003e"} -->
-		<!-- wp:woocommerce/product-images-field {"images":[],"property":"images"} /-->
+	<!-- wp:woocommerce/product-section {"title":"Buy button","description":"Add a link and choose a label for the button linked to a product sold elsewhere.","_templateBlockId":"product-buy-button-section","_templateBlockOrder":30,"_templateBlockHideConditions":[{"expression":"editedProduct.type !== \u0022external\u0022"}]} -->
+		<!-- wp:woocommerce/product-text-field {"property":"external_url","label":"Link to the external product","placeholder":"Enter the external URL to the product","suffix":true,"type":{"value":"url","message":"Link to the external product is an invalid URL."},"_templateBlockId":"product-external-url","_templateBlockOrder":10} /-->
+		<!-- wp:columns {"_templateBlockId":"product-button-text-columns","_templateBlockOrder":20} --><div class="wp-block-columns"></div>
+			<!-- wp:column {"_templateBlockId":"product-button-text-column1","_templateBlockOrder":10} --><div class="wp-block-column"></div>
+				<!-- wp:woocommerce/product-text-field {"property":"button_text","label":"Buy button text","_templateBlockId":"product-button-text","_templateBlockOrder":10} /-->
+			<!-- /wp:column -->
+			<!-- wp:column {"_templateBlockId":"product-button-text-column2","_templateBlockOrder":20} /--><div class="wp-block-column"></div>
+		<!-- /wp:columns -->
 	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
-		<!-- wp:woocommerce/product-toggle-field {"property":"downloadable","label":"Include downloads","checkedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","uncheckedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info."} /-->
-		<!-- wp:woocommerce/product-subsection {"title":"Downloads","description":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=downloadable\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eproduct settings\u003c/a\u003e."} -->
-			<!-- wp:woocommerce/product-downloads-field /-->
+	<!-- wp:woocommerce/product-section {"title":"Products in this group","description":"Make a collection of related products, enabling customers to purchase multiple items together.","_templateBlockId":"product-list-section","_templateBlockOrder":35,"_templateBlockHideConditions":[{"expression":"editedProduct.type !== \u0022grouped\u0022"}]} -->
+		<!-- wp:woocommerce/product-list-field {"property":"grouped_products","_templateBlockId":"product-list","_templateBlockOrder":10} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Images","description":"Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. \u003ca href=\u0022https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to prepare images?\u003c/a\u003e","_templateBlockId":"product-images-section","_templateBlockOrder":40} -->
+		<!-- wp:woocommerce/product-images-field {"images":[],"property":"images","_templateBlockId":"product-images","_templateBlockOrder":10} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"blockGap":"unit-40","_templateBlockId":"product-downloads-section-group","_templateBlockOrder":50,"_templateBlockHideConditions":[{"expression":"postType === \u0022product\u0022 \u0026\u0026 editedProduct.type !== \u0022simple\u0022"}]} -->
+		<!-- wp:woocommerce/product-toggle-field {"property":"downloadable","label":"Include downloads","checkedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","uncheckedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","_templateBlockId":"product-downloadable","_templateBlockOrder":10} /-->
+		<!-- wp:woocommerce/product-subsection {"title":"Downloads","description":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=downloadable\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eproduct settings\u003c/a\u003e.","_templateBlockId":"product-downloads-section","_templateBlockOrder":20,"_templateBlockHideConditions":[{"expression":"editedProduct.downloadable !== true"}]} -->
+			<!-- wp:woocommerce/product-downloads-field {"_templateBlockId":"product-downloads","_templateBlockOrder":10} /-->
 		<!-- /wp:woocommerce/product-subsection -->
 	<!-- /wp:woocommerce/product-section -->
 <!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Variations","id":"variations"} -->
-	<!-- wp:woocommerce/product-section {"title":"Variation options","description":"Add and manage attributes used for product options, such as size and color."} -->
-		<!-- wp:woocommerce/product-variations-options-field /-->
+<!-- wp:woocommerce/product-tab {"title":"Variations","id":"variations","_templateBlockId":"variations","_templateBlockOrder":20,"_templateBlockHideConditions":[{"expression":"editedProduct.type === \u0022grouped\u0022"},{"expression":"editedProduct.type === \u0022external\u0022"}]} -->
+	<!-- wp:woocommerce/product-section {"title":"Variation options","description":"Add and manage attributes used for product options, such as size and color.","_templateBlockId":"product-variation-options-section","_templateBlockOrder":10} -->
+		<!-- wp:woocommerce/product-variations-options-field {"_templateBlockId":"product-variation-options","_templateBlockOrder":10} /-->
 	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Variations","description":"Manage individual product combinations created from options."} -->
-		<!-- wp:woocommerce/product-variation-items-field /-->
-	<!-- /wp:woocommerce/product-section -->
-<!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Organization","id":"organization"} -->
-	<!-- wp:woocommerce/product-section {"title":"Product catalog","description":"Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels."} -->
-		<!-- wp:woocommerce/product-taxonomy-field {"slug":"product_cat","property":"categories","label":"Categories","createTitle":"Create new category","dialogNameHelpText":"Shown to customers on the product page.","parentTaxonomyText":"Parent category","placeholder":"Search or create categories…"} /-->
-		<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide in product catalog","visibility":"search"} /-->
-		<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide from search results","visibility":"catalog"} /-->
-		<!-- wp:woocommerce/product-checkbox-field {"label":"Enable product reviews","property":"reviews_allowed"} /-->
-		<!-- wp:woocommerce/product-password-field {"label":"Require a password"} /-->
-		<!-- wp:woocommerce/product-tag-field {"name":"tags"} /-->
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Attributes","description":"Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information.","blockGap":"unit-40"} -->
-		<!-- wp:woocommerce/product-attributes-field /-->
-	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section -->
-		<!-- wp:woocommerce/product-custom-fields-toggle-field {"label":"Show custom fields"} -->
-			<!-- wp:woocommerce/product-section {"blockGap":"unit-30","title":"Custom fields","description":"Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. \u003ca href=\u0022https://woocommerce.com/document/custom-product-fields/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about custom fields\u003c/a\u003e"} -->
-				<!-- wp:woocommerce/product-custom-fields /-->
-			<!-- /wp:woocommerce/product-section -->
-		<!-- /wp:woocommerce/product-custom-fields-toggle-field -->
+	<!-- wp:woocommerce/product-section {"title":"Variations","description":"Manage individual product combinations created from options.","_templateBlockId":"product-variation-section","_templateBlockOrder":20} -->
+		<!-- wp:woocommerce/product-variation-items-field {"_templateBlockId":"product-variation-items","_templateBlockOrder":10} /-->
 	<!-- /wp:woocommerce/product-section -->
 <!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Inventory","id":"inventory"} -->
-	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
-	<!-- wp:woocommerce/product-section {"title":"Inventory","description":"Set up and manage inventory for this product, including status and available quantity. \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=inventory\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eManage store inventory settings\u003c/a\u003e","blockGap":"unit-40"} -->
-		<!-- wp:woocommerce/product-subsection -->
-			<!-- wp:woocommerce/product-sku-field /-->
-			<!-- wp:woocommerce/product-toggle-field {"label":"Track inventory","property":"manage_stock","disabled":false,"disabledCopy":null} /-->
-			<!-- wp:woocommerce/product-inventory-quantity-field /-->
+<!-- wp:woocommerce/product-tab {"title":"Organization","id":"organization","_templateBlockId":"organization","_templateBlockOrder":30} -->
+	<!-- wp:woocommerce/product-section {"title":"Product catalog","description":"Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels.","_templateBlockId":"product-catalog-section","_templateBlockOrder":10} -->
+		<!-- wp:woocommerce/product-taxonomy-field {"slug":"product_cat","property":"categories","label":"Categories","createTitle":"Create new category","dialogNameHelpText":"Shown to customers on the product page.","parentTaxonomyText":"Parent category","placeholder":"Search or create categories…","_templateBlockId":"product-categories","_templateBlockOrder":10} /-->
+		<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide in product catalog","visibility":"search","_templateBlockId":"product-catalog-search-visibility","_templateBlockOrder":20} /-->
+		<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide from search results","visibility":"catalog","_templateBlockId":"product-catalog-catalog-visibility","_templateBlockOrder":30} /-->
+		<!-- wp:woocommerce/product-checkbox-field {"label":"Enable product reviews","property":"reviews_allowed","_templateBlockId":"product-enable-product-reviews","_templateBlockOrder":40} /-->
+		<!-- wp:woocommerce/product-password-field {"label":"Require a password","_templateBlockId":"product-post-password","_templateBlockOrder":50} /-->
+		<!-- wp:woocommerce/product-tag-field {"name":"tags","_templateBlockId":"product-tags","_templateBlockOrder":10000} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Attributes","description":"Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information.","blockGap":"unit-40","_templateBlockId":"product-attributes-section","_templateBlockOrder":20} -->
+		<!-- wp:woocommerce/product-attributes-field {"_templateBlockId":"product-attributes","_templateBlockOrder":10} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"_templateBlockId":"product-custom-fields-wrapper-section","_templateBlockOrder":30} -->
+		<!-- wp:woocommerce/product-custom-fields-toggle-field {"label":"Show custom fields","_templateBlockId":"product-custom-fields-toggle","_templateBlockOrder":10} -->
+		<!-- wp:woocommerce/product-section {"blockGap":"unit-30","title":"Custom fields","description":"Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. \u003ca href=\u0022https://woocommerce.com/document/custom-product-fields/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about custom fields\u003c/a\u003e","_templateBlockId":"product-custom-fields-section","_templateBlockOrder":10} -->
+			<!-- wp:woocommerce/product-custom-fields {"_templateBlockId":"product-custom-fields","_templateBlockOrder":10} /-->
+		<!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-custom-fields-toggle-field -->
+	<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Inventory","id":"inventory","_templateBlockId":"inventory","_templateBlockOrder":50} --><!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.","buttonText":"Go to Variations","type":"info","_templateBlockId":"product_variation_notice_inventory_tab","_templateBlockOrder":10} /-->
+	<!-- wp:woocommerce/product-section {"title":"Inventory","description":"Set up and manage inventory for this product, including status and available quantity. \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=inventory\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eManage store inventory settings\u003c/a\u003e","blockGap":"unit-40","_templateBlockId":"product-inventory-section","_templateBlockOrder":20} -->
+		<!-- wp:woocommerce/product-subsection {"_templateBlockId":"product-inventory-inner-section","_templateBlockOrder":10} -->
+			<!-- wp:woocommerce/product-sku-field {"_templateBlockId":"product-sku-field","_templateBlockOrder":10,"_templateBlockDisableConditions":[{"expression":"editedProduct.type === \u0022variable\u0022"}]} /-->
+			<!-- wp:woocommerce/product-toggle-field {"label":"Track inventory","property":"manage_stock","disabled":false,"disabledCopy":null,"_templateBlockId":"product-track-stock","_templateBlockOrder":20,"_templateBlockHideConditions":[{"expression":"editedProduct.type === \u0022external\u0022 || editedProduct.type === \u0022grouped\u0022"}],"_templateBlockDisableConditions":[{"expression":"editedProduct.type === \u0022variable\u0022"}]} /-->
+			<!-- wp:woocommerce/product-inventory-quantity-field {"_templateBlockId":"product-inventory-quantity","_templateBlockOrder":30,"_templateBlockHideConditions":[{"expression":"editedProduct.manage_stock === false"},{"expression":"editedProduct.type === \u0022grouped\u0022"}]} /-->
 		<!-- /wp:woocommerce/product-subsection -->
-		<!-- wp:woocommerce/product-radio-field {"title":"Stock status","property":"stock_status","options":[{"label":"In stock","value":"instock"},{"label":"Out of stock","value":"outofstock"},{"label":"On backorder","value":"onbackorder"}]} /-->
-		<!-- wp:woocommerce/product-text-area-field {"property":"purchase_note","label":"Post-purchase note","placeholder":"Enter an optional note attached to the order confirmation message sent to the shopper."} /-->
-		<!-- wp:woocommerce/product-collapsible {"toggleText":"Advanced","initialCollapsed":true,"persistRender":true} -->
-			<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
-				<!-- wp:woocommerce/product-radio-field {"title":"When out of stock","property":"backorders","options":[{"label":"Allow purchases","value":"yes"},{"label":"Allow purchases, but notify customers","value":"notify"},{"label":"Don't allow purchases","value":"no"}]} /-->
-				<!-- wp:woocommerce/product-inventory-email-field /-->
-				<!-- wp:woocommerce/product-checkbox-field {"title":"Restrictions","label":"Limit purchases to 1 item per order","property":"sold_individually","tooltip":"When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods."} /-->
+		<!-- wp:woocommerce/product-radio-field {"title":"Stock status","property":"stock_status","options":[{"label":"In stock","value":"instock"},{"label":"Out of stock","value":"outofstock"},{"label":"On backorder","value":"onbackorder"}],"_templateBlockId":"product-stock-status","_templateBlockOrder":10,"_templateBlockHideConditions":[{"expression":"editedProduct.manage_stock === true"},{"expression":"editedProduct.type === \u0022grouped\u0022"}],"_templateBlockDisableConditions":[{"expression":"editedProduct.type === \u0022variable\u0022"}]} /-->
+		<!-- wp:woocommerce/product-text-area-field {"property":"purchase_note","label":"Post-purchase note","placeholder":"Enter an optional note attached to the order confirmation message sent to the shopper.","_templateBlockId":"product-purchase-note","_templateBlockOrder":20} /-->
+		<!-- wp:woocommerce/product-collapsible {"toggleText":"Advanced","initialCollapsed":true,"persistRender":true,"_templateBlockId":"product-inventory-advanced","_templateBlockOrder":30,"_templateBlockHideConditions":[{"expression":"editedProduct.type === \u0022grouped\u0022"}]} -->
+			<!-- wp:woocommerce/product-section {"blockGap":"unit-40","_templateBlockId":"woocommerce/product-section-1","_templateBlockOrder":10} -->
+				<!-- wp:woocommerce/product-radio-field {"title":"When out of stock","property":"backorders","options":[{"label":"Allow purchases","value":"yes"},{"label":"Allow purchases, but notify customers","value":"notify"},{"label":"Don't allow purchases","value":"no"}],"_templateBlockId":"product-out-of-stock","_templateBlockOrder":10,"_templateBlockHideConditions":[{"expression":"editedProduct.manage_stock === false"}]} /-->
+				<!-- wp:woocommerce/product-inventory-email-field {"_templateBlockId":"product-inventory-email","_templateBlockOrder":20,"_templateBlockHideConditions":[{"expression":"editedProduct.manage_stock === false"}]} /-->
+				<!-- wp:woocommerce/product-checkbox-field {"title":"Restrictions","label":"Limit purchases to 1 item per order","property":"sold_individually","tooltip":"When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods.","_templateBlockId":"product-limit-purchase","_templateBlockOrder":20} /-->
 			<!-- /wp:woocommerce/product-section -->
 		<!-- /wp:woocommerce/product-collapsible -->
 	<!-- /wp:woocommerce/product-section -->
 <!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Shipping","id":"shipping"} -->
-	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
-	<!-- wp:woocommerce/product-section -->
-		<!-- wp:woocommerce/product-toggle-field {"property":"virtual","checkedValue":false,"uncheckedValue":true,"label":"This product requires shipping or pickup","uncheckedHelp":"This product will not trigger your customer's shipping calculator in cart or at checkout. This product also won't require your customers to enter their shipping details at checkout. \u003ca href=\u0022https://woocommerce.com/document/managing-products/#adding-a-virtual-product\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about virtual products\u003c/a\u003e."} /-->
+<!-- wp:woocommerce/product-tab {"title":"Shipping","id":"shipping","_templateBlockId":"shipping","_templateBlockOrder":60,"_templateBlockHideConditions":[{"expression":"editedProduct.type === \u0022grouped\u0022"},{"expression":"editedProduct.type === \u0022external\u0022"}]} -->
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.","buttonText":"Go to Variations","type":"info","_templateBlockId":"product_variation_notice_shipping_tab","_templateBlockOrder":10} /-->
+	<!-- wp:woocommerce/product-section {"_templateBlockId":"product-virtual-section","_templateBlockOrder":10,"_templateBlockHideConditions":[{"expression":"editedProduct.type !== \u0022simple\u0022"}]} -->
+		<!-- wp:woocommerce/product-toggle-field {"property":"virtual","checkedValue":false,"uncheckedValue":true,"label":"This product requires shipping or pickup","uncheckedHelp":"This product will not trigger your customer's shipping calculator in cart or at checkout. This product also won't require your customers to enter their shipping details at checkout. \u003ca href=\u0022https://woocommerce.com/document/managing-products/#adding-a-virtual-product\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about virtual products\u003c/a\u003e.","_templateBlockId":"product-virtual","_templateBlockOrder":10} /-->
 	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Fees \u0026 dimensions","description":"Set up shipping costs and enter dimensions used for accurate rate calculations. \u003ca href=\u0022https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to get started?\u003c/a\u003e"} -->
-		<!-- wp:woocommerce/product-shipping-class-field /-->
-		<!-- wp:woocommerce/product-shipping-dimensions-fields /-->
+	<!-- wp:woocommerce/product-section {"title":"Fees \u0026 dimensions","description":"Set up shipping costs and enter dimensions used for accurate rate calculations. \u003ca href=\u0022https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to get started?\u003c/a\u003e","_templateBlockId":"product-fee-and-dimensions-section","_templateBlockOrder":20} -->
+		<!-- wp:woocommerce/product-shipping-class-field {"_templateBlockId":"product-shipping-class","_templateBlockOrder":10,"_templateBlockDisableConditions":[{"expression":"editedProduct.type === \u0022variable\u0022"}]} /-->
+		<!-- wp:woocommerce/product-shipping-dimensions-fields {"_templateBlockId":"product-shipping-dimensions","_templateBlockOrder":20,"_templateBlockDisableConditions":[{"expression":"editedProduct.type === \u0022variable\u0022"}]} /-->
 	<!-- /wp:woocommerce/product-section -->
 <!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Linked products","id":"linked-products"} -->
-	<!-- wp:woocommerce/product-section {"title":"Upsells","description":"Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
-		<!-- wp:woocommerce/product-linked-list-field {"property":"upsell_ids","emptyState":{"image":"ShoppingBags","tip":"Tip: Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.","isDismissible":true}} /-->
+<!-- wp:woocommerce/product-tab {"title":"Linked products","id":"linked-products","_templateBlockId":"linked-products","_templateBlockOrder":70} -->
+	<!-- wp:woocommerce/product-section {"title":"Upsells","description":"Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e","_templateBlockId":"product-linked-upsells-section","_templateBlockOrder":10} -->
+		<!-- wp:woocommerce/product-linked-list-field {"property":"upsell_ids","emptyState":{"image":"ShoppingBags","tip":"Tip: Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.","isDismissible":true},"_templateBlockId":"product-linked-upsells","_templateBlockOrder":10} /-->
 	<!-- /wp:woocommerce/product-section -->
-	<!-- wp:woocommerce/product-section {"title":"Cross-sells","description":"By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
-		<!-- wp:woocommerce/product-linked-list-field {"property":"cross_sell_ids","emptyState":{"image":"CashRegister","tip":"Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.","isDismissible":true}} /-->
+	<!-- wp:woocommerce/product-section {"title":"Cross-sells","description":"By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e","_templateBlockId":"product-linked-cross-sells-section","_templateBlockOrder":20,"_templateBlockHideConditions":[{"expression":"editedProduct.type === \u0022external\u0022 || editedProduct.type === \u0022grouped\u0022"}]} -->
+	<!-- wp:woocommerce/product-linked-list-field {"property":"cross_sell_ids","emptyState":{"image":"CashRegister","tip":"Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.","isDismissible":true},"_templateBlockId":"product-linked-cross-sells","_templateBlockOrder":10} /-->
 	<!-- /wp:woocommerce/product-section -->
 <!-- /wp:woocommerce/product-tab -->

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -17,43 +17,110 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 
-<!-- wp:woocommerce/product-tab {"title":"General","id":"general"} --><!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
-<!-- wp:woocommerce/product-section {"title":"Basic details","description":"This info will be displayed on the product page, category pages, social media, and search results."} --><!-- wp:woocommerce/product-details-section-description /-->
-<!-- wp:woocommerce/product-name-field {"name":"Product name","autoFocus":true,"metadata":{"bindings":{"value":{"source":"woocommerce/entity-product","args":{"prop":"name"}}}}} /-->
-<!-- wp:columns --><div class="wp-block-columns"></div><!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div><!-- wp:woocommerce/product-regular-price-field {"name":"regular_price","label":"Regular price","help":"Per your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=general\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003estore settings\u003c/a\u003e, taxes are not enabled."} /--><!-- /wp:column -->
-<!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div><!-- wp:woocommerce/product-sale-price-field {"label":"Sale price"} /--><!-- /wp:column --><!-- /wp:columns -->
-<!-- wp:woocommerce/product-schedule-sale-fields /-->
-<!-- wp:woocommerce/product-text-area-field {"label":"Summary","help":"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.","property":"short_description"} /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Description","description":"What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks."} --><!-- wp:woocommerce/product-description-field --><!-- wp:woocommerce/product-summary-field {"helpText":null,"label":null,"property":"description"} /--><!-- /wp:woocommerce/product-description-field --><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Buy button","description":"Add a link and choose a label for the button linked to a product sold elsewhere."} --><!-- wp:woocommerce/product-text-field {"property":"external_url","label":"Link to the external product","placeholder":"Enter the external URL to the product","suffix":true,"type":{"value":"url","message":"Link to the external product is an invalid URL."}} /-->
-<!-- wp:columns --><div class="wp-block-columns"></div><!-- wp:column --><div class="wp-block-column"></div><!-- wp:woocommerce/product-text-field {"property":"button_text","label":"Buy button text"} /--><!-- /wp:column -->
-<!-- /wp:columns --><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Products in this group","description":"Make a collection of related products, enabling customers to purchase multiple items together."} --><!-- wp:woocommerce/product-list-field {"property":"grouped_products"} /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Images","description":"Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. \u003ca href=\u0022https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to prepare images?\u003c/a\u003e"} --><!-- wp:woocommerce/product-images-field {"images":[],"property":"images"} /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} --><!-- wp:woocommerce/product-toggle-field {"property":"downloadable","label":"Include downloads","checkedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","uncheckedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info."} /-->
-<!-- wp:woocommerce/product-subsection {"title":"Downloads","description":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=downloadable\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eproduct settings\u003c/a\u003e."} --><!-- wp:woocommerce/product-downloads-field /--><!-- /wp:woocommerce/product-subsection --><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Variations","id":"variations"} --><!-- wp:woocommerce/product-section {"title":"Variation options","description":"Add and manage attributes used for product options, such as size and color."} --><!-- wp:woocommerce/product-variations-options-field /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Variations","description":"Manage individual product combinations created from options."} --><!-- wp:woocommerce/product-variation-items-field /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Organization","id":"organization"} --><!-- wp:woocommerce/product-section {"title":"Product catalog","description":"Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels."} --><!-- wp:woocommerce/product-taxonomy-field {"slug":"product_cat","property":"categories","label":"Categories","createTitle":"Create new category","dialogNameHelpText":"Shown to customers on the product page.","parentTaxonomyText":"Parent category","placeholder":"Search or create categories…"} /-->
-<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide in product catalog","visibility":"search"} /-->
-<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide from search results","visibility":"catalog"} /-->
-<!-- wp:woocommerce/product-checkbox-field {"label":"Enable product reviews","property":"reviews_allowed"} /-->
-<!-- wp:woocommerce/product-password-field {"label":"Require a password"} /-->
-<!-- wp:woocommerce/product-tag-field {"name":"tags"} /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Attributes","description":"Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information.","blockGap":"unit-40"} --><!-- wp:woocommerce/product-attributes-field /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section --><!-- wp:woocommerce/product-custom-fields-toggle-field {"label":"Show custom fields"} --><!-- wp:woocommerce/product-section {"blockGap":"unit-30","title":"Custom fields","description":"Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. \u003ca href=\u0022https://woocommerce.com/document/custom-product-fields/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about custom fields\u003c/a\u003e"} --><!-- wp:woocommerce/product-custom-fields /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-custom-fields-toggle-field --><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Inventory","id":"inventory"} --><!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
-<!-- wp:woocommerce/product-section {"title":"Inventory","description":"Set up and manage inventory for this product, including status and available quantity. \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=inventory\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eManage store inventory settings\u003c/a\u003e","blockGap":"unit-40"} --><!-- wp:woocommerce/product-subsection --><!-- wp:woocommerce/product-sku-field /-->
-<!-- wp:woocommerce/product-toggle-field {"label":"Track inventory","property":"manage_stock","disabled":false,"disabledCopy":null} /-->
-<!-- wp:woocommerce/product-inventory-quantity-field /--><!-- /wp:woocommerce/product-subsection -->
-<!-- wp:woocommerce/product-radio-field {"title":"Stock status","property":"stock_status","options":[{"label":"In stock","value":"instock"},{"label":"Out of stock","value":"outofstock"},{"label":"On backorder","value":"onbackorder"}]} /-->
-<!-- wp:woocommerce/product-text-area-field {"property":"purchase_note","label":"Post-purchase note","placeholder":"Enter an optional note attached to the order confirmation message sent to the shopper."} /-->
-<!-- wp:woocommerce/product-collapsible {"toggleText":"Advanced","initialCollapsed":true,"persistRender":true} --><!-- wp:woocommerce/product-section {"blockGap":"unit-40"} --><!-- wp:woocommerce/product-radio-field {"title":"When out of stock","property":"backorders","options":[{"label":"Allow purchases","value":"yes"},{"label":"Allow purchases, but notify customers","value":"notify"},{"label":"Don't allow purchases","value":"no"}]} /-->
-<!-- wp:woocommerce/product-inventory-email-field /-->
-<!-- wp:woocommerce/product-checkbox-field {"title":"Restrictions","label":"Limit purchases to 1 item per order","property":"sold_individually","tooltip":"When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods."} /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-collapsible --><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Shipping","id":"shipping"} --><!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
-<!-- wp:woocommerce/product-section --><!-- wp:woocommerce/product-toggle-field {"property":"virtual","checkedValue":false,"uncheckedValue":true,"label":"This product requires shipping or pickup","uncheckedHelp":"This product will not trigger your customer's shipping calculator in cart or at checkout. This product also won't require your customers to enter their shipping details at checkout. \u003ca href=\u0022https://woocommerce.com/document/managing-products/#adding-a-virtual-product\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about virtual products\u003c/a\u003e."} /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Fees \u0026 dimensions","description":"Set up shipping costs and enter dimensions used for accurate rate calculations. \u003ca href=\u0022https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to get started?\u003c/a\u003e"} --><!-- wp:woocommerce/product-shipping-class-field /-->
-<!-- wp:woocommerce/product-shipping-dimensions-fields /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
-<!-- wp:woocommerce/product-tab {"title":"Linked products","id":"linked-products"} --><!-- wp:woocommerce/product-section {"title":"Upsells","description":"Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} --><!-- wp:woocommerce/product-linked-list-field {"property":"upsell_ids","emptyState":{"image":"ShoppingBags","tip":"Tip: Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.","isDismissible":true}} /--><!-- /wp:woocommerce/product-section -->
-<!-- wp:woocommerce/product-section {"title":"Cross-sells","description":"By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} --><!-- wp:woocommerce/product-linked-list-field {"property":"cross_sell_ids","emptyState":{"image":"CashRegister","tip":"Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.","isDismissible":true}} /--><!-- /wp:woocommerce/product-section --><!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"General","id":"general"} -->
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
+	<!-- wp:woocommerce/product-section {"title":"Basic details","description":"This info will be displayed on the product page, category pages, social media, and search results."} -->
+		<!-- wp:woocommerce/product-details-section-description /-->
+		<!-- wp:woocommerce/product-name-field {"name":"Product name","autoFocus":true,"metadata":{"bindings":{"value":{"source":"woocommerce/entity-product","args":{"prop":"name"}}}}} /-->
+		<!-- wp:columns --><div class="wp-block-columns"></div>
+			<!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div>
+				<!-- wp:woocommerce/product-regular-price-field {"name":"regular_price","label":"Regular price","help":"Per your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=general\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003estore settings\u003c/a\u003e, taxes are not enabled."} /-->
+			<!-- /wp:column -->
+			<!-- wp:column {"templateLock":"all"} --><div class="wp-block-column"></div>
+				<!-- wp:woocommerce/product-sale-price-field {"label":"Sale price"} /-->
+			<!-- /wp:column -->
+		<!-- /wp:columns -->
+		<!-- wp:woocommerce/product-schedule-sale-fields /-->
+		<!-- wp:woocommerce/product-text-area-field {"label":"Summary","help":"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.","property":"short_description"} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Description","description":"What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks."} -->
+		<!-- wp:woocommerce/product-description-field -->
+			<!-- wp:woocommerce/product-summary-field {"helpText":null,"label":null,"property":"description"} /-->
+		<!-- /wp:woocommerce/product-description-field -->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Buy button","description":"Add a link and choose a label for the button linked to a product sold elsewhere."} -->
+		<!-- wp:woocommerce/product-text-field {"property":"external_url","label":"Link to the external product","placeholder":"Enter the external URL to the product","suffix":true,"type":{"value":"url","message":"Link to the external product is an invalid URL."}} /-->
+		<!-- wp:columns --><div class="wp-block-columns"></div>
+			<!-- wp:column --><div class="wp-block-column"></div>
+				<!-- wp:woocommerce/product-text-field {"property":"button_text","label":"Buy button text"} /-->
+			<!-- /wp:column -->
+		<!-- /wp:columns -->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Products in this group","description":"Make a collection of related products, enabling customers to purchase multiple items together."} -->
+		<!-- wp:woocommerce/product-list-field {"property":"grouped_products"} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Images","description":"Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. \u003ca href=\u0022https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to prepare images?\u003c/a\u003e"} -->
+		<!-- wp:woocommerce/product-images-field {"images":[],"property":"images"} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
+		<!-- wp:woocommerce/product-toggle-field {"property":"downloadable","label":"Include downloads","checkedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","uncheckedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info."} /-->
+		<!-- wp:woocommerce/product-subsection {"title":"Downloads","description":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=downloadable\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eproduct settings\u003c/a\u003e."} -->
+			<!-- wp:woocommerce/product-downloads-field /-->
+		<!-- /wp:woocommerce/product-subsection -->
+	<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Variations","id":"variations"} -->
+	<!-- wp:woocommerce/product-section {"title":"Variation options","description":"Add and manage attributes used for product options, such as size and color."} -->
+		<!-- wp:woocommerce/product-variations-options-field /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Variations","description":"Manage individual product combinations created from options."} -->
+		<!-- wp:woocommerce/product-variation-items-field /-->
+	<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Organization","id":"organization"} -->
+	<!-- wp:woocommerce/product-section {"title":"Product catalog","description":"Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels."} -->
+		<!-- wp:woocommerce/product-taxonomy-field {"slug":"product_cat","property":"categories","label":"Categories","createTitle":"Create new category","dialogNameHelpText":"Shown to customers on the product page.","parentTaxonomyText":"Parent category","placeholder":"Search or create categories…"} /-->
+		<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide in product catalog","visibility":"search"} /-->
+		<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide from search results","visibility":"catalog"} /-->
+		<!-- wp:woocommerce/product-checkbox-field {"label":"Enable product reviews","property":"reviews_allowed"} /-->
+		<!-- wp:woocommerce/product-password-field {"label":"Require a password"} /-->
+		<!-- wp:woocommerce/product-tag-field {"name":"tags"} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Attributes","description":"Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information.","blockGap":"unit-40"} -->
+		<!-- wp:woocommerce/product-attributes-field /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section -->
+		<!-- wp:woocommerce/product-custom-fields-toggle-field {"label":"Show custom fields"} -->
+			<!-- wp:woocommerce/product-section {"blockGap":"unit-30","title":"Custom fields","description":"Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. \u003ca href=\u0022https://woocommerce.com/document/custom-product-fields/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about custom fields\u003c/a\u003e"} -->
+				<!-- wp:woocommerce/product-custom-fields /-->
+			<!-- /wp:woocommerce/product-section -->
+		<!-- /wp:woocommerce/product-custom-fields-toggle-field -->
+	<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Inventory","id":"inventory"} -->
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
+	<!-- wp:woocommerce/product-section {"title":"Inventory","description":"Set up and manage inventory for this product, including status and available quantity. \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=inventory\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eManage store inventory settings\u003c/a\u003e","blockGap":"unit-40"} -->
+		<!-- wp:woocommerce/product-subsection -->
+			<!-- wp:woocommerce/product-sku-field /-->
+			<!-- wp:woocommerce/product-toggle-field {"label":"Track inventory","property":"manage_stock","disabled":false,"disabledCopy":null} /-->
+			<!-- wp:woocommerce/product-inventory-quantity-field /-->
+		<!-- /wp:woocommerce/product-subsection -->
+		<!-- wp:woocommerce/product-radio-field {"title":"Stock status","property":"stock_status","options":[{"label":"In stock","value":"instock"},{"label":"Out of stock","value":"outofstock"},{"label":"On backorder","value":"onbackorder"}]} /-->
+		<!-- wp:woocommerce/product-text-area-field {"property":"purchase_note","label":"Post-purchase note","placeholder":"Enter an optional note attached to the order confirmation message sent to the shopper."} /-->
+		<!-- wp:woocommerce/product-collapsible {"toggleText":"Advanced","initialCollapsed":true,"persistRender":true} -->
+			<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
+				<!-- wp:woocommerce/product-radio-field {"title":"When out of stock","property":"backorders","options":[{"label":"Allow purchases","value":"yes"},{"label":"Allow purchases, but notify customers","value":"notify"},{"label":"Don't allow purchases","value":"no"}]} /-->
+				<!-- wp:woocommerce/product-inventory-email-field /-->
+				<!-- wp:woocommerce/product-checkbox-field {"title":"Restrictions","label":"Limit purchases to 1 item per order","property":"sold_individually","tooltip":"When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods."} /-->
+			<!-- /wp:woocommerce/product-section -->
+		<!-- /wp:woocommerce/product-collapsible -->
+	<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Shipping","id":"shipping"} -->
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.","buttonText":"Go to Variations","type":"info"} /-->
+	<!-- wp:woocommerce/product-section -->
+		<!-- wp:woocommerce/product-toggle-field {"property":"virtual","checkedValue":false,"uncheckedValue":true,"label":"This product requires shipping or pickup","uncheckedHelp":"This product will not trigger your customer's shipping calculator in cart or at checkout. This product also won't require your customers to enter their shipping details at checkout. \u003ca href=\u0022https://woocommerce.com/document/managing-products/#adding-a-virtual-product\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about virtual products\u003c/a\u003e."} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Fees \u0026 dimensions","description":"Set up shipping costs and enter dimensions used for accurate rate calculations. \u003ca href=\u0022https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to get started?\u003c/a\u003e"} -->
+		<!-- wp:woocommerce/product-shipping-class-field /-->
+		<!-- wp:woocommerce/product-shipping-dimensions-fields /-->
+	<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Linked products","id":"linked-products"} -->
+	<!-- wp:woocommerce/product-section {"title":"Upsells","description":"Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
+		<!-- wp:woocommerce/product-linked-list-field {"property":"upsell_ids","emptyState":{"image":"ShoppingBags","tip":"Tip: Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.","isDismissible":true}} /-->
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Cross-sells","description":"By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
+		<!-- wp:woocommerce/product-linked-list-field {"property":"cross_sell_ids","emptyState":{"image":"CashRegister","tip":"Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.","isDismissible":true}} /-->
+	<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->

--- a/plugins/woocommerce/templates/product-form/simple.php
+++ b/plugins/woocommerce/templates/product-form/simple.php
@@ -16,16 +16,307 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:woocommerce/product-section {"title":"<?php esc_attr_e( 'Basic details', 'woocommerce' ); ?>"} -->
-<div data-block-name="woocommerce/product-section" class="wp-block-woocommerce-product-section" data-title="<?php esc_attr_e( 'Basic details', 'woocommerce' ); ?>">
-	<div>
-		<!-- wp:woocommerce/product-regular-price-field -->
-		<div data-block-name="woocommerce/product-regular-price-field" class="wp-block-woocommerce-product-regular-price-field"></div>
-		<!-- /wp:woocommerce/product-regular-price-field -->
+<!-- wp:woocommerce/product-tab {"title":"General","id":"general"} -->
+<div data-block-name="woocommerce/product-tab" data-title="General" data-id="general">
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.","buttonText":"Go to Variations","type":"info"} -->
+	<div data-block-name="woocommerce/product-has-variations-notice"
+	data-content="This product has options, such as size or color. You can manage each variation&#039;s images, downloads, and other details individually."
+	data-buttonText="Go to Variations" data-type="info">
 
-		<!-- wp:woocommerce/product-checkbox-field {"label":"<?php esc_attr_e( 'Translatable Label', 'woocommerce' ); ?>","property":"testproperty"} -->
-		<div data-block-name="woocommerce/product-checkbox-field" class="wp-block-woocommerce-product-checkbox-field" data-label="<?php esc_attr_e( 'Translatable Label', 'woocommerce' ); ?>"></div>
-		<!-- /wp:woocommerce/product-checkbox-field -->
 	</div>
+	<!-- /wp:woocommerce/product-has-variations-notice -->
+	<!-- wp:woocommerce/product-section {"title":"Basic details","description":"This info will be displayed on the product page, category pages, social media, and search results."} -->
+	<div data-block-name="woocommerce/product-section" data-title="Basic details"
+	data-description="This info will be displayed on the product page, category pages, social media, and search results.">
+
+	<!-- wp:woocommerce/product-name-field {"name":"Product name","autoFocus":true,"metadata":{"bindings":{"value":{"source":"woocommerce/entity-product","args":{"prop":"name"}}}}} -->
+	<div data-block-name="woocommerce/product-name-field" data-name="Product name" data-autoFocus="1"
+		data-metadata="Array">
+
+	</div>
+	<!-- /wp:woocommerce/product-name-field -->
+	<!-- wp:column {"templateLock":"all"} -->
+	<div data-block-name="core/column" data-templateLock="all">
+		<!-- wp:woocommerce/product-regular-price-field {"name":"regular_price","label":"Regular price","help":"Per your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=general\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003estore settings\u003c/a\u003e, taxes are not enabled."} -->
+		<div data-block-name="woocommerce/product-regular-price-field" data-name="regular_price"
+		data-label="Regular price"
+		data-help="Per your &lt;a href=&quot;https://test.local/wp-admin/admin.php?page=wc-settings&amp;tab=general&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;store settings&lt;/a&gt;, taxes are not enabled.">
+
+		</div>
+		<!-- /wp:woocommerce/product-regular-price-field -->
+	</div>
+	<!-- /wp:column -->
+	<!-- wp:column {"templateLock":"all"} -->
+	<div data-block-name="core/column" data-templateLock="all">
+		<!-- wp:woocommerce/product-sale-price-field {"label":"Sale price"} -->
+		<div data-block-name="woocommerce/product-sale-price-field" data-label="Sale price">
+
+		</div>
+		<!-- /wp:woocommerce/product-sale-price-field -->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:woocommerce/product-text-area-field {"label":"Summary","help":"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.","property":"short_description"} -->
+	<div data-block-name="woocommerce/product-text-area-field" data-label="Summary"
+		data-help="Summarize this product in 1-2 short sentences. We&#039;ll show it at the top of the page."
+		data-property="short_description">
+
+	</div>
+	<!-- /wp:woocommerce/product-text-area-field -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Description","description":"What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks."} -->
+	<div data-block-name="woocommerce/product-section" data-title="Description"
+	data-description="What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks.">
+	<!-- wp:woocommerce/product-summary-field {"helpText":null,"label":null,"property":"description"} -->
+	<div data-block-name="woocommerce/product-summary-field" data-helpText="" data-label="" data-property="description">
+
+	</div>
+	<!-- /wp:woocommerce/product-summary-field -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Buy button","description":"Add a link and choose a label for the button linked to a product sold elsewhere."} -->
+	<div data-block-name="woocommerce/product-section" data-title="Buy button"
+	data-description="Add a link and choose a label for the button linked to a product sold elsewhere.">
+	<!-- wp:woocommerce/product-text-field {"property":"external_url","label":"Link to the external product","placeholder":"Enter the external URL to the product","suffix":true,"type":{"value":"url","message":"Link to the external product is an invalid URL."}} -->
+	<div data-block-name="woocommerce/product-text-field" data-property="external_url"
+		data-label="Link to the external product" data-placeholder="Enter the external URL to the product" data-suffix="1"
+		data-type="Array">
+
+	</div>
+	<!-- /wp:woocommerce/product-text-field -->
+	<!-- wp:woocommerce/product-text-field {"property":"button_text","label":"Buy button text"} -->
+	<div data-block-name="woocommerce/product-text-field" data-property="button_text" data-label="Buy button text">
+
+	</div>
+	<!-- /wp:woocommerce/product-text-field -->
+
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Products in this group","description":"Make a collection of related products, enabling customers to purchase multiple items together."} -->
+	<div data-block-name="woocommerce/product-section" data-title="Products in this group"
+	data-description="Make a collection of related products, enabling customers to purchase multiple items together.">
+	<!-- wp:woocommerce/product-list-field {"property":"grouped_products"} -->
+	<div data-block-name="woocommerce/product-list-field" data-property="grouped_products">
+
+	</div>
+	<!-- /wp:woocommerce/product-list-field -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Images","description":"Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. \u003ca href=\u0022https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to prepare images?\u003c/a\u003e"} -->
+	<div data-block-name="woocommerce/product-section" data-title="Images"
+	data-description="Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. &lt;a href=&quot;https://woocommerce.com/posts/how-to-take-professional-product-photos-top-tips&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;How to prepare images?&lt;/a&gt;">
+	<!-- wp:woocommerce/product-images-field {"images":[],"property":"images"} -->
+	<div data-block-name="woocommerce/product-images-field" data-images="Array" data-property="images">
+
+	</div>
+	<!-- /wp:woocommerce/product-images-field -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
+	<div data-block-name="woocommerce/product-section" data-blockGap="unit-40">
+	<!-- wp:woocommerce/product-toggle-field {"property":"downloadable","label":"Include downloads","checkedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.","uncheckedHelp":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info."} -->
+	<div data-block-name="woocommerce/product-toggle-field" data-property="downloadable" data-label="Include downloads"
+		data-checkedHelp="Add any files you&#039;d like to make available for the customer to download after purchasing, such as instructions or warranty info."
+		data-uncheckedHelp="Add any files you&#039;d like to make available for the customer to download after purchasing, such as instructions or warranty info.">
+
+	</div>
+	<!-- /wp:woocommerce/product-toggle-field -->
+	<!-- wp:woocommerce/product-subsection {"title":"Downloads","description":"Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=downloadable\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eproduct settings\u003c/a\u003e."} -->
+	<div data-block-name="woocommerce/product-subsection" data-title="Downloads"
+		data-description="Add any files you&#039;d like to make available for the customer to download after purchasing, such as instructions or warranty info. Store-wide updates can be managed in your &lt;a href=&quot;https://test.local/wp-admin/admin.php?page=wc-settings&amp;tab=products&amp;section=downloadable&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;product settings&lt;/a&gt;.">
+
+	</div>
+	<!-- /wp:woocommerce/product-subsection -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
 </div>
-<!-- /wp:woocommerce/product-section -->
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Variations","id":"variations"} -->
+<div data-block-name="woocommerce/product-tab" data-title="Variations" data-id="variations">
+	<!-- wp:woocommerce/product-section {"title":"Variation options","description":"Add and manage attributes used for product options, such as size and color."} -->
+	<div data-block-name="woocommerce/product-section" data-title="Variation options"
+	data-description="Add and manage attributes used for product options, such as size and color.">
+
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Variations","description":"Manage individual product combinations created from options."} -->
+	<div data-block-name="woocommerce/product-section" data-title="Variations"
+	data-description="Manage individual product combinations created from options.">
+
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+</div>
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Organization","id":"organization"} -->
+<div data-block-name="woocommerce/product-tab" data-title="Organization" data-id="organization">
+	<!-- wp:woocommerce/product-section {"title":"Product catalog","description":"Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels."} -->
+	<div data-block-name="woocommerce/product-section" data-title="Product catalog"
+	data-description="Help customers find this product by assigning it to categories, adding extra details, and managing its visibility in your store and other channels.">
+	<!-- wp:woocommerce/product-taxonomy-field {"slug":"product_cat","property":"categories","label":"Categories","createTitle":"Create new category","dialogNameHelpText":"Shown to customers on the product page.","parentTaxonomyText":"Parent category","placeholder":"Search or create categories…"} -->
+	<div data-block-name="woocommerce/product-taxonomy-field" data-slug="product_cat" data-property="categories"
+		data-label="Categories" data-createTitle="Create new category"
+		data-dialogNameHelpText="Shown to customers on the product page." data-parentTaxonomyText="Parent category"
+		data-placeholder="Search or create categories…">
+
+	</div>
+	<!-- /wp:woocommerce/product-taxonomy-field -->
+	<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide in product catalog","visibility":"search"} -->
+	<div data-block-name="woocommerce/product-catalog-visibility-field" data-label="Hide in product catalog"
+		data-visibility="search">
+
+	</div>
+	<!-- /wp:woocommerce/product-catalog-visibility-field -->
+	<!-- wp:woocommerce/product-catalog-visibility-field {"label":"Hide from search results","visibility":"catalog"} -->
+	<div data-block-name="woocommerce/product-catalog-visibility-field" data-label="Hide from search results"
+		data-visibility="catalog">
+
+	</div>
+	<!-- /wp:woocommerce/product-catalog-visibility-field -->
+	<!-- wp:woocommerce/product-checkbox-field {"label":"Enable product reviews","property":"reviews_allowed"} -->
+	<div data-block-name="woocommerce/product-checkbox-field" data-label="Enable product reviews"
+		data-property="reviews_allowed">
+
+	</div>
+	<!-- /wp:woocommerce/product-checkbox-field -->
+	<!-- wp:woocommerce/product-password-field {"label":"Require a password"} -->
+	<div data-block-name="woocommerce/product-password-field" data-label="Require a password">
+
+	</div>
+	<!-- /wp:woocommerce/product-password-field -->
+	<!-- wp:woocommerce/product-tag-field {"name":"tags"} -->
+	<div data-block-name="woocommerce/product-tag-field" data-name="tags">
+
+	</div>
+	<!-- /wp:woocommerce/product-tag-field -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Attributes","description":"Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information.","blockGap":"unit-40"} -->
+	<div data-block-name="woocommerce/product-section" data-title="Attributes"
+	data-description="Use global attributes to allow shoppers to filter and search for this product. Use custom attributes to provide detailed product information."
+	data-blockGap="unit-40">
+
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-custom-fields-toggle-field {"label":"Show custom fields"} -->
+	<div data-block-name="woocommerce/product-custom-fields-toggle-field" data-label="Show custom fields">
+	<!-- wp:woocommerce/product-section {"blockGap":"unit-30","title":"Custom fields","description":"Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. \u003ca href=\u0022https://woocommerce.com/document/custom-product-fields/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about custom fields\u003c/a\u003e"} -->
+	<div data-block-name="woocommerce/product-section" data-blockGap="unit-30" data-title="Custom fields"
+		data-description="Custom fields can be used in a variety of ways, such as sharing more detailed product information, showing more input fields, or for internal inventory organization. &lt;a href=&quot;https://woocommerce.com/document/custom-product-fields/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Read more about custom fields&lt;/a&gt;">
+
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	</div>
+	<!-- /wp:woocommerce/product-custom-fields-toggle-field -->
+</div>
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Inventory","id":"inventory"} -->
+<div data-block-name="woocommerce/product-tab" data-title="Inventory" data-id="inventory">
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.","buttonText":"Go to Variations","type":"info"} -->
+	<div data-block-name="woocommerce/product-has-variations-notice"
+	data-content="This product has options, such as size or color. You can now manage each variation&#039;s inventory and other details individually."
+	data-buttonText="Go to Variations" data-type="info">
+
+	</div>
+	<!-- /wp:woocommerce/product-has-variations-notice -->
+	<!-- wp:woocommerce/product-section {"title":"Inventory","description":"Set up and manage inventory for this product, including status and available quantity. \u003ca href=\u0022https://test.local/wp-admin/admin.php?page=wc-settings\u0026tab=products\u0026section=inventory\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eManage store inventory settings\u003c/a\u003e","blockGap":"unit-40"} -->
+	<div data-block-name="woocommerce/product-section" data-title="Inventory"
+	data-description="Set up and manage inventory for this product, including status and available quantity. &lt;a href=&quot;https://test.local/wp-admin/admin.php?page=wc-settings&amp;tab=products&amp;section=inventory&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Manage store inventory settings&lt;/a&gt;"
+	data-blockGap="unit-40">
+
+	<!-- wp:woocommerce/product-toggle-field {"label":"Track inventory","property":"manage_stock","disabled":false,"disabledCopy":null} -->
+	<div data-block-name="woocommerce/product-toggle-field" data-label="Track inventory" data-property="manage_stock"
+		data-disabled="" data-disabledCopy="">
+
+	</div>
+	<!-- /wp:woocommerce/product-toggle-field -->
+
+	<!-- wp:woocommerce/product-radio-field {"title":"Stock status","property":"stock_status","options":[{"label":"In stock","value":"instock"},{"label":"Out of stock","value":"outofstock"},{"label":"On backorder","value":"onbackorder"}]} -->
+	<div data-block-name="woocommerce/product-radio-field" data-title="Stock status" data-property="stock_status"
+		data-options="Array">
+
+	</div>
+	<!-- /wp:woocommerce/product-radio-field -->
+	<!-- wp:woocommerce/product-text-area-field {"property":"purchase_note","label":"Post-purchase note","placeholder":"Enter an optional note attached to the order confirmation message sent to the shopper."} -->
+	<div data-block-name="woocommerce/product-text-area-field" data-property="purchase_note"
+		data-label="Post-purchase note"
+		data-placeholder="Enter an optional note attached to the order confirmation message sent to the shopper.">
+
+	</div>
+	<!-- /wp:woocommerce/product-text-area-field -->
+	<!-- wp:woocommerce/product-collapsible {"toggleText":"Advanced","initialCollapsed":true,"persistRender":true} -->
+	<div data-block-name="woocommerce/product-collapsible" data-toggleText="Advanced" data-initialCollapsed="1"
+		data-persistRender="1">
+		<!-- wp:woocommerce/product-section {"blockGap":"unit-40"} -->
+		<div data-block-name="woocommerce/product-section" data-blockGap="unit-40">
+		<!-- wp:woocommerce/product-radio-field {"title":"When out of stock","property":"backorders","options":[{"label":"Allow purchases","value":"yes"},{"label":"Allow purchases, but notify customers","value":"notify"},{"label":"Don't allow purchases","value":"no"}]} -->
+		<div data-block-name="woocommerce/product-radio-field" data-title="When out of stock" data-property="backorders"
+			data-options="Array">
+
+		</div>
+		<!-- /wp:woocommerce/product-radio-field -->
+
+		<!-- wp:woocommerce/product-checkbox-field {"title":"Restrictions","label":"Limit purchases to 1 item per order","property":"sold_individually","tooltip":"When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods."} -->
+		<div data-block-name="woocommerce/product-checkbox-field" data-title="Restrictions"
+			data-label="Limit purchases to 1 item per order" data-property="sold_individually"
+			data-tooltip="When checked, customers will be able to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, like art or handmade goods.">
+
+		</div>
+		<!-- /wp:woocommerce/product-checkbox-field -->
+		</div>
+		<!-- /wp:woocommerce/product-section -->
+	</div>
+	<!-- /wp:woocommerce/product-collapsible -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+</div>
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Shipping","id":"shipping"} -->
+<div data-block-name="woocommerce/product-tab" data-title="Shipping" data-id="shipping">
+	<!-- wp:woocommerce/product-has-variations-notice {"content":"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.","buttonText":"Go to Variations","type":"info"} -->
+	<div data-block-name="woocommerce/product-has-variations-notice"
+	data-content="This product has options, such as size or color. You can now manage each variation&#039;s shipping settings and other details individually."
+	data-buttonText="Go to Variations" data-type="info">
+
+	</div>
+	<!-- /wp:woocommerce/product-has-variations-notice -->
+	<!-- wp:woocommerce/product-toggle-field {"property":"virtual","checkedValue":false,"uncheckedValue":true,"label":"This product requires shipping or pickup","uncheckedHelp":"This product will not trigger your customer's shipping calculator in cart or at checkout. This product also won't require your customers to enter their shipping details at checkout. \u003ca href=\u0022https://woocommerce.com/document/managing-products/#adding-a-virtual-product\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eRead more about virtual products\u003c/a\u003e."} -->
+	<div data-block-name="woocommerce/product-toggle-field" data-property="virtual" data-checkedValue=""
+	data-uncheckedValue="1" data-label="This product requires shipping or pickup"
+	data-uncheckedHelp="This product will not trigger your customer&#039;s shipping calculator in cart or at checkout. This product also won&#039;t require your customers to enter their shipping details at checkout. &lt;a href=&quot;https://woocommerce.com/document/managing-products/#adding-a-virtual-product&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Read more about virtual products&lt;/a&gt;.">
+
+	</div>
+	<!-- /wp:woocommerce/product-toggle-field -->
+	<!-- wp:woocommerce/product-section {"title":"Fees \u0026 dimensions","description":"Set up shipping costs and enter dimensions used for accurate rate calculations. \u003ca href=\u0022https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eHow to get started?\u003c/a\u003e"} -->
+	<div data-block-name="woocommerce/product-section" data-title="Fees &amp; dimensions"
+	data-description="Set up shipping costs and enter dimensions used for accurate rate calculations. &lt;a href=&quot;https://woocommerce.com/posts/how-to-calculate-shipping-costs-for-your-woocommerce-store/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;How to get started?&lt;/a&gt;">
+
+
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+</div>
+<!-- /wp:woocommerce/product-tab -->
+<!-- wp:woocommerce/product-tab {"title":"Linked products","id":"linked-products"} -->
+<div data-block-name="woocommerce/product-tab" data-title="Linked products" data-id="linked-products">
+	<!-- wp:woocommerce/product-section {"title":"Upsells","description":"Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
+	<div data-block-name="woocommerce/product-section" data-title="Upsells"
+	data-description="Upsells are typically products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales. &lt;br /&gt;&lt;a href=&quot;https://woocommerce.com/document/related-products-up-sells-and-cross-sells/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Learn more about linked products&lt;/a&gt;">
+	<!-- wp:woocommerce/product-linked-list-field {"property":"upsell_ids","emptyState":{"image":"ShoppingBags","tip":"Tip: Upsells are products that are extra profitable or better quality or more expensive. Experiment with combinations to boost sales.","isDismissible":true}} -->
+	<div data-block-name="woocommerce/product-linked-list-field" data-property="upsell_ids" data-emptyState="Array">
+
+	</div>
+	<!-- /wp:woocommerce/product-linked-list-field -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+	<!-- wp:woocommerce/product-section {"title":"Cross-sells","description":"By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. \u003cbr /\u003e\u003ca href=\u0022https://woocommerce.com/document/related-products-up-sells-and-cross-sells/\u0022 target=\u0022_blank\u0022 rel=\u0022noreferrer\u0022\u003eLearn more about linked products\u003c/a\u003e"} -->
+	<div data-block-name="woocommerce/product-section" data-title="Cross-sells"
+	data-description="By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value. &lt;br /&gt;&lt;a href=&quot;https://woocommerce.com/document/related-products-up-sells-and-cross-sells/&quot; target=&quot;_blank&quot; rel=&quot;noreferrer&quot;&gt;Learn more about linked products&lt;/a&gt;">
+	<!-- wp:woocommerce/product-linked-list-field {"property":"cross_sell_ids","emptyState":{"image":"CashRegister","tip":"Tip: By suggesting complementary products in the cart using cross-sells, you can significantly increase the average order value.","isDismissible":true}} -->
+	<div data-block-name="woocommerce/product-linked-list-field" data-property="cross_sell_ids" data-emptyState="Array">
+
+	</div>
+	<!-- /wp:woocommerce/product-linked-list-field -->
+	</div>
+	<!-- /wp:woocommerce/product-section -->
+</div>
+<!-- /wp:woocommerce/product-tab -->

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -711,7 +711,7 @@ class BlockTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertSame( 'test-value', $block->get_comment_delimited_template() ); // TODO it's a wrong assumption.
+		$this->assertSame( 'test-value', $template->get_comment_delimited_template() ); // TODO it's a wrong assumption.
 
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -674,4 +674,44 @@ class BlockTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'test-value', $block->get_attributes()['test-attr'] );
 	}
+
+	public function test_get_comment_delimited_formatted_template() {
+		$template = new BlockTemplate();
+
+		$block = $template->add_block(
+			array(
+				'id'         => 'test-block-id',
+				'blockName'  => 'test-block-name',
+				'attributes' => array(
+					'attr-1' => 'value-1',
+					'attr-2' => 'value-2',
+				),
+			)
+		);
+
+		$block->add_hide_condition( 'foo === bar' );
+
+		$block->add_disable_condition( 'test > 100' );
+
+		$block->add_block(
+			array(
+				'id'         => 'test-block-id-2',
+				'blockName'  => 'test-block-name-2',
+				'attributes' => array(
+					'attr-3' => 'value-3',
+					'attr-4' => 'value-4',
+				),
+			)
+		);
+
+		$block->add_block(
+			array(
+				'id'        => 'test-block-id-3',
+				'blockName' => 'test-block-name-3',
+			)
+		);
+
+		$this->assertSame( 'test-value', $block->get_comment_delimited_template() ); // TODO it's a wrong assumption.
+
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -713,6 +713,20 @@ class BlockTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertSame( '<!-- wp:test-block-name {"attr-1":"value-1","attr-2":"value-2","_templateBlockId":"test-block-id","_templateBlockOrder":10000,"_templateBlockHideConditions":[{"expression":"foo === bar"}],"_templateBlockDisableConditions":[{"expression":"test \u003e 100"}]} --><!-- wp:test-block-name-2 {"attr-3":"value-3","attr-4":"value-4","_templateBlockId":"test-block-id-2","_templateBlockOrder":10000} /-->' . "\n" . '<!-- wp:test-block-name-3 {"_templateBlockId":"test-block-id-3","_templateBlockOrder":10000} /--><!-- /wp:test-block-name -->', $template->get_comment_delimited_template() );
+		$columns = $block->add_block(
+			array(
+				'id'        => 'test-block-id-4',
+				'blockName' => 'core/columns',
+			)
+		);
+
+		$columns->add_block(
+			array(
+				'id'        => 'test-block-id-5',
+				'blockName' => 'core/column',
+			)
+		);
+
+		$this->assertSame( '<!-- wp:test-block-name {"attr-1":"value-1","attr-2":"value-2","_templateBlockId":"test-block-id","_templateBlockOrder":10000,"_templateBlockHideConditions":[{"expression":"foo === bar"}],"_templateBlockDisableConditions":[{"expression":"test \u003e 100"}]} --><!-- wp:test-block-name-2 {"attr-3":"value-3","attr-4":"value-4","_templateBlockId":"test-block-id-2","_templateBlockOrder":10000} /--><!-- wp:test-block-name-3 {"_templateBlockId":"test-block-id-3","_templateBlockOrder":10000} /--><!-- wp:columns {"_templateBlockId":"test-block-id-4","_templateBlockOrder":10000} --><div class="wp-block-columns" /><!-- wp:column {"_templateBlockId":"test-block-id-5","_templateBlockOrder":10000} --><div class="wp-block-column" /><!-- /wp:column --><!-- /wp:columns --><!-- /wp:test-block-name -->', $template->get_comment_delimited_template() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -714,6 +714,5 @@ class BlockTest extends WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( '<!-- wp:test-block-name {"attr-1":"value-1","attr-2":"value-2","_templateBlockId":"test-block-id","_templateBlockOrder":10000,"_templateBlockHideConditions":[{"expression":"foo === bar"}],"_templateBlockDisableConditions":[{"expression":"test \u003e 100"}]} --><!-- wp:test-block-name-2 {"attr-3":"value-3","attr-4":"value-4","_templateBlockId":"test-block-id-2","_templateBlockOrder":10000} /-->' . "\n" . '<!-- wp:test-block-name-3 {"_templateBlockId":"test-block-id-3","_templateBlockOrder":10000} /--><!-- /wp:test-block-name -->', $template->get_comment_delimited_template() );
-
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -674,8 +674,10 @@ class BlockTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'test-value', $block->get_attributes()['test-attr'] );
 	}
-
-	public function test_get_comment_delimited_formatted_template() {
+	/**
+	 * Test for get_comment_delimited_template method.
+	 */
+	public function test_get_comment_delimited_template() {
 		$template = new BlockTemplate();
 
 		$block = $template->add_block(
@@ -711,7 +713,7 @@ class BlockTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertSame( 'test-value', $template->get_comment_delimited_template() ); // TODO it's a wrong assumption.
+		$this->assertSame( '<!-- wp:test-block-name {"attr-1":"value-1","attr-2":"value-2","_templateBlockId":"test-block-id","_templateBlockOrder":10000,"_templateBlockHideConditions":[{"expression":"foo === bar"}],"_templateBlockDisableConditions":[{"expression":"test \u003e 100"}]} --><!-- wp:test-block-name-2 {"attr-3":"value-3","attr-4":"value-4","_templateBlockId":"test-block-id-2","_templateBlockOrder":10000} /-->' . "\n" . '<!-- wp:test-block-name-3 {"_templateBlockId":"test-block-id-3","_templateBlockOrder":10000} /--><!-- /wp:test-block-name -->', $template->get_comment_delimited_template() );
 
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds some code to convert existing templates to comment-delimited format. The code is not used in production, but is being used manually to support the migration of the existing templates. 

Its result is in the `simple.php` file. The file was also manually formatted.

Part of #47999 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new Product Editor
2. Enable the `product-editor-template-system` feature flag
  a. Install the WooCommerce Beta Tester plugin
  b. Go to the Settings -> WCA Test Helper -> Features
  c. Enable the `product-editor-template-system` feature flag

![image](https://github.com/woocommerce/woocommerce/assets/77539/4fbfeeae-3ed2-417f-8419-ef813d3a0e0a)

3. Update the Simple product_form post
  a. Install and activate the plugin [pft-dev-tools](https://github.com/woocommerce/pft-dev-tools/archive/refs/heads/trunk.zip) (note that this plugin forces the `product-editor-template-system` feature flag to be enabled)
  b. Generate the `Simple` form template by running the following `wp-cli` command:

```sh
wp trigger upgrader_process_complete --action=install
```

4. Create a new product from the new Product Editor
5. Click on the `Change product type` link/button
6. Confirm you see the Simple template there
7. Select it
8. Check that the template is loaded with all the fields

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
