### PR TITLE
Add a close button to dismiss store alerts

### DIFF
--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import {
 	Button,
@@ -16,7 +16,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import moment from 'moment';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight, close } from '@wordpress/icons';
 import { NOTES_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
@@ -28,6 +28,7 @@ import { navigateTo, parseAdminUrl } from '@woocommerce/navigation';
 import sanitizeHTML from '../../lib/sanitize-html';
 import StoreAlertsPlaceholder from './placeholder';
 import { getAdminSetting } from '~/utils/admin-settings';
+import { getScreenName } from '../../utils';
 
 import './style.scss';
 
@@ -37,10 +38,17 @@ export class StoreAlerts extends Component {
 
 		this.state = {
 			currentIndex: 0,
+			alerts: props.alerts,
 		};
 
 		this.previousAlert = this.previousAlert.bind( this );
 		this.nextAlert = this.nextAlert.bind( this );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.alerts !== this.props.alerts ) {
+			this.setState( { alerts: this.props.alerts } );
+		}
 	}
 
 	previousAlert( event ) {
@@ -202,7 +210,7 @@ export class StoreAlerts extends Component {
 	}
 
 	getAlerts() {
-		return ( this.props.alerts || [] ).filter(
+		return ( this.state.alerts || [] ).filter(
 			( note ) => note.status === 'unactioned'
 		);
 	}
@@ -232,8 +240,52 @@ export class StoreAlerts extends Component {
 			'is-alert-update': type === 'update',
 		} );
 
+		const onDismiss = async ( note ) => {
+			const screen = getScreenName();
+			const { createNotice, removeNote } = this.props;
+
+			recordEvent( 'inbox_action_dismiss', {
+				note_name: note.name,
+				note_title: note.title,
+				note_name_dismiss_all: false,
+				note_name_dismiss_confirmation: true,
+				screen,
+			} );
+
+			const noteId = note.id;
+
+			try {
+				await removeNote( noteId );
+				this.setState( {
+					alerts: this.state.alerts.filter(
+						( _alert ) => _alert.id !== noteId
+					),
+				} );
+				createNotice(
+					'success',
+					__( 'Message dismissed', 'woocommerce' )
+				);
+			} catch ( e ) {
+				createNotice(
+					'error',
+					_n(
+						'Message could not be dismissed',
+						'Messages could not be dismissed',
+						1,
+						'woocommerce'
+					)
+				);
+			}
+		};
+
 		return (
 			<Card className={ className } size={ null }>
+				<Button
+					className="woocommerce-store-alerts__close"
+					onClick={ () => onDismiss( alert ) }
+				>
+					<Icon icon={ close } />
+				</Button>
 				<CardHeader isBorderless>
 					<Text
 						variant="title.medium"
@@ -330,13 +382,15 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { triggerNoteAction, updateNote } = dispatch( NOTES_STORE_NAME );
+		const { triggerNoteAction, updateNote, removeNote } =
+			dispatch( NOTES_STORE_NAME );
 		const { createNotice } = dispatch( 'core/notices' );
 
 		return {
 			triggerNoteAction,
 			updateNote,
 			createNotice,
+			removeNote,
 		};
 	} )
 )( StoreAlerts );

--- a/plugins/woocommerce-admin/client/layout/store-alerts/style.scss
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/style.scss
@@ -40,6 +40,16 @@
 		}
 	}
 
+	.woocommerce-store-alerts__close {
+		position: absolute;
+		top: 2px;
+		right: 0;
+		svg {
+			width: 14px;
+			height: 14px;
+		}
+	}
+
 	@include breakpoint( "<782px" ) {
 		margin-bottom: $gap-large;
 		padding: $gap;

--- a/plugins/woocommerce-admin/client/layout/store-alerts/style.scss
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/style.scss
@@ -42,8 +42,8 @@
 
 	.woocommerce-store-alerts__close {
 		position: absolute;
-		top: 2px;
-		right: 0;
+		top: -3px;
+		right: -3px;
 		svg {
 			width: 14px;
 			height: 14px;

--- a/plugins/woocommerce-admin/client/layout/store-alerts/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/test/index.js
@@ -85,11 +85,15 @@ describe( 'StoreAlerts', () => {
 		);
 
 		expect(
-			container.querySelector( '.components-button' ).textContent
+			container.querySelector(
+				'.components-button:not(.woocommerce-store-alerts__close)'
+			).textContent
 		).toBe( 'Click me!' );
 		expect(
 			container
-				.querySelector( '.components-button' )
+				.querySelector(
+					'.components-button:not(.woocommerce-store-alerts__close)'
+				)
 				.getAttribute( 'href' )
 		).toBe( '#' );
 		expect(
@@ -105,11 +109,15 @@ describe( 'StoreAlerts', () => {
 		);
 
 		expect(
-			container.querySelector( '.components-button' ).textContent
+			container.querySelector(
+				'.components-button:not(.woocommerce-store-alerts__close)'
+			).textContent
 		).toBe( 'Click me!' );
 		expect(
 			container
-				.querySelector( '.components-button' )
+				.querySelector(
+					'.components-button:not(.woocommerce-store-alerts__close)'
+				)
 				.getAttribute( 'href' )
 		).toBe( '#' );
 		expect(

--- a/plugins/woocommerce/changelog/48453-update-add-dismiss-button-for-update-note
+++ b/plugins/woocommerce/changelog/48453-update-add-dismiss-button-for-update-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+</details>  <details>  <summary>Changelog Entry Comment</summary>  Add a close button to dismiss store alerts


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a close button to dismiss store alerts. 

![Screen Shot 2024-06-12 at 1 40 55 PM](https://github.com/woocommerce/woocommerce/assets/4723145/64e23b49-df89-4a6f-989f-b3e8a7c5f1b5)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Install and activate `SQL Executioner` plugin.
3. Go to `Tools -> SQL Executioner` and run the following query. This query updates the last note's type to `update`


```
UPDATE wp_wc_admin_notes 
SET `type` = 'update'
WHERE note_id = (
    SELECT max_note_id FROM (
        SELECT MAX(note_id) AS max_note_id FROM wp_wc_admin_notes
    ) AS subquery
);
```

4. Go to `WooCommerce -> Home` 
5. Confirm a store alert has been added.
6. Confirm the alert has `x` button.
7. Click on it and the alert should disappear.
8. Refresh the page and confirm no alert has been added.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

Add a close button to dismiss store alerts

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
