### PR TITLE
Fix: stack coupon fields on smaller screens

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -19,19 +19,17 @@
 	.wc-block-components-totals-coupon__input,
 	.wc-block-components-totals-coupon__button {
 		margin: 0;
-		flex-basis: auto;
 	}
 
 	.wc-block-components-totals-coupon__input {
-		flex-grow: 3;
-		min-width: 120px;
+		flex: 3 1 120px;
 	}
 
 	.wc-block-components-totals-coupon__button {
 		padding-left: $gap;
 		padding-right: $gap;
 		white-space: nowrap;
-		flex-grow: 1;
+		flex: 1 1 auto;
 	}
 }
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -13,23 +13,25 @@
 	display: flex;
 	width: 100%;
 	margin-bottom: 0;
+	gap: $gap-smaller;
+	flex-wrap: wrap;
+
+	.wc-block-components-totals-coupon__input,
+	.wc-block-components-totals-coupon__button {
+		margin: 0;
+		flex-basis: auto;
+	}
 
 	.wc-block-components-totals-coupon__input {
-		margin-bottom: 0;
-		margin-top: 0;
-		flex-grow: 1;
+		flex-grow: 3;
+		min-width: 120px;
 	}
 
 	.wc-block-components-totals-coupon__button {
-		flex-shrink: 0;
-		margin-left: $gap-smaller;
-		padding-left: $gap-large;
-		padding-right: $gap-large;
+		padding-left: $gap;
+		padding-right: $gap;
 		white-space: nowrap;
-	}
-
-	.wc-block-components-totals-coupon__button.no-margin {
-		margin: 0;
+		flex-grow: 1;
 	}
 }
 

--- a/plugins/woocommerce-blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/text-input/style.scss
@@ -9,7 +9,7 @@
 		@include font-size(regular);
 		position: absolute;
 		transform: translateY(em($gap));
-		line-height: 1.25; // =20px when font-size is 16px.
+		line-height: 1;
 		left: em($gap-smaller + 1px);
 		top: 0;
 		transform-origin: top left;
@@ -44,7 +44,7 @@
 	input[type="number"],
 	input[type="email"] {
 		@include font-size(regular);
-		padding: em($gap);
+		padding: em($gap) em($gap-smaller);
 		line-height: em($gap);
 		width: 100%;
 		border-radius: $universal-border-radius;
@@ -54,7 +54,7 @@
 		margin: 0;
 		box-sizing: border-box;
 		min-height: 0;
-		max-height: 50px;
+		max-height: 52px;
 		background-color: #fff;
 		color: currentColor;
 

--- a/plugins/woocommerce/changelog/fix-47655-stack-coupon-fields
+++ b/plugins/woocommerce/changelog/fix-47655-stack-coupon-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Made coupon fields during block checkout stack on smaller screen sizes


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

On smaller screens the coupon input can become too narrow, causing data entry to become more difficult.

This PR tweaks the flexbox CSS display rules so that fields wrap if the input gets smaller than 120px. I chose not to use the viewport size because the checkout block can be within any size wrapper.

![Screenshot 2024-06-19 at 14 45 27](https://github.com/woocommerce/woocommerce/assets/90977/3d4bbdaf-e462-4d13-aadf-e9069d1cd579)

I added a few other related tweaks which I will comment inline. I also tested that wrapping occurs if the "apply" button text is longer.

Closes #47655

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to block checkout
2. Toggle open the "add a coupon" area to see the coupon form
3. In most cases on desktop, fields should be side by side with a small gap between input and button.
4. Shrink the browser window. When you get to very narrow width, ensure the fields stack.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
