### PR TITLE
Return HTTP 404 in REST API for non-existent webhooks

### DIFF
--- a/plugins/woocommerce/changelog/fix-35290
+++ b/plugins/woocommerce/changelog/fix-35290
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Return HTTP 404 when accessing non-existent webhooks via REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
@@ -561,7 +561,7 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 		$webhook = wc_get_webhook( $id );
 
 		if ( empty( $webhook ) || is_null( $webhook ) ) {
-			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 400 ) );
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$data = array(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-webhooks-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-webhooks-v2-controller.php
@@ -36,7 +36,7 @@ class WC_REST_Webhooks_V2_Controller extends WC_REST_Webhooks_V1_Controller {
 		$webhook = wc_get_webhook( $id );
 
 		if ( empty( $webhook ) || is_null( $webhook ) ) {
-			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 400 ) );
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$data = array(

--- a/plugins/woocommerce/tests/api-core-tests/tests/webhooks/webhooks-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/webhooks/webhooks-crud.test.js
@@ -1,11 +1,4 @@
-const {
-	test,
-	expect
-} = require('@playwright/test');
-const exp = require('constants');
-const {
-	refund
-} = require('../../data');
+const { test, expect } = require( '@playwright/test' );
 
 /**
  * Tests for the WooCommerce Refunds API.
@@ -14,225 +7,212 @@ const {
  * @group webhooks
  *
  */
-test.describe('Webhooks API tests', () => {
+test.describe( 'Webhooks API tests', () => {
 	let webhookId;
 
-	test.describe('Create a webhook', () => {
-
-		test('can create a webhook', async ({
-			request,
-		}) => {
+	test.describe( 'Create a webhook', () => {
+		test( 'can create a webhook', async ( { request } ) => {
 			// call API to create a webhook
-			const response = await request.post(
-				'/wp-json/wc/v3/webhooks', {
+			const response = await request.post( '/wp-json/wc/v3/webhooks', {
+				data: {
+					name: 'Order updated',
+					topic: 'order.updated',
+					delivery_url: 'http://requestb.in/1g0sxmo1',
+				},
+			} );
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 201 );
+			expect( typeof responseJSON.id ).toEqual( 'number' );
+			expect( responseJSON.name ).toEqual( 'Order updated' );
+			expect( responseJSON.status ).toEqual( 'active' );
+			expect( responseJSON.topic ).toEqual( 'order.updated' );
+			expect( responseJSON.delivery_url ).toEqual(
+				'http://requestb.in/1g0sxmo1'
+			);
+			expect( responseJSON.hooks ).toEqual(
+				expect.arrayContaining( [
+					'woocommerce_update_order',
+					'woocommerce_order_refunded',
+				] )
+			);
+
+			webhookId = responseJSON.id;
+		} );
+	} );
+
+	test.describe( 'Retrieve after create', () => {
+		test( 'can retrieve a webhook', async ( { request } ) => {
+			// call API to retrieve the previously saved webhook
+			const response = await request.get(
+				`/wp-json/wc/v3/webhooks/${ webhookId }`
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( false );
+			expect( typeof responseJSON.id ).toEqual( 'number' );
+			expect( responseJSON.name ).toEqual( 'Order updated' );
+			expect( responseJSON.status ).toEqual( 'active' );
+			expect( responseJSON.topic ).toEqual( 'order.updated' );
+			expect( responseJSON.delivery_url ).toEqual(
+				'http://requestb.in/1g0sxmo1'
+			);
+			expect( responseJSON.hooks ).toEqual(
+				expect.arrayContaining( [
+					'woocommerce_update_order',
+					'woocommerce_order_refunded',
+				] )
+			);
+		} );
+
+		test( 'can retrieve all webhooks', async ( { request } ) => {
+			// call API to retrieve all webhooks
+			const response = await request.get( '/wp-json/wc/v3/webhooks' );
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	test.describe( 'Update a webhook', () => {
+		test( `can update a web hook`, async ( { request } ) => {
+			// update webhook
+			const response = await request.put(
+				`/wp-json/wc/v3/webhooks/${ webhookId }`,
+				{
 					data: {
-						name: "Order updated",
-						topic: "order.updated",
-						delivery_url: "http://requestb.in/1g0sxmo1"
+						status: 'paused',
 					},
 				}
 			);
 			const responseJSON = await response.json();
-			expect(response.status()).toEqual(201);
-			expect(typeof responseJSON.id).toEqual('number');
-			expect(responseJSON.name).toEqual("Order updated");
-			expect(responseJSON.status).toEqual("active");
-			expect(responseJSON.topic).toEqual("order.updated");
-			expect(responseJSON.delivery_url).toEqual("http://requestb.in/1g0sxmo1");
-			expect(responseJSON.hooks).toEqual(
-				expect.arrayContaining([
-					"woocommerce_update_order",
-					"woocommerce_order_refunded"
-				])
-			);
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.status ).toEqual( 'paused' );
+		} );
+	} );
 
-			webhookId = responseJSON.id;
-		});
-
-	});
-
-	test.describe('Retrieve after create', () => {
-		test('can retrieve a webhook', async ({
-			request
-		}) => {
-			// call API to retrieve the previously saved webhook
-			const response = await request.get(
-				`/wp-json/wc/v3/webhooks/${webhookId}`
-			);
-			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
-			expect(Array.isArray(responseJSON)).toBe(false);
-			expect(typeof responseJSON.id).toEqual('number');
-			expect(responseJSON.name).toEqual("Order updated");
-			expect(responseJSON.status).toEqual("active");
-			expect(responseJSON.topic).toEqual("order.updated");
-			expect(responseJSON.delivery_url).toEqual("http://requestb.in/1g0sxmo1");
-			expect(responseJSON.hooks).toEqual(
-				expect.arrayContaining([
-					"woocommerce_update_order",
-					"woocommerce_order_refunded"
-				])
-			);
-		});
-
-		test('can retrieve all webhooks', async ({
-			request
-		}) => {
-			// call API to retrieve all webhooks
-			const response = await request.get('/wp-json/wc/v3/webhooks');
-			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
-			expect(Array.isArray(responseJSON)).toBe(true);
-			expect(responseJSON.length).toBeGreaterThan(0);
-		});
-	});
-
-	test.describe('Update a webhook', () => {
-		test(`can update a web hook`, async ({
-			request,
-		}) => {
-			// update webhook
-			const response = await request.put(
-				`/wp-json/wc/v3/webhooks/${ webhookId }`, {
-					data: {
-						status: "paused"
-					}
-				}
-			);
-			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
-			expect(responseJSON.status).toEqual("paused");
-		});
-	});
-
-	test.describe('Delete a webhook', () => {
-		test('can permanently delete a webhook', async ({
-			request
-		}) => {
-
+	test.describe( 'Delete a webhook', () => {
+		test( 'can permanently delete a webhook', async ( { request } ) => {
 			// Delete the webhook
-			const response = await request.delete(`/wp-json/wc/v3/webhooks/${ webhookId }`, {
-				data: {
-					force: true
+			const response = await request.delete(
+				`/wp-json/wc/v3/webhooks/${ webhookId }`,
+				{
+					data: {
+						force: true,
+					},
 				}
-			});
-			expect(response.status()).toEqual(200);
+			);
+			expect( response.status() ).toEqual( 200 );
 
 			// Verify that the webhook can no longer be retrieved
 			const getDeletedWebhookResponse = await request.get(
 				`/wp-json/wc/v3/webhooks/${ webhookId }`
 			);
 
-			/**
-			 * Issue raised as we would expect this to return a 400 to be
-			 * consistent with the other API calls
-			 * Issue: https://github.com/woocommerce/woocommerce/issues/35290
-			 */
-			expect(getDeletedWebhookResponse.status()).toEqual(404);
-		});
-	});
+			expect( getDeletedWebhookResponse.status() ).toEqual( 404 );
+		} );
+	} );
 
-
-	test.describe('Batch webhook operations', () => {
+	test.describe( 'Batch webhook operations', () => {
 		let webhookId1;
 		let webhookId2;
 		let webhookId3;
-		test('can batch create webhooks', async ({
-			request
-		}) => {
+		test( 'can batch create webhooks', async ( { request } ) => {
 			// Batch create webhooks
 			// call API to batch create a webhook
-			const response = await request.post('wp-json/wc/v3/webhooks/batch', {
-				data: {
-					create: [{
-							name: "Round toe",
-							topic: "coupon.created",
-							delivery_url: "http://requestb.in/1g0sxmo1"
-						},
-						{
-							name: "Customer deleted",
-							topic: "customer.deleted",
-							delivery_url: "http://requestb.in/1g0sxmo1"
-						}
-					]
-				},
-			});
+			const response = await request.post(
+				'wp-json/wc/v3/webhooks/batch',
+				{
+					data: {
+						create: [
+							{
+								name: 'Round toe',
+								topic: 'coupon.created',
+								delivery_url: 'http://requestb.in/1g0sxmo1',
+							},
+							{
+								name: 'Customer deleted',
+								topic: 'customer.deleted',
+								delivery_url: 'http://requestb.in/1g0sxmo1',
+							},
+						],
+					},
+				}
+			);
 			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
+			expect( response.status() ).toEqual( 200 );
 
 			// Verify that the new webhooks were created
 			const webhooks = responseJSON.create;
-			expect(webhooks).toHaveLength(2);
-			webhookId1 = webhooks[0].id;
-			webhookId2 = webhooks[1].id;
-			expect(webhookId1).toBeDefined();
-			expect(webhookId2).toBeDefined();
-			expect(webhooks[0].name).toEqual('Round toe');
-			expect(webhooks[1].name).toEqual('Customer deleted');
-		});
+			expect( webhooks ).toHaveLength( 2 );
+			webhookId1 = webhooks[ 0 ].id;
+			webhookId2 = webhooks[ 1 ].id;
+			expect( webhookId1 ).toBeDefined();
+			expect( webhookId2 ).toBeDefined();
+			expect( webhooks[ 0 ].name ).toEqual( 'Round toe' );
+			expect( webhooks[ 1 ].name ).toEqual( 'Customer deleted' );
+		} );
 
-		test('can batch update webhooks', async ({
-			request
-		}) => {
+		test( 'can batch update webhooks', async ( { request } ) => {
 			// set payload to create, update and delete webhooks
 			const batchUpdatePayload = {
-				create: [{
-					name: "Order Created",
-					topic: "order.created",
-					delivery_url: "http://requestb.in/1g0sxmo1"
-				}, ],
-				update: [{
-					id: webhookId1,
-					name: 'Square toe',
-				}, ],
-				delete: [webhookId2]
+				create: [
+					{
+						name: 'Order Created',
+						topic: 'order.created',
+						delivery_url: 'http://requestb.in/1g0sxmo1',
+					},
+				],
+				update: [
+					{
+						id: webhookId1,
+						name: 'Square toe',
+					},
+				],
+				delete: [ webhookId2 ],
 			};
 
 			// Call API to batch update the webhooks
 			const response = await request.post(
-				'wp-json/wc/v3/webhooks/batch', {
+				'wp-json/wc/v3/webhooks/batch',
+				{
 					data: batchUpdatePayload,
 				}
 			);
 			const responseJSON = await response.json();
-			expect(response.status()).toEqual(200);
-			expect(responseJSON.create).toHaveLength(1);
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.create ).toHaveLength( 1 );
 
-			webhookId3 = responseJSON.create[0].id;
-			expect(webhookId3).toBeDefined();
-			expect(responseJSON.create[0].name).toEqual('Order Created');
-			expect(responseJSON.create[0].topic).toEqual('order.created');
-			expect(responseJSON.create[0].delivery_url).toEqual('http://requestb.in/1g0sxmo1');
+			webhookId3 = responseJSON.create[ 0 ].id;
+			expect( webhookId3 ).toBeDefined();
+			expect( responseJSON.create[ 0 ].name ).toEqual( 'Order Created' );
+			expect( responseJSON.create[ 0 ].topic ).toEqual( 'order.created' );
+			expect( responseJSON.create[ 0 ].delivery_url ).toEqual(
+				'http://requestb.in/1g0sxmo1'
+			);
 
-			expect(responseJSON.update).toHaveLength(1);
-			expect(responseJSON.update[0].id).toEqual(webhookId1);
-			expect(responseJSON.update[0].name).toEqual('Square toe');
+			expect( responseJSON.update ).toHaveLength( 1 );
+			expect( responseJSON.update[ 0 ].id ).toEqual( webhookId1 );
+			expect( responseJSON.update[ 0 ].name ).toEqual( 'Square toe' );
 
 			// Verify that the deleted webhook can no longer be retrieved
 			const getDeletedWebhookResponse = await request.get(
 				`/wp-json/wc/v3/webhooks/${ webhookId2 }`
 			);
-			/**
-			 * Issue raised as we would expect this to return a 400 to be
-			 * consistent with the other API calls
-			 * Issue: https://github.com/woocommerce/woocommerce/issues/35290
-			 */
-			expect(getDeletedWebhookResponse.status()).toEqual(400);
+			expect( getDeletedWebhookResponse.status() ).toEqual( 404 );
+		} );
 
-		});
-
-		test('can batch delete webhooks', async ({
-			request
-		}) => {
+		test( 'can batch delete webhooks', async ( { request } ) => {
 			// Batch delete the created webhooks
 			const response = await request.post(
-				'wp-json/wc/v3/webhooks/batch', {
+				'wp-json/wc/v3/webhooks/batch',
+				{
 					data: {
-						delete: [webhookId1, webhookId3]
+						delete: [ webhookId1, webhookId3 ],
 					},
 				}
 			);
-			const responseJSON = await response.json();
+			await response.json();
 
 			//Call the API to attempte to retrieve the deleted webhooks
 			const deletedResponse1 = await request.get(
@@ -241,14 +221,9 @@ test.describe('Webhooks API tests', () => {
 			const deletedResponse3 = await request.get(
 				`wp-json/wc/v3/webhooks/${ webhookId3 }`
 			);
-			/**
-			 * Issue raised as we would expect this to return a 400 to be
-			 * consistent with the other API calls
-			 * Issue: https://github.com/woocommerce/woocommerce/issues/35290
-			 */
-			expect(deletedResponse1.status()).toEqual(400);
-			expect(deletedResponse3.status()).toEqual(400);
 
-		});
-	});
-});
+			expect( deletedResponse1.status() ).toEqual( 404 );
+			expect( deletedResponse3.status() ).toEqual( 404 );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/tests/api-core-tests/tests/webhooks/webhooks-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/webhooks/webhooks-crud.test.js
@@ -128,7 +128,7 @@ test.describe('Webhooks API tests', () => {
 			 * consistent with the other API calls
 			 * Issue: https://github.com/woocommerce/woocommerce/issues/35290
 			 */
-			expect(getDeletedWebhookResponse.status()).toEqual(400);
+			expect(getDeletedWebhookResponse.status()).toEqual(404);
 		});
 	});
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When performing a GET or DELETE request to `/wp-json/wc/v3/webhooks/<id>`, if the webhook specified by `<id>` doesn't exist, the response has HTTP code 400 instead of 404, as other endpoints do (for example: `/wc/v3/products/<id>`).

This PR makes those webhook endpoints return 404 as appropriate with an error message.

Closes #35290.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Generate and take note of your API consumer key and secret on WC > Settings > Advanced > REST API.
1. Go to WC > Settings > Advanced > Webhooks and create a webhook with any topic.
1. Configure your favorite REST client to use Basic Auth and use your consumer key and secret as username and password, respectively.
1. Perform a GET request to `<yoursite>/wp-json/wc/v3/webhooks` and confirm that you get a list of the webhooks defined on your settings screen in step 2.
1. Choose any id from the list.
   1. Perform a GET request to `<yoursite>/wp-json/wc/v3/webhooks/<id>`. You should get the details of the webhook.
   1. Temporarily disable auth for the request and repeat the above. Confirm you get a 401.
   1. Perform a DELETE request to `<yoursite>/wp-json/wc/v3/webhooks/<id>`. Make sure to pass `force=true` as param.
      You should see the details of the webhook and it should be gone from WC > Settings > Advanced > Webhooks.
1. Repeat the requests from the previous step with the same `<id>`. The response in both cases should now be an error message and the HTTP status should be 404.
1. Go through all of the above steps but using `v1` and `v2` in the endpoints instead of `v3`. Results should be identical.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
