### PR TITLE
Fix flaky customize store transitional e2e test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-customize-store-transitional
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-customize-store-transitional
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixing flaky customize store transitional test

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
@@ -148,6 +148,10 @@ test.describe( 'Store owner can view the Transitional page', () => {
 			name: 'Cancel',
 		} );
 
+		await expect(
+			page.locator( '.edit-site-site-hub__site-title' )
+		).toBeVisible();
+
 		await shareFeedbackButton.click();
 
 		await expect( shareFeedbackModal ).toBeVisible();
@@ -158,10 +162,25 @@ test.describe( 'Store owner can view the Transitional page', () => {
 
 		await shareFeedbackButton.click();
 
+		await expect( shareFeedbackModal ).toBeVisible();
+		await expect( sendButton ).toBeDisabled();
+		await expect(
+			assembler.locator( 'text=I wanted to design my own theme.' )
+		).toBeVisible();
+
 		await assembler.getByRole( 'button', { name: '★' } ).first().click();
 		await assembler
 			.locator( 'text=I wanted to design my own theme.' )
 			.click();
+		await assembler.getByRole( 'button', { name: '★' } ).first().click();
+		await assembler
+			.locator( `text=I didn't like any of the available themes.` )
+			.click();
+		await assembler.getByRole( 'button', { name: '★' } ).first().click();
+		await assembler
+			.locator( `text=I didn't find a theme that matched my needs.` )
+			.click();
+		await expect( sendButton ).toBeEnabled();
 		await sendButton.click();
 		await expect( shareFeedbackModal ).toBeHidden();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48531

The test was failing because of race conditions that caused the survey unstable for submitting.

Added stability to test.

[video.webm](https://github.com/woocommerce/woocommerce/assets/21279898/a0fcc63e-6da1-4a32-9eb1-c475a3dabd87)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `pnpm test:e2e-pw ./tests/e2e-pw/tests/customize-store/transitional.spec.js --headed`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
