### PR TITLE
Product Editor: Increase the number of terms to 100 per request

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-increase-loading-terms-number-per-request
+++ b/packages/js/product-editor/changelog/update-product-editor-increase-loading-terms-number-per-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Editor: Increase the number of terms per request to 100

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -62,6 +62,9 @@ const stringToTokenItem = ( v: string | TokenItem ): TokenItem => ( {
 const tokenItemToString = ( item: string | TokenItem ): string =>
 	typeof item === 'string' ? item : item.value;
 
+const INITIAL_MAX_TOKENS_TO_SHOW = 20;
+const MAX_TERMS_TO_LOAD = 100;
+
 export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 	index,
 	attribute,
@@ -103,6 +106,7 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 				? ( getProductAttributeTerms( {
 						search: '',
 						attribute_id: attributeId,
+						per_page: MAX_TERMS_TO_LOAD, // @todo: handle this by using `search` arg
 				  } ) as ProductAttributeTerm[] )
 				: [];
 		},
@@ -202,8 +206,12 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 			return onTermsSelect( [ terms[ 0 ] ], index, attribute );
 		}
 
-		// auto select all terms
-		onTermsSelect( terms, index, attribute );
+		// auto select the first INITIAL_MAX_TOKENS_TO_SHOW terms
+		onTermsSelect(
+			terms.slice( 0, INITIAL_MAX_TOKENS_TO_SHOW ),
+			index,
+			attribute
+		);
 	}, [
 		termsAutoSelection,
 		initiallyPopulated,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR increases the terms in the async request to `100` (the max allowed by the endpoint). It partially mitigates the lack of the usage of the `search` argument in the request. `search` is always in an empty string.

The current issue is that when the site contains more than 20 items, they are not visible because the app does not define the `per_page` argument. Due to these changes, the app now displays a maximum of 100 items in the dropdown, and initially 20 tokens.

The implementation of the `search` argument will be addressed in a follow-up.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. For your site, create many terms for a global attribute
<img width="1010" alt="Screenshot 2024-06-19 at 1 12 56 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/efdabd71-21e6-422d-a18a-4fb9ea9be8d6">

3. Go to the new Product Editor
4. Go to the Variations tab
5. Click on the `Add options` button
6. Select the attribute with any terms
7. **Before**, Confirm that the terms input doesn't show all terms in the dropdown

<img width="802" alt="Screenshot 2024-06-19 at 1 20 42 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/e6db2e7c-9400-46b4-a7a4-657284a72e10">


8. **After**, Confirm the dropdown and tokens are many terms, with 100 as the maximum.

<img width="657" alt="Screenshot 2024-06-19 at 1 17 28 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/902154bf-bf8a-4999-af66-82f638e17abe">


https://github.com/woocommerce/woocommerce/assets/77539/bab6703e-6ba7-4e85-8099-b5dbfbf8d0cb


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
