### PR TITLE
[ci] Always run the resolve artifacts path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
               run: 'pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }}'
               
             - name: 'Resolve artifacts path'
+              if: ${{ always() && matrix.report.resultsPath != '' }}
               # Blocks e2e use a relative path which is not supported by actions/upload-artifact@v4
               # https://github.com/actions/upload-artifact/issues/176
               env:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The 'Resolve artifacts path' was not running if the previous step failed and the artifacts failed to upload.

### How to test the changes in this Pull Request:

Check [this run](https://github.com/woocommerce/woocommerce/actions/runs/9526906879/job/26262915117). With failed steps before, the steps ran successfully.