### PR TITLE
[Experimental] Product Filters: add layout and block spacing support

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/block.json
@@ -29,8 +29,10 @@
 			"default": {
 				"type": "flex",
 				"orientation": "vertical",
-				"justifyContent": "stretch"
+				"justifyContent": "stretch",
+				"verticalAlignment": "top"
 			},
+			"allowVerticalAlignment": true,
 			"allowInheriting": false
 		},
 		"spacing": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/block.json
@@ -24,6 +24,17 @@
 		"typography": {
 			"fontSize": true,
 			"textAlign": true
+		},
+		"layout": {
+			"default": {
+				"type": "flex",
+				"orientation": "vertical",
+				"justifyContent": "stretch"
+			},
+			"allowInheriting": false
+		},
+		"spacing": {
+			"blockGap": true
 		}
 	},
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce-blocks/docs/contributors/e2e-guidelines.md
+++ b/plugins/woocommerce-blocks/docs/contributors/e2e-guidelines.md
@@ -14,10 +14,8 @@ pnpm --filter='@woocommerce/plugin-woocommerce' watch:build
 
 Next, run the following command from the [`woocommerce-blocks` plugin folder](../../../woocommerce-blocks/) to start a `wp-env` instance and install all the testing products, languages, etc.:
 
-```shell
+````shell
 cd plugins/woocommerce-blocks/
-pnpm env:start
-```
 
 > [!TIP]
 > If you want to start/stop the environment without running the whole setup, use the native `wp-env` commands directly, e.g. `npx wp-env start` and `npx wp-env stop`.
@@ -30,14 +28,14 @@ Occasionally, you'll need to reset the environment, e.g., when testing products 
 
 ```shell
 pnpm env:restart
-```
+````
 
 ## Running and debugging tests
 
 > [!NOTE]
 > If you're using VSCode, we recommend using the [Playwright Test](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) extension to run and debug the tests.
 
-Here is a basic set of commands to quickly start running and debugging the tests. For full documentation, see the official Playwright guide on [Running and Debugging Tests](https://playwright.dev/docs/running-tests). 
+Here is a basic set of commands to quickly start running and debugging the tests. For full documentation, see the official Playwright guide on [Running and Debugging Tests](https://playwright.dev/docs/running-tests).
 
 ```shell
 # Run all available tests.
@@ -120,7 +118,6 @@ function my_fancy_plugin() {
 add_action('wp_footer', 'my_fancy_plugin');
 ```
 
-
 Once the plugin is saved, it will be automatically picked up by `wp-env` - no need to restart the environment. To activate your plugin, use the `RequestUtils.activatePlugin()` API, for example:
 
 ```ts
@@ -129,17 +126,17 @@ Once the plugin is saved, it will be automatically picked up by `wp-env` - no ne
 import { test, expect } from '@woocommerce/e2e-utils';
 
 test( 'My fancy plugin', async ( { page, requestUtils } ) => {
-  await requestUtils.activatePlugin(
-    'woocommerce-blocks-test-my-fancy-plugin'
-  );
+	await requestUtils.activatePlugin(
+		'woocommerce-blocks-test-my-fancy-plugin'
+	);
 
-  await page.goto( '/shop' );
+	await page.goto( '/shop' );
 
-  await expect( page.getByText( 'Howdy!' ) ).toBeVisible();
+	await expect( page.getByText( 'Howdy!' ) ).toBeVisible();
 } );
 ```
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > A plugin's slug is created automatically **from the plugin's name**, not from the `@package` statement as you might think. So, if your plugin is named `WooCommerce Blocks Test Bazzinga`, you'll need to activate it by `woocommerce-blocks-test-bazzinga`.
 
 ### Themes
@@ -148,11 +145,11 @@ Currently, the default theme is Twenty Twenty Four. Activating other themes is d
 
 ```ts
 test.beforeEach( async ( { page, requestUtils } ) => {
-  await requestUtils.activateTheme( 'storefront' );
+	await requestUtils.activateTheme( 'storefront' );
 } );
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Unless it's a one-off thing, remember to use the `beforeEach` hook to activate your theme. Each test starts with a clean database, which means the theme will be reset to the default one as well.
 
 #### Adding a new theme
@@ -171,36 +168,36 @@ Most of the time, it's better to do a little repetition instead of creating a ut
 import { test as base, expect, Editor } from '@woocommerce/e2e-utils';
 
 class CartUtils {
-  editor: Editor
+	editor: Editor;
 
-  constructor( { editor }: { editor: Editor } ) {
-    this.editor = editor;
-  }
+	constructor( { editor }: { editor: Editor } ) {
+		this.editor = editor;
+	}
 
-  async addClothes( list ) {
-    // Add clothes from the list.
-  }
+	async addClothes( list ) {
+		// Add clothes from the list.
+	}
 
-  async addBooks( list ) {
-    // Add books from the list.
-  }
+	async addBooks( list ) {
+		// Add books from the list.
+	}
 }
 
 const test = base.extend< { cartUtils: CartUtils } >( {
-  cartUtils: async ( { editor }, use ) => {
-    await use( new CartUtils( { editor } ) );
-  },
+	cartUtils: async ( { editor }, use ) => {
+		await use( new CartUtils( { editor } ) );
+	},
 } );
 
-test( 'Add products', async( { admin, cartUtils } ) => {
-  await admin.createNewPost();
-  await cartUtils.addClotes( [ 'Shirt', 'Cap', 'Pants' ] );
-  await cartUtils.addBooks( [ 'Cooking with Woo' ] )
+test( 'Add products', async ( { admin, cartUtils } ) => {
+	await admin.createNewPost();
+	await cartUtils.addClotes( [ 'Shirt', 'Cap', 'Pants' ] );
+	await cartUtils.addBooks( [ 'Cooking with Woo' ] );
 
-  await page.goto( '/cart' );
+	await page.goto( '/cart' );
 
-  await expect( this.page.getByLabel( 'Shirt' ) ).toBeVisible();
-  // etc.
+	await expect( this.page.getByLabel( 'Shirt' ) ).toBeVisible();
+	// etc.
 } );
 ```
 
@@ -214,11 +211,11 @@ If you've come up with a utility that you think should be a part of the Core uti
 import { Editor as CoreEditor } from '@wordpress/e2e-test-utils-playwright';
 
 export class Editor extends CoreEditor {
-  async insertAllWooBlocks() {
-    for ( const wooBlock of [ 'all', 'woo', 'blocks' ] ) {
-      await this.insertBlock( wooBlock );
-    }
-  }
+	async insertAllWooBlocks() {
+		for ( const wooBlock of [ 'all', 'woo', 'blocks' ] ) {
+			await this.insertBlock( wooBlock );
+		}
+	}
 }
 ```
 
@@ -237,51 +234,51 @@ When you have the template ready, we recommend creating a [test fixture](https:/
 import { test as base, expect, TemplateCompiler } from '@woocommerce/e2e-utils';
 
 const test = base.extend< {
-  filteredProductsTemplate: TemplateCompiler
+	filteredProductsTemplate: TemplateCompiler;
 } >( {
-  filteredProductsTemplate: async ( { requestUtils }, use ) => {
-    const compiler = await requestUtils.createTemplateFromFile(
-      'archive-product_with-filters'
-    );
-    await use( compiler );
-  },
+	filteredProductsTemplate: async ( { requestUtils }, use ) => {
+		const compiler = await requestUtils.createTemplateFromFile(
+			'archive-product_with-filters'
+		);
+		await use( compiler );
+	},
 } );
 
 test( 'Renders correct products for $10-$99 price range', async ( {
-  page,
-  filteredProductsTemplate,
+	page,
+	filteredProductsTemplate,
 } ) => {
-  await filteredProductsTemplate.compile( {
-    price: {
-      from: '$10',
-      to: '$99',
-    },
-  } );
+	await filteredProductsTemplate.compile( {
+		price: {
+			from: '$10',
+			to: '$99',
+		},
+	} );
 
-  await page.goto( '/shop' );
+	await page.goto( '/shop' );
 
-  await expect( page.getByLabel( 'Products' ) ).toHaveText( [
-    'Socks',
-    'T-Shirt',
-  ] );
+	await expect( page.getByLabel( 'Products' ) ).toHaveText( [
+		'Socks',
+		'T-Shirt',
+	] );
 } );
 
 test( 'Renders correct products for $100-$999 price range', async ( {
-  page,
-  filteredProductsTemplate,
+	page,
+	filteredProductsTemplate,
 } ) => {
-  await filteredProductsTemplate.compile( {
-    price: {
-      from: '$100',
-      to: '$990',
-    },
-  } );
+	await filteredProductsTemplate.compile( {
+		price: {
+			from: '$100',
+			to: '$990',
+		},
+	} );
 
-  await page.goto( '/shop' );
+	await page.goto( '/shop' );
 
-  await expect( page.getByLabel( 'Products' ) ).toHaveText( [
-    'Rolex',
-    'Lambo',
-  ] );
+	await expect( page.getByLabel( 'Products' ) ).toHaveText( [
+		'Rolex',
+		'Lambo',
+	] );
 } );
 ```

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 } );
 
 test.describe( `${ blockData.name }`, () => {
-	test.beforeEach( async ( { admin, requestUtils } ) => {
+	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 		await requestUtils.activatePlugin(
 			'woocommerce-blocks-test-enable-experimental-features'
 		);
@@ -42,6 +42,9 @@ test.describe( `${ blockData.name }`, () => {
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+		// Even visitSiteEditor disables welcome modal by default, sometimes
+		// the modal still shows up, which causes tests to fail.
+		await editor.disableWelcomeModal();
 	} );
 
 	test( 'should be visible and contain correct inner blocks', async ( {
@@ -119,7 +122,8 @@ test.describe( `${ blockData.name }`, () => {
 		await expect( ratingFilterBlock ).toBeVisible();
 	} );
 
-	test( 'should display the correct customization settings', async ( {
+	test( 'should display the correct inspector style controls', async ( {
+		page,
 		editor,
 		pageObject,
 	} ) => {
@@ -131,6 +135,8 @@ test.describe( `${ blockData.name }`, () => {
 		await expect( block ).toBeVisible();
 
 		await editor.openDocumentSettingsSidebar();
+
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
 
 		// Color settings
 		const colorSettings = editor.page.getByText( 'ColorTextBackground' );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -285,4 +285,30 @@ test.describe( `${ blockData.name }`, () => {
 			)
 		).toHaveCSS( 'flex-direction', 'row' );
 	} );
+
+	test( 'Dimentions > Block spacing: changing option should update the preview', async ( {
+		editor,
+		pageObject,
+	} ) => {
+		await pageObject.addProductFiltersBlock( { cleanContent: true } );
+
+		const block = editor.canvas.getByLabel(
+			'Block: Product Filters (Experimental)'
+		);
+		await expect( block ).toBeVisible();
+
+		await editor.openDocumentSettingsSidebar();
+
+		await editor.page.getByRole( 'tab', { name: 'Styles' } ).click();
+
+		const blockSpacingSettings = editor.page.getByLabel( 'Block spacing' );
+
+		await blockSpacingSettings.fill( '4' );
+
+		await expect(
+			block.locator(
+				'.wp-block-woocommerce-product-filters-is-layout-flex'
+			)
+		).toHaveCSS( 'gap', 'var(--wp--preset--spacing--30)' );
+	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -164,5 +164,10 @@ test.describe( `${ blockData.name }`, () => {
 			name: 'Border',
 		} );
 		await expect( borderSettings ).toBeVisible();
+
+		// Block spacing settings
+		await expect(
+			editor.page.getByText( 'DimensionsBlock spacing' )
+		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 } );
 
 test.describe( `${ blockData.name }`, () => {
-	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+	test.beforeEach( async ( { admin, requestUtils } ) => {
 		await requestUtils.activatePlugin(
 			'woocommerce-blocks-test-enable-experimental-features'
 		);
@@ -42,9 +42,6 @@ test.describe( `${ blockData.name }`, () => {
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
-		// Even visitSiteEditor disables welcome modal by default, sometimes
-		// the modal still shows up, which causes tests to fail.
-		await editor.disableWelcomeModal();
 	} );
 
 	test( 'should be visible and contain correct inner blocks', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -170,4 +170,23 @@ test.describe( `${ blockData.name }`, () => {
 			editor.page.getByText( 'DimensionsBlock spacing' )
 		).toBeVisible();
 	} );
+
+	test( 'should display the correct inspector setting controls', async ( {
+		editor,
+		pageObject,
+	} ) => {
+		await pageObject.addProductFiltersBlock( { cleanContent: true } );
+
+		const block = editor.canvas.getByLabel(
+			'Block: Product Filters (Experimental)'
+		);
+		await expect( block ).toBeVisible();
+
+		await editor.openDocumentSettingsSidebar();
+
+		// Layout settings
+		await expect(
+			editor.page.getByText( 'LayoutJustificationOrientation' )
+		).toBeVisible();
+	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -198,7 +198,6 @@ test.describe( `${ blockData.name }`, () => {
 		const block = editor.canvas.getByLabel(
 			'Block: Product Filters (Experimental)'
 		);
-
 		await expect( block ).toBeVisible();
 
 		await editor.openDocumentSettingsSidebar();
@@ -218,5 +217,42 @@ test.describe( `${ blockData.name }`, () => {
 		await expect( layoutSettings.getByLabel( 'Vertical' ) ).toHaveAttribute(
 			'data-active-item'
 		);
+	} );
+
+	test( 'Layout > Justification: changing option should update preview', async ( {
+		editor,
+		pageObject,
+	} ) => {
+		await pageObject.addProductFiltersBlock( { cleanContent: true } );
+
+		const block = editor.canvas.getByLabel(
+			'Block: Product Filters (Experimental)'
+		);
+		await expect( block ).toBeVisible();
+
+		await editor.openDocumentSettingsSidebar();
+
+		const layoutSettings = editor.page.getByText(
+			'LayoutJustificationOrientation'
+		);
+		await layoutSettings.getByLabel( 'Justify items left' ).click();
+		await expect(
+			layoutSettings.getByLabel( 'Justify items left' )
+		).toHaveAttribute( 'data-active-item' );
+		await expect(
+			block.locator(
+				'.wp-block-woocommerce-product-filters-is-layout-flex'
+			)
+		).toHaveCSS( 'align-items', 'flex-start' );
+
+		await layoutSettings.getByLabel( 'Justify items center' ).click();
+		await expect(
+			layoutSettings.getByLabel( 'Justify items center' )
+		).toHaveAttribute( 'data-active-item' );
+		await expect(
+			block.locator(
+				'.wp-block-woocommerce-product-filters-is-layout-flex'
+			)
+		).toHaveCSS( 'align-items', 'center' );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -15,6 +15,8 @@ const blockData = {
 		frontend: {},
 		editor: {
 			settings: {},
+			layoutWrapper:
+				'.wp-block-woocommerce-product-filters-is-layout-flex',
 		},
 	},
 	slug: 'archive-product',
@@ -237,9 +239,7 @@ test.describe( `${ blockData.name }`, () => {
 			layoutSettings.getByLabel( 'Justify items left' )
 		).toHaveAttribute( 'data-active-item' );
 		await expect(
-			block.locator(
-				'.wp-block-woocommerce-product-filters-is-layout-flex'
-			)
+			block.locator( blockData.selectors.editor.layoutWrapper )
 		).toHaveCSS( 'align-items', 'flex-start' );
 
 		await layoutSettings.getByLabel( 'Justify items center' ).click();
@@ -247,9 +247,7 @@ test.describe( `${ blockData.name }`, () => {
 			layoutSettings.getByLabel( 'Justify items center' )
 		).toHaveAttribute( 'data-active-item' );
 		await expect(
-			block.locator(
-				'.wp-block-woocommerce-product-filters-is-layout-flex'
-			)
+			block.locator( blockData.selectors.editor.layoutWrapper )
 		).toHaveCSS( 'align-items', 'center' );
 	} );
 
@@ -277,9 +275,7 @@ test.describe( `${ blockData.name }`, () => {
 			layoutSettings.getByLabel( 'Space between items' )
 		).toBeVisible();
 		await expect(
-			block.locator(
-				'.wp-block-woocommerce-product-filters-is-layout-flex'
-			)
+			block.locator( blockData.selectors.editor.layoutWrapper )
 		).toHaveCSS( 'flex-direction', 'row' );
 	} );
 
@@ -301,11 +297,13 @@ test.describe( `${ blockData.name }`, () => {
 		const blockSpacingSettings = editor.page.getByLabel( 'Block spacing' );
 
 		await blockSpacingSettings.fill( '4' );
-
 		await expect(
-			block.locator(
-				'.wp-block-woocommerce-product-filters-is-layout-flex'
-			)
-		).toHaveCSS( 'gap', 'var(--wp--preset--spacing--30)' );
+			block.locator( blockData.selectors.editor.layoutWrapper )
+		).not.toHaveCSS( 'gap', '0px' );
+
+		await blockSpacingSettings.fill( '0' );
+		await expect(
+			block.locator( blockData.selectors.editor.layoutWrapper )
+		).toHaveCSS( 'gap', '0px' );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -123,7 +123,6 @@ test.describe( `${ blockData.name }`, () => {
 	} );
 
 	test( 'should display the correct inspector style controls', async ( {
-		page,
 		editor,
 		pageObject,
 	} ) => {
@@ -136,7 +135,7 @@ test.describe( `${ blockData.name }`, () => {
 
 		await editor.openDocumentSettingsSidebar();
 
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+		await editor.page.getByRole( 'tab', { name: 'Styles' } ).click();
 
 		// Color settings
 		const colorSettings = editor.page.getByText( 'ColorTextBackground' );
@@ -188,5 +187,36 @@ test.describe( `${ blockData.name }`, () => {
 		await expect(
 			editor.page.getByText( 'LayoutJustificationOrientation' )
 		).toBeVisible();
+	} );
+
+	test( 'Layout > default to vertical stretch', async ( {
+		editor,
+		pageObject,
+	} ) => {
+		await pageObject.addProductFiltersBlock( { cleanContent: true } );
+
+		const block = editor.canvas.getByLabel(
+			'Block: Product Filters (Experimental)'
+		);
+
+		await expect( block ).toBeVisible();
+
+		await editor.openDocumentSettingsSidebar();
+
+		const layoutSettings = editor.page.getByText(
+			'LayoutJustificationOrientation'
+		);
+		await expect(
+			layoutSettings.getByLabel( 'Justify items left' )
+		).not.toHaveAttribute( 'data-active-item' );
+		await expect(
+			layoutSettings.getByLabel( 'Stretch items' )
+		).toHaveAttribute( 'data-active-item' );
+		await expect(
+			layoutSettings.getByLabel( 'Horizontal' )
+		).not.toHaveAttribute( 'data-active-item' );
+		await expect( layoutSettings.getByLabel( 'Vertical' ) ).toHaveAttribute(
+			'data-active-item'
+		);
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -219,7 +219,7 @@ test.describe( `${ blockData.name }`, () => {
 		);
 	} );
 
-	test( 'Layout > Justification: changing option should update preview', async ( {
+	test( 'Layout > Justification: changing option should update the preview', async ( {
 		editor,
 		pageObject,
 	} ) => {
@@ -254,5 +254,35 @@ test.describe( `${ blockData.name }`, () => {
 				'.wp-block-woocommerce-product-filters-is-layout-flex'
 			)
 		).toHaveCSS( 'align-items', 'center' );
+	} );
+
+	test( 'Layout > Orientation: changing option should update the preview', async ( {
+		editor,
+		pageObject,
+	} ) => {
+		await pageObject.addProductFiltersBlock( { cleanContent: true } );
+
+		const block = editor.canvas.getByLabel(
+			'Block: Product Filters (Experimental)'
+		);
+		await expect( block ).toBeVisible();
+
+		await editor.openDocumentSettingsSidebar();
+
+		const layoutSettings = editor.page.getByText(
+			'LayoutJustificationOrientation'
+		);
+		await layoutSettings.getByLabel( 'Horizontal' ).click();
+		await expect(
+			layoutSettings.getByLabel( 'Stretch items' )
+		).toBeHidden();
+		await expect(
+			layoutSettings.getByLabel( 'Space between items' )
+		).toBeVisible();
+		await expect(
+			block.locator(
+				'.wp-block-woocommerce-product-filters-is-layout-flex'
+			)
+		).toHaveCSS( 'flex-direction', 'row' );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -275,8 +275,13 @@ test.describe( `${ blockData.name }`, () => {
 			layoutSettings.getByLabel( 'Space between items' )
 		).toBeVisible();
 		await expect(
-			block.locator( blockData.selectors.editor.layoutWrapper )
-		).toHaveCSS( 'flex-direction', 'row' );
+			block.locator( ':text("Status"):right-of(:text("Price"))' )
+		).toBeVisible();
+
+		await layoutSettings.getByLabel( 'Vertical' ).click();
+		await expect(
+			block.locator( ':text("Status"):below(:text("Price"))' )
+		).toBeVisible();
 	} );
 
 	test( 'Dimentions > Block spacing: changing option should update the preview', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -94,4 +94,10 @@ export class Editor extends CoreEditor {
 			.first()
 			.click();
 	}
+
+	async disableWelcomeModal() {
+		await this.setPreferences( 'core/edit-site', {
+			welcomeGuide: false,
+		} );
+	}
 }

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -94,10 +94,4 @@ export class Editor extends CoreEditor {
 			.first()
 			.click();
 	}
-
-	async disableWelcomeModal() {
-		await this.setPreferences( 'core/edit-site', {
-			welcomeGuide: false,
-		} );
-	}
 }

--- a/plugins/woocommerce/changelog/fix-48022-product-filters-block-spacing
+++ b/plugins/woocommerce/changelog/fix-48022-product-filters-block-spacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add layout and blockGap supports to the Product Filters block.
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -39,8 +39,6 @@ class ProductFilters extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		return <<<HTML
-			<div>Product Filters</div>
-		HTML;
+		return $content;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the Block Spacing setting to the Product Filters block by adding `blockGap` support. `layout` support is required for block spacing to work, so it was added in this PR too. The layout setting is based on the following design:

![image](https://github.com/woocommerce/woocommerce/assets/5423135/d092b8b0-8e20-4425-801a-e5cc1dca2786)


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48022.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR should be tested by developers only.

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester Plugin, you can enable the experimental blocks in Settings > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build` command to have experimental blocks available.
2. Edit Block Spacing in the Editor:
    - Go to Site Editor > Templates > Product Catalog, add the "Product Filters (Experimental)" wrapper block to the template.
    - See Layout settings and Block Spacing settings in the sidebar.
    - Adjust the block spacing setting.
    - Verify that the spacing changes are immediately visible in the editor.
1. Verify Spacing on Frontend:
    - Save the changes and view the page or post on the frontend.
    - Confirm that the spacing adjustments made in the editor are accurately reflected on the frontend.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
