### PR TITLE
Product Editor: restore and fix E2E test that creates product variations

### DIFF
--- a/plugins/woocommerce/changelog/udpate-e2e-test-improve-add-variation-test
+++ b/plugins/woocommerce/changelog/udpate-e2e-test-improve-add-variation-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Editor: restore and fix E2E test that creates product variations

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -279,17 +279,25 @@ test.describe( 'Variations tab', () => {
 					} )
 					.click();
 
-				const element = page.locator(
+				const snackbarLocator = page.locator(
 					'div.components-snackbar__content'
 				);
-				if ( Array.isArray( element ) ) {
-					await expect( await element[ 0 ].innerText() ).toMatch(
-						`${ attributesData.options.length } variations updated.`
-					);
-					await expect( await element[ 1 ].innerText() ).toMatch(
-						/Product published/
-					);
-				}
+
+				// Wait for the snackbar to appear
+				await snackbarLocator.waitFor( {
+					state: 'visible',
+					timeout: 20000,
+				} );
+
+				// Verify that the first message is the expected one
+				await expect( snackbarLocator.nth( 0 ) ).toHaveText(
+					`${ attributesData.terms.length } variations updated.`
+				);
+
+				// Verify that the second message is the expected one
+				await expect( snackbarLocator.nth( 1 ) ).toHaveText(
+					/Product published/
+				);
 			} );
 		} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -260,9 +260,7 @@ test.describe( 'Variations tab', () => {
 					.getByRole( 'button', { name: 'Set prices' } )
 					.click();
 
-				await expect(
-					page.getByText( '$50.00' ).nth( 2 )
-				).toBeVisible();
+				await expect( page.getByText( '50' ).nth( 2 ) ).toBeVisible();
 
 				await expect(
 					page.getByLabel( 'Dismiss this notice' )

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -161,21 +161,12 @@ test.describe( 'Variations tab', () => {
 
 				// Wait for the create-attribute async request to finish
 				const newAttrResponse = await page.waitForResponse(
-					( response ) => {
-						const url = response.url();
-						console.log( url );
-						const status = response.status();
-						console.log( status );
-						return (
-							response
-								.url()
-								.includes(
-									`wp-json/wc/v3/products/attributes?name=${ attributesData.name }&generate_slug=true`
-								) &&
-							( response.status() === 200 ||
-								response.status() === 201 )
-						);
-					}
+					( response ) =>
+						response
+							.url()
+							.includes(
+								`wp-json/wc/v3/products/attributes?name=${ attributesData.name }&generate_slug=true`
+							) && response.status() === 201
 				);
 
 				const newAttrData = await newAttrResponse.json();
@@ -190,14 +181,8 @@ test.describe( 'Variations tab', () => {
 					);
 
 				for ( const term of attributesData.terms ) {
-					await FormTokenFieldInputLocator.fill( term.name );
-					await FormTokenFieldInputLocator.press( 'Enter' );
-
 					// Fill the input field with the option
 					await FormTokenFieldInputLocator.fill( term.name );
-
-					// Ensure the input field is focused before pressing Enter
-					await FormTokenFieldInputLocator.focus();
 					await FormTokenFieldInputLocator.press( 'Enter' );
 
 					/*

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -28,7 +28,20 @@ const productData = {
 
 const attributesData = {
 	name: 'Size',
-	options: [ 'Small', 'Medium', 'Large' ],
+	terms: [
+		{
+			name: 'Small',
+			slug: 'small',
+		},
+		{
+			name: 'Medium',
+			slug: 'medium',
+		},
+		{
+			name: 'Large',
+			slug: 'large',
+		},
+	],
 };
 
 const tabs = [
@@ -76,7 +89,7 @@ test.describe( 'Variations tab', () => {
 			'The block product editor is not being tested'
 		);
 
-		test.skip( 'can create a variation option and publish the product', async ( {
+		test.only( 'can create a variation option and publish the product', async ( {
 			page,
 		} ) => {
 			await test.step( 'Load new product editor, disable tour', async () => {
@@ -118,27 +131,112 @@ test.describe( 'Variations tab', () => {
 
 				await page.waitForLoadState( 'domcontentloaded' );
 
-				await page
-					.locator(
-						'input[aria-describedby^="components-form-token-suggestions-howto-combobox-control"]'
-					)
-					.fill( attributesData.name );
+				/*
+				 * AttributeTableRow is the row that contains
+				 * the attribute name and the options (terms).
+				 */
+				const rowSelector =
+					'.woocommerce-new-attribute-modal__table-row';
+
+				/*
+				 * Check the app loads the attributes,
+				 * based on the Spinner visibility.
+				 */
+				const spinnerLocator = page.locator(
+					`${ rowSelector } .components-spinner`
+				);
+				await spinnerLocator.waitFor( {
+					state: 'visible',
+				} );
+				await spinnerLocator.waitFor( { state: 'hidden' } );
+
+				// Attribute combobox input
+				const attributeInputLocator = page.locator(
+					'input[aria-describedby^="components-form-token-suggestions-howto-combobox-control"]'
+				);
+
+				await attributeInputLocator.fill( attributesData.name );
 
 				await page.locator( 'text=Create "Size"' ).click();
 
-				for ( const option of attributesData.options ) {
-					const container = page.locator(
-						'td.woocommerce-new-attribute-modal__table-attribute-value-column'
-					);
+				// Wait for the create-attribute async request to finish
+				const newAttrResponse = await page.waitForResponse(
+					( response ) => {
+						const url = response.url();
+						console.log( url );
+						const status = response.status();
+						console.log( status );
+						return (
+							response
+								.url()
+								.includes(
+									`wp-json/wc/v3/products/attributes?name=${ attributesData.name }&generate_slug=true`
+								) &&
+							( response.status() === 200 ||
+								response.status() === 201 )
+						);
+					}
+				);
 
-					const inputLocator = container.locator(
+				const newAttrData = await newAttrResponse.json();
+
+				const FormTokenFieldLocator = page.locator(
+					'td.woocommerce-new-attribute-modal__table-attribute-value-column'
+				);
+
+				const FormTokenFieldInputLocator =
+					FormTokenFieldLocator.locator(
 						'input[id^="components-form-token-input-"]'
 					);
 
-					await inputLocator.fill( option );
-					await page.waitForTimeout( 500 ); // needs some time to be able to press Enter.
-					await inputLocator.press( 'Enter' );
-					await expect( container ).toContainText( option );
+				for ( const term of attributesData.terms ) {
+					await FormTokenFieldInputLocator.fill( term.name );
+					await FormTokenFieldInputLocator.press( 'Enter' );
+
+					// Fill the input field with the option
+					await FormTokenFieldInputLocator.fill( term.name );
+
+					// Ensure the input field is focused before pressing Enter
+					await FormTokenFieldInputLocator.focus();
+					await FormTokenFieldInputLocator.press( 'Enter' );
+
+					/*
+					 * Check the new option is added to the list,
+					 * by checking the last aria-hidden
+					 */
+					const newAriaHiddenTokenLocator =
+						FormTokenFieldLocator.locator(
+							'span.components-form-token-field__token-text > span[aria-hidden="true"]'
+						).last();
+
+					await expect( newAriaHiddenTokenLocator ).toHaveText(
+						term.name
+					);
+
+					/*
+					 * Check the option being added to the list,
+					 * by checking the token with validating state.
+					 */
+					const newValidatingTokenLocator =
+						FormTokenFieldLocator.locator( '.is-validating' );
+
+					await newValidatingTokenLocator.waitFor( {
+						state: 'visible',
+					} );
+
+					/*
+					 * Wait for the async POST request
+					 * that creates the new attribute term to finish.
+					 */
+					await page.waitForResponse( ( response ) => {
+						return (
+							response
+								.url()
+								.includes(
+									`/wp-json/wc/v3/products/attributes/${ newAttrData.id }/terms?name=${ term.name }&slug=${ term.slug }&_locale=user`
+								) && response.status() === 201
+						);
+					} );
 				}
 
 				await page

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -89,7 +89,7 @@ test.describe( 'Variations tab', () => {
 			'The block product editor is not being tested'
 		);
 
-		test.only( 'can create a variation option and publish the product', async ( {
+		test( 'can create a variation option and publish the product', async ( {
 			page,
 		} ) => {
 			await test.step( 'Load new product editor, disable tour', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes and restores the E2E that tests when creating product variations.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/48689

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Running E2E tests locally

```
cd plugins/woocommerce
```

```
pnpm test:e2e-pw tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
```

```
pnpm exec playwright show-report tests/e2e-pw/test-results/playwright-report
```

<img width="918" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/c42bb4a6-5840-4014-92e9-9b8f436614d1">


### Running with UI

In the same woocommerce folder:

```
pnpm test:e2e-pw tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js --ui
```

https://github.com/woocommerce/woocommerce/assets/77539/43041dd0-749e-4b7e-b12b-ab6a0b40bba8

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
