### PR TITLE
Get tax line lable instead of name

### DIFF
--- a/plugins/woocommerce/changelog/48445-update-get-tax-line-label
+++ b/plugins/woocommerce/changelog/48445-update-get-tax-line-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Get tax line lable instead of name </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48445-update-get-tax-line-label
+++ b/plugins/woocommerce/changelog/48445-update-get-tax-line-label
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Get tax line lable instead of name.
+Get tax line lable instead of name </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48445-update-get-tax-line-label
+++ b/plugins/woocommerce/changelog/48445-update-get-tax-line-label
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Get tax line lable instead of name </details>  <details>  <summary>Changelog Entry Comment</summary>
+Get tax line lable instead of name.

--- a/plugins/woocommerce/changelog/48445-update-get-tax-line-label
+++ b/plugins/woocommerce/changelog/48445-update-get-tax-line-label
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Get tax line lable instead of name </details>  <details>  <summary>Changelog Entry Comment</summary>
+Get tax line label instead of name in order endpoint

--- a/plugins/woocommerce/changelog/48445-update-get-tax-line-label
+++ b/plugins/woocommerce/changelog/48445-update-get-tax-line-label
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Get tax line label instead of name in order endpoint
+Get tax line label instead of name in StoreAPI Order endpoint.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -378,8 +378,10 @@ class OrderSchema extends AbstractSchema {
 			'total_shipping_tax' => $this->prepare_money_response( $order->get_shipping_tax() ),
 			'tax_lines'          => array_map(
 				function( $item ) {
+					error_log('print_r($item,true)');
+					error_log(print_r($item,true));
 					return [
-						'name'  => $item->get_name(),
+						'name'  => $item->get_label(),
 						'price' => $this->prepare_money_response( $item->get_tax_total() ),
 						'rate'  => strval( $item->get_rate_percent() ),
 					];

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -378,8 +378,6 @@ class OrderSchema extends AbstractSchema {
 			'total_shipping_tax' => $this->prepare_money_response( $order->get_shipping_tax() ),
 			'tax_lines'          => array_map(
 				function( $item ) {
-					error_log('print_r($item,true)');
-					error_log(print_r($item,true));
 					return [
 						'name'  => $item->get_label(),
 						'price' => $this->prepare_money_response( $item->get_tax_total() ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Get tax line lable instead of name.

Closes #46577
Request commnet: https://github.com/woocommerce/woocommerce/issues/46577#issuecomment-2056663025 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Log [this](https://github.com/woocommerce/woocommerce/blob/2620ff75f61101f8e348d84f830d4a021f7325fb/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderSchema.php#L380) `$item`
2. As a shopper, make a purchase and copy the `key`, `order_id`, and `billing_email` for below order endpoint
3. Test order endpoint `/wp-json/wc/store/v1/order/{order_id}?key={key}&billing_email={billing_email}`
4. Check the order endpoint response `tax_lines.name` value is the same as the log `label` value
<img width="571" alt="name and label" src="https://github.com/woocommerce/woocommerce/assets/56378160/03932705-f8a3-4146-8a19-f84d7c3c144c">
<img width="232" alt="after" src="https://github.com/woocommerce/woocommerce/assets/56378160/cd84732f-64d6-4d8e-9a74-2846cd0bc512">

5. Update `get_label` to `get_name` [here](https://github.com/woocommerce/woocommerce/blob/2620ff75f61101f8e348d84f830d4a021f7325fb/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderSchema.php#L384)
6. Send the order endpoint request again from the step 3
7.  Check the order endpoint response `tax_lines.name` value is the same as the log `rate_code` value because [`get_name` returns `get_rate_code`](https://github.com/woocommerce/woocommerce/blob/2620ff75f61101f8e348d84f830d4a021f7325fb/plugins/woocommerce/includes/class-wc-order-item-tax.php#L147-L148)

<img width="238" alt="before" src="https://github.com/woocommerce/woocommerce/assets/56378160/26c359d0-02ea-4d4c-806a-2ad14e56b4c5">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [X] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Get tax line label instead of name in StoreAPI Order endpoint.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
