### PR TITLE
Return 404 when using the REST API to access a non existing tax class

### DIFF
--- a/plugins/woocommerce/changelog/fix-35291
+++ b/plugins/woocommerce/changelog/fix-35291
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Return HTTP 404 for REST API requests involving non-existing tax class.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-tax-classes-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-tax-classes-v1-controller.php
@@ -213,7 +213,11 @@ class WC_REST_Tax_Classes_V1_Controller extends WC_REST_Controller {
 		}
 
 		$tax_class = WC_Tax::get_tax_class_by( 'slug', sanitize_title( $request['slug'] ) );
-		$deleted   = WC_Tax::delete_tax_class_by( 'slug', sanitize_title( $request['slug'] ) );
+		if ( ! $tax_class ) {
+			return new WP_Error( 'woocommerce_rest_tax_class_invalid_slug', __( 'Invalid slug.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$deleted = WC_Tax::delete_tax_class_by( 'slug', sanitize_title( $request['slug'] ) );
 
 		if ( ! $deleted ) {
 			return new WP_Error( 'woocommerce_rest_invalid_id', __( 'Invalid resource id.', 'woocommerce' ), array( 'status' => 400 ) );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-tax-classes-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-tax-classes-v2-controller.php
@@ -97,12 +97,14 @@ class WC_REST_Tax_Classes_V2_Controller extends WC_REST_Tax_Classes_V1_Controlle
 			$tax_class = WC_Tax::get_tax_class_by( 'slug', sanitize_title( $request['slug'] ) );
 		}
 
-		$data = array();
-		if ( $tax_class ) {
-			$class  = $this->prepare_item_for_response( $tax_class, $request );
-			$class  = $this->prepare_response_for_collection( $class );
-			$data[] = $class;
+		if ( ! $tax_class ) {
+			return new WP_Error( 'woocommerce_rest_tax_class_invalid_slug', __( 'Invalid slug.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
+
+		$data   = array();
+		$class  = $this->prepare_item_for_response( $tax_class, $request );
+		$class  = $this->prepare_response_for_collection( $class );
+		$data[] = $class;
 
 		return rest_ensure_response( $data );
 	}

--- a/plugins/woocommerce/tests/api-core-tests/tests/taxes/tax-classes-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/taxes/tax-classes-crud.test.js
@@ -118,9 +118,9 @@ test.describe('Tax Classes API tests: CRUD', () => {
 				`/wp-json/wc/v3/taxes/classes/${ taxClassSlug }`
 			);
 			const getDeletedTaxClassResponseJSON = await getDeletedTaxClassResponse.json();
-			expect(getDeletedTaxClassResponse.status()).toEqual(200);
+			expect(getDeletedTaxClassResponse.status()).toEqual(404);
 			expect(Array.isArray(getDeletedTaxClassResponseJSON)).toBe(true);
-			
+
 		});
 	});
 

--- a/plugins/woocommerce/tests/api-core-tests/tests/taxes/tax-classes-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/taxes/tax-classes-crud.test.js
@@ -1,7 +1,4 @@
-const {
-	test,
-	expect
-} = require('@playwright/test');
+const { test, expect } = require( '@playwright/test' );
 
 /**
  * Tests for the WooCommerce API.
@@ -10,118 +7,115 @@ const {
  * @group taxes
  *
  */
-test.describe('Tax Classes API tests: CRUD', () => {
+test.describe( 'Tax Classes API tests: CRUD', () => {
 	let taxClassSlug;
 
-	test.describe('Create a tax class', () => {
-
-		test('can enable tax calculations', async ({
-			request,
-		}) => {
+	test.describe( 'Create a tax class', () => {
+		test( 'can enable tax calculations', async ( { request } ) => {
 			// call API to enable taxes and calculations
 			const response = await request.put(
-				'/wp-json/wc/v3/settings/general/woocommerce_calc_taxes', {
+				'/wp-json/wc/v3/settings/general/woocommerce_calc_taxes',
+				{
 					data: {
 						value: 'yes',
 					},
 				}
 			);
 			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
-			expect(typeof responseJSON.id).toEqual('string');
-			expect(responseJSON.id).toEqual('woocommerce_calc_taxes');
-			expect(responseJSON.label).toEqual("Enable taxes");
-			expect(responseJSON.type).toEqual("checkbox");
-			expect(responseJSON.value).toEqual("yes");
-			expect(responseJSON.group_id).toEqual("general");
-		});
+			expect( response.status() ).toEqual( 200 );
+			expect( typeof responseJSON.id ).toEqual( 'string' );
+			expect( responseJSON.id ).toEqual( 'woocommerce_calc_taxes' );
+			expect( responseJSON.label ).toEqual( 'Enable taxes' );
+			expect( responseJSON.type ).toEqual( 'checkbox' );
+			expect( responseJSON.value ).toEqual( 'yes' );
+			expect( responseJSON.group_id ).toEqual( 'general' );
+		} );
 
-		test('can create a tax class', async ({
-			request,
-		}) => {
+		test( 'can create a tax class', async ( { request } ) => {
 			// call API to create a taxclass
-			const response = await request.post('/wp-json/wc/v3/taxes/classes', {
-				data: {
-					name: "Test Tax Class"
+			const response = await request.post(
+				'/wp-json/wc/v3/taxes/classes',
+				{
+					data: {
+						name: 'Test Tax Class',
+					},
 				}
-			});
+			);
 			const responseJSON = await response.json();
 			taxClassSlug = responseJSON.slug;
-			expect(response.status()).toEqual(201);
-			expect(responseJSON.name).toEqual("Test Tax Class");
-			expect(taxClassSlug).toEqual("test-tax-class");
-		});
-	});
+			expect( response.status() ).toEqual( 201 );
+			expect( responseJSON.name ).toEqual( 'Test Tax Class' );
+			expect( taxClassSlug ).toEqual( 'test-tax-class' );
+		} );
+	} );
 
-	test.describe('Retrieve after create', () => {
-		test('can retrieve a tax class', async ({
-			request
-		}) => {
+	test.describe( 'Retrieve after create', () => {
+		test( 'can retrieve a tax class', async ( { request } ) => {
 			// call API to retrieve the previously saved tax class by slug
 			const response = await request.get(
-				`/wp-json/wc/v3/taxes/classes/${taxClassSlug}`
+				`/wp-json/wc/v3/taxes/classes/${ taxClassSlug }`
 			);
 			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
-			expect(responseJSON.length).toEqual(1);
-			expect(responseJSON[0].name).toEqual('Test Tax Class');
-		});
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.length ).toEqual( 1 );
+			expect( responseJSON[ 0 ].name ).toEqual( 'Test Tax Class' );
+		} );
 
-		test('can retrieve all tax classes', async ({
-			request
-		}) => {
+		test( 'can retrieve all tax classes', async ( { request } ) => {
 			// call API to retrieve all tax classes
-			const response = await request.get('/wp-json/wc/v3/taxes/classes');
+			const response = await request.get(
+				'/wp-json/wc/v3/taxes/classes'
+			);
 			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
-			expect(Array.isArray(responseJSON)).toBe(true);
-			expect(responseJSON.length).toBeGreaterThan(0);
-		});
-	});
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON.length ).toBeGreaterThan( 0 );
+		} );
+	} );
 
-	test.describe('Update a tax class', () => {
-
-		test(`cannot update a tax class`, async ({
-			request,
-		}) => {
+	test.describe( 'Update a tax class', () => {
+		test( `cannot update a tax class`, async ( { request } ) => {
 			// attempt to update tax class should fail
 			const response = await request.put(
-				`/wp-json/wc/v3/taxes/classes/${ taxClassSlug }`, {
+				`/wp-json/wc/v3/taxes/classes/${ taxClassSlug }`,
+				{
 					data: {
-						name: "Not able to update tax class"
-					}
+						name: 'Not able to update tax class',
+					},
 				}
 			);
 			const responseJSON = await response.json();
-			expect(response.status()).toEqual(404);
-			expect(responseJSON.code).toEqual("rest_no_route");
-			expect(responseJSON.message).toEqual("No route was found matching the URL and request method.");
-		});
-	});
+			expect( response.status() ).toEqual( 404 );
+			expect( responseJSON.code ).toEqual( 'rest_no_route' );
+			expect( responseJSON.message ).toEqual(
+				'No route was found matching the URL and request method.'
+			);
+		} );
+	} );
 
-	test.describe('Delete a tax class', () => {
-		test('can permanently delete a tax class', async ({
-			request
-		}) => {
+	test.describe( 'Delete a tax class', () => {
+		test( 'can permanently delete a tax class', async ( { request } ) => {
 			// Delete the tax class.
 			const response = await request.delete(
-				`/wp-json/wc/v3/taxes/classes/${ taxClassSlug }`, {
+				`/wp-json/wc/v3/taxes/classes/${ taxClassSlug }`,
+				{
 					data: {
 						force: true,
 					},
 				}
 			);
-			expect(response.status()).toEqual(200);
+			expect( response.status() ).toEqual( 200 );
 
 			// Verify that the tax class can no longer be retrieved (empty array returned)
 			const getDeletedTaxClassResponse = await request.get(
 				`/wp-json/wc/v3/taxes/classes/${ taxClassSlug }`
 			);
-			const getDeletedTaxClassResponseJSON = await getDeletedTaxClassResponse.json();
-			expect(getDeletedTaxClassResponse.status()).toEqual(404);
-			expect(Array.isArray(getDeletedTaxClassResponseJSON)).toBe(true);
-
-		});
-	});
-
-});
+			const getDeletedTaxClassResponseJSON =
+				await getDeletedTaxClassResponse.json();
+			expect( getDeletedTaxClassResponse.status() ).toEqual( 404 );
+			expect( getDeletedTaxClassResponseJSON.code ).toEqual(
+				'woocommerce_rest_tax_class_invalid_slug'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When performing a GET or DELETE request to `/wp-json/wc/v3/taxes/classes/<slug>`, if the tax class specified by `<slug>` doesn't exist, the response has HTTP code 200 (OK), instead of 404, as other endpoints do (for example: `/wc/v3/products/<id>`).

In the case of the `GET` request you don't even get an error back but just an empty array, which isn't great.

This PR makes those tax class endpoints return 404 as appropriate with an error message.

Closes #35291.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Generate and take note of your API consumer key and secret on WC > Settings > Advanced > REST API. Make sure this key is read/write.
1. Go to WC > Settings > Tax and enter a few test tax classes in the **Additional tax classes** field. Save changes.
    - Tip: if you don't see this tab, visit **WooCommerce ‣ Settings ‣ General** and enable *tax rates and calculations.*
1. Configure your favorite REST client to use Basic Auth and use your consumer key and secret as username and password, respectively.
1. Perform a GET request to `<yoursite>/wp-json/wc/v3/taxes/classes` and confirm that you get a list of the tax classes defined on your settings screen in step 2.
1. Choose any slug from the list.
   1. Perform a GET request to `<yoursite>/wp-json/wc/v3/taxes/classes/<slug>`. You should get the details of said tax class (name and slug).
   1. Perform a DELETE request to `<yoursite>/wp-json/wc/v3/taxes/classes/<slug>`. Make sure to pass `force=true` as parameter in the URL.
      You should see the details of the tax class and it should be gone from WC > Settings > Tax > Additional tax classes.
1. Repeat the requests from the previous step with the same `<slug>`. The response in both cases should now be an error message and the HTTP status should be 404.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
