### PR TITLE
Make product variations endpoints aware of parent product id provided

### DIFF
--- a/plugins/woocommerce/changelog/fix-41373
+++ b/plugins/woocommerce/changelog/fix-41373
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Enforce product parent checks in variations REST API.

--- a/plugins/woocommerce/changelog/fix-41373
+++ b/plugins/woocommerce/changelog/fix-41373
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Enforce product parent checks in variations REST API.
+Ensures the product ID is valid when interacting with product variations via the REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -153,7 +153,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	 *
 	 * @since 9.2.0
 	 */
-	protected function check_variation_parent( int $variation_id, int $parent_id ) {
+	protected function check_variation_parent( int $variation_id, int $parent_id ): bool {
 		$variation = $this->get_object( $variation_id );
 		if ( ! $variation || $parent_id !== $variation->get_parent_id() ) {
 			return false;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -144,15 +144,27 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 		return ( $object && 0 !== $object->get_parent_id() ) ? $object : null;
 	}
 
-	protected function get_object_for_parent( int $id, int $parent_id ) {
-		$object = $this->get_object( $id );
-		$parent = wc_get_product( $parent_id );
-
-		if ( $object && ( ! $parent || $parent_id !== $object->get_parent_id() ) ) {
-			return new \WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 404 ) );
+	/**
+	 * Checks that a variation belongs to the specified parent product.
+	 *
+	 * @param int $variation_id Variation ID.
+	 * @param int $parent_id    Parent product ID to check against.
+	 * @return bool TRUE if variation and parent product exist. FALSE otherwise.
+	 *
+	 * @since 9.2.0
+	 */
+	protected function check_variation_parent( int $variation_id, int $parent_id ) {
+		$variation = $this->get_object( $variation_id );
+		if ( ! $variation || $parent_id !== $variation->get_parent_id() ) {
+			return false;
 		}
 
-		return $object;
+		$parent = wc_get_product( $variation->get_parent_id() );
+		if ( ! $parent ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -162,9 +174,8 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-		$object = $this->get_object_for_parent( (int) $request['id'], (int) $request['product_id'] );
-		if ( is_wp_error( $object ) ) {
-			return $object;
+		if ( ! $this->check_variation_parent( (int) $request['id'], (int) $request['product_id'] ) ) {
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'Invalid ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		return parent::get_item_permissions_check( $request );
@@ -177,18 +188,31 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	 * @return WP_Error|boolean
 	 */
 	public function update_item_permissions_check( $request ) {
+		if ( ! $this->check_variation_parent( (int) $request['id'], (int) $request['product_id'] ) ) {
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'Invalid ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
 		$object = $this->get_object( (int) $request['id'] );
 
 		if ( $object && 0 !== $object->get_id() && ! wc_rest_check_post_permissions( $this->post_type, 'edit', $object->get_id() ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you are not allowed to edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
-		// Check if variation belongs to the correct parent product.
-		if ( $object && 0 !== $object->get_parent_id() && absint( $request['product_id'] ) !== $object->get_parent_id() ) {
-			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Parent product does not match current variation.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to delete an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		if ( ! $this->check_variation_parent( (int) $request['id'], (int) $request['product_id'] ) ) {
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'Invalid ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		return true;
+		return parent::delete_item_permissions_check( $request );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/product-variations.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/product-variations.php
@@ -255,7 +255,7 @@ class Product_Variations_API_V2 extends WC_REST_Unit_Test_Case {
 			)
 		);
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 404, $response->get_status() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/product-variations.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/product-variations.php
@@ -257,7 +257,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 			)
 		);
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 404, $response->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
[Most variations endpoints](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variations) take the form `/products/<product_id>/variations/<id>`, but with the exception of `PUT` (update) requests, `<product_id>` was ignored altogether and we only checked that the variation with ID `<id>` exists.

This PR enforces some additional checks to ensure that that the product referred by `<product_id>` also exists and that `<id>` is actually a variation of said product.
This makes the variations endpoints consistent with `/products/<product_id>` which would obviously check that the product exists, so we no longer have a situation where `/products/1234` would fail but `/products/1234/variations/<existing_variation_id>` would be successful.

⚠️ Changes here could be considered backwards incompatible as it'd no longer be possible to get details for a variation or delete it by using `/products/<random int>/variations/<variation_id>`. Related: p1719503648061859-slack-C0E1AV8T0.

Closes #41373.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Generate and take note of your API consumer key and secret in WC > Settings > Advanced > REST API.
2. Go to WC > Products and create at least 2 variable products with at least a couple variations each. Take note of the product IDs.
3. Configure your favorite REST client to use Basic Auth and use your consumer key and secret as username and password, respectively.
4. Perform a GET request to `<yoursite>/wp-json/wc/v3/products/<product_id>/variations/`, where `<product_id>` is one of the IDs from step 2, and confirm that all the variations for that product are listed. Take note of the ID (`id`) for a couple of those variations.
5. Confirm that `GET`, `PUT` and `DELETE` requests to `/wc/v3/products/<product_id>/variations/<id>` where `<product_id>` is a product ID from step 2 and `<id>` is a variation ID from step 4 all work as [described in the REST API documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-variations).
6. Confirm that `GET`, `PUT` and `DELETE` requests to `/wc/v3/products/<product_id>/variations/<id>` all return 404 when...
   - `<product_id>` is the ID of an existing variable product, and `<id>` is either a non-existent ID or the ID of a variation of a different product.
   - `<product_id>` is a non-existent product ID and `<id>` is an existing variation ID.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>