### PR TITLE
Make coupon metadata read robust against wrongly stored product related metadata

### DIFF
--- a/plugins/woocommerce/changelog/pr-48362
+++ b/plugins/woocommerce/changelog/pr-48362
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make coupon metadata read robust against wrongly stored product related metadata

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -465,7 +465,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 */
 	public function get_usage_by_user_id( &$coupon, $user_id ) {
 		global $wpdb;
-		$usage_count = $wpdb->get_var(
+		$usage_count           = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value = %s;",
 				$coupon->get_id(),
@@ -486,7 +486,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 */
 	public function get_usage_by_email( &$coupon, $email ) {
 		global $wpdb;
-		$usage_count = $wpdb->get_var(
+		$usage_count           = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value = %s;",
 				$coupon->get_id(),
@@ -510,7 +510,6 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		return $wpdb->get_var(
 			$this->get_tentative_usage_query_for_user( $coupon_id, $user_aliases )
 		); // WPCS: unprepared SQL ok.
-
 	}
 
 	/**
@@ -662,8 +661,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$query_for_tentative_usages = $this->get_tentative_usage_query_for_user( $coupon->get_id(), $user_aliases );
 		$db_timestamp               = $wpdb->get_var( 'SELECT UNIX_TIMESTAMP() FROM ' . $wpdb->posts . ' LIMIT 1' );
 
-		$coupon_used_by_meta_key    = '_maybe_used_by_' . ( (int) $db_timestamp + $held_time ) . '_' . wp_generate_password( 6, false );
-		$insert_statement           = $wpdb->prepare(
+		$coupon_used_by_meta_key = '_maybe_used_by_' . ( (int) $db_timestamp + $held_time ) . '_' . wp_generate_password( 6, false );
+		$insert_statement        = $wpdb->prepare(
 			"
 			INSERT INTO $wpdb->postmeta ( post_id, meta_key, meta_value )
 			SELECT %d, %s, %s FROM $wpdb->posts

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -159,8 +159,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * WooCommerce always stores the coupon product ids as a comma-separated string, but it seems that
 	 * some plugins mistakenly change these to an array.
 	 *
-	 * @param $coupon_id The coupon id.
-	 * @param string                  $meta_key The meta key to get.
+	 * @param int    $coupon_id The coupon id.
+	 * @param string $meta_key The meta key to get.
 	 * @return array The metadata value as an array, with empty values removed.
 	 */
 	private function get_coupon_meta_as_array( $coupon_id, string $meta_key ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Coupon metadata keys `product_ids` and `excluded_product_ids` are stored by WooCommerce as a comma-saparated list of values, but apparently some plugins mistakenly re-store these as serialized arrays. This pull request changes the database metadata read code so that it supports both comma-separated lists and serialized arrays.

Closes #40569.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to the coupons page in the WooCommerce admin area (Marketing - Coupons) and create a coupon with both allowed and excluded products ("Usage restrictions" - "Products" and "Exclude Products").

2. Run the following command, you'll see that both product lists are stored as a list of comma-separated values:

```
wp db query "select * from wp_postmeta where post_id=<coupon id> and meta_key like '%product_ids'"
```

3. Run the following commands to simulate a plugin wrongly re-encoding these meta values as arrays (you can re-run the previous db query command afterwards to see the changes):

```
wp eval "update_post_meta( <coupon id>, 'product_ids', explode( ',', get_post_meta( <coupon id>, 'product_ids', true ) ) );"
wp eval "update_post_meta( <coupon id>, 'exclude_product_ids', explode( ',', get_post_meta( <coupon id>, 'exclude_product_ids', true ) ) );"
```

4. Reload the coupon page in the admin area. The page will load without issues and the allowed and excluded products lists will still have the proper values (whithout the fix the page load would have failed with a fatal error).

5. Make changes to both product lists and save the coupon. Repeat the db query command and you'll see that the meta values have been re-encoded as comma-separated lists.
