### PR TITLE
Enhancement: Show account created notice on order confirmation page

### DIFF
--- a/plugins/woocommerce/changelog/add-42529-account-created-notice
+++ b/plugins/woocommerce/changelog/add-42529-account-created-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added notice to the order confirmation page for new accounts instructing them to change the default password.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -376,6 +376,7 @@ class WC_Shortcode_My_Account {
 		do_action( 'password_reset', $user, $new_pass );
 
 		wp_set_password( $new_pass, $user->ID );
+		update_user_meta( $user->ID, 'default_password_nag', false );
 		self::set_reset_password_cookie();
 
 		if ( ! apply_filters( 'woocommerce_disable_password_change_notification', false ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -40,13 +40,17 @@ class Status extends AbstractOrderConfirmationBlock {
 			return '';
 		}
 
-		$additional_content = $this->render_confirmation_notice( $order );
+		$additional_content = $this->render_account_notice( $order ) . $this->render_confirmation_notice( $order );
 
-		return $additional_content ? $block . sprintf(
-			'<div class="wc-block-order-confirmation-status-description %1$s">%2$s</div>',
-			esc_attr( trim( $classname ) ),
-			$additional_content
-		) : $block;
+		if ( $additional_content ) {
+			return sprintf(
+				'<div class="wc-block-order-confirmation-status-description %1$s">%2$s</div>',
+				esc_attr( trim( $classname ) ),
+				$additional_content
+			) . $block;
+		}
+
+		return $block;
 	}
 
 	/**
@@ -140,6 +144,32 @@ class Status extends AbstractOrderConfirmationBlock {
 	protected function render_content_fallback() {
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		return '<p>' . esc_html__( 'Please check your email for the order confirmation.', 'woocommerce' ) . '</p>';
+	}
+
+	/**
+	 * If the user associated with the order needs to set a password (new account) show a notice.
+	 *
+	 * @param \WC_Order|null $order Order object.
+	 * @return string
+	 */
+	protected function render_account_notice( $order = null ) {
+		if ( $order && $order->get_customer_id() && 'store-api' === $order->get_created_via() ) {
+			$nag = get_user_option( 'default_password_nag', $order->get_customer_id() );
+
+			if ( $nag ) {
+				return wc_print_notice(
+					sprintf(
+						// translators: %s: site name.
+						__( 'Your account with %s has been successfully created. We emailed you a link to set your account password.', 'woocommerce' ),
+						esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
+					),
+					'notice',
+					array(),
+					true
+				);
+			}
+		}
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a notice to the order confirmation page for new accounts that need to reset their password (as per the design in https://github.com/woocommerce/woocommerce/issues/42529#issuecomment-2180176925).

![Screenshot 2024-06-20 at 13 57 52](https://github.com/woocommerce/woocommerce/assets/90977/7515308f-8df6-45b3-a1aa-3fcf645507fb)

This uses the existing `default_password_nag` user option to determine if the notice is needed. Once the password is reset, `default_password_nag` is set to false.

Closes #42529

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. As a guest, add something to your cart and checkout using the block based checkout.
2. Ensure you toggle the "create an account" box on.
3. After placing the order, assuming you're using the block based order confirmation, you'll see a notice at the top of the screen indicating the account was created. Leave this page open in a browser window.
4. Go find the account email your new account received and click the link to reset/set a password.
5. Set the password for the account and login.
6. Refresh the order confirmation page from earlier and confirm the notice is now hidden.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
