### PR TITLE
[e2e tests] Disable task list reminder bar in analytics-data spec - fixed flaky tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-analytics-data-spec-disable-task-list-reminder
+++ b/plugins/woocommerce/changelog/e2e-fix-analytics-data-spec-disable-task-list-reminder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E test: Improve analytics data spec by disabling the task list reminder bar

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -2,28 +2,7 @@ const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
-	product: async ( { api }, use ) => {
-		let product = {
-			id: 0,
-			name: `Product ${ Date.now() }`,
-			type: 'simple',
-			regular_price: '12.99',
-		};
 
-		await api.post( 'products', product ).then( ( response ) => {
-			product = response.data;
-		} );
-
-		await use( product );
-
-		// permanently delete the product if it still exists
-		const r = await api.get( `products/${ product.id }` );
-		if ( r.status !== 404 ) {
-			await api.delete( `products/${ product.id }`, {
-				force: true,
-			} );
-		}
-	},
 	page: async ( { page, wcAdminApi }, use ) => {
 		// Disable the task list reminder bar, it can interfere with the quick actions
 		await wcAdminApi.post( 'options', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -9,6 +9,11 @@ const test = baseTest.extend( {
 			woocommerce_task_list_reminder_bar_hidden: 'yes',
 		} );
 
+		// Disable the revenue report date tour
+		await wcAdminApi.post( 'options', {
+			woocommerce_revenue_report_date_tour_shown: 'yes',
+		} );
+
 		await use( page );
 	},
 } );
@@ -204,12 +209,6 @@ test.describe( 'Analytics-related tests', () => {
 		await page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue'
 		);
-		// FTUX tour on first run through
-		try {
-			await page.getByLabel( 'Close Tour' ).click( { timeout: 5000 } );
-		} catch ( e ) {
-			console.log( 'Tour was not visible, skipping.' );
-		}
 
 		// the revenue report can either download immediately, or get mailed.
 		try {
@@ -300,13 +299,6 @@ test.describe( 'Analytics-related tests', () => {
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue'
 		);
 
-		// FTUX tour on first run through
-		try {
-			await page.getByLabel( 'Close Tour' ).click( { timeout: 5000 } );
-		} catch ( e ) {
-			console.log( 'Tour was not visible, skipping.' );
-		}
-
 		// assert that current month is shown and that values are for that
 		await expect( page.getByText( 'Month to date' ).first() ).toBeVisible();
 		await expect(
@@ -390,13 +382,6 @@ test.describe( 'Analytics-related tests', () => {
 		await page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue'
 		);
-
-		// FTUX tour on first run through
-		try {
-			await page.getByLabel( 'Close Tour' ).click( { timeout: 5000 } );
-		} catch ( e ) {
-			console.log( 'Tour was not visible, skipping.' );
-		}
 
 		// assert that current month is shown and that values are for that
 		await expect( page.getByText( 'Month to date' ).first() ).toBeVisible();
@@ -494,13 +479,6 @@ test.describe( 'Analytics-related tests', () => {
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Forders'
 		);
 
-		// FTUX tour on first run through
-		try {
-			await page.getByLabel( 'Close Tour' ).click( { timeout: 5000 } );
-		} catch ( e ) {
-			console.log( 'Tour was not visible, skipping.' );
-		}
-
 		// no filters applied
 		await expect(
 			page.getByRole( 'menuitem', {
@@ -590,13 +568,6 @@ test.describe( 'Analytics-related tests', () => {
 		await page.goto(
 			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts'
 		);
-
-		// FTUX tour on first run through
-		try {
-			await page.getByLabel( 'Close Tour' ).click( { timeout: 5000 } );
-		} catch ( e ) {
-			console.log( 'Tour was not visible, skipping.' );
-		}
 
 		// no filters applied
 		await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/48335.

Tests in analytics-data.spec.js started failing lately. From what I can see it's because the task list reminder bar is intercepting events. Disabling the bar should help.

Other changes:
- Disabled the tour via the api instead of waiting 5s for the close button. This saved over 20 seconds, more than half of the total spec execution time.
- By introducing the fixture the `api` objects in the before/after hooks became redundant so I removed them in favour of the `api` fixture.
- Close the setupPage.

### How to test the changes in this Pull Request:

All e2e tests pass in CI.
Check `analytics-data.spec.js` in shard 1/5 in particular - it should pass on first attempt.

Locally, run `pnpm test:e2e-pw analytics-data.spec.js`. Check with a fresh environment, so that all tour options are set to default. Run it a few times, make sure it passes every time.
