### PR TITLE
Use createRoot in classic product editor cases

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-category-metabox/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-category-metabox/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, Suspense, lazy } from '@wordpress/element';
+import { createRoot, Suspense, lazy } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ if ( metaboxContainer ) {
 	const initialSelected = getSelectedCategoryData(
 		metaboxContainer.parentElement
 	);
-	render(
+	createRoot( metaboxContainer ).render(
 		<Suspense fallback={ null }>
 			<CategoryMetabox initialSelected={ initialSelected } />
 		</Suspense>,

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tour/index.tsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { render } from '@wordpress/element';
+// @ts-expect-error -- @wordpress/element doesn't export createRoot until WP6.2
+// eslint-disable-next-line @woocommerce/dependency-group
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,4 +12,5 @@ import { ProductTour } from '../../guided-tours/add-product-tour/index';
 
 const root = document.createElement( 'div' );
 root.setAttribute( 'id', 'product-tour-root' );
-render( <ProductTour />, document.body.appendChild( root ) );
+
+createRoot( document.body.appendChild( root ) ).render( <ProductTour /> );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/variable-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/variable-product-tour/index.tsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { render } from '@wordpress/element';
+// @ts-expect-error -- @wordpress/element doesn't export createRoot until WP6.2
+// eslint-disable-next-line @woocommerce/dependency-group
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,4 +12,7 @@ import { VariableProductTour } from '../../guided-tours/variable-product-tour';
 
 const root = document.createElement( 'div' );
 root.setAttribute( 'id', 'variable-product-tour-root' );
-render( <VariableProductTour />, document.body.appendChild( root ) );
+
+createRoot( document.body.appendChild( root ) ).render(
+	<VariableProductTour />
+);

--- a/plugins/woocommerce/changelog/fix-wcadmin-react18-createroot-product-editor
+++ b/plugins/woocommerce/changelog/fix-wcadmin-react18-createroot-product-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Changed from using React.render to React.createRoot for product editor areas as it has been deprecated since React 18


### PR DESCRIPTION
**_Note: The original code changes (without any testing instructions) were created by @rjchow. Figuring out how to test the changes and writing up the testing instructions were done by @mattsherman._**

Related to #46879

Additional information on this issue can be found in [How to Upgrade to React 18](https://react.dev/blog/2022/03/08/react-18-upgrade-guide) and in [Upgrading to React 18 and common pitfalls of concurrent mode](https://make.wordpress.org/core/2023/03/07/upgrading-to-react-18-and-common-pitfalls-of-concurrent-mode/).

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the creation of React roots used in the classic product editor from using `render` to `createRoot`, enabling React 18 mode behavior.

The following ares are affected:

- Category meta box in classic product editor when the `async-product-editor-category-field` feature flag is enabled; this will be totally removed in a future issue #49120, and is not enabled in production, so minimal testing is required
- Product tour and Variable product tours

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `async-product-editor-category-field` feature flag using WCA Test Helper
2. Create 5 categories in **Products** > **Categories** (so, with **Uncategorized**, you will have a total of **6 categories**)
3. Go to **Products** > **Add New**
4. Verify the Product categories metabox loads (since this is not used in production and will be removed, no extensive testing is needed):

<img width="313" alt="Screenshot 2024-07-03 at 16 32 27" src="https://github.com/woocommerce/woocommerce/assets/2098816/b4116545-fa5f-43f0-a921-76dbcfb25291">

5. Append `&tutorial=true` to the page URL and reload the page.
6. Verify that the product tutorial shows:

<img width="798" alt="Screenshot 2024-07-03 at 16 34 30" src="https://github.com/woocommerce/woocommerce/assets/2098816/a393991d-d8dd-4833-ac91-835f9dc86738">

7. Change the product type to **Variable product** 
8. Verify the variable product tutorial shows:

<img width="899" alt="Screenshot 2024-07-03 at 16 35 40" src="https://github.com/woocommerce/woocommerce/assets/2098816/87412296-f096-44b5-b0c2-4c999224e164">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
