### PR TITLE
Update shipping method modal copy if block-based local pickup is active

### DIFF
--- a/plugins/woocommerce/changelog/update-shipping-modal-copy
+++ b/plugins/woocommerce/changelog/update-shipping-modal-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update shipping method setup modal copy if the block-based local pickup is enabled

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -7,6 +7,7 @@
 
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
+use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -242,10 +242,15 @@ do_action( 'woocommerce_shipping_zone_after_methods_table', $zone );
 									);
 
 								} else {
+									/* translators: %s: Local pickup settings page URL. */
+									$message = __( 'Local pickup: Set up pickup locations in the <a href="%s">Local pickup settings page</a>.', 'woocommerce' );
+									if ( LocalPickupUtils::is_local_pickup_enabled() ) {
+										/* translators: %s: Local pickup settings page URL. */
+										$message = __( 'Local pickup: Manage existing pickup locations in the <a href="%s">Local pickup settings page</a>.', 'woocommerce' );
+									}
 									printf(
 										wp_kses(
-										/* translators: %s: Local pickup settings page URL. */
-											__( 'Local pickup: Set up pickup locations in the <a href="%s">Local pickup settings page</a>.', 'woocommerce' ),
+											$message,
 											array( 'a' => array( 'href' => array() ) )
 										),
 										esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=pickup_location' ) )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the copy on the shipping method setup modal if block-based local pickup is enabled.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47734

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce -> Settings -> Shipping -> Local pickup.
2. Uncheck the Enable Local Pickup box and save the settings.
3. Go to WooCommerce -> Settings -> Shipping -> Shipping Zones and edit a zone.
4. Inside the zone, click `Add shipping method`.
5. At the bottom of the modal, ensure "Local pickup: **Set up** pickup locations in the Local pickup settings page" is visible.
6. Go to WooCommerce -> Settings -> Shipping -> Local pickup.
7. Check the Enable Local Pickup box and save the settings.
8. Go to WooCommerce -> Settings -> Shipping -> Shipping Zones and edit a zone.
9. Inside the zone, click `Add shipping method`.
10. At the bottom of the modal, ensure "Local pickup: **Manage existing** pickup locations in the Local pickup settings page" is visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
