### PR TITLE
Add back revert template e2e tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/constants.ts
@@ -17,7 +17,7 @@ type TemplateCustomizationTest = {
 	} ) => Promise< void | Response | null >;
 	templateName: string;
 	templatePath: string;
-	templateType: string;
+	templateType: 'wp_template' | 'wp_template_part';
 	fallbackTemplate?: {
 		templateName: string;
 		templatePath: string;

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -44,5 +44,15 @@ test.describe( 'Single Product template', () => {
 		// Verify edits are visible.
 		await page.goto( testData.permalink );
 		await expect( page.getByText( userText ).first() ).toBeVisible();
+
+		// Revert edition.
+		await admin.visitSiteEditor( {
+			postType: testData.templateType,
+		} );
+		await editor.revertTemplateCreation( testData.templateName );
+		await page.goto( testData.permalink );
+
+		// Verify the edits are no longer visible.
+		await expect( page.getByText( userText ) ).toHaveCount( 0 );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -11,7 +11,7 @@ const testData = {
 	permalink: '/product/belt',
 	templateName: 'Single Product Belt',
 	templatePath: 'single-product-belt',
-	templateType: 'wp_template',
+	templateType: 'wp_template' as 'wp_template' | 'wp_template_part',
 };
 
 const userText = 'Hello World in the Belt template';
@@ -48,5 +48,20 @@ test.describe( 'Single Product Template', () => {
 			page.getByText( themeTemplateText ).first()
 		).toBeVisible();
 		await expect( page.getByText( userText ).first() ).toBeVisible();
+
+		// Revert edition and verify the template from the theme is used.
+		await admin.visitSiteEditor( {
+			postType: testData.templateType,
+		} );
+		await editor.revertTemplateCustomizations( {
+			templateName: testData.templateName,
+			templateType: testData.templateType,
+		} );
+		await page.goto( testData.permalink );
+
+		await expect(
+			page.getByText( themeTemplateText ).first()
+		).toBeVisible();
+		await expect( page.getByText( userText ) ).toHaveCount( 0 );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -54,6 +54,17 @@ test.describe( 'Template customization', () => {
 				await expect(
 					page.getByText( userText ).first()
 				).toBeVisible();
+
+				// Verify the edition can be reverted.
+				await admin.visitSiteEditor( {
+					postType: testData.templateType,
+				} );
+				await editor.revertTemplateCustomizations( {
+					templateName: testData.templateName,
+					templateType: testData.templateType,
+				} );
+				await testData.visitPage( { frontendUtils, page } );
+				await expect( page.getByText( userText ) ).toHaveCount( 0 );
 			} );
 
 			if ( testData.fallbackTemplate ) {
@@ -83,6 +94,20 @@ test.describe( 'Template customization', () => {
 					await expect(
 						page.getByText( fallbackTemplateUserText ).first()
 					).toBeVisible();
+
+					// Verify the edition can be reverted.
+					await admin.visitSiteEditor( {
+						postType: testData.templateType,
+					} );
+					await editor.revertTemplateCustomizations( {
+						templateName:
+							testData.fallbackTemplate?.templateName || '',
+						templateType: 'wp_template',
+					} );
+					await testData.visitPage( { frontendUtils, page } );
+					await expect(
+						page.getByText( fallbackTemplateUserText )
+					).toHaveCount( 0 );
 				} );
 			}
 		} );
@@ -158,33 +183,10 @@ test.describe( 'Template customization', () => {
 					postType: testData.templateType,
 				} );
 
-				await page
-					.getByPlaceholder( 'Search' )
-					.fill( testData.templateName );
-
-				const resetNotice = page
-					.getByLabel( 'Dismiss this notice' )
-					.getByText(
-						testData.templateType === 'wp_template'
-							? `"${ testData.templateName }" reset.`
-							: `"${ testData.templateName }" deleted.`
-					);
-				const savedButton = page.getByRole( 'button', {
-					name: 'Saved',
+				await editor.revertTemplateCustomizations( {
+					templateName: testData.templateName,
+					templateType: testData.templateType,
 				} );
-
-				// Wait until search has finished.
-				const searchResults = page.getByLabel( 'Actions' );
-				await expect
-					.poll( async () => await searchResults.count() )
-					.toBeLessThan( CUSTOMIZABLE_WC_TEMPLATES.length );
-
-				await searchResults.first().click();
-				await page.getByRole( 'menuitem', { name: 'Reset' } ).click();
-				await page.getByRole( 'button', { name: 'Reset' } ).click();
-
-				await expect( resetNotice ).toBeVisible();
-				await expect( savedButton ).toBeVisible();
 
 				await testData.visitPage( { frontendUtils, page } );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -62,6 +62,25 @@ test.describe( 'Template customization', () => {
 				await expect(
 					page.getByText( userText ).first()
 				).toBeVisible();
+
+				// Revert edition and verify the template from the theme is used.
+				await admin.visitSiteEditor( {
+					postType: testData.templateType,
+				} );
+				await editor.revertTemplateCustomizations( {
+					templateName: testData.templateName,
+					templateType: testData.templateType,
+				} );
+				await testData.visitPage( { frontendUtils, page } );
+
+				await expect(
+					page
+						.getByText(
+							`${ testData.templateName } template loaded from theme`
+						)
+						.first()
+				).toBeVisible();
+				await expect( page.getByText( userText ) ).toHaveCount( 0 );
 			} );
 
 			if ( testData.fallbackTemplate ) {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Editor as CoreEditor } from '@wordpress/e2e-test-utils-playwright';
+import { expect } from '@woocommerce/e2e-utils';
 
 export class Editor extends CoreEditor {
 	async getBlockByName( name: string ) {
@@ -69,6 +70,62 @@ export class Editor extends CoreEditor {
 				isOnlyCurrentEntityDirty: true,
 			} );
 		}
+	}
+
+	async revertTemplateCreation( templateName: string ) {
+		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
+
+		const deletedNotice = this.page
+			.getByLabel( 'Dismiss this notice' )
+			.getByText( `"${ templateName }" deleted.` );
+
+		// Wait until search has finished.
+		const searchResults = this.page.getByLabel( 'Actions' );
+		const initialSearchResultsCount = await searchResults.count();
+		await expect
+			.poll( async () => await searchResults.count() )
+			.toBeLessThan( initialSearchResultsCount );
+
+		await searchResults.first().click();
+		await this.page.getByRole( 'menuitem', { name: 'Delete' } ).click();
+		await this.page.getByRole( 'button', { name: 'Delete' } ).click();
+
+		await expect( deletedNotice ).toBeVisible();
+	}
+
+	async revertTemplateCustomizations( {
+		templateName,
+		templateType,
+	}: {
+		templateName: string;
+		templateType: 'wp_template' | 'wp_template_part';
+	} ) {
+		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
+
+		const resetNotice = this.page
+			.getByLabel( 'Dismiss this notice' )
+			.getByText(
+				templateType === 'wp_template'
+					? `"${ templateName }" reset.`
+					: `"${ templateName }" deleted.`
+			);
+		const savedButton = this.page.getByRole( 'button', {
+			name: 'Saved',
+		} );
+
+		// Wait until search has finished.
+		const searchResults = this.page.getByLabel( 'Actions' );
+		const initialSearchResultsCount = await searchResults.count();
+		await expect
+			.poll( async () => await searchResults.count() )
+			.toBeLessThan( initialSearchResultsCount );
+
+		await searchResults.first().click();
+		await this.page.getByRole( 'menuitem', { name: 'Reset' } ).click();
+		await this.page.getByRole( 'button', { name: 'Reset' } ).click();
+
+		await expect( resetNotice ).toBeVisible();
+		await expect( savedButton ).toBeVisible();
 	}
 
 	async publishAndVisitPost() {

--- a/plugins/woocommerce/changelog/fix-add-back-revert-template-tests
+++ b/plugins/woocommerce/changelog/fix-add-back-revert-template-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add back revert template e2e tests
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The part of our e2e tests that was verifying block templates could be reverted was removed in https://github.com/woocommerce/woocommerce/pull/47660, I guess by mistake. This PR adds back that code and updates it to work with WP 6.6.

### How to test the changes in this Pull Request:

(No need to test when testing the release)

1. Verify code looks good and tests pass.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
