### PR TITLE
Add data from the template to the product when it is selected

### DIFF
--- a/packages/js/product-editor/changelog/fix-add-template-data
+++ b/packages/js/product-editor/changelog/fix-add-template-data
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add data from the template to the product when it is selected via URL query parameter
+
+

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -11,7 +11,7 @@ import {
 	lazy,
 	Suspense,
 } from '@wordpress/element';
-import { dispatch, select, useSelect } from '@wordpress/data';
+import { dispatch, select, useDispatch, useSelect } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
 import { __ } from '@wordpress/i18n';
 import { useLayoutTemplate } from '@woocommerce/block-templates';
@@ -310,14 +310,29 @@ export function BlockEditor( {
 		setIsEditorLoading( isEditorLoading );
 	}, [ isEditorLoading ] );
 
+	const { editEntityRecord } = useDispatch( 'core' );
+
 	useEffect( function maybeSetProductTemplateFromURL() {
 		const query: { template?: string } = getQuery();
 		const isAddProduct = getPath().endsWith( 'add-product' );
 		if ( isAddProduct && query.template ) {
 			const productTemplates =
 				window.productBlockEditorSettings?.productTemplates ?? [];
-			if ( productTemplates.find( ( t ) => t.id === query.template ) ) {
-				setProductTemplateId( query.template );
+			const selectedProductTemplate = productTemplates.find(
+				( t ) => t.id === query.template
+			);
+			if ( selectedProductTemplate ) {
+				editEntityRecord( 'postType', postType, productId, {
+					...selectedProductTemplate.productData,
+					meta_data: [
+						...( selectedProductTemplate.productData.meta_data ??
+							[] ),
+						{
+							key: '_product_template_id',
+							value: selectedProductTemplate.id,
+						},
+					],
+				} );
 			}
 		}
 	}, [] );

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -304,6 +304,8 @@ export function BlockEditor( {
 		setIsEditorLoading( isEditorLoading );
 	}, [ isEditorLoading ] );
 
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
 	const { editEntityRecord } = useDispatch( 'core' );
 
 	useEffect( function maybeSetProductTemplateFromURL() {

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -53,7 +53,6 @@ import { BlockEditorProps } from './types';
 import { LoadingState } from './loading-state';
 import type { ProductFormPostProps, ProductTemplate } from '../../types';
 import isProductFormTemplateSystemEnabled from '../../utils/is-product-form-template-system-enabled';
-import useProductEntityProp from '../../hooks/use-product-entity-prop';
 
 const PluginArea = lazy( () =>
 	import( '@wordpress/plugins' ).then( ( module ) => ( {
@@ -198,11 +197,6 @@ export function BlockEditor( {
 					metaEntry.key === '_product_template_id'
 			)?.value,
 		[ product?.meta_data ]
-	);
-
-	const [ , setProductTemplateId ] = useProductEntityProp(
-		'meta_data._product_template_id',
-		{ postType }
 	);
 
 	const { productTemplate } = useProductTemplate(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/48573, I forgot to copy the data defined in the template to the product when the template is selected through a query parameter, so this PR does that.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Open the URL /wp-admin/admin.php?page=wc-admin&path=%2Fadd-product&template=grouped-product-template
3. Check that it says 'This is a grouped product' in the Basic details tab
4. Add a name, save, and refresh the page
5. Check the response of the products API, it should have 'type: grouped', which was copied from the template 'product_data'.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
