### PR TITLE
Use `hasConnectedOwner` value instead to check if Jetpack is connected

### DIFF
--- a/packages/js/data/changelog/fix-unable-to-complete-tax-task
+++ b/packages/js/data/changelog/fix-unable-to-complete-tax-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use hasConnectedOwner value to check if jetpack is connected

--- a/packages/js/data/src/plugins/resolvers.ts
+++ b/packages/js/data/src/plugins/resolvers.ts
@@ -36,7 +36,20 @@ type PluginGetResponse = {
 } & Response;
 
 type JetpackConnectionResponse = {
+	// https://github.com/Automattic/jetpack/blob/2db5b61f15b9923f7438caaef29311b75db64ac5/tools/js-tools/types/global.d.ts#L33
 	isActive: boolean;
+	isStaging: boolean;
+	isRegistered: boolean;
+	isUserConnected: boolean;
+	hasConnectedOwner: boolean;
+	offlineMode: {
+		isActive: boolean;
+		constant: boolean;
+		url: boolean;
+		filter: boolean;
+		wpLocalConstant: boolean;
+	};
+	isPublic: boolean;
 } & Response;
 
 type ConnectJetpackResponse = {
@@ -86,7 +99,7 @@ export function* isJetpackConnected() {
 			method: 'GET',
 		} );
 
-		yield updateIsJetpackConnected( results.isActive );
+		yield updateIsJetpackConnected( results.hasConnectedOwner );
 	} catch ( error ) {
 		yield setError( 'isJetpackConnected', error );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When completing Core Profiler with Jetpack installed but not connected, users can't complete the tax task because `isJetpackConnected` is true. The value comes from the `isActive` value in the JP connection API. I'm not sure why it's different from `hasConnectedOwner`. 

<img width="1146" alt="Screenshot 2024-06-19 at 18 37 30" src="https://github.com/woocommerce/woocommerce/assets/4344253/10489a72-316b-4de5-9d2a-2f8efb86332b">

According to the code [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-rest-connector.php#L445-L469), they should be the same. We may need to investigate further or report to the Jetpack team, but it looks like the `isActive` will be deprecated in the future, so this PR replaces `isJetpackConnected` with `hasConnectedOwner` to fix the issue.

```php
		$connection_status = array(
			'isActive'          => $connection->has_connected_owner(), // TODO deprecate this.
			'isStaging'         => $status->in_safe_mode(), // TODO deprecate this.
			'isRegistered'      => $connection->is_connected(),
			'isUserConnected'   => $connection->is_user_connected(),
			'hasConnectedOwner' => $connection->has_connected_owner(),
			'offlineMode'       => array(
				'isActive'        => $status->is_offline_mode(),
				'constant'        => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
				'url'             => $status->is_local_site(),
				/** This filter is documented in packages/status/src/class-status.php */
				'filter'          => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
				'wpLocalConstant' => defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV,
			),
			'isPublic'          => '1' == get_option( 'blog_public' ), // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
		);
```

Here is the code WCS uses to check if Jetpack is connected or not

https://github.com/Automattic/woocommerce-services/blob/trunk/classes/class-wc-connect-jetpack.php#L124-L127

```php
		/**
		 * Determines if both the blog and a blog owner account are connected to Jetpack.
		 *
		 * @return bool Whether or nor Jetpack is connected
		 */
		public static function is_connected() {
			return self::get_connection_manager()->is_connected() &&
				   self::get_connection_manager()->has_connected_owner();
		}
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Choose the United States as the store country
3. Install Jetpack in the plugin step
4. Complete the core profiler without connecting to Jetpack (Click on `No, Thanks` in Jetpack connection screen)
5. Go to the WooCommerce > Home > Tax task
6. Confirm you can complete the task

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
