### PR TITLE
[CYS] Show tooltips in delete and shuffle buttons

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/delete.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
@@ -22,18 +22,17 @@ export default function Delete( {
 
 	return (
 		<ToolbarGroup>
-			<ToolbarButton>
-				<Button
-					label={ __( 'Remove', 'woocommerce' ) }
-					icon={ trash }
-					onClick={ () => {
-						removeBlock( clientId );
-						if ( nextBlockClientId ) {
-							selectBlock( nextBlockClientId );
-						}
-					} }
-				/>
-			</ToolbarButton>
+			<ToolbarButton
+				showTooltip={ true }
+				label={ __( 'Remove', 'woocommerce' ) }
+				icon={ trash }
+				onClick={ () => {
+					removeBlock( clientId );
+					if ( nextBlockClientId ) {
+						selectBlock( nextBlockClientId );
+					}
+				} }
+			/>
 		</ToolbarGroup>
 	);
 }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
@@ -7,13 +7,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	Path,
-	SVG,
-	ToolbarButton,
-	ToolbarGroup,
-} from '@wordpress/components';
+import { Path, SVG, ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import {
 	unlock,
 	// @ts-expect-error No types for this exist yet.
@@ -108,24 +102,22 @@ export default function Shuffle( { clientId }: { clientId: string } ) {
 
 	return (
 		<ToolbarGroup>
-			<ToolbarButton>
-				<Button
-					label={ __( 'Shuffle', 'woocommerce' ) }
-					icon={ shuffleIcon }
-					onClick={ () => {
-						const nextPattern = getNextPattern();
-						// @ts-expect-error - attributes is marked as readonly.
-						nextPattern.blocks[ 0 ].attributes = {
-							...nextPattern.blocks[ 0 ].attributes,
-							metadata: {
-								...nextPattern.blocks[ 0 ].attributes.metadata,
-								categories,
-							},
-						};
-						replaceBlocks( clientId, nextPattern.blocks );
-					} }
-				/>
-			</ToolbarButton>
+			<ToolbarButton
+				label={ __( 'Shuffle', 'woocommerce' ) }
+				icon={ shuffleIcon }
+				onClick={ () => {
+					const nextPattern = getNextPattern();
+					// @ts-expect-error - attributes is marked as readonly.
+					nextPattern.blocks[ 0 ].attributes = {
+						...nextPattern.blocks[ 0 ].attributes,
+						metadata: {
+							...nextPattern.blocks[ 0 ].attributes.metadata,
+							categories,
+						},
+					};
+					replaceBlocks( clientId, nextPattern.blocks );
+				} }
+			/>
 		</ToolbarGroup>
 	);
 }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/style.scss
@@ -2,4 +2,8 @@
 	.block-editor-block-mover__drag-handle {
 		display: none;
 	}
+
+	.block-editor-block-mover {
+		padding: 0;
+	}
 }

--- a/plugins/woocommerce/changelog/48465-48438-tooltip-shuffle-delete-buttons
+++ b/plugins/woocommerce/changelog/48465-48438-tooltip-shuffle-delete-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Show tooltips on the Shuffle and Delete buttons in the assembler toolbar.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/48438

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have the `WooCommerce Beta Tester` plugin installed.
2. Head over to `Tools > WCA Test Helper > Features`.
3. Make sure you see the `pattern-toolkit-full-composability` on the list.
4. Enable it.
5. Head over to `WooCommerce > Home > Customize your store` and click `Start designing`.
6. Click on `Design your homepage`.
7. Click on the second template on the sidebar.
8. Hover over the shuffle and the delete buttons and make sure you see tooltips appearing.
<img width="300" alt="Screenshot 2024-06-13 at 14 28 12" src="https://github.com/woocommerce/woocommerce/assets/186112/01281a4a-2292-493b-90c8-ab49da0f21f0">



<!-- End testing instructions -->


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Show tooltips on the Shuffle and Delete buttons in the assembler toolbar.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
