### PR TITLE
Avoid Product Search Results block template to fall back to the Product Catalog template from the theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-48536-product-search-results-fallback
+++ b/plugins/woocommerce/changelog/fix-48536-product-search-results-fallback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Avoid Product Search Results block template to fall back to the Product Catalog template from the theme

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -18,13 +18,6 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 	const SLUG = 'product-search-results';
 
 	/**
-	 * The template used as a fallback if that one is customized.
-	 *
-	 * @var string
-	 */
-	public $fallback_template = ProductCatalogTemplate::SLUG;
-
-	/**
 	 * Initialization method.
 	 */
 	public function init() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/48536.

This PR removes the logic that made the Product Search Results block template to fall back to the Product Catalog template from the theme. Two things to highlight here:

1. That was how the template was expected to work: Product Search Results block should never fall back to the Product Catalog template. However, I introduced the regression in https://github.com/woocommerce/woocommerce/pull/44537 (aka WC 8.8).
2. Even though there was the regression, the issue was not reproducible for templates created by the user, as we were using the `taxonomy_template_hierarchy` filter to hook database templates into the rendering logic, and that hook didn't run when rendering the Product Search Results template.

In other words, since WC 8.8 there has been a regression that if a theme had and `archive-product.html` template but didn't have a `product-search-results.html` template, Product Search Results template would fall back to `archive-product.html` and this PR fixes this. There are some more details about the issue in the comment here: https://github.com/woocommerce/woocommerce/issues/48536#issuecomment-2179081033.

### How to test the changes in this Pull Request:

1. With a block theme, go to Appearance > Editor > Templates and make a modification to the Product Catalog template.
2. Visit the Product Search Results template in the frontend (url: `example.com/?s=shirt&post_type=product`).
3. Verify the changes you made in the Product Catalog template **aren't** visible.
4. Go back to Appearance > Editor > Templates and reset the edits you did to the Product Catalog template.
5. Add a `templates/archive-product.html` template file to your theme or install [this theme](https://github.com/user-attachments/files/16012063/twentytwentyfour.zip).
6. Visit the Product Search Results template in the frontend again and verify you still see the default Product Search Results template.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
