### PR TITLE
Run `add_archive_product_to_eligible_for_fallback_templates` for block themes only

### DIFF
--- a/plugins/woocommerce/changelog/48385-fix-btc-classic-theme-leak
+++ b/plugins/woocommerce/changelog/48385-fix-btc-classic-theme-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Prevent running `add_archive_product_to_eligible_for_fallback_templates` in classic themes.

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -27,10 +27,11 @@ class BlockTemplatesController {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
-		add_filter( 'taxonomy_template_hierarchy', array( $this, 'add_archive_product_to_eligible_for_fallback_templates' ), 10, 1 );
 		add_action( 'after_switch_theme', array( $this, 'check_should_use_blockified_product_grid_templates' ), 10, 2 );
 
 		if ( wc_current_theme_is_fse_theme() ) {
+			add_filter( 'taxonomy_template_hierarchy', array( $this, 'add_archive_product_to_eligible_for_fallback_templates' ), 10, 1 );
+
 			// By default, the Template Part Block only supports template parts that are in the current theme directory.
 			// This render_callback wrapper allows us to add support for plugin-housed template parts.
 			add_filter(


### PR DESCRIPTION
### What?

Closes https://github.com/woocommerce/woocommerce/issues/46461

Ensure the `add_archive_product_to_eligible_for_fallback_templates` hook runs for block themes only.

### How to test

Ensure the hook does not leak into classic themes:
- Activate a block theme (e.g. TT4),
- Add `die()` inside the `add_archive_product_to_eligible_for_fallback_templates` hook,
- Go to a specific `category` or `tag` page, e.g. `/product-category/clothing/`,
- Ensure the page dies,
- Activate a classic theme (e.g. Storefront),
- Go to the same page as above,
- Ensure the page does not die.