### PR TITLE
PluginUtil: Add method to get active valid plugins

### DIFF
--- a/plugins/woocommerce/changelog/fix-48132-system-status-plugin-caching
+++ b/plugins/woocommerce/changelog/fix-48132-system-status-plugin-caching
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Ensure that active plugins shown in the System Status api endpoint actually exist

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchro
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper as WCConnectionHelper;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
-use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Utilities\{ OrderUtil, PluginUtil };
 use Automattic\WooCommerce\Internal\Utilities\PluginInstaller;
 
 defined( 'ABSPATH' ) || exit;
@@ -1263,7 +1263,8 @@ class WC_Install {
 				return;
 			}
 
-			if ( in_array( $legacy_api_plugin, wp_get_active_and_valid_plugins(), true ) ) {
+			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_active_and_valid_plugins();
+			if ( in_array( $legacy_api_plugin, $active_valid_plugins, true ) ) {
 				return;
 			}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1263,7 +1263,7 @@ class WC_Install {
 				return;
 			}
 
-			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_active_and_valid_plugins();
+			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_all_active_valid_plugins();
 			if ( in_array( $legacy_api_plugin, $active_valid_plugins, true ) ) {
 				return;
 			}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
-use Automattic\WooCommerce\Utilities\{ LoggingUtil, OrderUtil };
+use Automattic\WooCommerce\Utilities\{ LoggingUtil, OrderUtil, PluginUtil };
 
 /**
  * System status controller class.
@@ -1044,16 +1044,11 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				return array();
 			}
 
-			$active_plugins = (array) get_option( 'active_plugins', array() );
-			if ( is_multisite() ) {
-				$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
-				$active_plugins            = array_merge( $active_plugins, $network_activated_plugins );
-			}
+			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_active_and_valid_plugins();
+			$active_plugins_data  = array();
 
-			$active_plugins_data = array();
-
-			foreach ( $active_plugins as $plugin ) {
-				$data                  = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
+			foreach ( $active_valid_plugins as $plugin ) {
+				$data                  = get_plugin_data( $plugin );
 				$active_plugins_data[] = $this->format_plugin_data( $plugin, $data );
 			}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -1044,7 +1044,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				return array();
 			}
 
-			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_active_and_valid_plugins();
+			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_all_active_valid_plugins();
 			$active_plugins_data  = array();
 
 			foreach ( $active_valid_plugins as $plugin ) {

--- a/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
@@ -206,7 +206,7 @@ class PluginInstaller implements RegisterHooksInterface {
 	 * @return bool True if WooCommerce is installed and active in the current blog, false otherwise.
 	 */
 	private static function woocommerce_is_active_in_current_site(): bool {
-		$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_active_and_valid_plugins();
+		$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_all_active_valid_plugins();
 
 		return ! empty(
 			array_filter(

--- a/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\Internal\Utilities;
 
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
-use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Utilities\{ PluginUtil, StringUtil };
 
 /**
  * This class allows installing a plugin programmatically.
@@ -206,7 +206,14 @@ class PluginInstaller implements RegisterHooksInterface {
 	 * @return bool True if WooCommerce is installed and active in the current blog, false otherwise.
 	 */
 	private static function woocommerce_is_active_in_current_site(): bool {
-		return ! empty( array_filter( wp_get_active_and_valid_plugins(), fn( $plugin ) => substr_compare( $plugin, '/woocommerce.php', -strlen( '/woocommerce.php' ) ) === 0 ) );
+		$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_active_and_valid_plugins();
+
+		return ! empty(
+			array_filter(
+				$active_valid_plugins,
+				fn( $plugin ) => substr_compare( $plugin, '/woocommerce.php', -strlen( '/woocommerce.php' ) ) === 0
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -68,6 +68,23 @@ class PluginUtil {
 	}
 
 	/**
+	 * Wrapper for WP's private `wp_get_active_and_valid_plugins` function.
+	 *
+	 * This function is more useful in some cases compared to just using get_option( 'active_plugins' )
+	 * because it also validates that the plugin files actually exist. We're wrapping it here rather than
+	 * using the function directly because it's marked as "@access private", so if it changes in a
+	 * backward-incompatible way, we can update our method here to preserve the functionality.
+	 *
+	 * Note that the doc block for the WP function says it returns "Array of paths to plugin files relative
+	 * to the plugins directory", but it actually returns absolute paths.
+	 *
+	 * @return string[] Array of absolute paths to plugin files.
+	 */
+	public function get_active_and_valid_plugins() {
+		return wp_get_active_and_valid_plugins();
+	}
+
+	/**
 	 * Get a list with the names of the WordPress plugins that are WooCommerce aware
 	 * (they have a "WC tested up to" header).
 	 *

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -33,6 +33,43 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox `get_active_and_valid_plugins` gets the active plugins *that actually exist* and returns them
+	 *          as a list of absolute file paths.
+	 *
+	 * The tested function is just a wrapper around a core WP function that's marked as "private" so this is
+	 * mostly just to ensure that there haven't been any breaking changes to that function.
+	 */
+	public function test_get_active_and_valid_plugins() {
+		self::touch( WP_PLUGIN_DIR . '/test1/test1.php' );
+		self::touch( WP_PLUGIN_DIR . '/test2/test2_x.php' );
+
+		$orig_active_plugins = get_option( 'active_plugins' );
+
+		update_option(
+			'active_plugins',
+			array(
+				'test1/test1.php',
+				'test2/test2.php',
+			)
+		);
+
+		$active_valid_plugins = $this->sut->get_active_and_valid_plugins();
+		$this->assertCount( 1, $active_valid_plugins );
+		$this->assertContains( WP_PLUGIN_DIR . '/test1/test1.php', $active_valid_plugins );
+
+		if ( false === $orig_active_plugins ) {
+			delete_option( 'active_plugins' );
+		} else {
+			update_option( 'active_plugins', $orig_active_plugins );
+		}
+
+		$this->rmdir( WP_PLUGIN_DIR . '/test1' );
+		$this->rmdir( WP_PLUGIN_DIR . '/test2' );
+		$this->delete_folders( WP_PLUGIN_DIR . '/test1' );
+		$this->delete_folders( WP_PLUGIN_DIR . '/test2' );
+	}
+
+	/**
 	 * @testdox 'get_woocommerce_aware_plugins' properly gets the names of all the existing WooCommerce aware plugins.
 	 */
 	public function test_get_all_woo_aware_plugins() {

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -33,17 +33,19 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox `get_active_and_valid_plugins` gets the active plugins *that actually exist* and returns them
+	 * @testdox `get_all_active_valid_plugins` gets the active plugins *that actually exist* and returns them
 	 *          as a list of absolute file paths.
 	 *
-	 * The tested function is just a wrapper around a core WP function that's marked as "private" so this is
-	 * mostly just to ensure that there haven't been any breaking changes to that function.
+	 * The tested function is just a wrapper around two core WP functions that are marked as "private" so this is
+	 * mostly just to ensure that there haven't been any breaking changes to those functions.
 	 */
-	public function test_get_active_and_valid_plugins() {
+	public function test_get_all_active_valid_plugins() {
 		self::touch( WP_PLUGIN_DIR . '/test1/test1.php' );
 		self::touch( WP_PLUGIN_DIR . '/test2/test2_x.php' );
+		self::touch( WP_PLUGIN_DIR . '/test3/test3.php' );
 
-		$orig_active_plugins = get_option( 'active_plugins' );
+		$orig_local_plugins   = get_option( 'active_plugins' );
+		$orig_network_plugins = get_site_option( 'active_sitewide_plugins' );
 
 		update_option(
 			'active_plugins',
@@ -53,20 +55,40 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 			)
 		);
 
-		$active_valid_plugins = $this->sut->get_active_and_valid_plugins();
-		$this->assertCount( 1, $active_valid_plugins );
+		update_site_option(
+			'active_sitewide_plugins',
+			array( 'test3/test3.php' )
+		);
+
+		$active_valid_plugins = $this->sut->get_all_active_valid_plugins();
+
+		if ( is_multisite() ) {
+			$this->assertCount( 2, $active_valid_plugins );
+			$this->assertContains( WP_PLUGIN_DIR . '/test3/test3.php', $active_valid_plugins );
+		} else {
+			$this->assertCount( 1, $active_valid_plugins );
+		}
+
 		$this->assertContains( WP_PLUGIN_DIR . '/test1/test1.php', $active_valid_plugins );
 
-		if ( false === $orig_active_plugins ) {
+		if ( false === $orig_local_plugins ) {
 			delete_option( 'active_plugins' );
 		} else {
-			update_option( 'active_plugins', $orig_active_plugins );
+			update_option( 'active_plugins', $orig_local_plugins );
+		}
+
+		if ( false === $orig_network_plugins ) {
+			delete_site_option( 'active_sitewide_plugins' );
+		} else {
+			update_site_option( 'active_sitewide_plugins', $orig_network_plugins );
 		}
 
 		$this->rmdir( WP_PLUGIN_DIR . '/test1' );
 		$this->rmdir( WP_PLUGIN_DIR . '/test2' );
+		$this->rmdir( WP_PLUGIN_DIR . '/test3' );
 		$this->delete_folders( WP_PLUGIN_DIR . '/test1' );
 		$this->delete_folders( WP_PLUGIN_DIR . '/test2' );
+		$this->delete_folders( WP_PLUGIN_DIR . '/test3' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When getting a list of active plugins directly from the options table, you can run into an error if you try to then access one of the plugin files if it doesn't actually exist. WP Core has a method that verifies that the files exist before returning the list. But it's marked as a "private" method, which means it could change and break backcompat. That seems very unlikely, though, so we're using the method (it was already in use actually), but putting in some safeguards so we can detect if a backcompat issue arises.

Fixes #48132

### How to test the changes in this Pull Request:

Replicate the issue on trunk:

1. Ensure that `WP_DEBUG` and `WP_DEBUG_LOG` constants are set to true.
1. Have at least two plugins active on your test site.
1. Make a request to `wc/v3/system_status`. Filter the response to view the `active_plugins` property, and note which plugins are shown.
1. Now in the filesystem, remove or rename one of the active plugins (this must be done outside of a WordPress context so that the cached values don't get updated automatically).
1. Clear the transient that stores the current active plugins list for the System Status tool: `wp transient delete --all`
1. Now make another request to `wc/v3/system_status`. There may not be a difference in the list of active plugins. But if you check your WP debug log file, you should see an error message like the following: `PHP Warning:  file_get_contents(/var/www/html/wp-content/plugins/wc-smooth-generator/wc-smooth-generator.php): Failed to open stream: No such file or directory in /var/www/html/wp-includes/functions.php on line 6852`

On this PR branch:

1. Follow the same steps as above. This time, when making the second request to `wc/v3/system_status`, you should only see the active plugins that haven't been renamed/deleted, and there shouldn't be any new PHP warnings in the log file.
2. Try the same thing on a multisite network, with network activated plugins.