### PR TITLE
Make sure the correct block template file is used in the Site Editor for templates with fallback

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-utils';
+
+test.describe( 'Product Search Results template', () => {
+	// This is a test to verify there are no regressions on
+	// https://github.com/woocommerce/woocommerce/issues/48489
+	test( 'loads the correct template in the Site Editor', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		const templateName = 'Product Search Results';
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Templates' } ).click();
+		await page.getByPlaceholder( 'Search' ).fill( templateName );
+		// Wait until search has finished.
+		const searchResults = page.getByLabel( 'Actions' );
+		await expect.poll( async () => await searchResults.count() ).toBe( 1 );
+		await page.getByLabel( templateName, { exact: true } ).click();
+
+		// Make sure the correct template is loaded.
+		await expect(
+			editor.canvas.getByLabel( 'Block: Search Results Title' )
+		).toBeVisible();
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
@@ -17,7 +17,7 @@ test.describe( 'Product Search Results template', () => {
 		await page.getByPlaceholder( 'Search' ).fill( templateName );
 		// Wait until search has finished.
 		const searchResults = page.getByLabel( 'Actions' );
-		await expect.poll( async () => await searchResults.count() ).toBe( 1 );
+		await expect( searchResults ).toHaveCount( 1 );
 		await page.getByLabel( templateName, { exact: true } ).click();
 
 		// Make sure the correct template is loaded.

--- a/plugins/woocommerce/changelog/fix-48489-ensure-correct-tempalte-file-is-used-in-editor
+++ b/plugins/woocommerce/changelog/fix-48489-ensure-correct-tempalte-file-is-used-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure the correct block template file is used in the Site Editor for templates with fallback

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -469,14 +469,6 @@ class BlockTemplatesController {
 				continue;
 			}
 
-			// At this point the template only exists in the Blocks filesystem, if is a taxonomy-product_cat/tag/attribute.html template
-			// let's use the archive-product.html template from Blocks.
-			if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $template_slug ) ) {
-				$template_file = $this->get_template_path_from_woocommerce( ProductCatalogTemplate::SLUG );
-				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug, false );
-				continue;
-			}
-
 			// At this point the template only exists in the Blocks filesystem and has not been saved in the DB,
 			// or superseded by the theme.
 			$templates[] = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug );

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -493,18 +493,6 @@ class BlockTemplatesController {
 	}
 
 	/**
-	 * Returns the path of a template on the Blocks template folder.
-	 *
-	 * @param string $template_slug Block template slug e.g. single-product.
-	 * @param string $template_type wp_template or wp_template_part.
-	 *
-	 * @return string
-	 */
-	public function get_template_path_from_woocommerce( $template_slug, $template_type = 'wp_template' ) {
-		return BlockTemplateUtils::get_templates_directory( $template_type ) . '/' . $template_slug . '.html';
-	}
-
-	/**
 	 * Checks whether a block template with that name exists in Woo Blocks
 	 *
 	 * @param string $template_name Template to check.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes #48489.

This PR fixes the logic that was handling the template file retrieval for templates which fall back to another template. As mentioned in #48489, we were always loading the fallback template file (aka, Product Catalog), instead of the specific template file. That was a problem for the Product Search Results template, as it has a different file than Product Catalog.

Sidenote: in https://github.com/woocommerce/woocommerce/issues/48536 we are investigating next steps to make sure the Product Search Results template doesn't fall back to the Product Catalog template.

### How to test the changes in this Pull Request:

1. From `example.com/wp-admin/`, go to Appearance > Site Editor > Templates and open the Product Search Results template. (Note: it's important to open the template by clicking on the links mentioned, instead of navigating directly to the template page using the URL).
2. Verify the correct template is loaded. You can notice it by the title that is used:

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/2b1d6ddb-48f1-4760-b8e4-d0f9e61feac5) | ![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/04836434-adfe-4dbc-9133-5f72c37dd8c7)


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
