### PR TITLE
CYS: fix pattern wrapped twice by group blocks

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/sidebar-pattern-screen.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/sidebar-pattern-screen.tsx
@@ -3,7 +3,7 @@
  */
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { useSelect, useDispatch, select } from '@wordpress/data';
-import { cloneBlock } from '@wordpress/blocks';
+import { BlockInstance, cloneBlock } from '@wordpress/blocks';
 import { close } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
@@ -68,11 +68,13 @@ export const SidebarPatternScreen = ( { category }: { category: string } ) => {
 				select( blockEditorStore )
 			).__experimentalGetParsedPattern( pattern.name );
 
-			const clonedParsedPattern = parsedPattern.blocks.map( cloneBlock );
+			const cloneBlocks = parsedPattern.blocks.map(
+				( blockInstance: BlockInstance ) => cloneBlock( blockInstance )
+			);
 
-			insertBlocks( clonedParsedPattern, insertableIndex );
+			insertBlocks( cloneBlocks, insertableIndex );
 
-			selectBlock( clonedParsedPattern[ 0 ].clientId, -1 );
+			selectBlock( cloneBlocks.blocks[ 0 ].clientId, -1 );
 		},
 		[ insertBlocks, insertableIndex, selectBlock ]
 	);

--- a/plugins/woocommerce/changelog/48712-48711-cys-the-added-patterns-are-wrapped-twice-by-group-blocks
+++ b/plugins/woocommerce/changelog/48712-48711-cys-the-added-patterns-are-wrapped-twice-by-group-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS: fix pattern wrapped twice by group blocks


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48711 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the pattern-toolkit-full-composability on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on Start designing.
8. Click on "Design your Homepage".
9. Click on Intro.
10. Add the third pattern.
11. Ensure that the pattern doesn't look like this image:


![aYeIqB.png](https://github.com/woocommerce/woocommerce/assets/4463174/4d583037-353c-4458-b923-3d419a36a82a)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: fix pattern wrapped twice by group blocks

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>