### PR TITLE
Add email type to email field in Checkout block

### DIFF
--- a/plugins/woocommerce/changelog/add-type-to-email-field
+++ b/plugins/woocommerce/changelog/add-type-to-email-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add email type to Checkout block email field.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -32,14 +32,14 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $supported_field_types = [ 'text', 'select', 'checkbox' ];
+	private $supported_field_types = ['text', 'select', 'checkbox'];
 
 	/**
 	 * Groups of fields to be saved.
 	 *
 	 * @var array
 	 */
-	protected $groups = [ 'billing', 'shipping', 'other' ];
+	protected $groups = ['billing', 'shipping', 'other'];
 
 	/**
 	 * Instance of the asset data registry.
@@ -82,34 +82,34 @@ class CheckoutFields {
 	 *
 	 * @param AssetDataRegistry $asset_data_registry Instance of the asset data registry.
 	 */
-	public function __construct( AssetDataRegistry $asset_data_registry ) {
+	public function __construct(AssetDataRegistry $asset_data_registry) {
 		$this->asset_data_registry = $asset_data_registry;
 
 		$this->fields_locations = [
 			// omit email from shipping and billing fields.
-			'address' => array_merge( \array_diff_key( $this->get_core_fields_keys(), array( 'email' ) ) ),
-			'contact' => array( 'email' ),
+			'address' => array_merge(\array_diff_key($this->get_core_fields_keys(), array('email'))),
+			'contact' => array('email'),
 			'order'   => [],
 		];
 
-		add_filter( 'woocommerce_get_country_locale_default', array( $this, 'update_default_locale_with_fields' ) );
+		add_filter('woocommerce_get_country_locale_default', array($this, 'update_default_locale_with_fields'));
 	}
 
 	/**
 	 * Initialize hooks.
 	 */
 	public function init() {
-		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'add_fields_data' ) );
-		add_action( 'woocommerce_blocks_cart_enqueue_data', array( $this, 'add_fields_data' ) );
-		add_filter( 'woocommerce_customer_allowed_session_meta_keys', array( $this, 'add_session_meta_keys' ) );
+		add_action('woocommerce_blocks_checkout_enqueue_data', array($this, 'add_fields_data'));
+		add_action('woocommerce_blocks_cart_enqueue_data', array($this, 'add_fields_data'));
+		add_filter('woocommerce_customer_allowed_session_meta_keys', array($this, 'add_session_meta_keys'));
 	}
 
 	/**
 	 * Add fields data to the asset data registry.
 	 */
 	public function add_fields_data() {
-		$this->asset_data_registry->add( 'defaultFields', array_merge( $this->get_core_fields(), $this->get_additional_fields() ) );
-		$this->asset_data_registry->add( 'addressFieldsLocations', $this->fields_locations );
+		$this->asset_data_registry->add('defaultFields', array_merge($this->get_core_fields(), $this->get_additional_fields()));
+		$this->asset_data_registry->add('addressFieldsLocations', $this->fields_locations);
 	}
 
 	/**
@@ -120,23 +120,23 @@ class CheckoutFields {
 	 * @param array $keys Session meta keys.
 	 * @return array
 	 */
-	public function add_session_meta_keys( $keys ) {
+	public function add_session_meta_keys($keys) {
 		$meta_keys = array();
 		try {
-			foreach ( $this->get_additional_fields() as $field_key => $field ) {
-				if ( 'address' === $field['location'] ) {
+			foreach ($this->get_additional_fields() as $field_key => $field) {
+				if ('address' === $field['location']) {
 					$meta_keys[] = self::BILLING_FIELDS_PREFIX . $field_key;
 					$meta_keys[] = self::SHIPPING_FIELDS_PREFIX . $field_key;
 				} else {
 					$meta_keys[] = self::OTHER_FIELDS_PREFIX . $field_key;
 				}
 			}
-		} catch ( \Throwable $e ) {
+		} catch (\Throwable $e) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'Error adding session meta keys for checkout fields. %s',
-					esc_attr( $e->getMessage() )
+					esc_attr($e->getMessage())
 				),
 				E_USER_WARNING
 			);
@@ -144,7 +144,7 @@ class CheckoutFields {
 			return $keys;
 		}
 
-		return array_merge( $keys, $meta_keys );
+		return array_merge($keys, $meta_keys);
 	}
 
 	/**
@@ -154,7 +154,7 @@ class CheckoutFields {
 	 * @param array $field Field data.
 	 * @return mixed
 	 */
-	public function default_sanitize_callback( $value, $field ) {
+	public function default_sanitize_callback($value, $field) {
 		return $value;
 	}
 
@@ -165,13 +165,13 @@ class CheckoutFields {
 	 * @param array $field Field data.
 	 * @return WP_Error|void If there is a validation error, return an WP_Error object.
 	 */
-	public function default_validate_callback( $value, $field ) {
-		if ( ! empty( $field['required'] ) && empty( $value ) ) {
+	public function default_validate_callback($value, $field) {
+		if (! empty($field['required']) && empty($value)) {
 			return new WP_Error(
 				'woocommerce_required_checkout_field',
 				sprintf(
-				// translators: %s is field key.
-					__( 'The field %s is required.', 'woocommerce' ),
+					// translators: %s is field key.
+					__('The field %s is required.', 'woocommerce'),
 					$field['id']
 				)
 			);
@@ -185,9 +185,9 @@ class CheckoutFields {
 	 *
 	 * @return WP_Error|void True if the field was registered, a WP_Error otherwise.
 	 */
-	public function register_checkout_field( $options ) {
+	public function register_checkout_field($options) {
 		// Check the options and show warnings if they're not supplied. Return early if an error that would prevent registration is encountered.
-		if ( false === $this->validate_options( $options ) ) {
+		if (false === $this->validate_options($options)) {
 			return;
 		}
 
@@ -199,7 +199,7 @@ class CheckoutFields {
 				'label'                      => '',
 				'optionalLabel'              => sprintf(
 					/* translators: %s Field label. */
-					__( '%s (optional)', 'woocommerce' ),
+					__('%s (optional)', 'woocommerce'),
 					$options['label']
 				),
 				'location'                   => '',
@@ -208,27 +208,27 @@ class CheckoutFields {
 				'required'                   => false,
 				'attributes'                 => [],
 				'show_in_order_confirmation' => true,
-				'sanitize_callback'          => array( $this, 'default_sanitize_callback' ),
-				'validate_callback'          => array( $this, 'default_validate_callback' ),
+				'sanitize_callback'          => array($this, 'default_sanitize_callback'),
+				'validate_callback'          => array($this, 'default_validate_callback'),
 			]
 		);
 
-		$field_data['attributes'] = $this->register_field_attributes( $field_data['id'], $field_data['attributes'] );
+		$field_data['attributes'] = $this->register_field_attributes($field_data['id'], $field_data['attributes']);
 
-		if ( 'checkbox' === $field_data['type'] ) {
-			$field_data = $this->process_checkbox_field( $field_data, $options );
-		} elseif ( 'select' === $field_data['type'] ) {
-			$field_data = $this->process_select_field( $field_data, $options );
+		if ('checkbox' === $field_data['type']) {
+			$field_data = $this->process_checkbox_field($field_data, $options);
+		} elseif ('select' === $field_data['type']) {
+			$field_data = $this->process_select_field($field_data, $options);
 		}
 
 		// $field_data will be false if an error that will prevent the field being registered is encountered.
-		if ( false === $field_data ) {
+		if (false === $field_data) {
 			return;
 		}
 
 		// Insert new field into the correct location array.
-		$this->additional_fields[ $field_data['id'] ]        = $field_data;
-		$this->fields_locations[ $field_data['location'] ][] = $field_data['id'];
+		$this->additional_fields[$field_data['id']]        = $field_data;
+		$this->fields_locations[$field_data['location']][] = $field_data['id'];
 	}
 
 	/**
@@ -238,18 +238,18 @@ class CheckoutFields {
 	 *
 	 * @internal
 	 */
-	public function deregister_checkout_field( $field_id ) {
-		if ( empty( $this->additional_fields[ $field_id ] ) ) {
+	public function deregister_checkout_field($field_id) {
+		if (empty($this->additional_fields[$field_id])) {
 			return;
 		}
 
-		$location = $this->get_field_location( $field_id );
+		$location = $this->get_field_location($field_id);
 
 		// Remove the field from the fields_locations array.
-		$this->fields_locations[ $location ] = array_diff( $this->fields_locations[ $location ], array( $field_id ) );
+		$this->fields_locations[$location] = array_diff($this->fields_locations[$location], array($field_id));
 
 		// Remove the field from the additional_fields array.
-		unset( $this->additional_fields[ $field_id ] );
+		unset($this->additional_fields[$field_id]);
 	}
 
 	/**
@@ -258,39 +258,39 @@ class CheckoutFields {
 	 * @param array $options The options supplied during field registration.
 	 * @return bool false if an error was encountered, true otherwise.
 	 */
-	private function validate_options( &$options ) {
-		if ( empty( $options['id'] ) ) {
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0' );
+	private function validate_options(&$options) {
+		if (empty($options['id'])) {
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0');
 			return false;
 		}
 
 		// Having fewer than 2 after exploding around a / means there is no namespace.
-		if ( count( explode( '/', $options['id'] ) ) < 2 ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'A checkout field id must consist of namespace/name.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (count(explode('/', $options['id'])) < 2) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'A checkout field id must consist of namespace/name.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 
-		if ( empty( $options['label'] ) ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field label is required.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (empty($options['label'])) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'The field label is required.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 
-		if ( empty( $options['location'] ) ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is required.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (empty($options['location'])) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'The field location is required.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 
-		if ( 'additional' === $options['location'] ) {
-			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
+		if ('additional' === $options['location']) {
+			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
 			$options['location'] = 'order';
 		}
 
-		if ( ! in_array( $options['location'], array_keys( $this->fields_locations ), true ) ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is invalid.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (! in_array($options['location'], array_keys($this->fields_locations), true)) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'The field location is invalid.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 
@@ -299,41 +299,41 @@ class CheckoutFields {
 		$id       = $options['id'];
 
 		// Check to see if field is already in the array.
-		if ( ! empty( $this->additional_fields[ $id ] ) || in_array( $id, $this->fields_locations[ $location ], true ) ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The field is already registered.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (! empty($this->additional_fields[$id]) || in_array($id, $this->fields_locations[$location], true)) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'The field is already registered.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 
-		if ( ! empty( $options['type'] ) ) {
-			if ( ! in_array( $options['type'], $this->supported_field_types, true ) ) {
+		if (! empty($options['type'])) {
+			if (! in_array($options['type'], $this->supported_field_types, true)) {
 				$message = sprintf(
 					'Unable to register field with id: "%s". Registering a field with type "%s" is not supported. The supported types are: %s.',
 					$id,
 					$options['type'],
-					implode( ', ', $this->supported_field_types )
+					implode(', ', $this->supported_field_types)
 				);
-				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+				_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 				return false;
 			}
 		}
 
-		if ( ! empty( $options['sanitize_callback'] ) && ! is_callable( $options['sanitize_callback'] ) ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The sanitize_callback must be a valid callback.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (! empty($options['sanitize_callback']) && ! is_callable($options['sanitize_callback'])) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'The sanitize_callback must be a valid callback.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 
-		if ( ! empty( $options['validate_callback'] ) && ! is_callable( $options['validate_callback'] ) ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (! empty($options['validate_callback']) && ! is_callable($options['validate_callback'])) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 
 		// Hidden fields are not supported right now. They will be registered with hidden => false.
-		if ( ! empty( $options['hidden'] ) && true === $options['hidden'] ) {
-			$message = sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (! empty($options['hidden']) && true === $options['hidden']) {
+			$message = sprintf('Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id);
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			// Don't return here unlike the other fields because this is not an issue that will prevent registration.
 		}
 
@@ -348,31 +348,31 @@ class CheckoutFields {
 	 *
 	 * @return array|false The updated $field_data array or false if an error was encountered.
 	 */
-	private function process_select_field( $field_data, $options ) {
+	private function process_select_field($field_data, $options) {
 		$id = $options['id'];
 
-		if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
-			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options".' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (empty($options['options']) || ! is_array($options['options'])) {
+			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options".');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return false;
 		}
 		$cleaned_options = [];
 		$added_values    = [];
 
 		// Check all entries in $options['options'] has a key and value member.
-		foreach ( $options['options'] as $option ) {
-			if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
-				$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.' );
-				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		foreach ($options['options'] as $option) {
+			if (! isset($option['value']) || ! isset($option['label'])) {
+				$message = sprintf('Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.');
+				_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 				return false;
 			}
 
-			$sanitized_value = sanitize_text_field( $option['value'] );
-			$sanitized_label = sanitize_text_field( $option['label'] );
+			$sanitized_value = sanitize_text_field($option['value']);
+			$sanitized_label = sanitize_text_field($option['label']);
 
-			if ( in_array( $sanitized_value, $added_values, true ) ) {
-				$message = sprintf( 'Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', $id, $sanitized_value );
-				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+			if (in_array($sanitized_value, $added_values, true)) {
+				$message = sprintf('Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', $id, $sanitized_value);
+				_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 				continue;
 			}
 
@@ -386,8 +386,8 @@ class CheckoutFields {
 
 		$field_data['options'] = $cleaned_options;
 
-		if ( isset( $field_data['placeholder'] ) ) {
-			$field_data['placeholder'] = sanitize_text_field( $field_data['placeholder'] );
+		if (isset($field_data['placeholder'])) {
+			$field_data['placeholder'] = sanitize_text_field($field_data['placeholder']);
 		}
 
 		return $field_data;
@@ -401,15 +401,15 @@ class CheckoutFields {
 	 *
 	 * @return array|false The updated $field_data array or false if an error was encountered.
 	 */
-	private function process_checkbox_field( $field_data, $options ) {
+	private function process_checkbox_field($field_data, $options) {
 		$id = $options['id'];
 
 		// Checkbox fields are always optional. Log a warning if it's set explicitly as true.
 		$field_data['required'] = false;
 
-		if ( isset( $options['required'] ) && true === $options['required'] ) {
-			$message = sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (isset($options['required']) && true === $options['required']) {
+			$message = sprintf('Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id);
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 		}
 
 		return $field_data;
@@ -423,16 +423,16 @@ class CheckoutFields {
 	 *
 	 * @return array The processed attributes.
 	 */
-	private function register_field_attributes( $id, $attributes ) {
+	private function register_field_attributes($id, $attributes) {
 		// We check if attributes are valid. This is done to prevent too much nesting and also to allow field registration
 		// even if the attributes property is invalid. We can just skip it and register the field without attributes.
-		if ( empty( $attributes ) ) {
+		if (empty($attributes)) {
 			return [];
 		}
 
-		if ( ! is_array( $attributes ) || 0 === count( $attributes ) ) {
-			$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (! is_array($attributes) || 0 === count($attributes)) {
+			$message = sprintf('An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.');
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 			return [];
 		}
 
@@ -448,23 +448,23 @@ class CheckoutFields {
 
 		$valid_attributes = array_filter(
 			$attributes,
-			function ( $_, $key ) use ( $allowed_attributes ) {
-				return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0 || strpos( $key, 'data-' ) === 0;
+			function ($_, $key) use ($allowed_attributes) {
+				return in_array($key, $allowed_attributes, true) || strpos($key, 'aria-') === 0 || strpos($key, 'data-') === 0;
 			},
 			ARRAY_FILTER_USE_BOTH
 		);
 
 		// Any invalid attributes should show a doing_it_wrong warning. It shouldn't stop field registration, though.
-		if ( count( $attributes ) !== count( $valid_attributes ) ) {
-			$invalid_attributes = array_keys( array_diff_key( $attributes, $valid_attributes ) );
-			$message            = sprintf( 'Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode( ', ', $invalid_attributes ) );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if (count($attributes) !== count($valid_attributes)) {
+			$invalid_attributes = array_keys(array_diff_key($attributes, $valid_attributes));
+			$message            = sprintf('Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode(', ', $invalid_attributes));
+			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
 		}
 
 		// Escape attributes to remove any malicious code and return them.
 		return array_map(
-			function ( $value ) {
-				return esc_attr( $value );
+			function ($value) {
+				return esc_attr($value);
 			},
 			$valid_attributes
 		);
@@ -499,7 +499,7 @@ class CheckoutFields {
 	public function get_core_fields() {
 		return [
 			'email'      => [
-				'label'          => __( 'Email address', 'woocommerce' ),
+				'label'          => __('Email address', 'woocommerce'),
 				'optionalLabel'  => __(
 					'Email address (optional)',
 					'woocommerce'
@@ -508,10 +508,11 @@ class CheckoutFields {
 				'hidden'         => false,
 				'autocomplete'   => 'email',
 				'autocapitalize' => 'none',
+				'type'           => 'email',
 				'index'          => 0,
 			],
 			'country'    => [
-				'label'         => __( 'Country/Region', 'woocommerce' ),
+				'label'         => __('Country/Region', 'woocommerce'),
 				'optionalLabel' => __(
 					'Country/Region (optional)',
 					'woocommerce'
@@ -522,7 +523,7 @@ class CheckoutFields {
 				'index'         => 1,
 			],
 			'first_name' => [
-				'label'          => __( 'First name', 'woocommerce' ),
+				'label'          => __('First name', 'woocommerce'),
 				'optionalLabel'  => __(
 					'First name (optional)',
 					'woocommerce'
@@ -534,7 +535,7 @@ class CheckoutFields {
 				'index'          => 10,
 			],
 			'last_name'  => [
-				'label'          => __( 'Last name', 'woocommerce' ),
+				'label'          => __('Last name', 'woocommerce'),
 				'optionalLabel'  => __(
 					'Last name (optional)',
 					'woocommerce'
@@ -546,7 +547,7 @@ class CheckoutFields {
 				'index'          => 20,
 			],
 			'company'    => [
-				'label'          => __( 'Company', 'woocommerce' ),
+				'label'          => __('Company', 'woocommerce'),
 				'optionalLabel'  => __(
 					'Company (optional)',
 					'woocommerce'
@@ -558,7 +559,7 @@ class CheckoutFields {
 				'index'          => 30,
 			],
 			'address_1'  => [
-				'label'          => __( 'Address', 'woocommerce' ),
+				'label'          => __('Address', 'woocommerce'),
 				'optionalLabel'  => __(
 					'Address (optional)',
 					'woocommerce'
@@ -570,7 +571,7 @@ class CheckoutFields {
 				'index'          => 40,
 			],
 			'address_2'  => [
-				'label'          => __( 'Apartment, suite, etc.', 'woocommerce' ),
+				'label'          => __('Apartment, suite, etc.', 'woocommerce'),
 				'optionalLabel'  => __(
 					'Apartment, suite, etc. (optional)',
 					'woocommerce'
@@ -582,7 +583,7 @@ class CheckoutFields {
 				'index'          => 50,
 			],
 			'city'       => [
-				'label'          => __( 'City', 'woocommerce' ),
+				'label'          => __('City', 'woocommerce'),
 				'optionalLabel'  => __(
 					'City (optional)',
 					'woocommerce'
@@ -594,7 +595,7 @@ class CheckoutFields {
 				'index'          => 70,
 			],
 			'state'      => [
-				'label'          => __( 'State/County', 'woocommerce' ),
+				'label'          => __('State/County', 'woocommerce'),
 				'optionalLabel'  => __(
 					'State/County (optional)',
 					'woocommerce'
@@ -606,7 +607,7 @@ class CheckoutFields {
 				'index'          => 80,
 			],
 			'postcode'   => [
-				'label'          => __( 'Postal code', 'woocommerce' ),
+				'label'          => __('Postal code', 'woocommerce'),
 				'optionalLabel'  => __(
 					'Postal code (optional)',
 					'woocommerce'
@@ -618,7 +619,7 @@ class CheckoutFields {
 				'index'          => 90,
 			],
 			'phone'      => [
-				'label'          => __( 'Phone', 'woocommerce' ),
+				'label'          => __('Phone', 'woocommerce'),
 				'optionalLabel'  => __(
 					'Phone (optional)',
 					'woocommerce'
@@ -648,9 +649,9 @@ class CheckoutFields {
 	 * @param string $field_key The key of the field to get the location for.
 	 * @return string The location of the field.
 	 */
-	public function get_field_location( $field_key ) {
-		foreach ( $this->fields_locations as $location => $fields ) {
-			if ( in_array( $field_key, $fields, true ) ) {
+	public function get_field_location($field_key) {
+		foreach ($this->fields_locations as $location => $fields) {
+			if (in_array($field_key, $fields, true)) {
 				return $location;
 			}
 		}
@@ -666,12 +667,12 @@ class CheckoutFields {
 	 * @param mixed  $field_value The value of the field.
 	 * @return mixed
 	 */
-	public function sanitize_field( $field_key, $field_value ) {
+	public function sanitize_field($field_key, $field_value) {
 		try {
-			$field = $this->additional_fields[ $field_key ] ?? null;
+			$field = $this->additional_fields[$field_key] ?? null;
 
-			if ( $field ) {
-				$field_value = call_user_func( $field['sanitize_callback'], $field_value, $field );
+			if ($field) {
+				$field_value = call_user_func($field['sanitize_callback'], $field_value, $field);
 			}
 
 			/**
@@ -683,7 +684,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.7.0 Use woocommerce_sanitize_additional_field instead.
 			 */
-			$field_value = apply_filters_deprecated( '__experimental_woocommerce_blocks_sanitize_additional_field', array( $field_value, $field_key ), '8.7.0', 'woocommerce_sanitize_additional_field', 'This action has been graduated, use woocommerce_sanitize_additional_field instead.' );
+			$field_value = apply_filters_deprecated('__experimental_woocommerce_blocks_sanitize_additional_field', array($field_value, $field_key), '8.7.0', 'woocommerce_sanitize_additional_field', 'This action has been graduated, use woocommerce_sanitize_additional_field instead.');
 
 			/**
 			 * Allow custom sanitization of an additional field.
@@ -693,16 +694,15 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			return apply_filters( 'woocommerce_sanitize_additional_field', $field_value, $field_key );
-
-		} catch ( \Throwable $e ) {
+			return apply_filters('woocommerce_sanitize_additional_field', $field_value, $field_key);
+		} catch (\Throwable $e) {
 			// One of the filters errored so skip it. This allows the checkout process to continue.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'Field sanitization for %s encountered an error. %s',
-					esc_html( $field_key ),
-					esc_html( $e->getMessage() )
+					esc_html($field_key),
+					esc_html($e->getMessage())
 				),
 				E_USER_WARNING
 			);
@@ -720,17 +720,17 @@ class CheckoutFields {
 	 * @param mixed  $field_value  The value of the field.
 	 * @return WP_Error
 	 */
-	public function validate_field( $field_key, $field_value ) {
+	public function validate_field($field_key, $field_value) {
 		$errors = new WP_Error();
 
 		try {
-			$field = $this->additional_fields[ $field_key ] ?? null;
+			$field = $this->additional_fields[$field_key] ?? null;
 
-			if ( $field ) {
-				$validation = call_user_func( $field['validate_callback'], $field_value, $field );
+			if ($field) {
+				$validation = call_user_func($field['validate_callback'], $field_value, $field);
 
-				if ( is_wp_error( $validation ) ) {
-					$errors->merge_from( $validation );
+				if (is_wp_error($validation)) {
+					$errors->merge_from($validation);
 				}
 			}
 
@@ -744,7 +744,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.7.0 Use woocommerce_validate_additional_field instead.
 			 */
-			wc_do_deprecated_action( '__experimental_woocommerce_blocks_validate_additional_field', array( $errors, $field_key, $field_value ), '8.7.0', 'woocommerce_validate_additional_field', 'This action has been graduated, use woocommerce_validate_additional_field instead.' );
+			wc_do_deprecated_action('__experimental_woocommerce_blocks_validate_additional_field', array($errors, $field_key, $field_value), '8.7.0', 'woocommerce_validate_additional_field', 'This action has been graduated, use woocommerce_validate_additional_field instead.');
 			/**
 			 * Pass an error object to allow validation of an additional field.
 			 *
@@ -754,17 +754,16 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			do_action( 'woocommerce_validate_additional_field', $errors, $field_key, $field_value );
-
-		} catch ( \Throwable $e ) {
+			do_action('woocommerce_validate_additional_field', $errors, $field_key, $field_value);
+		} catch (\Throwable $e) {
 
 			// One of the filters errored so skip them and validate the field. This allows the checkout process to continue.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'Field validation for %s encountered an error. %s',
-					esc_html( $field_key ),
-					esc_html( $e->getMessage() )
+					esc_html($field_key),
+					esc_html($e->getMessage())
 				),
 				E_USER_WARNING
 			);
@@ -779,10 +778,10 @@ class CheckoutFields {
 	 * @param array $locale The locale to update.
 	 * @return mixed
 	 */
-	public function update_default_locale_with_fields( $locale ) {
-		foreach ( $this->get_fields_for_location( 'address' ) as $field_id => $additional_field ) {
-			if ( empty( $locale[ $field_id ] ) ) {
-				$locale[ $field_id ] = $additional_field;
+	public function update_default_locale_with_fields($locale) {
+		foreach ($this->get_fields_for_location('address') as $field_id => $additional_field) {
+			if (empty($locale[$field_id])) {
+				$locale[$field_id] = $additional_field;
 			}
 		}
 		return $locale;
@@ -813,7 +812,7 @@ class CheckoutFields {
 	 * @deprecated 8.9.0 Use get_order_fields_keys instead.
 	 */
 	public function get_additional_fields_keys() {
-		wc_deprecated_function( __METHOD__, '8.9.0', 'get_order_fields_keys' );
+		wc_deprecated_function(__METHOD__, '8.9.0', 'get_order_fields_keys');
 		return $this->get_order_fields_keys();
 	}
 
@@ -832,19 +831,19 @@ class CheckoutFields {
 	 * @param string $location The location to get fields for (address|contact|order).
 	 * @return array An array of fields definitions.
 	 */
-	public function get_fields_for_location( $location ) {
-		if ( 'additional' === $location ) {
-			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
+	public function get_fields_for_location($location) {
+		if ('additional' === $location) {
+			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
 			$location = 'order';
 		}
 
-		if ( in_array( $location, array_keys( $this->fields_locations ), true ) ) {
-			$order_fields_keys = $this->fields_locations[ $location ];
+		if (in_array($location, array_keys($this->fields_locations), true)) {
+			$order_fields_keys = $this->fields_locations[$location];
 
 			return array_filter(
 				$this->get_additional_fields(),
-				function ( $key ) use ( $order_fields_keys ) {
-					return in_array( $key, $order_fields_keys, true );
+				function ($key) use ($order_fields_keys) {
+					return in_array($key, $order_fields_keys, true);
 				},
 				ARRAY_FILTER_USE_KEY
 			);
@@ -860,16 +859,16 @@ class CheckoutFields {
 	 * @param string $group The group to get the field value for (shipping|billing|other).
 	 * @return WP_Error
 	 */
-	public function validate_fields_for_location( $fields, $location, $group = 'other' ) {
+	public function validate_fields_for_location($fields, $location, $group = 'other') {
 		$errors = new WP_Error();
 
-		if ( 'additional' === $location ) {
-			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
+		if ('additional' === $location) {
+			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
 			$location = 'order';
 		}
 
-		if ( 'additional' === $group ) {
-			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
+		if ('additional' === $group) {
+			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
 			$group = 'other';
 		}
 
@@ -884,7 +883,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.9.0 Use woocommerce_blocks_validate_location_order_fields instead.
 			 */
-			wc_do_deprecated_action( 'woocommerce_blocks_validate_location_additional_fields', array( $errors, $fields, $group ), '8.9.0', 'woocommerce_blocks_validate_location_additional_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_additional_fields instead.' );
+			wc_do_deprecated_action('woocommerce_blocks_validate_location_additional_fields', array($errors, $fields, $group), '8.9.0', 'woocommerce_blocks_validate_location_additional_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_additional_fields instead.');
 			/**
 			 * Pass an error object to allow validation of an additional field.
 			 *
@@ -895,7 +894,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.9.0 Use woocommerce_blocks_validate_location_{location}_fields instead.
 			 */
-			wc_do_deprecated_action( '__experimental_woocommerce_blocks_validate_location_' . $location . '_fields', array( $errors, $fields, $group ), '8.9.0', 'woocommerce_blocks_validate_location_' . $location . '_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_' . $location . '_fields instead.' );
+			wc_do_deprecated_action('__experimental_woocommerce_blocks_validate_location_' . $location . '_fields', array($errors, $fields, $group), '8.9.0', 'woocommerce_blocks_validate_location_' . $location . '_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_' . $location . '_fields instead.');
 
 			/**
 			 * Pass an error object to allow validation of an additional field.
@@ -906,18 +905,17 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			do_action( 'woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group );
-
-		} catch ( \Throwable $e ) {
+			do_action('woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group);
+		} catch (\Throwable $e) {
 
 			// One of the filters errored so skip them. This allows the checkout process to continue.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'The action %s encountered an error. The field location %s may not have any custom validation applied to it. %s',
-					esc_html( 'woocommerce_blocks_validate_' . $location . '_fields' ),
-					esc_html( $location ),
-					esc_html( $e->getMessage() )
+					esc_html('woocommerce_blocks_validate_' . $location . '_fields'),
+					esc_html($location),
+					esc_html($e->getMessage())
 				),
 				E_USER_WARNING
 			);
@@ -937,42 +935,42 @@ class CheckoutFields {
 	 *
 	 * @return true|WP_Error True if the field is valid, a WP_Error otherwise.
 	 */
-	public function validate_field_for_location( $key, $value, $location ) {
-		if ( 'additional' === $location ) {
-			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
+	public function validate_field_for_location($key, $value, $location) {
+		if ('additional' === $location) {
+			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
 			$location = 'order';
 		}
 
-		if ( ! $this->is_field( $key ) ) {
+		if (! $this->is_field($key)) {
 			return new WP_Error(
 				'woocommerce_invalid_checkout_field',
 				\sprintf(
-				// translators: % is field key.
-					__( 'The field %s is invalid.', 'woocommerce' ),
+					// translators: % is field key.
+					__('The field %s is invalid.', 'woocommerce'),
 					$key
 				)
 			);
 		}
 
-		if ( ! in_array( $key, $this->fields_locations[ $location ], true ) ) {
+		if (! in_array($key, $this->fields_locations[$location], true)) {
 			return new WP_Error(
 				'woocommerce_invalid_checkout_field_location',
 				\sprintf(
-				// translators: %1$s is field key, %2$s location.
-					__( 'The field %1$s is invalid for the location %2$s.', 'woocommerce' ),
+					// translators: %1$s is field key, %2$s location.
+					__('The field %1$s is invalid for the location %2$s.', 'woocommerce'),
 					$key,
 					$location
 				)
 			);
 		}
 
-		$field = $this->additional_fields[ $key ];
-		if ( ! empty( $field['required'] ) && empty( $value ) ) {
+		$field = $this->additional_fields[$key];
+		if (! empty($field['required']) && empty($value)) {
 			return new WP_Error(
 				'woocommerce_required_checkout_field',
 				\sprintf(
-				// translators: %s is field key.
-					__( 'The field %s is required.', 'woocommerce' ),
+					// translators: %s is field key.
+					__('The field %s is required.', 'woocommerce'),
 					$key
 				)
 			);
@@ -988,18 +986,18 @@ class CheckoutFields {
 	 *
 	 * @return string[] Field keys.
 	 */
-	public function get_fields_for_group( $group = 'other' ) {
-		if ( 'shipping' === $group ) {
-			return $this->get_fields_for_location( 'address' );
+	public function get_fields_for_group($group = 'other') {
+		if ('shipping' === $group) {
+			return $this->get_fields_for_location('address');
 		}
 
-		if ( 'billing' === $group ) {
-			return $this->get_fields_for_location( 'address' );
+		if ('billing' === $group) {
+			return $this->get_fields_for_location('address');
 		}
 
 		return \array_merge(
-			$this->get_fields_for_location( 'contact' ),
-			$this->get_fields_for_location( 'order' )
+			$this->get_fields_for_location('contact'),
+			$this->get_fields_for_location('order')
 		);
 	}
 
@@ -1010,8 +1008,8 @@ class CheckoutFields {
 	 *
 	 * @return bool True if the field is valid, false otherwise.
 	 */
-	public function is_field( $key ) {
-		return array_key_exists( $key, $this->additional_fields );
+	public function is_field($key) {
+		return array_key_exists($key, $this->additional_fields);
 	}
 
 	/**
@@ -1023,8 +1021,8 @@ class CheckoutFields {
 	 *
 	 * @return bool True if the field is valid, false otherwise.
 	 */
-	public function is_customer_field( $key ) {
-		return in_array( $key, array_intersect( array_merge( $this->get_address_fields_keys(), $this->get_contact_fields_keys() ), array_keys( $this->additional_fields ) ), true );
+	public function is_customer_field($key) {
+		return in_array($key, array_intersect(array_merge($this->get_address_fields_keys(), $this->get_contact_fields_keys()), array_keys($this->additional_fields)), true);
 	}
 
 	/**
@@ -1038,16 +1036,16 @@ class CheckoutFields {
 	 *
 	 * @return void
 	 */
-	public function persist_field_for_order( string $key, $value, WC_Order $order, string $group = 'other', bool $set_customer = true ) {
-		if ( 'additional' === $group ) {
-			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
+	public function persist_field_for_order(string $key, $value, WC_Order $order, string $group = 'other', bool $set_customer = true) {
+		if ('additional' === $group) {
+			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
 			$group = 'other';
 		}
 
-		$this->set_array_meta( $key, $value, $order, $group );
-		if ( $set_customer && $order->get_customer_id() ) {
-			$customer = new WC_Customer( $order->get_customer_id() );
-			$this->persist_field_for_customer( $key, $value, $customer, $group );
+		$this->set_array_meta($key, $value, $order, $group);
+		if ($set_customer && $order->get_customer_id()) {
+			$customer = new WC_Customer($order->get_customer_id());
+			$this->persist_field_for_customer($key, $value, $customer, $group);
 		}
 	}
 
@@ -1061,13 +1059,13 @@ class CheckoutFields {
 	 *
 	 * @return void
 	 */
-	public function persist_field_for_customer( string $key, $value, WC_Customer $customer, string $group = 'other' ) {
-		if ( 'additional' === $group ) {
-			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
+	public function persist_field_for_customer(string $key, $value, WC_Customer $customer, string $group = 'other') {
+		if ('additional' === $group) {
+			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
 			$group = 'other';
 		}
 
-		$this->set_array_meta( $key, $value, $customer, $group );
+		$this->set_array_meta($key, $value, $customer, $group);
 	}
 
 	/**
@@ -1080,8 +1078,8 @@ class CheckoutFields {
 	 *
 	 * @return void
 	 */
-	private function set_array_meta( string $key, $value, WC_Data $wc_object, string $group ) {
-		$meta_key = self::get_group_key( $group ) . $key;
+	private function set_array_meta(string $key, $value, WC_Data $wc_object, string $group) {
+		$meta_key = self::get_group_key($group) . $key;
 
 		/**
 		 * Allow reacting for saving an additional field value.
@@ -1093,13 +1091,13 @@ class CheckoutFields {
 		 *
 		 * @since 8.9.0
 		 */
-		do_action( 'woocommerce_set_additional_field_value', $key, $value, $group, $wc_object );
+		do_action('woocommerce_set_additional_field_value', $key, $value, $group, $wc_object);
 		// Convert boolean values to strings because Data Stores will skip false values.
-		if ( is_bool( $value ) ) {
+		if (is_bool($value)) {
 			$value = $value ? '1' : '0';
 		}
 		// Replacing all meta using `add_meta_data`. For some reason `update_meta_data` causes duplicate keys.
-		$wc_object->add_meta_data( $meta_key, $value, true );
+		$wc_object->add_meta_data($meta_key, $value, true);
 	}
 
 	/**
@@ -1111,17 +1109,17 @@ class CheckoutFields {
 	 *
 	 * @return mixed The field value.
 	 */
-	public function get_field_from_object( string $key, WC_Data $wc_object, string $group = 'other' ) {
-		if ( 'additional' === $group ) {
-			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
+	public function get_field_from_object(string $key, WC_Data $wc_object, string $group = 'other') {
+		if ('additional' === $group) {
+			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
 			$group = 'other';
 		}
 
-		$meta_key = self::get_group_key( $group ) . $key;
+		$meta_key = self::get_group_key($group) . $key;
 
-		$value = $wc_object->get_meta( $meta_key, true );
+		$value = $wc_object->get_meta($meta_key, true);
 
-		if ( ! $value ) {
+		if (! $value) {
 			/**
 			 * Allow providing a default value for additional fields if no value is already set.
 			 *
@@ -1131,15 +1129,15 @@ class CheckoutFields {
 			 *
 			 * @since 8.9.0
 			 */
-			$value = apply_filters( "woocommerce_get_default_value_for_{$key}", null, $group, $wc_object );
+			$value = apply_filters("woocommerce_get_default_value_for_{$key}", null, $group, $wc_object);
 		}
 
 		// We cast the value to a boolean if the field is a checkbox.
-		if ( $this->is_field( $key ) && 'checkbox' === $this->additional_fields[ $key ]['type'] ) {
+		if ($this->is_field($key) && 'checkbox' === $this->additional_fields[$key]['type']) {
 			return '1' === $value;
 		}
 
-		if ( null === $value ) {
+		if (null === $value) {
 			return '';
 		}
 
@@ -1155,44 +1153,44 @@ class CheckoutFields {
 	 *
 	 * @return array An array of fields.
 	 */
-	public function get_all_fields_from_object( WC_Data $wc_object, string $group = 'other', bool $all = false ) {
-		if ( 'additional' === $group ) {
-			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
+	public function get_all_fields_from_object(WC_Data $wc_object, string $group = 'other', bool $all = false) {
+		if ('additional' === $group) {
+			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
 			$group = 'other';
 		}
 
 		$meta_data = [];
 
-		$prefix = self::get_group_key( $group );
+		$prefix = self::get_group_key($group);
 
-		if ( $wc_object instanceof WC_Data ) {
+		if ($wc_object instanceof WC_Data) {
 			$meta = $wc_object->get_meta_data();
-			foreach ( $meta as $meta_data_object ) {
-				if ( 0 === \strpos( $meta_data_object->key, $prefix ) ) {
-					$key = \str_replace( $prefix, '', $meta_data_object->key );
-					if ( $all || $this->is_field( $key ) ) {
-						$meta_data[ $key ] = $meta_data_object->value;
+			foreach ($meta as $meta_data_object) {
+				if (0 === \strpos($meta_data_object->key, $prefix)) {
+					$key = \str_replace($prefix, '', $meta_data_object->key);
+					if ($all || $this->is_field($key)) {
+						$meta_data[$key] = $meta_data_object->value;
 					}
 				}
 			}
 		}
 
-		$missing_fields = array_diff( array_keys( $this->get_fields_for_group( $group ) ), array_keys( $meta_data ) );
+		$missing_fields = array_diff(array_keys($this->get_fields_for_group($group)), array_keys($meta_data));
 
-		foreach ( $missing_fields as $missing_field ) {
-				/**
-				 * Allow providing a default value for additional fields if no value is already set.
-				 *
-				 * @param null $value The default value for the filter, always null.
-				 * @param string $group The group of this key (shipping|billing|other).
-				 * @param WC_Data $wc_object The object to get the field value for.
-				 *
-				 * @since 8.9.0
-				 */
-				$value = apply_filters( "woocommerce_get_default_value_for_{$missing_field}", null, $group, $wc_object );
+		foreach ($missing_fields as $missing_field) {
+			/**
+			 * Allow providing a default value for additional fields if no value is already set.
+			 *
+			 * @param null $value The default value for the filter, always null.
+			 * @param string $group The group of this key (shipping|billing|other).
+			 * @param WC_Data $wc_object The object to get the field value for.
+			 *
+			 * @since 8.9.0
+			 */
+			$value = apply_filters("woocommerce_get_default_value_for_{$missing_field}", null, $group, $wc_object);
 
-			if ( isset( $value ) ) {
-				$meta_data[ $missing_field ] = $value;
+			if (isset($value)) {
+				$meta_data[$missing_field] = $value;
 			}
 		}
 
@@ -1205,14 +1203,14 @@ class CheckoutFields {
 	 * @param WC_Order    $order The order to sync the fields for.
 	 * @param WC_Customer $customer The customer to sync the fields for.
 	 */
-	public function sync_customer_additional_fields_with_order( WC_Order $order, WC_Customer $customer ) {
-		foreach ( $this->groups as $group ) {
-			$order_additional_fields = $this->get_all_fields_from_object( $order, $group, true );
+	public function sync_customer_additional_fields_with_order(WC_Order $order, WC_Customer $customer) {
+		foreach ($this->groups as $group) {
+			$order_additional_fields = $this->get_all_fields_from_object($order, $group, true);
 
 			// Sync customer additional fields with order additional fields.
-			foreach ( $order_additional_fields as $key => $value ) {
-				if ( $this->is_customer_field( $key ) ) {
-					$this->persist_field_for_customer( $key, $value, $customer, $group );
+			foreach ($order_additional_fields as $key => $value) {
+				if ($this->is_customer_field($key)) {
+					$this->persist_field_for_customer($key, $value, $customer, $group);
 				}
 			}
 		}
@@ -1224,14 +1222,14 @@ class CheckoutFields {
 	 * @param WC_Order    $order The order to sync the fields for.
 	 * @param WC_Customer $customer The customer to sync the fields for.
 	 */
-	public function sync_order_additional_fields_with_customer( WC_Order $order, WC_Customer $customer ) {
-		foreach ( $this->groups as $group ) {
-			$customer_additional_fields = $this->get_all_fields_from_object( $customer, $group, true );
+	public function sync_order_additional_fields_with_customer(WC_Order $order, WC_Customer $customer) {
+		foreach ($this->groups as $group) {
+			$customer_additional_fields = $this->get_all_fields_from_object($customer, $group, true);
 
 			// Sync order additional fields with customer additional fields.
-			foreach ( $customer_additional_fields as $key => $value ) {
-				if ( $this->is_field( $key ) ) {
-					$this->persist_field_for_order( $key, $value, $order, $group, false );
+			foreach ($customer_additional_fields as $key => $value) {
+				if ($this->is_field($key)) {
+					$this->persist_field_for_order($key, $value, $order, $group, false);
 				}
 			}
 		}
@@ -1243,16 +1241,16 @@ class CheckoutFields {
 	 * @param string $location The location to validate the field for (address|contact|order).
 	 * @return array The filtered fields.
 	 */
-	public function filter_fields_for_location( array $fields, string $location ) {
-		if ( 'additional' === $location ) {
-			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
+	public function filter_fields_for_location(array $fields, string $location) {
+		if ('additional' === $location) {
+			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
 			$location = 'order';
 		}
 
 		return array_filter(
 			$fields,
-			function ( $key ) use ( $location ) {
-				return $this->is_field( $key ) && $this->get_field_location( $key ) === $location;
+			function ($key) use ($location) {
+				return $this->is_field($key) && $this->get_field_location($key) === $location;
 			},
 			ARRAY_FILTER_USE_KEY
 		);
@@ -1264,11 +1262,11 @@ class CheckoutFields {
 	 * @param array $fields The fields to filter.
 	 * @return array The filtered fields.
 	 */
-	public function filter_fields_for_order_confirmation( $fields ) {
+	public function filter_fields_for_order_confirmation($fields) {
 		return array_filter(
 			$fields,
-			function ( $field ) {
-				return ! empty( $field['show_in_order_confirmation'] );
+			function ($field) {
+				return ! empty($field['show_in_order_confirmation']);
 			}
 		);
 	}
@@ -1282,42 +1280,42 @@ class CheckoutFields {
 	 * @param string   $context The context to get the field value for (edit|view).
 	 * @return array An array of fields definitions as well as their values formatted for display.
 	 */
-	public function get_order_additional_fields_with_values( WC_Order $order, string $location, string $group = 'other', string $context = 'edit' ) {
+	public function get_order_additional_fields_with_values(WC_Order $order, string $location, string $group = 'other', string $context = 'edit') {
 
 		// Because the Additional Checkout Fields API only applies to orders created with Store API, we should not
 		// return any values unless it was created using Store API. This is mainly to prevent "empty" checkbox values
 		// from being shown on the order confirmation page for orders placed using the shortcode. It's rare that this
 		// will happen but not impossible.
-		if ( 'store-api' !== $order->get_created_via() ) {
+		if ('store-api' !== $order->get_created_via()) {
 			return [];
 		}
 
-		if ( 'additional' === $location ) {
-			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
+		if ('additional' === $location) {
+			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
 			$location = 'order';
 		}
 
-		if ( 'additional' === $group ) {
-			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
+		if ('additional' === $group) {
+			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
 			$group = 'other';
 		}
 
-		$fields             = $this->get_fields_for_location( $location );
+		$fields             = $this->get_fields_for_location($location);
 		$fields_with_values = [];
 
-		foreach ( $fields as $field_key => $field ) {
-			$value = $this->get_field_from_object( $field_key, $order, $group );
+		foreach ($fields as $field_key => $field) {
+			$value = $this->get_field_from_object($field_key, $order, $group);
 
-			if ( '' === $value || null === $value ) {
+			if ('' === $value || null === $value) {
 				continue;
 			}
 
-			if ( 'view' === $context ) {
-				$value = $this->format_additional_field_value( $value, $field );
+			if ('view' === $context) {
+				$value = $this->format_additional_field_value($value, $field);
 			}
 
 			$field['value']                   = $value;
-			$fields_with_values[ $field_key ] = $field;
+			$fields_with_values[$field_key] = $field;
 		}
 
 		return $fields_with_values;
@@ -1330,14 +1328,14 @@ class CheckoutFields {
 	 * @param array  $field Additional field definition.
 	 * @return string
 	 */
-	public function format_additional_field_value( $value, $field ) {
-		if ( 'checkbox' === $field['type'] ) {
-			$value = $value ? __( 'Yes', 'woocommerce' ) : __( 'No', 'woocommerce' );
+	public function format_additional_field_value($value, $field) {
+		if ('checkbox' === $field['type']) {
+			$value = $value ? __('Yes', 'woocommerce') : __('No', 'woocommerce');
 		}
 
-		if ( 'select' === $field['type'] ) {
-			$options = array_column( $field['options'], 'label', 'value' );
-			$value   = isset( $options[ $value ] ) ? $options[ $value ] : $value;
+		if ('select' === $field['type']) {
+			$options = array_column($field['options'], 'label', 'value');
+			$value   = isset($options[$value]) ? $options[$value] : $value;
 		}
 
 		return $value;
@@ -1349,16 +1347,16 @@ class CheckoutFields {
 	 * @param string $group_name The group name (billing|shipping|other).
 	 * @return string The group meta prefix.
 	 */
-	public static function get_group_key( $group_name ) {
-		if ( 'additional' === $group_name ) {
-			wc_deprecated_argument( 'group_name', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
+	public static function get_group_key($group_name) {
+		if ('additional' === $group_name) {
+			wc_deprecated_argument('group_name', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
 			$group_name = 'other';
 		}
 
-		if ( 'billing' === $group_name ) {
+		if ('billing' === $group_name) {
 			return self::BILLING_FIELDS_PREFIX;
 		}
-		if ( 'shipping' === $group_name ) {
+		if ('shipping' === $group_name) {
 			return self::SHIPPING_FIELDS_PREFIX;
 		}
 		return self::OTHER_FIELDS_PREFIX;
@@ -1370,16 +1368,16 @@ class CheckoutFields {
 	 * @param string $group_key The group name (_wc_billing|_wc_shipping|_wc_other).
 	 * @return string The group meta prefix.
 	 */
-	public static function get_group_name( $group_key ) {
-		if ( '_wc_additional' === $group_key ) {
-			wc_deprecated_argument( 'group_key', '8.9.0', 'The "_wc_additional" group key is deprecated. Use "_wc_other" instead.' );
+	public static function get_group_name($group_key) {
+		if ('_wc_additional' === $group_key) {
+			wc_deprecated_argument('group_key', '8.9.0', 'The "_wc_additional" group key is deprecated. Use "_wc_other" instead.');
 			$group_key = '_wc_other';
 		}
 
-		if ( 0 === \strpos( self::BILLING_FIELDS_PREFIX, $group_key ) ) {
+		if (0 === \strpos(self::BILLING_FIELDS_PREFIX, $group_key)) {
 			return 'billing';
 		}
-		if ( 0 === \strpos( self::SHIPPING_FIELDS_PREFIX, $group_key ) ) {
+		if (0 === \strpos(self::SHIPPING_FIELDS_PREFIX, $group_key)) {
 			return 'shipping';
 		}
 		return 'other';

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -32,14 +32,14 @@ class CheckoutFields {
 	 *
 	 * @var array
 	 */
-	private $supported_field_types = ['text', 'select', 'checkbox'];
+	private $supported_field_types = [ 'text', 'select', 'checkbox' ];
 
 	/**
 	 * Groups of fields to be saved.
 	 *
 	 * @var array
 	 */
-	protected $groups = ['billing', 'shipping', 'other'];
+	protected $groups = [ 'billing', 'shipping', 'other' ];
 
 	/**
 	 * Instance of the asset data registry.
@@ -82,34 +82,34 @@ class CheckoutFields {
 	 *
 	 * @param AssetDataRegistry $asset_data_registry Instance of the asset data registry.
 	 */
-	public function __construct(AssetDataRegistry $asset_data_registry) {
+	public function __construct( AssetDataRegistry $asset_data_registry ) {
 		$this->asset_data_registry = $asset_data_registry;
 
 		$this->fields_locations = [
 			// omit email from shipping and billing fields.
-			'address' => array_merge(\array_diff_key($this->get_core_fields_keys(), array('email'))),
-			'contact' => array('email'),
+			'address' => array_merge( \array_diff_key( $this->get_core_fields_keys(), array( 'email' ) ) ),
+			'contact' => array( 'email' ),
 			'order'   => [],
 		];
 
-		add_filter('woocommerce_get_country_locale_default', array($this, 'update_default_locale_with_fields'));
+		add_filter( 'woocommerce_get_country_locale_default', array( $this, 'update_default_locale_with_fields' ) );
 	}
 
 	/**
 	 * Initialize hooks.
 	 */
 	public function init() {
-		add_action('woocommerce_blocks_checkout_enqueue_data', array($this, 'add_fields_data'));
-		add_action('woocommerce_blocks_cart_enqueue_data', array($this, 'add_fields_data'));
-		add_filter('woocommerce_customer_allowed_session_meta_keys', array($this, 'add_session_meta_keys'));
+		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'add_fields_data' ) );
+		add_action( 'woocommerce_blocks_cart_enqueue_data', array( $this, 'add_fields_data' ) );
+		add_filter( 'woocommerce_customer_allowed_session_meta_keys', array( $this, 'add_session_meta_keys' ) );
 	}
 
 	/**
 	 * Add fields data to the asset data registry.
 	 */
 	public function add_fields_data() {
-		$this->asset_data_registry->add('defaultFields', array_merge($this->get_core_fields(), $this->get_additional_fields()));
-		$this->asset_data_registry->add('addressFieldsLocations', $this->fields_locations);
+		$this->asset_data_registry->add( 'defaultFields', array_merge( $this->get_core_fields(), $this->get_additional_fields() ) );
+		$this->asset_data_registry->add( 'addressFieldsLocations', $this->fields_locations );
 	}
 
 	/**
@@ -120,23 +120,23 @@ class CheckoutFields {
 	 * @param array $keys Session meta keys.
 	 * @return array
 	 */
-	public function add_session_meta_keys($keys) {
+	public function add_session_meta_keys( $keys ) {
 		$meta_keys = array();
 		try {
-			foreach ($this->get_additional_fields() as $field_key => $field) {
-				if ('address' === $field['location']) {
+			foreach ( $this->get_additional_fields() as $field_key => $field ) {
+				if ( 'address' === $field['location'] ) {
 					$meta_keys[] = self::BILLING_FIELDS_PREFIX . $field_key;
 					$meta_keys[] = self::SHIPPING_FIELDS_PREFIX . $field_key;
 				} else {
 					$meta_keys[] = self::OTHER_FIELDS_PREFIX . $field_key;
 				}
 			}
-		} catch (\Throwable $e) {
+		} catch ( \Throwable $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'Error adding session meta keys for checkout fields. %s',
-					esc_attr($e->getMessage())
+					esc_attr( $e->getMessage() )
 				),
 				E_USER_WARNING
 			);
@@ -144,7 +144,7 @@ class CheckoutFields {
 			return $keys;
 		}
 
-		return array_merge($keys, $meta_keys);
+		return array_merge( $keys, $meta_keys );
 	}
 
 	/**
@@ -154,7 +154,7 @@ class CheckoutFields {
 	 * @param array $field Field data.
 	 * @return mixed
 	 */
-	public function default_sanitize_callback($value, $field) {
+	public function default_sanitize_callback( $value, $field ) {
 		return $value;
 	}
 
@@ -165,13 +165,13 @@ class CheckoutFields {
 	 * @param array $field Field data.
 	 * @return WP_Error|void If there is a validation error, return an WP_Error object.
 	 */
-	public function default_validate_callback($value, $field) {
-		if (! empty($field['required']) && empty($value)) {
+	public function default_validate_callback( $value, $field ) {
+		if ( ! empty( $field['required'] ) && empty( $value ) ) {
 			return new WP_Error(
 				'woocommerce_required_checkout_field',
 				sprintf(
-					// translators: %s is field key.
-					__('The field %s is required.', 'woocommerce'),
+				// translators: %s is field key.
+					__( 'The field %s is required.', 'woocommerce' ),
 					$field['id']
 				)
 			);
@@ -185,9 +185,9 @@ class CheckoutFields {
 	 *
 	 * @return WP_Error|void True if the field was registered, a WP_Error otherwise.
 	 */
-	public function register_checkout_field($options) {
+	public function register_checkout_field( $options ) {
 		// Check the options and show warnings if they're not supplied. Return early if an error that would prevent registration is encountered.
-		if (false === $this->validate_options($options)) {
+		if ( false === $this->validate_options( $options ) ) {
 			return;
 		}
 
@@ -199,7 +199,7 @@ class CheckoutFields {
 				'label'                      => '',
 				'optionalLabel'              => sprintf(
 					/* translators: %s Field label. */
-					__('%s (optional)', 'woocommerce'),
+					__( '%s (optional)', 'woocommerce' ),
 					$options['label']
 				),
 				'location'                   => '',
@@ -208,27 +208,27 @@ class CheckoutFields {
 				'required'                   => false,
 				'attributes'                 => [],
 				'show_in_order_confirmation' => true,
-				'sanitize_callback'          => array($this, 'default_sanitize_callback'),
-				'validate_callback'          => array($this, 'default_validate_callback'),
+				'sanitize_callback'          => array( $this, 'default_sanitize_callback' ),
+				'validate_callback'          => array( $this, 'default_validate_callback' ),
 			]
 		);
 
-		$field_data['attributes'] = $this->register_field_attributes($field_data['id'], $field_data['attributes']);
+		$field_data['attributes'] = $this->register_field_attributes( $field_data['id'], $field_data['attributes'] );
 
-		if ('checkbox' === $field_data['type']) {
-			$field_data = $this->process_checkbox_field($field_data, $options);
-		} elseif ('select' === $field_data['type']) {
-			$field_data = $this->process_select_field($field_data, $options);
+		if ( 'checkbox' === $field_data['type'] ) {
+			$field_data = $this->process_checkbox_field( $field_data, $options );
+		} elseif ( 'select' === $field_data['type'] ) {
+			$field_data = $this->process_select_field( $field_data, $options );
 		}
 
 		// $field_data will be false if an error that will prevent the field being registered is encountered.
-		if (false === $field_data) {
+		if ( false === $field_data ) {
 			return;
 		}
 
 		// Insert new field into the correct location array.
-		$this->additional_fields[$field_data['id']]        = $field_data;
-		$this->fields_locations[$field_data['location']][] = $field_data['id'];
+		$this->additional_fields[ $field_data['id'] ]        = $field_data;
+		$this->fields_locations[ $field_data['location'] ][] = $field_data['id'];
 	}
 
 	/**
@@ -238,18 +238,18 @@ class CheckoutFields {
 	 *
 	 * @internal
 	 */
-	public function deregister_checkout_field($field_id) {
-		if (empty($this->additional_fields[$field_id])) {
+	public function deregister_checkout_field( $field_id ) {
+		if ( empty( $this->additional_fields[ $field_id ] ) ) {
 			return;
 		}
 
-		$location = $this->get_field_location($field_id);
+		$location = $this->get_field_location( $field_id );
 
 		// Remove the field from the fields_locations array.
-		$this->fields_locations[$location] = array_diff($this->fields_locations[$location], array($field_id));
+		$this->fields_locations[ $location ] = array_diff( $this->fields_locations[ $location ], array( $field_id ) );
 
 		// Remove the field from the additional_fields array.
-		unset($this->additional_fields[$field_id]);
+		unset( $this->additional_fields[ $field_id ] );
 	}
 
 	/**
@@ -258,39 +258,39 @@ class CheckoutFields {
 	 * @param array $options The options supplied during field registration.
 	 * @return bool false if an error was encountered, true otherwise.
 	 */
-	private function validate_options(&$options) {
-		if (empty($options['id'])) {
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0');
+	private function validate_options( &$options ) {
+		if ( empty( $options['id'] ) ) {
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', 'A checkout field cannot be registered without an id.', '8.6.0' );
 			return false;
 		}
 
 		// Having fewer than 2 after exploding around a / means there is no namespace.
-		if (count(explode('/', $options['id'])) < 2) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'A checkout field id must consist of namespace/name.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( count( explode( '/', $options['id'] ) ) < 2 ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'A checkout field id must consist of namespace/name.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
-		if (empty($options['label'])) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'The field label is required.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( empty( $options['label'] ) ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field label is required.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
-		if (empty($options['location'])) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'The field location is required.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( empty( $options['location'] ) ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is required.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
-		if ('additional' === $options['location']) {
-			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
+		if ( 'additional' === $options['location'] ) {
+			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
 			$options['location'] = 'order';
 		}
 
-		if (! in_array($options['location'], array_keys($this->fields_locations), true)) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $options['id'], 'The field location is invalid.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( ! in_array( $options['location'], array_keys( $this->fields_locations ), true ) ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The field location is invalid.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
@@ -299,41 +299,41 @@ class CheckoutFields {
 		$id       = $options['id'];
 
 		// Check to see if field is already in the array.
-		if (! empty($this->additional_fields[$id]) || in_array($id, $this->fields_locations[$location], true)) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'The field is already registered.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( ! empty( $this->additional_fields[ $id ] ) || in_array( $id, $this->fields_locations[ $location ], true ) ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The field is already registered.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
-		if (! empty($options['type'])) {
-			if (! in_array($options['type'], $this->supported_field_types, true)) {
+		if ( ! empty( $options['type'] ) ) {
+			if ( ! in_array( $options['type'], $this->supported_field_types, true ) ) {
 				$message = sprintf(
 					'Unable to register field with id: "%s". Registering a field with type "%s" is not supported. The supported types are: %s.',
 					$id,
 					$options['type'],
-					implode(', ', $this->supported_field_types)
+					implode( ', ', $this->supported_field_types )
 				);
-				_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 				return false;
 			}
 		}
 
-		if (! empty($options['sanitize_callback']) && ! is_callable($options['sanitize_callback'])) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'The sanitize_callback must be a valid callback.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( ! empty( $options['sanitize_callback'] ) && ! is_callable( $options['sanitize_callback'] ) ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The sanitize_callback must be a valid callback.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
-		if (! empty($options['validate_callback']) && ! is_callable($options['validate_callback'])) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( ! empty( $options['validate_callback'] ) && ! is_callable( $options['validate_callback'] ) ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 
 		// Hidden fields are not supported right now. They will be registered with hidden => false.
-		if (! empty($options['hidden']) && true === $options['hidden']) {
-			$message = sprintf('Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id);
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( ! empty( $options['hidden'] ) && true === $options['hidden'] ) {
+			$message = sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			// Don't return here unlike the other fields because this is not an issue that will prevent registration.
 		}
 
@@ -348,31 +348,31 @@ class CheckoutFields {
 	 *
 	 * @return array|false The updated $field_data array or false if an error was encountered.
 	 */
-	private function process_select_field($field_data, $options) {
+	private function process_select_field( $field_data, $options ) {
 		$id = $options['id'];
 
-		if (empty($options['options']) || ! is_array($options['options'])) {
-			$message = sprintf('Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options".');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( empty( $options['options'] ) || ! is_array( $options['options'] ) ) {
+			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options".' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
 		}
 		$cleaned_options = [];
 		$added_values    = [];
 
 		// Check all entries in $options['options'] has a key and value member.
-		foreach ($options['options'] as $option) {
-			if (! isset($option['value']) || ! isset($option['label'])) {
-				$message = sprintf('Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.');
-				_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		foreach ( $options['options'] as $option ) {
+			if ( ! isset( $option['value'] ) || ! isset( $option['label'] ) ) {
+				$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'Fields of type "select" must have an array of "options" and each option must contain a "value" and "label" member.' );
+				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 				return false;
 			}
 
-			$sanitized_value = sanitize_text_field($option['value']);
-			$sanitized_label = sanitize_text_field($option['label']);
+			$sanitized_value = sanitize_text_field( $option['value'] );
+			$sanitized_label = sanitize_text_field( $option['label'] );
 
-			if (in_array($sanitized_value, $added_values, true)) {
-				$message = sprintf('Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', $id, $sanitized_value);
-				_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+			if ( in_array( $sanitized_value, $added_values, true ) ) {
+				$message = sprintf( 'Duplicate key found when registering field with id: "%s". The value in each option of "select" fields must be unique. Duplicate value "%s" found. The duplicate key will be removed.', $id, $sanitized_value );
+				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 				continue;
 			}
 
@@ -386,8 +386,8 @@ class CheckoutFields {
 
 		$field_data['options'] = $cleaned_options;
 
-		if (isset($field_data['placeholder'])) {
-			$field_data['placeholder'] = sanitize_text_field($field_data['placeholder']);
+		if ( isset( $field_data['placeholder'] ) ) {
+			$field_data['placeholder'] = sanitize_text_field( $field_data['placeholder'] );
 		}
 
 		return $field_data;
@@ -401,15 +401,15 @@ class CheckoutFields {
 	 *
 	 * @return array|false The updated $field_data array or false if an error was encountered.
 	 */
-	private function process_checkbox_field($field_data, $options) {
+	private function process_checkbox_field( $field_data, $options ) {
 		$id = $options['id'];
 
 		// Checkbox fields are always optional. Log a warning if it's set explicitly as true.
 		$field_data['required'] = false;
 
-		if (isset($options['required']) && true === $options['required']) {
-			$message = sprintf('Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id);
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( isset( $options['required'] ) && true === $options['required'] ) {
+			$message = sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 		}
 
 		return $field_data;
@@ -423,16 +423,16 @@ class CheckoutFields {
 	 *
 	 * @return array The processed attributes.
 	 */
-	private function register_field_attributes($id, $attributes) {
+	private function register_field_attributes( $id, $attributes ) {
 		// We check if attributes are valid. This is done to prevent too much nesting and also to allow field registration
 		// even if the attributes property is invalid. We can just skip it and register the field without attributes.
-		if (empty($attributes)) {
+		if ( empty( $attributes ) ) {
 			return [];
 		}
 
-		if (! is_array($attributes) || 0 === count($attributes)) {
-			$message = sprintf('An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.');
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( ! is_array( $attributes ) || 0 === count( $attributes ) ) {
+			$message = sprintf( 'An invalid attributes value was supplied when registering field with id: "%s". %s', $id, 'Attributes must be a non-empty array.' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return [];
 		}
 
@@ -448,23 +448,23 @@ class CheckoutFields {
 
 		$valid_attributes = array_filter(
 			$attributes,
-			function ($_, $key) use ($allowed_attributes) {
-				return in_array($key, $allowed_attributes, true) || strpos($key, 'aria-') === 0 || strpos($key, 'data-') === 0;
+			function ( $_, $key ) use ( $allowed_attributes ) {
+				return in_array( $key, $allowed_attributes, true ) || strpos( $key, 'aria-' ) === 0 || strpos( $key, 'data-' ) === 0;
 			},
 			ARRAY_FILTER_USE_BOTH
 		);
 
 		// Any invalid attributes should show a doing_it_wrong warning. It shouldn't stop field registration, though.
-		if (count($attributes) !== count($valid_attributes)) {
-			$invalid_attributes = array_keys(array_diff_key($attributes, $valid_attributes));
-			$message            = sprintf('Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode(', ', $invalid_attributes));
-			_doing_it_wrong('woocommerce_register_additional_checkout_field', esc_html($message), '8.6.0');
+		if ( count( $attributes ) !== count( $valid_attributes ) ) {
+			$invalid_attributes = array_keys( array_diff_key( $attributes, $valid_attributes ) );
+			$message            = sprintf( 'Invalid attribute found when registering field with id: "%s". Attributes: %s are not allowed.', $id, implode( ', ', $invalid_attributes ) );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 		}
 
 		// Escape attributes to remove any malicious code and return them.
 		return array_map(
-			function ($value) {
-				return esc_attr($value);
+			function ( $value ) {
+				return esc_attr( $value );
 			},
 			$valid_attributes
 		);
@@ -499,7 +499,7 @@ class CheckoutFields {
 	public function get_core_fields() {
 		return [
 			'email'      => [
-				'label'          => __('Email address', 'woocommerce'),
+				'label'          => __( 'Email address', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Email address (optional)',
 					'woocommerce'
@@ -512,7 +512,7 @@ class CheckoutFields {
 				'index'          => 0,
 			],
 			'country'    => [
-				'label'         => __('Country/Region', 'woocommerce'),
+				'label'         => __( 'Country/Region', 'woocommerce' ),
 				'optionalLabel' => __(
 					'Country/Region (optional)',
 					'woocommerce'
@@ -523,7 +523,7 @@ class CheckoutFields {
 				'index'         => 1,
 			],
 			'first_name' => [
-				'label'          => __('First name', 'woocommerce'),
+				'label'          => __( 'First name', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'First name (optional)',
 					'woocommerce'
@@ -535,7 +535,7 @@ class CheckoutFields {
 				'index'          => 10,
 			],
 			'last_name'  => [
-				'label'          => __('Last name', 'woocommerce'),
+				'label'          => __( 'Last name', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Last name (optional)',
 					'woocommerce'
@@ -547,7 +547,7 @@ class CheckoutFields {
 				'index'          => 20,
 			],
 			'company'    => [
-				'label'          => __('Company', 'woocommerce'),
+				'label'          => __( 'Company', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Company (optional)',
 					'woocommerce'
@@ -559,7 +559,7 @@ class CheckoutFields {
 				'index'          => 30,
 			],
 			'address_1'  => [
-				'label'          => __('Address', 'woocommerce'),
+				'label'          => __( 'Address', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Address (optional)',
 					'woocommerce'
@@ -571,7 +571,7 @@ class CheckoutFields {
 				'index'          => 40,
 			],
 			'address_2'  => [
-				'label'          => __('Apartment, suite, etc.', 'woocommerce'),
+				'label'          => __( 'Apartment, suite, etc.', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Apartment, suite, etc. (optional)',
 					'woocommerce'
@@ -583,7 +583,7 @@ class CheckoutFields {
 				'index'          => 50,
 			],
 			'city'       => [
-				'label'          => __('City', 'woocommerce'),
+				'label'          => __( 'City', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'City (optional)',
 					'woocommerce'
@@ -595,7 +595,7 @@ class CheckoutFields {
 				'index'          => 70,
 			],
 			'state'      => [
-				'label'          => __('State/County', 'woocommerce'),
+				'label'          => __( 'State/County', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'State/County (optional)',
 					'woocommerce'
@@ -607,7 +607,7 @@ class CheckoutFields {
 				'index'          => 80,
 			],
 			'postcode'   => [
-				'label'          => __('Postal code', 'woocommerce'),
+				'label'          => __( 'Postal code', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Postal code (optional)',
 					'woocommerce'
@@ -619,7 +619,7 @@ class CheckoutFields {
 				'index'          => 90,
 			],
 			'phone'      => [
-				'label'          => __('Phone', 'woocommerce'),
+				'label'          => __( 'Phone', 'woocommerce' ),
 				'optionalLabel'  => __(
 					'Phone (optional)',
 					'woocommerce'
@@ -649,9 +649,9 @@ class CheckoutFields {
 	 * @param string $field_key The key of the field to get the location for.
 	 * @return string The location of the field.
 	 */
-	public function get_field_location($field_key) {
-		foreach ($this->fields_locations as $location => $fields) {
-			if (in_array($field_key, $fields, true)) {
+	public function get_field_location( $field_key ) {
+		foreach ( $this->fields_locations as $location => $fields ) {
+			if ( in_array( $field_key, $fields, true ) ) {
 				return $location;
 			}
 		}
@@ -667,12 +667,12 @@ class CheckoutFields {
 	 * @param mixed  $field_value The value of the field.
 	 * @return mixed
 	 */
-	public function sanitize_field($field_key, $field_value) {
+	public function sanitize_field( $field_key, $field_value ) {
 		try {
-			$field = $this->additional_fields[$field_key] ?? null;
+			$field = $this->additional_fields[ $field_key ] ?? null;
 
-			if ($field) {
-				$field_value = call_user_func($field['sanitize_callback'], $field_value, $field);
+			if ( $field ) {
+				$field_value = call_user_func( $field['sanitize_callback'], $field_value, $field );
 			}
 
 			/**
@@ -684,7 +684,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.7.0 Use woocommerce_sanitize_additional_field instead.
 			 */
-			$field_value = apply_filters_deprecated('__experimental_woocommerce_blocks_sanitize_additional_field', array($field_value, $field_key), '8.7.0', 'woocommerce_sanitize_additional_field', 'This action has been graduated, use woocommerce_sanitize_additional_field instead.');
+			$field_value = apply_filters_deprecated( '__experimental_woocommerce_blocks_sanitize_additional_field', array( $field_value, $field_key ), '8.7.0', 'woocommerce_sanitize_additional_field', 'This action has been graduated, use woocommerce_sanitize_additional_field instead.' );
 
 			/**
 			 * Allow custom sanitization of an additional field.
@@ -694,15 +694,16 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			return apply_filters('woocommerce_sanitize_additional_field', $field_value, $field_key);
-		} catch (\Throwable $e) {
+			return apply_filters( 'woocommerce_sanitize_additional_field', $field_value, $field_key );
+
+		} catch ( \Throwable $e ) {
 			// One of the filters errored so skip it. This allows the checkout process to continue.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'Field sanitization for %s encountered an error. %s',
-					esc_html($field_key),
-					esc_html($e->getMessage())
+					esc_html( $field_key ),
+					esc_html( $e->getMessage() )
 				),
 				E_USER_WARNING
 			);
@@ -720,17 +721,17 @@ class CheckoutFields {
 	 * @param mixed  $field_value  The value of the field.
 	 * @return WP_Error
 	 */
-	public function validate_field($field_key, $field_value) {
+	public function validate_field( $field_key, $field_value ) {
 		$errors = new WP_Error();
 
 		try {
-			$field = $this->additional_fields[$field_key] ?? null;
+			$field = $this->additional_fields[ $field_key ] ?? null;
 
-			if ($field) {
-				$validation = call_user_func($field['validate_callback'], $field_value, $field);
+			if ( $field ) {
+				$validation = call_user_func( $field['validate_callback'], $field_value, $field );
 
-				if (is_wp_error($validation)) {
-					$errors->merge_from($validation);
+				if ( is_wp_error( $validation ) ) {
+					$errors->merge_from( $validation );
 				}
 			}
 
@@ -744,7 +745,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.7.0 Use woocommerce_validate_additional_field instead.
 			 */
-			wc_do_deprecated_action('__experimental_woocommerce_blocks_validate_additional_field', array($errors, $field_key, $field_value), '8.7.0', 'woocommerce_validate_additional_field', 'This action has been graduated, use woocommerce_validate_additional_field instead.');
+			wc_do_deprecated_action( '__experimental_woocommerce_blocks_validate_additional_field', array( $errors, $field_key, $field_value ), '8.7.0', 'woocommerce_validate_additional_field', 'This action has been graduated, use woocommerce_validate_additional_field instead.' );
 			/**
 			 * Pass an error object to allow validation of an additional field.
 			 *
@@ -754,16 +755,17 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			do_action('woocommerce_validate_additional_field', $errors, $field_key, $field_value);
-		} catch (\Throwable $e) {
+			do_action( 'woocommerce_validate_additional_field', $errors, $field_key, $field_value );
+
+		} catch ( \Throwable $e ) {
 
 			// One of the filters errored so skip them and validate the field. This allows the checkout process to continue.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'Field validation for %s encountered an error. %s',
-					esc_html($field_key),
-					esc_html($e->getMessage())
+					esc_html( $field_key ),
+					esc_html( $e->getMessage() )
 				),
 				E_USER_WARNING
 			);
@@ -778,10 +780,10 @@ class CheckoutFields {
 	 * @param array $locale The locale to update.
 	 * @return mixed
 	 */
-	public function update_default_locale_with_fields($locale) {
-		foreach ($this->get_fields_for_location('address') as $field_id => $additional_field) {
-			if (empty($locale[$field_id])) {
-				$locale[$field_id] = $additional_field;
+	public function update_default_locale_with_fields( $locale ) {
+		foreach ( $this->get_fields_for_location( 'address' ) as $field_id => $additional_field ) {
+			if ( empty( $locale[ $field_id ] ) ) {
+				$locale[ $field_id ] = $additional_field;
 			}
 		}
 		return $locale;
@@ -812,7 +814,7 @@ class CheckoutFields {
 	 * @deprecated 8.9.0 Use get_order_fields_keys instead.
 	 */
 	public function get_additional_fields_keys() {
-		wc_deprecated_function(__METHOD__, '8.9.0', 'get_order_fields_keys');
+		wc_deprecated_function( __METHOD__, '8.9.0', 'get_order_fields_keys' );
 		return $this->get_order_fields_keys();
 	}
 
@@ -831,19 +833,19 @@ class CheckoutFields {
 	 * @param string $location The location to get fields for (address|contact|order).
 	 * @return array An array of fields definitions.
 	 */
-	public function get_fields_for_location($location) {
-		if ('additional' === $location) {
-			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
+	public function get_fields_for_location( $location ) {
+		if ( 'additional' === $location ) {
+			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
 			$location = 'order';
 		}
 
-		if (in_array($location, array_keys($this->fields_locations), true)) {
-			$order_fields_keys = $this->fields_locations[$location];
+		if ( in_array( $location, array_keys( $this->fields_locations ), true ) ) {
+			$order_fields_keys = $this->fields_locations[ $location ];
 
 			return array_filter(
 				$this->get_additional_fields(),
-				function ($key) use ($order_fields_keys) {
-					return in_array($key, $order_fields_keys, true);
+				function ( $key ) use ( $order_fields_keys ) {
+					return in_array( $key, $order_fields_keys, true );
 				},
 				ARRAY_FILTER_USE_KEY
 			);
@@ -859,16 +861,16 @@ class CheckoutFields {
 	 * @param string $group The group to get the field value for (shipping|billing|other).
 	 * @return WP_Error
 	 */
-	public function validate_fields_for_location($fields, $location, $group = 'other') {
+	public function validate_fields_for_location( $fields, $location, $group = 'other' ) {
 		$errors = new WP_Error();
 
-		if ('additional' === $location) {
-			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
+		if ( 'additional' === $location ) {
+			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
 			$location = 'order';
 		}
 
-		if ('additional' === $group) {
-			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
+		if ( 'additional' === $group ) {
+			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
 			$group = 'other';
 		}
 
@@ -883,7 +885,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.9.0 Use woocommerce_blocks_validate_location_order_fields instead.
 			 */
-			wc_do_deprecated_action('woocommerce_blocks_validate_location_additional_fields', array($errors, $fields, $group), '8.9.0', 'woocommerce_blocks_validate_location_additional_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_additional_fields instead.');
+			wc_do_deprecated_action( 'woocommerce_blocks_validate_location_additional_fields', array( $errors, $fields, $group ), '8.9.0', 'woocommerce_blocks_validate_location_additional_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_additional_fields instead.' );
 			/**
 			 * Pass an error object to allow validation of an additional field.
 			 *
@@ -894,7 +896,7 @@ class CheckoutFields {
 			 * @since 8.6.0
 			 * @deprecated 8.9.0 Use woocommerce_blocks_validate_location_{location}_fields instead.
 			 */
-			wc_do_deprecated_action('__experimental_woocommerce_blocks_validate_location_' . $location . '_fields', array($errors, $fields, $group), '8.9.0', 'woocommerce_blocks_validate_location_' . $location . '_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_' . $location . '_fields instead.');
+			wc_do_deprecated_action( '__experimental_woocommerce_blocks_validate_location_' . $location . '_fields', array( $errors, $fields, $group ), '8.9.0', 'woocommerce_blocks_validate_location_' . $location . '_fields', 'This action has been graduated, use woocommerce_blocks_validate_location_' . $location . '_fields instead.' );
 
 			/**
 			 * Pass an error object to allow validation of an additional field.
@@ -905,17 +907,18 @@ class CheckoutFields {
 			 *
 			 * @since 8.7.0
 			 */
-			do_action('woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group);
-		} catch (\Throwable $e) {
+			do_action( 'woocommerce_blocks_validate_location_' . $location . '_fields', $errors, $fields, $group );
+
+		} catch ( \Throwable $e ) {
 
 			// One of the filters errored so skip them. This allows the checkout process to continue.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error(
 				sprintf(
 					'The action %s encountered an error. The field location %s may not have any custom validation applied to it. %s',
-					esc_html('woocommerce_blocks_validate_' . $location . '_fields'),
-					esc_html($location),
-					esc_html($e->getMessage())
+					esc_html( 'woocommerce_blocks_validate_' . $location . '_fields' ),
+					esc_html( $location ),
+					esc_html( $e->getMessage() )
 				),
 				E_USER_WARNING
 			);
@@ -935,42 +938,42 @@ class CheckoutFields {
 	 *
 	 * @return true|WP_Error True if the field is valid, a WP_Error otherwise.
 	 */
-	public function validate_field_for_location($key, $value, $location) {
-		if ('additional' === $location) {
-			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
+	public function validate_field_for_location( $key, $value, $location ) {
+		if ( 'additional' === $location ) {
+			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
 			$location = 'order';
 		}
 
-		if (! $this->is_field($key)) {
+		if ( ! $this->is_field( $key ) ) {
 			return new WP_Error(
 				'woocommerce_invalid_checkout_field',
 				\sprintf(
-					// translators: % is field key.
-					__('The field %s is invalid.', 'woocommerce'),
+				// translators: % is field key.
+					__( 'The field %s is invalid.', 'woocommerce' ),
 					$key
 				)
 			);
 		}
 
-		if (! in_array($key, $this->fields_locations[$location], true)) {
+		if ( ! in_array( $key, $this->fields_locations[ $location ], true ) ) {
 			return new WP_Error(
 				'woocommerce_invalid_checkout_field_location',
 				\sprintf(
-					// translators: %1$s is field key, %2$s location.
-					__('The field %1$s is invalid for the location %2$s.', 'woocommerce'),
+				// translators: %1$s is field key, %2$s location.
+					__( 'The field %1$s is invalid for the location %2$s.', 'woocommerce' ),
 					$key,
 					$location
 				)
 			);
 		}
 
-		$field = $this->additional_fields[$key];
-		if (! empty($field['required']) && empty($value)) {
+		$field = $this->additional_fields[ $key ];
+		if ( ! empty( $field['required'] ) && empty( $value ) ) {
 			return new WP_Error(
 				'woocommerce_required_checkout_field',
 				\sprintf(
-					// translators: %s is field key.
-					__('The field %s is required.', 'woocommerce'),
+				// translators: %s is field key.
+					__( 'The field %s is required.', 'woocommerce' ),
 					$key
 				)
 			);
@@ -986,18 +989,18 @@ class CheckoutFields {
 	 *
 	 * @return string[] Field keys.
 	 */
-	public function get_fields_for_group($group = 'other') {
-		if ('shipping' === $group) {
-			return $this->get_fields_for_location('address');
+	public function get_fields_for_group( $group = 'other' ) {
+		if ( 'shipping' === $group ) {
+			return $this->get_fields_for_location( 'address' );
 		}
 
-		if ('billing' === $group) {
-			return $this->get_fields_for_location('address');
+		if ( 'billing' === $group ) {
+			return $this->get_fields_for_location( 'address' );
 		}
 
 		return \array_merge(
-			$this->get_fields_for_location('contact'),
-			$this->get_fields_for_location('order')
+			$this->get_fields_for_location( 'contact' ),
+			$this->get_fields_for_location( 'order' )
 		);
 	}
 
@@ -1008,8 +1011,8 @@ class CheckoutFields {
 	 *
 	 * @return bool True if the field is valid, false otherwise.
 	 */
-	public function is_field($key) {
-		return array_key_exists($key, $this->additional_fields);
+	public function is_field( $key ) {
+		return array_key_exists( $key, $this->additional_fields );
 	}
 
 	/**
@@ -1021,8 +1024,8 @@ class CheckoutFields {
 	 *
 	 * @return bool True if the field is valid, false otherwise.
 	 */
-	public function is_customer_field($key) {
-		return in_array($key, array_intersect(array_merge($this->get_address_fields_keys(), $this->get_contact_fields_keys()), array_keys($this->additional_fields)), true);
+	public function is_customer_field( $key ) {
+		return in_array( $key, array_intersect( array_merge( $this->get_address_fields_keys(), $this->get_contact_fields_keys() ), array_keys( $this->additional_fields ) ), true );
 	}
 
 	/**
@@ -1036,16 +1039,16 @@ class CheckoutFields {
 	 *
 	 * @return void
 	 */
-	public function persist_field_for_order(string $key, $value, WC_Order $order, string $group = 'other', bool $set_customer = true) {
-		if ('additional' === $group) {
-			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
+	public function persist_field_for_order( string $key, $value, WC_Order $order, string $group = 'other', bool $set_customer = true ) {
+		if ( 'additional' === $group ) {
+			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
 			$group = 'other';
 		}
 
-		$this->set_array_meta($key, $value, $order, $group);
-		if ($set_customer && $order->get_customer_id()) {
-			$customer = new WC_Customer($order->get_customer_id());
-			$this->persist_field_for_customer($key, $value, $customer, $group);
+		$this->set_array_meta( $key, $value, $order, $group );
+		if ( $set_customer && $order->get_customer_id() ) {
+			$customer = new WC_Customer( $order->get_customer_id() );
+			$this->persist_field_for_customer( $key, $value, $customer, $group );
 		}
 	}
 
@@ -1059,13 +1062,13 @@ class CheckoutFields {
 	 *
 	 * @return void
 	 */
-	public function persist_field_for_customer(string $key, $value, WC_Customer $customer, string $group = 'other') {
-		if ('additional' === $group) {
-			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
+	public function persist_field_for_customer( string $key, $value, WC_Customer $customer, string $group = 'other' ) {
+		if ( 'additional' === $group ) {
+			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
 			$group = 'other';
 		}
 
-		$this->set_array_meta($key, $value, $customer, $group);
+		$this->set_array_meta( $key, $value, $customer, $group );
 	}
 
 	/**
@@ -1078,8 +1081,8 @@ class CheckoutFields {
 	 *
 	 * @return void
 	 */
-	private function set_array_meta(string $key, $value, WC_Data $wc_object, string $group) {
-		$meta_key = self::get_group_key($group) . $key;
+	private function set_array_meta( string $key, $value, WC_Data $wc_object, string $group ) {
+		$meta_key = self::get_group_key( $group ) . $key;
 
 		/**
 		 * Allow reacting for saving an additional field value.
@@ -1091,13 +1094,13 @@ class CheckoutFields {
 		 *
 		 * @since 8.9.0
 		 */
-		do_action('woocommerce_set_additional_field_value', $key, $value, $group, $wc_object);
+		do_action( 'woocommerce_set_additional_field_value', $key, $value, $group, $wc_object );
 		// Convert boolean values to strings because Data Stores will skip false values.
-		if (is_bool($value)) {
+		if ( is_bool( $value ) ) {
 			$value = $value ? '1' : '0';
 		}
 		// Replacing all meta using `add_meta_data`. For some reason `update_meta_data` causes duplicate keys.
-		$wc_object->add_meta_data($meta_key, $value, true);
+		$wc_object->add_meta_data( $meta_key, $value, true );
 	}
 
 	/**
@@ -1109,17 +1112,17 @@ class CheckoutFields {
 	 *
 	 * @return mixed The field value.
 	 */
-	public function get_field_from_object(string $key, WC_Data $wc_object, string $group = 'other') {
-		if ('additional' === $group) {
-			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
+	public function get_field_from_object( string $key, WC_Data $wc_object, string $group = 'other' ) {
+		if ( 'additional' === $group ) {
+			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
 			$group = 'other';
 		}
 
-		$meta_key = self::get_group_key($group) . $key;
+		$meta_key = self::get_group_key( $group ) . $key;
 
-		$value = $wc_object->get_meta($meta_key, true);
+		$value = $wc_object->get_meta( $meta_key, true );
 
-		if (! $value) {
+		if ( ! $value ) {
 			/**
 			 * Allow providing a default value for additional fields if no value is already set.
 			 *
@@ -1129,15 +1132,15 @@ class CheckoutFields {
 			 *
 			 * @since 8.9.0
 			 */
-			$value = apply_filters("woocommerce_get_default_value_for_{$key}", null, $group, $wc_object);
+			$value = apply_filters( "woocommerce_get_default_value_for_{$key}", null, $group, $wc_object );
 		}
 
 		// We cast the value to a boolean if the field is a checkbox.
-		if ($this->is_field($key) && 'checkbox' === $this->additional_fields[$key]['type']) {
+		if ( $this->is_field( $key ) && 'checkbox' === $this->additional_fields[ $key ]['type'] ) {
 			return '1' === $value;
 		}
 
-		if (null === $value) {
+		if ( null === $value ) {
 			return '';
 		}
 
@@ -1153,44 +1156,44 @@ class CheckoutFields {
 	 *
 	 * @return array An array of fields.
 	 */
-	public function get_all_fields_from_object(WC_Data $wc_object, string $group = 'other', bool $all = false) {
-		if ('additional' === $group) {
-			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
+	public function get_all_fields_from_object( WC_Data $wc_object, string $group = 'other', bool $all = false ) {
+		if ( 'additional' === $group ) {
+			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
 			$group = 'other';
 		}
 
 		$meta_data = [];
 
-		$prefix = self::get_group_key($group);
+		$prefix = self::get_group_key( $group );
 
-		if ($wc_object instanceof WC_Data) {
+		if ( $wc_object instanceof WC_Data ) {
 			$meta = $wc_object->get_meta_data();
-			foreach ($meta as $meta_data_object) {
-				if (0 === \strpos($meta_data_object->key, $prefix)) {
-					$key = \str_replace($prefix, '', $meta_data_object->key);
-					if ($all || $this->is_field($key)) {
-						$meta_data[$key] = $meta_data_object->value;
+			foreach ( $meta as $meta_data_object ) {
+				if ( 0 === \strpos( $meta_data_object->key, $prefix ) ) {
+					$key = \str_replace( $prefix, '', $meta_data_object->key );
+					if ( $all || $this->is_field( $key ) ) {
+						$meta_data[ $key ] = $meta_data_object->value;
 					}
 				}
 			}
 		}
 
-		$missing_fields = array_diff(array_keys($this->get_fields_for_group($group)), array_keys($meta_data));
+		$missing_fields = array_diff( array_keys( $this->get_fields_for_group( $group ) ), array_keys( $meta_data ) );
 
-		foreach ($missing_fields as $missing_field) {
-			/**
-			 * Allow providing a default value for additional fields if no value is already set.
-			 *
-			 * @param null $value The default value for the filter, always null.
-			 * @param string $group The group of this key (shipping|billing|other).
-			 * @param WC_Data $wc_object The object to get the field value for.
-			 *
-			 * @since 8.9.0
-			 */
-			$value = apply_filters("woocommerce_get_default_value_for_{$missing_field}", null, $group, $wc_object);
+		foreach ( $missing_fields as $missing_field ) {
+				/**
+				 * Allow providing a default value for additional fields if no value is already set.
+				 *
+				 * @param null $value The default value for the filter, always null.
+				 * @param string $group The group of this key (shipping|billing|other).
+				 * @param WC_Data $wc_object The object to get the field value for.
+				 *
+				 * @since 8.9.0
+				 */
+				$value = apply_filters( "woocommerce_get_default_value_for_{$missing_field}", null, $group, $wc_object );
 
-			if (isset($value)) {
-				$meta_data[$missing_field] = $value;
+			if ( isset( $value ) ) {
+				$meta_data[ $missing_field ] = $value;
 			}
 		}
 
@@ -1203,14 +1206,14 @@ class CheckoutFields {
 	 * @param WC_Order    $order The order to sync the fields for.
 	 * @param WC_Customer $customer The customer to sync the fields for.
 	 */
-	public function sync_customer_additional_fields_with_order(WC_Order $order, WC_Customer $customer) {
-		foreach ($this->groups as $group) {
-			$order_additional_fields = $this->get_all_fields_from_object($order, $group, true);
+	public function sync_customer_additional_fields_with_order( WC_Order $order, WC_Customer $customer ) {
+		foreach ( $this->groups as $group ) {
+			$order_additional_fields = $this->get_all_fields_from_object( $order, $group, true );
 
 			// Sync customer additional fields with order additional fields.
-			foreach ($order_additional_fields as $key => $value) {
-				if ($this->is_customer_field($key)) {
-					$this->persist_field_for_customer($key, $value, $customer, $group);
+			foreach ( $order_additional_fields as $key => $value ) {
+				if ( $this->is_customer_field( $key ) ) {
+					$this->persist_field_for_customer( $key, $value, $customer, $group );
 				}
 			}
 		}
@@ -1222,14 +1225,14 @@ class CheckoutFields {
 	 * @param WC_Order    $order The order to sync the fields for.
 	 * @param WC_Customer $customer The customer to sync the fields for.
 	 */
-	public function sync_order_additional_fields_with_customer(WC_Order $order, WC_Customer $customer) {
-		foreach ($this->groups as $group) {
-			$customer_additional_fields = $this->get_all_fields_from_object($customer, $group, true);
+	public function sync_order_additional_fields_with_customer( WC_Order $order, WC_Customer $customer ) {
+		foreach ( $this->groups as $group ) {
+			$customer_additional_fields = $this->get_all_fields_from_object( $customer, $group, true );
 
 			// Sync order additional fields with customer additional fields.
-			foreach ($customer_additional_fields as $key => $value) {
-				if ($this->is_field($key)) {
-					$this->persist_field_for_order($key, $value, $order, $group, false);
+			foreach ( $customer_additional_fields as $key => $value ) {
+				if ( $this->is_field( $key ) ) {
+					$this->persist_field_for_order( $key, $value, $order, $group, false );
 				}
 			}
 		}
@@ -1241,16 +1244,16 @@ class CheckoutFields {
 	 * @param string $location The location to validate the field for (address|contact|order).
 	 * @return array The filtered fields.
 	 */
-	public function filter_fields_for_location(array $fields, string $location) {
-		if ('additional' === $location) {
-			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
+	public function filter_fields_for_location( array $fields, string $location ) {
+		if ( 'additional' === $location ) {
+			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
 			$location = 'order';
 		}
 
 		return array_filter(
 			$fields,
-			function ($key) use ($location) {
-				return $this->is_field($key) && $this->get_field_location($key) === $location;
+			function ( $key ) use ( $location ) {
+				return $this->is_field( $key ) && $this->get_field_location( $key ) === $location;
 			},
 			ARRAY_FILTER_USE_KEY
 		);
@@ -1262,11 +1265,11 @@ class CheckoutFields {
 	 * @param array $fields The fields to filter.
 	 * @return array The filtered fields.
 	 */
-	public function filter_fields_for_order_confirmation($fields) {
+	public function filter_fields_for_order_confirmation( $fields ) {
 		return array_filter(
 			$fields,
-			function ($field) {
-				return ! empty($field['show_in_order_confirmation']);
+			function ( $field ) {
+				return ! empty( $field['show_in_order_confirmation'] );
 			}
 		);
 	}
@@ -1280,42 +1283,42 @@ class CheckoutFields {
 	 * @param string   $context The context to get the field value for (edit|view).
 	 * @return array An array of fields definitions as well as their values formatted for display.
 	 */
-	public function get_order_additional_fields_with_values(WC_Order $order, string $location, string $group = 'other', string $context = 'edit') {
+	public function get_order_additional_fields_with_values( WC_Order $order, string $location, string $group = 'other', string $context = 'edit' ) {
 
 		// Because the Additional Checkout Fields API only applies to orders created with Store API, we should not
 		// return any values unless it was created using Store API. This is mainly to prevent "empty" checkbox values
 		// from being shown on the order confirmation page for orders placed using the shortcode. It's rare that this
 		// will happen but not impossible.
-		if ('store-api' !== $order->get_created_via()) {
+		if ( 'store-api' !== $order->get_created_via() ) {
 			return [];
 		}
 
-		if ('additional' === $location) {
-			wc_deprecated_argument('location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.');
+		if ( 'additional' === $location ) {
+			wc_deprecated_argument( 'location', '8.9.0', 'The "additional" location is deprecated. Use "order" instead.' );
 			$location = 'order';
 		}
 
-		if ('additional' === $group) {
-			wc_deprecated_argument('group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
+		if ( 'additional' === $group ) {
+			wc_deprecated_argument( 'group', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
 			$group = 'other';
 		}
 
-		$fields             = $this->get_fields_for_location($location);
+		$fields             = $this->get_fields_for_location( $location );
 		$fields_with_values = [];
 
-		foreach ($fields as $field_key => $field) {
-			$value = $this->get_field_from_object($field_key, $order, $group);
+		foreach ( $fields as $field_key => $field ) {
+			$value = $this->get_field_from_object( $field_key, $order, $group );
 
-			if ('' === $value || null === $value) {
+			if ( '' === $value || null === $value ) {
 				continue;
 			}
 
-			if ('view' === $context) {
-				$value = $this->format_additional_field_value($value, $field);
+			if ( 'view' === $context ) {
+				$value = $this->format_additional_field_value( $value, $field );
 			}
 
 			$field['value']                   = $value;
-			$fields_with_values[$field_key] = $field;
+			$fields_with_values[ $field_key ] = $field;
 		}
 
 		return $fields_with_values;
@@ -1328,14 +1331,14 @@ class CheckoutFields {
 	 * @param array  $field Additional field definition.
 	 * @return string
 	 */
-	public function format_additional_field_value($value, $field) {
-		if ('checkbox' === $field['type']) {
-			$value = $value ? __('Yes', 'woocommerce') : __('No', 'woocommerce');
+	public function format_additional_field_value( $value, $field ) {
+		if ( 'checkbox' === $field['type'] ) {
+			$value = $value ? __( 'Yes', 'woocommerce' ) : __( 'No', 'woocommerce' );
 		}
 
-		if ('select' === $field['type']) {
-			$options = array_column($field['options'], 'label', 'value');
-			$value   = isset($options[$value]) ? $options[$value] : $value;
+		if ( 'select' === $field['type'] ) {
+			$options = array_column( $field['options'], 'label', 'value' );
+			$value   = isset( $options[ $value ] ) ? $options[ $value ] : $value;
 		}
 
 		return $value;
@@ -1347,16 +1350,16 @@ class CheckoutFields {
 	 * @param string $group_name The group name (billing|shipping|other).
 	 * @return string The group meta prefix.
 	 */
-	public static function get_group_key($group_name) {
-		if ('additional' === $group_name) {
-			wc_deprecated_argument('group_name', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.');
+	public static function get_group_key( $group_name ) {
+		if ( 'additional' === $group_name ) {
+			wc_deprecated_argument( 'group_name', '8.9.0', 'The "additional" group is deprecated. Use "other" instead.' );
 			$group_name = 'other';
 		}
 
-		if ('billing' === $group_name) {
+		if ( 'billing' === $group_name ) {
 			return self::BILLING_FIELDS_PREFIX;
 		}
-		if ('shipping' === $group_name) {
+		if ( 'shipping' === $group_name ) {
 			return self::SHIPPING_FIELDS_PREFIX;
 		}
 		return self::OTHER_FIELDS_PREFIX;
@@ -1368,16 +1371,16 @@ class CheckoutFields {
 	 * @param string $group_key The group name (_wc_billing|_wc_shipping|_wc_other).
 	 * @return string The group meta prefix.
 	 */
-	public static function get_group_name($group_key) {
-		if ('_wc_additional' === $group_key) {
-			wc_deprecated_argument('group_key', '8.9.0', 'The "_wc_additional" group key is deprecated. Use "_wc_other" instead.');
+	public static function get_group_name( $group_key ) {
+		if ( '_wc_additional' === $group_key ) {
+			wc_deprecated_argument( 'group_key', '8.9.0', 'The "_wc_additional" group key is deprecated. Use "_wc_other" instead.' );
 			$group_key = '_wc_other';
 		}
 
-		if (0 === \strpos(self::BILLING_FIELDS_PREFIX, $group_key)) {
+		if ( 0 === \strpos( self::BILLING_FIELDS_PREFIX, $group_key ) ) {
 			return 'billing';
 		}
-		if (0 === \strpos(self::SHIPPING_FIELDS_PREFIX, $group_key)) {
+		if ( 0 === \strpos( self::SHIPPING_FIELDS_PREFIX, $group_key ) ) {
 			return 'shipping';
 		}
 		return 'other';


### PR DESCRIPTION
Previous to additional fields, the email field was hardcoded in the contact information step, this also included its type, when we abstracted that, we started using fields from CheckoutFields, however those didn't include a type. This PR includes that.

Closes https://github.com/woocommerce/woocommerce/issues/48610
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. From a mobile phone (or via the link to the playground), add a product to cart and go to Checkout.
2. Focus on Email field, make sure an email keyboard is shown (`@` is a top level key in the keyboard).
3. If you have access to an ipad, make sure it also shows provider autocomplete buttons.
4. You can also inspect the page and see if the field type is email and autocomplete is email.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

> Mark Checkout email field as type email to show relevant keyboard when filling.

