### PR TITLE
Fix flaky e2e test and update login util

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-login-user-create
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-login-user-create
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixing flaky merchant user create and logging

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-create.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-create.spec.js
@@ -80,7 +80,11 @@ for ( const userData of users ) {
 
 		await test.step( 'verify the new user can login', async () => {
 			await page.context().clearCookies();
-			await page.goto( '/wp-admin' );
+			await page.goto( '/wp-login.php' );
+			await expect(
+				page.getByLabel( 'Username or Email Address' )
+			).toBeVisible();
+
 			await logIn( page, userData.username, user.password, false );
 
 			const expectedTitle =

--- a/plugins/woocommerce/tests/e2e-pw/utils/login.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/login.js
@@ -1,8 +1,12 @@
 const { expect } = require( '../fixtures/fixtures' );
 const logIn = async ( page, username, password, assertSuccess = true ) => {
-	await page.getByLabel( 'Username or Email Address' ).click();
+	await page
+		.getByLabel( 'Username or Email Address' )
+		.click( { delay: 100 } );
 	await page.getByLabel( 'Username or Email Address' ).fill( username );
-	await page.getByRole( 'textbox', { name: 'Password' } ).click();
+	await page
+		.getByRole( 'textbox', { name: 'Password' } )
+		.click( { delay: 100 } );
 	await page.getByRole( 'textbox', { name: 'Password' } ).fill( password );
 	await page.getByRole( 'button', { name: 'Log In' } ).click();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47957

We use login util to create admin/customer token but we also use it for some tests like this one and you can imagine how many times it has been executed so it is sometimes flaky. This was one of the most flakiest tests recently and just because of that login util.

I changed url to wp-login.php so there is no redirection from wp-admin, however, I also updated login util to just a slowly a bit fill username and password. This is so tiny difference with delay of 100ms, that you can't see the difference. However, it makes the login pretty non flaky.

I tested this 80 times: https://d.pr/i/Ts6oMI with previously reproduced on 20 times execution without changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `pnpm test:e2e-pw ./tests/merchant/users-create.spec.js --repeat-each=10`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
