### PR TITLE
 fix: wcadmin react18 createroot wc addon tour

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/wc-addons-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/wc-addons-tour/index.tsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { render } from '@wordpress/element';
+// @ts-expect-error -- @wordpress/element doesn't export createRoot until WP6.2
+// eslint-disable-next-line @woocommerce/dependency-group
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,4 +12,5 @@ import WCAddonsTour from '../../guided-tours/wc-addons-tour/index';
 
 const root = document.createElement( 'div' );
 root.setAttribute( 'id', 'wc-addons-tour-root' );
-render( <WCAddonsTour />, document.body.appendChild( root ) );
+
+createRoot( document.body.appendChild( root ) ).render( <WCAddonsTour /> );

--- a/plugins/woocommerce/changelog/fix-wcadmin-react18-createroot-addon-tour
+++ b/plugins/woocommerce/changelog/fix-wcadmin-react18-createroot-addon-tour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Changed from using React.render to React.createRoot for wc addon tour as it has been deprecated since React 18


### PR DESCRIPTION
Related to #46879


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Change how we render the `WCAddons` tour component onto the page. We did it with `ReactDOM.render` but that's no longer supported after React 18. This PR updates it to `createRoot`. 

Please note that we have [disabled](https://github.com/woocommerce/woocommerce/pull/39618/) the tour a while ago. So this currently edited code doesn't run in clients.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the `WCAddonsTour` component back into the `marketplace/index.tsx` page. The patch to apply is here: [addons-patch.zip](https://github.com/user-attachments/files/16641980/addons-patch.zip)
2. Get a new build
3. Visit the **WooCommece  > Extensions** [page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions).
4. Confirm you see the tour loaded.
5. Please test around this issue.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Screenshot
![image](https://github.com/user-attachments/assets/6f15df97-689b-4aae-a6c5-64fd1998af3d)

