### PR TITLE
Logging: Ensure filtered log messages don't persist across multiple log handlers

### DIFF
--- a/plugins/woocommerce/changelog/fix-47126-logger-filter-multiple-handlers
+++ b/plugins/woocommerce/changelog/fix-47126-logger-filter-multiple-handlers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure data filtered by `woocommerce_logger_log_message` does not carry across multiple log handlers

--- a/plugins/woocommerce/includes/class-wc-logger.php
+++ b/plugins/woocommerce/includes/class-wc-logger.php
@@ -183,10 +183,10 @@ class WC_Logger implements WC_Logger_Interface {
 				 * @param array  $context Additional information for log handlers.
 				 * @param object $handler The handler object, such as WC_Log_Handler_File. Available since 5.3.
 				 */
-				$message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context, $handler );
+				$filtered_message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context, $handler );
 
-				if ( null !== $message ) {
-					$handler->handle( $timestamp, $level, $message, $context );
+				if ( null !== $filtered_message ) {
+					$handler->handle( $timestamp, $level, $filtered_message, $context );
 				}
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Log messages can be modified via the `woocommerce_logger_log_message` filter hook on a per-handler basis, but if the message is modified for the first handler, the subsequent handlers were receiving the modified message instead of the original. This simply ensures each handler receives the original message instead.

Fixes #47126

### How to test the changes in this Pull Request:

1. Install [this snippet](https://gist.github.com/coreymckrill/782e771d6166708e6cf6fd53f3a31233) on your test site.
2. Open up two browser tabs: 1) `WooCommerce > Status > Logs`, and 2) `WooCommerce > Status > Tools`.
3. On the Tools tab, click the "Generate" button for the "Debug Log Generator" tool.
4. On the Logs tab, find the new log file that was just created, "test_47126" and open it. You should see a series of log entries that looks like the following, where the "[MODIFIED]" indicates the log handler where the message has been filtered. You can see that the log handler that fires _after_ the modified one has the original message.

```
2024-06-10T19:55:53+00:00 Debug Test 1
2024-06-10T19:55:53+00:00 Debug [MODIFIED] Test 1
2024-06-10T19:55:53+00:00 Debug Test 1
2024-06-10T19:55:53+00:00 Debug Test 2
2024-06-10T19:55:53+00:00 Debug [MODIFIED] Test 2
2024-06-10T19:55:53+00:00 Debug Test 2
2024-06-10T19:55:53+00:00 Debug Test 3
2024-06-10T19:55:53+00:00 Debug [MODIFIED] Test 3
2024-06-10T19:55:53+00:00 Debug Test 3
2024-06-10T19:55:53+00:00 Debug Test 4
2024-06-10T19:55:53+00:00 Debug [MODIFIED] Test 4
2024-06-10T19:55:53+00:00 Debug Test 4
2024-06-10T19:55:53+00:00 Debug Test 5
2024-06-10T19:55:53+00:00 Debug [MODIFIED] Test 5
2024-06-10T19:55:53+00:00 Debug Test 5
```

5. If you do this same sequence on the trunk branch instead of this PR branch, you should see that both the second and third entry for each test number has the "[MODIFIED]" string prepended.

