### PR TITLE
Add CYS Fiverr Logo Maker CTA

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
@@ -31,6 +31,8 @@ import {
 } from '@wordpress/block-editor';
 // @ts-ignore No types for this exist yet.
 import { store as noticesStore } from '@wordpress/notices';
+import interpolateComponents from '@automattic/interpolate-components';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -531,17 +533,21 @@ export const SidebarNavigationScreenLogo = ( {
 							{ __( "DON'T HAVE A LOGO YET?", 'woocommerce' ) }
 						</strong>
 						<p>
-							{ __(
-								'Get a custom logo designed by a professional on ',
-								'woocommerce'
-							) }
-							<a
-								href="https://www.fiverr.com/logo-maker/woo?afp=&cxd_token=917527_33214203&show_join=true"
-								target="_blank"
-								rel="noreferrer"
-							>
-								{ __( 'Fiverr.', 'woocommerce' ) }
-							</a>
+							{ interpolateComponents( {
+								mixedString: __(
+									'Get a custom logo designed by a professional on {{link}}Fiverr{{/link}}.',
+									'woocommerce'
+								),
+								components: {
+									link: (
+										<Link
+											href="https://www.fiverr.com/logo-maker/woo?afp=&cxd_token=917527_33214203&show_join=true"
+											target="_blank"
+											type="external"
+										/>
+									),
+								},
+							} ) }
 						</p>
 					</div>
 				</div>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
@@ -526,6 +526,24 @@ export const SidebarNavigationScreenLogo = ( {
 						mediaItemData={ mediaItemData }
 						isLoading={ isLoading }
 					/>
+					<div className="woocommerce-customize-store__fiverr-cta-group">
+						<strong>
+							{ __( "DON'T HAVE A LOGO YET?", 'woocommerce' ) }
+						</strong>
+						<p>
+							{ __(
+								'Get a custom logo designed by a professional on ',
+								'woocommerce'
+							) }
+							<a
+								href="https://www.fiverr.com/logo-maker/woo?afp=&cxd_token=917527_33214203&show_join=true"
+								target="_blank"
+								rel="noreferrer"
+							>
+								{ __( 'Fiverr.', 'woocommerce' ) }
+							</a>
+						</p>
+					</div>
 				</div>
 			}
 		/>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -345,6 +345,17 @@ body.woocommerce-assembler {
 		}
 	}
 
+	.woocommerce-customize-store__fiverr-cta-group {
+		margin-top: 32px;
+		padding-top: 32px;
+		border-top: 1px solid var(--gutenberg-gray-700, #dcdcde);
+		color: var(--gutenberg-gray-900, #1e1e1e);
+
+		p {
+			margin-top: 6px;
+		}
+	}
+
 	.block-editor-block-patterns-list__item-title {
 		display: none;
 	}

--- a/plugins/woocommerce/changelog/48486-add-cys-fiverr-logo-maker-cta
+++ b/plugins/woocommerce/changelog/48486-add-cys-fiverr-logo-maker-cta
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: add
 
 </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48486-add-cys-fiverr-logo-maker-cta
+++ b/plugins/woocommerce/changelog/48486-add-cys-fiverr-logo-maker-cta
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-</details>  <details>  <summary>Changelog Entry Comment</summary>
+CYS: add CTA to our Fiverr Logo Maker landing page.   </details>  <details>  <summary>Changelog Entry Comment</summary>

--- a/plugins/woocommerce/changelog/48486-add-cys-fiverr-logo-maker-cta
+++ b/plugins/woocommerce/changelog/48486-add-cys-fiverr-logo-maker-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+</details>  <details>  <summary>Changelog Entry Comment</summary>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds the text CTA with a link to the WooCommerce landing page for the Fiverr logo maker in the sidebar navigation on the logo view.

For context, see p7fD6U-eEJ-p2#comment-27868 (internal link).

~Closes # .~

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to **WooCommerce > Home > Customize your store**.
2. Click on **Customize your theme** (or **Use the store designer**).
3. Click on **Add your logo**.
4. Confirm the Fiverr CTA text appears below the logo upload input (see screenshot below).
5. Click on the **Fiverr** link in the text and confirm the [Woo-branded Fiverr logo maker landing page](https://www.fiverr.com/logo-maker/woo?afp=&cxd_token=917527_33214203&show_join=true) opens in a new tab.

![CleanShot 2024-06-13 at 22 21 37](https://github.com/woocommerce/woocommerce/assets/481776/e1bb368a-6e22-4341-bf5c-bfd592af3237)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: add CTA to our Fiverr Logo Maker landing page. 

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>