### PR TITLE
Update WC blocks e2e tests to WordPress 6.6

### DIFF
--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,4 +1,5 @@
 {
+	"core": "https://wordpress.org/wordpress-6.6-beta2.zip",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.6-beta2.zip",
+	"core": "https://wordpress.org/wordpress-6.6-beta3.zip",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -182,7 +182,7 @@
 		"@wordpress/dom": "3.27.0",
 		"@wordpress/dom-ready": "3.27.0",
 		"@wordpress/e2e-test-utils": "10.12.0",
-		"@wordpress/e2e-test-utils-playwright": "wp-6.5",
+		"@wordpress/e2e-test-utils-playwright": "wp-6.6",
 		"@wordpress/e2e-tests": "^4.9.2",
 		"@wordpress/element": "5.22.0",
 		"@wordpress/env": "^9.7.0",

--- a/plugins/woocommerce-blocks/tests/e2e/tests/attributes-filter/attribute-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/attributes-filter/attribute-filter.block_theme.spec.ts
@@ -109,9 +109,9 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
 
-		await editor.enterEditMode();
 		await editor.insertBlock( {
 			name: 'woocommerce/filter-wrapper',
 			attributes: {
@@ -124,7 +124,9 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		await attributeFilter.getByText( 'Size' ).click();
 		await attributeFilter.getByText( 'Done' ).click();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( '/shop' );
 	} );
 
@@ -217,9 +219,9 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: template.type,
+			canvas: 'edit',
 		} );
 
-		await editor.enterEditMode();
 		const attributeFilterControl = await editor.getBlockByName(
 			blockData.slug
 		);
@@ -229,7 +231,9 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 
 		await page.getByText( "Show 'Apply filters' button" ).click();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( '/shop' );
 
 		await page.getByRole( 'checkbox', { name: 'Small' } ).click();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-block.merchant.block_theme.spec.ts
@@ -24,12 +24,12 @@ test.describe( 'Merchant → Cart', () => {
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
 	test.describe( 'in page editor', () => {
-		test.beforeEach( async ( { editor, admin } ) => {
+		test.beforeEach( async ( { admin } ) => {
 			await admin.visitSiteEditor( {
 				postId: 'woocommerce/woocommerce//page-cart',
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 		} );
 
 		test( 'renders without crashing and can only be inserted once', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -49,8 +49,8 @@ test.describe( 'Merchant → Checkout', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.openDocumentSettingsSidebar();
 	} );
 
@@ -161,8 +161,8 @@ test.describe( 'Merchant → Checkout', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.openDocumentSettingsSidebar();
 		await editor.selectBlocks(
 			blockSelectorInEditor +
@@ -173,7 +173,9 @@ test.describe( 'Merchant → Checkout', () => {
 			exact: true,
 		} );
 		await requireTermsCheckbox.check();
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
@@ -204,8 +206,8 @@ test.describe( 'Merchant → Checkout', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.openDocumentSettingsSidebar();
 		await editor.selectBlocks(
 			blockSelectorInEditor +
@@ -216,7 +218,9 @@ test.describe( 'Merchant → Checkout', () => {
 			exact: true,
 		} );
 		await requireTermsCheckbox.uncheck();
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 	} );
 
 	test( 'inner blocks can be added/removed by filters', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -173,9 +173,7 @@ test.describe( 'Merchant → Checkout', () => {
 			exact: true,
 		} );
 		await requireTermsCheckbox.check();
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await editor.saveSiteEditorEntities();
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
 		await frontendUtils.goToCheckout();
@@ -218,9 +216,7 @@ test.describe( 'Merchant → Checkout', () => {
 			exact: true,
 		} );
 		await requireTermsCheckbox.uncheck();
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await editor.saveSiteEditorEntities();
 	} );
 
 	test( 'inner blocks can be added/removed by filters', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -272,9 +272,7 @@ test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 				'div.wc-block-components-address-form__company'
 			)
 		).toBeVisible();
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await editor.saveSiteEditorEntities();
 	} );
 
 	test( 'User can add postcodes for different countries', async ( {
@@ -527,9 +525,7 @@ test.describe( 'Billing Address Form', () => {
 		const companyInput = editor.canvas.getByLabel( 'Company (optional)' );
 		await expect( companyInput ).toBeVisible();
 
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await editor.saveSiteEditorEntities();
 	} );
 
 	test.describe( 'Guest user', () => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -251,8 +251,8 @@ test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 
 		await editor.selectBlocks(
 			blockSelectorInEditor +
@@ -272,7 +272,9 @@ test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 				'div.wc-block-components-address-form__company'
 			)
 		).toBeVisible();
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 	} );
 
 	test( 'User can add postcodes for different countries', async ( {
@@ -525,7 +527,9 @@ test.describe( 'Billing Address Form', () => {
 		const companyInput = editor.canvas.getByLabel( 'Company (optional)' );
 		await expect( companyInput ).toBeVisible();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 	} );
 
 	test.describe( 'Guest user', () => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
@@ -43,8 +43,8 @@ test.describe( 'Shopper → Order Confirmation (logged in user)', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//order-confirmation',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.transformIntoBlocks();
 	} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -92,7 +92,9 @@ test.describe( `${ blockData.name } Block `, () => {
 				attributes: { content: 'Hello World' },
 			} );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( template.path );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.spec.ts
@@ -208,9 +208,7 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		await fakeInput.pressSequentially( 'This is a test' ); // We can't use locator.fill() because it's not a valid input element.
 
 		await editor.canvas.getByText( 'This is a test' ).isVisible();
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await editor.saveSiteEditorEntities();
 
 		// Now check if it's visible in the local pickup settings.
 		await localPickupUtils.openLocalPickupSettings();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/local-pickup/local-pickup.merchant.block_theme.spec.ts
@@ -195,8 +195,8 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		const block = editor.canvas.locator(
 			'[data-type="woocommerce/checkout-shipping-method-block"]'
 		);
@@ -208,7 +208,9 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		await fakeInput.pressSequentially( 'This is a test' ); // We can't use locator.fill() because it's not a valid input element.
 
 		await editor.canvas.getByText( 'This is a test' ).isVisible();
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		// Now check if it's visible in the local pickup settings.
 		await localPickupUtils.openLocalPickupSettings();
@@ -225,8 +227,8 @@ test.describe( 'Merchant → Local Pickup Settings', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//page-checkout',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 
 		await expect(
 			editor.canvas.getByText( 'Edited from settings page' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
@@ -22,8 +22,8 @@ test.describe( 'Merchant → Mini Cart', () => {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//single-product`,
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 
 			await editor.setContent( '' );
 
@@ -37,8 +37,8 @@ test.describe( 'Merchant → Mini Cart', () => {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//single-product`,
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 			await editor.openGlobalBlockInserter();
 
 			await editor.page

--- a/plugins/woocommerce-blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
@@ -96,8 +96,8 @@ test.describe( `${ blockData.name }`, () => {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//${ blockData.slug }`,
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 			await editor.setContent( '' );
 		} );
 
@@ -124,7 +124,9 @@ test.describe( `${ blockData.name }`, () => {
 
 			await pageObject.toggleFullScreenOnClickSetting( false );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -146,7 +148,9 @@ test.describe( `${ blockData.name }`, () => {
 
 			await pageObject.toggleFullScreenOnClickSetting( false );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPageNotOnSale );
 
@@ -186,7 +190,9 @@ test.describe( `${ blockData.name }`, () => {
 				} )
 				.toEqual( blockData.margin );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -231,7 +237,9 @@ test.describe( `${ blockData.name }`, () => {
 				} )
 				.toBe( true );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -268,7 +276,9 @@ test.describe( `${ blockData.name }`, () => {
 				} )
 				.toEqual( blockData.margin );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
@@ -62,7 +62,7 @@ for ( const template of templates ) {
 				attributes: { content: userText },
 			} );
 
-			await page.getByRole( 'button', { name: 'Update' } ).click();
+			await page.getByRole( 'button', { name: 'Save' } ).click();
 
 			await page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
@@ -233,9 +233,8 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-
-		await editor.enterEditMode();
 
 		await editor.insertBlock( {
 			name: 'woocommerce/filter-wrapper',
@@ -244,7 +243,9 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 				heading: 'Filter By Price',
 			},
 		} );
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( '/shop' );
 	} );
 
@@ -336,9 +337,8 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: template.type,
+			canvas: 'edit',
 		} );
-
-		await editor.enterEditMode();
 
 		const priceFilterControls = await editor.getBlockByName(
 			blockData.slug
@@ -348,7 +348,9 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 		await editor.openDocumentSettingsSidebar();
 		await page.getByText( "Show 'Apply filters' button" ).click();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( '/shop' );
 
 		const maxPriceInput = page.getByRole( 'textbox', {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -125,7 +125,9 @@ test.describe( 'Product Collection', () => {
 			).toHaveCount( 16 );
 
 			await insertProductElements( pageObject );
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 			await pageObject.goToProductCatalogFrontend();
 
 			// Workaround for the issue with the product change not being
@@ -151,7 +153,9 @@ test.describe( 'Product Collection', () => {
 			).toHaveCount( 9 );
 
 			await insertProductElements( pageObject );
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 			await pageObject.goToHomePageFrontend();
 
 			for ( const content of expectedProductContent ) {
@@ -793,9 +797,9 @@ test.describe( 'Product Collection', () => {
 			await admin.visitSiteEditor( {
 				postId: 'woocommerce/woocommerce//archive-product',
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
 
-			await editor.enterEditMode();
 			await editor.setContent( '' );
 
 			await pageObject.insertProductCollection();
@@ -1012,8 +1016,8 @@ test.describe( 'Product Collection', () => {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//taxonomy-product_cat`,
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 			await editor.insertBlockUsingGlobalInserter(
 				pageObject.BLOCK_NAME
 			);
@@ -1041,8 +1045,8 @@ test.describe( 'Product Collection', () => {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//taxonomy-product_tag`,
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 			await editor.insertBlockUsingGlobalInserter(
 				pageObject.BLOCK_NAME
 			);
@@ -1220,7 +1224,9 @@ test.describe( 'Product Collection', () => {
 			await expect( productTemplate ).toHaveCount( 2 );
 
 			// Refresh the template and verify "On Sale" collection is still visible
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 			await page.reload();
 			await expect( productTemplate ).toHaveCount( 2 );
 		} );
@@ -1308,11 +1314,13 @@ test.describe( 'Product Collection', () => {
 				await admin.visitSiteEditor( {
 					postId: `woocommerce/woocommerce//${ slug }`,
 					postType: 'wp_template',
+					canvas: 'edit',
 				} );
-				await editor.enterEditMode();
 				await editor.insertBlock( { name: legacyBlockName } );
 				await editor.canvas.locator( 'body' ).click();
-				await editor.saveSiteEditorEntities();
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
 				await page.goto( frontendPage );
 				await pageObject.refreshLocators( 'frontend' );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -201,8 +201,8 @@ class ProductCollectionPage {
 		await this.admin.visitSiteEditor( {
 			postId: template,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await this.editor.enterEditMode();
 		await this.refreshLocators( 'editor' );
 	}
 
@@ -227,8 +227,8 @@ class ProductCollectionPage {
 		await this.admin.visitSiteEditor( {
 			postId: template,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await this.editor.enterEditMode();
 		await this.editor.canvas.locator( 'body' ).click();
 		await this.insertProductCollection();
 		await this.chooseCollectionInTemplate( collection );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -33,15 +33,15 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 } );
 
 test.describe( `${ blockData.name }`, () => {
-	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+	test.beforeEach( async ( { admin, requestUtils } ) => {
 		await requestUtils.activatePlugin(
 			'woocommerce-blocks-test-enable-experimental-features'
 		);
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//${ blockData.slug }`,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 	} );
 
 	test( 'should be visible and contain correct inner blocks', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.spec.ts
@@ -86,12 +86,12 @@ const test = base.extend< { pageObject: ProductGalleryPage } >( {
 } );
 
 test.describe( `${ blockData.name }`, () => {
-	test.beforeEach( async ( { admin, editor } ) => {
+	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//${ blockData.slug }`,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 	} );
 
 	// eslint-disable-next-line playwright/no-skipped-test
@@ -119,7 +119,9 @@ test.describe( `${ blockData.name }`, () => {
 	} ) => {
 		await addBlock( admin, editor );
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await page.goto( blockData.productPage );
 
@@ -156,7 +158,9 @@ test.describe( `${ blockData.name }`, () => {
 
 			await expect( container ).toBeHidden();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -220,7 +224,9 @@ test.describe( `${ blockData.name }`, () => {
 				editorBoundingClientRect.gallery.right
 			);
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -290,7 +296,9 @@ test.describe( `${ blockData.name }`, () => {
 				editorBoundingClientRect.gallery.right
 			);
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -349,7 +357,9 @@ test.describe( `${ blockData.name }`, () => {
 
 			await expect( block ).toHaveCSS( 'align-items', 'flex-start' );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -402,7 +412,9 @@ test.describe( `${ blockData.name }`, () => {
 
 			await expect( block ).toHaveCSS( 'align-items', 'center' );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -447,7 +459,9 @@ test.describe( `${ blockData.name }`, () => {
 
 			await expect( block ).toHaveCSS( 'align-items', 'flex-end' );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/utils.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/utils.ts
@@ -7,8 +7,8 @@ export const addBlock = async ( admin: Admin, editor: Editor ) => {
 	await admin.visitSiteEditor( {
 		postId: `woocommerce/woocommerce//single-product`,
 		postType: 'wp_template',
+		canvas: 'edit',
 	} );
-	await editor.enterEditMode();
 
 	await editor.insertBlock( {
 		name: 'woocommerce/product-gallery',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -34,8 +34,8 @@ test.describe( `${ blockData.name }`, () => {
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//${ blockData.slug }`,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.openDocumentSettingsSidebar();
 	} );
 
@@ -52,7 +52,9 @@ test.describe( `${ blockData.name }`, () => {
 
 		await expect( block ).toBeVisible();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await page.goto( blockData.productPage );
 
@@ -78,7 +80,9 @@ test.describe( `${ blockData.name }`, () => {
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
 			await pageObject.toggleZoomWhileHoveringSetting( true );
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -112,7 +116,9 @@ test.describe( `${ blockData.name }`, () => {
 
 			await expect( buttonElement ).not.toBeChecked();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -149,7 +155,9 @@ test.describe( `${ blockData.name }`, () => {
 
 		await expect( block ).toBeVisible();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await page.goto( blockData.productPage );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-pager/product-gallery-pager.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-pager/product-gallery-pager.block_theme.spec.ts
@@ -47,8 +47,8 @@ test.describe( `${ blockData.name }`, () => {
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//${ blockData.slug }`,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.openDocumentSettingsSidebar();
 	} );
 
@@ -65,7 +65,9 @@ test.describe( `${ blockData.name }`, () => {
 
 		await expect( block ).toBeVisible();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await page.goto( blockData.productPage );
 
@@ -99,7 +101,9 @@ test.describe( `${ blockData.name }`, () => {
 				)
 				.click();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -132,7 +136,9 @@ test.describe( `${ blockData.name }`, () => {
 				)
 				.click();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -172,7 +178,9 @@ test.describe( `${ blockData.name }`, () => {
 				)
 				.click();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
@@ -44,7 +44,9 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 				)
 			).toBeVisible();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 		} );
 
 		await test.step( 'in frontend', async () => {
@@ -90,7 +92,9 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 
 				await expect( thumbailsBlock ).toBeHidden();
 
-				await editor.saveSiteEditorEntities();
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
 			} );
 
 			await test.step( 'in frontend', async () => {
@@ -145,7 +149,9 @@ test.describe( 'Product Gallery Thumbnails block', () => {
 						)
 					).toBeVisible();
 
-					await editor.saveSiteEditorEntities();
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: true,
+					} );
 				} );
 
 				await test.step( 'in frontend', async () => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -628,24 +628,17 @@ test.describe( `${ blockData.name }`, () => {
 			isOnlyCurrentEntityDirty: true,
 		} );
 
+		// Switch to the Index template.
 		await page.getByLabel( 'Open Navigation' ).click();
-		const navigationSidebar = page.getByLabel( 'Navigation' );
-		const navigationBackButton = navigationSidebar.getByLabel( 'Back' );
-		await expect( navigationBackButton ).toBeVisible();
-		await navigationSidebar.getByLabel( 'Back' ).click();
 		await page.getByRole( 'button', { name: 'Index' } ).click();
 
-		const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
-		const headerTitle = editorFrame.getByRole( 'document', {
-			name: 'Block: Site Title',
-		} );
-		await expect( headerTitle ).toBeVisible();
-
-		await navigationSidebar.getByLabel( 'Back' ).click();
+		// Go back to the Custom Single Product template.
+		await page.getByLabel( 'Open Navigation' ).click();
 		await page
 			.getByRole( 'button', { name: 'Custom Single Product' } )
 			.click();
 
+		const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
 		const productGalleryBlock = editorFrame.getByLabel(
 			'Block: Product Gallery (Beta)'
 		);

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -638,8 +638,7 @@ test.describe( `${ blockData.name }`, () => {
 			.getByRole( 'button', { name: 'Custom Single Product' } )
 			.click();
 
-		const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
-		const productGalleryBlock = editorFrame.getByLabel(
+		const productGalleryBlock = editor.canvas.getByLabel(
 			'Block: Product Gallery (Beta)'
 		);
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -106,7 +106,9 @@ test.describe( `${ blockData.name }`, () => {
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -133,7 +135,9 @@ test.describe( `${ blockData.name }`, () => {
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -179,7 +183,9 @@ test.describe( `${ blockData.name }`, () => {
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -240,7 +246,9 @@ test.describe( `${ blockData.name }`, () => {
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -310,7 +318,9 @@ test.describe( `${ blockData.name }`, () => {
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: false } );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -371,7 +381,9 @@ test.describe( `${ blockData.name }`, () => {
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -477,7 +489,9 @@ test.describe( `${ blockData.name }`, () => {
 			editor,
 		} ) => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -500,7 +514,9 @@ test.describe( `${ blockData.name }`, () => {
 			await pageObject.addProductGalleryBlock( { cleanContent: true } );
 			await editor.openDocumentSettingsSidebar();
 			await pageObject.toggleFullScreenOnClickSetting( false );
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( blockData.productPage );
 
@@ -538,8 +554,8 @@ test.describe( `${ blockData.name }`, () => {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//product-gallery`,
 				postType: 'wp_template_part',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 			await editor.openGlobalBlockInserter();
 			await page.getByRole( 'tab', { name: 'Blocks' } ).click();
 			const productGalleryBlockOption = page
@@ -576,7 +592,9 @@ test.describe( `${ blockData.name }`, () => {
 			.locator( blockData.selectors.editor.settings.cropImagesOption )
 			.click();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await expect(
 			page.locator( blockData.selectors.editor.settings.cropImagesOption )
@@ -606,7 +624,9 @@ test.describe( `${ blockData.name }`, () => {
 		page,
 	} ) => {
 		await pageObject.addProductGalleryBlock( { cleanContent: true } );
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await page.getByLabel( 'Open Navigation' ).click();
 		const navigationSidebar = page.getByLabel( 'Navigation' );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/products/products.block_theme.spec.ts
@@ -65,8 +65,8 @@ test.describe( `${ blockData.name } Block `, () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.setContent( '' );
 		await insertProductsQuery( editor );
 		const block = await editor.getBlockByName( blockData.name );
@@ -104,14 +104,16 @@ for ( const {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//${ slug }`,
 				postType: 'wp_template',
+				canvas: 'edit',
 			} );
-			await editor.enterEditMode();
 			await editor.setContent( '' );
 			await insertProductsQuery( editor );
 			await editor.insertBlock( { name: legacyBlockName } );
 			await editor.canvas.locator( 'body' ).click();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 
 			await page.goto( frontendPage );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/rating-filter/rating-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/rating-filter/rating-filter.block_theme.spec.ts
@@ -107,9 +107,8 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-
-		await editor.enterEditMode();
 
 		await editor.insertBlock( {
 			name: 'woocommerce/filter-wrapper',
@@ -120,7 +119,9 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		} );
 
 		await page.keyboard.press( 'Escape' );
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await page.goto( '/shop' );
 	} );
@@ -210,9 +211,8 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: template.type,
+			canvas: 'edit',
 		} );
-
-		await editor.enterEditMode();
 
 		const ratingFilterControls = await editor.getBlockByName(
 			'woocommerce/rating-filter'
@@ -222,7 +222,9 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 		await editor.openDocumentSettingsSidebar();
 		await page.getByText( "Show 'Apply filters' button" ).click();
 
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( '/shop' );
 
 		await page

--- a/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
@@ -31,8 +31,8 @@ test.describe( `${ blockData.name } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//archive-product`,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 
 		await editor.setContent( '' );
 
@@ -54,8 +54,8 @@ test.describe( `${ blockData.name } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//single-product`,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.setContent( '' );
 		await editor.insertBlock( { name: blockData.slug } );
 
@@ -72,8 +72,8 @@ test.describe( `${ blockData.name } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//single-product`,
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		const relatedProducts = await editor.getBlockByName( blockData.slug );
 		await editor.selectBlocks( relatedProducts );
 		await editor.openDocumentSettingsSidebar();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/stock-filter/stock-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/stock-filter/stock-filter.block_theme.spec.ts
@@ -118,9 +118,8 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-
-		await editor.enterEditMode();
 
 		await editor.insertBlock( {
 			name: 'woocommerce/filter-wrapper',
@@ -129,7 +128,9 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 				heading: 'Filter By Price',
 			},
 		} );
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( '/shop' );
 	} );
 
@@ -216,8 +217,8 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 		await admin.visitSiteEditor( {
 			postId: template.id,
 			postType: template.type,
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 
 		const stockFilterControls = await editor.getBlockByName(
 			blockData.slug
@@ -226,7 +227,9 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 		await editor.selectBlocks( stockFilterControls );
 		await editor.openDocumentSettingsSidebar();
 		await page.getByText( "Show 'Apply filters' button" ).click();
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( '/shop' );
 
 		await page.getByText( 'Out of Stock' ).click();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/store-notices/store-notices.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/store-notices/store-notices.block_theme.spec.ts
@@ -20,8 +20,8 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//archive-product',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		const block = await editor.getBlockByName( blockData.slug );
 		await expect( block ).toBeVisible();
 		await expect( block ).toHaveText(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -15,8 +15,8 @@ test.describe( 'Test the cart template', () => {
 		await admin.visitSiteEditor( {
 			postId: templatePath,
 			postType: templateType,
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await expect(
 			editor.canvas.getByLabel( 'Block: Title' )
 		).toBeVisible();
@@ -63,8 +63,8 @@ test.describe( 'Test editing the cart template', () => {
 		await admin.visitSiteEditor( {
 			postId: templatePath,
 			postType: templateType,
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"cart"} /-->'
 		);

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -27,11 +27,14 @@ test.describe( 'Test the cart template', () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor( { path: '/page' } );
+		await admin.visitSiteEditor( { postType: 'page' } );
 		await editor.page
 			.getByRole( 'button', { name: 'Cart', exact: true } )
 			.click();
-		await editor.enterEditMode();
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.locator( 'body' )
+			.click();
 
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Cart")' ).first()

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -31,10 +31,7 @@ test.describe( 'Test the cart template', () => {
 		await editor.page
 			.getByRole( 'button', { name: 'Cart', exact: true } )
 			.click();
-		await page
-			.frameLocator( 'iframe[name="editor-canvas"]' )
-			.locator( 'body' )
-			.click();
+		await editor.canvas.locator( 'body' ).click();
 
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Cart")' ).first()

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -64,7 +64,16 @@ test.describe( 'Test the checkout template', () => {
 		await frontendUtils.addToCart();
 		await admin.page.goto( permalink );
 		await admin.page.locator( '#wp-admin-bar-site-editor a' ).click();
-		await admin.page.getByRole( 'button', { name: 'Get started' } ).click();
+
+		// Close welcome popup.
+		const getStartedButton = admin.page.getByRole( 'button', {
+			name: 'Get started',
+		} );
+		const isGetStartedButtonVisible = await getStartedButton.isVisible();
+		if ( isGetStartedButtonVisible ) {
+			await getStartedButton.click();
+		}
+
 		await expect(
 			editor.canvas.getByRole( 'button', {
 				name: 'Place Order',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -33,10 +33,7 @@ test.describe( 'Test the checkout template', () => {
 		await editor.page
 			.getByRole( 'button', { name: 'Checkout', exact: true } )
 			.click();
-		await page
-			.frameLocator( 'iframe[name="editor-canvas"]' )
-			.locator( 'body' )
-			.click();
+		await editor.canvas.locator( 'body' ).click();
 
 		await expect(
 			editor.canvas.getByRole( 'button', {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -63,13 +63,7 @@ test.describe( 'Test the checkout template', () => {
 		await admin.page.locator( '#wp-admin-bar-site-editor a' ).click();
 
 		// Close welcome popup.
-		const getStartedButton = admin.page.getByRole( 'button', {
-			name: 'Get started',
-		} );
-		const isGetStartedButtonVisible = await getStartedButton.isVisible();
-		if ( isGetStartedButtonVisible ) {
-			await getStartedButton.click();
-		}
+		await admin.page.getByRole( 'button', { name: 'Get started' } ).click();
 
 		await expect(
 			editor.canvas.getByRole( 'button', {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -29,11 +29,14 @@ test.describe( 'Test the checkout template', () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor( { path: '/page' } );
+		await admin.visitSiteEditor( { postType: 'page' } );
 		await editor.page
 			.getByRole( 'button', { name: 'Checkout', exact: true } )
 			.click();
-		await editor.enterEditMode();
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.locator( 'body' )
+			.click();
 
 		await expect(
 			editor.canvas.getByRole( 'button', {
@@ -61,6 +64,7 @@ test.describe( 'Test the checkout template', () => {
 		await frontendUtils.addToCart();
 		await admin.page.goto( permalink );
 		await admin.page.locator( '#wp-admin-bar-site-editor a' ).click();
+		await admin.page.getByRole( 'button', { name: 'Get started' } ).click();
 		await expect(
 			editor.canvas.getByRole( 'button', {
 				name: 'Place Order',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -15,8 +15,8 @@ test.describe( 'Test the checkout template', () => {
 		await admin.visitSiteEditor( {
 			postId: templatePath,
 			postType: templateType,
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await expect(
 			editor.canvas.getByRole( 'button', {
 				name: 'Place Order',
@@ -29,10 +29,6 @@ test.describe( 'Test the checkout template', () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor( {
-			postId: templatePath,
-			postType: templateType,
-		} );
 		await admin.visitSiteEditor( { path: '/page' } );
 		await editor.page
 			.getByRole( 'button', { name: 'Checkout', exact: true } )
@@ -81,8 +77,8 @@ test.describe( 'Test editing the checkout template', () => {
 		await admin.visitSiteEditor( {
 			postId: templatePath,
 			postType: templateType,
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"checkout"} /-->'
 		);

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/legacy-templates.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/legacy-templates.block_theme.spec.ts
@@ -39,7 +39,9 @@ test.describe( 'Legacy templates', () => {
 				editor.canvas.getByText( template.customText )
 			).toBeVisible();
 
-			await editor.saveSiteEditorEntities();
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 		} );
 
 		await test.step( 'Update created term to legacy format in the DB', async () => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/legacy-templates.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/legacy-templates.block_theme.spec.ts
@@ -67,7 +67,7 @@ test.describe( 'Legacy templates', () => {
 
 		await test.step( 'Verify the template is listed in the Site Editor UI', async () => {
 			await admin.visitSiteEditor( {
-				path: '/wp_template/all',
+				postType: 'wp_template',
 			} );
 
 			await page.getByPlaceholder( 'Search' ).fill( template.name );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
@@ -11,8 +11,8 @@ test.describe( 'Test the order confirmation template', () => {
 		await admin.visitSiteEditor( {
 			postId: 'woocommerce/woocommerce//order-confirmation',
 			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 		await editor.transformIntoBlocks();
 		await expect(
 			editor.canvas.getByText(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -37,7 +37,9 @@ test.describe( 'Single Product template', () => {
 			name: 'core/paragraph',
 			attributes: { content: userText },
 		} );
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		// Verify edits are visible.
 		await page.goto( testData.permalink );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -31,14 +31,16 @@ test.describe( 'Single Product Template', () => {
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
 			postType: testData.templateType,
+			canvas: 'edit',
 		} );
-		await editor.enterEditMode();
 
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: userText },
 		} );
-		await editor.saveSiteEditorEntities();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 		await page.goto( testData.permalink );
 
 		// Verify edits are visible in the frontend.

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -162,26 +162,30 @@ test.describe( 'Template customization', () => {
 					.getByPlaceholder( 'Search' )
 					.fill( testData.templateName );
 
-				const revertedNotice = page
+				const resetNotice = page
 					.getByLabel( 'Dismiss this notice' )
-					.getByText( `"${ testData.templateName }" reset.` );
+					.getByText(
+						testData.templateType === 'wp_template'
+							? `"${ testData.templateName }" reset.`
+							: `"${ testData.templateName }" deleted.`
+					);
 				const savedButton = page.getByRole( 'button', {
 					name: 'Saved',
 				} );
 
 				// Wait until search has finished.
-				await page.waitForFunction( () => {
+				await page.waitForFunction( ( templatesLength ) => {
 					return (
 						document.querySelectorAll( '[aria-label="Actions"]' )
-							.length === 1
+							.length < templatesLength
 					);
-				} );
+				}, CUSTOMIZABLE_WC_TEMPLATES.length );
 
-				await page.getByLabel( 'Actions' ).click();
+				await page.getByLabel( 'Actions' ).first().click();
 				await page.getByRole( 'menuitem', { name: 'Reset' } ).click();
 				await page.getByRole( 'button', { name: 'Reset' } ).click();
 
-				await expect( revertedNotice ).toBeVisible();
+				await expect( resetNotice ).toBeVisible();
 				await expect( savedButton ).toBeVisible();
 
 				await testData.visitPage( { frontendUtils, page } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -174,12 +174,10 @@ test.describe( 'Template customization', () => {
 				} );
 
 				// Wait until search has finished.
-				await page.waitForFunction( ( templatesLength ) => {
-					return (
-						document.querySelectorAll( '[aria-label="Actions"]' )
-							.length < templatesLength
-					);
-				}, CUSTOMIZABLE_WC_TEMPLATES.length );
+				const searchResults = page.getByLabel( 'Actions' );
+				await expect
+					.poll( async () => await searchResults.count() )
+					.toBeLessThan( CUSTOMIZABLE_WC_TEMPLATES.length );
 
 				await page.getByLabel( 'Actions' ).first().click();
 				await page.getByRole( 'menuitem', { name: 'Reset' } ).click();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -32,15 +32,16 @@ test.describe( 'Template customization', () => {
 				await admin.visitSiteEditor( {
 					postId: `woocommerce/woocommerce//${ testData.templatePath }`,
 					postType: testData.templateType,
+					canvas: 'edit',
 				} );
-
-				await editor.enterEditMode();
 
 				await editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: { content: userText },
 				} );
-				await editor.saveSiteEditorEntities();
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
 				// Verify template name didn't change.
 				// See: https://github.com/woocommerce/woocommerce/issues/42221
 				await expect(
@@ -66,9 +67,8 @@ test.describe( 'Template customization', () => {
 					await admin.visitSiteEditor( {
 						postId: `woocommerce/woocommerce//${ testData.fallbackTemplate?.templatePath }`,
 						postType: testData.templateType,
+						canvas: 'edit',
 					} );
-
-					await editor.enterEditMode();
 
 					await editor.insertBlock( {
 						name: 'core/paragraph',
@@ -76,7 +76,9 @@ test.describe( 'Template customization', () => {
 							content: fallbackTemplateUserText,
 						},
 					} );
-					await editor.saveSiteEditorEntities();
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: true,
+					} );
 					await testData.visitPage( { frontendUtils, page } );
 					await expect(
 						page.getByText( fallbackTemplateUserText ).first()
@@ -106,14 +108,16 @@ test.describe( 'Template customization', () => {
 				await admin.visitSiteEditor( {
 					postId: `woocommerce/woocommerce//${ testData.templatePath }`,
 					postType: testData.templateType,
+					canvas: 'edit',
 				} );
-				await editor.enterEditMode();
 
 				await editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: { content: woocommerceTemplateUserText },
 				} );
-				await editor.saveSiteEditorEntities();
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
 
 				await requestUtils.activateTheme(
 					BLOCK_THEME_WITH_TEMPLATES_SLUG
@@ -125,14 +129,16 @@ test.describe( 'Template customization', () => {
 				await admin.visitSiteEditor( {
 					postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
 					postType: testData.templateType,
+					canvas: 'edit',
 				} );
-				await editor.enterEditMode();
 
 				await editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: { content: userText },
 				} );
-				await editor.saveSiteEditorEntities();
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
 
 				// Verify the template is the one modified by the user based on the theme.
 				await testData.visitPage( { frontendUtils, page } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -155,30 +155,31 @@ test.describe( 'Template customization', () => {
 				// duplicate templates with the same name.
 				// See: https://github.com/woocommerce/woocommerce/issues/42220
 				await admin.visitSiteEditor( {
-					path: `/${ testData.templateType }/all`,
+					postType: testData.templateType,
 				} );
 
 				await page
 					.getByPlaceholder( 'Search' )
 					.fill( testData.templateName );
 
-				const templateRow = page.getByRole( 'row' ).filter( {
-					has: page.getByRole( 'link', {
-						name: testData.templateName,
-						exact: true,
-					} ),
-				} );
-				const resetButton = templateRow.getByLabel( 'Reset', {
-					exact: true,
-				} );
 				const revertedNotice = page
 					.getByLabel( 'Dismiss this notice' )
-					.getByText( `"${ testData.templateName }" reverted.` );
+					.getByText( `"${ testData.templateName }" reset.` );
 				const savedButton = page.getByRole( 'button', {
 					name: 'Saved',
 				} );
 
-				await resetButton.click();
+				// Wait until search has finished.
+				await page.waitForFunction( () => {
+					return (
+						document.querySelectorAll( '[aria-label="Actions"]' )
+							.length === 1
+					);
+				} );
+
+				await page.getByLabel( 'Actions' ).click();
+				await page.getByRole( 'menuitem', { name: 'Reset' } ).click();
+				await page.getByRole( 'button', { name: 'Reset' } ).click();
 
 				await expect( revertedNotice ).toBeVisible();
 				await expect( savedButton ).toBeVisible();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -179,7 +179,7 @@ test.describe( 'Template customization', () => {
 					.poll( async () => await searchResults.count() )
 					.toBeLessThan( CUSTOMIZABLE_WC_TEMPLATES.length );
 
-				await page.getByLabel( 'Actions' ).first().click();
+				await searchResults.first().click();
 				await page.getByRole( 'menuitem', { name: 'Reset' } ).click();
 				await page.getByRole( 'button', { name: 'Reset' } ).click();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -39,14 +39,16 @@ test.describe( 'Template customization', () => {
 				await admin.visitSiteEditor( {
 					postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
 					postType: testData.templateType,
+					canvas: 'edit',
 				} );
-				await editor.enterEditMode();
 
 				await editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: { content: userText },
 				} );
-				await editor.saveSiteEditorEntities();
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
 				// Verify template name didn't change.
 				// See: https://github.com/woocommerce/woocommerce/issues/42221
 				await expect(
@@ -74,8 +76,8 @@ test.describe( 'Template customization', () => {
 					await admin.visitSiteEditor( {
 						postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.fallbackTemplate?.templatePath }`,
 						postType: testData.templateType,
+						canvas: 'edit',
 					} );
-					await editor.enterEditMode();
 
 					await editor.insertBlock( {
 						name: 'core/paragraph',
@@ -83,7 +85,9 @@ test.describe( 'Template customization', () => {
 							content: fallbackTemplateUserText,
 						},
 					} );
-					await editor.saveSiteEditorEntities();
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: true,
+					} );
 					await testData.visitPage( { frontendUtils, page } );
 					await expect(
 						page.getByText( fallbackTemplateUserText )

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -85,7 +85,9 @@ export class Editor extends CoreEditor {
 			await transformButton.click();
 
 			// save changes
-			await this.saveSiteEditorEntities();
+			await this.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
 		}
 	}
 

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -45,26 +45,6 @@ export class Editor extends CoreEditor {
 		}
 	}
 
-	async enterEditMode() {
-		await this.page
-			.getByRole( 'button', {
-				name: 'Edit',
-				exact: true,
-			} )
-			.dispatchEvent( 'click' );
-
-		const sidebar = this.page.locator( '.edit-site-layout__sidebar' );
-		const canvasLoader = this.page.locator( '.edit-site-canvas-loader' );
-
-		await sidebar.waitFor( {
-			state: 'hidden',
-		} );
-
-		await canvasLoader.waitFor( {
-			state: 'hidden',
-		} );
-	}
-
 	async transformIntoBlocks() {
 		// Select the block, so the button is visible.
 		const block = this.canvas

--- a/plugins/woocommerce/changelog/add-wp-env-6.6
+++ b/plugins/woocommerce/changelog/add-wp-env-6.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update WC blocks e2e tests to WordPress 6.6

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -13,7 +13,7 @@ class ProductFilters extends AbstractBlock {
 	protected $block_name = 'product-filters';
 
 	/**
-	 *  Register the context
+	 * Register the context.
 	 *
 	 * @return string[]
 	 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4225,8 +4225,8 @@ importers:
         specifier: 10.12.0
         version: 10.12.0(encoding@0.1.13)(jest@29.7.0(@types/node@16.18.68)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.2)))(puppeteer-core@21.6.0(encoding@0.1.13))
       '@wordpress/e2e-test-utils-playwright':
-        specifier: wp-6.5
-        version: 0.19.2(@playwright/test@1.44.1)(encoding@0.1.13)(typescript@5.3.2)
+        specifier: wp-6.6
+        version: 1.0.1(@playwright/test@1.44.1)(encoding@0.1.13)(typescript@5.3.2)
       '@wordpress/e2e-tests':
         specifier: ^4.9.2
         version: 4.9.2(@swc/core@1.3.100)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.3.2))(eslint-import-resolver-webpack@0.13.2)(eslint-plugin-import@2.28.1)(eslint@8.55.0))(eslint-import-resolver-webpack@0.13.2(eslint-plugin-import@2.28.1)(webpack@5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack@5.91.0))))(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack@5.91.0))))(jest@29.7.0(@types/node@16.18.68)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.2)))(node-notifier@8.0.2)(puppeteer-core@21.6.0(encoding@0.1.13))(puppeteer@17.1.3(encoding@0.1.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.2))(type-fest@2.19.0)(typescript@5.3.2)(webpack-hot-middleware@2.25.4)
@@ -10641,9 +10641,9 @@ packages:
     resolution: {integrity: sha512-d8ouvBiKDFu67O9Y8MtlUR2YojCAjmLf0LuBKsSOS5r3MOiwte1tQwsLdzFmGYkdCK09mZhT3UVKdOOiAC3kKA==}
     engines: {node: '>=12'}
 
-  '@wordpress/api-fetch@6.51.0':
-    resolution: {integrity: sha512-9jPBMk/TEBR9DFQxCcHvCq7YQJzbFMyDH56vKeYNN0q+hvlJ2Ju2CWVFfsQ4mCSCGBJAblcBxZ7F2D3H4JQJ/A==}
-    engines: {node: '>=12'}
+  '@wordpress/api-fetch@7.0.1':
+    resolution: {integrity: sha512-amS/byydyz0Ipz23AYGjQEZl9uug1w831i9JIkrBKPhb9L+uKBCz5LompD6kHYWxOYbwaJwPpXiXJm8v4DqUyw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/autop@3.16.0':
     resolution: {integrity: sha512-cepLM41mF1h7f2JIU12XhLLfep1R0DNkI0gM2GoVzp0DlM0qSnJVuU93R75wTnR0OTija0cVVPUovt+gBWIR2Q==}
@@ -11100,9 +11100,9 @@ packages:
     peerDependencies:
       '@playwright/test': '>=1'
 
-  '@wordpress/e2e-test-utils-playwright@0.19.2':
-    resolution: {integrity: sha512-pB/WsJwtbKLrKEhdr8HEmjThP6XGuFJmEHfxSm76l/S5Hc0dzhFHAYojk3iu0VEZMUlgppUNYfXTab8JTCkwBA==}
-    engines: {node: '>=12'}
+  '@wordpress/e2e-test-utils-playwright@1.0.1':
+    resolution: {integrity: sha512-DNR45Q0px6p3XLnJzRXANIXSQ1OKLdWCwQLQctuSmhVyqSyKS0VZApiYVoaPTKLEdxl+WeJ7jN153q1vUa5Lcg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@playwright/test': '>=1'
 
@@ -11297,6 +11297,10 @@ packages:
     resolution: {integrity: sha512-4sIngmH64M1jzcprfkffo1GHsQbd/QNbTweq6cSPIJNorKfE63Inf59NQ6r0pq6+Nz+cuq64eMz5v4eyngjZ/A==}
     engines: {node: '>=12'}
 
+  '@wordpress/hooks@4.0.1':
+    resolution: {integrity: sha512-5SKw1LMQp9H5CFTDUYGcWZd6YEof2aAjfwp/7otpE6QXgGQyZhXKIAsppACSda0dMcUH74vwbn/vMb/hfsHf3w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/html-entities@3.24.0':
     resolution: {integrity: sha512-rwvx8aEJb9gRCj/pJ0v7vh6sT7R6G922LQzHc5cObcSm5cmzPz/Wz07+AZkHA1cmCDQdPiDd3yB8X8l+yeFy0A==}
     engines: {node: '>=12'}
@@ -11340,6 +11344,11 @@ packages:
   '@wordpress/i18n@4.6.1':
     resolution: {integrity: sha512-hdi+hyEzIqZhEFSmiwApTCfsu5qRpFDSKzpPf5uJbCeCGcY/BVB2m8kh7E0M5Ltva9Hct/4AKR34bR6bm9INFA==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  '@wordpress/i18n@5.0.1':
+    resolution: {integrity: sha512-JXfaiorZKMTUFP1IbLutLNDNHbFxP3otsfxniq+LdNUmQ9c9rtpW/WQXEAhZHE3J2wTbXrh5fHWuOKecj8UKOw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
   '@wordpress/icons@4.1.0':
@@ -11490,10 +11499,6 @@ packages:
     resolution: {integrity: sha512-dmYpqCWUoCM290YA5ApES9nqz/0D1JngIlZtel+BvELf8fj/jctdsT5wDB7dVdvZCuyr5SF+1Od00DYbMbb5oA==}
     engines: {node: '>=12'}
 
-  '@wordpress/keycodes@3.54.0':
-    resolution: {integrity: sha512-perPl0Hoq9Kp2hNSe5t7U68is2EljRA6sE6wQ50pqrgTJ1IMk9x8fLa/osRtC7B9AXmGlxKcbIn5i9rlsopN6Q==}
-    engines: {node: '>=12'}
-
   '@wordpress/keycodes@3.57.0':
     resolution: {integrity: sha512-8u9MlHE5xPxJf7jROBO8IGYKN54IkjXQD3mfsxVE+dtONeNwRaPvvcZOuOfySerABcCat2OgWCh1s0cV5WNCuw==}
     engines: {node: '>=12'}
@@ -11501,6 +11506,10 @@ packages:
   '@wordpress/keycodes@3.6.1':
     resolution: {integrity: sha512-bqKk3zaJ2tN0hYBhrrgajKnsFMnahQT3FxR5fvqA6e1jVeRAntve3ILUUNTW3lKjmZpKXUaYs7fVrCbRNa4q3A==}
     engines: {node: '>=12'}
+
+  '@wordpress/keycodes@4.0.1':
+    resolution: {integrity: sha512-GLKho4gAFbqgmP3GxEPP5iSS2WwOtqX0xL0zVjElNC/uHKCULyZ2UlyDAc2clN5wiVNf3hC4A1BsxzKeKIMNFQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/lazy-import@1.34.0':
     resolution: {integrity: sha512-ZF4YhWDJtvlev1GqZ7FRr2CPg5Vssw6lb4gn2OH56/KWuHf/LrBPVdshXR6ujDPvgUMnNFRf39ofHIENoj7JPA==}
@@ -11863,13 +11872,13 @@ packages:
     resolution: {integrity: sha512-12bjIBBGcA5X8RPvUURLJZzpB60O5DI3WxQVIBBKPF4Mv8nUmgT4uemGzf5/ble8lqzJVntyEhEWKPOxEbUbJg==}
     engines: {node: '>=12'}
 
-  '@wordpress/url@3.55.0':
-    resolution: {integrity: sha512-xAN/VxImq+KG8PDV7i3HtmPR6Y4LFb7lc0CvBxlHkwv2/PF+vu+1IZYMzj2kCiOvDYrue82n/5rE+Em0+l31aA==}
-    engines: {node: '>=12'}
-
   '@wordpress/url@3.7.1':
     resolution: {integrity: sha512-wX/Uck/If+/b8nLhB3UazLMlG7s6jjHv7isG/+/QCaJ01cf/VXXg8x6bRWnoB84ObhwBbBiM4rDTperge7+elg==}
     engines: {node: '>=12'}
+
+  '@wordpress/url@4.0.1':
+    resolution: {integrity: sha512-Tm0UEGxx4gsWshornP/6EdTq/ILfNA9T5LOvPCaUEPpiFB8d1C/sV5XU+uZfztYIDEwfEXQHAh/pUn/dPvInvw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/viewport@4.20.0':
     resolution: {integrity: sha512-bCtUJNvrLGdCGwgW6k0vN3gE435pHo6zzSMoGdGeMMcv9lrVURYkOhKwYgUOpIrs4FeldrzcbAv9Mvko/ihA6A==}
@@ -38877,11 +38886,11 @@ snapshots:
       '@wordpress/i18n': 4.47.0
       '@wordpress/url': 3.48.0
 
-  '@wordpress/api-fetch@6.51.0':
+  '@wordpress/api-fetch@7.0.1':
     dependencies:
-      '@babel/runtime': 7.23.6
-      '@wordpress/i18n': 4.54.0
-      '@wordpress/url': 3.55.0
+      '@babel/runtime': 7.24.7
+      '@wordpress/i18n': 5.0.1
+      '@wordpress/url': 4.0.1
 
   '@wordpress/autop@3.16.0':
     dependencies:
@@ -41045,12 +41054,12 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@wordpress/e2e-test-utils-playwright@0.19.2(@playwright/test@1.44.1)(encoding@0.1.13)(typescript@5.3.2)':
+  '@wordpress/e2e-test-utils-playwright@1.0.1(@playwright/test@1.44.1)(encoding@0.1.13)(typescript@5.3.2)':
     dependencies:
       '@playwright/test': 1.44.1
-      '@wordpress/api-fetch': 6.51.0
-      '@wordpress/keycodes': 3.54.0
-      '@wordpress/url': 3.55.0
+      '@wordpress/api-fetch': 7.0.1
+      '@wordpress/keycodes': 4.0.1
+      '@wordpress/url': 4.0.1
       change-case: 4.1.2
       form-data: 4.0.0
       get-port: 5.1.1
@@ -41697,6 +41706,10 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.5
 
+  '@wordpress/hooks@4.0.1':
+    dependencies:
+      '@babel/runtime': 7.24.7
+
   '@wordpress/html-entities@3.24.0':
     dependencies:
       '@babel/runtime': 7.23.5
@@ -41766,6 +41779,15 @@ snapshots:
       gettext-parser: 1.4.0
       lodash: 4.17.21
       memize: 1.1.0
+      sprintf-js: 1.1.3
+      tannin: 1.2.0
+
+  '@wordpress/i18n@5.0.1':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@wordpress/hooks': 4.0.1
+      gettext-parser: 1.4.0
+      memize: 2.1.0
       sprintf-js: 1.1.3
       tannin: 1.2.0
 
@@ -42096,11 +42118,6 @@ snapshots:
       '@wordpress/i18n': 4.47.0
       change-case: 4.1.2
 
-  '@wordpress/keycodes@3.54.0':
-    dependencies:
-      '@babel/runtime': 7.23.6
-      '@wordpress/i18n': 4.54.0
-
   '@wordpress/keycodes@3.57.0':
     dependencies:
       '@babel/runtime': 7.23.6
@@ -42111,6 +42128,11 @@ snapshots:
       '@babel/runtime': 7.23.5
       '@wordpress/i18n': 4.6.1
       lodash: 4.17.21
+
+  '@wordpress/keycodes@4.0.1':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@wordpress/i18n': 5.0.1
 
   '@wordpress/lazy-import@1.34.0':
     dependencies:
@@ -43161,15 +43183,15 @@ snapshots:
       '@babel/runtime': 7.23.6
       remove-accents: 0.5.0
 
-  '@wordpress/url@3.55.0':
-    dependencies:
-      '@babel/runtime': 7.23.6
-      remove-accents: 0.5.0
-
   '@wordpress/url@3.7.1':
     dependencies:
       '@babel/runtime': 7.23.5
       lodash: 4.17.21
+
+  '@wordpress/url@4.0.1':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      remove-accents: 0.5.0
 
   '@wordpress/viewport@4.20.0(react@17.0.2)':
     dependencies:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates WC blocks e2e tests to work with WordPress 6.6. Most updates were related to changes in the Site Editor UI.

### How to test the changes in this Pull Request:

_(No need to test when testing the release)_

1. Make sure e2e tests pass.
2. Make sure code changes make sense.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
