### PR TITLE
Fix flaky color palette picker e2e test

### DIFF
--- a/plugins/woocommerce/changelog/47724-fix-flaky-e2e-test-color-palette-picker
+++ b/plugins/woocommerce/changelog/47724-fix-flaky-e2e-test-color-palette-picker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixing flaky color palette picker test

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
@@ -308,10 +308,6 @@ test.describe( 'Assembler -> Color Pickers', () => {
 					response.status() === 200
 			);
 
-			await saveButton.click();
-
-			await waitResponse;
-
 			const buttons = await editor
 				.locator( '.wp-block-button > .wp-block-button__link' )
 				.evaluateAll( ( elements ) =>
@@ -392,6 +388,10 @@ test.describe( 'Assembler -> Color Pickers', () => {
 			for ( const element of headersInCoverBlock ) {
 				expect( element.color ).toEqual( 'rgb(255, 255, 255)' );
 			}
+
+			await saveButton.click();
+
+			await waitResponse;
 		} );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47724

There is no need to press the Save button and then verify colors while saving and redirecting. I moved the Save button to the bottom after completing the expected assertions.

This produced unnecessary race condition flakiness.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `pnpm test:e2e-pw ./tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
