### PR TITLE
CYS: make the entire shuffle section clickable

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
@@ -7,7 +7,13 @@ import { capitalize } from 'lodash';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Path, SVG, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import {
+	Button,
+	Path,
+	SVG,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import {
 	unlock,
 	// @ts-expect-error No types for this exist yet.
@@ -115,9 +121,9 @@ export default function Shuffle( { clientId }: { clientId: string } ) {
 
 	return (
 		<ToolbarGroup className="woocommerce-customize-your-store-toolbar-shuffle-container">
-			<ToolbarButton
-				label={ __( 'Shuffle', 'woocommerce' ) }
+			<Button
 				icon={ shuffleIcon }
+				label={ __( 'Shuffle', 'woocommerce' ) }
 				onClick={ () => {
 					const nextPattern = getNextPattern();
 					// @ts-expect-error - attributes is marked as readonly.
@@ -130,8 +136,11 @@ export default function Shuffle( { clientId }: { clientId: string } ) {
 					};
 					replaceBlocks( clientId, nextPattern.blocks );
 				} }
-			/>
-			{ categoryLabel && <span>{ capitalize( categoryLabel ) }</span> }
+			>
+				{ categoryLabel && (
+					<span>{ capitalize( categoryLabel ) }</span>
+				) }
+			</Button>
 		</ToolbarGroup>
 	);
 }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
@@ -7,13 +7,7 @@ import { capitalize } from 'lodash';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	Path,
-	SVG,
-	ToolbarButton,
-	ToolbarGroup,
-} from '@wordpress/components';
+import { Button, Path, SVG, ToolbarGroup } from '@wordpress/components';
 import {
 	unlock,
 	// @ts-expect-error No types for this exist yet.

--- a/plugins/woocommerce/changelog/48889-48888-cys-block-toolbar-make-the-entire-shuffle-section-clickable
+++ b/plugins/woocommerce/changelog/48889-48888-cys-block-toolbar-make-the-entire-shuffle-section-clickable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+CYS: make the entire shuffle section clickable.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->





| Before | After |
|--------|--------|
| <video src="https://github.com/woocommerce/woocommerce/assets/4463174/becff3bc-23a4-47eb-b80b-0fba56dadb42" /> | <video src="https://github.com/woocommerce/woocommerce/assets/4463174/59ad8da9-2dae-4486-86b9-f737277be75f" /> | 


Closes #48888.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled
2. Make sure you have the WooCommerce beta tester plugin installed
3. Head over to Tools > WCA Test Helper > Features
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on Design Your Homepage.
8. In the site preview, hover a pattern.
9. Ensure that the Block Toolbar is visible.
10. Ensure that the category and icon are both clickable.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: make the entire shuffle section clickable.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>