### PR TITLE
Revert PR 46857 for backward compatibility

### DIFF
--- a/plugins/woocommerce/changelog/fix-46857
+++ b/plugins/woocommerce/changelog/fix-46857
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert 46857 to preserve backcompat with earlier WC versions.

--- a/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -108,9 +108,6 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		// Remove whitespace from string.
 		$sum = preg_replace( '/\s+/', '', $sum );
 
-		// Removed thousand separator.
-		$sum = str_replace( wc_get_price_thousand_separator(), '', $sum );
-
 		// Remove locale from string.
 		$sum = str_replace( $decimals, '.', $sum );
 

--- a/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
+++ b/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
@@ -1,0 +1,154 @@
+<?php
+
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- backcompat nomenclature.
+
+/**
+ * Test for WC_Shipping_Flat_Rate class.
+ */
+class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * @var WC_Shipping_Flat_Rate Shipping method instance.
+	 */
+	private $sut;
+
+	/**
+	 * @var Closure Function to call protected method evaluate_cost.
+	 */
+	private $call_evaluate_cost;
+
+	/**
+	 * Set up test case.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut                = new WC_Shipping_Flat_Rate();
+		$this->call_evaluate_cost = function ( $sum, $args ) {
+			return $this->evaluate_cost( $sum, $args );
+		};
+		update_option( 'woocommerce_price_decimal_sep', ',' );
+		update_option( 'woocommerce_price_thousand_sep', '.' );
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		update_option( 'woocommerce_price_decimal_sep', '.' );
+		update_option( 'woocommerce_price_thousand_sep', ',' );
+		parent::tearDown();
+	}
+
+
+	/**
+	 * @testDox Shipping cost with decimal seperator works as expected.
+	 */
+	public function test_evaluate_cost_sep_dec() {
+		$val = $this->call_evaluate_cost->call(
+			$this->sut,
+			'12345,67',
+			array(
+				'qty'  => 1,
+				'cost' => 1,
+			)
+		);
+		$this->assertEquals( 12345.67, $val );
+	}
+
+	/**
+	 * @testDox Shipping cost with incorrect decimal seperator works as expected.
+	 */
+	public function test_evaluate_cost_dec_seperator_inverse() {
+		$val = $this->call_evaluate_cost->call(
+			$this->sut,
+			'12345.67',
+			array(
+				'qty'  => 1,
+				'cost' => 1,
+			)
+		);
+		$this->assertEquals( 12345.67, $val );
+	}
+
+	/**
+	 * @testDox Shipping cost with thousand and decimal seperator works as expected.
+	 */
+	public function test_evaluate_cost_sep_thou_dec() {
+		$this->markTestSkipped( 'This test currently fails because we dont support thousand seperator in shipping price.' );
+		$val = $this->call_evaluate_cost->call(
+			$this->sut,
+			'12.345,67',
+			array(
+				'qty'  => 1,
+				'cost' => 1,
+			)
+		);
+		$this->assertEquals( 12345.67, $val );
+	}
+
+	/**
+	 * @testDox Shipping cost with two decimal separator works as expected.
+	 */
+	public function test_evaluate_cost_sep_dec_dec() {
+		$this->markTestSkipped( 'This test currently fails because we dont support thousand seperator in shipping price.' );
+		$val = $this->call_evaluate_cost->call(
+			$this->sut,
+			'12,345,67',
+			array(
+				'qty'  => 1,
+				'cost' => 1,
+			)
+		);
+		$this->assertEquals( 12345.67, $val );
+	}
+
+	/**
+	 * @testDox Shipping cost with two thousand separator works as expected.
+	 */
+	public function test_evaluate_cost_sep_thou_thou() {
+		$this->markTestSkipped( 'This test currently fails because we dont support thousand seperator in shipping price.' );
+		$val = $this->call_evaluate_cost->call(
+			$this->sut,
+			'12.345.67',
+			array(
+				'qty'  => 1,
+				'cost' => 1,
+			)
+		);
+		$this->assertEquals( 1234567, $val );
+	}
+
+	/**
+	 * Percent fee calculation works as expected.
+	 */
+	public function test_evaluate_cost_percent_fee() {
+		$val = $this->call_evaluate_cost->call(
+			$this->sut,
+			'[fee percent="10.1"]',
+			array(
+				'qty'  => 1,
+				'cost' => 100,
+			)
+		);
+		$this->assertEquals( 10.1, $val );
+	}
+
+	/**
+	 * Percent fee calculation works as expected with comma as decimal separator. Value after the comma is ignored.
+	 */
+	public function test_evaluate_cost_percent_fee_comma() {
+		$val = $this->call_evaluate_cost->call(
+			$this->sut,
+			'[fee percent="10,1"]',
+			array(
+				'qty'  => 1,
+				'cost' => 100,
+			)
+		);
+		$this->assertEquals( 10, $val );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
+++ b/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
@@ -45,7 +45,7 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 
 
 	/**
-	 * @testDox Shipping cost with decimal seperator works as expected.
+	 * @testDox Shipping cost with decimal separator works as expected.
 	 */
 	public function test_evaluate_cost_sep_dec() {
 		$val = $this->call_evaluate_cost->call(
@@ -60,9 +60,9 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox Shipping cost with incorrect decimal seperator works as expected.
+	 * @testDox Shipping cost with incorrect decimal separator works as expected.
 	 */
-	public function test_evaluate_cost_dec_seperator_inverse() {
+	public function test_evaluate_cost_dec_separator_inverse() {
 		$val = $this->call_evaluate_cost->call(
 			$this->sut,
 			'12345.67',
@@ -75,10 +75,10 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox Shipping cost with thousand and decimal seperator works as expected.
+	 * @testDox Shipping cost with a thousand and decimal separator works as expected.
 	 */
 	public function test_evaluate_cost_sep_thou_dec() {
-		$this->markTestSkipped( 'This test currently fails because we dont support thousand seperator in shipping price.' );
+		$this->markTestSkipped( 'This test currently fails because we dont support thousand separator in shipping price.' );
 		$val = $this->call_evaluate_cost->call(
 			$this->sut,
 			'12.345,67',
@@ -94,7 +94,7 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	 * @testDox Shipping cost with two decimal separator works as expected.
 	 */
 	public function test_evaluate_cost_sep_dec_dec() {
-		$this->markTestSkipped( 'This test currently fails because we dont support thousand seperator in shipping price.' );
+		$this->markTestSkipped( 'This test currently fails because we dont support thousand separator in shipping price.' );
 		$val = $this->call_evaluate_cost->call(
 			$this->sut,
 			'12,345,67',
@@ -110,7 +110,7 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	 * @testDox Shipping cost with two thousand separator works as expected.
 	 */
 	public function test_evaluate_cost_sep_thou_thou() {
-		$this->markTestSkipped( 'This test currently fails because we dont support thousand seperator in shipping price.' );
+		$this->markTestSkipped( 'This test currently fails because we dont support thousand separator in shipping price.' );
 		$val = $this->call_evaluate_cost->call(
 			$this->sut,
 			'12.345.67',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Note that we don't support a thousand separators in the shipping fee prices because it conflicts with the math evaluation logic for complex formulas. PR #46857 attempted to add support for it, however, it broke the calculation for formulas and when shipping rate was entered assuming that `.` is a decimal seperator (i.e. thousand seperator is not supported).

This PR reverts that commit, additionally, it also adds unit test for fee calculations. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add shipping flat rate as `10.1`. Set the decimal separator to `,` and the thousand separator to `.`. 
2. Check out any product, and verify that the shipping rate is 10.1 (and not 101).

Repeat the same testing with the flat rate set to `[fee percent="10.1"]`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
