### PR TITLE
Product Editor: restore Product (local) Attributes E2E test

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-restore-product-with-local-attrs-2e2-test
+++ b/plugins/woocommerce/changelog/update-product-editor-restore-product-with-local-attrs-2e2-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Editor: restore Product (local) Attributes E2E test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -247,7 +247,7 @@ test.only(
 					has: page.getByText( attribute.name, { exact: true } ),
 				} );
 				await expect( item ).toBeVisible();
-				await expect( item ).toContainText( attribute.value );
+				await expect( item ).toContainText( attribute.name );
 			}
 		} );
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -135,23 +135,20 @@ test.only(
 		} );
 
 		await test.step( 'create local attributes with terms', async () => {
-			// // Add attributes that do not exist
-			// await page.getByPlaceholder( 'Search or create attribute' ).click();
-
-			// // Unless we wait for the list to be visible, the attribute name will be filled too soon and the test will fail.
-			// await waitForAttributeList( page );
-
 			/*
-			 * AttributeTableRow is the row that contains
-			 * the attribute name and the options (terms).
+			 * attributeRowsLocator are the rows that contains
+			 * the Attribute combobox and the Term FormTokenField.
 			 */
-			const rowSelector = '.woocommerce-new-attribute-modal__table-row';
+			const attributeRowsLocator = page.locator(
+				'.woocommerce-new-attribute-modal__table-row'
+			);
+
 			/*
-			 * Check the app loads the attributes,
+			 * First, check the app loads the attributes,
 			 * based on the Spinner visibility.
 			 */
-			const spinnerLocator = page.locator(
-				`${ rowSelector } .components-spinner`
+			const spinnerLocator = attributeRowsLocator.locator(
+				'.components-spinner'
 			);
 			await spinnerLocator.waitFor( {
 				state: 'visible',
@@ -159,18 +156,17 @@ test.only(
 			await spinnerLocator.waitFor( { state: 'hidden' } );
 
 			for ( const term of newAttributes ) {
-				// Attribute/Terms row
-				const attributeRowLocator = page.locator( rowSelector ).last();
+				const attributeRowLocator = attributeRowsLocator.last();
 
 				// Attribute combobox input
-				const attributeInputLocator = attributeRowLocator
+				const attributeComboboxLocator = attributeRowLocator
 					.locator(
 						'input[aria-describedby^="components-form-token-suggestions-howto-combobox-control"]'
 					)
 					.last();
 
 				// Create new (local) product attribute.
-				await attributeInputLocator.fill( term.name );
+				await attributeComboboxLocator.fill( term.name );
 				await page.locator( `text=Create "${ term.name }"` ).click();
 
 				const FormTokenFieldLocator = attributeRowLocator.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -102,17 +102,15 @@ test.only(
 		const newAttributes = [
 			{
 				name: 'Color',
-				value: 'color',
+
 				terms: [ 'Red', 'Blue', 'Green' ],
 			},
 			{
 				name: 'Size',
-				value: 'size',
 				terms: [ 'Small', 'Medium', 'Large' ],
 			},
 			{
 				name: 'Style',
-				value: 'style',
 				terms: [ 'Modern', 'Classic', 'Vintage' ],
 			},
 		];

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -95,7 +95,7 @@ const test = baseTest.extend( {
 	},
 } );
 
-test.only(
+test(
 	'add local attribute (with terms) to the Product',
 	{ tag: '@gutenberg' },
 	async ( { page, product } ) => {
@@ -158,7 +158,6 @@ test.only(
 			for ( const term of newAttributes ) {
 				const attributeRowLocator = attributeRowsLocator.last();
 
-				// Attribute combobox input
 				const attributeComboboxLocator = attributeRowLocator
 					.locator(
 						'input[aria-describedby^="components-form-token-suggestions-howto-combobox-control"]'
@@ -211,7 +210,7 @@ test.only(
 				await expect( attributeRowLocator ).toBeVisible();
 
 				for ( const term of attribute.terms ) {
-					// Pick the term element/locator by aria-hidden="true"
+					// Pick the term element/locator
 					const termLocator = attributeRowLocator
 						.locator( `[aria-hidden="true"]` )
 						.filter( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -3,6 +3,7 @@ const {
 } = require( '../../../../fixtures/block-editor-fixtures' );
 const { expect } = require( '../../../../fixtures/fixtures' );
 const { updateProduct } = require( '../../../../utils/product-block-editor' );
+const { clickOnTab } = require( '../../../../utils/simple-products' );
 
 async function waitForAttributeList( page ) {
 	// The list child is different in case there are no results versus when there already are some attributes, so we need to wait for either one to be visible.
@@ -94,8 +95,8 @@ const test = baseTest.extend( {
 	},
 } );
 
-test.skip(
-	'can create and add attributes',
+test.only(
+	'Add local attribute (with terms) to the Product',
 	{ tag: '@gutenberg' },
 	async ( { page, product } ) => {
 		const newAttributes = [
@@ -109,18 +110,26 @@ test.skip(
 			},
 		];
 
-		await test.step( 'go to product editor, Organization tab', async () => {
+		await test.step( 'Go to product editor -> Organization tab -> Click on `Add new`', async () => {
 			await page.goto(
 				`wp-admin/post.php?post=${ product.id }&action=edit`
 			);
-			await page.getByRole( 'tab', { name: 'Organization' } ).click();
-		} );
+			await clickOnTab( 'Organization', page );
 
-		await test.step( 'add new attributes', async () => {
+			await page
+				.getByRole( 'heading', { name: 'Attributes' } )
+				.isVisible();
+
 			await page.getByRole( 'button', { name: 'Add new' } ).click();
 
-			await page.waitForLoadState( 'domcontentloaded' );
+			await page
+				.getByRole( 'heading', { name: 'Add variation options' } )
+				.isVisible();
 
+			await page.waitForLoadState( 'domcontentloaded' );
+		} );
+
+		await test.step( 'Create local attributes with terms', async () => {
 			// Add attributes that do not exist
 			await page.getByPlaceholder( 'Search or create attribute' ).click();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -194,7 +194,7 @@ test(
 		} );
 
 		await test.step( 'verify attributes in product editor', async () => {
-			// Select the main locator by data-template-block-id="product-attributes-section"
+			// Locate the main attributes list element
 			const attributesListLocator = page.locator(
 				'[data-template-block-id="product-attributes-section"]'
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR restores the E2E test that checks the correct functionality of the product editor when adding (local) attributes from the "Organization" tab.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


### Running E2E tests locally

```
cd plugins/woocommerce
```

Ensure Playwright is installed

```
npx playwright install
```

Ensure wp-env is running

```
pnpm env:start
```

Run the test

```
pnpm test:e2e-pw tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
```

<img width="540" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/0636e0f7-1d24-4d42-9cf7-1bcf7d13bb68">


Additionally, take a look at the report
```
pnpm exec playwright show-report tests/e2e-pw/test-results/playwright-report
```

<img width="792" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/de241fc4-a3bd-4696-bea9-2b13e5f4ff67">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
