### PR TITLE
Checkout: Update legacy status handling

### DIFF
--- a/plugins/woocommerce/changelog/fix-48126-legacy-status-handling
+++ b/plugins/woocommerce/changelog/fix-48126-legacy-status-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update allowed statuses in legacy payment handler for checkout block.

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -60,8 +60,11 @@ class Legacy {
 		// and a generic notice will be shown instead if payment failed.
 		wc_clear_notices();
 
-		// Handle result.
-		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );
+		// Handle result. If status was not returned we consider this invalid and return failure.
+		$result_status = $gateway_result['result'] ?? 'failure';
+		// These are the same statuses supported by the API and indicate processing status. This is not the same as order status.
+		$valid_status = array( 'success', 'failure', 'pending', 'error' );
+		$result->set_status( in_array( $result_status, $valid_status, true ) ? $result_status : 'failure' );
 
 		// set payment_details from result.
 		$result->set_payment_details( array_merge( $result->payment_details, $gateway_result ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small change that allows legacy payment methods to return `pending` status. This aligns with the expected statuses defined here:

https://github.com/woocommerce/woocommerce/blob/cebeac1b47f1878f298912b0423d3d9b8dad2fb2/plugins/woocommerce-blocks/assets/js/types/type-defs/checkout.ts#L21

https://github.com/woocommerce/woocommerce/blob/cebeac1b47f1878f298912b0423d3d9b8dad2fb2/plugins/woocommerce/src/StoreApi/Payments/PaymentResult.php#L13

Before this change, anything other than `success` would fail checkout side with an error.

After this change, `pending` will succeed. These are treated like `success`.

Closes #48126

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Developer facing change only:

1. Edit `includes/gateways/bacs/class-wc-gateway-bacs.php`
2. Change `'result'   => 'success',` to `'result'   => 'pending',`
3. Complete checkout with BACS
4. Complete checkout with a different gateway to ensure there are no regressions

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
