### PR TITLE
Don't display WCS&T help in tasks if WCShip or WCTax is active

### DIFF
--- a/packages/js/data/changelog/48703-tweak-dont-display-wcservices-help-if-wcship-or-wctax-is-active
+++ b/packages/js/data/changelog/48703-tweak-dont-display-wcservices-help-if-wcship-or-wctax-is-active
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't display information about setting up WooCommerce Shipping & Tax in the task steppers for "Collect sales tax" and "Select your shipping options".  The changes in this PR only adjust the help items merchants see.
-

--- a/packages/js/data/changelog/48703-tweak-dont-display-wcservices-help-if-wcship-or-wctax-is-active
+++ b/packages/js/data/changelog/48703-tweak-dont-display-wcservices-help-if-wcship-or-wctax-is-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't display information about setting up WooCommerce Shipping & Tax in the task steppers for "Collect sales tax" and "Select your shipping options".  The changes in this PR only adjust the help items merchants see.
+

--- a/plugins/woocommerce-admin/client/activity-panel/panels/help.js
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/help.js
@@ -190,7 +190,10 @@ function getProductsItems() {
 function getShippingItems( { activePlugins, countryCode } ) {
 	const showWCS =
 		countryCode === 'US' &&
-		! activePlugins.includes( 'woocommerce-services' );
+		! activePlugins.includes( 'woocommerce-services' ) &&
+		! activePlugins.includes( 'woocommerce-shipping' ) &&
+		! activePlugins.includes( 'woocommerce-tax' );
+
 	return [
 		{
 			title: __( 'Setting up Shipping Zones', 'woocommerce' ),
@@ -235,11 +238,18 @@ function getTaxItems( props ) {
 	}
 
 	const { additionalData } = task;
-	const { woocommerceTaxCountries = [], taxJarActivated } = additionalData;
+	const {
+		woocommerceTaxCountries = [],
+		taxJarActivated,
+		woocommerceTaxActivated,
+		woocommerceShippingActivated,
+	} = additionalData;
 
 	const showWCS =
 		! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
-		woocommerceTaxCountries.includes( countryCode );
+		woocommerceTaxCountries.includes( countryCode ) &&
+		! woocommerceTaxActivated &&
+		! woocommerceShippingActivated;
 
 	return [
 		{

--- a/plugins/woocommerce-admin/client/activity-panel/test/help-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/help-panel.js
@@ -77,119 +77,218 @@ describe( 'Activity Panels', () => {
 			} );
 		} );
 
-		it( 'only shows links for automated tax when supported', () => {
-			const taxjarPluginEnabled = render(
-				<HelpPanel
-					countryCode="US"
-					taskLists={ [
-						{
-							id: 'setup',
-							tasks: [
-								{
-									id: 'tax',
-									additionalData: {
-										woocommerceTaxCountries: [ 'US' ],
-										taxJarActivated: true,
+		describe( 'only shows links for WooCommerce Tax (powered by WCS&T) when supported', () => {
+			it( 'displays if no conflicting conditions are present', () => {
+				const supportedCountry = render(
+					<HelpPanel
+						countryCode="US"
+						taskLists={ [
+							{
+								id: 'setup',
+								tasks: [
+									{
+										id: 'tax',
+										additionalData: {
+											woocommerceTaxCountries: [ 'US' ],
+											taxJarActivated: false,
+										},
 									},
-								},
-							],
-						},
-					] }
-					taskName="tax"
-				/>
-			);
+								],
+							},
+						] }
+						taskName="tax"
+					/>
+				);
 
-			expect(
-				taxjarPluginEnabled.queryByText( /WooCommerce Tax/ )
-			).toBeNull();
+				expect(
+					supportedCountry.getByText( /WooCommerce Tax/ )
+				).toBeDefined();
+			} );
 
-			const unSupportedCountry = render(
-				<HelpPanel
-					countryCode="NZ"
-					taskLists={ [
-						{
-							id: 'setup',
-							tasks: [
-								{
-									id: 'tax',
-									additionalData: {
-										woocommerceTaxCountries: [ 'US' ],
-										taxJarActivated: false,
+			it( 'does not display if the TaxJar plugin is active', () => {
+				const taxjarPluginEnabled = render(
+					<HelpPanel
+						countryCode="US"
+						taskLists={ [
+							{
+								id: 'setup',
+								tasks: [
+									{
+										id: 'tax',
+										additionalData: {
+											woocommerceTaxCountries: [ 'US' ],
+											taxJarActivated: true,
+										},
 									},
-								},
-							],
-						},
-					] }
-					taskName="tax"
-				/>
-			);
+								],
+							},
+						] }
+						taskName="tax"
+					/>
+				);
 
-			expect(
-				unSupportedCountry.queryByText( /WooCommerce Tax/ )
-			).toBeNull();
+				expect(
+					taxjarPluginEnabled.queryByText( /WooCommerce Tax/ )
+				).toBeNull();
+			} );
 
-			const supportedCountry = render(
-				<HelpPanel
-					countryCode="US"
-					taskLists={ [
-						{
-							id: 'setup',
-							tasks: [
-								{
-									id: 'tax',
-									additionalData: {
-										woocommerceTaxCountries: [ 'US' ],
-										taxJarActivated: false,
+			it( 'does not display if in an unsupported country', () => {
+				const unSupportedCountry = render(
+					<HelpPanel
+						countryCode="NZ"
+						taskLists={ [
+							{
+								id: 'setup',
+								tasks: [
+									{
+										id: 'tax',
+										additionalData: {
+											woocommerceTaxCountries: [ 'US' ],
+											taxJarActivated: false,
+										},
 									},
-								},
-							],
-						},
-					] }
-					taskName="tax"
-				/>
-			);
+								],
+							},
+						] }
+						taskName="tax"
+					/>
+				);
 
-			expect(
-				supportedCountry.getByText( /WooCommerce Tax/ )
-			).toBeDefined();
+				expect(
+					unSupportedCountry.queryByText( /WooCommerce Tax/ )
+				).toBeNull();
+			} );
+
+			it( 'does not display if the WooCommerce Tax plugin is active', () => {
+				const woocommerceTaxActivated = render(
+					<HelpPanel
+						countryCode="US"
+						taskLists={ [
+							{
+								id: 'setup',
+								tasks: [
+									{
+										id: 'tax',
+										additionalData: {
+											woocommerceTaxCountries: [ 'US' ],
+											taxJarActivated: false,
+											woocommerceTaxActivated: true,
+										},
+									},
+								],
+							},
+						] }
+						taskName="tax"
+					/>
+				);
+
+				expect(
+					woocommerceTaxActivated.queryByText( /WooCommerce Tax/ )
+				).toBeNull();
+			} );
+
+			it( 'does not display if the WooCommerce Shipping plugin is active', () => {
+				const woocommerceShippingActivated = render(
+					<HelpPanel
+						countryCode="US"
+						taskLists={ [
+							{
+								id: 'setup',
+								tasks: [
+									{
+										id: 'tax',
+										additionalData: {
+											woocommerceTaxCountries: [ 'US' ],
+											taxJarActivated: false,
+											woocommerceTaxActivated: false,
+											woocommerceShippingActivated: true,
+										},
+									},
+								],
+							},
+						] }
+						taskName="tax"
+					/>
+				);
+
+				expect(
+					woocommerceShippingActivated.queryByText(
+						/WooCommerce Tax/
+					)
+				).toBeNull();
+			} );
 		} );
 
-		it( 'only shows links for WooCommerce Shipping when supported', () => {
-			const wcsActive = render(
-				<HelpPanel
-					activePlugins={ [ 'woocommerce-services' ] }
-					countryCode="US"
-					taskName="shipping"
-				/>
-			);
+		describe( 'only shows links for WooCommerce Shipping (powered by WCS&T) when supported', () => {
+			it( 'displays if no conflicting conditions are present', () => {
+				const supportedCountry = render(
+					<HelpPanel
+						activePlugins={ [] }
+						countryCode="US"
+						taskName="shipping"
+					/>
+				);
 
-			expect(
-				wcsActive.queryByText( /WooCommerce Shipping/ )
-			).toBeNull();
+				expect(
+					supportedCountry.getByText( /WooCommerce Shipping/ )
+				).toBeDefined();
+			} );
 
-			const unSupportedCountry = render(
-				<HelpPanel
-					activePlugins={ [ 'woocommerce-services' ] }
-					countryCode="UK"
-					taskName="shipping"
-				/>
-			);
+			it( 'does not display if the WooCommerce Shipping & Tax plugin is active', () => {
+				const wcsActive = render(
+					<HelpPanel
+						activePlugins={ [ 'woocommerce-services' ] }
+						countryCode="US"
+						taskName="shipping"
+					/>
+				);
 
-			expect(
-				unSupportedCountry.queryByText( /WooCommerce Shipping/ )
-			).toBeNull();
+				expect(
+					wcsActive.queryByText( /WooCommerce Shipping/ )
+				).toBeNull();
+			} );
 
-			const supportedCountry = render(
-				<HelpPanel
-					activePlugins={ [] }
-					countryCode="US"
-					taskName="shipping"
-				/>
-			);
+			it( 'does not display if the WooCommerce Shipping plugin is active', () => {
+				const wcsActive = render(
+					<HelpPanel
+						activePlugins={ [ 'woocommerce-shipping' ] }
+						countryCode="US"
+						taskName="shipping"
+					/>
+				);
 
-			expect(
-				supportedCountry.getByText( /WooCommerce Shipping/ )
-			).toBeDefined();
+				expect(
+					wcsActive.queryByText( /WooCommerce Shipping/ )
+				).toBeNull();
+			} );
+
+			it( 'does not display if the WooCommerce Tax plugin is active', () => {
+				const wcsActive = render(
+					<HelpPanel
+						activePlugins={ [ 'woocommerce-tax' ] }
+						countryCode="US"
+						taskName="shipping"
+					/>
+				);
+
+				expect(
+					wcsActive.queryByText( /WooCommerce Shipping/ )
+				).toBeNull();
+			} );
+
+			it( 'does not display if in an unsupported country', () => {
+				const unSupportedCountry = render(
+					<HelpPanel
+						activePlugins={ [] }
+						countryCode="UK"
+						taskName="shipping"
+					/>
+				);
+
+				expect(
+					unSupportedCountry.queryByText( /WooCommerce Shipping/ )
+				).toBeNull();
+			} );
 		} );
 
 		it( 'only shows links for home screen when supported', () => {

--- a/plugins/woocommerce/changelog/48703-tweak-dont-display-wcservices-help-if-wcship-or-wctax-is-active
+++ b/plugins/woocommerce/changelog/48703-tweak-dont-display-wcservices-help-if-wcship-or-wctax-is-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't display information about setting up WooCommerce Shipping & Tax in the task steppers for "Collect sales tax" and "Select your shipping options".  The changes in this PR only adjust the help items merchants see.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce-shipping/issues/187.

If the "WooCommerce Shipping" or "WooCommerce Tax" extension is active, don't recommend the incompatible "WooCommerce Shipping & Tax" extension.

This PR removes WCS&T-related help pages from the "Select your shipping options" and "Collect sales tax" tasks if either the WCShip or WCTax extension is active.

### Screenshots

<img width="742" alt="Screenshot 2024-06-06 at 13 54 06" src="https://github.com/woocommerce/woocommerce/assets/1759681/3f6a48b9-787a-4c02-a23b-ed65c944e7a2">

<img width="744" alt="Screenshot 2024-06-06 at 13 56 19" src="https://github.com/woocommerce/woocommerce/assets/1759681/4efb3b43-f154-4c9d-b480-72b987841d97">

Note that despite the help items saying "WooCommerce Shipping" and "WooCommerce Tax", they actually refers to WCS&T's functionalities.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Clone this repo, check out this PR's branch, and build WooCommerce. [The official instructions are in the repo README file](https://github.com/woocommerce/woocommerce?tab=readme-ov-file#getting-started) but here's a shortcut:
   ```
   nvm use && pnpm i -g pnpm@9.1.0 && pnpm i && pnpm run build
   ```
2. In your local test site's `wp-content/plugins`, link the WooCommerce plugin you just built.
   Let's assume you checked out the WooCommerce repo to `/home/me/woocommerce`.
   Note how below we aren't creating a link to `/home/me/woocommerce` but rather to a directory within it:
   ```
   ln -s /home/me/woocommerce/plugins/woocommerce /var/www/your-test-site/wp-content/plugins/woocommerce
   ```
3. That's it for building WC Core. Now let's test the tax task:

#### Testing the "Collect sales tax" task

1. In WP admin, go to WooCommerce > Home. Click the "Collect sales tax" task:
   <img width="712" alt="Screenshot 2024-06-24 at 20 32 21" src="https://github.com/woocommerce/woocommerce/assets/1759681/a77acf6d-21e3-48b9-a062-96886711fe5f">
1. Click the "?" icon in the top right:
   <img width="1003" alt="Screenshot 2024-06-24 at 20 33 05" src="https://github.com/woocommerce/woocommerce/assets/1759681/9595c707-c51d-42e3-9ee4-4fcdbe2671eb">
1. Without WCShip and/or WCTax installed, you should see this WCS&T-related help item:
   <img width="744" alt="Screenshot 2024-06-06 at 13 56 19" src="https://github.com/woocommerce/woocommerce/assets/1759681/4efb3b43-f154-4c9d-b480-72b987841d97">
   Note that despite the help item saying "WooCommerce Tax", it actually refers to WCS&T's tax functionality.
1. With WCShip and/or WCTax installed, you should not see it.

#### Testing the "Select your shipping options" task

1. To force the task to show up and guide us to the wizard, we have to tweak the code a little. Apply the following patch:
   ```patch
   diff --git a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
   index f06534b87c..649d0a7f87 100644
   --- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
   +++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
   @@ -84,6 +84,7 @@ class Shipping extends Task {
    	 * @return bool
    	 */
    	public function can_view() {
   +		return true;
    		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
    			if ( 'yes' === get_option( 'woocommerce_admin_created_default_shipping_zones' ) ) {
    				// If the user has already created a default shipping zone, we don't need to show the task.
   @@ -128,6 +129,7 @@ class Shipping extends Task {
    	 * @return string
    	 */
    	public function get_action_url() {
   +		return null;
    		return self::has_shipping_zones()
    			? admin_url( 'admin.php?page=wc-settings&tab=shipping' )
    			: null;

   ```
1. In WP admin, go to WooCommerce > Home. Click the "Select your shipping options" task:
   <img width="742" alt="Screenshot 2024-06-06 at 13 54 06" src="https://github.com/woocommerce/woocommerce/assets/1759681/3f6a48b9-787a-4c02-a23b-ed65c944e7a2">
1. Click the "?" icon in the top right.
1. Without WCShip and/or WCTax installed, you should see this WCS&T-related help item:
   <img width="742" alt="Screenshot 2024-06-06 at 13 54 06" src="https://github.com/woocommerce/woocommerce/assets/1759681/3f6a48b9-787a-4c02-a23b-ed65c944e7a2">
   Note that despite the help item saying "WooCommerce Shipping", it actually refers to WCS&T's shipping functionality.
1. With WCShip and/or WCTax installed, you should not see it.

<!-- End testing instructions -->


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't display information about setting up WooCommerce Shipping & Tax in the task steppers for "Collect sales tax" and "Select your shipping options".

The changes in this PR only adjust the help items merchants see.

</details>
