### PR TITLE
Product Editor: Show error notice when error occurs uploading an image via drop on Images

### DIFF
--- a/packages/js/components/changelog/fix-product-editor-images-drop-error
+++ b/packages/js/components/changelog/fix-product-editor-images-drop-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Export MediaUploaderErrorCallback type.

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -23,7 +23,7 @@ export { ImageGallery, ImageGalleryItem } from './image-gallery';
 export { default as ImageUpload } from './image-upload';
 export { Link } from './link';
 export { default as List } from './list';
-export { MediaUploader } from './media-uploader';
+export { MediaUploader, MediaUploaderErrorCallback } from './media-uploader';
 export { default as MenuItem } from './ellipsis-menu/menu-item';
 export { default as MenuTitle } from './ellipsis-menu/menu-title';
 export { default as OrderStatus } from './order-status';

--- a/packages/js/components/src/media-uploader/media-uploader.tsx
+++ b/packages/js/components/src/media-uploader/media-uploader.tsx
@@ -9,10 +9,16 @@ import {
 	MediaUpload,
 	uploadMedia as wpUploadMedia,
 	UploadMediaOptions,
-	UploadMediaErrorCode,
 } from '@wordpress/media-utils';
 
+/**
+ * Internal dependencies
+ */
+import { ErrorType } from './types';
+
 const DEFAULT_ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+export type MediaUploaderErrorCallback = ( error: ErrorType ) => void;
 
 type MediaUploaderProps = {
 	allowedMediaTypes?: string[];
@@ -30,11 +36,7 @@ type MediaUploaderProps = {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		value: ( { id: number } & { [ k: string ]: any } ) | MediaItem[]
 	) => void;
-	onError?: ( error: {
-		code: UploadMediaErrorCode;
-		message: string;
-		file: File;
-	} ) => void;
+	onError?: MediaUploaderErrorCallback;
 	onMediaGalleryOpen?: () => void;
 	onUpload?: ( files: MediaItem | MediaItem[] ) => void;
 	onFileUploadChange?: ( files: MediaItem | MediaItem[] ) => void;

--- a/packages/js/components/src/media-uploader/types.ts
+++ b/packages/js/components/src/media-uploader/types.ts
@@ -10,4 +10,4 @@ export type ErrorType = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type File = { id: number } & { [ k: string ]: any };
+export type File = { id?: number } & { [ k: string ]: any };

--- a/packages/js/product-editor/changelog/fix-product-editor-images-drop-error
+++ b/packages/js/product-editor/changelog/fix-product-editor-images-drop-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show error notice when unable to upload an image.

--- a/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
@@ -5,6 +5,7 @@ import { DragEvent } from 'react';
 import { __ } from '@wordpress/i18n';
 import { BlockAttributes } from '@wordpress/blocks';
 import { DropZone } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { createElement, useState } from '@wordpress/element';
 import { Icon, trash } from '@wordpress/icons';
@@ -12,6 +13,7 @@ import { MediaItem } from '@wordpress/media-utils';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	MediaUploader,
+	MediaUploaderErrorCallback,
 	ImageGallery,
 	ImageGalleryItem,
 } from '@woocommerce/components';
@@ -62,6 +64,8 @@ export function ImageBlockEdit( {
 				: Boolean( propertyValue ),
 		} ),
 	} );
+
+	const { createErrorNotice } = useDispatch( 'core/notices' );
 
 	function orderImages( newOrder: JSX.Element[] ) {
 		if ( Array.isArray( propertyValue ) ) {
@@ -186,6 +190,12 @@ export function ImageBlockEdit( {
 		}
 	}
 
+	const handleMediaUploaderError: MediaUploaderErrorCallback = function (
+		error
+	) {
+		createErrorNotice( `Error uploading image:\n${ error.message }` );
+	};
+
 	const isImageGalleryVisible =
 		propertyValue !== null &&
 		( ! Array.isArray( propertyValue ) || propertyValue.length > 0 );
@@ -219,7 +229,7 @@ export function ImageBlockEdit( {
 										: propertyValue?.id ?? undefined
 								}
 								multipleSelect={ multiple ? 'add' : false }
-								onError={ () => null }
+								onError={ handleMediaUploaderError }
 								onFileUploadChange={ uploadHandler(
 									'product_images_add_via_file_upload_area'
 								) }

--- a/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
@@ -195,9 +195,9 @@ export function ImageBlockEdit( {
 	) {
 		createErrorNotice(
 			sprintf(
-				// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
-				/* translators: %s is the detailed error message */
-				__( 'Error uploading image:\n%s', 'woocommerce' ),
+				/* translators: %1$s is a line break, %2$s is the detailed error message */
+				__( 'Error uploading image:%1$s%2$s', 'woocommerce' ),
+				'\n',
 				error.message
 			)
 		);

--- a/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { DragEvent } from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { BlockAttributes } from '@wordpress/blocks';
 import { DropZone } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -193,7 +193,14 @@ export function ImageBlockEdit( {
 	const handleMediaUploaderError: MediaUploaderErrorCallback = function (
 		error
 	) {
-		createErrorNotice( `Error uploading image:\n${ error.message }` );
+		createErrorNotice(
+			sprintf(
+				// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
+				/* translators: %s is the detailed error message */
+				__( 'Error uploading image:\n%s', 'woocommerce' ),
+				error.message
+			)
+		);
 	};
 
 	const isImageGalleryVisible =


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR shows errors that occur when uploading an image via drop on the Images section by displaying an error notice (snackbar).


Closes #48393.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**), and the Gutenberg plugin installed...

1. Go to **Products** > **Add New**
2. Drag a `.txt` file to the Images section
3. Verify an error notice is shown and the file isn't uploaded.

https://github.com/woocommerce/woocommerce/assets/2098816/94544d40-7eea-4f74-a13f-ac5abfafa025

Note: If multiple invalid files are dropped, an error notice will be shown for each one...

https://github.com/woocommerce/woocommerce/assets/2098816/6eb20165-77c7-435b-a790-bced975faf9e


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
