### PR TITLE
CYS: apply white color to the heading elements in the core/cover block

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/constants.ts
@@ -1597,7 +1597,7 @@ export const COLOR_PALETTES = [
 					elements: {
 						heading: {
 							color: {
-								text: 'var(--wp--preset--color--tertiary)',
+								text: '#ffffff',
 							},
 						},
 					},

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/constants.ts
@@ -1593,6 +1593,15 @@ export const COLOR_PALETTES = [
 						text: 'var(--wp--preset--color--foreground)',
 					},
 				},
+				'core/cover': {
+					elements: {
+						heading: {
+							color: {
+								text: 'var(--wp--preset--color--tertiary)',
+							},
+						},
+					},
+				},
 				'core/site-title': {
 					elements: {
 						link: {

--- a/plugins/woocommerce/changelog/48447-48440-cys-headers-are-black
+++ b/plugins/woocommerce/changelog/48447-48440-cys-headers-are-black
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: apply white color to the heading elements in the core/cover block  </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
@@ -350,6 +350,25 @@ test.describe( 'Assembler -> Color Pickers', () => {
 					} )
 				);
 
+			const headersInCoverBlock = await editor
+				.locator(
+					`.wp-block-cover__inner-container h1,
+					 .wp-block-cover__inner-container h2,
+					 .wp-block-cover__inner-container h3,
+					 .wp-block-cover__inner-container h4,
+					 .wp-block-cover__inner-container h5,
+					 .wp-block-cover__inner-container h6`
+				)
+				.evaluateAll( ( elements ) =>
+					elements.map( ( element ) => {
+						const style = window.getComputedStyle( element );
+						return {
+							background: style.backgroundColor,
+							color: style.color,
+						};
+					} )
+				);
+
 			for ( const element of buttons ) {
 				await expect( element.background ).toEqual(
 					colors.button.background
@@ -366,6 +385,12 @@ test.describe( 'Assembler -> Color Pickers', () => {
 				expect( colors.header.color.includes( element.color ) ).toBe(
 					true
 				);
+			}
+
+			// Check that the headers in the cover block are white text.
+			// See: https://github.com/woocommerce/woocommerce/pull/48447
+			for ( const element of headersInCoverBlock ) {
+				expect( element.color ).toEqual( 'rgb(255, 255, 255)' );
 			}
 		} );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48440.

This PR fixes a regression caused by the changes included in this Gutenberg PR: https://github.com/WordPress/gutenberg/pull/61638

This happens because it is changed the specifity of the CSS generated by Global Styles.

| Before Gutenberg PR | After Gutenberg PR |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce/assets/4463174/904b0cb9-3887-4bc0-93e9-69a24fb42830) |![image](https://github.com/woocommerce/woocommerce/assets/4463174/d4169f98-e624-4dce-a35b-749349fc093e)| 

As you can see, with the last changes in Gutenberg, the color isn't override anymore. For this reason, it is necessary specificy the color of the header blocks inside the cover block in the palette definition.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled
2. Head over to WooCommerce > Home > Customize your store.
3. Ensure that "Sound like no other" text is white.
4. Click on "Choose your color palette".
5. For each palette, ensure that "Sound like no other" text is white.
6. Disable Gutenberg.
7. Head over to WooCommerce > Home > Customize your store.
8. Ensure that "Sound like no other" text is white.
9. Click on "Choose your color palette".
10.  For each palette, ensure that "Sound like no other" text is white.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: apply white color to the heading elements in the core/cover block

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
