### PR TITLE
[test reports] Send the run attempt to the reports workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,7 @@ jobs:
                   gh workflow run report.yml \
                     -f artifact="$REPORT_NAME" \
                     -f run_id="$GITHUB_RUN_ID" \
+                    -f run_attempt="$GITHUB_RUN_ATTEMPT" \
                     -f event="$EVENT_NAME" \
                     -f pr_number="$PR_NUMBER" \
                     -f ref_name="$REF_NAME" \


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Send the run attempt as input to the report workflow call in woocommerce/woocommerce-test-reports repo.

### How to test the changes in this Pull Request:

Tested with this [daily run triggered manually](https://github.com/woocommerce/woocommerce/actions/runs/9543485897/job/26301349124). 