### PR TITLE
[LYS] Fix product archive page not hidden behind coming soon page

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-archive-page-not-hidden-behind-coming-soon
+++ b/plugins/woocommerce/changelog/fix-product-archive-page-not-hidden-behind-coming-soon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product archive page not hidden behind the coming soon page

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -149,6 +149,7 @@ class WCAdminHelper {
 			return false;
 		}
 		$normalized_path = self::get_normalized_url_path( $url );
+		$p               = get_page_by_path( 'shop' );
 
 		// WC store pages.
 		$store_pages = array(
@@ -168,12 +169,24 @@ class WCAdminHelper {
 		 */
 		$store_pages = apply_filters( 'woocommerce_store_pages', $store_pages );
 
+		// If the shop page is not set, check if the URL is a product archive page.
+		if ( $store_pages['shop'] <= 0 ) {
+			$product_post_archive_link = get_post_type_archive_link( 'product' );
+
+			if ( is_string( $product_post_archive_link ) &&
+				0 === strpos( $normalized_path, self::get_normalized_url_path( $product_post_archive_link ) )
+			) {
+				return true;
+			}
+		}
+
 		foreach ( $store_pages as $page => $page_id ) {
 			if ( 0 >= $page_id ) {
 				continue;
 			}
 
 			$permalink = get_permalink( $page_id );
+
 			if ( ! $permalink ) {
 				continue;
 			}

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -149,7 +149,6 @@ class WCAdminHelper {
 			return false;
 		}
 		$normalized_path = self::get_normalized_url_path( $url );
-		$p               = get_page_by_path( 'shop' );
 
 		// WC store pages.
 		$store_pages = array(
@@ -169,7 +168,8 @@ class WCAdminHelper {
 		 */
 		$store_pages = apply_filters( 'woocommerce_store_pages', $store_pages );
 
-		// If the shop page is not set, check if the URL is a product archive page.
+		// If the shop page is not set, we will still show the product archive page.
+		// Therefore, we need to check if the URL is a product archive page when the shop page is not set.
 		if ( $store_pages['shop'] <= 0 ) {
 			$product_post_archive_link = get_post_type_archive_link( 'product' );
 
@@ -186,7 +186,6 @@ class WCAdminHelper {
 			}
 
 			$permalink = get_permalink( $page_id );
-
 			if ( ! $permalink ) {
 				continue;
 			}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -219,14 +219,14 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 	 * @return array[] list of store page test data.
 	 */
 	public function get_store_page_test_data() {
-			return array(
-				array( get_permalink( wc_get_page_id( 'cart' ) ), true ), // Test case 1: URL matches cart page.
-				array( 'https://example.com/product-category/sample-category/', true ), // Test case 3: URL matches product category page.
-				array( 'https://example.com/product-tag/sample-tag/', true ), // Test case 4: URL matches product tag page.
-				array( 'https://example.com/shop/uncategorized/test/', true ), // Test case 5: URL matches product page.
-				array( '/shop/t-shirt/test/', true ), // Test case 6: URL path matches product page.
-				array( 'https://example.com/about-us/', false ), // Test case 7: URL does not match any store page.
-			);
+		return array(
+			array( get_permalink( wc_get_page_id( 'cart' ) ), true ), // Test case 1: URL matches cart page.
+			array( 'https://example.com/product-category/sample-category/', true ), // Test case 3: URL matches product category page.
+			array( 'https://example.com/product-tag/sample-tag/', true ), // Test case 4: URL matches product tag page.
+			array( 'https://example.com/shop/uncategorized/test/', true ), // Test case 5: URL matches product page.
+			array( '/shop/t-shirt/test/', true ), // Test case 6: URL path matches product page.
+			array( 'https://example.com/about-us/', false ), // Test case 7: URL does not match any store page.
+		);
 	}
 
 	/**
@@ -235,26 +235,45 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 	 *
 	 */
 	public function test_is_store_page() {
-			global $wp_rewrite;
+		global $wp_rewrite;
 
-			$wp_rewrite = $this->getMockBuilder( 'WP_Rewrite' )->getMock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_rewrite = $this->getMockBuilder( 'WP_Rewrite' )->getMock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-			$permalink_structure = array(
-				'category_base' => 'product-category',
-				'tag_base'      => 'product-tag',
-				'product_base'  => 'product',
-			);
+		$permalink_structure = array(
+			'category_base' => 'product-category',
+			'tag_base'      => 'product-tag',
+			'product_base'  => 'product',
+		);
 
-			$wp_rewrite->expects( $this->any() )
-				->method( 'generate_rewrite_rule' )
-				->willReturn( array( 'shop/(.+?)/?$' => 'index.php?product_cat=$matches[1]&year=$matches[2]' ) );
+		$wp_rewrite->expects( $this->any() )
+			->method( 'generate_rewrite_rule' )
+			->willReturn( array( 'shop/(.+?)/?$' => 'index.php?product_cat=$matches[1]&year=$matches[2]' ) );
 
-			$test_data = $this->get_store_page_test_data();
+		$test_data = $this->get_store_page_test_data();
 
-			foreach ( $test_data as $data ) {
-				list( $url, $expected_result ) = $data;
-				$result                        = WCAdminHelper::is_store_page( $url );
-				$this->assertEquals( $expected_result, $result );
-			}
+		foreach ( $test_data as $data ) {
+			list( $url, $expected_result ) = $data;
+			$result                        = WCAdminHelper::is_store_page( $url );
+			$this->assertEquals( $expected_result, $result );
+		}
+	}
+
+	/** Test product archive link is store page even if shop page not set. */
+	public function test_is_store_page_even_if_shop_page_not_set() {
+		$shop_page_id = get_option( 'woocommerce_shop_page_id' );
+
+		// Unset shop page.
+		delete_option( 'woocommerce_shop_page_id' );
+		// Unregister product post type to register it again with theme support.
+		unregister_post_type( 'product' );
+		add_theme_support( 'woocommerce' );
+		WC_Post_types::register_post_types();
+
+		$link = get_post_type_archive_link( 'product' );
+		$this->assertTrue( WCAdminHelper::is_store_page( $link ) );
+
+		// Reset.
+		add_option( 'woocommerce_shop_page_id', $shop_page_id );
+		remove_theme_support( 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -263,17 +263,25 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 		$shop_page_id = get_option( 'woocommerce_shop_page_id' );
 
 		// Unset shop page.
-		delete_option( 'woocommerce_shop_page_id' );
-		// Unregister product post type to register it again with theme support.
-		unregister_post_type( 'product' );
-		add_theme_support( 'woocommerce' );
-		WC_Post_types::register_post_types();
+		add_filter(
+			'woocommerce_get_shop_page_id',
+			function () {
+				return false;
+			},
+			10,
+			1
+		);
+
+		$product_post_type = get_post_type_object( 'product' );
+
+		if ( ! $product_post_type || ! $product_post_type->has_archive ) {
+			// Make sure product post type has archive.
+			unregister_post_type( 'product' );
+			add_theme_support( 'woocommerce' );
+			WC_Post_types::register_post_types();
+		}
 
 		$link = get_post_type_archive_link( 'product' );
 		$this->assertTrue( WCAdminHelper::is_store_page( $link ) );
-
-		// Reset.
-		add_option( 'woocommerce_shop_page_id', $shop_page_id );
-		remove_theme_support( 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -271,15 +271,10 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 			10,
 			1
 		);
+		global $wp_post_types;
+		$wp_post_types['product']->has_archive = 'shop';
 
 		$product_post_type = get_post_type_object( 'product' );
-
-		if ( ! $product_post_type || ! $product_post_type->has_archive ) {
-			// Make sure product post type has archive.
-			unregister_post_type( 'product' );
-			add_theme_support( 'woocommerce' );
-			WC_Post_types::register_post_types();
-		}
 
 		$link = get_post_type_archive_link( 'product' );
 		$this->assertTrue( WCAdminHelper::is_store_page( $link ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -46,7 +46,6 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		// Check shop page
 		$this->load_shop_page();
 		$this->assertDefaultTemplateFileName( 'archive-product' );
-
 	}
 
 	public function test_wc_template_loader_loads_template_with_blocks() {
@@ -81,21 +80,27 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		// Check shop page
 		$this->load_shop_page();
 		$this->assertDefaultTemplateFileName();
-
 	}
 
 
 	private function initialize_template_loader() {
 		// be sure shop is always returning same id doesn't matter the test setup environment
-		add_filter( 'woocommerce_get_shop_page_id', function ( $page ) {
-			return 5;
-		}, 10, 1 );
+		add_filter(
+			'woocommerce_get_shop_page_id',
+			function ( $page ) {
+				return 5;
+			},
+			10,
+			1
+		);
 
 		if ( ! function_exists( 'wp_is_block_theme' ) ) {
 			function wp_is_block_theme() {
 				return true;
 			}
 		}
+
+		add_theme_support( 'woocommerce' );
 
 		WC_Template_Loader::init();
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -87,7 +87,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		// be sure shop is always returning same id doesn't matter the test setup environment
 		add_filter(
 			'woocommerce_get_shop_page_id',
-			function ( $page ) {
+			function () {
 				return 5;
 			},
 			10,


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/48197.

When we register the `product` post type using `register_post_type` function, we set `has_archive` param to `shop`.  The has_archive field controls whether WordPress automatically creates an archive page for the custom post type. If set to a `string`, WordPress will create an archive page for the custom post type at the URL specified by the string. For example, if you set `has_archive` to `'library'`, the archive URL will be `http://yourdomain.com/library/`.

Therefore, even If no shop page is assigned, an automatically generated product archive page is still accessible, and it's not hidden behind the coming soon page when the coming soon mode is enabled.

This PR adds a check to see if the shop page is assigned and if not, it will hide the product archive page behind the coming soon page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Skip Core Profiler
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=site-visibility`
4. Turn on `Coming soon` and `Restrict to store pages only` options
5. Go to `/wp-admin/admin.php?page=wc-settings&tab=products`
6. Unassign the shop page and save changes
7. Open a incognito window and go to the /shop page
8. Verify that the coming soon page is displayed
9. Go to `wp-admin/options-permalink.php`
10. Change `Permalink structure` to `Plain`
11. Go to the `/?post_type=product`
12. Verify that the coming soon page is displayed

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
