### PR TITLE
Add coming soon example code documentation

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -358,7 +358,7 @@
           "post_title": "Integrating with coming soon mode",
           "tags": "how-to, coming-soon",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/integrating-coming-soon-mode.md",
-          "hash": "05b5644f50a898e6b3635ef12d91bef88693cb6cfbbc7685725468a22fcefdc6",
+          "hash": "eea34a5e37ceb5448f859d3bb350b6716e4c843a1477bfa5b9a7c369ed837f78",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/integrating-coming-soon-mode.md",
           "id": "787743efb6ef0ad509b17735eaf58b2a9a08afbc"
         },
@@ -1367,5 +1367,5 @@
       "categories": []
     }
   ],
-  "hash": "b9057fdc98f6a72a39c759097bc8f3a5a2d43f8e33aaebccf73a1eb0140175ca"
+  "hash": "f28ecd23ddeca12c13736f3708c95e0bf8918cca5431abbeb066a9950745bc1e"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -309,7 +309,7 @@
           "menu_title": "Integrating admin pages",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/working-with-woocommerce-admin-pages.md",
-          "hash": "9d01da78347ee7379fe096cce5e3982cd13e46617f90ad78e03af72bc3fb8aba",
+          "hash": "c172fff2814f552e2ab5712edb9e716f75c27946d993a1ade8f2269cc9a8689d",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/working-with-woocommerce-admin-pages.md",
           "id": "6f9cc63bc4c614b9e01174069a5ddc4f3d7aa467"
         },
@@ -353,6 +353,14 @@
           "hash": "844689b6d9c482fb217a512db6ddab0afd4d76b2b9e378a9302681d2a8dfe517",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/logging.md",
           "id": "c684e2efba45051a4e1f98eb5e6ef6bab194f25c"
+        },
+        {
+          "post_title": "Integrating with coming soon mode",
+          "tags": "how-to, coming-soon",
+          "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/integrating-coming-soon-mode.md",
+          "hash": "05b5644f50a898e6b3635ef12d91bef88693cb6cfbbc7685725468a22fcefdc6",
+          "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/integrating-coming-soon-mode.md",
+          "id": "787743efb6ef0ad509b17735eaf58b2a9a08afbc"
         },
         {
           "post_title": "Creating custom settings for WooCommerce extensions",
@@ -1359,5 +1367,5 @@
       "categories": []
     }
   ],
-  "hash": "7998790ab69ca3a0f7d480c0dfa0b58916e9c46a04b7e80940cac69f69b50ab4"
+  "hash": "b9057fdc98f6a72a39c759097bc8f3a5a2d43f8e33aaebccf73a1eb0140175ca"
 }

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -9,7 +9,7 @@ This guide provides examples for third-party developers and hosting providers on
 
 ## Clear server cache on site visibility settings change
 
-When the site's visibility settings is changed, it may be necessary to clear the server cache in order for the changes to be applied and customer-facing pages re-cached. We can utilize [`update_option`](https://developer.wordpress.org/reference/hooks/update_option/) hook to achieve this.
+When the site's visibility settings is changed, it may be necessary to clear a server cache in order for the changes to be applied and customer-facing pages re-cached. We can utilize [`update_option`](https://developer.wordpress.org/reference/hooks/update_option/) hook to achieve this.
 
 ```php
 add_action( 'update_option_woocommerce_coming_soon', 'clear_server_cache', 10, 3 );

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -7,9 +7,19 @@ tags: how-to, coming-soon
 
 This guide provides examples for third-party developers and hosting providers on how to integrate their systems with WooCommerce's coming soon mode. For more details, please read the [developer blog post](https://developer.woocommerce.com/2024/06/18/introducing-coming-soon-mode/).
 
-## Clear server cache on site visibility settings change
+## Introduction
 
-When the site's visibility settings is changed, it may be necessary to clear a server cache in order for the changes to be applied and customer-facing pages re-cached. You can utilize [`update_option`](https://developer.wordpress.org/reference/hooks/update_option/) hook to achieve this.
+WooCommerce's coming soon mode allows you to temporarily make your site invisible to the public while you work on it. This guide will show you how to integrate this feature with your system, clear server cache when site visibility settings change, and sync coming soon mode with other plugins.
+
+## Prerequisites
+
+-   Familiarity with PHP and WordPress development.
+
+## Step-by-step instructions
+
+### Clear server cache on site visibility settings change
+
+When the site's visibility settings change, it may be necessary to clear a server cache to apply the changes and re-cache customer-facing pages. The [`update_option`](https://developer.wordpress.org/reference/hooks/update_option/) hook can be used to achieve this.
 
 ```php
 add_action( 'update_option_woocommerce_coming_soon', 'clear_server_cache', 10, 3 );
@@ -23,14 +33,16 @@ function clear_server_cache( $old_value, $new_value, $option ) {
 }
 ```
 
-## Syncing coming soon mode with other plugins
+### Syncing coming soon mode with other plugins
 
-You can programmatically sync the coming soon mode from your plugin or application. Here are some example use cases:
+The coming soon mode can be programmatically synced from a plugin or application. Here are some example use cases:
 
 -   Integrating with a maintenance mode plugin.
--   Integrating with hosting provider's coming soon mode.
+-   Integrating with a hosting provider's coming soon mode.
 
-### Trigger from WooCommerce
+#### Trigger from WooCommerce
+
+You can use the following example to run a code such as setting your plugin's status when coming soon mode option is updated:
 
 ```php
 add_action( 'update_option_woocommerce_coming_soon', 'sync_coming_soon_to_other_plugins', 10, 3 );
@@ -45,9 +57,9 @@ function sync_coming_soon_to_other_plugins( $old_value, $new_value, $option ) {
 }
 ```
 
-### Trigger from other plugins
+#### Trigger from other plugins
 
-The following function example can be called from another plugin to enable or disable WooCommerce coming soon mode.
+You can use the following example to enable or disable WooCommerce coming soon mode from another plugin by directy updating `woocommerce_coming_soon` option:
 
 ```php
 function sync_coming_soon_from_other_plugins( $is_enabled ) {
@@ -63,9 +75,9 @@ function sync_coming_soon_from_other_plugins( $is_enabled ) {
 }
 ```
 
-### 2-way sync with plugins
+#### 2-way sync with plugins
 
-If 2-way sync is needed, you can use the following example where `update_option` will not recursively call `sync_coming_soon_from_other_plugins`.
+If 2-way sync is needed, use the following example where `update_option` will not recursively call `sync_coming_soon_from_other_plugins`:
 
 ```php
 add_action( 'update_option_woocommerce_coming_soon', 'sync_coming_soon_to_other_plugins', 10, 3 );
@@ -98,18 +110,19 @@ function sync_coming_soon_from_other_plugins( $is_enabled ) {
 }
 ```
 
-## Disable coming soon customer-facing page
+### Disable coming soon customer-facing page
 
-If you already have another feature that behaves similarly to WooCommerce's coming soon mode, it can cause unintended conflicts. You can disable the coming soon mode by excluding all shopper-facing pages.
+If there is another feature that behaves similarly to WooCommerce's coming soon mode, it can cause unintended conflicts. The coming soon mode can be disabled by excluding all shopper-facing pages.
+
+Exclude all customer-facing pages from coming soon mode by adding the following code:
 
 ```php
-// Exclude all customer-facing pages from coming soon mode.
 add_filter( 'woocommerce_coming_soon_exclude', function() {
     return true;
 }, 10 );
 ```
 
-You can also use it to apply coming soon mode to all pages except for a specific page:
+Apply coming soon mode to all pages except for a specific page by using this code:
 
 ```php
 add_filter( 'woocommerce_coming_soon_exclude', function( $is_excluded ) {

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -9,7 +9,7 @@ This guide provides examples for third-party developers and hosting providers on
 
 ## Clear server cache on site visibility settings change
 
-When the site's visibility settings is changed, it may be necessary to clear a server cache in order for the changes to be applied and customer-facing pages re-cached. We can utilize [`update_option`](https://developer.wordpress.org/reference/hooks/update_option/) hook to achieve this.
+When the site's visibility settings is changed, it may be necessary to clear a server cache in order for the changes to be applied and customer-facing pages re-cached. You can utilize [`update_option`](https://developer.wordpress.org/reference/hooks/update_option/) hook to achieve this.
 
 ```php
 add_action( 'update_option_woocommerce_coming_soon', 'clear_server_cache', 10, 3 );
@@ -75,3 +75,13 @@ add_filter( 'woocommerce_coming_soon_exclude', function() {
 }, 10 );
 ```
 
+You can also use it to apply coming soon mode to all pages except for a specific page:
+
+```php
+add_filter( 'woocommerce_coming_soon_exclude', function( $is_excluded ) {
+    if ( get_the_ID() === <page-id> ) {
+        return true;
+    }
+    return $is_excluded;
+}, 10 );
+```

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -1,0 +1,51 @@
+---
+post_title: Integrating with coming soon mode
+tags: how-to, coming-soon
+---
+
+# Integrating with coming soon mode
+
+This guide provides examples for third-party developers and hosting providers on how to integrate their systems with WooCommerce's coming soon mode. We will cover common tasks using hooks as described in the [WooCommerce Developer Blog Post](https://developer.woocommerce.com/2024/06/18/introducing-coming-soon-mode/).
+
+## Clear server cache on site visibility settings change
+
+When the site's visibility settings is changed, it may be necessary to clear the server cache in order for the changes to be applied and customer-facing pages re-cached. We can utilize [`update_option`](https://developer.wordpress.org/reference/hooks/update_option/) hook to achieve this.
+
+```php
+add_action( 'update_option_woocommerce_coming_soon', 'clear_server_cache', 10, 3 );
+add_action( 'update_option_woocommerce_store_pages_only', 'clear_server_cache', 10, 3 );
+
+function clear_server_cache( $old_value, $new_value, $option ) {
+    // Implement your logic to clear the server cache.
+    if ( function_exists( 'your_cache_clear_function' ) ) {
+        your_cache_clear_function();
+    }
+}
+```
+
+## Syncing coming soon mode from other plugins
+
+You can also programatically sync the coming soon mode from your application by direcly setting the relevant options. An example use case is such as using the coming soon page as a maintenance page.
+
+```php
+function enable_coming_soon() {
+    // Check user capability.
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( 'You do not have sufficient permissions to access this page.' );
+    }
+
+    // Enable coming soon.
+    update_option( 'woocommerce_coming_soon', 'yes' );
+}
+```
+
+## Disable coming soon customer-facing page
+
+If you already have another feature that behaves similar to WooCommerce's coming soon mode, it can cause unintended conflicts. You could disable the coming soon mode by excluding all shopper-facing pages.
+
+```php
+add_filter( 'woocommerce_coming_soon_exclude', function() {
+    return true;
+}, 10 );
+```
+

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -5,7 +5,7 @@ tags: how-to, coming-soon
 
 # Integrating with coming soon mode
 
-This guide provides examples for third-party developers and hosting providers on how to integrate their systems with WooCommerce's coming soon mode. We will cover common tasks using hooks as described in the [WooCommerce Developer Blog Post](https://developer.woocommerce.com/2024/06/18/introducing-coming-soon-mode/).
+This guide provides examples for third-party developers and hosting providers on how to integrate their systems with WooCommerce's coming soon mode. For more details, please read the [developer blog post](https://developer.woocommerce.com/2024/06/18/introducing-coming-soon-mode/).
 
 ## Clear server cache on site visibility settings change
 
@@ -23,27 +23,53 @@ function clear_server_cache( $old_value, $new_value, $option ) {
 }
 ```
 
-## Syncing coming soon mode from other plugins
+## Syncing coming soon mode with other plugins
 
-You can also programatically sync the coming soon mode from your application by direcly setting the relevant options. An example use case is such as using the coming soon page as a maintenance page.
+You can programmatically sync the coming soon mode from your plugin or application. Here are some example use cases:
+
+- Integrating with a maintenance mode plugin.
+- Integrating with hosting provider's coming soon mode.
+
+### Trigger from WooCommerce
 
 ```php
-function enable_coming_soon() {
+// Priority set to 11 to ensure the options are already saved.
+add_action( 'woocommerce_update_options_site-visibility', 'sync_coming_soon_to_other_plugins', 11 );
+
+function sync_coming_soon_to_other_plugins() {
+    $is_enabled = get_option( 'woocommerce_coming_soon' ) === 'yes';
+
+    // Implement your logic to sync coming soon status.
+    if ( function_exists( 'set_your_plugin_status' ) ) {
+        set_your_plugin_status( $is_enabled );
+    }
+}
+```
+
+### Trigger from other plugins
+
+The following function example can be called from another plugin to enable or disable WooCommerce coming soon mode.
+
+```php
+function sync_coming_soon_from_other_plugins( $is_enabled ) {
     // Check user capability.
     if ( ! current_user_can( 'manage_options' ) ) {
         wp_die( 'You do not have sufficient permissions to access this page.' );
     }
 
-    // Enable coming soon.
-    update_option( 'woocommerce_coming_soon', 'yes' );
+    // Set coming soon mode.
+    if ( isset( $is_enabled ) ) {
+        update_option( 'woocommerce_coming_soon', $is_enabled ? 'yes' : 'no' );
+    }
 }
 ```
 
 ## Disable coming soon customer-facing page
 
-If you already have another feature that behaves similar to WooCommerce's coming soon mode, it can cause unintended conflicts. You could disable the coming soon mode by excluding all shopper-facing pages.
+If you already have another feature that behaves similarly to WooCommerce's coming soon mode, it can cause unintended conflicts. You can disable the coming soon mode by excluding all shopper-facing pages.
 
 ```php
+// Exclude all customer-facing pages from coming soon mode.
 add_filter( 'woocommerce_coming_soon_exclude', function() {
     return true;
 }, 10 );

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -27,8 +27,8 @@ function clear_server_cache( $old_value, $new_value, $option ) {
 
 You can programmatically sync the coming soon mode from your plugin or application. Here are some example use cases:
 
-- Integrating with a maintenance mode plugin.
-- Integrating with hosting provider's coming soon mode.
+-   Integrating with a maintenance mode plugin.
+-   Integrating with hosting provider's coming soon mode.
 
 ### Trigger from WooCommerce
 

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -110,11 +110,13 @@ function sync_coming_soon_from_other_plugins( $is_enabled ) {
 }
 ```
 
-### Disable coming soon customer-facing page
+### Custom exclusions filter
 
-If there is another feature that behaves similarly to WooCommerce's coming soon mode, it can cause unintended conflicts. The coming soon mode can be disabled by excluding all shopper-facing pages.
+It is possible for developers to add custom exclusions that bypass the coming soon protection. This is useful for exclusions like always bypassing the screen on a specific IP address, or making a specific landing page available.
 
-Exclude all customer-facing pages from coming soon mode by adding the following code:
+#### Disabling coming soon in all pages
+
+If there is another feature that behaves similarly to WooCommerce's coming soon mode, it can cause unintended conflicts. The coming soon mode can be disabled by excluding all customer-facing pages. The following is an example:
 
 ```php
 add_filter( 'woocommerce_coming_soon_exclude', function() {
@@ -122,7 +124,9 @@ add_filter( 'woocommerce_coming_soon_exclude', function() {
 }, 10 );
 ```
 
-Apply coming soon mode to all pages except for a specific page by using this code:
+#### Disabling coming soon except for a specific page
+
+Use the following example to exclude a certain page based on the page's ID. Replace `<page-id>` with your page identifier:
 
 ```php
 add_filter( 'woocommerce_coming_soon_exclude', function( $is_excluded ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds initial documentation and example code.

### How to test the changes in this Pull Request:

1. Review the `.md` file for factual accuracy
2. Test the code snippets with `trunk` branch. Following sample codes are suited to test in a JN site, I recommend to use the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin:

### Clear server cache on site visibility settings change

```php
add_action( 'update_option_woocommerce_coming_soon', 'clear_server_cache', 10, 3 );
add_action( 'update_option_woocommerce_store_pages_only', 'clear_server_cache', 10, 3 );

function clear_server_cache( $old_value, $new_value, $option ) {
    // Implement your logic to clear the server cache.
    if ( function_exists( 'your_cache_clear_function' ) ) {
        your_cache_clear_function();
    }
}

function your_cache_clear_function() {
	var_dump('Cache cleared');
}
```

1. Deactivate other snippets, save & activate the above snippet
2. Go to `WooCommerce > Settings > Site visibility`
3. If coming soon is enabled, select live, otherwise, vice versa
4. Save
5. Observe `Cache cleared` is shown with boolean status of radio button briefly (view source to see it clearer)

### Trigger from WooCommerce

```php
// Priority set to 11 to ensure the options are already saved.
add_action( 'woocommerce_update_options_site-visibility', 'sync_coming_soon_to_other_plugins', 11 );

function sync_coming_soon_to_other_plugins() {
    $is_enabled = get_option( 'woocommerce_coming_soon' ) === 'yes';

    // Implement your logic to sync coming soon status.
    if ( function_exists( 'set_your_plugin_status' ) ) {
        set_your_plugin_status( $is_enabled );
    }
}

function set_your_plugin_status( $is_enabled ) {
	var_dump( 'Setting other plugin status', $is_enabled );
}
```

1. Deactivate other snippets, save & activate the above snippet
2. Go to `WooCommerce > Settings > Site visibility`
3. If coming soon is enabled, select live, otherwise, vice versa
4. Save
5. Observe `Setting other plugin status` is shown with boolean status of radio button briefly (view source to see it clearer)

### Trigger from other plugins

```php
function sync_coming_soon_from_other_plugins( $is_enabled ) {
    // Check user capability.
    if ( ! current_user_can( 'manage_options' ) ) {
        wp_die( 'You do not have sufficient permissions to access this page.' );
    }

    // Set coming soon mode.
    if ( isset( $is_enabled ) ) {
        update_option( 'woocommerce_coming_soon', $is_enabled ? 'yes' : 'no' );
    }
}

function update_coming_soon_using_query() {
	if ( isset($_GET['coming_soon'] ) ) {
		sync_coming_soon_from_other_plugins( $_GET['coming_soon'] === 'yes' );
	}
}

add_action( 'admin_init', 'update_coming_soon_using_query' );
```

1. Deactivate other snippets, save & activate the above snippet
2. Go to `WooCommerce > Settings > Site visibility`
3. In the URL query, append `&coming_soon=yes` and navigate
4. Observe `Coming soon` radio button is selected
3. In the URL query, append `&coming_soon=no` and navigate
4. Observe `Live` radio button is selected

#### Disable coming soon customer-facing page

```php
add_filter( 'woocommerce_coming_soon_exclude', function() {
    return true;
}, 10 );
```

1. Deactivate other snippets, save & activate the above snippet
7. Ensure coming soon is enabled
8. Go to any shopper page in incognito
9. Observe no coming soon is shown

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
