### PR TITLE
Accessibility: Prevent shipping losing focus when making selections during checkout

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -68,13 +68,6 @@ const PackageRates = ( {
 		}
 	}, [ onSelectRate, rates, selectedOption ] );
 
-	// Update the data store when the local selected rate changes.
-	useEffect( () => {
-		if ( selectedOption ) {
-			onSelectRate( selectedOption );
-		}
-	}, [ onSelectRate, selectedOption ] );
-
 	if ( rates.length === 0 ) {
 		return noResultsMessage;
 	}

--- a/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/option.tsx
@@ -47,7 +47,21 @@ const Option = ( {
 					[ `${ name }-${ value }__secondary-description` ]:
 						secondaryDescription,
 				} ) }
-				disabled={ disabled }
+				aria-disabled={ disabled }
+				onKeyDown={ ( event ) => {
+					// Prevent option changing via keyboard when loading from server.
+					if (
+						disabled &&
+						[
+							'ArrowUp',
+							'ArrowDown',
+							'AllowLeft',
+							'ArrowRight',
+						].includes( event.key )
+					) {
+						event.preventDefault();
+					}
+				} }
 			/>
 			<OptionLayout
 				id={ `${ name }-${ value }` }

--- a/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/radio-control/style.scss
@@ -208,6 +208,7 @@
 			}
 		}
 
+		&[aria-disabled="true"],
 		&[disabled] {
 			cursor: not-allowed;
 			opacity: 0.5;

--- a/plugins/woocommerce/changelog/48370-fix-shipping-focus-lost-48104
+++ b/plugins/woocommerce/changelog/48370-fix-shipping-focus-lost-48104
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Accessibility: Prevent shipping losing focus when making selections during checkout.  </details>  <details>  <summary>Changelog Entry Comment</summary>
+Accessibility: Prevent shipping losing focus when making selections during checkout.

--- a/plugins/woocommerce/changelog/48370-fix-shipping-focus-lost-48104
+++ b/plugins/woocommerce/changelog/48370-fix-shipping-focus-lost-48104
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Accessibility: Prevent shipping losing focus when making selections during checkout.  </details>  <details>  <summary>Changelog Entry Comment</summary>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR prevents focus being lost on the radio inputs in the shipping component of the block based checkout. To do this we need to change `disabled` to `aria-disabled` so focus can be left in place.

A side effect of this is that you can still select options while the selected option is being pushed to the server. This can cause the UI to update unexpectedly as you toggle options too quickly. I've mitigated this by:

1. Disabling keyboard (arrow key) navigation between items when `aria-disabled` is true. This means you must wait for the option to propagate to server before switching options again. You can still tab out of the component if you wish.
2. Implementing request cancelling for the select shipping event. This is so when you use the mouse to toggle options, requests do not keep stacking on top of each other.

Additionally, I found and removed a rogue `useEffect` which was causing two requests each time you choose a shipping option. The request is made `onChange` so the `useEffect` was not needed.

Closes #48104

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Shipping and ensure you have several shipping rates setup. For testing purposes 3 or 4 is a good amount. 
4. Add an item to your cart and go to checkout (block based checkout).
5. Click on a shipping option.
6. Keyboard navigation test
     - Press the down and up keys to navigate between shipping options
     - When a new option is selected it should fade and keyboard navigation should be prevented
     - Once the option s updated, navigation is restored
     - You should be able to tab out of the area at any point
7. Mouse test 
     - Click on shipping options
     - Click around while they are loading. There should be no errors, and your last selection should propagate to the server.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Accessibility: Prevent shipping losing focus when making selections during checkout.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
