### PR TITLE
Fix the mini cart items not being visible when zoomed in 

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/style.scss
@@ -7,6 +7,20 @@
 	height: 100%;
 }
 
+// Remove the stickiness from the footer when there isn't enough room
+// to display the items.
+@media screen and (max-height: 500px) {
+	.wp-block-woocommerce-mini-cart-contents {
+		height: auto;
+	}
+	.wc-block-mini-cart__drawer {
+		overflow-y: auto;
+	}
+	.wc-block-mini-cart__footer {
+		position: static;
+	}
+}
+
 .wc-block-mini-cart__button {
 	align-items: center;
 	background-color: transparent;
@@ -98,7 +112,7 @@
 }
 
 .wp-block-woocommerce-empty-mini-cart-contents-block
-.wc-block-mini-cart__empty-cart-wrapper {
+	.wc-block-mini-cart__empty-cart-wrapper {
 	overflow-y: auto;
 	padding: $gap-largest $gap $gap;
 }
@@ -140,7 +154,7 @@ h2.wc-block-mini-cart__title {
 }
 
 .wc-block-mini-cart__footer {
-	@include with-translucent-border( 1px 0 0 );
+	@include with-translucent-border(1px 0 0);
 	padding: $gap-large $gap;
 
 	.wc-block-components-totals-item.wc-block-mini-cart__footer-subtotal {
@@ -160,7 +174,9 @@ h2.wc-block-mini-cart__title {
 
 	// First selector for the frontend, second selector for the editor.
 	.wc-block-mini-cart__footer-actions,
-	.wc-block-mini-cart__footer-actions > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	.wc-block-mini-cart__footer-actions
+		> .block-editor-inner-blocks
+		> .block-editor-block-list__layout {
 		display: flex;
 		gap: $gap;
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/style.scss
@@ -112,7 +112,7 @@
 }
 
 .wp-block-woocommerce-empty-mini-cart-contents-block
-	.wc-block-mini-cart__empty-cart-wrapper {
+.wc-block-mini-cart__empty-cart-wrapper {
 	overflow-y: auto;
 	padding: $gap-largest $gap $gap;
 }
@@ -174,9 +174,7 @@ h2.wc-block-mini-cart__title {
 
 	// First selector for the frontend, second selector for the editor.
 	.wc-block-mini-cart__footer-actions,
-	.wc-block-mini-cart__footer-actions
-		> .block-editor-inner-blocks
-		> .block-editor-block-list__layout {
+	.wc-block-mini-cart__footer-actions > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		gap: $gap;
 

--- a/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
+++ b/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the mini cart items not being visible when zoomed in

--- a/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
+++ b/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the mini cart items not being visible when zoomed in   </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
+++ b/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the mini cart items not being visible when zoomed in

--- a/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
+++ b/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the Mini Cart items not being visible when zoomed in   </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
+++ b/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix the Mini Cart items not being visible when zoomed in   </details>  <details>  <summary>Changelog Entry Comment</summary>
+Fix the mini cart items not being visible when zoomed in

--- a/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
+++ b/plugins/woocommerce/changelog/48384-fix-43639-zoom-mini-cart
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix the mini cart items not being visible when zoomed in   </details>  <details>  <summary>Changelog Entry Comment</summary>
+Fix the Mini Cart items not being visible when zoomed in   </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48384-fix-mini-cart-zoom
+++ b/plugins/woocommerce/changelog/48384-fix-mini-cart-zoom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the mini cart items not being visible when zoomed in

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -459,7 +459,7 @@ class MiniCart extends AbstractBlock {
 
 			// It is not necessary to load the Mini-Cart Block on Cart and Checkout page.
 			return '<div class="' . esc_attr( $wrapper_classes ) . '" style="visibility:hidden" aria-hidden="true">
-				<button class="wc-block-mini-cart__button" disabled>' . $button_html . '</button>
+				<button class="wc-block-mini-cart__button" disabled aria-label="' . __( 'Cart', 'woocommerce' ) . '">' . $button_html . '</button>
 			</div>';
 		}
 
@@ -487,7 +487,7 @@ class MiniCart extends AbstractBlock {
 		}
 
 		return '<div class="' . esc_attr( $wrapper_classes ) . '" style="' . esc_attr( $wrapper_styles ) . '">
-			<button class="wc-block-mini-cart__button">' . $button_html . '</button>
+			<button class="wc-block-mini-cart__button" aria-label="' . __( 'Cart', 'woocommerce' ) . '">' . $button_html . '</button>
 			<div class="is-loading wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
 				<div class="wc-block-mini-cart__drawer wc-block-components-drawer">
 					<div class="wc-block-components-drawer__content">
@@ -546,7 +546,7 @@ class MiniCart extends AbstractBlock {
 				'tax_label'                         => $tax_label,
 				'display_cart_prices_including_tax' => false,
 			);
-		};
+		}
 
 		return array(
 			'tax_label'                         => '',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes the mini cart footer non sticky when there isn't enough room to display the cart items. This is beneficial both for small screens and when a user zooms into the page (as is often the case with visually impaired people)

Closes #43639.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Make sure a block theme is enabled
2. Make sure the mini cart is included either in the template or in a page
3. Add at least 4 items to your cart
4. Open the mini cart
5. Zoom in multiple times, until the footer with the subtotal and 2 buttons disappears (this will depend on your screen height - the change happens when the screen height is 500px or less.
6. Make sure you can scroll and see all the items in your cart
7. Make sure the footer is visible after the last cart item
8. Zoom in further. Check the footer is still at the bottom and doesn't display on top of the cart items
9. Zoom back out until the footer appears sticky again. Make sure there is ample room to view the items in the cart and that you can scroll to see all items.