### PR TITLE
Do not attempt to re-save hooks after delivery when not already persisted

### DIFF
--- a/plugins/woocommerce/changelog/fix-32346
+++ b/plugins/woocommerce/changelog/fix-32346
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not create empty webhooks after failure to deliver deleted webhook.

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -533,7 +533,10 @@ class WC_Webhook extends WC_Legacy_Webhook {
 		// Check for a success, which is a 2xx, 301 or 302 Response Code.
 		if ( intval( $response_code ) >= 200 && intval( $response_code ) < 303 ) {
 			$this->set_failure_count( 0 );
-			$this->save();
+
+			if ( 0 !== $this->get_id() ) {
+				$this->save();
+			}
 		} else {
 			$this->failed_delivery();
 		}
@@ -557,7 +560,9 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			$this->set_failure_count( ++$failures );
 		}
 
-		$this->save();
+		if ( 0 !== $this->get_id() ) {
+			$this->save();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-webhook-functions.php
+++ b/plugins/woocommerce/includes/wc-webhook-functions.php
@@ -75,6 +75,11 @@ add_action( 'woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery
  */
 function wc_deliver_webhook_async( $webhook_id, $arg ) {
 	$webhook = new WC_Webhook( $webhook_id );
+
+	if ( 0 === $webhook->get_id() ) {
+		return;
+	}
+
 	$webhook->deliver( $arg );
 }
 add_action( 'woocommerce_deliver_webhook_async', 'wc_deliver_webhook_async', 10, 2 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When a webhook is delivered, we either reset its failure count to 0 or increase it to indicate it has failed. This triggers a `save()` which might end up storing in the database webhooks that were not stored in the first place or have incomplete data (for example, when calling `$webhook->deliver()` on a webhook that hasn't been `save()`'d yet).

In the scenario where you've deleted a webhook and there are N async deliveries pending, this will result in N invalid webhooks being created, which isn't great.

This PR makes sure we only persist data after delivery if the webhook is already in the database. Otherwise, only the properties on the object are updated.

Closes #32346.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Confirm that attempting delivery of a not-yet-persisted invalid/complete webhook doesn't automatically save it:
   1. Run `wp eval '(new \WC_Webhook())->deliver( 1 );'
` to simulate delivery of an incomplete webhook.
   1. Go to WC > Settings > Advanced > Webhooks and confirm that no new webhooks have been created.
   1. (Optional) Constrast this with `trunk` where a new "empty" webhook would get created every time you run the code above.
1. Go to WC > Orders and make sure you have at least one order. If not, create one by clicking **Add Order**.
   I suggest keeping this order edit screen open in a different tab as that'll be handy later.
1. Go to WC > Settings > Advanced > Webhooks and create at least two **Active** webhooks, associated to the **Order updated** topic.
   You can use any valid URL but if you truly care about the details, I suggest pointing them to a [RequestBin](https://pipedream.com/requestbin).
1. Go to WC > Orders and open the order you created in step 2. Click **Update**.
1. Go to Tools > Scheduled Actions > Pending and confirm that there are 2 `woocommerce_deliver_webhook_async` actions related to this order and the two webhooks you have created.
1. Either wait for A-S to run those actions or manually run them by clicking **Run**.
1. Go to WC > Status > Logs and check the `webhooks-delivery` log, which should contain entries for your 2 webhooks that were just delivered.
1. Go back to WC > Orders > (any order) and click **Update** again.
1. Quickly, delete **one** of the webhooks you created in step 3.
1. Again, quickly, go to Tools > Scheduled Actions > Pending and confirm that you see the 2 pending `woocommerce_deliver_webhook_async` actions again. Run those actions or wait for A-S to process the queue.
1. Check the `webhooks-delivery` log in WC > Status > Logs again, and confirm that the only new entry corresponds to the only webhook that remains active on your site.
1. Go to WC > Settings > Advanced > Webhooks and confirm that no new webhooks have been created in the process.
   **Optional:** Repeat the above on `trunk` and confirm that the delivery of the deleted webhook automatically creates an empty webhook in WC > Settings > Advanced > Webhooks.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
