### PR TITLE
CI: lint strict types directive for new files

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -10,12 +10,21 @@
 
 baseBranch=${1:-"trunk"}
 
+# Lint changed php-files to match code style.
 changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=d -- '*.php')
-
-# Only complete this if changed files are detected.
-if [[ -z $changedFiles ]]; then
-    echo "No changed files detected."
-    exit 0
+if [[ -n $changedFiles ]]; then
+    composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
 fi
 
-composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
+# Lint new (excl. renamed) php-files to contain strict types directive.
+newFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=r -- '*.php')
+if [[ -n $newFiles ]]; then
+	passingFiles=$(find $newFiles -type f -exec grep -xl --regexp='declare(\s*strict_types\s*=\s*1\s*);' /dev/null {} +)
+	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort))
+	if [[ -n violatingFiles ]]; then
+		redColoured='\033[0;31m'
+		printf "${redColoured}Following files are missing 'declare( strict_types = 1)' directive:\n"
+		printf "${redColoured}%s\n" $violatingFiles
+		exit 1
+	fi
+fi

--- a/plugins/woocommerce/changelog/add-41443-lint-strict-types-directive-for-new-files
+++ b/plugins/woocommerce/changelog/add-41443-lint-strict-types-directive-for-new-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Lint new PHP files for strict types directive


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR extends linting with checking strict types directive for new files (excl. renamed).

Closes #41443.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

For testing purposes, I created https://github.com/woocommerce/woocommerce/pull/48836 which fails to pass CI workflow:
https://github.com/woocommerce/woocommerce/actions/runs/9676108899/job/26695017590?pr=48836

![Screenshot from 2024-06-25 09-01-26](https://github.com/woocommerce/woocommerce/assets/1577185/4a021d5d-8b94-4945-9b00-6cfbdeb53e02)

There is a rule in [Slevomat Coding Standard](https://github.com/slevomat/coding-standard), but it cannot distinguish new files from others and is an additional package — hence, the bash-based approach.