### PR TITLE
Remove edit_comments_screen_text on gettext filter for performance

### DIFF
--- a/plugins/woocommerce/changelog/remove-filter-on-gettext-to-edit-comments-screen-title
+++ b/plugins/woocommerce/changelog/remove-filter-on-gettext-to-edit-comments-screen-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Revert changing the title of the edit comments screen when editing a review.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -49,7 +49,6 @@ class Reviews {
 		self::add_action( 'wp_ajax_replyto-comment', [ $this, 'handle_reply_to_review' ], -1 );
 
 		self::add_filter( 'parent_file', [ $this, 'edit_review_parent_file' ] );
-		self::add_filter( 'gettext', [ $this, 'edit_comments_screen_text' ], 10, 2 );
 		self::add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
 
@@ -520,45 +519,6 @@ class Reviews {
 		}
 
 		return $parent_file;
-	}
-
-	/**
-	 * Replaces Edit/Moderate Comment title/headline with Edit Review, when editing/moderating a review.
-	 *
-	 * @param  string|mixed $translation Translated text.
-	 * @param  string|mixed $text        Text to translate.
-	 * @return string|mixed              Translated text.
-	 */
-	protected function edit_comments_screen_text( $translation, $text ) {
-		global $comment;
-
-		// Bail out if not a text we should replace.
-		if ( ! in_array( $text, [ 'Edit Comment', 'Moderate Comment' ], true ) ) {
-			return $translation;
-		}
-
-		// Try to get comment from query params when not in context already.
-		if ( ! $comment && isset( $_GET['action'], $_GET['c'] ) && $_GET['action'] === 'editcomment' ) {
-			$comment_id = absint( $_GET['c'] );
-			$comment    = get_comment( $comment_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		}
-
-		$is_reply = isset( $comment->comment_parent ) && $comment->comment_parent > 0;
-
-		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
-		if ( isset( $comment->comment_post_ID ) && get_post_type( $comment->comment_post_ID ) === 'product' ) {
-			if ( $text === 'Edit Comment' ) {
-				$translation = $is_reply
-					? __( 'Edit Review Reply', 'woocommerce' )
-					: __( 'Edit Review', 'woocommerce' );
-			} elseif ( $text === 'Moderate Comment' ) {
-				$translation = $is_reply
-					? __( 'Moderate Review Reply', 'woocommerce' )
-					: __( 'Moderate Review', 'woocommerce' );
-			}
-		}
-
-		return $translation;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-reviews.spec.js
@@ -135,7 +135,7 @@ test.describe( 'Product Reviews > Edit Product Review', () => {
 		await page.goto(
 			`wp-admin/comment.php?action=editcomment&c=${ review.id }`
 		);
-		await expect( page.getByText( 'Edit Review' ) ).toBeVisible();
+		await expect( page.getByText( 'Edit Comment' ) ).toBeVisible();
 
 		// Create new comment and edit the review with it
 		const updatedReview = `(edited ${ Date.now() })`;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -192,58 +192,6 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox `edit_comments_screen_text` will update the page heading when editing or moderating a review or a reply to a review.
-	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::edit_comments_screen_text()
-	 * @dataProvider data_provider_edit_comments_screen_text
-	 *
-	 * @param string $translated_text Translated text.
-	 * @param string $original_text   Original text (raw).
-	 * @param bool   $is_review       Whether we should test a review comment.
-	 * @param bool   $is_reply        Whether we should test a reply to a review comment.
-	 * @param string $expected_text   Expected text output.
-	 *
-	 * @return void
-	 * @throws ReflectionException If the method doesn't exist.
-	 */
-	public function test_edit_comments_screen_text( string $translated_text, string $original_text, bool $is_review, bool $is_reply, string $expected_text ) : void {
-		global $comment;
-
-		$product = $this->factory()->post->create( [ 'post_type' => 'product' ] );
-		$review  = $this->factory()->comment->create_and_get( [ 'comment_post_ID' => $product ] );
-		$reply   = $this->factory()->comment->create_and_get(
-			[
-				'comment_post_ID' => $product,
-				'comment_parent'  => $review->comment_ID,
-			]
-		);
-
-		if ( ! $is_review ) {
-			$post    = $this->factory()->post->create();
-			$comment = $this->factory()->comment->create_and_get( [ 'comment_post_ID' => $post ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		} else {
-			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		}
-
-		$reviews = ( wc_get_container()->get( Reviews::class ) );
-
-		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'edit_comments_screen_text' );
-		$method->setAccessible( true );
-
-		$this->assertSame( $expected_text, $method->invoke( $reviews, $translated_text, $original_text ) );
-	}
-
-	/** @see test_edit_comments_screen_text */
-	public function data_provider_edit_comments_screen_text() : Generator {
-		yield 'Regular comment' => [ 'Edit Comment', 'Edit Comment', false, false, 'Edit Comment' ];
-		yield 'Not the expected text'  => [ 'Foo', 'Bar', true, false, 'Foo' ];
-		yield 'Edit Review' => [ 'Edit Comment Translated', 'Edit Comment', true, false, 'Edit Review' ];
-		yield 'Edit Review Reply' => [ 'Edit Comment Translated', 'Edit Comment', true, true, 'Edit Review Reply' ];
-		yield 'Moderate Review' => [ 'Moderate Comment Translated', 'Moderate Comment', true, false, 'Moderate Review' ];
-		yield 'Moderate Review Reply' => [ 'Moderate Comment Translated', 'Moderate Comment', true, true, 'Moderate Review Reply' ];
-	}
-
-	/**
 	 * @testdox `render_reviews_list_table` will output the filterable reviews list table.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::render_reviews_list_table()


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The function `edit_comments_screen_text` changes the title of the edit comments screen. When you click on a product review to edit it, you see 'Edit Review' instead of 'Edit Comment'.
<img width="1077" alt="EditReviewCustomized" src="https://github.com/woocommerce/woocommerce/assets/8002881/010c25bd-5528-4202-91b1-40e8f26036ff">


`edit_comments_screen_text` hooks into filter `gettext` and thus it gets called everywhere, whenever there is a translation. This leads for instance, to 40000 unnecessary calls during the checkout. See the profiling example in the screenshot

![edit-comments-screent-text](https://github.com/woocommerce/woocommerce/assets/8002881/f18dcaa3-5362-4eed-951b-4c039a219c93)


[The string with the title in the edit comments string](https://github.com/WordPress/WordPress/blob/master/wp-admin/edit-form-comment.php#L22) can not be easily customized.

Because of the performance impact and the lack of customization options, this PR removes the code to customize the title with the tradeoff that when editing a product review, the title will say 'Edit Comment' instead of 'Edit Reply'.
<img width="1216" alt="EditCommentsScreen" src="https://github.com/woocommerce/woocommerce/assets/8002881/8abfe27b-da0f-40fb-af96-ac2032f10a35">


Closes [#35372](https://github.com/woocommerce/woocommerce/issues/35372)

p7bje6-5Yv

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To view the change in the functionality (tradeoff):
1. On a store that has product reviews enabled
2. Add a review to a product
3. From the admin dashboard, go to Product Reviews
4. Click to edit the review you added
5. See that the title is `Edit Comment` instead of `Edit Review`
<img width="1216" alt="EditCommentsScreen" src="https://github.com/woocommerce/woocommerce/assets/8002881/7e4af29b-61a6-48b3-b1f7-8027c23eb112">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
