### PR TITLE
WooCommerce: fixes the checks when migrating the product form template

### DIFF
--- a/plugins/woocommerce/changelog/update-product-form-template-fix-update-post-type-bug
+++ b/plugins/woocommerce/changelog/update-product-form-template-fix-update-post-type-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooCommerce: fixes the checks when migrating the product form template

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -34,7 +34,7 @@ class ProductFormsController {
 	 * @return void
 	 */
 	public function migrate_templates_when_plugin_updated( \WP_Upgrader $upgrader, array $hook_extra ) {
-		// If it is not a plugin update, bail early.
+		// If it is not a plugin hook type, bail early.
 		$type = isset( $hook_extra['type'] ) ? $hook_extra['type'] : '';
 		if ( $type !== 'plugin' ) {
 			return;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -34,32 +34,27 @@ class ProductFormsController {
 	 * @return void
 	 */
 	public function migrate_templates_when_plugin_updated( \WP_Upgrader $upgrader, array $hook_extra ) {
-		/*
-		 * Check whether $hook_extra['plugins'] contains the WooCommerce plugin.
-		 * It seems that $hook_extra may be `null` in some cases.
-		 * @see https://github.com/woocommerce/woocommerce/pull/48221#pullrequestreview-2102772713
-		 */
-		if ( ! isset( $hook_extra['plugins'] ) || ! is_array( $hook_extra['plugins'] ) ) {
+		// If it is not a plugin update, bail early.
+		$type = isset( $hook_extra['type'] ) ? $hook_extra['type'] : '';
+		if ( $type !== 'plugin' ) {
 			return;
 		}
 
-		// Check if WooCommerce plugin was updated.
+		// If it is not the WooCommerce plugin, bail early.
+		$plugins = isset( $hook_extra['plugins'] ) ? $hook_extra['plugins'] : array();
 		if (
-			! in_array( 'woocommerce/woocommerce.php', $hook_extra['plugins'], true )
+			! in_array( 'woocommerce/woocommerce.php', $plugins, true )
 		) {
 			return;
 		}
 
-		// Check if the action is an `update` or `install` action for a plugin.
+		// If the action is not install or update, bail early.
 		$action = isset( $hook_extra['action'] ) ? $hook_extra['action'] : '';
-
-		if (
-			'install' !== $action && 'update' !== $action ||
-			'plugin' !== $hook_extra['type']
-		) {
+		if ( 'install' !== $action && 'update' !== $action ) {
 			return;
 		}
 
+		// Trigger the migration process.
 		$this->migrate_product_form_posts( $action );
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductFormsController.php
@@ -36,7 +36,7 @@ class ProductFormsController {
 	public function migrate_templates_when_plugin_updated( \WP_Upgrader $upgrader, array $hook_extra ) {
 		// If it is not a plugin hook type, bail early.
 		$type = isset( $hook_extra['type'] ) ? $hook_extra['type'] : '';
-		if ( $type !== 'plugin' ) {
+		if ( 'plugin' !== $type ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

This PR fixes a bug when checking the conditions to trigger the migrating process of the Simple Form Template file to dB.
The issue is described correctly here #48375, but in short, the function bound to the [upgrader_process_complete](https://developer.wordpress.org/reference/hooks/upgrader_process_complete/) hook is not checking properly the hook `type`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48375.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


## Test the #48375 bug is fixed with these changes:

1. Create a new WordPress site from scratch.
2. Install `WooCommerce` and `WooCommerce Beta Tester` plugins from the trunk and enable them.
3. Enable the `product-editor-template-system` feature flag
  a. Install the WooCommerce Beta Tester plugin
  b. Go to the Settings -> WCA Test Helper -> Features
  c. Enable the `product-editor-template-system` feature flag

![image](https://github.com/woocommerce/woocommerce/assets/77539/77509ff9-8fbf-45b0-9a0d-164c4611f427)

4. Create an example product.
5. Visit the product in the frontend. Everything will look alright.
6. Now, switch the store theme from TT4 to TT3.
7. Visit the product you created in step 3 again.
8. Confirm:
**Before (trunk)**: You will see a 404 error.
**Now( this PR)**: Confirm everything looks alright.


## Triggering the migration process

1. Install and activate the PFT dev tools plugin.

[pft-dev-tools](https://github.com/woocommerce/pft-dev-tools/archive/refs/heads/trunk.zip)

2.. Go to the Product Forms page `wp-admin/edit.php?post_type=product_form`
3. Confirm the `Simple` form post isn't there. Remove it in case it exists.

<img width="701" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/10a1efbd-6d51-4114-ab44-00dc7a1c22d1">

5. Run the following WP CLI command to trigger the upgrader_process_complete action, passing the `update` action and `theme` type:

```sh
wp trigger upgrader_process_complete --action=update --type=theme
```

6. Hard refresh
7. Confirm the Simple post was not created yet
8.  Run the same command, but this time passing the `plugin` type parameter:

```sh
wp trigger upgrader_process_complete --action=update --type=plugin
```

9. Confirm now the Simple PFT has been created

<img width="661" alt="Screenshot 2024-06-06 at 1 05 27 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/7c115882-d41f-4f2e-8844-3355deac921d">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
