### PR TITLE
Revise community review policy.

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -81,6 +81,13 @@
 "plugins/woocommerce/**/*":
   - team: proton
 
+"plugins/woocommerce/templates/**/*":
+  - team: rubik
+  - team: woo-fse
+
+"plugins/woocommerce/templates/emails/**/*":
+  - team: proton
+
 "plugins/woocommerce/src/Admin/**/*":
   - team: mothra
   - team: ghidorah


### PR DESCRIPTION
In general, Proton shouldn't handle classic storefront, cart or checkout work so it seems to make sense to update the community PR assignments accordingly. At the same time, I wanted to make an exception for changes touching email templates.

I think this works in a sort of cascading fashion, but I'm also unfamiliar with how this pieces together—so please do point me in the right direction if I've erred.
