### PR TITLE
Fix `WC_Settings_API` textarea validation method

### DIFF
--- a/plugins/woocommerce/changelog/fix-settings-api-textarea-validation
+++ b/plugins/woocommerce/changelog/fix-settings-api-textarea-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix settings-api textarea validation to prevent insertion of iframes in description areas by default

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -394,13 +394,23 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	}
 
 	/**
-	 * If There are no payment fields show the description if set.
-	 * Override this in your gateway if you have some.
+	 * Default payment fields display. Override this in your gateway to customize displayed fields.
+	 *
+	 * By default this renders the payment gateway description.
+	 *
+	 * @since 1.5.7
 	 */
 	public function payment_fields() {
-		$description = $this->get_description();
-		if ( $description ) {
-			echo wpautop( wptexturize( $description ) ); // @codingStandardsIgnoreLine.
+		$description              = $this->get_description();
+		$has_extended_description = $description !== $this->description;
+
+		if ( $has_extended_description ) {
+			// Description can be overridden by extending classes so we cannot enforce escaping via kses here as it would
+			// break custom HTML. Therefore this is treated as trusted data.
+			echo wpautop( wptexturize( $description ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		} else {
+			// If the description was not modified, we can safely escape it.
+			echo wp_kses_post( wpautop( wptexturize( $description ) ) );
 		}
 
 		if ( $this->supports( 'default_credit_card_form' ) ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -459,13 +459,15 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		$description              = $this->get_description();
 		$has_extended_description = $description !== $this->description;
 
-		if ( $has_extended_description ) {
-			// Description can be overridden by extending classes so we cannot enforce escaping via kses here as it would
-			// break custom HTML. Therefore this is treated as trusted data.
-			echo wpautop( wptexturize( $description ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		} else {
-			// If the description was not modified, we can safely escape it.
-			echo wp_kses_post( wpautop( wptexturize( $description ) ) );
+		if ( $description ) {
+			if ( $has_extended_description ) {
+				// Description can be overridden by extending classes so we cannot enforce escaping via kses here as it would
+				// break custom HTML. Therefore this is treated as trusted data.
+				echo wpautop( wptexturize( $description ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			} else {
+				// If the description was not modified, we can safely escape it.
+				echo wp_kses_post( wpautop( wptexturize( $description ) ) );
+			}
 		}
 
 		if ( $this->supports( 'default_credit_card_form' ) ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -324,7 +324,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_icon() {
-		$icon = $this->icon ? '<img src="' . esc_attr( WC_HTTPS::force_https_url( $this->icon ) ) . '" alt="' . esc_attr( $this->get_title() ) . '" />' : '';
+		$icon = $this->icon ? '<img src="' . esc_url( WC_HTTPS::force_https_url( $this->icon ) ) . '" alt="' . esc_attr( $this->get_title() ) . '" />' : '';
 
 		return apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
 	}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -172,6 +172,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_method_title() {
+		/**
+		 * Filter the method title.
+		 *
+		 * @since 2.6.0
+		 * @param string $title Method title.
+		 * @param WC_Payment_Gateway $this Payment gateway instance.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_gateway_method_title', $this->method_title, $this );
 	}
 
@@ -181,6 +189,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_method_description() {
+		/**
+		 * Filter the method description.
+		 *
+		 * @since 2.6.0
+		 * @param string $description Method description.
+		 * @param WC_Payment_Gateway $this Payment gateway instance.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_gateway_method_description', $this->method_description, $this );
 	}
 
@@ -229,6 +245,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			$return_url = wc_get_endpoint_url( 'order-received', '', wc_get_checkout_url() );
 		}
 
+		/**
+		 * Filter the return url.
+		 *
+		 * @since 2.4.0
+		 * @param string $return_url Return URL.
+		 * @param WC_Order|null $order Order object.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_get_return_url', $return_url, $order );
 	}
 
@@ -247,6 +271,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			$return_url = sprintf( $this->view_transaction_url, $transaction_id );
 		}
 
+		/**
+		 * Filter the transaction url.
+		 *
+		 * @since 2.2.0
+		 * @param string $return_url Transaction URL.
+		 * @param WC_Order|null $order Order object.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_get_transaction_url', $return_url, $order, $this );
 	}
 
@@ -306,6 +338,15 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 */
 	public function get_title() {
 		$title = wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $this->title, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
+
+		/**
+		 * Filter the gateway title.
+		 *
+		 * @since 1.5.8
+		 * @param string $title Gateway title.
+		 * @param string $id Gateway ID.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_gateway_title', $title, $this->id );
 	}
 
@@ -315,6 +356,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_description() {
+		/**
+		 * Filter the gateway description.
+		 *
+		 * @since 1.5.8
+		 * @param string $description Gateway description.
+		 * @param string $id Gateway ID.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_gateway_description', $this->description, $this->id );
 	}
 
@@ -325,7 +374,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 */
 	public function get_icon() {
 		$icon = $this->icon ? '<img src="' . esc_url( WC_HTTPS::force_https_url( $this->icon ) ) . '" alt="' . esc_attr( $this->get_title() ) . '" />' : '';
-
+		/**
+		 * Filter the gateway icon.
+		 *
+		 * @since 1.5.8
+		 * @param string $icon Gateway icon.
+		 * @param string $id Gateway ID.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
 	}
 
@@ -428,6 +484,15 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @since 1.5.7
 	 */
 	public function supports( $feature ) {
+		/**
+		 * Filter the gateway supported features.
+		 *
+		 * @since 1.5.7
+		 * @param boolean $supports If the gateway supports the feature.
+		 * @param string $feature Feature to check.
+		 * @param WC_Payment_Gateway $this Payment gateway instance.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_payment_gateway_supports', in_array( $feature, $this->supports, true ), $feature, $this );
 	}
 
@@ -467,7 +532,8 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			'woocommerce-tokenization-form',
 			plugins_url( '/assets/js/frontend/tokenization-form' . ( Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min' ) . '.js', WC_PLUGIN_FILE ),
 			array( 'jquery' ),
-			WC()->version
+			WC()->version,
+			false
 		);
 
 		wp_localize_script(
@@ -517,6 +583,15 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			checked( $token->is_default(), true, false )
 		);
 
+		/**
+		 * Filter the saved payment method HTML.
+		 *
+		 * @since 2.6.0
+		 * @param string $html HTML for the saved payment methods.
+		 * @param string $token Token.
+		 * @param WC_Payment_Gateway $this Payment gateway instance.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_payment_gateway_get_saved_payment_method_option_html', $html, $token, $this );
 	}
 
@@ -527,6 +602,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @since 2.6.0
 	 */
 	public function get_new_payment_method_option_html() {
+		/**
+		 * Filter the saved payment method label.
+		 *
+		 * @since 2.6.0
+		 * @param string $label Label.
+		 * @param WC_Payment_Gateway $this Payment gateway instance.
+		 * @return string
+		 */
 		$label = apply_filters( 'woocommerce_payment_gateway_get_new_payment_method_option_html_label', $this->new_method_label ? $this->new_method_label : __( 'Use a new payment method', 'woocommerce' ), $this );
 		$html  = sprintf(
 			'<li class="woocommerce-SavedPaymentMethods-new">
@@ -536,7 +619,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			esc_attr( $this->id ),
 			esc_html( $label )
 		);
-
+		/**
+		 * Filter the saved payment method option.
+		 *
+		 * @since 2.6.0
+		 * @param string $html Option HTML.
+		 * @param WC_Payment_Gateway $this Payment gateway instance.
+		 * @return string
+		 */
 		return apply_filters( 'woocommerce_payment_gateway_get_new_payment_method_option_html', $html, $this );
 	}
 
@@ -554,7 +644,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			esc_attr( $this->id ),
 			esc_html__( 'Save to account', 'woocommerce' )
 		);
-
+		/**
+		 * Filter the saved payment method checkbox HTML
+		 *
+		 * @since 2.6.0
+		 * @param string $html Checkbox HTML.
+		 * @param WC_Payment_Gateway $this Payment gateway instance.
+		 * @return string
+		 */
 		echo apply_filters( 'woocommerce_payment_gateway_save_new_payment_method_option_html', $html, $this ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -324,8 +324,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_icon() {
-
-		$icon = $this->icon ? '<img src="' . WC_HTTPS::force_https_url( $this->icon ) . '" alt="' . esc_attr( $this->get_title() ) . '" />' : '';
+		$icon = $this->icon ? '<img src="' . esc_attr( WC_HTTPS::force_https_url( $this->icon ) ) . '" alt="' . esc_attr( $this->get_title() ) . '" />' : '';
 
 		return apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
 	}
@@ -429,7 +428,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @since 1.5.7
 	 */
 	public function supports( $feature ) {
-		return apply_filters( 'woocommerce_payment_gateway_supports', in_array( $feature, $this->supports ), $feature, $this );
+		return apply_filters( 'woocommerce_payment_gateway_supports', in_array( $feature, $this->supports, true ), $feature, $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -944,6 +944,7 @@ abstract class WC_Settings_API {
 	/**
 	 * Validate Textarea Field.
 	 *
+	 * @since 9.0.0 No longer allows storing IFRAME, which was allowed for "ShareThis" integration no longer found in core.
 	 * @param  string $key Field key.
 	 * @param  string $value Posted Value.
 	 * @return string

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -950,20 +950,7 @@ abstract class WC_Settings_API {
 	 */
 	public function validate_textarea_field( $key, $value ) {
 		$value = is_null( $value ) ? '' : $value;
-		return wp_kses(
-			trim( stripslashes( $value ) ),
-			array_merge(
-				array(
-					'iframe' => array(
-						'src'   => true,
-						'style' => true,
-						'id'    => true,
-						'class' => true,
-					),
-				),
-				wp_kses_allowed_html( 'post' )
-			)
-		);
+		return wp_kses_post( trim( stripslashes( $value ) ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -435,6 +435,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * Validate textarea based settings.
 	 *
 	 * @since 3.0.0
+	 * @since 9.0.0 No longer allows storing IFRAME, which was allowed for "ShareThis" integration no longer found in core.
 	 * @param string $value Value.
 	 * @param array  $setting Setting.
 	 * @return string

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -441,20 +441,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 */
 	public function validate_setting_textarea_field( $value, $setting ) {
 		$value = is_null( $value ) ? '' : $value;
-		return wp_kses(
-			trim( stripslashes( $value ) ),
-			array_merge(
-				array(
-					'iframe' => array(
-						'src'   => true,
-						'style' => true,
-						'id'    => true,
-						'class' => true,
-					),
-				),
-				wp_kses_allowed_html( 'post' )
-			)
-		);
+		return wp_kses_post( trim( stripslashes( $value ) ) );
 	}
 
 	/**
@@ -491,7 +478,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'items'       => array(
-						'type'    => 'object',
+						'type' => 'object',
 					),
 				),
 				'update' => array(
@@ -499,7 +486,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'items'       => array(
-						'type'    => 'object',
+						'type' => 'object',
 					),
 				),
 				'delete' => array(
@@ -507,7 +494,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'items'       => array(
-						'type'    => 'integer',
+						'type' => 'integer',
 					),
 				),
 			),
@@ -578,7 +565,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		// Return the list of all requested fields which appear in the schema.
 		$this->_fields = array_reduce(
 			$requested_fields,
-			function( $response_fields, $field ) use ( $fields ) {
+			function ( $response_fields, $field ) use ( $fields ) {
 				if ( in_array( $field, $fields, true ) ) {
 					$response_fields[] = $field;
 					return $response_fields;
@@ -620,7 +607,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		if ( ! empty( $include ) ) {
 			$meta_data = array_filter(
 				$meta_data,
-				function( WC_Meta_Data $item ) use ( $include ) {
+				function ( WC_Meta_Data $item ) use ( $include ) {
 					$data = $item->get_data();
 					return in_array( $data['key'], $include, true );
 				}
@@ -628,7 +615,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		} elseif ( ! empty( $exclude ) ) {
 			$meta_data = array_filter(
 				$meta_data,
-				function( WC_Meta_Data $item ) use ( $exclude ) {
+				function ( WC_Meta_Data $item ) use ( $exclude ) {
 					$data = $item->get_data();
 					return ! in_array( $data['key'], $exclude, true );
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The default validation method for textarea fields included a custom `wp_kses` call which allowed iframes. [This was added a few years ago to satisfy the requirements of an integration that is no longer present in core.](https://github.com/woocommerce/woocommerce/issues/3254)

Since using iframes in these locations is not properly supported, we should revert this back to using `wp_kses_post` on save. This mirrors how other text fields are sanitized on save.

On the render side, most fields get ran through `wp_kses_post` again ([example](https://github.com/woocommerce/woocommerce/blob/c85fe30dd2a784b9ff3d421d5205ac1294d54a7a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php#L398)), however, `description` was an exception. To avoid breakage we cannot add this now because extensions may be injecting custom HTML/scripts which would be stripped out. 

~While this is still discouraged (and not compatible with block based checkout) we can keep support by checking if the description was changed from the value loaded from the database. If the value changed this indicates an extension either extended the `get_description` method, or used the `woocommerce_gateway_description` filter, to change the content. In these cases we skip `wp_kses_post`. In all remaining cases we add the escaping.~

We can escape the value of description before passing it through the filter. This will avoid problems if a gateway extends the value with custom HTML which cannot be escaped at render time.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Before checking out this PR, as an admin user, go to WC > Settings > Payments > Direct Bank Transfer. 
2. Add an iframe to the description field. e.g. `<iframe src="https://woocommerce.com"></iframe>`. Save and view the shortcode checkout. You'll see the iframe in the description of this payment method.
3. Check out this PR. 
4. View the shortcode checkout. No iframe is rendered.
5. Go to WC > Settings > Payments > Direct Bank Transfer. Save again. The iframe should be removed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
