### PR TITLE
Fix shipping zones add zone button flinching

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-zones-add-zone-button-flinching
+++ b/plugins/woocommerce/changelog/fix-shipping-zones-add-zone-button-flinching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix add zone button flinching and vertical centering

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4522,8 +4522,8 @@ table {
 	display: flex;
 	align-items: center;
 
-	.page-title-action {
-		margin: 0 12px;
+	.page-title-action, .page-title-action:active {
+		margin: 7px 0 0 10px;
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes `Add zone` button flinching when clicked (toggling `:active` state)

### How to test the changes in this Pull Request:

1. Go to `WooCommerce > Settings > Shipping`
5. Observe the button is vertically centered to `Shipping zones` heading
2. Hover your mouse to the rightmost edge of `Add zone` button and click
4. Observe the button does not flinch and you're navigated to "Add zone" screen

#### Before

![Flinch](https://github.com/woocommerce/woocommerce/assets/3747241/533999cf-c055-4866-9b3c-77624830318c)

#### After

![Non flinch](https://github.com/woocommerce/woocommerce/assets/3747241/71232a31-9e8e-4351-884d-e65e7d3d2ffa)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
