### PR TITLE
Do not initialize product form template systems

### DIFF
--- a/plugins/woocommerce/changelog/update-do-not-call-product-form-template-system
+++ b/plugins/woocommerce/changelog/update-do-not-call-product-form-template-system
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Do not initialize product form template systems. The project is on standby for the moment

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -34,7 +34,6 @@
 		"wc-pay-promotion": true,
 		"wc-pay-welcome-page": true,
 		"async-product-editor-category-field": false,
-		"launch-your-store": true,
-		"product-editor-template-system": false
+		"launch-your-store": true
 	}
 }

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -34,7 +34,6 @@
 		"wc-pay-promotion": true,
 		"wc-pay-welcome-page": true,
 		"async-product-editor-category-field": true,
-		"launch-your-store": true,
-		"product-editor-template-system": false
+		"launch-your-store": true
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -410,12 +410,6 @@ class Init {
 		);
 
 		$this->redirection_controller->set_product_templates( $this->product_templates );
-
-		// PFT: Initialize the product form controller.
-		if ( Features::is_enabled( 'product-editor-template-system' ) ) {
-			$product_form_controller = new ProductFormsController();
-			$product_form_controller->init();
-		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the Product Form Template system is currently on standby, we should remove the code that initializes the process. The implementation was halted during development, so it's best not to use it .

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Build the WooCommerce plugin 
2. Install the Woo Dev Tools plugin
3. Ensure the feature `product-editor-template-system` flag is not available anymore

<img width="913" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/f51a1885-619b-4ded-a695-cf3a1fb6aaef">

4. Ensure that the WordPress app does not exhibit any unexpected behavior: unexpected warning, errors,
Testing might be challenging since this PR involves removing code. 

In general, a visual review should be enough.

A visual code review should be enough. Test the whole WordPress admin page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
