### PR TITLE
Update revert button text and description

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/templates/revert-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/templates/revert-button/index.tsx
@@ -112,7 +112,7 @@ const RevertClassicTemplateButton = () => {
 									strongText: (
 										<strong>
 											{ template?.record?.title?.rendered
-												? `Classic ${ template.record.title.rendered }`
+												? `${ template.record.title.rendered } (Classic)`
 												: '' }
 										</strong>
 									),

--- a/plugins/woocommerce-blocks/assets/js/templates/revert-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/templates/revert-button/index.tsx
@@ -98,21 +98,22 @@ const RevertClassicTemplateButton = () => {
 							} }
 						>
 							{ __(
-								'Revert to Classic Product Template',
+								'Revert to Classic Template',
 								'woocommerce'
 							) }
 						</Button>
 						<span>
 							{ createInterpolateElement(
 								__(
-									`The <strongText /> template doesn’t allow for reordering or customizing blocks, but might work better with your extensions`,
+									`The <strongText /> template doesn’t allow for reordering or customizing blocks, but might work better with your extensions.`,
 									'woocommerce'
 								),
 								{
 									strongText: (
 										<strong>
-											{ template?.record?.title
-												?.rendered ?? '' }
+											{ template?.record?.title?.rendered
+												? `Classic ${ template.record.title.rendered }`
+												: '' }
 										</strong>
 									),
 								}

--- a/plugins/woocommerce-blocks/assets/js/templates/revert-button/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/templates/revert-button/style.scss
@@ -2,7 +2,10 @@
 	display: flex;
 	flex-direction: column;
 	gap: $gap;
-	justify-content: center;
+
+	button {
+		justify-content: center;
+	}
 
 	span {
 		color: $gray-700;

--- a/plugins/woocommerce-blocks/assets/js/templates/revert-button/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/templates/revert-button/style.scss
@@ -2,6 +2,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: $gap;
+	justify-content: center;
+
 	span {
 		color: $gray-700;
 	}

--- a/plugins/woocommerce/changelog/48717-fix-48695-fix-confusing-messages-prompting-switch-to-classic-templates
+++ b/plugins/woocommerce/changelog/48717-fix-48695-fix-confusing-messages-prompting-switch-to-classic-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix confusing messages prompting switch to classic templates


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I have updated the text of the button from "Revert to Classic Product Template" to "Revert to Classic Template". Also, I have updated the description below the button to include "(Classic)" in then End of the template name. This will help in making the message more clear and consistent for following templates:
- Products by Attribute
- Products by Tag
- Products by Category
- Product Search results
- Product Catalog
- Single Product

For more context, you may check this slack discussion: p1718959820891299-slack-C02FL3X7KR6

Closes #48695 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to "Products by Attribute" template
2. As shown in screenshot below, verify that 
  - The button text is "Revert to Classic Template"  
  - The description is "The [name] (Classic) template doesn’t allow for reordering or customizing blocks, but might work better with your extensions"
    - Here [name] is the name of the template you are currently editing
![image](https://github.com/woocommerce/woocommerce/assets/16707866/4efd674b-fbee-4d28-9964-4c8e8bf4bd65)



3. Verify it for other templates as well
  - Products by Tag
  - Products by Category
  - Product Search results
  - Product Catalog
  - Single Product

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix confusing messages prompting switch to classic templates

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>