### PR TITLE
Register block in PHP and Add default opt in text when saving example block in `@woocommerce/extend-cart-checkout-block`

### DIFF
--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -20,6 +20,7 @@
  */
 add_action( 'woocommerce_blocks_loaded',
 	function () {
+		register_block_type_from_metadata( __DIR__ . '/build/js/checkout-newsletter-subscription-block' );
 		require_once __DIR__ . '/{{slug}}-blocks-integration.php';
 		add_action(
 			'woocommerce_blocks_cart_block_registration',

--- a/packages/js/extend-cart-checkout-block/changelog/fix-missing-default-text-eccb
+++ b/packages/js/extend-cart-checkout-block/changelog/fix-missing-default-text-eccb
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures the default text shows when saving the example newsletter subscription block.

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/edit.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/edit.js.mustache
@@ -43,7 +43,7 @@ export const Save = ( { attributes } ) => {
 	const { text } = attributes;
 	return (
 		<div { ...useBlockProps.save() }>
-			<RichText.Content value={ text } />
+			<RichText.Content value={ text || optInDefaultText } />
 		</div>
 	);
 };


### PR DESCRIPTION
Note: The testing instructions for this PR require the changes from https://github.com/woocommerce/woocommerce/pull/48543 to work.

### Changes proposed in this Pull Request:

- Adds the `defaultOptInText` fallback to the `RichText.Content` component's value when saving the example newsletter signup block.
- Registers the block in PHP using the block.json metadata.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note: The testing instructions for this PR require the changes from https://github.com/woocommerce/woocommerce/pull/48543 to work.

1. Go to the console in your `wp-content/plugins` directory, run `npx @wordpress/create-block -t woocommerce-monorepo/packages/js/extend-cart-checkout-block test-plugin` (Note: you may need to update the path to the monorepo)
2. Go to the `block.json` file in `test-plugin/src/js/checkout-newsletter-subscription-block/block.json` and change the `lock` attribute. Set the `remove` property to `false`.
3. Go to the Checkout Block in the editor and add the `Newsletter Subscription!` block to the Checkout Information block. 
4. Go to the Checkout block on the front end and ensure the `Newsletter Subscription!` appears and that the checkbox can be toggled.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
