### PR TITLE
E2E Tweaks - Stricter selector and smart wait

### DIFF
--- a/plugins/woocommerce/changelog/48471-24-06-e2e-tweaks
+++ b/plugins/woocommerce/changelog/48471-24-06-e2e-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+</details> Improve E2E selector by making it stricter. Wait for text due to AJAX call. <details>  <summary>E2E test tweaks</summary>

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
@@ -171,7 +171,9 @@ for ( const productType of Object.keys( productData ) ) {
 		if ( productData[ productType ].shipping ) {
 			await test.step( 'add shipping details', async () => {
 				await page.getByRole( 'link', { name: 'Shipping' } ).click();
-				await expect( page.getByText( 'Shipping class', { exact: true } ) ).toBeVisible();
+				await expect(
+					page.getByText( 'Shipping class', { exact: true } )
+				).toBeVisible();
 				await page
 					.getByPlaceholder( '0' )
 					.fill( productData[ productType ].shipping.weight );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
@@ -171,6 +171,7 @@ for ( const productType of Object.keys( productData ) ) {
 		if ( productData[ productType ].shipping ) {
 			await test.step( 'add shipping details', async () => {
 				await page.getByRole( 'link', { name: 'Shipping' } ).click();
+				await expect( page.getByText( 'Shipping class', { exact: true } ) ).toBeVisible();
 				await page
 					.getByPlaceholder( '0' )
 					.fill( productData[ productType ].shipping.weight );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -64,6 +64,7 @@ async function userDeletionTest( page, username ) {
 		await expect(
 			page.getByRole( 'heading', { name: 'Delete Users' } )
 		).toBeVisible();
+
 		await expect( page.getByText( `${ username }` ) ).toBeVisible();
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -61,9 +61,11 @@ async function userDeletionTest( page, username ) {
 	} );
 
 	await test.step( 'confirm deletion', async () => {
+		await expect( page.locator( '#the-list tr' ) ).toHaveCount( 1 );
 		await expect(
-			page.getByText( `Search results for: ${ username }` )
-		).toBeVisible();
+			page.locator( '#the-list tr td.username a' )
+		).toContainText( username );
+
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -62,7 +62,7 @@ async function userDeletionTest( page, username ) {
 
 	await test.step( 'confirm deletion', async () => {
 		await expect(
-			page.getByRole( 'link', { name: `${ username }`, exact: true } )
+			page.getByRole( 'link', { name: username, exact: true } )
 		).toBeVisible();
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -61,7 +61,7 @@ async function userDeletionTest( page, username ) {
 	} );
 
 	await test.step( 'confirm deletion', async () => {
-		await expect( page.getByText( `${ username }` ) ).toBeVisible();
+		await expect( page.getByRole( 'link', { name: `${ username }`, exact: true } ) ).toBeVisible();
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -61,11 +61,10 @@ async function userDeletionTest( page, username ) {
 	} );
 
 	await test.step( 'confirm deletion', async () => {
-		await expect( page.locator( '#the-list tr' ) ).toHaveCount( 1 );
 		await expect(
-			page.locator( '#the-list tr td.username a' )
-		).toContainText( username );
-
+			page.getByRole( 'heading', { name: 'Delete Users' } )
+		).toBeVisible();
+		await expect( page.getByText( `${ username }` ) ).toBeVisible();
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -61,7 +61,9 @@ async function userDeletionTest( page, username ) {
 	} );
 
 	await test.step( 'confirm deletion', async () => {
-		await expect( page.getByRole( 'link', { name: `${ username }`, exact: true } ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: `${ username }`, exact: true } )
+		).toBeVisible();
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -62,7 +62,7 @@ async function userDeletionTest( page, username ) {
 
 	await test.step( 'confirm deletion', async () => {
 		await expect(
-			page.getByRole( 'link', { name: username, exact: true } )
+			page.getByText( `Search results for: ${ username }` )
 		).toBeVisible();
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes some small tweaks to the E2E tests to make them more robust.

- Wait for a specific text to appear before searching for an element to prevent strict selector issues
- Wait for text to appear before attempting to fill field with placeholder of value zero, as the previous tab might also have a input with placeholder with value 0 and this is an AJAX call

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/48470

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. E2E tests should pass

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>
Improve E2E selector by making it stricter. Wait for text due to AJAX call.
<details>

<summary>E2E test tweaks</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
