### PR TITLE
Add best practices advice to the API generation screen

### DIFF
--- a/plugins/woocommerce/changelog/2024-05-31-20-04-57-478391
+++ b/plugins/woocommerce/changelog/2024-05-31-20-04-57-478391
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Adds best practice advice to the API key generation screen.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5031,6 +5031,13 @@ img.help_tip {
 		background: #dfdfdf !important;
 	}
 
+	.settings-panel {
+		ul.advice {
+			list-style: square;
+			list-style-position: inside;
+		}
+	}
+
 	table.form-table {
 		margin: 0;
 		position: relative;

--- a/plugins/woocommerce/client/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings.js
@@ -267,5 +267,34 @@
 				$( this ).addClass( 'is-busy' );
 			}
 		} );
+
+		/**
+		 * Support conditionally displaying a settings field description when another element
+		 * is set to a specific value.
+		 *
+		 * This logic is subject to change, and is not intended for use by other plugins.
+		 * Note that we can't avoid jQuery here, because of our current dependence on Select2
+		 * for various controls.
+		 */
+		document.querySelectorAll( 'body.woocommerce_page_wc-settings #mainform .conditional.description' ).forEach( description => {
+			const $underObservation = $( description.dataset.dependsOn );
+			const showIfEquals      = description.dataset.showIfEquals;
+
+			if ( undefined === showIfEquals || $underObservation.length === 0 ) {
+				return;
+			}
+
+			/**
+			 * Set visibility of the description element according to whether its value
+			 * matches that of showIfEquals.
+			 */
+			const changeAgent = () => {
+				description.style.visibility = $underObservation.val() === showIfEquals ? 'visible' : 'hidden';
+			};
+
+			// Monitor future changes, and take action based on the current state.
+			$underObservation.on( 'change', changeAgent );
+			changeAgent();
+		} );
 	} );
 } )( jQuery, woocommerce_settings_params, wp );

--- a/plugins/woocommerce/includes/admin/settings/views/html-keys-edit.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-keys-edit.php
@@ -11,6 +11,13 @@ defined( 'ABSPATH' ) || exit;
 <div id="key-fields" class="settings-panel">
 	<h2><?php esc_html_e( 'Key details', 'woocommerce' ); ?></h2>
 
+	<div class="inline notice">
+		<ul class="advice">
+			<li><?php esc_html_e( 'API keys open up access to potentially sensitive information. Only share them with organizations you trust.', 'woocommerce' ); ?></li>
+			<li><?php esc_html_e( 'Stick to one key per client: this makes it easier to revoke access in the future for a single client, without causing disruption for others.', 'woocommerce' ); ?></li>
+		</ul>
+	</div>
+
 	<input type="hidden" id="key_id" value="<?php echo esc_attr( $key_id ); ?>" />
 
 	<table id="api-keys-options" class="form-table">
@@ -24,6 +31,9 @@ defined( 'ABSPATH' ) || exit;
 				</th>
 				<td class="forminp">
 					<input maxlength="200" id="key_description" type="text" class="input-text regular-input" value="<?php echo esc_attr( $key_data['description'] ); ?>" />
+					<p class="description">
+						<?php esc_html_e( 'Add a meaningful description, including a note of the person, company or app you are sharing the key with.', 'woocommerce' ); ?>
+					</p>
 				</td>
 			</tr>
 			<tr valign="top">
@@ -72,6 +82,9 @@ defined( 'ABSPATH' ) || exit;
 							<option value="<?php echo esc_attr( $permission_id ); ?>" <?php selected( $key_data['permissions'], $permission_id, true ); ?>><?php echo esc_html( $permission_name ); ?></option>
 						<?php endforeach; ?>
 					</select>
+					<p class="conditional description" data-depends-on="#key_permissions" data-show-if-equals="write">
+						<?php esc_html_e( 'Write-only keys do not prevent clients from seeing information about the entities they are updating.', 'woocommerce' ); ?>
+					</p>
 				</td>
 			</tr>
 
@@ -104,19 +117,6 @@ defined( 'ABSPATH' ) || exit;
 					</td>
 				</tr>
 			<?php endif ?>
-			<tr>
-				<th scope="row" class="titledesc">
-					<?php esc_html_e( 'Best practices', 'woocommerce' ); ?>
-				</th>
-				<td class="forminp">
-					<ul class="advice">
-						<li><?php esc_html_e( 'API keys open up access to potentially sensitive information. Only share them with organizations you trust.', 'woocommerce' ); ?></li>
-						<li><?php esc_html_e( 'Stick to one key per client: this makes it easier to revoke access in the future for a single client, without causing disruption for others.', 'woocommerce' ); ?></li>
-						<li><?php esc_html_e( 'Add a meaningful description, including a note of the person, company or app you are sharing the key with.', 'woocommerce' ); ?></li>
-						<li><?php esc_html_e( 'Write-only keys do not prevent clients from seeing information about the entities they are updating.', 'woocommerce' ); ?></li>
-					</ul>
-				</td>
-			</tr>
 		</tbody>
 	</table>
 

--- a/plugins/woocommerce/includes/admin/settings/views/html-keys-edit.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-keys-edit.php
@@ -104,6 +104,19 @@ defined( 'ABSPATH' ) || exit;
 					</td>
 				</tr>
 			<?php endif ?>
+			<tr>
+				<th scope="row" class="titledesc">
+					<?php esc_html_e( 'Best practices', 'woocommerce' ); ?>
+				</th>
+				<td class="forminp">
+					<ul class="advice">
+						<li><?php esc_html_e( 'API keys open up access to potentially sensitive information. Only share them with organizations you trust.', 'woocommerce' ); ?></li>
+						<li><?php esc_html_e( 'Stick to one key per client: this makes it easier to revoke access in the future for a single client, without causing disruption for others.', 'woocommerce' ); ?></li>
+						<li><?php esc_html_e( 'Add a meaningful description, including a note of the person, company or app you are sharing the key with.', 'woocommerce' ); ?></li>
+						<li><?php esc_html_e( 'Write-only keys do not prevent clients from seeing information about the entities they are updating.', 'woocommerce' ); ?></li>
+					</ul>
+				</td>
+			</tr>
 		</tbody>
 	</table>
 


### PR DESCRIPTION
![API generation screen, with additional advice added to promote safety and security.](https://github.com/woocommerce/woocommerce/assets/3594411/4ace0c0f-3b03-4e22-b7de-3e0b71e299ae)

☝🏼 Based on recent experiences and feedback, this change adds a few additional pieces of advice to the API key generation screen. Always present are reminders that:

- Sharing an API key gives general access to store data.
- A one-key-per-client policy is best.
- The description field should be set to something meaningful, that makes it easy to remember who it was shared with in the future.

Conditionally visible:

- A reminder that consumers of write-only keys will still be able to access information about any of the entities they update (implicitly covered in the REST API documentation already, but also worth calling out here explicitly).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and (re-)build the legacy/classic assets. One way to do this, from the `plugins/woocommerce` directory of the mono-repo, is to run `pnpm --filter='@woocommerce/classic-assets' build && cp -r client/legacy/build/* assets/` (...but you could also use a live branch, etc).
2. Navigate to **WooCommerce ‣ Settings ‣ Advanced ‣ REST API** and click **Add key**.
3. You should see additional advice has been added to the page, as per the screenshot at the top of the PR description. Please review: 
    - Does this make sense, is it clear?
    - Any typos?
    - Anything missing, etc?
4. In particular, ensure that advice specific to write-only keys appears when you set the `Permissions` selector to `Write`.
5. Lastly, perform a functional test. You should still be able to create new keys with this change.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
