### PR TITLE
Fix LYS private link query parameter when permalink is plain

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -70,16 +70,23 @@ const SiteVisibility = () => {
 	const [ copyLinkText, setCopyLinkText ] = useState( copyLink );
 
 	const getPrivateLink = () => {
+		const settings = window?.wcSettings;
+		const homeUrl = settings?.homeUrl;
+		const urlObject = new URL( homeUrl );
+
 		if ( storePagesOnly === 'yes' ) {
-			return (
-				window?.wcSettings?.admin?.siteVisibilitySettings
-					?.shop_permalink +
-				'?woo-share=' +
-				shareKey
-			);
+			const shopPermalink =
+				settings?.admin?.siteVisibilitySettings?.shop_permalink;
+			if ( shopPermalink ) {
+				urlObject.href = shopPermalink;
+			}
 		}
 
-		return window?.wcSettings?.homeUrl + '?woo-share=' + shareKey;
+		const params = new URLSearchParams( urlObject.search );
+		params.set( 'woo-share', shareKey );
+		urlObject.search = params.toString();
+
+		return urlObject.toString();
 	};
 
 	const copyClipboardRef = useCopyToClipboard( getPrivateLink, () => {

--- a/plugins/woocommerce/changelog/fix-48323-remove-unintended-query-param
+++ b/plugins/woocommerce/changelog/fix-48323-remove-unintended-query-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix LYS private link URL parameter regardless of permalink settings


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #48323

### How to test the changes in this Pull Request:

1. In a fresh store, go to `Settings > Permalinks`
2. Select `Plain` and save
3. Go to `WooCommerce > Site visibility`
4. Enable `Coming soon`, `Restrict to store pages only`, and `Share your site with a private link`
5. Observe the private link contains only one `?` character, ex: `http://localhost/?page_id=2&woo-share=...`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
