### PR TITLE
Update - Disable toggle by default and secondary enhancements

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/attributes.tsx
@@ -10,7 +10,7 @@ export default {
 	},
 	showReturnToCart: {
 		type: 'boolean',
-		default: true,
+		default: false,
 	},
 	className: {
 		type: 'string',

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -33,7 +33,7 @@ export const Edit = ( {
 	const blockProps = useBlockProps();
 	const {
 		cartPageId = 0,
-		showReturnToCart = true,
+		showReturnToCart = false,
 		placeOrderButtonLabel,
 	} = attributes;
 	const { current: savedCartPageId } = useRef( cartPageId );
@@ -51,10 +51,14 @@ export const Edit = ( {
 	return (
 		<div { ...blockProps }>
 			<InspectorControls>
-				<PanelBody title={ __( 'Account options', 'woocommerce' ) }>
+				<PanelBody title={ __( 'Navigation options', 'woocommerce' ) }>
 					<ToggleControl
 						label={ __(
 							'Show a "Return to Cart" link',
+							'woocommerce'
+						) }
+						help={ __(
+							'Recommended to enable only if there is no Cart link in the header.',
 							'woocommerce'
 						) }
 						checked={ showReturnToCart }

--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-translations.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-translations.shopper.block_theme.spec.ts
@@ -95,10 +95,6 @@ test.describe( 'Shopper → Translations', () => {
 		).toBeVisible();
 
 		await expect(
-			page.getByRole( 'link', { name: 'Terug naar winkelwagen' } )
-		).toBeVisible();
-
-		await expect(
 			page.getByRole( 'button', { name: 'Bestel en betaal' } )
 		).toBeVisible();
 

--- a/plugins/woocommerce/changelog/48762-update-disable-toggle-by-default-and-secondary-enhancements
+++ b/plugins/woocommerce/changelog/48762-update-disable-toggle-by-default-and-secondary-enhancements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Made the "return to cart" link in the checkout block hidden by default.

--- a/plugins/woocommerce/changelog/48762-update-disable-toggle-by-default-and-secondary-enhancements
+++ b/plugins/woocommerce/changelog/48762-update-disable-toggle-by-default-and-secondary-enhancements
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Made the "return to cart" link in the checkout block hidden by default.
+Made the "return to cart" link (in the checkout block) hidden by default.


### PR DESCRIPTION
- Disabled toggle by default in Checkout blocks Return to cart button.

- Changed "Account options" to "Navigation options".

- Added a subtext to explain when to turn it on or off.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48757 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a page and add checkout block.
2. Click on Place Order section and see options.
3. Show a "Return to Cart" link button is unchecked by default.
4. "Account options" is changed to "Navigation options".
5. A subtext is added.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Made the "return to cart" link in the checkout block hidden by default.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
