### PR TITLE
Prevent checkout step divider overflowing causing horizontal scroll on mobile

### DIFF
--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -30,12 +30,11 @@
 				position: absolute;
 				content: "";
 				bottom: -$gap-larger;
-				left: 50%;
 				transform: translateX(-50%);
-				width: 100vw;
+				width: 100%;
 				height: 1px;
-				background: currentColor;
-				opacity: 0.11;
+				opacity: .11;
+				box-shadow: 0 0 0 0 currentColor, 15px 1px 0 0 currentColor, 340px 1px 0 0 currentColor;
 			}
 		}
 	}

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -33,7 +33,7 @@
 				transform: translateX(-50%);
 				width: 100%;
 				height: 1px;
-				opacity: .11;
+				opacity: 0.11;
 				box-shadow: 0 0 0 0 currentColor, 15px 1px 0 0 currentColor, 340px 1px 0 0 currentColor;
 			}
 		}

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -34,7 +34,7 @@
 				width: 100%;
 				height: 1px;
 				opacity: 0.11;
-				box-shadow: 0 0 0 0 currentColor, 15px 1px 0 0 currentColor, 340px 1px 0 0 currentColor;
+				box-shadow: 0 1px 0 0 currentColor, 50vw 1px 0 0 currentColor;
 			}
 		}
 	}

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -29,7 +29,8 @@
 			&::after {
 				position: absolute;
 				content: "";
-				bottom: -$gap-larger;
+				// Required because the box shadows are offset by 1px down so we need to move the element up by 1px.
+				bottom: calc(1px - $gap-larger);
 				transform: translateX(-50%);
 				width: 100%;
 				height: 1px;

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -35,6 +35,10 @@
 				width: 100%;
 				height: 1px;
 				opacity: 0.11;
+				// This box-shadow rule creates two visible shadows:
+				// - One 1 pixel directly below the element.
+				// - Another 50% of the viewport width to the right and 1 pixel down from the element.
+				// Both shadows are sharp (no blur) and use the current color of the element.
 				box-shadow: 0 1px 0 0 currentColor, 50vw 1px 0 0 currentColor;
 			}
 		}

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -31,15 +31,17 @@
 				content: "";
 				// Required because the box shadows are offset by 1px down so we need to move the element up by 1px.
 				bottom: calc(1px - $gap-larger);
-				transform: translateX(-50%);
 				width: 100%;
 				height: 1px;
 				opacity: 0.11;
+				background: currentColor;
 				// This box-shadow rule creates two visible shadows:
-				// - One 1 pixel directly below the element.
-				// - Another 50% of the viewport width to the right and 1 pixel down from the element.
+				// - One 50vw to the left of the element.
+				// - Another 50vw to the right
 				// Both shadows are sharp (no blur) and use the current color of the element.
-				box-shadow: 0 1px 0 0 currentColor, 50vw 1px 0 0 currentColor;
+				// Its purpose is to add a full-width divider between checkout sections which is otherwise impossible as
+				// the parent element has padding.
+				box-shadow: -50vw 0 0 0 currentColor, 50vw 0 0 0 currentColor;
 			}
 		}
 	}

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -30,8 +30,9 @@
 				position: absolute;
 				content: "";
 				bottom: -$gap-larger;
-				left: -100vw;
-				width: 200vw;
+				left: 50%;
+				transform: translateX(-50%);
+				width: 100vw;
 				height: 1px;
 				background: currentColor;
 				opacity: 0.11;

--- a/plugins/woocommerce/changelog/fix-checkout-width
+++ b/plugins/woocommerce/changelog/fix-checkout-width
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Addresses a styling bug for something not yet released into WC 9.1
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents the checkout step section divider exceeding the viewport width and making the checkout scroll horizontally on mobile. Thanks @tomxygen for reporting this!

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48297

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **These steps should be tested on multiple browsers (chrome, edge, firefox, safari)**
2. Add an item to your cart and go to the Checkout block.
3. Ensure you're in mobile view ( 400px or so)
4. Ensure a full-width separator appears between each checkout form step.
5. Ensure horizontal scrolling isn't possible because of the separator.

<img width="404" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/60c21c13-8267-4359-a88c-c519e037d654">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
