### PR TITLE
Return HTTP 404 in REST API for non-existent product reviews 

### DIFF
--- a/plugins/woocommerce/changelog/fix-35162
+++ b/plugins/woocommerce/changelog/fix-35162
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Return HTTP 404 when trying to read or delete a non-existent product review.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
@@ -144,7 +144,8 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-		if ( ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
+		$review = $this->get_review( (int) $request['id'], (int) $request['product_id'] );
+		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -172,7 +173,8 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function update_item_permissions_check( $request ) {
-		if ( ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
+		$review = $this->get_review( (int) $request['id'], (int) $request['product_id'] );
+		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -186,7 +188,8 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function delete_item_permissions_check( $request ) {
-		if ( ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
+		$review = $this->get_review( (int) $request['id'], (int) $request['product_id'] );
+		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'Sorry, you cannot delete this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -219,23 +222,37 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	}
 
 	/**
+	 * Fetch a single product review from the database.
+	 *
+	 * @param int $id         Review ID.
+	 * @param int $product_id Product ID.
+	 *
+	 * @since  9.2.0
+	 * @return \WP_Comment
+	 */
+	protected function get_review( int $id, int $product_id ) {
+		if ( 0 >= $product_id || 'product' !== get_post_type( $product_id ) ) {
+			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$review = 0 <= $id ? get_comment( $id ) : null;
+		if ( empty( $review ) || empty( $review->comment_ID ) || empty( $review->comment_post_ID ) || (int) $review->comment_post_ID !== $product_id ) {
+			return new WP_Error( 'woocommerce_rest_product_review_invalid_id', __( 'Invalid product review ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		return $review;
+	}
+
+	/**
 	 * Get a single product review.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {
-		$id         = (int) $request['id'];
-		$product_id = (int) $request['product_id'];
-
-		if ( 'product' !== get_post_type( $product_id ) ) {
-			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
-		}
-
-		$review = get_comment( $id );
-
-		if ( empty( $id ) || empty( $review ) || intval( $review->comment_post_ID ) !== $product_id ) {
-			return new WP_Error( 'woocommerce_rest_invalid_id', __( 'Invalid resource ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		$review = $this->get_review( (int) $request['id'], (int) $request['product_id'] );
+		if ( is_wp_error( $review ) ) {
+			return $review;
 		}
 
 		$delivery = $this->prepare_item_for_response( $review, $request );
@@ -309,14 +326,9 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 		$product_review_id = (int) $request['id'];
 		$product_id        = (int) $request['product_id'];
 
-		if ( 'product' !== get_post_type( $product_id ) ) {
-			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
-		}
-
-		$review = get_comment( $product_review_id );
-
-		if ( empty( $product_review_id ) || empty( $review ) || intval( $review->comment_post_ID ) !== $product_id ) {
-			return new WP_Error( 'woocommerce_rest_product_review_invalid_id', __( 'Invalid resource ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		$review = $this->get_review( $product_review_id, $product_id );
+		if ( is_wp_error( $review ) ) {
+			return $review;
 		}
 
 		$prepared_review = $this->prepare_item_for_database( $request );
@@ -358,15 +370,11 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	public function delete_item( $request ) {
 		$product_id        = (int) $request['product_id'];
 		$product_review_id = (int) $request['id'];
-		$force             = isset( $request['force'] ) ? (bool) $request['force']     : false;
+		$product_review    = $this->get_review( $product_review_id, $product_id );
+		$force             = isset( $request['force'] ) ? (bool) $request['force'] : false;
 
-		if ( 'product' !== get_post_type( $product_id ) ) {
-			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
-		}
-
-		$product_review = get_comment( $product_review_id );
-		if ( empty( $product_review_id ) || empty( $product_review->comment_ID ) || empty( $product_review->comment_post_ID ) ) {
-			return new WP_Error( 'woocommerce_rest_product_review_invalid_id', __( 'Invalid product review ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		if ( is_wp_error( $product_review ) ) {
+			return $product_review;
 		}
 
 		/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
@@ -236,7 +236,7 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 		}
 
 		$review = 0 <= $id ? get_comment( $id ) : null;
-		if ( empty( $review ) || empty( $review->comment_ID ) || empty( $review->comment_post_ID ) || (int) $review->comment_post_ID !== $product_id ) {
+		if ( empty( $review ) || empty( $review->comment_ID ) || 'review' !== get_comment_type( $id ) || empty( $review->comment_post_ID ) || (int) $review->comment_post_ID !== $product_id ) {
 			return new WP_Error( 'woocommerce_rest_product_review_invalid_id', __( 'Invalid product review ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
@@ -145,7 +145,11 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 		$review = $this->get_review( (int) $request['id'], (int) $request['product_id'] );
-		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
+		if ( is_wp_error( $review ) ) {
+			return $review;
+		}
+
+		if ( ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -174,7 +178,11 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	 */
 	public function update_item_permissions_check( $request ) {
 		$review = $this->get_review( (int) $request['id'], (int) $request['product_id'] );
-		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
+		if ( is_wp_error( $review ) ) {
+			return $review;
+		}
+
+		if ( ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -189,7 +197,11 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	 */
 	public function delete_item_permissions_check( $request ) {
 		$review = $this->get_review( (int) $request['id'], (int) $request['product_id'] );
-		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
+		if ( is_wp_error( $review ) ) {
+			return $review;
+		}
+
+		if ( ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'Sorry, you cannot delete this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
@@ -150,8 +150,11 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 		$review = $this->get_review( (int) $request['id'] );
+		if ( is_wp_error( $review ) ) {
+			return $review;
+		}
 
-		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
+		if ( ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -180,8 +183,11 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 */
 	public function update_item_permissions_check( $request ) {
 		$review = $this->get_review( (int) $request['id'] );
+		if ( is_wp_error( $review ) ) {
+			return $review;
+		}
 
-		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
+		if ( ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -196,8 +202,11 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 */
 	public function delete_item_permissions_check( $request ) {
 		$review = $this->get_review( (int) $request['id'] );
+		if ( is_wp_error( $review ) ) {
+			return $review;
+		}
 
-		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
+		if ( ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'Sorry, you cannot delete this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
@@ -149,7 +149,9 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-		if ( ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
+		$review = $this->get_review( (int) $request['id'] );
+
+		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'read', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -177,7 +179,9 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function update_item_permissions_check( $request ) {
-		if ( ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
+		$review = $this->get_review( (int) $request['id'] );
+
+		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'edit', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -191,7 +195,9 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function delete_item_permissions_check( $request ) {
-		if ( ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
+		$review = $this->get_review( (int) $request['id'] );
+
+		if ( ! is_wp_error( $review ) && ! wc_rest_check_product_reviews_permissions( 'delete', (int) $request['id'] ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'Sorry, you cannot delete this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -1057,13 +1063,11 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		}
 
 		$review = get_comment( $id );
-		if ( empty( $review ) ) {
+		if ( empty( $review ) || 'review' !== get_comment_type( $id ) ) {
 			return $error;
 		}
 
 		if ( ! empty( $review->comment_post_ID ) ) {
-			$post = get_post( (int) $review->comment_post_ID );
-
 			if ( 'product' !== get_post_type( (int) $review->comment_post_ID ) ) {
 				return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
 			}

--- a/plugins/woocommerce/tests/api-core-tests/tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/products/products-crud.test.js
@@ -1,6 +1,6 @@
 const { test, expect } = require( '@playwright/test' );
 const { API_BASE_URL } = process.env;
-const shouldSkip = API_BASE_URL != undefined;
+const shouldSkip = API_BASE_URL !== undefined;
 
 /**
  * Internal dependencies
@@ -717,12 +717,7 @@ test.describe( 'Products API tests: CRUD', () => {
 			const getDeletedProductReviewResponse = await request.get(
 				`wp-json/wc/v3/products/reviews/${ productReviewId }`
 			);
-			/**
-			 *  currently returns a 403 (forbidden) rather than a 404 (not found)
-			 *  an issue has been raised to track this
-			 *  See: https://github.com/woocommerce/woocommerce/issues/35162
-			 */
-			expect( getDeletedProductReviewResponse.status() ).toEqual( 403 );
+			expect( getDeletedProductReviewResponse.status() ).toEqual( 404 );
 		} );
 
 		test( 'can batch update product reviews', async ( { request } ) => {
@@ -817,12 +812,7 @@ test.describe( 'Products API tests: CRUD', () => {
 			const getDeletedProductReviewResponse = await request.get(
 				`wp-json/wc/v3/products/reviews/${ review2Id }`
 			);
-			/**
-			 *  currently returns a 403 (forbidden) rather than a 404 (not found)
-			 *  an issue has been raised to track this
-			 *  See: https://github.com/woocommerce/woocommerce/issues/35162
-			 */
-			expect( getDeletedProductReviewResponse.status() ).toEqual( 403 );
+			expect( getDeletedProductReviewResponse.status() ).toEqual( 404 );
 
 			// Batch delete the created tags
 			await request.post( `wp-json/wc/v3/products/reviews/batch`, {
@@ -1534,12 +1524,9 @@ test.describe( 'Products API tests: CRUD', () => {
 			// Send request to batch delete the products created earlier
 			const idsToDelete = expectedProducts.map( ( { id } ) => id );
 			const batchDeletePayload = batch( 'delete', idsToDelete );
-			const response = await request.post(
-				'wp-json/wc/v3/products/batch',
-				{
-					data: batchDeletePayload,
-				}
-			);
+			let response = await request.post( 'wp-json/wc/v3/products/batch', {
+				data: batchDeletePayload,
+			} );
 			const responseJSON = await response.json();
 			const actualBatchDeletedProducts = responseJSON.delete;
 
@@ -1556,7 +1543,7 @@ test.describe( 'Products API tests: CRUD', () => {
 
 			// Verify that the deleted product ID's can no longer be retrieved
 			for ( const id of idsToDelete ) {
-				const response = await request.get(
+				response = await request.get(
 					`wp-json/wc/v3/products/${ id }`
 				);
 				expect( response.status() ).toEqual( 404 );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller-tests.php
@@ -75,6 +75,7 @@ class WC_REST_Product_Reviews_V1_Controller_Tests extends WC_Unit_Test_Case {
 	 */
 	public function test_permissions_for_updating_product_reviews() {
 		$api_request = new WP_REST_Request( 'PUT', '/wc/v1/products/' . $this->product_id . '/reviews/' . $this->review_id );
+		$api_request->set_param( 'product_id', $this->product_id );
 		$api_request->set_param( 'id', $this->review_id );
 		$api_request->set_body( '{ "review": "Modified automatically." }' );
 
@@ -93,6 +94,7 @@ class WC_REST_Product_Reviews_V1_Controller_Tests extends WC_Unit_Test_Case {
 
 		$nonexistent_product_id = $this->product_id * 10;
 		$api_request->set_route( "/wc/v1/products/{$nonexistent_product_id}/reviews/" . $this->review_id );
+		$api_request->set_param( 'product_id', $nonexistent_product_id );
 
 		$this->assertEquals(
 			'woocommerce_rest_product_invalid_id',
@@ -146,8 +148,8 @@ class WC_REST_Product_Reviews_V1_Controller_Tests extends WC_Unit_Test_Case {
 		$request->set_param( 'id', $order_note_id );
 
 		$this->assertEquals(
-			'woocommerce_rest_cannot_delete',
-			$this->sut->delete_item_permissions_check( $request )->get_error_code(),
+			'woocommerce_rest_product_invalid_id',
+			$this->sut->delete_item( $request )->get_error_code(),
 			'Comments that are not product reviews cannot be deleted via this endpoint.'
 		);
 
@@ -163,8 +165,8 @@ class WC_REST_Product_Reviews_V1_Controller_Tests extends WC_Unit_Test_Case {
 		$request->set_param( 'id', $comment_id );
 
 		$this->assertEquals(
-			'woocommerce_rest_cannot_delete',
-			$this->sut->delete_item_permissions_check( $request )->get_error_code(),
+			'woocommerce_rest_product_invalid_id',
+			$this->sut->delete_item( $request )->get_error_code(),
 			'Comments that are not product reviews (including other types of comments belonging to products) cannot be deleted via this endpoint.'
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller-tests.php
@@ -178,8 +178,8 @@ class WC_REST_Product_Reviews_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'id', $order_note_id );
 
 		$this->assertEquals(
-			'woocommerce_rest_cannot_delete',
-			$this->sut->delete_item_permissions_check( $request )->get_error_code(),
+			'woocommerce_rest_review_invalid_id',
+			$this->sut->delete_item( $request )->get_error_code(),
 			'Comments that are not product reviews cannot be deleted via this endpoint.'
 		);
 
@@ -195,8 +195,8 @@ class WC_REST_Product_Reviews_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'id', $comment_id );
 
 		$this->assertEquals(
-			'woocommerce_rest_cannot_delete',
-			$this->sut->delete_item_permissions_check( $request )->get_error_code(),
+			'woocommerce_rest_review_invalid_id',
+			$this->sut->delete_item( $request )->get_error_code(),
 			'Comments that are not product reviews (including other types of comments belonging to products) cannot be deleted via this endpoint.'
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When performing a GET or DELETE request to `/wp-json/wc/v3/products/reviews/<id>`, if the product review specified by `<id>` doesn't exist, the response has HTTP code 403 instead of 404, as other endpoints do (for example: `/wc/v3/products/<id>`). Similarly for v1 and v2 endpoints (`/wc/v{1,2}/products/<product_id>/reviews/<id>`).

This PR makes v1, v2 and v3 product review endpoints return 404 as appropriate when either the review ID or the product ID provided as args don't exist.

Closes #35162.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Generate and take note of your API consumer key and secret on **WC > Settings > Advanced > REST API**.
1. Go to **WC > Settings > Products** and make sure that **Enable product reviews** is enabled.
1. Go to **Products** and create at least one product (if you have none). This will be used below as `<product_id>` in a few URLs.
1. Open the (frontend) page of said product and add a few product reviews.
1. Configure your favorite REST client to use Basic Auth and use your consumer key and secret as username and password, respectively.
1.
   1. Perform a GET request to `<yoursite>/wp-json/wc/v3/products/reviews` and confirm that you get a list of reviews, which should include those you added in step 2.
   1. Check this for v1 and v2 too, by using `<yoursite>/wp-json/wc/v2/products/<product_id>/reviews/` as URL instead.
1. Choose any id from the list(s) above.
1. For these two URLs...
   - `<yoursite>/wp-json/wc/v3/products/reviews/<id>`.
   - `<yoursite>/wp-json/wc/v2/products/<product_id>/reviews/<id>`.

   ... confirm that:

   1. If auth is configured, a `GET` request returns the review details. If not configured, it returns a 401.
   2. A `PUT` request with the following body returns an updated version of the review:

      ```json
      { "reviewer": "Tenacious D" }
      ```

      **Note:** For the `v2` URL, use `name` instead of `reviewer`.
   3. A `DELETE` request trashes the review, which can be checked in **Products > Reviews > Trash.**
      **Note:** Make sure to restore the review between requests so that it can be trashed again.
   4. Any type of request (`GET`, `DELETE` or `PUT`) returns a 404 when you use a non-existent product ID as `<product_id>` or a non-existent review ID as `<id>`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
