### PR TITLE
Check WC_Legacy_API instead of WC_API as that seems to be cached by lightspeed servers

### DIFF
--- a/plugins/woocommerce/changelog/fix-48587
+++ b/plugins/woocommerce/changelog/fix-48587
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check WC_Legacy_API instead of WC_API as that seems to be cached by lightspeed servers.

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -65,6 +65,14 @@ class WC_Autoloader {
 	public function autoload( $class ) {
 		$class = strtolower( $class );
 
+		// The Legacy REST API was removed in WooCommerce 9.0, but some servers still have
+		// the includes/class-wc-api.php file after they upgrade, which causes a fatal error when executing
+		// "class_exists('WC_API')". This will prevent this error, while still making the class visible
+		// when it's provided by the WooCommerce Legacy REST API plugin.
+		if( 'wc_api' === $class ) {
+			return;
+		}
+
 		if ( 0 !== strpos( $class, 'wc_' ) ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -65,15 +65,15 @@ class WC_Autoloader {
 	public function autoload( $class ) {
 		$class = strtolower( $class );
 
+		if ( 0 !== strpos( $class, 'wc_' ) ) {
+			return;
+		}
+
 		// The Legacy REST API was removed in WooCommerce 9.0, but some servers still have
 		// the includes/class-wc-api.php file after they upgrade, which causes a fatal error when executing
 		// "class_exists('WC_API')". This will prevent this error, while still making the class visible
 		// when it's provided by the WooCommerce Legacy REST API plugin.
-		if( 'wc_api' === $class ) {
-			return;
-		}
-
-		if ( 0 !== strpos( $class, 'wc_' ) ) {
+		if ( 'wc_api' === $class ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Utilities/LegacyRestApiStub.php
+++ b/plugins/woocommerce/src/Internal/Utilities/LegacyRestApiStub.php
@@ -57,8 +57,8 @@ class LegacyRestApiStub {
 	private static function parse_legacy_rest_api_request() {
 		global $wp;
 
-		// The WC_API class existing means that the Legacy REST API extension is installed and active.
-		if ( class_exists( 'WC_Legacy_API' ) ) {
+		// The WC_Legacy_REST_API_Plugin class existence means that the Legacy REST API extension is installed and active.
+		if ( class_exists( 'WC_Legacy_REST_API_Plugin' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Utilities/LegacyRestApiStub.php
+++ b/plugins/woocommerce/src/Internal/Utilities/LegacyRestApiStub.php
@@ -58,7 +58,7 @@ class LegacyRestApiStub {
 		global $wp;
 
 		// The WC_API class existing means that the Legacy REST API extension is installed and active.
-		if ( class_exists( 'WC_API' ) ) {
+		if ( class_exists( 'WC_Legacy_API' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
…ightspeed servers.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We are getting reports of the `includes/class-wc-api.php` file still being present on the server, even though they were deleted with WooCommerce 9.0. In some of the reports, the common denominator is usage of LiteSpeed server and/or LiteSpeed cache; in others, the WooCommerce 9.0 files were copied directly on top of the old WooCommerce files, thus causing the old legacy REST API files to not be deleted. However, since we don't really know the root cause, it can potentially happen with some other config too.

This pull request makes two changes to deal with this situation:

1. Modify the autoloader so that it never loads the `WC_API` class.

This is needed bacause the Legacy REST API plugin itself does a `class_exists('WC_API')`. With this change, the plugin will continue to load its own copy of the class without issues.

2. Detect the `WC_Legacy_REST_API_Plugin` class in the legacy API stub, instead of `WC_API`, to determine if the plugin is installed and active. This is a performant and bulletproof way to detect the plugin.

This PR changes the class check to parent, so that even the wc-api file incorrectly, we at least won't trigger a fatal. Note that this is just a symptomatic fix, and does nothing for the root cause of deleted files still existing, which is not something we can probably fix in WC core.

Closes #48587 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a temporary file with following contents in `includes/class-wc-api.php` 
```php
<?php
class WC_API extends WC_Legacy_API {

}
```

2. Open any page to see the fatal error.

3. Switch to this patch, test that the error goes away. 

4. Query any of the Legacy REST API endpoints, verify that you get a "The WooCommerce API is disabled on this site" error response.

5. Repeat the previous step after installing the Legacy REST API plugin, the endpoint should return the expected data.

6. Verify that you can activate/deactivate the Legacy REST API plugin without issues.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
