### PR TITLE
[Experimental] Product Filters Redesign > Wrapper block: Fix icon

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/icon.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/icon.tsx
@@ -7,28 +7,8 @@ const Icon = () => (
 		xmlns="http://www.w3.org/2000/svg"
 	>
 		<path
-			d="M19 3H5C4.4 3 4 3.4 4 4V11C4 11.5 4.4 12 5 12H19C19.5 12 20 11.6 20 11V4C20 3.4 19.6 3 19 3ZM5.5 10.5V10.1L7.3 8.8L8.6 9.6C8.9 9.8 9.3 9.8 9.5 9.5L11 8.1L13.4 10.5H5.5ZM18.5 10.5H15.6L11.6 6.5C11.3 6.2 10.8 6.2 10.5 6.5L8.9 8L7.7 7.2C7.4 7 7.1 7 6.8 7.2L5.5 8.2V4.5H18.5V10.5Z"
+			d="M10 17.5H14V16H10V17.5ZM6 6V7.5H18V6H6ZM8 12.5H16V11H8V12.5Z"
 			fill="currentColor"
-		/>
-		<rect
-			x="4.75"
-			y="15.5"
-			width="5"
-			height="4.5"
-			rx="1"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			fill="none"
-		/>
-		<rect
-			x="12.25"
-			y="15.5"
-			width="5"
-			height="4.5"
-			rx="1"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			fill="none"
 		/>
 	</svg>
 );

--- a/plugins/woocommerce/changelog/48635-fix-46984-add-correct-icon-to-product-filters-wrapper-block
+++ b/plugins/woocommerce/changelog/48635-fix-46984-add-correct-icon-to-product-filters-wrapper-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: The block is currently on experimental state, so the changes done in this PR won't be available for the users.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the Product Filters Wrapper Block icon. The current icon is similar to what is being used by the Product Gallery block.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46984.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template - or any archive template).
2. Click on "Edit" to open the WordPress editor.
3. In the editor, you should see a block inserter icon or an option to "Add Block". Click on it.
4. Search for "Product Filters (Experimental)" in the block inserter or browse the available blocks until you find them. Add it to your content.
5. Make sure you can see the correct icon for the block.

| Current | Expected |
|--------|--------|
| ![CleanShot 2024-06-19 at 14 39 57@2x](https://github.com/woocommerce/woocommerce/assets/20469356/fb5ce7e0-e98a-4476-a1a1-97dd86e2aabf) | ![CleanShot 2024-06-19 at 14 38 21@2x](https://github.com/woocommerce/woocommerce/assets/20469356/3de71c77-e4ef-413d-b09c-7ffbef3875c8) | 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead --> The block is currently on experimental state, so the changes done in this PR won't be available for the users.

</details>
