### PR TITLE
Create an API that manage the custom field names

### DIFF
--- a/plugins/woocommerce/changelog/add-46918
+++ b/plugins/woocommerce/changelog/add-46918
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a rest api to manage the product custom fields

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -78,20 +78,27 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 		$base_query = $wpdb->prepare(
 			"SELECT DISTINCT m.meta_key
 			FROM {$wpdb->postmeta} m LEFT JOIN {$wpdb->posts} p ON m.post_id = p.id
-			WHERE p.post_type = '{$this->post_type}' AND m.meta_key NOT LIKE '\_%' AND m.meta_key LIKE %s",
-			"%{$search}%",
+			WHERE p.post_type = %s AND m.meta_key NOT LIKE %s AND m.meta_key LIKE %s",
+			$this->post_type,
+			$wpdb->esc_like( '_' ) . '%',
+			"%{$search}%"
 		);
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already and $order is a static value.
 		$query = $wpdb->prepare(
 			"$base_query ORDER BY m.meta_key $order LIMIT %d, %d",
 			$offset,
 			$limit
 		);
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already.
 		$total_query = "SELECT COUNT(1) FROM ($base_query) AS t";
-
+		
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $query has been prepared already.
 		$query_result = $wpdb->get_results( $query );
-		$total_items  = $wpdb->get_var( $total_query );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $total_query has been prepared already.
+		$total_items = $wpdb->get_var( $total_query );
 
 		$custom_field_names = array();
 		foreach ( $query_result as $custom_field_name ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -93,7 +93,7 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already.
 		$total_query = "SELECT COUNT(1) FROM ($base_query) AS t";
-		
+
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $query has been prepared already.
 		$query_result = $wpdb->get_results( $query );
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * REST API CustomFields controller
+ *
+ * Handles requests to the /products endpoint.
+ *
+ * @package WooCommerce\RestApi
+ * @since   9.2.0
+ */
+
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Product Custom Fields controller class.
+ *
+ * @package WooCommerce\RestApi
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'product-custom-fields';
+
+	/**
+	 * Post type.
+	 *
+	 * @var string
+	 */
+	protected $post_type = 'product';
+
+	/**
+	 * Register the routes for products.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/names',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item_names' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Get a collection of custom field names.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item_names( $request ) {
+		global $wpdb;
+
+		$search = trim( $request['search'] );
+		$order  = strtoupper( $request['order'] ) === 'DESC' ? 'DESC' : 'ASC';
+
+		$query = $wpdb->prepare(
+			"SELECT DISTINCT m.meta_key
+			FROM {$wpdb->postmeta} m LEFT JOIN {$wpdb->posts} p ON m.post_id = p.id
+			WHERE p.post_type = '{$this->post_type}' AND m.meta_key NOT LIKE '\_%' AND m.meta_key LIKE %s
+			ORDER BY m.meta_key {$order}
+			LIMIT 100",
+			"%{$search}%"
+		);
+
+		$query_result = $wpdb->get_results( $query );
+
+		$custom_field_names = array();
+		foreach ( $query_result as $custom_field_name ) {
+			$custom_field_names[] = $custom_field_name->meta_key;
+		}
+
+		$response = rest_ensure_response( $custom_field_names );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request has access to read items.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_post_permissions( $this->post_type, 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -32,7 +32,7 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'product-custom-fields';
+	protected $rest_base = 'products/custom-fields';
 
 	/**
 	 * Post type.
@@ -141,5 +141,22 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Add new options for 'order' to the collection params.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params          = parent::get_collection_params();
+		$params['order'] = array(
+			'description'       => __( 'Order sort items ascending or descending.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'asc',
+			'enum'              => array( 'asc', 'desc' ),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -76,9 +76,9 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 		$offset = ( $page - 1 ) * $limit;
 
 		$base_query = $wpdb->prepare(
-			"SELECT DISTINCT m.meta_key
-			FROM {$wpdb->postmeta} m LEFT JOIN {$wpdb->posts} p ON m.post_id = p.id
-			WHERE p.post_type = %s AND m.meta_key NOT LIKE %s AND m.meta_key LIKE %s",
+			"SELECT DISTINCT post_metas.meta_key
+			FROM {$wpdb->postmeta} post_metas LEFT JOIN {$wpdb->posts} posts ON post_metas.post_id = posts.id
+			WHERE posts.post_type = %s AND post_metas.meta_key NOT LIKE %s AND post_metas.meta_key LIKE %s",
 			$this->post_type,
 			$wpdb->esc_like( '_' ) . '%',
 			"%{$search}%"
@@ -86,13 +86,13 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already and $order is a static value.
 		$query = $wpdb->prepare(
-			"$base_query ORDER BY m.meta_key $order LIMIT %d, %d",
+			"$base_query ORDER BY post_metas.meta_key $order LIMIT %d, %d",
 			$offset,
 			$limit
 		);
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already.
-		$total_query = "SELECT COUNT(1) FROM ($base_query) AS t";
+		$total_query = "SELECT COUNT(1) FROM ($base_query) AS total";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $query has been prepared already.
 		$query_result = $wpdb->get_results( $query );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -2,7 +2,7 @@
 /**
  * REST API CustomFields controller
  *
- * Handles requests to the /products endpoint.
+ * Handles requests to the /products/custom-fields endpoint.
  *
  * @package WooCommerce\RestApi
  * @since   9.2.0

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -157,6 +157,7 @@ class Server {
 			'product-attribute-terms'  => 'WC_REST_Product_Attribute_Terms_Controller',
 			'product-attributes'       => 'WC_REST_Product_Attributes_Controller',
 			'product-categories'       => 'WC_REST_Product_Categories_Controller',
+			'product-custom-fields'    => 'WC_REST_Product_Custom_Fields_Controller',
 			'product-reviews'          => 'WC_REST_Product_Reviews_Controller',
 			'product-shipping-classes' => 'WC_REST_Product_Shipping_Classes_Controller',
 			'product-tags'             => 'WC_REST_Product_Tags_Controller',

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller-tests.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * class WC_REST_Product_Custom_Fields_Controller_Tests.
+ * Product Custom Fields Controller tests for V3 REST API.
+ */
+class WC_REST_Product_Custom_Fields_Controller_Tests extends WC_REST_Unit_Test_Case {
+	/**
+	 * @var WC_Product_Simple[]
+	 */
+	protected static $products = array();
+
+	/**
+	 * Create products for tests.
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Pancake',
+				'sku'  => 'pancake-1',
+			)
+		);
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Waffle 1',
+				'sku'  => 'pancake-2',
+			)
+		);
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'French Toast',
+				'sku'  => 'waffle-2',
+			)
+		);
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Waffle 3',
+				'sku'  => 'waffle-3',
+			)
+		);
+
+		foreach ( self::$products as $product ) {
+			for ( $i = 0; $i < 20; $i++ ) {
+				$product->add_meta_data( "Custom field $i", "Value $i", true );
+			}
+			$product->save();
+		}
+	}
+
+	/**
+	 * Clean up products after tests.
+	 *
+	 * @return void
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$products as $product ) {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->endpoint = new WC_REST_Product_Custom_Fields_Controller();
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user );
+	}
+
+	/**
+	 * Test the default custom field names endpoint response.
+	 *
+	 * @return void
+	 */
+	public function test_custom_fields_without_params() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertEquals( 10, count( $data ) );
+		$this->assertEquals( 'Custom field 0', $data[0] );
+		$this->assertEquals( 'Custom field 1', $data[1] );
+		$this->assertEquals( 'Custom field 10', $data[2] );
+		$this->assertEquals( 'Custom field 11', $data[3] );
+		$this->assertEquals( 'Custom field 12', $data[4] );
+		$this->assertEquals( 'Custom field 13', $data[5] );
+		$this->assertEquals( 'Custom field 14', $data[6] );
+		$this->assertEquals( 'Custom field 15', $data[7] );
+		$this->assertEquals( 'Custom field 16', $data[8] );
+		$this->assertEquals( 'Custom field 17', $data[9] );
+	}
+
+	/**
+	 * Test the custom field names searching.
+	 *
+	 * @return void
+	 */
+	public function test_custom_fields_searching() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+		$request->set_query_params(
+			array(
+				'search' => '0',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertEquals( 2, count( $data ) );
+		$this->assertEquals( 'Custom field 0', $data[0] );
+		$this->assertEquals( 'Custom field 10', $data[1] );
+	}
+
+	/**
+	 * Test the custom field names ordering.
+	 *
+	 * @return void
+	 */
+	public function test_custom_fields_ordering() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+		$request->set_query_params(
+			array(
+				'order'  => 'desc',
+				'search' => 'Custom',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertEquals( 10, count( $data ) );
+		$this->assertEquals( 'Custom field 9', $data[0] );
+		$this->assertEquals( 'Custom field 8', $data[1] );
+		$this->assertEquals( 'Custom field 7', $data[2] );
+		$this->assertEquals( 'Custom field 6', $data[3] );
+		$this->assertEquals( 'Custom field 5', $data[4] );
+		$this->assertEquals( 'Custom field 4', $data[5] );
+		$this->assertEquals( 'Custom field 3', $data[6] );
+		$this->assertEquals( 'Custom field 2', $data[7] );
+		$this->assertEquals( 'Custom field 19', $data[8] );
+		$this->assertEquals( 'Custom field 18', $data[9] );
+	}
+
+	/**
+	 * Test the custom field names pagination.
+	 *
+	 * @return void
+	 */
+	public function test_custom_fields_pagination() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+		$request->set_query_params(
+			array(
+				'per_page' => 3,
+				'page'     => 2,
+				'search'   => 'Custom',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertEquals( 3, count( $data ) );
+		$this->assertEquals( 'Custom field 11', $data[0] );
+		$this->assertEquals( 'Custom field 12', $data[1] );
+		$this->assertEquals( 'Custom field 13', $data[2] );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller-tests.php
@@ -85,7 +85,7 @@ class WC_REST_Product_Custom_Fields_Controller_Tests extends WC_REST_Unit_Test_C
 	 * @return void
 	 */
 	public function test_custom_fields_without_params() {
-		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products/custom-fields/names' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -110,7 +110,7 @@ class WC_REST_Product_Custom_Fields_Controller_Tests extends WC_REST_Unit_Test_C
 	 * @return void
 	 */
 	public function test_custom_fields_searching() {
-		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products/custom-fields/names' );
 		$request->set_query_params(
 			array(
 				'search' => '0',
@@ -131,7 +131,7 @@ class WC_REST_Product_Custom_Fields_Controller_Tests extends WC_REST_Unit_Test_C
 	 * @return void
 	 */
 	public function test_custom_fields_ordering() {
-		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products/custom-fields/names' );
 		$request->set_query_params(
 			array(
 				'order'  => 'desc',
@@ -161,7 +161,7 @@ class WC_REST_Product_Custom_Fields_Controller_Tests extends WC_REST_Unit_Test_C
 	 * @return void
 	 */
 	public function test_custom_fields_pagination() {
-		$request = new WP_REST_Request( 'GET', '/wc/v3/product-custom-fields/names' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products/custom-fields/names' );
 		$request->set_query_params(
 			array(
 				'per_page' => 3,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46918

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure to add some [custom fields](https://woocommerce.com/document/custom-product-fields/) to some products using the classic experience
2. Install [WP API SwaggerUI](https://wordpress.org/plugins/wp-api-swaggerui/) to easily test the new endpoint
3. Go to `Settings > Swagger`
4. Select `wc/v3` from the combobox and `Save changes`
5. Then click `Docs URL` link
6. From the Docs page click `Authorize` button and use the user credentials <img width="1025" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/d656643f-4c66-4df0-9a91-7432c0356ea5">
7. Find the `/wc/v3/products/custom-fields/names` item and expand it <img width="1025" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/cab134e0-25b7-440e-845e-1a591fd41e74">
8. Then click `Try it out` button
9. When requesting GET:`/wp-json/wc/v3/products/custom-fields/names` the response should be all names of the created custom fields in point 1 ordered ASC and limited to only 10 items by default.
10. When requesting GET:`/wp-json/wc/v3/products/custom-fields/names?search={criteria}` where `{criteria}` is the text you want to search by, the response should be a limit of 10 custom field names that match the criteria.
11. When requesting GET:`/wp-json/wc/v3/products/custom-fields/names?page=1&per_page=3` let you paginate the custom field names.
12. When requesting GET:`/wp-json/wc/v3/products/custom-fields/names?order=desc` let you order the items DESC or ASC.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
