### PR TITLE
CYS: when the footer/header is clicked, the border color is blue

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
@@ -301,6 +301,11 @@ function ScaledBlockPreview( {
 							display: none !important;
 						}
 
+						footer.is-selected::after,
+						header.is-selected::after {
+							outline-color: var(--wp-admin-theme-color) !important;
+						}
+
 						${ additionalStyles }
 					` }
 						</style>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
@@ -306,6 +306,14 @@ function ScaledBlockPreview( {
 							outline-color: var(--wp-admin-theme-color) !important;
 						}
 
+						header.is-selected::after {
+						    border-top-left-radius: 20px;
+					    }
+
+						footer.is-selected::after {
+						    border-bottom-left-radius: 20px;
+					    }
+
 						${ additionalStyles }
 					` }
 						</style>

--- a/plugins/woocommerce/changelog/48765-48669-cys-in-some-cases-the-border-of-the-footerheader-is-violet
+++ b/plugins/woocommerce/changelog/48765-48669-cys-in-some-cases-the-border-of-the-footerheader-is-violet
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS: when the footer/header is clicked, the border color is blue.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


| Before | After |
|--------|--------|
| <video src="https://github.com/woocommerce/woocommerce/assets/4463174/ea0bfd46-03e9-4881-97ad-ffb126eeb66e" /> | <video src="https://github.com/woocommerce/woocommerce/assets/4463174/0e6775bf-5497-40d8-8bce-079b2dd6f675" /> | 








Closes #48669.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on Start designing.
8. Click on "Choose your Header".
9. Hover the header in the side preview and ensure that the border is blue.
10. Click on the header.
11. Ensure that the border is still blue.
12. Repeat 9-11 for "Choose your Footer".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: when the footer/header is clicked, the border color is blue.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>