### PR TITLE
Conditionally allow stock_quantity to be non-integer in REST API product schema

### DIFF
--- a/plugins/woocommerce/changelog/fix-27375
+++ b/plugins/woocommerce/changelog/fix-27375
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow products with non-integer stock to be created via REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -1951,7 +1951,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 				),
 				'stock_quantity' => array(
 					'description' => __( 'Stock quantity.', 'woocommerce' ),
-					'type'        => 'integer',
+					'type'        => has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'integer' : 'number',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'in_stock' => array(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -1908,7 +1908,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 				),
 				'stock_quantity'        => array(
 					'description' => __( 'Stock quantity.', 'woocommerce' ),
-					'type'        => 'integer',
+					'type'        => has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'integer' : 'number',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'in_stock'              => array(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1131,7 +1131,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 				),
 				'stock_quantity'        => array(
 					'description' => __( 'Stock quantity.', 'woocommerce' ),
-					'type'        => 'integer',
+					'type'        => has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'integer' : 'number',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'stock_status'          => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
By default, we apply `intval` [to stock amounts](https://github.com/woocommerce/woocommerce/blob/f64aec8cc6eb9918a6a7b7e632bb3b418988a506/plugins/woocommerce/includes/wc-core-functions.php#L42) to make them integer, but this is not a requirement for WC to operate. The filter can be unhooked, and plugins such as [Smart Product Quantity](https://woocommerce.com/products/smart-product-quantity/) allow merchants to use decimal stock amounts.

Regardless of whether the filter forcing integers is in use, the REST API currently exposes `stock_quantity` as integer, which breaks sites using REST to work with decimal stock amounts as the REST API will refuse to take non-integer values. This PR conditionally sets this property as just numeric, allowing this use case.

Closes #27375.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Settings > Advanced > REST API and create a new read/write API key. Take note of the consumer key and secret.
1. Make an OPTIONS request to `<your site>/wp-json/wc/v3/products` and confirm that `schema > properties > stock_quantity > type` is `integer`.

   In cURL, this can be:

   ```sh
   curl -X OPTIONS https://proton.test/wp-json/wc/v3/products | jq .schema.properties.stock_quantity.type
   ```
1. Make a POST request to `<your site>/wp-json/wc/v3/products/` with the following body:

   ```json
   {
     "name": "My REST API product",
     "type": "simple",
     "regular_price": "5.0",
     "description": "This is a product created through the REST API",
     "manage_stock": true,
     "stock_quantity": 3.5
   }
   ```

   In cURL this could be:

   ```sh
   curl -X "POST" "<your site>/wp-json/wc/v3/products/" \
        -H 'Content-Type: application/json' \
        -u '<consumer key>:<consumer secret>' \
        -d $'{ "regular_price": "5.0", "stock_quantity": 3.5, "manage_stock": true, "name": "My REST API product", "type": "simple", "description": "This is a product created through the REST API" }'
   ```
1. Confirm that the request fails with an "invalid parameter" error referring to `stock_quantity`.
1. Activate the following snippet on your site, for example by dropping it as a .php file in `wp-content/mu-plugins/`:
   ```php
   <?php
   add_action(
	   'init',
	   function() {
		   remove_filter( 'woocommerce_stock_amount', 'intval' );
	   }
   );
   ```
1. Repeat step 2 above and confirm that this time `type` is `number`.
1. Repeat step 3 above and confirm that the product is correctly created this time. Optionally, go to WC > Products and look for the most recently created product, which should have a stock of `3.5`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
