### PR TITLE
Fix interpolation syntax.

### DIFF
--- a/plugins/woocommerce/changelog/fix-attr-lookup-cli-tool
+++ b/plugins/woocommerce/changelog/fix-attr-lookup-cli-tool
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: This is a correction for currently unreleased change https://github.com/woocommerce/woocommerce/pull/47311.
+
+

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/CLIRunner.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/CLIRunner.php
@@ -201,13 +201,13 @@ class CLIRunner {
 			if ( ! $this->data_regenerator->has_scheduled_action_for_regeneration_step() ) {
 				$this->log( 'However, there are %9NO%n actions scheduled to run the regeneration steps (a %9wp cli palt regenerate%n command was aborted?).' );
 			}
-			$this->log( "The last product id that will be processed is %Y${max_product_id_to_process}%n." );
+			$this->log( "The last product id that will be processed is %Y{$max_product_id_to_process}%n." );
 			$this->log( "\nRun %9wp cli palt abort_regeneration%n to abort the regeneration process," );
 			$this->log( "then you'll be able to run %9wp cli palt resume_regeneration%n to resume the regeneration process," );
 		} elseif ( $this->lookup_data_store->regeneration_was_aborted() ) {
 			$max_product_id_to_process = get_option( 'woocommerce_attribute_lookup_last_product_id_to_process', '???' );
 			WP_CLI::log( '' );
-			$this->warning( "Full regeneration of the table has been %Raborted.%n\nThe last product id that will be processed is %Y${max_product_id_to_process}%n." );
+			$this->warning( "Full regeneration of the table has been %Raborted.%n\nThe last product id that will be processed is %Y{$max_product_id_to_process}%n." );
 			$this->log( "\nRun %9wp cli palt resume_regeneration%n to resume the regeneration process." );
 		}
 	}


### PR DESCRIPTION
- Minor correction for https://github.com/woocommerce/woocommerce/pull/47311.
- The above uses a [deprecated syntax for string interpolation](https://www.php.net/releases/8.2/en.php), which can throw errors when running unrelated WP CLI commands.
- This can be observed when executing pretty much any WP CLI command, with `WP_DEBUG` set to true and a recent PHP version (I used 8.3).

Updates #47311.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Beyond code review, you can try:

1. Running various WP CLI commands (example: `wp plugin list`) using PHP 8.2 or higher, with debug mode enabled (`WP_DEBUG` and `WP_DEBUG_DISPLAY` both set to `true` in your `wp-config.php` file).
2. When testing *without* this change, look out for warnings about the deprecated syntax:

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /.../plugins/woocommerce/src/Internal/ProductAttributesLookup/CLIRunner.php on line 210
```

3. With this change, there should be no such errors.
4. Please also test per the original instructions in https://github.com/woocommerce/woocommerce/pull/47311 to ensure no regressions.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
