### PR TITLE
Product Editor: Respect system setting for maximum upload file size for Images and Downloads

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-max-upload-size
+++ b/packages/js/product-editor/changelog/fix-product-editor-max-upload-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect system setting for maximum image upload file size.

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/downloads-menu.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/downloads-menu.tsx
@@ -18,6 +18,7 @@ export function DownloadsMenu( {
 	maxUploadFileSize,
 	onUploadSuccess,
 	onUploadError,
+	onLinkError,
 }: DownloadsMenuProps ) {
 	return (
 		<Dropdown
@@ -54,11 +55,14 @@ export function DownloadsMenu( {
 						/>
 
 						<InsertUrlMenuItem
-							onUploadSuccess={ ( files ) => {
+							onLinkSuccess={ ( files ) => {
 								onUploadSuccess( files );
 								onClose();
 							} }
-							onUploadError={ onUploadError }
+							onLinkError={ ( error ) => {
+								onLinkError( error );
+								onClose();
+							} }
 						/>
 					</MenuGroup>
 				</div>

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/downloads-menu.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/downloads-menu.tsx
@@ -47,7 +47,10 @@ export function DownloadsMenu( {
 								onUploadSuccess( files );
 								onClose();
 							} }
-							onUploadError={ onUploadError }
+							onUploadError={ ( error ) => {
+								onUploadError( error );
+								onClose();
+							} }
 						/>
 
 						<InsertUrlMenuItem

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/types.ts
@@ -4,9 +4,15 @@
 import { MediaItem } from '@wordpress/media-utils';
 import { MediaUploaderErrorCallback } from '@woocommerce/components';
 
+/**
+ * Internal dependencies
+ */
+import { InsertUrlLinkErrorCallback } from '../insert-url-menu-item';
+
 export type DownloadsMenuProps = {
 	allowedTypes?: string[];
 	maxUploadFileSize?: number;
 	onUploadSuccess( files: MediaItem[] ): void;
 	onUploadError: MediaUploaderErrorCallback;
+	onLinkError: InsertUrlLinkErrorCallback;
 };

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/types.ts
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import { MediaItem } from '@wordpress/media-utils';
+import { MediaUploaderErrorCallback } from '@woocommerce/components';
 
 export type DownloadsMenuProps = {
 	allowedTypes?: string[];
 	maxUploadFileSize?: number;
 	onUploadSuccess( files: MediaItem[] ): void;
-	onUploadError( error: unknown ): void;
+	onUploadError: MediaUploaderErrorCallback;
 };

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
@@ -30,7 +30,7 @@ export interface Image {
 }
 
 export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
-	downloableItem,
+	downloadableItem,
 	onCancel,
 	onChange,
 	onRemove,
@@ -40,7 +40,7 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 	const [ isCopingToClipboard, setIsCopingToClipboard ] =
 		useState< boolean >( false );
 
-	const { id = 0, file = '', name = '' } = downloableItem;
+	const { id = 0, file = '', name = '' } = downloadableItem;
 
 	const onCopySuccess = () => {
 		createNotice(

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
@@ -4,7 +4,7 @@
 import { ProductDownload } from '@woocommerce/data';
 
 export type EditDownloadsModalProps = {
-	downloableItem: ProductDownload;
+	downloadableItem: ProductDownload;
 	maxUploadFileSize?: number;
 	onCancel: () => void;
 	onRemove: () => void;

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
@@ -5,7 +5,6 @@ import { ProductDownload } from '@woocommerce/data';
 
 export type EditDownloadsModalProps = {
 	downloadableItem: ProductDownload;
-	maxUploadFileSize?: number;
 	onCancel: () => void;
 	onRemove: () => void;
 	onSave: () => void;

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { ProductDownload } from '@woocommerce/data';
-import { MediaItem } from '@wordpress/media-utils';
 
 export type EditDownloadsModalProps = {
 	downloableItem: ProductDownload;
@@ -11,6 +10,4 @@ export type EditDownloadsModalProps = {
 	onRemove: () => void;
 	onSave: () => void;
 	onChange: ( name: string ) => void;
-	onUploadSuccess( files: MediaItem[] ): void;
-	onUploadError( error: unknown ): void;
 };

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button, Spinner } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -13,7 +13,12 @@ import {
 import { closeSmall } from '@wordpress/icons';
 import { MediaItem } from '@wordpress/media-utils';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { ListItem, MediaUploader, Sortable } from '@woocommerce/components';
+import {
+	ListItem,
+	MediaUploader,
+	MediaUploaderErrorCallback,
+	Sortable,
+} from '@woocommerce/components';
 import { Product, ProductDownload } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -164,13 +169,16 @@ export function DownloadBlockEdit( {
 		};
 	}
 
-	function handleUploadError( error: unknown ) {
+	const handleUploadError: MediaUploaderErrorCallback = function ( error ) {
 		createErrorNotice(
-			typeof error === 'string'
-				? error
-				: __( 'There was an error uploading files', 'woocommerce' )
+			sprintf(
+				/* translators: %1$s is a line break, %2$s is the detailed error message */
+				__( 'Error uploading file:%1$s%2$s', 'woocommerce' ),
+				'\n',
+				error.message
+			)
 		);
-	}
+	};
 
 	function editDownloadsModalSaveHandler( value: ProductDownload ) {
 		return function handleEditDownloadsModalSave() {

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -274,6 +274,9 @@ export function DownloadBlockEdit( {
 					buttonText=""
 					allowedMediaTypes={ allowedTypes }
 					multipleSelect={ 'add' }
+					maxUploadFileSize={
+						window.productBlockEditorSettings?.maxUploadFileSize
+					}
 					onUpload={ handleFileUpload }
 					onFileUploadChange={ handleFileUpload }
 					onError={ handleUploadError }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -353,7 +353,7 @@ export function DownloadBlockEdit( {
 			) }
 			{ selectedDownload && (
 				<EditDownloadsModal
-					downloableItem={ { ...selectedDownload } }
+					downloadableItem={ { ...selectedDownload } }
 					onCancel={ () => setSelectedDownload( null ) }
 					onRemove={ () => {
 						removeDownload( selectedDownload );

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -135,35 +135,6 @@ export function DownloadBlockEdit( {
 		}
 	}
 
-	function handleFileReplace( files: MediaItem | MediaItem[] ) {
-		if (
-			! Array.isArray( files ) ||
-			! files?.length ||
-			files[ 0 ]?.id === undefined
-		) {
-			return;
-		}
-
-		const uploadedFile = {
-			id: stringifyId( files[ 0 ].id ),
-			file: files[ 0 ].url,
-			name:
-				files[ 0 ].title ||
-				files[ 0 ].alt ||
-				files[ 0 ].caption ||
-				getFileName( files[ 0 ].url ),
-		};
-		const stringifyIds = downloads.map( ( download ) => {
-			if ( download.file === selectedDownload?.file ) {
-				return stringifyEntityId( uploadedFile );
-			}
-			return stringifyEntityId( download );
-		} );
-
-		setDownloads( stringifyIds );
-		setSelectedDownload( uploadedFile );
-	}
-
 	function removeDownload( download: ProductDownload ) {
 		const otherDownloads = downloads.reduce< ProductDownload[] >(
 			function removeDownloadElement(

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -366,8 +366,6 @@ export function DownloadBlockEdit( {
 						} );
 					} }
 					onSave={ editDownloadsModalSaveHandler( selectedDownload ) }
-					onUploadSuccess={ handleFileReplace }
-					onUploadError={ handleUploadError }
 				/>
 			) }
 		</div>

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -38,6 +38,7 @@ import {
 import { EditDownloadsModal } from './edit-downloads-modal';
 import { UploadImage } from './upload-image';
 import { SectionActions } from '../../../components/block-slot-fill';
+import { InsertUrlLinkErrorCallback } from './insert-url-menu-item';
 
 function getFileName( url?: string ) {
 	const [ name ] = url?.split( '/' ).reverse() ?? [];
@@ -180,6 +181,18 @@ export function DownloadBlockEdit( {
 		);
 	};
 
+	const handleLinkError: InsertUrlLinkErrorCallback = function (
+		error: string
+	) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %1$s is a line break, %2$s is the detailed error message */
+				__( 'Error linking file:%1$s%2$s', 'woocommerce' ),
+				'\n',
+				error
+			)
+		);
+	};
 	function editDownloadsModalSaveHandler( value: ProductDownload ) {
 		return function handleEditDownloadsModalSave() {
 			const newDownloads = downloads
@@ -209,6 +222,7 @@ export function DownloadBlockEdit( {
 					allowedTypes={ allowedTypes }
 					onUploadSuccess={ handleFileUpload }
 					onUploadError={ handleUploadError }
+					onLinkError={ handleLinkError }
 				/>
 			</SectionActions>
 

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/insert-url-menu-item/insert-url-menu-item.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/insert-url-menu-item/insert-url-menu-item.tsx
@@ -33,8 +33,8 @@ function validateInput( input: HTMLInputElement ) {
 }
 
 export function InsertUrlMenuItem( {
-	onUploadSuccess,
-	onUploadError,
+	onLinkSuccess,
+	onLinkError,
 }: InsertUrlMenuItemProps ) {
 	function handleSubmit( event: FormEvent< HTMLFormElement > ) {
 		event.preventDefault();
@@ -50,9 +50,9 @@ export function InsertUrlMenuItem( {
 				url,
 			} as MediaItem;
 
-			onUploadSuccess( [ mediaItem ] );
+			onLinkSuccess( [ mediaItem ] );
 		} else {
-			onUploadError( urlInput.validationMessage );
+			onLinkError( urlInput.validationMessage );
 		}
 	}
 

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/insert-url-menu-item/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/insert-url-menu-item/types.ts
@@ -3,7 +3,9 @@
  */
 import { MediaItem } from '@wordpress/media-utils';
 
+export type InsertUrlLinkErrorCallback = ( error: string ) => void;
+
 export type InsertUrlMenuItemProps = {
-	onUploadSuccess( files: MediaItem[] ): void;
-	onUploadError( error: unknown ): void;
+	onLinkSuccess( files: MediaItem[] ): void;
+	onLinkError: InsertUrlLinkErrorCallback;
 };

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/upload-files-menu-item/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/upload-files-menu-item/types.ts
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import { MediaItem } from '@wordpress/media-utils';
+import { MediaUploaderErrorCallback } from '@woocommerce/components';
 
 export type UploadFilesMenuItemProps = {
 	allowedTypes?: string[];
 	maxUploadFileSize?: number;
 	onUploadSuccess( files: MediaItem[] ): void;
-	onUploadError( error: unknown ): void;
+	onUploadError: MediaUploaderErrorCallback;
 };

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/upload-files-menu-item/upload-files-menu-item.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/upload-files-menu-item/upload-files-menu-item.tsx
@@ -15,10 +15,15 @@ import { UploadFilesMenuItemProps } from './types';
 
 export function UploadFilesMenuItem( {
 	allowedTypes,
-	maxUploadFileSize = 10000000,
+	maxUploadFileSize,
 	onUploadSuccess,
 	onUploadError,
 }: UploadFilesMenuItemProps ) {
+	const resolvedMaxUploadFileSize =
+		maxUploadFileSize ||
+		window.productBlockEditorSettings?.maxUploadFileSize ||
+		10 * 1024 * 1024; // 10 MB by default if not set and not provided by the settings
+
 	function handleFormFileUploadChange(
 		event: ChangeEvent< HTMLInputElement >
 	) {
@@ -27,7 +32,7 @@ export function UploadFilesMenuItem( {
 		uploadMedia( {
 			allowedTypes,
 			filesList,
-			maxUploadFileSize,
+			maxUploadFileSize: resolvedMaxUploadFileSize,
 			onFileChange: onUploadSuccess,
 			onError: onUploadError,
 			additionalData: {

--- a/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/images/edit.tsx
@@ -236,6 +236,10 @@ export function ImageBlockEdit( {
 										: propertyValue?.id ?? undefined
 								}
 								multipleSelect={ multiple ? 'add' : false }
+								maxUploadFileSize={
+									window.productBlockEditorSettings
+										?.maxUploadFileSize
+								}
 								onError={ handleMediaUploaderError }
 								onFileUploadChange={ uploadHandler(
 									'product_images_add_via_file_upload_area'

--- a/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/types.ts
+++ b/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/types.ts
@@ -5,19 +5,8 @@ import {
 	FormFileUpload,
 	MenuItem as DropdownMenuItem,
 } from '@wordpress/components';
-import {
-	MediaItem,
-	UploadMediaErrorCode,
-	UploadMediaOptions,
-} from '@wordpress/media-utils';
-
-type ErrorType = {
-	code: UploadMediaErrorCode;
-	message: string;
-	file: File;
-};
-
-export type UploadFilesMenuItemErrorCallback = ( error: ErrorType ) => void;
+import { MediaItem, UploadMediaOptions } from '@wordpress/media-utils';
+import { MediaUploaderErrorCallback } from '@woocommerce/components';
 
 export type UploadFilesMenuItemProps = Omit<
 	FormFileUpload.Props,
@@ -35,5 +24,5 @@ export type UploadFilesMenuItemProps = Omit<
 	> & {
 		onUploadProgress?( files: MediaItem[] ): void;
 		onUploadSuccess( files: MediaItem[] ): void;
-		onUploadError: UploadFilesMenuItemErrorCallback;
+		onUploadError: MediaUploaderErrorCallback;
 	};

--- a/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/types.ts
+++ b/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/types.ts
@@ -5,7 +5,19 @@ import {
 	FormFileUpload,
 	MenuItem as DropdownMenuItem,
 } from '@wordpress/components';
-import { MediaItem, UploadMediaOptions } from '@wordpress/media-utils';
+import {
+	MediaItem,
+	UploadMediaErrorCode,
+	UploadMediaOptions,
+} from '@wordpress/media-utils';
+
+type ErrorType = {
+	code: UploadMediaErrorCode;
+	message: string;
+	file: File;
+};
+
+export type UploadFilesMenuItemErrorCallback = ( error: ErrorType ) => void;
 
 export type UploadFilesMenuItemProps = Omit<
 	FormFileUpload.Props,
@@ -23,5 +35,5 @@ export type UploadFilesMenuItemProps = Omit<
 	> & {
 		onUploadProgress?( files: MediaItem[] ): void;
 		onUploadSuccess( files: MediaItem[] ): void;
-		onUploadError( error: unknown ): void;
+		onUploadError: UploadFilesMenuItemErrorCallback;
 	};

--- a/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/upload-files-menu-item.tsx
+++ b/packages/js/product-editor/src/components/menu-items/upload-files-menu-item/upload-files-menu-item.tsx
@@ -16,7 +16,7 @@ import type { UploadFilesMenuItemProps } from './types';
 export function UploadFilesMenuItem( {
 	// UploadMediaOptions
 	allowedTypes,
-	maxUploadFileSize = 10000000,
+	maxUploadFileSize,
 	wpAllowedMimeTypes,
 	additionalData,
 	// MenuItem.Props
@@ -31,6 +31,11 @@ export function UploadFilesMenuItem( {
 	// FormFileUpload.Props
 	...props
 }: UploadFilesMenuItemProps ) {
+	const resolvedMaxUploadFileSize =
+		maxUploadFileSize ||
+		window.productBlockEditorSettings?.maxUploadFileSize ||
+		10 * 1024 * 1024; // 10 MB by default if not set and not provided by the settings
+
 	function handleFormFileUploadChange(
 		event: ChangeEvent< HTMLInputElement >
 	) {
@@ -39,7 +44,7 @@ export function UploadFilesMenuItem( {
 		uploadMedia( {
 			allowedTypes,
 			filesList,
-			maxUploadFileSize,
+			maxUploadFileSize: resolvedMaxUploadFileSize,
 			additionalData,
 			wpAllowedMimeTypes,
 			onFileChange( files ) {

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
@@ -2,15 +2,19 @@
  * External dependencies
  */
 import { Dropdown, MenuGroup } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createElement, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { MediaItem } from '@wordpress/media-utils';
 
 /**
  * Internal dependencies
  */
 import { MediaLibraryMenuItem } from '../../menu-items/media-library-menu-item';
-import { UploadFilesMenuItem } from '../../menu-items/upload-files-menu-item';
+import {
+	UploadFilesMenuItem,
+	UploadFilesMenuItemErrorCallback,
+} from '../../menu-items/upload-files-menu-item';
 import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
 import { VariationQuickUpdateMenuItem } from '../variation-actions-menus';
 import type { ImageActionsMenuProps } from './types';
@@ -22,6 +26,8 @@ export function ImageActionsMenu( {
 	...props
 }: ImageActionsMenuProps ) {
 	const [ isUploading, setIsUploading ] = useState( false );
+
+	const { createErrorNotice } = useDispatch( 'core/notices' );
 
 	function uploadSuccessHandler( onClose: () => void ) {
 		return function handleUploadSuccess( files: MediaItem[] ) {
@@ -39,6 +45,19 @@ export function ImageActionsMenu( {
 			onClose();
 		};
 	}
+
+	const uploadErrorHandler: UploadFilesMenuItemErrorCallback = function (
+		error
+	) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %1$s is a line break, %2$s is the detailed error message */
+				__( 'Error uploading file:%1$s%2$s', 'woocommerce' ),
+				'\n',
+				error.message
+			)
+		);
+	};
 
 	function mediaLibraryMenuItemSelectHandler( onClose: () => void ) {
 		return function handleMediaLibraryMenuItemSelect( media: never ) {
@@ -79,7 +98,8 @@ export function ImageActionsMenu( {
 								onClose();
 							} }
 							onUploadSuccess={ uploadSuccessHandler( onClose ) }
-							onUploadError={ () => {
+							onUploadError={ ( error ) => {
+								uploadErrorHandler( error );
 								setIsUploading( false );
 								onClose();
 							} }

--- a/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/image-actions-menu/image-actions-menu.tsx
@@ -6,15 +6,13 @@ import { useDispatch } from '@wordpress/data';
 import { createElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { MediaItem } from '@wordpress/media-utils';
+import { MediaUploaderErrorCallback } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
 import { MediaLibraryMenuItem } from '../../menu-items/media-library-menu-item';
-import {
-	UploadFilesMenuItem,
-	UploadFilesMenuItemErrorCallback,
-} from '../../menu-items/upload-files-menu-item';
+import { UploadFilesMenuItem } from '../../menu-items/upload-files-menu-item';
 import { mapUploadImageToImage } from '../../../utils/map-upload-image-to-image';
 import { VariationQuickUpdateMenuItem } from '../variation-actions-menus';
 import type { ImageActionsMenuProps } from './types';
@@ -46,9 +44,7 @@ export function ImageActionsMenu( {
 		};
 	}
 
-	const uploadErrorHandler: UploadFilesMenuItemErrorCallback = function (
-		error
-	) {
+	const uploadErrorHandler: MediaUploaderErrorCallback = function ( error ) {
 		createErrorNotice(
 			sprintf(
 				/* translators: %1$s is a line break, %2$s is the detailed error message */

--- a/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/test/use-product-template.test.ts
@@ -77,6 +77,7 @@ describe( 'useProductTemplate', () => {
 					},
 				},
 			],
+			maxUploadFileSize: 100 * 1024 * 1024, // 100 MB
 		};
 	} );
 

--- a/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
+++ b/packages/js/product-editor/src/hooks/use-product-template/use-product-template.ts
@@ -8,14 +8,6 @@ import { Product } from '@woocommerce/data';
  */
 import { Metadata, ProductTemplate } from '../../types';
 
-declare global {
-	interface Window {
-		productBlockEditorSettings: {
-			productTemplates: ProductTemplate[];
-		};
-	}
-}
-
 const matchesAllTemplateMetaFields = (
 	templateMeta: Metadata< string >[],
 	productMeta: Metadata< string >[]

--- a/packages/js/product-editor/typings/global.d.ts
+++ b/packages/js/product-editor/typings/global.d.ts
@@ -1,5 +1,9 @@
 declare global {
 	interface Window {
+		productBlockEditorSettings: {
+			productTemplates: ProductTemplate[];
+			maxUploadFileSize: number;
+		};
 		wcAdminFeatures: Record< string, boolean >;
 		wcTracks: {
 			isEnabled: boolean;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR uses the system defined maximum upload file size when not using the Media Library. The Media Library already respected the system defined maximum update file size, so those uses were already covered.

In addition to the main change to respect the maximum upload file size, the following changes were made in this PR:

- Refactor error handling to use types
- Improve error notices shown for failed uploaded files
- Add error notices for failed variation image uploads

#### Dropping images on the Images section to upload them

<img width="676" alt="Screenshot 2024-06-14 at 10 35 38" src="https://github.com/woocommerce/woocommerce/assets/2098816/cdb1a1c4-2c0c-4f39-b616-bc1446ff5cb4">

#### Dropping files on the Downloads section to upload them

<img width="676" alt="Screenshot 2024-06-14 at 10 37 37" src="https://github.com/woocommerce/woocommerce/assets/2098816/4e975324-7208-43cf-920a-f23aa6c08610">

#### Using the **Downloads** > **Add new** > **Upload** menu item to upload a file

<img width="672" alt="Screenshot 2024-06-14 at 10 18 51" src="https://github.com/woocommerce/woocommerce/assets/2098816/790f229f-fd0c-4eb2-aac2-cbc77ab39a1f">

#### Using the **Variations** > **+** > **Upload** menu item to upload an image

<img width="825" alt="Screenshot 2024-06-14 at 10 21 09" src="https://github.com/woocommerce/woocommerce/assets/2098816/3804a678-1bdd-48f5-a253-b01ad0b8a6bc">

Closes #48398.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Drag an image larger than 10 MB to the Images section (note: to see your current maximum image upload file size, you can go to **Choose an image** > **Upload files** and see the current limit).
3. Verify that the image uploads (note: the UI currently offers absolutely no progress indicator, see #38398, so just wait!).

https://github.com/woocommerce/woocommerce/assets/2098816/1d20c4f4-c8a8-4ba4-86b9-1e7d4483bfbc

4. Change the upload size limit via code such as the following (you can use the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/) to "run snippet everywhere"):

```php
<?php

add_filter(
	'upload_size_limit',
	function() {
		return 1 * 1024 * 1024; // 1 MB
	}
);
```

5. Drag an image larger than 1 MB to the **Images** section.
6. Verify that an error notice is shown and the image does not upload.
7. Drag a file larger than 1 MB to the **Downloads** section.
8. Verify that an error notice is shown and the file does not upload.
9. Use  **Downloads** > **Add new** > **Upload** menu item to pick a file larger than 1 MB.
10. Verify that an error notice is shown and the file does not upload.
11. Use **Downloads** > **Add new** > **Insert from URL** menu item to enter an invalid URL.
12. Verify that an error notice is shown and the link is not added.
13. Create some **Variations**.
14. Use **Variations** > **+** > **Upload** menu item on an individual variation in the variations list to pick an image larger than 1 MB.
15. Verify that an error notice is shown and the file does not upload.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
