### PR TITLE
[e2e tests] Update the report configuration for core e2e tests and add a new workflow call for report publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,8 @@ jobs:
                     REPORT_TITLE=$(echo "$REPORT_TITLE" | tr -cd '[:alnum:] ')
                   fi
                 
+                  echo "$REPORT_TITLE"
+                
                   gh workflow run report.yml \
                     -f artifact=$REPORT_NAME \
                     -f run_id=$GITHUB_RUN_ID \
@@ -345,7 +347,7 @@ jobs:
                     -f commit_sha=$GITHUB_SHA \
                     -f repository=$GITHUB_REPOSITORY \
                     -f suite=$REPORT_NAME \
-                    -f report_title=$REPORT_TITLE \
+                    -f report_title="$REPORT_TITLE" \
                     --repo woocommerce/woocommerce-test-reports
                 
             - name: 'Publish report to dashboard (deprecated)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,9 +330,10 @@ jobs:
                   EVENT_NAME: ${{ inputs.trigger == '' && github.event_name || inputs.trigger }}
               run: |
                   if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    REPORT_TITLE="$PR_TITLE"
+                    REPORT_TITLE=$(echo "$PR_TITLE" | tr -cd '[:alnum:] ')
                   else
                     REPORT_TITLE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
+                    REPORT_TITLE=$(echo "$REPORT_TITLE" | tr -cd '[:alnum:] ')
                   fi
                 
                   gh workflow run report.yml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,8 +332,11 @@ jobs:
                   if [[ "${{ github.event_name }}" == "pull_request" ]]; then
                     REPORT_TITLE="$PR_TITLE"
                     REF_NAME="$GITHUB_HEAD_REF"
-                  else
+                  elif [[ "${{ github.event_name }}" == "push" ]]; then
                     REPORT_TITLE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
+                    REF_NAME="$GITHUB_REF_NAME"
+                  else
+                    REPORT_TITLE="$EVENT_NAME"
                     REF_NAME="$GITHUB_REF_NAME"
                   fi
                 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,33 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.REPORTS_TOKEN }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPORT_NAME: ${{ matrix.report }}
+                  HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+                  EVENT_NAME: ${{ inputs.trigger == '' && github.event_name || inputs.trigger }}
+              run: |
+                  if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                    REPORT_TITLE="$PR_TITLE"
+                  else
+                    REPORT_TITLE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
+                  fi
+                
+                  gh workflow run report.yml \
+                    -f artifact=$REPORT_NAME \
+                    -f run_id=$GITHUB_RUN_ID \
+                    -f event=$EVENT_NAME \
+                    -f pr_number=$PR_NUMBER \
+                    -f ref_name=$GITHUB_REF_NAME \
+                    -f commit_sha=$GITHUB_SHA \
+                    -f repository=$GITHUB_REPOSITORY \
+                    -f suite=$REPORT_NAME \
+                    -f report_title=$REPORT_TITLE \
+                    --repo woocommerce/woocommerce-test-reports
+                
+            - name: 'Publish report to dashboard (deprecated)'
+              env:
+                  GH_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
                   RUN_ID: ${{ github.run_id }}
                   REPORT_NAME: ${{ matrix.report }}
               if: ${{ contains(matrix.report, 'e2e') }} # temporary until we adapt the woocommerce-test-reports side to not care about the test type

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,23 +330,20 @@ jobs:
                   EVENT_NAME: ${{ inputs.trigger == '' && github.event_name || inputs.trigger }}
               run: |
                   if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                    REPORT_TITLE=$(echo "$PR_TITLE" | tr -cd '[:alnum:] ')
+                    REPORT_TITLE="$PR_TITLE"
                   else
                     REPORT_TITLE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
-                    REPORT_TITLE=$(echo "$REPORT_TITLE" | tr -cd '[:alnum:] ')
                   fi
                 
-                  echo "$REPORT_TITLE"
-                
                   gh workflow run report.yml \
-                    -f artifact=$REPORT_NAME \
-                    -f run_id=$GITHUB_RUN_ID \
-                    -f event=$EVENT_NAME \
-                    -f pr_number=$PR_NUMBER \
-                    -f ref_name=$GITHUB_REF_NAME \
-                    -f commit_sha=$GITHUB_SHA \
-                    -f repository=$GITHUB_REPOSITORY \
-                    -f suite=$REPORT_NAME \
+                    -f artifact="$REPORT_NAME" \
+                    -f run_id="$GITHUB_RUN_ID" \
+                    -f event="$EVENT_NAME" \
+                    -f pr_number="$PR_NUMBER" \
+                    -f ref_name="$GITHUB_REF_NAME" \
+                    -f commit_sha="$GITHUB_SHA" \
+                    -f repository="$GITHUB_REPOSITORY" \
+                    -f suite="$REPORT_NAME" \
                     -f report_title="$REPORT_TITLE" \
                     --repo woocommerce/woocommerce-test-reports
                 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,8 +331,10 @@ jobs:
               run: |
                   if [[ "${{ github.event_name }}" == "pull_request" ]]; then
                     REPORT_TITLE="$PR_TITLE"
+                    REF_NAME="$GITHUB_HEAD_REF"
                   else
                     REPORT_TITLE=`echo "$HEAD_COMMIT_MESSAGE" | head -1`
+                    REF_NAME="$GITHUB_REF_NAME"
                   fi
                 
                   gh workflow run report.yml \
@@ -340,7 +342,7 @@ jobs:
                     -f run_id="$GITHUB_RUN_ID" \
                     -f event="$EVENT_NAME" \
                     -f pr_number="$PR_NUMBER" \
-                    -f ref_name="$GITHUB_REF_NAME" \
+                    -f ref_name="$REF_NAME" \
                     -f commit_sha="$GITHUB_SHA" \
                     -f repository="$GITHUB_REPOSITORY" \
                     -f suite="$REPORT_NAME" \

--- a/.github/workflows/tests-daily-run.yml
+++ b/.github/workflows/tests-daily-run.yml
@@ -9,5 +9,5 @@ jobs:
     name: 'Run tests'
     uses: ./.github/workflows/ci.yml
     with:
-      trigger: 'daily-e2e'
+      trigger: 'daily-checks'
     secrets: inherit

--- a/plugins/woocommerce/changelog/e2e-call_new_report_workflow
+++ b/plugins/woocommerce/changelog/e2e-call_new_report_workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: update the report configuration for all core jobs

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -278,6 +278,11 @@
 					],
 					"testEnv": {
 						"start": "env:test"
+					},
+					"report": {
+						"resultsBlobName": "gutenberg-stable-e2e-report",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
 					}
 				},
 				{
@@ -298,6 +303,11 @@
 					],
 					"testEnv": {
 						"start": "env:test"
+					},
+					"report": {
+						"resultsBlobName": "gutenberg-nightly-e2e-report",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
 					}
 				},
 				{
@@ -312,6 +322,11 @@
 					],
 					"testEnv": {
 						"start": "env:test"
+					},
+					"report": {
+						"resultsBlobName": "wcpayments-e2e-report",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
 					}
 				},
 				{
@@ -326,6 +341,11 @@
 					],
 					"testEnv": {
 						"start": "env:test"
+					},
+					"report": {
+						"resultsBlobName": "wc-paypal-payments-e2e-report",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
 					}
 				},
 				{
@@ -340,6 +360,11 @@
 					],
 					"testEnv": {
 						"start": "env:test"
+					},
+					"report": {
+						"resultsBlobName": "wc-services-e2e-report",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
 					}
 				},
 				{
@@ -373,8 +398,9 @@
 						}
 					},
 					"report": {
-						"resultsBlobName": "all-blob-e2e-reports-non-hpos",
-						"resultsPath": "tests/e2e-pw/test-results"
+						"resultsBlobName": "core-e2e-reports-non-hpos",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
 					}
 				},
 				{
@@ -397,7 +423,12 @@
 					},
 					"events": [
 						"release-checks"
-					]
+					],
+					"report": {
+						"resultsBlobName": "core-e2e-report-php-8.1",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
+					}
 				},
 				{
 					"name": "Core e2e tests - WP latest-1",
@@ -419,7 +450,12 @@
 					},
 					"events": [
 						"release-checks"
-					]
+					],
+					"report": {
+						"resultsBlobName": "core-e2e-report-wp-latest-1",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
+					}
 				},
 				{
 					"name": "Core API tests",
@@ -472,6 +508,11 @@
 						"config": {
 							"disableHpos": true
 						}
+					},
+					"report": {
+						"resultsBlobName": "core-api-report-hpos-disabled",
+						"resultsPath": "tests/e2e-pw/test-results",
+						"allure": true
 					}
 				},
 				{

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -272,7 +272,7 @@
 					],
 					"changes": [],
 					"events": [
-						"daily-e2e",
+						"daily-checks",
 						"nightly-checks",
 						"release-checks"
 					],
@@ -298,7 +298,7 @@
 					],
 					"changes": [],
 					"events": [
-						"daily-e2e",
+						"daily-checks",
 						"release-checks"
 					],
 					"testEnv": {
@@ -317,7 +317,7 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"daily-e2e",
+						"daily-checks",
 						"release-checks"
 					],
 					"testEnv": {
@@ -336,7 +336,7 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"daily-e2e",
+						"daily-checks",
 						"release-checks"
 					],
 					"testEnv": {
@@ -355,7 +355,7 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"daily-e2e",
+						"daily-checks",
 						"release-checks"
 					],
 					"testEnv": {

--- a/plugins/woocommerce/tests/api-core-tests/global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/global-setup.js
@@ -143,7 +143,7 @@ module.exports = async ( config ) => {
 				await expect(
 					setupPage.locator( 'p.install-help' )
 				).toContainText(
-					'If you have a plugin in a .zip format, you may install or update it by uploading it here.'
+					'If you have a plugin in a .zip format, you may install or update it by uploading it here'
 				);
 				const [ fileChooser ] = await Promise.all( [
 					setupPage.waitForEvent( 'filechooser' ),

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -24,7 +24,7 @@ module.exports = async ( config ) => {
 		console.log( 'Admin state file deleted successfully.' );
 	} catch ( err ) {
 		if ( err.code === 'ENOENT' ) {
-			console.log( 'Admin state file does not exist.' );
+			console.log( 'Admin state file does not exist' );
 		} else {
 			console.log( 'Admin state file could not be deleted: ' + err );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/48319

A new workflow that creates reports on the woocommerce-test-reports repo side was created. To start getting data on new reports I added a call to this new workflow on parallel with the old one that will be deprecated once the new dashboard is in a good state to make the switch.

I also configured the report objects for all core e2e and api jobs, so we can create reports for those too.

### How to test the changes in this Pull Request:

Check CI. Is should be green. The reporting job should not fail.
