### PR TITLE
fix null strpos param

### DIFF
--- a/plugins/woocommerce/changelog/48476-fix-null-strpos-44598
+++ b/plugins/woocommerce/changelog/48476-fix-null-strpos-44598
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a null parameter being passed into strpos in Admin/Orders/PageController.php

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -143,7 +143,7 @@ class PageController {
 		}
 
 		// Not on an Orders page.
-		if ( empty($plugin_page) || 'admin.php' !== $pagenow || 0 !== strpos( $plugin_page, 'wc-orders' ) ) {
+		if ( empty( $plugin_page ) || 'admin.php' !== $pagenow || 0 !== strpos( $plugin_page, 'wc-orders' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -143,7 +143,7 @@ class PageController {
 		}
 
 		// Not on an Orders page.
-		if ( 'admin.php' !== $pagenow || 0 !== strpos( $plugin_page, 'wc-orders' ) ) {
+		if ( ! isset( $plugin_page ) || 'admin.php' !== $pagenow || 0 !== strpos( $plugin_page, 'wc-orders' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -143,7 +143,7 @@ class PageController {
 		}
 
 		// Not on an Orders page.
-		if ( ! isset( $plugin_page ) || 'admin.php' !== $pagenow || 0 !== strpos( $plugin_page, 'wc-orders' ) ) {
+		if ( empty($plugin_page) || 'admin.php' !== $pagenow || 0 !== strpos( $plugin_page, 'wc-orders' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
check whether $plugin_page is set prior to passing it to strpos

### Submission Review Guidelines:

- [x]  I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x]  I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a bug where null was being passed to strpos causing an error

> Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /wp-content/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php on line 146

Closes #44598 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

to reproduce the issue

1. clone woocommerce, ensure you're on the trunk branch and go through the setup instructions
2. edit "phpVersion" in plugins/woocommerce/.wp-env.json from "7.4" to "8.2"
3. run `pnpm --filter=@woocommerce/plugin-woocommerce env:dev`
4. on port 8888 you can now log in - install and activate the plugin "FG Joomla to WordPress"
5. on the installed plugins page click "Import" under the new plugin
6. confirm you see the following error at the top of the page

> Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php on line 146

to confirm the fix, repeat all of the above with the following changes
in step 1: ensure you're on the branch in this pr
in step 6: confirm no error appears at the top of the page

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix a null parameter being passed into strpos in Admin/Orders/PageController.php
</details>