### PR TITLE
Fix: Block theme template overrides for notices were impacting all templates

### DIFF
--- a/plugins/woocommerce/changelog/fix-48505-notice-template-override
+++ b/plugins/woocommerce/changelog/fix-48505-notice-template-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Narrowed scope of block theme notice templates so other template overrides are unaffected

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Notices.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Notices.php
@@ -43,7 +43,7 @@ class Notices {
 	public function init() {
 		add_action(
 			'after_setup_theme',
-			function() {
+			function () {
 				/**
 				 * Allow classic theme developers to opt-in to using block notices.
 				 *
@@ -104,13 +104,14 @@ class Notices {
 	 * @return string
 	 */
 	public function get_notices_template( $template, $template_name, $args, $template_path, $default_path ) {
-		$directory = get_stylesheet_directory();
-		$file      = $directory . '/woocommerce/' . $template_name;
-		if ( file_exists( $file ) ) {
-			return $file;
-		}
-
 		if ( in_array( $template_name, $this->notice_templates, true ) ) {
+			$directory = get_stylesheet_directory();
+			$file      = $directory . '/woocommerce/' . $template_name;
+
+			if ( file_exists( $file ) ) {
+				return $file;
+			}
+
 			$template = $this->package->get_path( 'templates/block-' . $template_name );
 			wp_enqueue_style( 'wc-blocks-style' );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This hook is there (I believe) to ensure that theme overrides of notice templates still work and take priority over the new block notice templates.

https://github.com/woocommerce/woocommerce/blob/cac7e0dfe9909cdcee941a7803cbb7048ef5037a/plugins/woocommerce/src/Blocks/Domain/Services/Notices.php#L106-L119

The issue is that it is outside of the `in_array( $template_name, $this->notice_templates, true )` check, so it actually applies to **all** templates. This prevents other template overrides by other plugins from working correctly. [I believe this was introduced in this PR.](https://github.com/woocommerce/woocommerce/pull/44283)

Closes #48505

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Developer testing only**

1. Install and activate this test override plugin: [test-template-override-plugin.zip](https://github.com/user-attachments/files/15916294/test-template-override-plugin.zip)
2. Copy `woocommerce/templates/my-account` into `yourtheme/woocommerce/my-account` so that overrides are in place
3. Logged in, go to my account and view an order. You should see the message "At Plugin Template!!". Without this fix in place you will get a fatal error.

To test regressions in https://github.com/woocommerce/woocommerce/pull/44283:

1. Ensure Storefront is installed. Upload and activate this child theme it contains customisation to the notices:
[storefront-child.zip](https://github.com/woocommerce/woocommerce/files/14129576/storefront-child.zip)
2. Go to the Shortcode Cart and add a coupon. Ensure the notice has the customised text: CLASSIC {TYPE} NOTICE - {Notice text}
3. Ensure Twenty Twenty-Four is installed.
4. Upload and activate this child theme: [twentytwentyfour-child.zip](https://github.com/woocommerce/woocommerce/files/14129607/twentytwentyfour-child.zip)
5. Go to the Shortcode Cart and add a coupon. Ensure the notice has the customised text: BLOCK {TYPE} NOTICE - {Notice text}

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
