### PR TITLE
Invalidate cache for SiteGround Speed Optimizer when coming soon options are changed

### DIFF
--- a/plugins/woocommerce/changelog/update-purge-cache-siteground-wpengine
+++ b/plugins/woocommerce/changelog/update-purge-cache-siteground-wpengine
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Invalidate cache for SiteGround Speed Optimizer and WP Engine
+Invalidate cache for SiteGround Speed Optimizer

--- a/plugins/woocommerce/changelog/update-purge-cache-siteground-wpengine
+++ b/plugins/woocommerce/changelog/update-purge-cache-siteground-wpengine
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Invalidate cache for SiteGround Speed Optimizer and WP Engine

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
@@ -41,13 +41,13 @@ class ComingSoonCacheInvalidator {
 		}
 
 		// Invalidate the SiteGround Speed Optimizer cache.
-		if ( function_exists( 'sg_cachepress_purge_everything' ) ) {
-			sg_cachepress_purge_everything();
+		if ( function_exists( '\sg_cachepress_purge_everything' ) ) {
+			\sg_cachepress_purge_everything();
 		}
 
 		// Invalidate the WP Engine cache.
-		if ( class_exists( 'wpecommon' ) && method_exists( 'wpecommon', 'purge_varnish_cache' ) ) {
-			wpecommon::purge_varnish_cache();
+		if ( class_exists( '\wpecommon' ) && method_exists( 'wpecommon', 'purge_varnish_cache' ) ) {
+			\wpecommon::purge_varnish_cache();
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
@@ -44,6 +44,5 @@ class ComingSoonCacheInvalidator {
 		if ( function_exists( '\sg_cachepress_purge_cache' ) ) {
 			\sg_cachepress_purge_cache();
 		}
-
 	}
 }

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
@@ -39,5 +39,15 @@ class ComingSoonCacheInvalidator {
 				)
 			);
 		}
+
+		// Invalidate the SiteGround Speed Optimizer cache.
+		if ( function_exists( 'sg_cachepress_purge_everything' ) ) {
+			sg_cachepress_purge_everything();
+		}
+
+		// Invalidate the WP Engine cache.
+		if ( class_exists( 'wpecommon' ) && method_exists( 'wpecommon', 'purge_varnish_cache' ) ) {
+			wpecommon::purge_varnish_cache();
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
@@ -45,9 +45,5 @@ class ComingSoonCacheInvalidator {
 			\sg_cachepress_purge_cache();
 		}
 
-		// Invalidate the WP Engine cache.
-		if ( class_exists( '\wpecommon' ) && method_exists( 'wpecommon', 'purge_varnish_cache' ) ) {
-			\wpecommon::purge_varnish_cache();
-		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php
@@ -41,8 +41,8 @@ class ComingSoonCacheInvalidator {
 		}
 
 		// Invalidate the SiteGround Speed Optimizer cache.
-		if ( function_exists( '\sg_cachepress_purge_everything' ) ) {
-			\sg_cachepress_purge_everything();
+		if ( function_exists( '\sg_cachepress_purge_cache' ) ) {
+			\sg_cachepress_purge_cache();
 		}
 
 		// Invalidate the WP Engine cache.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/48515.

Expire the following caches in [ComingSoonCacheInvalidator.php](https://github.com/woocommerce/woocommerce/blob/5dd7713346786c5874615b34a1d56f81a29b673f/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonCacheInvalidator.php)

- [Siteground](https://wordpress.org/plugins/sg-cachepress/) (https://wordpress.org/support/topic/instructions-needed-helper-function-to-purge-everything/)

```php
/**
 * Public function to purge the entire cache.
 *
 * @since  5.7.14
 */
function sg_cachepress_purge_everything() {
	global $siteground_optimizer_loader;

	// Purge Dynamic cache if enabled.
	if ( Options::is_enabled( 'siteground_optimizer_enable_cache' ) ) {
		$siteground_optimizer_loader->supercacher->purge_cache();
	}

	// Purge Memcached if enabled.
	if ( Options::is_enabled( 'siteground_optimizer_enable_memcached' ) ) {
		$siteground_optimizer_loader->supercacher->flush_memcache();
	}

	if ( Options::is_enabled( 'siteground_optimizer_file_caching' ) ) {
		$siteground_optimizer_loader->file_cacher->purge_everything();
	}

	$siteground_optimizer_loader->supercacher->delete_assets();
}
```

- [WPEngine](https://wpengine.com/support/cache/#Purge_Server_Caches) (see "Purge Cache with PHP")

> Through the WP Engine MU plugin there is a function called wpecommon::purge_varnish_cache(). The post ID you want to purge can be passed into this function. Varnish page cache is purged only for that post URL, and not for the entire domain. This can have a positive impact on a website’s performance by keeping all other pages stored in cached.

> If wpecommon::purge_varnish_cache() is called without being passed a post ID, then Varnish will be purged for the entire domain.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build the plugin zip file
2. Upload the plugin zip file to a SiteGround site (p1718618167417629/1718593364.831769-slack-C01SFMVEYAK)
3. Activate the plugin
4. Set the site to coming soon mode
5. Go to the site front end in a incognito window and confirm the site is in coming soon mode
6. Change the coming soon mode settings to Live
7. Confirm the cache is invalidated and the site is live

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>