### PR TITLE
Don't recommend WCS&T on Edit Order page with WCShip/WCTax active

### DIFF
--- a/plugins/woocommerce/changelog/48704-tweak-dont-recommend-wcservices-on-edit-order-page-with-wcship-or-wctax-active
+++ b/plugins/woocommerce/changelog/48704-tweak-dont-recommend-wcservices-on-edit-order-page-with-wcship-or-wctax-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't display a banner recommending WooCommerce Shipping & Tax on the "Edit order" page.  The changes in this PR only remove the banner recommending WCS&T which, if installed, would lead to a notice about incompatibility.
+

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -60,7 +60,9 @@ class ShippingLabelBanner {
 			$incompatible_plugins = class_exists( '\WC_Shipping_Fedex_Init' ) ||
 				class_exists( '\WC_Shipping_UPS_Init' ) ||
 				class_exists( '\WC_Integration_ShippingEasy' ) ||
-				class_exists( '\WC_ShipStation_Integration' );
+				class_exists( '\WC_ShipStation_Integration' ) ||
+				class_exists( '\Automattic\WCShipping\Loader' ) ||
+				class_exists( '\Automattic\WCTax\Loader' );
 
 			$this->shipping_label_banner_display_rules =
 				new ShippingLabelBannerDisplayRules(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of woocommerce/woocommerce-shipping#187.

If the "WooCommerce Shipping" or "WooCommerce Tax" extension is active, don't recommend the incompatible "WooCommerce Shipping & Tax" extension.

This PR removes the banner suggesting installing WCS&T from the Edit Order page if either the WCShip or WCTax extension is active.

### Screenshots

![image](https://github.com/woocommerce/woocommerce/assets/1759681/340d07e8-ac42-4151-8432-bc68a41fb88a)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Clone this repo, check out this PR's branch, and build WooCommerce. [The official instructions are in the repo README file](https://github.com/woocommerce/woocommerce?tab=readme-ov-file#getting-started) but here's a shortcut:
   ```
   nvm use && pnpm i -g pnpm@9.1.0 && pnpm i && pnpm run build
   ```
2. In your local test site's `wp-content/plugins`, link the WooCommerce plugin you just built.
   Let's assume you checked out the WooCommerce repo to `/home/me/woocommerce`.
   Note how below we aren't creating a link to `/home/me/woocommerce` but rather to a directory within it:
   ```
   ln -s /home/me/woocommerce/plugins/woocommerce /var/www/your-test-site/wp-content/plugins/woocommerce
   ```
3. That's it for building WC Core. Now let's test the banner.
4. Ensure your site is connected to WPCOM. Otherwise the banner will not appear.
5. Ensure your WC site is set to use the legacy post type order storage. You can do this in **WC > Settings > Advanced > Features**.
   - Since HPOS was implemented, this banner hasn't been functioning on HPOS-enabled sites due to a change in how the "Edit order" page identified itself with and without HPOS. This is why we need to change this.
7. Go to the "Edit order" page with WCS&T, WCShip, and WCTax inactive. See the banner.
8. Test that if any of the extensions is active (WCS&T included), the banner does not show up.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't display a banner recommending WooCommerce Shipping & Tax on the "Edit order" page.

The changes in this PR only remove the banner recommending WCS&T which, if installed, would lead to a notice about incompatibility.

</details>
