### PR TITLE
CYS: fix tooltip position

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
@@ -37,6 +37,7 @@ import { useAddAutoBlockPreviewEventListenersAndObservers } from './hooks/auto-b
 import { IsResizingContext } from './resizable-frame';
 import { __ } from '@wordpress/i18n';
 import { useQuery } from '@woocommerce/navigation';
+import clsx from 'clsx';
 
 // @ts-ignore No types for this exist yet.
 const { Provider: DisabledProvider } = Disabled.Context;
@@ -178,7 +179,10 @@ function ScaledBlockPreview( {
 				) }
 			<DisabledProvider value={ true }>
 				<div
-					className="block-editor-block-preview__content"
+					className={ clsx( 'block-editor-block-preview__content', {
+						'woocommerce-customize-store-assembler':
+							! isPatternPreview,
+					} ) }
 					style={
 						autoScale
 							? {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/hooks/auto-block-preview-event-listener.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/hooks/auto-block-preview-event-listener.ts
@@ -191,8 +191,6 @@ const updateSelectedBlock = (
 		} );
 
 		updatePopoverPosition( {
-			mainBodyWidth: window.document.body.clientWidth,
-			iframeWidth: body.clientWidth,
 			event,
 			hoveredBlockClientId: null,
 			clickedBlockClientId: clickedBlockClientId as string,
@@ -208,8 +206,6 @@ const updateSelectedBlock = (
 
 		if ( selectedBlockClientId ) {
 			updatePopoverPosition( {
-				mainBodyWidth: window.document.body.clientWidth,
-				iframeWidth: body.clientWidth,
 				event,
 				hoveredBlockClientId: selectedBlockClientId,
 				clickedBlockClientId: null,
@@ -272,8 +268,6 @@ type useAutoBlockPreviewEventListenersCallbacks = {
 	getBlockParents: ( clientId: string ) => string[];
 	setBlockEditingMode: ( clientId: string ) => void;
 	updatePopoverPosition: ( options: {
-		mainBodyWidth: number;
-		iframeWidth: number;
 		event: MouseEvent;
 		hoveredBlockClientId: string | null;
 		clickedBlockClientId: string | null;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/hooks/use-popover-handler.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/hooks/use-popover-handler.ts
@@ -38,20 +38,16 @@ export const usePopoverHandler = () => {
 	);
 
 	const updatePopoverPosition = ( {
-		mainBodyWidth,
-		iframeWidth,
 		event,
 		clickedBlockClientId,
 		hoveredBlockClientId,
 	}: {
-		mainBodyWidth: number;
-		iframeWidth: number;
 		event: MouseEvent;
 		clickedBlockClientId: string | null;
 		hoveredBlockClientId: string | null;
 	} ) => {
 		const iframe = window.document.querySelector(
-			'iframe[name="editor-canvas"]'
+			'.woocommerce-customize-store-assembler > iframe[name="editor-canvas"]'
 		) as HTMLElement;
 
 		clickedClientId =
@@ -72,10 +68,8 @@ export const usePopoverHandler = () => {
 
 			const newElement = {
 				getBoundingClientRect: generateGetBoundingClientRect(
-					event.clientX +
-						( mainBodyWidth - iframeWidth - iframeRect.left ) +
-						200,
-					event.clientY + iframeRect.top + 40
+					event.clientX + iframeRect.left,
+					event.clientY + iframeRect.top + 20
 				),
 			} as VirtualElement;
 

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -815,6 +815,7 @@ body.woocommerce-assembler {
 }
 
 .woocommerce-customize-store_popover-tooltip {
+	pointer-events: none;
 	.components-popover__content {
 		width: fit-content;
 		user-select: none;

--- a/plugins/woocommerce/changelog/48495-fix-cys-tooltip-position
+++ b/plugins/woocommerce/changelog/48495-fix-cys-tooltip-position
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS: fix tooltip position.  </details>  <details>  <summary>Changelog Entry Comment</summary>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves how the tooltip position is computed. I noticed that sometimes the iframe instance wasn't the right one. For this reason, I created a dedicated CSS class to ensure that the right iframe element is targeted

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on Start designing.
8. Click on "Design your Homepage"
9. Click on a pattern.
10. Ensure that the tooltip is rendered under the mouse pointer.
11. Move the pointer.
12. Ensure that the tooltip follows the pointer.
13. Resize the iframe.
14. Ensure that the tooltip follows the pointer.
15. Repeat for 9-14 for "Choose your header" and "Choose your footer".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: fix tooltip position.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
