### PR TITLE
Fix Classic Template block registration on WP 6.6

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
@@ -7,7 +7,6 @@ import {
 	getBlockType,
 	registerBlockType,
 	unregisterBlockType,
-	parse,
 } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
@@ -19,17 +18,10 @@ import {
 import { Button, Placeholder, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { box, Icon } from '@wordpress/icons';
-import {
-	useDispatch,
-	subscribe,
-	useSelect,
-	select,
-	dispatch,
-} from '@wordpress/data';
+import { useDispatch, subscribe, useSelect, select } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';
-import { debounce } from '@woocommerce/base-utils';
 import { woo } from '@woocommerce/icons';
 
 /**
@@ -368,44 +360,6 @@ const registerClassicTemplateBlock = ( {
 		save: () => null,
 	} );
 };
-
-/**
- * Attempts to recover the Classic Template block if it fails to render on the Single Product template
- * due to the user resetting customizations without refreshing the page.
- *
- * When the Classic Template block fails to render, it is replaced by the 'core/missing' block, which
- * displays an error message stating that the WooCommerce Classic template block is unsupported.
- *
- * This function replaces the 'core/missing' block with the original Classic Template block that failed
- * to render, allowing the block to be displayed correctly.
- *
- * @see {@link https://github.com/woocommerce/woocommerce-blocks/issues/9637|Issue: Block error is displayed on clearing customizations for Woo Templates}
- *
- */
-const tryToRecoverClassicTemplateBlockWhenItFailsToRender = debounce( () => {
-	const blocks = select( 'core/block-editor' ).getBlocks();
-	const blocksIncludingInnerBlocks = blocks.flatMap( ( block ) => [
-		block,
-		...block.innerBlocks,
-	] );
-	const classicTemplateThatFailedToRender = blocksIncludingInnerBlocks.find(
-		( block ) =>
-			block.name === 'core/missing' &&
-			block.attributes.originalName === BLOCK_SLUG
-	);
-
-	if ( classicTemplateThatFailedToRender ) {
-		const blockToReplaceClassicTemplateBlockThatFailedToRender = parse(
-			classicTemplateThatFailedToRender.attributes.originalContent
-		);
-		if ( blockToReplaceClassicTemplateBlockThatFailedToRender ) {
-			dispatch( 'core/block-editor' ).replaceBlock(
-				classicTemplateThatFailedToRender.clientId,
-				blockToReplaceClassicTemplateBlockThatFailedToRender
-			);
-		}
-	}
-}, 100 );
 
 // @todo Refactor when there will be possible to show a block according on a template/post with a Gutenberg API. https://github.com/WordPress/gutenberg/pull/41718
 let previousEditedTemplate: string | number | null = null;

--- a/plugins/woocommerce-blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
@@ -6,8 +6,9 @@ The Compatibility Layer is disabled when either of classic template blocks are a
 
 - `Product (Classic)`,
 - `Product Attribute (Classic)`,
-- `Product Taxonomy (Classic)`,
+- `Product Category (Classic)`,
 - `Product Tag (Classic)`,
+- `Product's Custom Taxonomy (Classic)`,
 - `Product Search Results (Classic)`,
 - `Product Grid (Classic)`.
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -257,7 +257,6 @@ test.describe( `${ blockData.name } Block `, () => {
 			.getByText( `"Single Product" reset.` );
 		const searchResults = editor.page.getByLabel( 'Actions' );
 		await expect.poll( async () => await searchResults.count() ).toBe( 1 );
-
 		await searchResults.first().click();
 		await editor.page.getByRole( 'menuitem', { name: 'Reset' } ).click();
 		await editor.page.getByRole( 'button', { name: 'Reset' } ).click();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect, wpCLI, BlockData } from '@woocommerce/e2e-utils';
+import { test, expect, wpCLI, BlockData, Editor } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -10,6 +10,17 @@ import { test, expect, wpCLI, BlockData } from '@woocommerce/e2e-utils';
 const blockData: Partial< BlockData > = {
 	name: 'woocommerce/legacy-template',
 };
+
+const classicTemplateBlockNames = [
+	'WooCommerce Classic Template',
+	'Product (Classic)',
+	'Product Attribute (Classic)',
+	'Product Category (Classic)',
+	'Product Tag (Classic)',
+	"Product's Custom Taxonomy (Classic)",
+	'Product Search Results (Classic)',
+	'Product Grid (Classic)',
+];
 
 const templates = [
 	{
@@ -46,11 +57,223 @@ const templates = [
 	},
 ];
 
+const getClassicTemplateBlocksInInserter = async ( {
+	editor,
+}: {
+	editor: Editor;
+} ) => {
+	await editor.openGlobalBlockInserter();
+
+	await editor.page
+		.getByLabel( 'Search for blocks and patterns' )
+		.fill( 'classic' );
+
+	// Wait for blocks search to have finished.
+	await expect(
+		editor.page.getByRole( 'heading', {
+			name: 'Available to install',
+			exact: true,
+		} )
+	).toBeVisible();
+
+	const inserterBlocks = editor.page.getByRole( 'listbox', {
+		name: 'Blocks',
+		exact: true,
+	} );
+	const options = inserterBlocks.locator( 'role=option' );
+
+	// Filter out blocks that don't match one of the possible Classic Template block names (case-insensitive).
+	const classicTemplateBlocks = await options.evaluateAll(
+		( elements, blockNames ) => {
+			const blockOptions = elements.filter( ( element ) => {
+				return blockNames.some(
+					( name ) => element.textContent === name
+				);
+			} );
+			return blockOptions.map( ( element ) => element.textContent );
+		},
+		classicTemplateBlockNames
+	);
+
+	return classicTemplateBlocks;
+};
+
 test.describe( `${ blockData.name } Block `, () => {
 	test.beforeEach( async () => {
 		await wpCLI(
 			'option update wc_blocks_use_blockified_product_grid_block_as_template false'
 		);
+	} );
+
+	test( `is registered/unregistered when navigating from a non-WC template to a WC template and back`, async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: `twentytwentyfour//home`,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		let classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks ).toHaveLength( 0 );
+
+		await editor.page.getByLabel( 'Open Navigation' ).click();
+		await editor.page
+			.getByLabel( 'Product Catalog', { exact: true } )
+			.click();
+
+		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks ).toHaveLength( 1 );
+
+		await editor.page.getByLabel( 'Open Navigation' ).click();
+		await editor.page.getByLabel( 'Blog Home', { exact: true } ).click();
+
+		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks ).toHaveLength( 0 );
+	} );
+
+	test( `is registered/unregistered when navigating from a WC template to a non-WC template and back`, async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: `woocommerce/woocommerce//archive-product`,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		let classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks ).toHaveLength( 1 );
+
+		await editor.page.getByLabel( 'Open Navigation' ).click();
+		await editor.page.getByLabel( 'Blog Home', { exact: true } ).click();
+
+		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks ).toHaveLength( 0 );
+
+		await editor.page.getByLabel( 'Open Navigation' ).click();
+		await editor.page
+			.getByLabel( 'Product Catalog', { exact: true } )
+			.click();
+
+		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks ).toHaveLength( 1 );
+	} );
+
+	test( `updates block title when navigating between WC templates`, async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: `woocommerce/woocommerce//archive-product`,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		let classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks[ 0 ] ).toBe( 'Product Grid (Classic)' );
+
+		await editor.page.getByLabel( 'Open Navigation' ).click();
+		await editor.page
+			.getByLabel( 'Product Search Results', { exact: true } )
+			.click();
+
+		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
+			editor,
+		} );
+
+		expect( classicTemplateBlocks[ 0 ] ).toBe(
+			'Product Search Results (Classic)'
+		);
+	} );
+
+	test( `is not available when editing template parts`, async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: `twentytwentyfour//header`,
+			postType: 'wp_template_part',
+			canvas: 'edit',
+		} );
+
+		const classicTemplateBlocks = await getClassicTemplateBlocksInInserter(
+			{
+				editor,
+			}
+		);
+
+		expect( classicTemplateBlocks ).toHaveLength( 0 );
+	} );
+
+	// @see https://github.com/woocommerce/woocommerce-blocks/issues/9637
+	test( `is still available after resetting a modified WC template`, async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: `woocommerce/woocommerce//single-product`,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello World' },
+		} );
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await editor.page.getByLabel( 'Open Navigation' ).click();
+
+		// Reset the template.
+		await editor.page.getByPlaceholder( 'Search' ).fill( 'Single Product' );
+		const resetNotice = editor.page
+			.getByLabel( 'Dismiss this notice' )
+			.getByText( `"Single Product" reset.` );
+		const searchResults = editor.page.getByLabel( 'Actions' );
+		await expect.poll( async () => await searchResults.count() ).toBe( 1 );
+
+		await searchResults.first().click();
+		await editor.page.getByRole( 'menuitem', { name: 'Reset' } ).click();
+		await editor.page.getByRole( 'button', { name: 'Reset' } ).click();
+		await expect( resetNotice ).toBeVisible();
+
+		// Open the template again.
+		await editor.page.getByRole( 'menuitem', { name: 'Edit' } ).click();
+
+		// Verify the Classic Template block is still registered.
+		const classicTemplateBlocks = await getClassicTemplateBlocksInInserter(
+			{
+				editor,
+			}
+		);
+
+		expect( classicTemplateBlocks ).toHaveLength( 1 );
 	} );
 
 	for ( const template of templates ) {

--- a/plugins/woocommerce/changelog/fix-48285-improve-classic-template-block-registration
+++ b/plugins/woocommerce/changelog/fix-48285-improve-classic-template-block-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Fix Classic Template block registration on WP 6.6


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/48285.

This PR changes the approach taken to register & unregister the Classic Template block in the Site Editor: now, it's always registered but we simply hide it or show it in the inserter depending on the active template. This fixes #48285 and allows us to simplify the logic a bit.

This PR also adds several e2e tests to make sure there are no regressions related to the logic to register/unregister the Classic Template block.

### How to test the changes in this Pull Request:

1. With WP 6.6 or Gutenberg 18.5 or later, verify you have the non-blockified templates. You can go to Appearance > Editor > Templates and open the WooCommerce templates (Product Catalog, Single Product, etc.) and click on Revert to Classic Product Template if necessary. Note: if the button isn't there, that probably means you already have the non-blockified templates and the Classic Template block is in the template.
2. Go again to Appearance > Editor > Templates.
3. Verify the Product Catalog preview shows the Classic Template block correctly.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/91712bde-868f-45a9-8f86-ac03b4479a2b) | ![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/3d5a3ef8-1c33-448b-8d02-d44256e581e5)

4. Navigate between templates and verify the block always shows up correctly. Also verify the block only appears in the inserter when you are in a WooCommerce template. When editing non-WooCommerce templates, searching for `Classic` in the block inserter should only show the Classic Cart and Classic Checkout blocks.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
