### PR TITLE
fix: fixed react18 React.render deprecation notice for WCAdmin

### DIFF
--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import '@wordpress/notices';
-import { render, createRoot } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import { CustomerEffortScoreTracksContainer } from '@woocommerce/customer-effort-score';
 import {
 	withCurrentUserHydration,
@@ -61,11 +61,11 @@ if ( appRoot ) {
 		HydratedPageLayout =
 			withCurrentUserHydration( hydrateUser )( HydratedPageLayout );
 	}
-	render(
+
+	createRoot( appRoot ).render(
 		<ErrorBoundary>
 			<HydratedPageLayout />
-		</ErrorBoundary>,
-		appRoot
+		</ErrorBoundary>
 	);
 } else if ( embeddedRoot ) {
 	let HydratedEmbedLayout = withSettingsHydration(
@@ -77,7 +77,7 @@ if ( appRoot ) {
 			withCurrentUserHydration( hydrateUser )( HydratedEmbedLayout );
 	}
 	// Render the header.
-	render( <HydratedEmbedLayout />, embeddedRoot );
+	createRoot( embeddedRoot ).render( <HydratedEmbedLayout /> );
 
 	embeddedRoot.classList.remove( 'is-embed-loading' );
 
@@ -90,17 +90,16 @@ if ( appRoot ) {
 		wpBody.querySelector( '.wrap' );
 	const noticeContainer = document.createElement( 'div' );
 
-	render(
+	createRoot( wpBody.insertBefore( noticeContainer, wrap ) ).render(
 		<div className="woocommerce-layout">
 			<NoticeArea />
-		</div>,
-		wpBody.insertBefore( noticeContainer, wrap )
+		</div>
 	);
 	const embeddedBodyContainer = document.createElement( 'div' );
-	render(
-		<EmbeddedBodyLayout />,
+
+	createRoot(
 		wpBody.insertBefore( embeddedBodyContainer, wrap.nextSibling )
-	);
+	).render( <EmbeddedBodyLayout /> );
 
 	possiblyRenderSettingsSlots();
 
@@ -123,11 +122,9 @@ if (
 	// Set up customer effort score survey.
 	( function () {
 		const root = appRoot || embeddedRoot;
-
-		render(
-			<CustomerEffortScoreTracksContainer />,
+		createRoot(
 			root.insertBefore( document.createElement( 'div' ), null )
-		);
+		).render( <CustomerEffortScoreTracksContainer /> );
 	} )();
 }
 

--- a/plugins/woocommerce-admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce-admin/client/settings/settings-slots.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import { createSlotFill, SlotFillProvider } from '@wordpress/components';
 import { PluginArea } from '@wordpress/plugins';
 
@@ -28,14 +28,13 @@ export const possiblyRenderSettingsSlots = () => {
 		const slotDomElement = document.getElementById( slot.id );
 
 		if ( slotDomElement ) {
-			render(
+			createRoot( slotDomElement ).render(
 				<>
 					<SlotFillProvider>
 						<Slot />
 						<PluginArea scope={ slot.scope } />
 					</SlotFillProvider>
-				</>,
-				slotDomElement
+				</>
 			);
 		}
 	} );

--- a/plugins/woocommerce/changelog/fix-wcadmin-react-18-create-root
+++ b/plugins/woocommerce/changelog/fix-wcadmin-react-18-create-root
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Changed from using React.render to React.createRoot for WCAdmin uses as it has been deprecated since React 18

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-list.spec.js
@@ -116,10 +116,16 @@ test.describe( 'Merchant > Customer List', { tag: '@services' }, () => {
 			let x = 1;
 			for ( const customer of customers ) {
 				await page
-					.locator( '#woocommerce-select-control-0__control-input' )
+					.getByRole( 'combobox', {
+						expanded: false,
+						disabled: false,
+					} )
 					.click();
 				await page
-					.locator( '#woocommerce-select-control-0__control-input' )
+					.getByRole( 'combobox', {
+						expanded: false,
+						disabled: false,
+					} )
 					.pressSequentially(
 						`${ customer.first_name } ${ customer.last_name }`
 					);
@@ -282,7 +288,8 @@ test.describe( 'Merchant > Customer List', { tag: '@services' }, () => {
 				.getByRole( 'button' )
 				.click();
 			await page
-				.locator( '#woocommerce-select-control-1__control-input' )
+				.getByRole( 'group', { name: 'Email' } )
+				.getByRole( 'combobox', { expanded: false } )
 				.fill( customers[ 1 ].email );
 			await page
 				.getByRole( 'option', {
@@ -299,7 +306,8 @@ test.describe( 'Merchant > Customer List', { tag: '@services' }, () => {
 				.getByRole( 'button' )
 				.click();
 			await page
-				.locator( '#woocommerce-select-control-2__control-input' )
+				.getByRole( 'group', { name: 'Country / Region' } )
+				.getByRole( 'combobox', { expanded: false } )
 				.fill( 'US' );
 			await page
 				.getByRole( 'option', { name: 'United States (US)' } )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce/issues/46879

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WC Admin and do a simple smoke test, any failures should be obvious and catastrophic. Affected areas:
- WC Admin React home page

![image](https://github.com/woocommerce/woocommerce/assets/27843274/6f6f4d66-aff3-4981-ab90-265af9a9b679)

- WC Admin Embedded React pages, e.g Analytics, Marketing

![image](https://github.com/woocommerce/woocommerce/assets/27843274/53d6c1d2-eb7b-4681-8f09-4e5c3febb53c)


- WC Admin Settings slot fills. e.g the "Site Visibility" tab

![image](https://github.com/woocommerce/woocommerce/assets/27843274/424669ee-2f58-4f18-b96e-a8209ab06cea)


- Customer Effort Score

![image](https://github.com/woocommerce/woocommerce/assets/27843274/82319103-886e-4508-a558-d4b1e695ec88)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
