### PR TITLE
Don't display Connect your store step in Shipping task if not installing WCS&T

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
@@ -192,7 +192,6 @@ export class Shipping extends Component {
 
 	getSteps() {
 		const {
-			countryCode,
 			createNotice,
 			invalidateResolutionForStoreSelector,
 			isJetpackConnected,

--- a/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
@@ -236,7 +236,8 @@ export class Shipping extends Component {
 		};
 
 		const requiresJetpackConnection =
-			! isJetpackConnected && countryCode === 'US';
+			! isJetpackConnected &&
+			pluginsToActivate.includes( 'woocommerce-services' );
 
 		let steps = [
 			{

--- a/plugins/woocommerce/changelog/48875-fix-dont-display-connect-your-store-in-shipping-task-if-not-installing-wcst
+++ b/plugins/woocommerce/changelog/48875-fix-dont-display-connect-your-store-in-shipping-task-if-not-installing-wcst
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't recommend WooCommerce Shipping & Tax in the "Select your shipping options" task.  Allowing WCS&T to be installed alongside WC Shipping or WC Tax would lead to a notice about incompatibility which is something this PR aims to avoid.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of woocommerce/woocommerce-shipping#187.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Clone this repo, check out this PR's branch, and build WooCommerce. [The official instructions are in the repo README file](https://github.com/woocommerce/woocommerce?tab=readme-ov-file#getting-started) but here's a shortcut:
   ```
   nvm use && pnpm i -g pnpm@9.1.0 && pnpm i && pnpm run build
   ```
2. In your local test site's `wp-content/plugins`, link the WooCommerce plugin you just built.
   Let's assume you checked out the WooCommerce repo to `/home/me/woocommerce`.
   Note how below we aren't creating a link to `/home/me/woocommerce` but rather to a directory within it:
   ```
   ln -s /home/me/woocommerce/plugins/woocommerce /var/www/your-test-site/wp-content/plugins/woocommerce
   ```
3. That's it for building WC Core. Now let's test the task.
4. To force the task to show up and guide us to the wizard, we have to tweak the code a little. Apply the following patch:
   ```patch
   diff --git a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
   index f06534b87c..649d0a7f87 100644
   --- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
   +++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
   @@ -84,6 +84,7 @@ class Shipping extends Task {
    	 * @return bool
    	 */
    	public function can_view() {
   +		return true;
    		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
    			if ( 'yes' === get_option( 'woocommerce_admin_created_default_shipping_zones' ) ) {
    				// If the user has already created a default shipping zone, we don't need to show the task.
   @@ -128,6 +129,7 @@ class Shipping extends Task {
    	 * @return string
    	 */
    	public function get_action_url() {
   +		return null;
    		return self::has_shipping_zones()
    			? admin_url( 'admin.php?page=wc-settings&tab=shipping' )
    			: null;

   ```
5. In WP admin, go to WooCommerce > Home. Click the "Select your shipping options" task:
   <img width="714" alt="Screenshot 2024-06-20 at 16 01 09" src="https://github.com/Automattic/woocommerce.com/assets/1759681/a14baf7b-cea8-427b-9aed-408b5a2f1712">
6. We have the following test scenarios to check:
   - WCShip/WCTax inactive, no preexisting WPCOM connection:
     - you should see 4 steps, incl. "3. Enable shipping label printing an discounted rates" and "4. Connect your store"
   - WCShip/WCTax inactive, with preexisting WPCOM connection:
     - you should see 3 steps, the last one being "3. Enable shipping label printing an discounted rates"
   - WCShip/WCTax active, no preexisting WPCOM connection:
     - you should see 2 steps (we could present the "Connect your store" step here but since this PR is implementing a somewhat transitory state before there's a task for WCShipping instead, I think we can just display 2 steps)
   - WCShip/WCTax active, with preexisting WPCOM connection:
     - you should see 2 steps

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

If either the upcoming WooCommerce Shipping or WooCommerce Tax extension is active, don't recommend WooCommerce Shipping & Tax in the "Select your shipping options" task.

Allowing WCS&T to be installed alongside WC Shipping or WC Tax would lead to a notice about incompatibility which is something this PR aims to avoid.

</details>
