### PR TITLE
Don't recommend WCS&T in default extension recommendations if WCShip or WCTax is active

### DIFF
--- a/plugins/woocommerce/changelog/48705-update-dont-recommend-wcservices-in-default-extension-recommendations-with-wcship-or-wctax-active
+++ b/plugins/woocommerce/changelog/48705-update-dont-recommend-wcservices-in-default-extension-recommendations-with-wcship-or-wctax-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't recommend WooCommerce Shipping & Tax in the onboarding wizards and the "Select your shipping options" task.  Allowing WCS&T to be installed alongside WC Shipping or WC Tax would lead to a notice about incompatibility which is something this PR aims to avoid.
+

--- a/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
+++ b/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
@@ -285,6 +285,24 @@ class DefaultShippingPartners {
 				'learn_more_link'   => 'https://woocommerce.com/products/shipping/',
 				'is_visible'        => array(
 					self::get_rules_for_countries( array( 'US' ) ),
+					(object) array(
+						'type' => 'not',
+						'operand' => array(
+							(object) array(
+								'type'    => 'plugins_activated',
+								'plugins' => array( 'woocommerce-shipping' ),
+							),
+						),
+					),
+					(object) array(
+						'type' => 'not',
+						'operand' => array(
+							(object) array(
+								'type'    => 'plugins_activated',
+								'plugins' => array( 'woocommerce-tax' ),
+							),
+						),
+					),
 				),
 				'available_layouts' => array( 'column' ),
 			),

--- a/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
+++ b/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
@@ -286,7 +286,7 @@ class DefaultShippingPartners {
 				'is_visible'        => array(
 					self::get_rules_for_countries( array( 'US' ) ),
 					(object) array(
-						'type' => 'not',
+						'type'    => 'not',
 						'operand' => array(
 							(object) array(
 								'type'    => 'plugins_activated',
@@ -295,7 +295,7 @@ class DefaultShippingPartners {
 						),
 					),
 					(object) array(
-						'type' => 'not',
+						'type'    => 'not',
 						'operand' => array(
 							(object) array(
 								'type'    => 'plugins_activated',

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -414,6 +414,24 @@ class DefaultFreeExtensions {
 						),
 					),
 					array(
+						'type'    => 'not',
+						'operand' => array(
+							array(
+								'type'    => 'plugins_activated',
+								'plugins' => array( 'woocommerce-shipping' ),
+							),
+						),
+					),
+					array(
+						'type'    => 'not',
+						'operand' => array(
+							array(
+								'type'    => 'plugins_activated',
+								'plugins' => array( 'woocommerce-tax' ),
+							),
+						),
+					),
+					array(
 						'type'     => 'or',
 						'operands' => array(
 							array(
@@ -468,63 +486,13 @@ class DefaultFreeExtensions {
 					'</a>'
 				),
 				'is_visible'     => array(
+					self::get_rules_for_wcservices_tax_countries(),
 					array(
-						'type'     => 'or',
-						'operands' => array(
+						'type'    => 'not',
+						'operand' => array(
 							array(
-								'type'      => 'base_location_country',
-								'value'     => 'US',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'FR',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'GB',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'DE',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'CA',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'AU',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'GR',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'BE',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'PT',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'DK',
-								'operation' => '=',
-							),
-							array(
-								'type'      => 'base_location_country',
-								'value'     => 'SE',
-								'operation' => '=',
+								'type'    => 'plugins_activated',
+								'plugins' => array( 'woocommerce-services' ),
 							),
 						),
 					),
@@ -533,7 +501,16 @@ class DefaultFreeExtensions {
 						'operand' => array(
 							array(
 								'type'    => 'plugins_activated',
-								'plugins' => array( 'woocommerce-services' ),
+								'plugins' => array( 'woocommerce-shipping' ),
+							),
+						),
+					),
+					array(
+						'type'    => 'not',
+						'operand' => array(
+							array(
+								'type'    => 'plugins_activated',
+								'plugins' => array( 'woocommerce-tax' ),
 							),
 						),
 					),
@@ -900,12 +877,56 @@ class DefaultFreeExtensions {
 			),
 		);
 
-		// Copy shipping for the core-profiler and remove is_visible conditions, except for the country restriction.
+		/*
+		 * Overwrite the is_visible conditions to just the country restriction
+		 * and the requirement for WooCommerce Shipping and WooCommerce Tax
+		 * to not be active.
+		 */
 		$_plugins['woocommerce-services:shipping']['is_visible'] = array(
 			array(
 				'type'      => 'base_location_country',
 				'value'     => 'US',
 				'operation' => '=',
+			),
+			array(
+				'type'    => 'not',
+				'operand' => array(
+					array(
+						'type'    => 'plugins_activated',
+						'plugins' => array( 'woocommerce-shipping' ),
+					),
+				),
+			),
+			array(
+				'type'    => 'not',
+				'operand' => array(
+					array(
+						'type'    => 'plugins_activated',
+						'plugins' => array( 'woocommerce-tax' ),
+					),
+				),
+			),
+		);
+
+		$_plugins['woocommerce-services:tax']['is_visible'] = array(
+			self::get_rules_for_wcservices_tax_countries(),
+			array(
+				'type'    => 'not',
+				'operand' => array(
+					array(
+						'type'    => 'plugins_activated',
+						'plugins' => array( 'woocommerce-shipping' ),
+					),
+				),
+			),
+			array(
+				'type'    => 'not',
+				'operand' => array(
+					array(
+						'type'    => 'plugins_activated',
+						'plugins' => array( 'woocommerce-tax' ),
+					),
+				),
 			),
 		);
 
@@ -934,12 +955,105 @@ class DefaultFreeExtensions {
 		foreach ( $plugins as &$plugin ) {
 			if ( isset( $_plugins[ $plugin['key'] ] ) ) {
 				$plugin = array_merge( $plugin, $_plugins[ $plugin['key'] ] );
-				if ( isset( $plugin['is_visible'] ) && is_array( $plugin['is_visible'] ) ) {
+				/*
+				 * Removes the "not plugins_activated" rules from the "is_visible"
+				 * ruleset except for the WooCommerce Services plugin.
+				 *
+				 * WC Services is a plugin that provides shipping and tax features.
+				 * WC Services is sometimes labelled as "WooCommerce Shipping" or
+				 * "WooCommerce Tax", depending on which functionality of the plugin
+				 * is advertised.
+				 *
+				 * We have two new upcoming, standalone plugins: "WooCommerce Shipping" and
+				 * "WooCommerce Tax" (same names as sometimes used for WC Services).
+				 * The new plugins are incompatible with the old WC Services plugin.
+				 * In order to prevent merchants from running into this plugin conflict,
+				 * we want to keep the "not plugins_activated" rules for recommending
+				 * WC Services.
+				 *
+				 * If WC Services and the new plugins are installed together,
+				 * a notice is displayed and the plugin functionality is not registered
+				 * by either WC Services or WC Shipping and WC Tax.
+				 */
+				if (
+					isset( $plugin['is_visible'] ) &&
+					is_array( $plugin['is_visible'] ) &&
+					! in_array( $plugin['key'], [ 'woocommerce-services:shipping', 'woocommerce-services:tax' ], true )
+				) {
 					$plugin['is_visible'] = $remove_plugins_activated_rule( $plugin['is_visible'] );
 				}
 			}
 		}
 
 		return $plugins;
+	}
+
+	/**
+	 * Returns the country restrictions for use in the `is_visible` key for
+	 * recommending the tax functionality of WooCommerce Shipping & Tax.
+	 *
+	 * @return array
+	 */
+	private static function get_rules_for_wcservices_tax_countries() {
+		return array(
+			'type'     => 'or',
+			'operands' => array(
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'US',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'FR',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'GB',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'DE',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'CA',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'AU',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'GR',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'BE',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'PT',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'DK',
+					'operation' => '=',
+				),
+				array(
+					'type'      => 'base_location_country',
+					'value'     => 'SE',
+					'operation' => '=',
+				),
+			),
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -955,6 +955,7 @@ class DefaultFreeExtensions {
 		foreach ( $plugins as &$plugin ) {
 			if ( isset( $_plugins[ $plugin['key'] ] ) ) {
 				$plugin = array_merge( $plugin, $_plugins[ $plugin['key'] ] );
+
 				/*
 				 * Removes the "not plugins_activated" rules from the "is_visible"
 				 * ruleset except for the WooCommerce Services plugin.
@@ -978,7 +979,7 @@ class DefaultFreeExtensions {
 				if (
 					isset( $plugin['is_visible'] ) &&
 					is_array( $plugin['is_visible'] ) &&
-					! in_array( $plugin['key'], [ 'woocommerce-services:shipping', 'woocommerce-services:tax' ], true )
+					! in_array( $plugin['key'], array( 'woocommerce-services:shipping', 'woocommerce-services:tax' ), true )
 				) {
 					$plugin['is_visible'] = $remove_plugins_activated_rule( $plugin['is_visible'] );
 				}

--- a/plugins/woocommerce/tests/php/src/Admin/ShippingPartnerSuggestions/DefaultShippingPartnersTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ShippingPartnerSuggestions/DefaultShippingPartnersTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Admin\Features\ShippingPartnerSuggestions;
+
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\EvaluateSuggestion;
+use Automattic\WooCommerce\Admin\Features\ShippingPartnerSuggestions\DefaultShippingPartners;
+use WC_Unit_Test_Case;
+
+class DefaultShippingPartnersTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+		/*
+		 * Required for the BaseLocationCountryRuleProcessor
+		 * to not return false for "US:CA" country-state combo.
+		 */
+		update_option( 'woocommerce_store_address', 'foo' );
+
+		update_option( 'active_plugins', array( 'foo/foo.php' ) );
+	}
+
+	public function test_it_evaluates_with_no_errors() {
+		$specs = DefaultShippingPartners::get_all();
+		$results = EvaluateSuggestion::evaluate_specs( $specs );
+
+		$this->assertCount( 0, $results['errors'] );
+	}
+
+	public function test_wcservices_is_present() {
+		$specs = DefaultShippingPartners::get_all();
+		$results = EvaluateSuggestion::evaluate_specs( $specs );
+
+		$this->assertCount( 0, $results['errors'] );
+		$this->assertCount( 1, $results['suggestions'] );
+		$this->assertEquals( 'woocommerce-services', $results['suggestions'][0]->id );
+	}
+
+	public function test_wcservices_is_absent_if_in_an_unsupported_country() {
+		update_option( 'woocommerce_default_country', 'FOO' );
+
+		$specs = DefaultShippingPartners::get_all();
+		$results = EvaluateSuggestion::evaluate_specs( $specs );
+
+		$this->assertCount( 0, $results['errors'] );
+		$this->assertCount( 0, $results['suggestions'] );
+	}
+
+	public function test_no_extensions_are_recommended_if_woocommerce_shipping_is_active() {
+		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php' ) );
+
+		$specs = DefaultShippingPartners::get_all();
+		$results = EvaluateSuggestion::evaluate_specs( $specs );
+
+		$this->assertCount( 0, $results['errors'] );
+		$this->assertCount( 0, $results['suggestions'] );
+	}
+
+	public function test_no_extensions_are_recommended_if_woocommerce_tax_is_active() {
+		update_option( 'active_plugins', array( 'woocommerce-tax/woocommerce-tax.php' ) );
+
+		$specs = DefaultShippingPartners::get_all();
+		$results = EvaluateSuggestion::evaluate_specs( $specs );
+
+		$this->assertCount( 0, $results['errors'] );
+		$this->assertCount( 0, $results['suggestions'] );
+	}
+
+	public function test_no_extensions_are_recommended_if_both_woocommerce_shipping_and_woocommerce_tax_are_active() {
+		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php', 'woocommerce-tax/woocommerce-tax.php' ) );
+
+		$specs = DefaultShippingPartners::get_all();
+		$results = EvaluateSuggestion::evaluate_specs( $specs );
+
+		$this->assertCount( 0, $results['errors'] );
+		$this->assertCount( 0, $results['suggestions'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/ShippingPartnerSuggestions/DefaultShippingPartnersTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ShippingPartnerSuggestions/DefaultShippingPartnersTest.php
@@ -6,10 +6,17 @@ use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\EvaluateSugg
 use Automattic\WooCommerce\Admin\Features\ShippingPartnerSuggestions\DefaultShippingPartners;
 use WC_Unit_Test_Case;
 
+/**
+ * DefaultShippingPartners test.
+ *
+ * @class DefaultShippingPartnersTest
+ */
 class DefaultShippingPartnersTest extends WC_Unit_Test_Case {
 
 	/**
-	 * Set up.
+	 * Set things up before each test case.
+	 *
+	 * @return void
 	 */
 	public function setUp(): void {
 		parent::setUp();
@@ -25,15 +32,25 @@ class DefaultShippingPartnersTest extends WC_Unit_Test_Case {
 		update_option( 'active_plugins', array( 'foo/foo.php' ) );
 	}
 
+	/**
+	 * Tests if in a default situation there are no errors.
+	 *
+	 * @return void
+	 */
 	public function test_it_evaluates_with_no_errors() {
-		$specs = DefaultShippingPartners::get_all();
+		$specs   = DefaultShippingPartners::get_all();
 		$results = EvaluateSuggestion::evaluate_specs( $specs );
 
 		$this->assertCount( 0, $results['errors'] );
 	}
 
+	/**
+	 * Tests if WCS&T is present by default.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_present() {
-		$specs = DefaultShippingPartners::get_all();
+		$specs   = DefaultShippingPartners::get_all();
 		$results = EvaluateSuggestion::evaluate_specs( $specs );
 
 		$this->assertCount( 0, $results['errors'] );
@@ -41,40 +58,60 @@ class DefaultShippingPartnersTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 'woocommerce-services', $results['suggestions'][0]->id );
 	}
 
+	/**
+	 * Asserts WCS&T is not recommended in unsupported countries.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_absent_if_in_an_unsupported_country() {
 		update_option( 'woocommerce_default_country', 'FOO' );
 
-		$specs = DefaultShippingPartners::get_all();
+		$specs   = DefaultShippingPartners::get_all();
 		$results = EvaluateSuggestion::evaluate_specs( $specs );
 
 		$this->assertCount( 0, $results['errors'] );
 		$this->assertCount( 0, $results['suggestions'] );
 	}
 
+	/**
+	 * Asserts no extensions are recommended if WooCommerce Shipping is active.
+	 *
+	 * @return void
+	 */
 	public function test_no_extensions_are_recommended_if_woocommerce_shipping_is_active() {
 		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php' ) );
 
-		$specs = DefaultShippingPartners::get_all();
+		$specs   = DefaultShippingPartners::get_all();
 		$results = EvaluateSuggestion::evaluate_specs( $specs );
 
 		$this->assertCount( 0, $results['errors'] );
 		$this->assertCount( 0, $results['suggestions'] );
 	}
 
+	/**
+	 * Asserts no extensions are recommended if WooCommerce Tax is active.
+	 *
+	 * @return void
+	 */
 	public function test_no_extensions_are_recommended_if_woocommerce_tax_is_active() {
 		update_option( 'active_plugins', array( 'woocommerce-tax/woocommerce-tax.php' ) );
 
-		$specs = DefaultShippingPartners::get_all();
+		$specs   = DefaultShippingPartners::get_all();
 		$results = EvaluateSuggestion::evaluate_specs( $specs );
 
 		$this->assertCount( 0, $results['errors'] );
 		$this->assertCount( 0, $results['suggestions'] );
 	}
 
+	/**
+	 * Asserts no extensions are recommended if both WooCommerce Shipping and WooCommerce Tax are active.
+	 *
+	 * @return void
+	 */
 	public function test_no_extensions_are_recommended_if_both_woocommerce_shipping_and_woocommerce_tax_are_active() {
 		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php', 'woocommerce-tax/woocommerce-tax.php' ) );
 
-		$specs = DefaultShippingPartners::get_all();
+		$specs   = DefaultShippingPartners::get_all();
 		$results = EvaluateSuggestion::evaluate_specs( $specs );
 
 		$this->assertCount( 0, $results['errors'] );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
@@ -6,8 +6,20 @@ use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\DefaultFreeExtens
 use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\EvaluateExtension;
 use WC_Unit_Test_Case;
 
+/**
+ * DefaultFreeExtensions test.
+ *
+ * @class DefaultFreeExtensionsTest
+ */
 class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 
+	/**
+	 * Mock of bundles of extensions to recommend.
+	 *
+	 * We will test the `is_visible` conditions on the plugins themselves.
+	 *
+	 * @var array
+	 */
 	private $bundles_mock;
 
 	/**
@@ -38,6 +50,11 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Tests the default behavior of recommending WCS&T twice - as a shipping solution and a tax solution.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_recommended_as_both_shipping_and_tax() {
 		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $this->bundles_mock );
 
@@ -46,6 +63,11 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertContains( 'woocommerce-services:tax', $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts WCS&T is not recommended in unsupported countries.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_not_recommended_if_in_an_unsupported_country() {
 		update_option( 'woocommerce_default_country', 'FOO' );
 
@@ -54,6 +76,11 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts WCS&T is not recommended if WooCommerce Shipping is active.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_not_recommended_if_woocommerce_shipping_is_active() {
 		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php' ) );
 
@@ -62,6 +89,11 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts WCS&T is not recommended if WooCommerce Tax is active.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_not_recommended_if_woocommerce_tax_is_active() {
 		update_option( 'active_plugins', array( 'woocommerce-tax/woocommerce-tax.php' ) );
 
@@ -70,6 +102,11 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts WCS&T is not recommended if WooCommerce Shipping and WooCommerce Tax are both active.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_not_recommended_if_both_woocommerce_shipping_and_woocommerce_tax_are_active() {
 		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php', 'woocommerce-tax/woocommerce-tax.php' ) );
 
@@ -78,6 +115,11 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts WCS&T is not recommended if it is already active.
+	 *
+	 * @return void
+	 */
 	public function test_wcservices_is_not_recommended_if_it_is_already_active() {
 		update_option( 'active_plugins', array( 'woocommerce-services/woocommerce-services.php' ) );
 
@@ -86,10 +128,15 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts that in the core profiler, WCS&T is displayed as a shipping solution and a tax solution even if active.
+	 *
+	 * @return void
+	 */
 	public function test_core_profiler_recommends_wcservices_as_shipping_and_tax_even_if_already_active() {
 		update_option( 'active_plugins', array( 'woocommerce-services/woocommerce-services.php' ) );
 
-		$bundles_with_core_profiler_fields_mock = $this->bundles_mock;
+		$bundles_with_core_profiler_fields_mock               = $this->bundles_mock;
 		$bundles_with_core_profiler_fields_mock[0]['plugins'] = DefaultFreeExtensions::with_core_profiler_fields( $this->bundles_mock[0]['plugins'] );
 
 		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $bundles_with_core_profiler_fields_mock );
@@ -97,10 +144,15 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 2, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts that in the core profiler, WCS&T is not displayed if WooCommerce Shipping is active.
+	 *
+	 * @return void
+	 */
 	public function test_core_profiler_does_not_recommend_wcservices_at_all_if_woocommerce_shipping_is_active() {
 		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php' ) );
 
-		$bundles_with_core_profiler_fields_mock = $this->bundles_mock;
+		$bundles_with_core_profiler_fields_mock               = $this->bundles_mock;
 		$bundles_with_core_profiler_fields_mock[0]['plugins'] = DefaultFreeExtensions::with_core_profiler_fields( $this->bundles_mock[0]['plugins'] );
 
 		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $bundles_with_core_profiler_fields_mock );
@@ -108,10 +160,15 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Asserts that in the core profiler, WCS&T is not displayed if WooCommerce Tax is active.
+	 *
+	 * @return void
+	 */
 	public function test_core_profiler_does_not_recommend_wcservices_at_all_if_woocommerce_tax_is_active() {
 		update_option( 'active_plugins', array( 'woocommerce-tax/woocommerce-tax.php' ) );
 
-		$bundles_with_core_profiler_fields_mock = $this->bundles_mock;
+		$bundles_with_core_profiler_fields_mock               = $this->bundles_mock;
 		$bundles_with_core_profiler_fields_mock[0]['plugins'] = DefaultFreeExtensions::with_core_profiler_fields( $this->bundles_mock[0]['plugins'] );
 
 		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $bundles_with_core_profiler_fields_mock );
@@ -119,12 +176,20 @@ class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $recommended_plugin_slugs );
 	}
 
+	/**
+	 * Evaluates bundles passed as argument and extracts keys of recommended plugins.
+	 *
+	 * @param array $bundles Array of bundles to evaluate.
+	 *
+	 * @return array
+	 */
 	private function get_recommended_plugin_slugs( $bundles ) {
 		/*
 		 * The json_decode( json_encode() ) call is a trick that
 		 * DefaultFreeExtensions::get_all uses to convert the entire
 		 * associative array into an object.
 		 */
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- We're duplicating what the tested class does.
 		$bundles = json_decode( json_encode( $bundles ) );
 		$results = EvaluateExtension::evaluate_bundles( $bundles );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensionsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\RemoteFreeExtensions;
+
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\DefaultFreeExtensions;
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\EvaluateExtension;
+use WC_Unit_Test_Case;
+
+class DefaultFreeExtensionsTest extends WC_Unit_Test_Case {
+
+	private $bundles_mock;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+		/*
+		 * Required for the BaseLocationCountryRuleProcessor
+		 * to not return false for "US:CA" country-state combo.
+		 */
+		update_option( 'woocommerce_store_address', 'foo' );
+
+		update_option( 'active_plugins', array( 'foo/foo.php' ) );
+
+		$this->bundles_mock = array(
+			array(
+				'key'     => 'foo',
+				'title'   => 'Test bundle',
+				'plugins' => array(
+					DefaultFreeExtensions::get_plugin( 'woocommerce-services:shipping' ),
+					DefaultFreeExtensions::get_plugin( 'woocommerce-services:tax' ),
+				),
+			),
+		);
+	}
+
+	public function test_wcservices_is_recommended_as_both_shipping_and_tax() {
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $this->bundles_mock );
+
+		$this->assertCount( 2, $recommended_plugin_slugs );
+		$this->assertContains( 'woocommerce-services:shipping', $recommended_plugin_slugs );
+		$this->assertContains( 'woocommerce-services:tax', $recommended_plugin_slugs );
+	}
+
+	public function test_wcservices_is_not_recommended_if_in_an_unsupported_country() {
+		update_option( 'woocommerce_default_country', 'FOO' );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $this->bundles_mock );
+
+		$this->assertCount( 0, $recommended_plugin_slugs );
+	}
+
+	public function test_wcservices_is_not_recommended_if_woocommerce_shipping_is_active() {
+		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php' ) );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $this->bundles_mock );
+
+		$this->assertCount( 0, $recommended_plugin_slugs );
+	}
+
+	public function test_wcservices_is_not_recommended_if_woocommerce_tax_is_active() {
+		update_option( 'active_plugins', array( 'woocommerce-tax/woocommerce-tax.php' ) );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $this->bundles_mock );
+
+		$this->assertCount( 0, $recommended_plugin_slugs );
+	}
+
+	public function test_wcservices_is_not_recommended_if_both_woocommerce_shipping_and_woocommerce_tax_are_active() {
+		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php', 'woocommerce-tax/woocommerce-tax.php' ) );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $this->bundles_mock );
+
+		$this->assertCount( 0, $recommended_plugin_slugs );
+	}
+
+	public function test_wcservices_is_not_recommended_if_it_is_already_active() {
+		update_option( 'active_plugins', array( 'woocommerce-services/woocommerce-services.php' ) );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $this->bundles_mock );
+
+		$this->assertCount( 0, $recommended_plugin_slugs );
+	}
+
+	public function test_core_profiler_recommends_wcservices_as_shipping_and_tax_even_if_already_active() {
+		update_option( 'active_plugins', array( 'woocommerce-services/woocommerce-services.php' ) );
+
+		$bundles_with_core_profiler_fields_mock = $this->bundles_mock;
+		$bundles_with_core_profiler_fields_mock[0]['plugins'] = DefaultFreeExtensions::with_core_profiler_fields( $this->bundles_mock[0]['plugins'] );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $bundles_with_core_profiler_fields_mock );
+
+		$this->assertCount( 2, $recommended_plugin_slugs );
+	}
+
+	public function test_core_profiler_does_not_recommend_wcservices_at_all_if_woocommerce_shipping_is_active() {
+		update_option( 'active_plugins', array( 'woocommerce-shipping/woocommerce-shipping.php' ) );
+
+		$bundles_with_core_profiler_fields_mock = $this->bundles_mock;
+		$bundles_with_core_profiler_fields_mock[0]['plugins'] = DefaultFreeExtensions::with_core_profiler_fields( $this->bundles_mock[0]['plugins'] );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $bundles_with_core_profiler_fields_mock );
+
+		$this->assertCount( 0, $recommended_plugin_slugs );
+	}
+
+	public function test_core_profiler_does_not_recommend_wcservices_at_all_if_woocommerce_tax_is_active() {
+		update_option( 'active_plugins', array( 'woocommerce-tax/woocommerce-tax.php' ) );
+
+		$bundles_with_core_profiler_fields_mock = $this->bundles_mock;
+		$bundles_with_core_profiler_fields_mock[0]['plugins'] = DefaultFreeExtensions::with_core_profiler_fields( $this->bundles_mock[0]['plugins'] );
+
+		$recommended_plugin_slugs = $this->get_recommended_plugin_slugs( $bundles_with_core_profiler_fields_mock );
+
+		$this->assertCount( 0, $recommended_plugin_slugs );
+	}
+
+	private function get_recommended_plugin_slugs( $bundles ) {
+		/*
+		 * The json_decode( json_encode() ) call is a trick that
+		 * DefaultFreeExtensions::get_all uses to convert the entire
+		 * associative array into an object.
+		 */
+		$bundles = json_decode( json_encode( $bundles ) );
+		$results = EvaluateExtension::evaluate_bundles( $bundles );
+
+		return array_map(
+			function ( $plugin ) {
+				return $plugin->key;
+			},
+			$results['bundles'][0]['plugins']
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce-shipping/issues/187.

Background: In Automattic/woocommerce.com#20789, we've updated the "onboarding wizard free extensions" and "shipping partner suggestions" API endpoints. These endpoints are accessed by WC Core to get the most up-to-date info on extension bundles and shipping products to recommend based on a store setup.

When this connection is for some reason unavailable, WooCommerce will instead use a set of local defaults. This is what this PR here updates.

The PR changes the when the "WooCommerce Shipping & Tax" extension is recommended. The change is to **not** suggest WCS&T if either of the following upcoming plugins are present:

- "WooCommerce Shipping", or
- "WooCommerce Tax".

**Caveat:**

An important thing to note is that items presented as "WooCommerce Shipping" or "WooCommerce Tax" are powered by WCS&T, just displayed under a feature-specific name.

This is also true when we recommend "WooCommerce Shipping" and "WooCommerce Tax" in the core profiler - both are actually WCS&T, just highlight its different features.

The test instructions are largely copied from Automattic/woocommerce.com#20789 as it's the same results that should be achieved by both PRs.

#### What is the "onboarding wizard free extensions" endpoint

This endpoint governs the list of extensions displayed in the core profiler (= the WC onboarding wizard; it uses the `obw/core-profiler` bundle) and its older, legacy sibling, the WC profile wizard (the `obw/basics` and `obw/grow` bundles).

#### What is the "shipping partner suggestions" endpoint

It governs what extensions to recommend in the "Select your shipping options" WC Home page task.

### Changes in this PR

- **In the core profiler (and the legacy profile wizard):**
  - Don't recommend WCS&T (branded as "WooCommerce Shipping") if the WC Shipping plugin or the WC Tax plugin is active.
  - Don't recommend WCS&T (branded as "WooCommerce Tax") if the WC Shipping plugin or the WC Tax plugin is active.
  - Tweak the rule overwriting logic so that the above rules aren't removed.
- **In the "Select your shipping options" task:**
  - Don't recommend WCS&T if the WC Shipping plugin or the WC Tax plugin is active.
- Tests for the above changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Clone this repo, check out this PR's branch, and build WooCommerce. [The official instructions are in the repo README file](https://github.com/woocommerce/woocommerce?tab=readme-ov-file#getting-started) but here's a shortcut:
   ```
   nvm use && pnpm i -g pnpm@9.1.0 && pnpm i && pnpm run build
   ```
2. In your local test site's `wp-content/plugins`, link the WooCommerce plugin you just built.
   Let's assume you checked out the WooCommerce repo to `/home/me/woocommerce`.
   Note how below we aren't creating a link to `/home/me/woocommerce` but rather to a directory within it:
   ```
   ln -s /home/me/woocommerce/plugins/woocommerce /var/www/your-test-site/wp-content/plugins/woocommerce
   ```
3. That's it for building WC Core. Now let's test the suggestions.
4. To test the changes, we have to enforce the default suggestions to apply instead of the API suggestions. We can do this by applying the following patch:
   ```diff
   diff --git a/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/ShippingPartnerSuggestions.php b/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/ShippingPartnerSuggestions.php
   index 19c2893252..854d1a4939 100644
   --- a/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/ShippingPartnerSuggestions.php
   +++ b/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/ShippingPartnerSuggestions.php
   @@ -44,6 +44,7 @@ class ShippingPartnerSuggestions extends RemoteSpecsEngine {
    	 * Get specs or fetch remotely if they don't exist.
    	 */
    	public static function get_specs() {
   +		return DefaultShippingPartners::get_all();
    		if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
    			/**
    			 * It can be used to modify shipping partner suggestions spec.
   diff --git a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
   index 65bc672a3b..f0982bd294 100644
   --- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
   +++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
   @@ -76,6 +76,7 @@ class Init extends RemoteSpecsEngine {
    	 * Get specs or fetch remotely if they don't exist.
    	 */
    	public static function get_specs() {
   +		return DefaultFreeExtensions::get_all();
    		if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
    			return DefaultFreeExtensions::get_all();
    		}
   ```

#### Testing the core profiler

1. In WP admin, click WooCommerce > Home. The core profiler will launch.
   - If it doesn't, or if you need to restart it after completing it, remove the `woocommerce_onboarding_profile` option from `wp_options`.
1. Click "Set up my store", "Continue", Industry "Clothing and accessories", Located in "California", "Continue".
1. **Alright stop. Testing time.** You'll see a list of extensions. It should include WC Shipping and WC Tax (both of which installing WCS&T). That's good.
1. Now **in another tab** open `/wp-admin/plugins.php` and activate WC Shipping/WC Tax/both.
1. Return to the onboarding wizard tab, refresh it and note that WooCommerce Shipping and WooCommerce Tax are no longer presented.
1. Try refreshing the wizard with WC Ship/WC Tax/both/none active.
1. For a final test, install WooCommerce Shipping & Tax from the WPORG plugin directory. You should see this, which is a different design - instead of the WooCommerce Shipping and WooCommerce Tax items extensions being hidden, they remain visible but with an "Installed" label.

##### Screenshots

**With WCShip and WCTax disabled:**

<img width="1004" alt="Screenshot 2024-06-20 at 14 19 48" src="https://github.com/Automattic/woocommerce.com/assets/1759681/57032826-7fa0-4c4a-9235-d795b9567948">

**With WCShip/WCTax/both enabled:**

<img width="1012" alt="Screenshot 2024-06-20 at 14 19 38" src="https://github.com/Automattic/woocommerce.com/assets/1759681/913ad0a0-690f-4c56-8090-e289f26009ee">

**With WCS&T enabled:**

<img width="1016" alt="Screenshot 2024-06-20 at 14 19 25" src="https://github.com/Automattic/woocommerce.com/assets/1759681/a556b671-0d62-4b0a-9708-871d57c2a525">

---

#### Testing the setup wizard

1. Add this code to your site:
   ```php
   add_filter( 'woocommerce_admin_features', function ( $features ) {
   	return array_filter( $features, function ( $item ) {
   		return 'core-profiler' !== $item;
   	} );
   }, 1000 );
   ```
   This will disable the core profiler (the newer onboarding wizard) so the setup wizard (the older onboarding wizard) will launch.
1. Remove the onboarding profile option from the DB: remove the `woocommerce_onboarding_profile` option from `wp_options`.
1. In WP admin, click WooCommerce > Home.
1. Store details: US California, `60 29th Street #343`, 94110, San Francisco, your email. Click "Continue".
1. Click "Fashion, apparel, and accessories", then "Continue".
   - If this step doesn't work, make sure you have removed the `woocommerce_onboarding_profile` option from the DB and refreshed the page.
1. Click "Physical products" and "Continue".
1. Click "I don't have any products yet" and "No" to "Currently selling elsewhere?". Click "Continue".
1. OK now we're cooking! Expand that list. You should see WooCommerce Shipping and WooCommerce Tax.
1. Now **in another tab** open `/wp-admin/plugins.php` and activate WC Shipping/WC Tax/WCS&T/all of them.
1. Return to the setup wizard tab, refresh it and note that WooCommerce Shipping and WooCommerce Tax are no longer presented.
1. Try refreshing the wizard with WC Ship/WC Tax/WCS&T/all of them/none of them active.
   - The behavior here is a bit different from the core profiler. With WCS&T active, the core profiler would still present Shipping and Tax but with an "Installed" label. The setup wizard we're testing here hides the items instead.

##### Screenshots

**With WCShip, WCTax, and WCS&T disabled:**

<img width="528" alt="Screenshot 2024-06-20 at 14 37 31" src="https://github.com/Automattic/woocommerce.com/assets/1759681/6bc7d4eb-64b4-4637-b0f0-6d98a0bc7fb7">

**With WCShip/WCTax/WCS&T enabled:**

<img width="522" alt="Screenshot 2024-06-20 at 14 37 11" src="https://github.com/Automattic/woocommerce.com/assets/1759681/db53ce5d-fad3-4cbe-895b-f077f8bfa08e">

---

#### Testing the "Select your shipping options" task

1. We have to force the task to appear. To do so, open `/wp-content/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php` and add this line at the top of the `can_view()` method:
   ```php
   public function can_view() {
		return true;
   ```
1. Go to WC Home and see the "Select your shipping options" task. Click it.
   - If you already have shipping zones, the task will be crossed out and upon clicking, you'll land at the shipping zones settings instead of where we want to land. Remove all shipping zones and return to WC Home to find the task no longer marked as completed.
1. You should see this screen:
   <img width="714" alt="Screenshot 2024-06-20 at 16 01 09" src="https://github.com/Automattic/woocommerce.com/assets/1759681/a14baf7b-cea8-427b-9aed-408b5a2f1712">
   Click "Save shipping options".
1. You should now see a recommendation for WCS&T:
   <img width="708" alt="Screenshot 2024-06-20 at 16 01 46" src="https://github.com/Automattic/woocommerce.com/assets/1759681/16ed951a-a2a1-4ac1-b78a-c7dfbfc65409">
1. Now **in another tab** open `/wp-admin/plugins.php` and activate WC Shipping/WC Tax/both of them (having WCS&T active doesn't affect this task).
1. Return to the shipping task tab, refresh it and note that WooCommerce Shipping & Tax is no longer presented.

##### Screenshots

**With neither WCShip nor WCTax enabled:**

<img width="705" alt="Screenshot 2024-06-20 at 16 16 56" src="https://github.com/Automattic/woocommerce.com/assets/1759681/3c8e3657-342f-4e98-8247-fb7c8f2cd6b8">

**With WCShip/WCTax enabled:**

<img width="704" alt="Screenshot 2024-06-20 at 16 17 40" src="https://github.com/Automattic/woocommerce.com/assets/1759681/6a8d71b9-faf4-4e40-a341-17996a0f4de4">

(This last "Connect your store" step actually shouldn't be displayed too; this PR fixes it: https://github.com/woocommerce/woocommerce/pull/48875)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't recommend WooCommerce Shipping & Tax in the onboarding wizards and the "Select your shipping options" task.

Allowing WCS&T to be installed alongside WC Shipping or WC Tax would lead to a notice about incompatibility which is something this PR aims to avoid.

</details>
