### PR TITLE
Add developer filter `woocommerce_printable_order_receipt_rendered_template`

### DIFF
--- a/plugins/woocommerce/changelog/48872-add-filter-order-receipt-rendered-template-issue-48812
+++ b/plugins/woocommerce/changelog/48872-add-filter-order-receipt-rendered-template-issue-48812
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add hook to customize the rendered receipt template

--- a/plugins/woocommerce/changelog/48872-add-filter-order-receipt-rendered-template-issue-48812
+++ b/plugins/woocommerce/changelog/48872-add-filter-order-receipt-rendered-template-issue-48812
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Add hook to filter the order receipt template path
+Add hook to customize the rendered receipt template

--- a/plugins/woocommerce/changelog/48872-add-filter-order-receipt-rendered-template-issue-48812
+++ b/plugins/woocommerce/changelog/48872-add-filter-order-receipt-rendered-template-issue-48812
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Add hook to customize the rendered receipt template
+Add hook to filter the order receipt template path

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
@@ -200,7 +200,17 @@ class ReceiptRenderingEngine {
 
 		ob_start();
 		include __DIR__ . '/Templates/order-receipt.php';
-		$rendered_template = ob_get_contents();
+		/**
+		 * Filter to customize the rendered receipt template.
+		 *
+		 * @param string   $rendered_template The original rendered template.
+		 * @param array    $data The set of data that is used to render the receipt.
+		 * @param WC_Order $order The order for which the receipt is being generated.
+		 * @return string The updated rendered template.
+		 *
+		 * @since 9.1.0
+		 */
+		$rendered_template = apply_filters( 'woocommerce_printable_order_receipt_rendered_template', ob_get_contents(), $data, $order );
 		ob_end_clean();
 
 		$file_name = $this->transient_files_engine->create_transient_file( $rendered_template, $expiration_date );

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
@@ -198,19 +198,35 @@ class ReceiptRenderingEngine {
 		 */
 		$data['css'] = apply_filters( 'woocommerce_printable_order_receipt_css', $css, $order );
 
-		ob_start();
-		include __DIR__ . '/Templates/order-receipt.php';
+		$default_template_path = __DIR__ . '/Templates/order-receipt.php';
+
 		/**
-		 * Filter to customize the rendered receipt template.
+		 * Filter the order receipt template path.
 		 *
-		 * @param string   $rendered_template The original rendered template.
-		 * @param array    $data The set of data that is used to render the receipt.
-		 * @param WC_Order $order The order for which the receipt is being generated.
-		 * @return string The updated rendered template.
-		 *
-		 * @since 9.1.0
+		 * @since 9.2.0
+		 * @hook wc_get_template
+		 * @param  string $template      The template path.
+		 * @param  string $template_name The template name.
+		 * @param  array  $args          The available data for the template.
+		 * @param string  $template_path The template path.
+		 * @param string  $default_path  The default template path.
 		 */
-		$rendered_template = apply_filters( 'woocommerce_printable_order_receipt_rendered_template', ob_get_contents(), $data, $order );
+		$template_path = apply_filters(
+			'wc_get_template',
+			$default_template_path,
+			'ReceiptRendering/order-receipt.php',
+			$data,
+			$default_template_path,
+			$default_template_path
+		);
+
+		if ( ! file_exists( $template_path ) ) {
+			$template_path = $default_template_path;
+		}
+
+		ob_start();
+		include $template_path;
+		$rendered_template = ob_get_contents();
 		ob_end_clean();
 
 		$file_name = $this->transient_files_engine->create_transient_file( $rendered_template, $expiration_date );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a new developer filter to customize/override the receipt template: `woocommerce_printable_order_receipt_rendered_template`.

Closes #48812

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a receipt for an order by sending a POST request to `wp-json/wc/v3/orders/<order id>/receipt?force_new=true`

```http
POST http://woocommerce.test/wp-json/wc/v3/orders/316/receipt?force_new=true
Authorization: Basic ck_aa9429:cs_ae8684
```

2. Open the URL for the generated receipt in your browser, and verify that it renders the default WooCommerce template.

![image](https://github.com/woocommerce/woocommerce/assets/6010232/4e928d70-7e23-41e9-aa98-89685f5afcd8)

3. Add the code snippet below to functions.php file of your theme

```php
add_filter(
	'wc_get_template',
	function( $template, $template_name, $args, $template_path, $default_path) {
		if ( 'ReceiptRendering/order-receipt.php' !== $template_name ) {
			return $template;
		}

		return __DIR__ . '/woocommerce/receipt/my-custom-receipt.php';
	},
	10,
	5
);
```

4. In the activate theme folder, create the file YOURTHEME/woocommerce/receipt/my-custom-receipt.php and add the content below

```php
<h1>My custom template</h1>

<h2>
	<?php echo esc_html( $data['texts']['summary_section_title'] ?? '' ); ?>
</h2>
```

4. Send the same HTTP request sent in step 1
6. Open the URL for the generated receipt in your browser and verify that it renders the custom template

![image](https://github.com/user-attachments/assets/744939af-299e-4ca6-a1bf-1b761a0a960f)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add hook to customize the rendered receipt template
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
