### PR TITLE
fix: core profiler already connected to jetpack

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1358,8 +1358,8 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 						onDone: [
 							{
 								target: 'sendToJetpackAuthPage',
-								guard: ( { event } ) => {
-									return ! event.output.data;
+								guard: ( { event } : { event: DoneActorEvent<typeof getJetpackIsConnected> } ) => {
+									return ! event.output;
 								},
 							},
 							{ actions: 'redirectToWooHome' },

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1358,7 +1358,13 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 						onDone: [
 							{
 								target: 'sendToJetpackAuthPage',
-								guard: ( { event } : { event: DoneActorEvent<typeof getJetpackIsConnected> } ) => {
+								guard: ( {
+									event,
+								}: {
+									event: DoneActorEvent<
+										typeof getJetpackIsConnected
+									>;
+								} ) => {
 									return ! event.output;
 								},
 							},

--- a/plugins/woocommerce/changelog/fix-core-profiler-jetpack-already-connected
+++ b/plugins/woocommerce/changelog/fix-core-profiler-jetpack-already-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug where Core Profiler initiates a Jetpack connection even if it was already connected before


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a small follow up to https://github.com/woocommerce/woocommerce/pull/48135

It fixes the bug where the Jetpack connection still shows even if the site was previously already connected to Jetpack, along with some refactoring for clarity.

Closes https://github.com/woocommerce/woocommerce/issues/48249.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

There are 4 flows to test. All of them can be tested using Jurassic Ninja or similar, with the ability to connect to Jetpack. 

If you'd like to test the error handling for sites that can't connect to Jetpack, feel free to also use localhost or playground. They will not show the Jetpack connection in any circumstances, but there should be no flow-breaking errors.

With reference to the testing instructions in https://github.com/woocommerce/woocommerce/pull/48135 or PdibGW-3gY-p2 , the below are Flows 2, 3, 8 and 9

#### With Jetpack Installed during Core Profiler

Flow 2a: All-Inclusive with Jetpack Login (Create New User)

- Ensure that you are not logged into a WordPress.com account when starting this test run
- On the Intro & Opt In page, leave the Opt In checkbox selected
- Step through all the pages in the happy path flow and fill out the information requested.
- Observe that the various pages should work correctly as noted above
- Make sure that Jetpack is part of the selected Extensions on the Extensions page
- Observe that the plugins installation loader should finish within 30s
- Observe that you are redirected to WordPress.com for Jetpack Connection
- Follow through with creating a new user and ensure it works
- You should be redirected back to your WooCommerce Home after it is complete
- All selected plugins should have completed installation by now

Flow 2b: All-Inclusive with Jetpack Login (Existing User)

- Same as 2a, but begin with a WordPress.com account already logged in
- On the Jetpack Connection pages observe that you are able to proceed with your currently logged in user

Flow 2c: All-Inclusive with Jetpack Login (Switch User)

- Same as 2c but observe that you are able to switch to another user and/or create a new WordPress.com account

#### Without Jetpack Installation

Flow 3: All-Inclusive without Jetpack Login

- Same as 2a but deselect Jetpack on the Extensions selection page
- Observe that the Jetpack Connection pages do not occur
- You should be immediately redirected to WooCommerce Home after extensions have installed

#### With Jetpack previously installed then going through Core Profiler

Flow 8: Start with Jetpack pre-installed but not connected

- If Jetpack is previously installed but not activated or connected, you should still see that Jetpack is available for installation
- Proceeding with Jetpack selected should redirect you to the Jetpack Connection pages

#### With Jetpack previously installed AND connected then going through Core Profiler

Flow 9: Start with Jetpack pre-installed and connected

- If Jetpack is previously installed and connected then Jetpack should present as already installed on the Extensions page
- Proceeding with the installation should not show you the Jetpack Connection pages




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>