### PR TITLE
Fix core api tests results path and artifacts naming pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
               if: ${{ always() && matrix.report.resultsPath != '' }}
               uses: actions/upload-artifact@v4
               with:
-                name: '${{ matrix.report.resultsBlobName }}-${{ strategy.job-index }}'
+                name: '${{ matrix.report.resultsBlobName }}__${{ strategy.job-index }}'
                 path: ${{ env.ARTIFACTS_PATH }}
                 
             - name: 'Upload flaky test reports'
@@ -295,7 +295,7 @@ jobs:
               continue-on-error: true
               with:
                 name: ${{ matrix.report }}
-                pattern: ${{ matrix.report }}-*
+                pattern: ${{ matrix.report }}__*
                 delete-merged: true
 
             - name: 'Download merged artifacts'

--- a/plugins/woocommerce/changelog/tests-fix-core-api-tests-results-path
+++ b/plugins/woocommerce/changelog/tests-fix-core-api-tests-results-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix path to test results for api core tests

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -511,7 +511,7 @@
 					},
 					"report": {
 						"resultsBlobName": "core-api-report-hpos-disabled",
-						"resultsPath": "tests/e2e-pw/test-results",
+						"resultsPath": "tests/api-core-tests/test-results",
 						"allure": true
 					}
 				},

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -501,6 +501,7 @@
 						"tests/e2e-pw/bin/**"
 					],
 					"events": [
+						"pull_request",
 						"push"
 					],
 					"testEnv": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -501,7 +501,6 @@
 						"tests/e2e-pw/bin/**"
 					],
 					"events": [
-						"pull_request",
 						"push"
 					],
 					"testEnv": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixed the path to the test results in the `Core API tests - HPOS disabled` job report configuration. 
I also updated the name pattern used for the uploaded artifacts to avoid conflicts. Having both `core-api-tests` and `core-api-tests-non-hpos` resulted in the first reporting job, for `core-api-tests` also matching and merging `core-api-tests-non-hpos`. 

### How to test the changes in this Pull Request:

Check the `Core API tests - HPOS disabled`, the results were uploaded: [run](https://github.com/woocommerce/woocommerce/actions/runs/9513489826/job/26223767375?pr=48490#step:10:29)
Check the corresponding reporting job (`core-api-report-hpos-disabled`), it passed: [run](https://github.com/woocommerce/woocommerce/actions/runs/9513489826/job/26224618049#step:5:13)


