### PR TITLE
Allow blocks with parents in the `woocommerce` namespace to be rendered as inner blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/render-parent-block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/render-parent-block.tsx
@@ -227,7 +227,7 @@ const renderInnerBlocks = ( {
 						>
 							{
 								/**
-								 * Within this Inner Block Component we also need to recursively render it's children. This
+								 * Within this Inner Block Component we also need to recursively render its children. This
 								 * is done here with a depth+1. The same block map and parent is used, but we pass new
 								 * children from this element.
 								 */

--- a/plugins/woocommerce/changelog/fix-rendering-unforced-blocks
+++ b/plugins/woocommerce/changelog/fix-rendering-unforced-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow blocks with parents in the "woocommerce" namespace to be added to the Checkout block without requiring them to be added to the "__experimental_woocommerce_blocks_add_data_attributes_to_block" hook.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -210,6 +210,8 @@ final class BlockTypesController {
 		 */
 		$allowed_blocks = (array) apply_filters( '__experimental_woocommerce_blocks_add_data_attributes_to_block', array() );
 
+		$blocks_with_woo_parents = $this->get_registered_blocks_with_woocommerce_parent();
+
 		$block_has_woo_parent = in_array( $block_name, array_keys( $this->registered_blocks_with_woocommerce_parents ), true );
 
 		if ( ! $block_has_woo_parent && ! in_array( $block_namespace, $allowed_namespaces, true ) && ! in_array( $block_name, $allowed_blocks, true ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -55,6 +55,7 @@ final class BlockTypesController {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
+		add_action( 'init', array( $this, 'cache_registered_blocks_with_woocommerce_parent' ) );
 		add_filter( 'block_categories_all', array( $this, 'register_block_categories' ), 10, 2 );
 		add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
@@ -70,6 +71,25 @@ final class BlockTypesController {
 			'woocommerce_is_cart',
 			function ( $ret ) {
 				return $ret || $this->has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart' );
+			}
+		);
+	}
+
+	public function cache_registered_blocks_with_woocommerce_parent() {
+		$registered_blocks                                = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+		$this->registered_blocks_with_woocommerce_parents = array_filter(
+			$registered_blocks,
+			function ( $block ) {
+				if ( empty( $block->parent ) ) {
+					return false;
+				}
+				$woocommerce_blocks = array_filter(
+					$block->parent,
+					function ( $parent_block_name ) {
+						return 'woocommerce' === strtok( $parent_block_name, '/' );
+					}
+				);
+				return ! empty( $woocommerce_blocks );
 			}
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -89,6 +89,9 @@ final class BlockTypesController {
 				if ( empty( $block->parent ) ) {
 					return false;
 				}
+				if ( ! is_array( $block->parent ) ) {
+					$block->parent = array( $block->parent );
+				}
 				$woocommerce_blocks = array_filter(
 					$block->parent,
 					function ( $parent_block_name ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -184,7 +184,7 @@ final class BlockTypesController {
 	 *
 	 * @param string $block_name Name of the block to check.
 	 *
-	 * @return mixed|void
+	 * @return boolean
 	 */
 	public function block_should_have_data_attributes( $block_name ) {
 		$block_namespace = strtok( $block_name ?? '', '/' );
@@ -216,10 +216,7 @@ final class BlockTypesController {
 		$in_allowed_namespace_list = in_array( $block_namespace, $allowed_namespaces, true );
 		$in_allowed_block_list     = in_array( $block_name, $allowed_blocks, true );
 
-		if ( $block_has_woo_parent || $in_allowed_block_list || $in_allowed_namespace_list ) {
-			return true;
-		}
-		return false;
+		return $block_has_woo_parent || $in_allowed_block_list || $in_allowed_namespace_list;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -75,6 +75,12 @@ final class BlockTypesController {
 		);
 	}
 
+	/**
+	 * Cache registered blocks that have WooCommerce blocks as their parents. Adds the value to the
+	 * `registered_blocks_with_woocommerce_parents` class property.
+	 *
+	 * @return void
+	 */
 	public function cache_registered_blocks_with_woocommerce_parent() {
 		$registered_blocks                                = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 		$this->registered_blocks_with_woocommerce_parents = array_filter(

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -75,13 +75,23 @@ final class BlockTypesController {
 	}
 
 	/**
-	 * Cache registered blocks that have WooCommerce blocks as their parents. Adds the value to the
-	 * `registered_blocks_with_woocommerce_parents` class property.
+	 * Get registered blocks that have WooCommerce blocks as their parents. Adds the value to the
+	 * `registered_blocks_with_woocommerce_parents` cache if `init` has been fired.
 	 *
-	 * @return void
+	 * @return array Registered blocks with WooCommerce blocks as parents.
 	 */
-	public function cache_registered_blocks_with_woocommerce_parent() {
-		$registered_blocks                                = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+	public function get_registered_blocks_with_woocommerce_parent() {
+		// If init has run and the cache is already set, return it.
+		if ( did_action( 'init' ) && ! empty( $this->registered_blocks_with_woocommerce_parents ) ) {
+			return $this->registered_blocks_with_woocommerce_parents;
+		}
+
+		$registered_blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+		if ( ! is_array( $registered_blocks ) ) {
+			return array();
+		}
+
 		$this->registered_blocks_with_woocommerce_parents = array_filter(
 			$registered_blocks,
 			function ( $block ) {
@@ -100,6 +110,7 @@ final class BlockTypesController {
 				return ! empty( $woocommerce_blocks );
 			}
 		);
+		return $this->registered_blocks_with_woocommerce_parents;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -191,7 +191,9 @@ final class BlockTypesController {
 		 */
 		$allowed_blocks = (array) apply_filters( '__experimental_woocommerce_blocks_add_data_attributes_to_block', array() );
 
-		if ( ! in_array( $block_namespace, $allowed_namespaces, true ) && ! in_array( $block_name, $allowed_blocks, true ) ) {
+		$block_has_woo_parent = in_array( $block_name, array_keys( $this->registered_blocks_with_woocommerce_parents ), true );
+
+		if ( ! $block_has_woo_parent && ! in_array( $block_namespace, $allowed_namespaces, true ) && ! in_array( $block_name, $allowed_blocks, true ) ) {
 			return $content;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -32,6 +32,13 @@ final class BlockTypesController {
 	protected $asset_data_registry;
 
 	/**
+	 * Holds the registered blocks that have WooCommerce blocks as their parents.
+	 *
+	 * @var array List of registered blocks.
+	 */
+	private $registered_blocks_with_woocommerce_parents;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param AssetApi          $asset_api Instance of the asset API.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -55,7 +55,6 @@ final class BlockTypesController {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
-		add_action( 'init', array( $this, 'cache_registered_blocks_with_woocommerce_parent' ) );
 		add_filter( 'block_categories_all', array( $this, 'register_block_categories' ), 10, 2 );
 		add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypesController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Blocks;
+
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\BlockTypesController as TestedBlockTypesController;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
+use Automattic\WooCommerce\Blocks\Package;
+
+/**
+ * Unit tests for the PatternRegistry class.
+ */
+class BlockTypesController extends \WP_UnitTestCase {
+
+	private $block_types_controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->block_types_controller = new TestedBlockTypesController(
+			Package::container()->get( Api::class ),
+			new AssetDataRegistryMock( Package::container()->get( API::class ) )
+		);
+	}
+
+	public function test_block_should_have_data_attributes() {
+		// Register 3 blocks, one will be allowed by full name, one by namespace,and one because it has a parent with a
+		// woocommerce namespace.
+
+		// A block that will not be allowed data attributes.
+		register_block_type(
+			'unrelated-namespace/unrelated-block-name',
+		);
+
+		// A block that will be allowed explicitly by full name.
+		register_block_type(
+			'namespace/allowed-block-name',
+		);
+
+		// A block that will be allowed explicitly by full name.
+		register_block_type(
+			'allowed-namespace/block-name',
+			[
+				'parent' => [ 'core/paragraph' ],
+			]
+		);
+
+		// A block that will be allowed because it has a parent with a woocommerce namespace.
+		register_block_type(
+			'child-of-woo/block-name',
+			[
+				'parent' => [ 'woocommerce/checkout-contact-information-block' ],
+			]
+		);
+
+		$answer = $this->block_types_controller->block_should_have_data_attributes( 'unrelated-namespace/unrelated-block-name' );
+		$this->assertFalse( $answer );
+
+		add_filter(
+			'__experimental_woocommerce_blocks_add_data_attributes_to_block',
+			function ( $blocks ) {
+				$blocks[] = 'namespace/allowed-block-name';
+				return $blocks;
+			}
+		);
+		$answer = $this->block_types_controller->block_should_have_data_attributes( 'namespace/allowed-block-name' );
+		$this->assertTrue( $answer );
+
+		add_filter(
+			'__experimental_woocommerce_blocks_add_data_attributes_to_namespace',
+			function ( $namespaces ) {
+				$namespaces[] = 'allowed-namespace';
+				return $namespaces;
+			}
+		);
+		$answer = $this->block_types_controller->block_should_have_data_attributes( 'allowed-namespace/block-name' );
+		$this->assertTrue( $answer );
+
+		$answer = $this->block_types_controller->block_should_have_data_attributes( 'child-of-woo/block-name' );
+		$this->assertTrue( $answer );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypesController.php
@@ -12,8 +12,19 @@ use Automattic\WooCommerce\Blocks\Package;
  */
 class BlockTypesController extends \WP_UnitTestCase {
 
+	/**
+	 * Holds the BlockTypesController under test.
+	 *
+	 * @var TestedBlockTypesController The BlockTypesController under test.
+	 */
 	private $block_types_controller;
 
+	/**
+	 * Sets up a new TestedBlockTypesController so it can be tested.
+	 *
+	 * @return void
+	 * @throws \Exception If there is no dependency for the given identifier in the container the setup will fail.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 		$this->block_types_controller = new TestedBlockTypesController(
@@ -22,9 +33,13 @@ class BlockTypesController extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Register 3 blocks, one will be allowed by full name, one by namespace,and one because it has a parent with a
+	 * woocommerce namespace.
+	 *
+	 * @return void
+	 */
 	public function test_block_should_have_data_attributes() {
-		// Register 3 blocks, one will be allowed by full name, one by namespace,and one because it has a parent with a
-		// woocommerce namespace.
 
 		// A block that will not be allowed data attributes.
 		register_block_type(

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypesController.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Cache the list of registered block types with at least one parent block in the `woocommerce` namespace. Do this on `init`.
- When checking blocks that can have `data-block-name` added, consider if their parent is in the `woocommerce` namespace (cached above)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46264

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Register a custom block, in this example we'll be using the `@woocommerce/extend-cart-checkout-block test-block` package.
2. Go to `wp-content/plugins` and run `npx @wordpress/create-block -t @woocommerce/extend-cart-checkout-block test-block`.
3. Edit the block's "lock" attribute (go to `src/js/checkout-newsletter-subscription/block.json`) so it is: 
```
	"lock": {
			"type": "object",
			"default": {
				"remove": false,
				"move": true
			}
		},
```
4. Make sure the block is rebuilt after changing this (use `npm run start`)
5. Go to the Checkout block in the editor, and go to the contact information block.
6. Add a new block, and select the `Newsletter Subscription!` block.
7. Add another new block and select the core Image block. Add an image to it.
8. Save the page.
9. Go to the front-end, add an item to your cart and visit the Checkout block.
10. Ensure you see the newsletter subscription block and the image block.
<img width="564" alt="image" src="https://github.com/woocommerce/woocommerce/assets/5656702/ee077857-2772-4f52-a8b4-7c26c68bb299">

11. Go back to the editor and delete the newsletter subscription block. Save the page.
12. Reload the Checkout block in the editor and ensure the newsletter subscription block is not there.
13. Reload the Checkout block on the front-end and ensure the newsletter subscription block is not there.
14. Go back to the `block.json` settings and set the `lock.remove` property to `true`.
15. Save and build, then go to the Checkout block on the **front end**.
16. Ensure the newsletter subscription block is visible again.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
