### PR TITLE
Fix e2e test for product filters overlay template part

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters-overlay-template-part/product-filters-overlay-template-part.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters-overlay-template-part/product-filters-overlay-template-part.block_theme.spec.ts
@@ -14,7 +14,7 @@ test.describe( 'Filters Overlay Template Part', () => {
 	} );
 
 	test( 'should be visible', async ( { page } ) => {
-		const block = page.getByText( 'Filters Overlay' );
+		const block = page.getByRole( 'button', { name: 'Filters Overlay 1' } );
 		await expect( block ).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-filters-overlay-template-part/product-filters-overlay-template-part.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-filters-overlay-template-part/product-filters-overlay-template-part.block_theme.spec.ts
@@ -9,12 +9,15 @@ test.describe( 'Filters Overlay Template Part', () => {
 			'woocommerce-blocks-test-enable-experimental-features'
 		);
 		await admin.visitSiteEditor( {
-			path: '/wp_template_part/all',
+			postType: 'wp_template_part',
 		} );
 	} );
 
 	test( 'should be visible', async ( { page } ) => {
-		const block = page.getByRole( 'button', { name: 'Filters Overlay 1' } );
+		const block = page
+			.getByLabel( 'Patterns content' )
+			.getByText( 'Filters Overlay' )
+			.and( page.getByRole( 'button' ) );
 		await expect( block ).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/changelog/48659-product-filters-overlay-template-part-e2e
+++ b/plugins/woocommerce/changelog/48659-product-filters-overlay-template-part-e2e
@@ -1,3 +1,4 @@
 Significance: patch
-Type: dev
-Comment: Fix e2e test
+Type: tweak
+Comment: Just fixing an e2e test.
+

--- a/plugins/woocommerce/changelog/48659-product-filters-overlay-template-part-e2e
+++ b/plugins/woocommerce/changelog/48659-product-filters-overlay-template-part-e2e
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Fix e2e test


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a failing e2e test mentioned here https://github.com/woocommerce/woocommerce/pull/48472#issuecomment-2179784156

Though the PR passed so it was merged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Developer testing only**

1. Just make sure the CI passes.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Just fixing an e2e test.

</details>
