### PR TITLE
Fix failing e2e test merchant/settings-tax

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-settings-tax-test
+++ b/plugins/woocommerce/changelog/e2e-fix-settings-tax-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix failing settings-tax e2e test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-tax.spec.js
@@ -125,18 +125,6 @@ test.describe.serial( 'WooCommerce Tax Settings', () => {
 			'Tax'
 		);
 
-		// Clear out existing tax classes
-		await page.locator( '#woocommerce_tax_classes' ).fill( '' );
-		await page.locator( 'text=Save changes' ).click();
-
-		// Verify that the settings have been saved
-		await expect( page.locator( 'div.updated.inline' ) ).toContainText(
-			'Your settings have been saved.'
-		);
-		await expect( page.locator( '#woocommerce_tax_classes' ) ).toHaveValue(
-			''
-		);
-
 		// Add a "fancy" tax class
 		await page.locator( '#woocommerce_tax_classes' ).fill( 'Fancy' );
 		await page.locator( 'text=Save changes' ).click();

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-tax.spec.js
@@ -56,9 +56,7 @@ test.describe.serial( 'WooCommerce Tax Settings', () => {
 	} );
 
 	test( 'can set tax options', async ( { page } ) => {
-		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=tax', {
-			waitUntil: 'networkidle',
-		} );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=tax', {} );
 
 		// Make sure we're on the tax tab
 		await expect( page.locator( 'a.nav-tab-active' ) ).toContainText(
@@ -117,9 +115,7 @@ test.describe.serial( 'WooCommerce Tax Settings', () => {
 	} );
 
 	test( 'can add tax classes', async ( { page } ) => {
-		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=tax', {
-			waitUntil: 'networkidle',
-		} );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=tax', {} );
 
 		await expect( page.locator( 'a.nav-tab-active' ) ).toContainText(
 			'Tax'
@@ -140,8 +136,7 @@ test.describe.serial( 'WooCommerce Tax Settings', () => {
 
 	test( 'can set rate settings', async ( { page } ) => {
 		await page.goto(
-			'wp-admin/admin.php?page=wc-settings&tab=tax&section=fancy',
-			{ waitUntil: 'networkidle' }
+			'wp-admin/admin.php?page=wc-settings&tab=tax&section=fancy'
 		);
 
 		// Make sure the tax tab is active, with the "fancy" subsection


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48590

There is no need to clear existing tax classes because `fill` action does it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check CI pass

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
