### PR TITLE
CRUD: Introduce `optimisticPropagation` feature

### DIFF
--- a/packages/js/data/changelog/update-crud-add-actions-unit-tests
+++ b/packages/js/data/changelog/update-crud-add-actions-unit-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+CRUD: introduce optimisticPropagation feature

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -9,7 +9,16 @@ import { apiFetch } from '@wordpress/data-controls';
 import { cleanQuery, getUrlParameters, getRestPath, parseId } from './utils';
 import CRUD_ACTIONS from './crud-actions';
 import TYPES from './action-types';
-import { IdType, IdQuery, Item, ItemQuery, CrudActionOptions } from './types';
+import type {
+	IdType,
+	IdQuery,
+	Item,
+	ItemQuery,
+	CrudActionOptions,
+	CreateAction,
+	DeleteAction,
+	UpdateAction,
+} from './types';
 
 type ResolverOptions = {
 	resourceName: string;
@@ -174,7 +183,7 @@ export function updateItemSuccess(
 	};
 }
 
-export const createDispatchActions = ( {
+export const createDispatchActions = < ResourceName extends string >( {
 	namespace,
 	resourceName,
 }: ResolverOptions ) => {
@@ -254,11 +263,15 @@ export const createDispatchActions = ( {
 		}
 	};
 
-	return {
+	const actions = {
 		[ `create${ resourceName }` ]: createItem,
 		[ `delete${ resourceName }` ]: deleteItem,
 		[ `update${ resourceName }` ]: updateItem,
-	};
+	} as CreateAction< ResourceName, Item > &
+		DeleteAction< ResourceName, Item > &
+		UpdateAction< ResourceName, Item >;
+
+	return actions;
 };
 
 export type Actions = ReturnType<

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -18,6 +18,7 @@ import type {
 	CreateAction,
 	DeleteAction,
 	UpdateAction,
+	CrudCreateItemActionOptions,
 } from './types';
 
 type ResolverOptions = {
@@ -34,10 +35,14 @@ export function createItemError( query: Partial< ItemQuery >, error: unknown ) {
 	};
 }
 
-export function createItemRequest( query: Partial< ItemQuery > ) {
+export function createItemRequest(
+	query: Partial< ItemQuery >,
+	options?: CrudCreateItemActionOptions
+) {
 	return {
 		type: TYPES.CREATE_ITEM_REQUEST as const,
 		query,
+		options,
 	};
 }
 
@@ -191,7 +196,7 @@ export const createDispatchActions = < ResourceName extends string >( {
 		query: Partial< ItemQuery >,
 		options: CrudActionOptions
 	) {
-		yield createItemRequest( query );
+		yield createItemRequest( query, options );
 		const urlParameters = getUrlParameters( namespace, query );
 
 		try {

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -6,7 +6,13 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import { cleanQuery, getUrlParameters, getRestPath, parseId } from './utils';
+import {
+	cleanQuery,
+	getUrlParameters,
+	getRestPath,
+	parseId,
+	generateTemporaryId,
+} from './utils';
 import CRUD_ACTIONS from './crud-actions';
 import TYPES from './action-types';
 import type {
@@ -39,11 +45,23 @@ export function createItemRequest(
 	query: Partial< ItemQuery >,
 	options?: CrudCreateItemActionOptions
 ) {
-	return {
+	const action = {
 		type: TYPES.CREATE_ITEM_REQUEST as const,
 		query,
 		options,
 	};
+
+	if ( options?.optimisticPropagation ) {
+		return {
+			...action,
+			options: {
+				...options,
+				tempId: generateTemporaryId(),
+			},
+		};
+	}
+
+	return action;
 }
 
 export function createItemSuccess(

--- a/packages/js/data/src/crud/test/actions.ts
+++ b/packages/js/data/src/crud/test/actions.ts
@@ -117,7 +117,7 @@ describe( 'crud actions', () => {
 			} );
 
 			// Step through the generator request action
-			const { value: requestAction } = generator.next() as any;
+			const { value: requestAction } = generator.next();
 
 			expect( requestAction.type ).toEqual( TYPES.CREATE_ITEM_REQUEST );
 			expect( requestAction.query ).toEqual( {

--- a/packages/js/data/src/crud/test/actions.ts
+++ b/packages/js/data/src/crud/test/actions.ts
@@ -49,7 +49,7 @@ describe( 'crud actions', () => {
 			const dispatch = jest.fn();
 
 			// Call the createMyThing action
-			const generator = createMyThing( query, {} );
+			const generator = createMyThing( query );
 
 			// Step through the generator request action
 			const { value: requestAction } = generator.next();
@@ -84,7 +84,6 @@ describe( 'crud actions', () => {
 				key: 1,
 				item: expectedItem,
 				query,
-				options: {},
 			} );
 
 			// Dispatch the actions
@@ -102,7 +101,34 @@ describe( 'crud actions', () => {
 				key: 1,
 				item: expectedItem,
 				query,
-				options: {},
+			} );
+		} );
+
+		it( 'with optimistc propagation', async () => {
+			const query = {
+				name: 'Zuri',
+				kind: 'dog',
+				age: 3,
+			};
+
+			// Call the createMyThing action
+			const generator = createMyThing( query, {
+				optimisticPropagation: true,
+			} );
+
+			// Step through the generator request action
+			const { value: requestAction } = generator.next();
+
+			expect( requestAction ).toEqual( {
+				type: TYPES.CREATE_ITEM_REQUEST,
+				query: {
+					name: 'Zuri',
+					kind: 'dog',
+					age: 3,
+				},
+				options: {
+					optimisticPropagation: true,
+				},
 			} );
 		} );
 	} );

--- a/packages/js/data/src/crud/test/actions.ts
+++ b/packages/js/data/src/crud/test/actions.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import { AnyAction } from 'redux';
 
 /**
  * Internal dependencies
@@ -10,6 +11,15 @@ import { createDispatchActions } from '../actions';
 import TYPES from '../action-types';
 import { cleanQuery, getRestPath, getUrlParameters } from '../utils';
 import type { Item } from '../types';
+
+interface RequestAction {
+	type: string;
+	query: Record< string, any >; // eslint-disable-line @typescript-eslint/no-explicit-any
+	options?: {
+		optimisticPropagation?: boolean;
+		tempId?: string;
+	};
+}
 
 const selectors = createDispatchActions( {
 	resourceName: 'Product',
@@ -104,7 +114,7 @@ describe( 'crud actions', () => {
 			} );
 		} );
 
-		it( 'with optimistc propagation', async () => {
+		it( 'with optimistic propagation', async () => {
 			const query = {
 				name: 'Zuri',
 				kind: 'dog',
@@ -117,7 +127,10 @@ describe( 'crud actions', () => {
 			} );
 
 			// Step through the generator request action
-			const { value: requestAction } = generator.next();
+			const { value: requestAction } = generator.next() as IteratorResult<
+				RequestAction,
+				AnyAction
+			>;
 
 			expect( requestAction.type ).toEqual( TYPES.CREATE_ITEM_REQUEST );
 			expect( requestAction.query ).toEqual( {

--- a/packages/js/data/src/crud/test/actions.ts
+++ b/packages/js/data/src/crud/test/actions.ts
@@ -8,7 +8,7 @@ const selectors = createDispatchActions( {
 	namespace: '/products',
 } );
 
-describe( 'crud selectors', () => {
+describe( 'crud actions', () => {
 	it( 'should return methods for the default actions', () => {
 		expect( Object.keys( selectors ).length ).toEqual( 3 );
 		expect( selectors ).toHaveProperty( 'createProduct' );

--- a/packages/js/data/src/crud/test/actions.ts
+++ b/packages/js/data/src/crud/test/actions.ts
@@ -1,7 +1,15 @@
 /**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+
+/**
  * Internal dependencies
  */
 import { createDispatchActions } from '../actions';
+import TYPES from '../action-types';
+import { cleanQuery, getRestPath, getUrlParameters } from '../utils';
+import type { Item } from '../types';
 
 const selectors = createDispatchActions( {
 	resourceName: 'Product',
@@ -14,5 +22,88 @@ describe( 'crud actions', () => {
 		expect( selectors ).toHaveProperty( 'createProduct' );
 		expect( selectors ).toHaveProperty( 'deleteProduct' );
 		expect( selectors ).toHaveProperty( 'updateProduct' );
+	} );
+
+	describe( 'should create a new item', () => {
+		const namespace = 'test-namespace';
+		const resourceName = 'MyThing';
+		const { createMyThing } = createDispatchActions( {
+			namespace,
+			resourceName,
+		} );
+
+		it( 'with regular query params', async () => {
+			const query = {
+				name: 'Zuri',
+				kind: 'dog',
+				age: 3,
+			};
+
+			const expectedItem: Item = {
+				id: 1,
+				name: 'Zuri',
+				kind: 'dog',
+				age: 3,
+			};
+
+			const dispatch = jest.fn();
+
+			// Call the createMyThing action
+			const generator = createMyThing( query, {} );
+
+			// Step through the generator request action
+			const { value: requestAction } = generator.next();
+
+			expect( requestAction ).toEqual( {
+				type: TYPES.CREATE_ITEM_REQUEST,
+				query,
+			} );
+
+			// Step through the generator fetch call
+			const urlParameters = getUrlParameters( namespace, query );
+			const path = getRestPath(
+				namespace,
+				cleanQuery( query, namespace ),
+				urlParameters
+			);
+
+			const { value: apiFetchCall } = generator.next();
+
+			expect( apiFetchCall ).toEqual(
+				apiFetch( {
+					path: expect.stringContaining( path ),
+					method: 'POST',
+				} )
+			);
+
+			// Continue the generator with the apiFetch response
+			const { value: successAction } = generator.next( expectedItem );
+
+			expect( successAction ).toEqual( {
+				type: TYPES.CREATE_ITEM_SUCCESS,
+				key: 1,
+				item: expectedItem,
+				query,
+				options: {},
+			} );
+
+			// Dispatch the actions
+			dispatch( requestAction );
+
+			// Check the actions dispatched to the store
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: TYPES.CREATE_ITEM_REQUEST,
+				query,
+			} );
+
+			dispatch( successAction );
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: TYPES.CREATE_ITEM_SUCCESS,
+				key: 1,
+				item: expectedItem,
+				query,
+				options: {},
+			} );
+		} );
 	} );
 } );

--- a/packages/js/data/src/crud/test/actions.ts
+++ b/packages/js/data/src/crud/test/actions.ts
@@ -117,19 +117,21 @@ describe( 'crud actions', () => {
 			} );
 
 			// Step through the generator request action
-			const { value: requestAction } = generator.next();
+			const { value: requestAction } = generator.next() as any;
 
-			expect( requestAction ).toEqual( {
-				type: TYPES.CREATE_ITEM_REQUEST,
-				query: {
-					name: 'Zuri',
-					kind: 'dog',
-					age: 3,
-				},
-				options: {
-					optimisticPropagation: true,
-				},
+			expect( requestAction.type ).toEqual( TYPES.CREATE_ITEM_REQUEST );
+			expect( requestAction.query ).toEqual( {
+				name: 'Zuri',
+				kind: 'dog',
+				age: 3,
 			} );
+
+			expect( requestAction.options.optimisticPropagation ).toEqual(
+				true
+			);
+
+			// Test the options.tmpId has a temporary id shape, starting with 'temp-'
+			expect( requestAction.options.tempId ).toMatch( /^temp-/ );
 		} );
 	} );
 } );

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -1,13 +1,13 @@
 /**
  * Internal dependencies
  */
-import { Actions } from '../actions';
-import { createReducer, ResourceState } from '../reducer';
+import { createReducer, type ResourceState } from '../reducer';
 import { CRUD_ACTIONS } from '../crud-actions';
 import { getResourceName, getTotalCountResourceName } from '../../utils';
 import { getRequestIdentifier } from '../utils';
-import { Item, ItemQuery } from '../types';
 import TYPES from '../action-types';
+import type { Item, ItemQuery } from '../types';
+import type { Actions } from '../actions';
 
 const defaultState: ResourceState = {
 	items: {},

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -424,6 +424,15 @@ describe( 'crud reducer', () => {
 			);
 
 			expect( state_last.items[ gettingQueryId ].data ).toHaveLength( 2 );
+
+			// todo: Continue how the reducer should handle CREATE_ITEM_SUCCESS
+			// const state_1 = reducer( state_last, {
+			// 	type: TYPES.CREATE_ITEM_SUCCESS
+			// 	key: item.id,
+			// 	item,
+			// 	query,
+			// 	options: {},
+			// } );
 		} );
 	} );
 

--- a/packages/js/data/src/crud/test/utils.ts
+++ b/packages/js/data/src/crud/test/utils.ts
@@ -15,6 +15,7 @@ import {
 	maybeReplaceIdQuery,
 	isValidIdQuery,
 	parseId,
+	generateTemporaryId,
 } from '../utils';
 import type { Item } from '../types';
 
@@ -332,6 +333,19 @@ describe( 'utils', () => {
 			} );
 
 			expect( ids ).toEqual( [ '200/10/1', '200/10/2' ] );
+		} );
+	} );
+
+	describe.only( 'generateTemporaryId', () => {
+		it( 'should generate a temporary ID with the correct format', () => {
+			const tempId = generateTemporaryId();
+			expect( tempId ).toMatch( /^temp-[a-z0-9]{10}$/ );
+		} );
+
+		it( 'should generate unique IDs on subsequent calls', () => {
+			const tempId1 = generateTemporaryId();
+			const tempId2 = generateTemporaryId();
+			expect( tempId1 ).not.toEqual( tempId2 );
 		} );
 	} );
 } );

--- a/packages/js/data/src/crud/test/utils.ts
+++ b/packages/js/data/src/crud/test/utils.ts
@@ -336,7 +336,7 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe.only( 'generateTemporaryId', () => {
+	describe( 'generateTemporaryId', () => {
 		it( 'should generate a temporary ID with the correct format', () => {
 			const tempId = generateTemporaryId();
 			expect( tempId ).toMatch( /^temp-[a-z0-9]{10}$/ );

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -45,6 +45,12 @@ export type CrudCreateItemActionOptions = {
 	optimisticQueryUpdate?: ItemQuery;
 	optimisticUrlParameters?: IdType[];
 	optimisticPropagation?: boolean;
+
+	/*
+	 * This is a temporary ID that is used to identify the item in the store
+	 * before the actual ID is known. This is used for optimistic updates.
+	 */
+	tempId?: IdType;
 };
 
 export type CrudActionOptions = {

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -46,6 +46,26 @@ export type CrudActionOptions = {
 	optimisticUrlParameters?: IdType[];
 };
 
+export type CreateAction< ResourceName extends string, ItemType > = {
+	[ Property in `create${ Capitalize< ResourceName > }` ]: (
+		query: Partial< ItemType >,
+		options?: CrudActionOptions
+	) => Generator< unknown, ItemType >;
+};
+
+export type DeleteAction< ResourceName extends string, ItemType > = {
+	[ Property in `delete${ Capitalize< ResourceName > }` ]: (
+		idQuery: IdQuery,
+		force?: boolean
+	) => Generator< unknown, ItemType >;
+};
+
+export type UpdateAction< ResourceName extends string, ItemType > = {
+	[ Property in `update${ Capitalize< ResourceName > }` ]: (
+		query: Partial< ItemType >
+	) => Generator< unknown, ItemType >;
+};
+
 export type CrudActions<
 	ResourceName,
 	ItemType,

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -41,6 +41,12 @@ type WithRequiredProperty< Type, Key extends keyof Type > = Type & {
 	[ Property in Key ]-?: Type[ Property ];
 };
 
+export type CrudCreateItemActionOptions = {
+	optimisticQueryUpdate?: ItemQuery;
+	optimisticUrlParameters?: IdType[];
+	optimisticPropagation?: boolean;
+};
+
 export type CrudActionOptions = {
 	optimisticQueryUpdate?: ItemQuery;
 	optimisticUrlParameters?: IdType[];
@@ -49,7 +55,7 @@ export type CrudActionOptions = {
 export type CreateAction< ResourceName extends string, ItemType > = {
 	[ Property in `create${ Capitalize< ResourceName > }` ]: (
 		query: Partial< ItemType >,
-		options?: CrudActionOptions
+		options?: CrudCreateItemActionOptions
 	) => Generator< unknown, ItemType >;
 };
 

--- a/packages/js/data/src/crud/utils.ts
+++ b/packages/js/data/src/crud/utils.ts
@@ -302,3 +302,13 @@ export const getGenericActionName = (
 
 	return action;
 };
+
+/**
+ * Generates a temporary unique identifier.
+ *
+ * @return {string} A temporary unique identifier in the format `temp-xxxxxxxxxx`.
+ */
+export const generateTemporaryId = (): string => {
+	const randomPart = Math.random().toString( 36 ).substring( 2, 12 );
+	return `temp-${ randomPart }`;
+};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces the `optimisticPropagation` to the CRUD implementation. The idea is implement a mechanism to populate the store right after the action is called.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Runing unit tests


```sh
pnpm --filter=./packages/js/data run test:js packages/js/data/src/crud
```

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
