### PR TITLE
CYS: fix logic to disable mover buttons

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
@@ -94,18 +94,34 @@ export const Toolbar = () => {
 
 		setIsHomepageSidebarOpen( isHomepageUrl( path ) );
 	}, [ query ] );
-	const { isPreviousBlockTemplatePart, isNextBlockTemplatePart } =
-		useMemo( () => {
-			return {
-				isPreviousBlockTemplatePart:
-					previousBlock?.name === 'core/template-part',
-				isNextBlockTemplatePart:
-					nextBlock?.name === 'core/template-part',
-			};
-		}, [ nextBlock?.name, previousBlock?.name ] );
 
 	const selectedBlockClientId =
 		currentBlock?.clientId ?? firstBlock?.clientId;
+
+	const { isBlockMoverUpButtonDisabled, isBlockMoverDownButtonDisabled } =
+		useMemo( () => {
+			const isPreviousBlockTemplatePart =
+				previousBlock?.name === 'core/template-part';
+			const isNextBlockTemplatePart =
+				nextBlock?.name === 'core/template-part';
+
+			return {
+				isBlockMoverUpButtonDisabled:
+					isPreviousBlockTemplatePart ||
+					// The first block is the header, which is not movable.
+					allBlocks[ 1 ]?.clientId === selectedBlockClientId,
+				isBlockMoverDownButtonDisabled:
+					isNextBlockTemplatePart ||
+					// The last block is the footer, which is not movable.
+					allBlocks[ allBlocks.length - 2 ]?.clientId ===
+						selectedBlockClientId,
+			};
+		}, [
+			allBlocks,
+			nextBlock?.name,
+			previousBlock?.name,
+			selectedBlockClientId,
+		] );
 
 	const isNoBlocksPlaceholderPresent =
 		useIsNoBlocksPlaceholderPresent( allBlocks );
@@ -136,10 +152,10 @@ export const Toolbar = () => {
 							<BlockMover
 								clientIds={ [ selectedBlockClientId ] }
 								isBlockMoverUpButtonDisabled={
-									isPreviousBlockTemplatePart
+									isBlockMoverUpButtonDisabled
 								}
 								isBlockMoverDownButtonDisabled={
-									isNextBlockTemplatePart
+									isBlockMoverDownButtonDisabled
 								}
 							/>
 						</ToolbarGroup>

--- a/plugins/woocommerce/changelog/48502-fix-cys-improve-logic-blocker-mover-disabled
+++ b/plugins/woocommerce/changelog/48502-fix-cys-improve-logic-blocker-mover-disabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS: fix logic to disable mover buttons.  </details>  <details>  <summary>Changelog Entry Comment</summary>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue with the logic of disabling the mover buttons. Currently, when the user clicks on the header, the mover-up button isn't disabled. Same for the footer. This PR fixes this wrong beavhiour.

| Before | After |
|--------|--------|
| <video src="https://github.com/woocommerce/woocommerce/assets/4463174/5c221426-8bbb-4f83-8c77-035accbc1798" /> | <video src="https://github.com/woocommerce/woocommerce/assets/4463174/c776ef07-3ed9-4d38-afbd-06e4833fda5a" /> | 





<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on Start designing.
8. Click on "Design your Homepage".
9. Click on the header.
10. Ensure that the mover up button is disabled.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: fix logic to disable mover buttons.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
