### PR TITLE
Add a link to the Theming docs from the blockified templates README.md file

### DIFF
--- a/plugins/woocommerce/changelog/fix-blockified-templates-readme-link-to-docs
+++ b/plugins/woocommerce/changelog/fix-blockified-templates-readme-link-to-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add a link to the Theming docs from the blockified templates README.md file

--- a/plugins/woocommerce/templates/templates/blockified/README.md
+++ b/plugins/woocommerce/templates/templates/blockified/README.md
@@ -1,3 +1,3 @@
 # Blockified templates
 
-This folder contains the blockified versions of the WooCommerce block templates. Currently, the content of these templates is temporary and should be replaced by the actual blockified version of each template when it's available.
+This folder contains the blockified versions of the WooCommerce block templates. You can read more about overriding these templates in the [''Theming'' docs for block themes](../../../../woocommerce-blocks/docs/designers/theming/README.md#block-templates).

--- a/plugins/woocommerce/templates/templates/blockified/README.md
+++ b/plugins/woocommerce/templates/templates/blockified/README.md
@@ -1,3 +1,3 @@
 # Blockified templates
 
-This folder contains the blockified versions of the WooCommerce block templates. You can read more about overriding these templates in the [''Theming'' docs for block themes](../../../../woocommerce-blocks/docs/designers/theming/README.md#block-templates).
+This folder contains the blockified versions of the WooCommerce block templates. You can read more about overriding these templates in the [_Theming_ docs for block themes](../../../../woocommerce-blocks/docs/designers/theming/README.md#block-templates).


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Small PR adding a link to the ''Theming docs'' from the blockified templates README.md file, so we keep all documentation centralized on the same page.

### How to test the changes in this Pull Request:

(No need to test when testing the release)

1. Make sure the text is correct and the link works correctly. You can see the updated docs here:

https://github.com/woocommerce/woocommerce/tree/fix/blockified-templates-readme-link-to-docs/plugins/woocommerce/templates/templates/blockified

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
