### PR TITLE
Product Editor: improve E2E tests. Test the `+3 More` item label in the Organization tab

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-polish-e2e-tests
+++ b/plugins/woocommerce/changelog/update-product-editor-polish-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Editor: improve E2E tests. Test the `+3 More` item label in the Organization tab

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -11,7 +11,7 @@ const { variableProducts: utils } = require( '../../../../utils' );
 const attributes = require( './fixtures/attributes' );
 const tabs = require( './data/tabs' );
 const {
-	confirmGlobalAttributesLoaded,
+	waitForGlobalAttributesLoaded,
 } = require( './helpers/confirm-global-attributes-loaded' );
 
 const {
@@ -111,7 +111,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 				 * Check the app loads the attributes,
 				 * based on the Spinner visibility.
 				 */
-				await confirmGlobalAttributesLoaded( page );
+				await waitForGlobalAttributesLoaded( page );
 
 				// Attribute combobox input
 				const attributeInputLocator = page.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -9,6 +9,7 @@ const {
 
 const { variableProducts: utils } = require( '../../../../utils' );
 const attributes = require( './fixtures/attributes' );
+const tabs = require( './data/tabs' );
 
 const {
 	createVariableProduct,
@@ -32,24 +33,6 @@ const sizeAttribute = attributes.find(
 );
 
 const termsLength = sizeAttribute.terms.length;
-
-const tabs = [
-	{
-		name: 'General',
-		noteText:
-			"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.",
-	},
-	{
-		name: 'Inventory',
-		noteText:
-			"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.",
-	},
-	{
-		name: 'Shipping',
-		noteText:
-			"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.",
-	},
-];
 
 let productId_editVariations,
 	productId_deleteVariations,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -10,6 +10,9 @@ const {
 const { variableProducts: utils } = require( '../../../../utils' );
 const attributes = require( './fixtures/attributes' );
 const tabs = require( './data/tabs' );
+const {
+	confirmGlobalAttributesLoaded,
+} = require( './helpers/confirm-global-attributes-loaded' );
 
 const {
 	createVariableProduct,
@@ -39,7 +42,7 @@ let productId_editVariations,
 	productId_singleVariation;
 
 test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
-	test.describe( 'Create variable product', () => {
+	test.describe( 'Create variable products', () => {
 		test.beforeAll( async ( { browser } ) => {
 			productId_editVariations = await createVariableProduct(
 				productAttributes
@@ -105,23 +108,10 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 				await page.waitForLoadState( 'domcontentloaded' );
 
 				/*
-				 * AttributeTableRow is the row that contains
-				 * the attribute name and the options (terms).
-				 */
-				const rowSelector =
-					'.woocommerce-new-attribute-modal__table-row';
-
-				/*
 				 * Check the app loads the attributes,
 				 * based on the Spinner visibility.
 				 */
-				const spinnerLocator = page.locator(
-					`${ rowSelector } .components-spinner`
-				);
-				await spinnerLocator.waitFor( {
-					state: 'visible',
-				} );
-				await spinnerLocator.waitFor( { state: 'hidden' } );
+				await confirmGlobalAttributesLoaded( page );
 
 				// Attribute combobox input
 				const attributeInputLocator = page.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -8,6 +8,7 @@ const {
 } = require( '../../../../utils/product-block-editor' );
 
 const { variableProducts: utils } = require( '../../../../utils' );
+const attributes = require( './fixtures/attributes' );
 
 const {
 	createVariableProduct,
@@ -26,23 +27,11 @@ const productData = {
 	summary: 'This is a product summary',
 };
 
-const attributesData = {
-	name: 'Size',
-	terms: [
-		{
-			name: 'Large',
-			slug: 'large',
-		},
-		{
-			name: 'Extra Large',
-			slug: 'extra-large',
-		},
-		{
-			name: 'Extra Extra Large',
-			slug: 'extra-extra-large',
-		},
-	],
-};
+const sizeAttribute = attributes.find(
+	( attribute ) => attribute.name === 'Size'
+);
+
+const termsLength = sizeAttribute.terms.length;
 
 const tabs = [
 	{
@@ -156,7 +145,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 					'input[aria-describedby^="components-form-token-suggestions-howto-combobox-control"]'
 				);
 
-				await attributeInputLocator.fill( attributesData.name );
+				await attributeInputLocator.fill( sizeAttribute.name );
 
 				await page.locator( 'text=Create "Size"' ).click();
 
@@ -166,7 +155,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 						response
 							.url()
 							.includes(
-								`wp-json/wc/v3/products/attributes?name=${ attributesData.name }&generate_slug=true`
+								`wp-json/wc/v3/products/attributes?name=${ sizeAttribute.name }&generate_slug=true`
 							) && response.status() === 201
 				);
 
@@ -183,7 +172,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 						'input[id^="components-form-token-input-"]'
 					);
 
-				for ( const term of attributesData.terms ) {
+				for ( const term of sizeAttribute.terms ) {
 					// Fill the input field with the option
 					await FormTokenFieldInputLocator.fill( term.name );
 					await FormTokenFieldInputLocator.press( 'Enter' );
@@ -228,6 +217,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 					} );
 				}
 
+				// Wait for the last term to be validated/added
 				await expect( page.locator( '.is-validating' ) ).toBeHidden();
 
 				await page
@@ -241,7 +231,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 			await test.step( 'Add prices to variations', async () => {
 				await expect(
 					page.getByText(
-						'3 variations do not have prices. Variations that do not have prices will not be visible to customers.Set prices'
+						`${ termsLength } variations do not have prices. Variations that do not have prices will not be visible to customers.Set prices`
 					)
 				).toBeVisible();
 
@@ -255,10 +245,12 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 
 				await expect(
 					page.getByLabel( 'Dismiss this notice' )
-				).toContainText( '3 variations updated.' );
+				).toContainText( `${ termsLength } variations updated.` );
 
 				await expect(
-					page.getByRole( 'button', { name: 'Select all (3)' } )
+					page.getByRole( 'button', {
+						name: `Select all (${ termsLength })`,
+					} )
 				).toBeVisible();
 			} );
 
@@ -282,7 +274,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 
 				// Verify that the first message is the expected one
 				await expect( snackbarLocator.nth( 0 ) ).toHaveText(
-					`${ attributesData.terms.length } variations updated.`
+					`${ sizeAttribute.terms.length } variations updated.`
 				);
 
 				// Verify that the second message is the expected one

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/data/tabs.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/data/tabs.js
@@ -1,0 +1,23 @@
+/*
+ * Tabs (groups) define the main menu (header) of the product edit page.
+ * Each tab has a name and a note text that is displayed below the tab name.
+ */
+const tabs = [
+	{
+		name: 'General',
+		noteText:
+			"This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.",
+	},
+	{
+		name: 'Inventory',
+		noteText:
+			"This product has options, such as size or color. You can now manage each variation's inventory and other details individually.",
+	},
+	{
+		name: 'Shipping',
+		noteText:
+			"This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.",
+	},
+];
+
+module.exports = tabs;

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/fixtures/attributes.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/fixtures/attributes.js
@@ -1,0 +1,35 @@
+/*
+ * Attributes data
+ * These attributes represent the attributes
+ * that the user can assign to a product.
+ */
+const attributes = [
+	{
+		name: 'Color',
+		terms: [
+			{ name: 'Red', slug: 'red' },
+			{ name: 'Blue', slug: 'blue' },
+			{ name: 'Green', slug: 'green' },
+		],
+	},
+	{
+		name: 'Size',
+		terms: [
+			{ name: 'Small', slug: 'small' },
+			{ name: 'Medium', slug: 'medium' },
+			{ name: 'Large', slug: 'large' },
+			{ name: 'Extra Large', slug: 'extra-large' },
+			{ name: 'Extra Extra Large', slug: 'extra-extra-large' },
+		],
+	},
+	{
+		name: 'Style',
+		terms: [
+			{ name: 'Modern', slug: 'modern' },
+			{ name: 'Classic', slug: 'classic' },
+			{ name: 'Vintage', slug: 'vintage' },
+		],
+	},
+];
+
+module.exports = attributes;

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/helpers/confirm-global-attributes-loaded.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/helpers/confirm-global-attributes-loaded.js
@@ -9,7 +9,7 @@
  *
  * @param {Object} page - The Playwright Page object.
  */
-export async function confirmGlobalAttributesLoaded( page ) {
+export async function waitForGlobalAttributesLoaded( page ) {
 	const spinnerLocator = page.locator(
 		'.woocommerce-new-attribute-modal__table-row .components-spinner'
 	);

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/helpers/confirm-global-attributes-loaded.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/helpers/confirm-global-attributes-loaded.js
@@ -1,0 +1,18 @@
+/**
+ * Waits for the spinner to appear and disappear,
+ * indicating that attributes have been loaded.
+ *
+ * This function confirms that the attributes have been
+ * loaded by waiting for a spinner to appear and then disappear.
+ * The spinner indicates that a loading process is occurring,
+ * and its disappearance indicates that the process is complete.
+ *
+ * @param {Object} page - The Playwright Page object.
+ */
+export async function confirmGlobalAttributesLoaded( page ) {
+	const spinnerLocator = page.locator(
+		'.woocommerce-new-attribute-modal__table-row .components-spinner'
+	);
+	await spinnerLocator.waitFor( { state: 'visible' } );
+	await spinnerLocator.waitFor( { state: 'hidden' } );
+}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -99,7 +99,7 @@ const test = baseTest.extend( {
 	},
 } );
 
-test.only(
+test(
 	'add local attribute (with terms) to the Product',
 	{ tag: '@gutenberg' },
 	async ( { page, product } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -4,6 +4,7 @@ const {
 const { expect } = require( '../../../../fixtures/fixtures' );
 const { updateProduct } = require( '../../../../utils/product-block-editor' );
 const { clickOnTab } = require( '../../../../utils/simple-products' );
+const attributesData = require( './fixtures/attributes' );
 const {
 	confirmGlobalAttributesLoaded,
 } = require( './helpers/confirm-global-attributes-loaded' );
@@ -98,26 +99,10 @@ const test = baseTest.extend( {
 	},
 } );
 
-test(
+test.only(
 	'add local attribute (with terms) to the Product',
 	{ tag: '@gutenberg' },
 	async ( { page, product } ) => {
-		const newAttributes = [
-			{
-				name: 'Color',
-
-				terms: [ 'Red', 'Blue', 'Green' ],
-			},
-			{
-				name: 'Size',
-				terms: [ 'Small', 'Medium', 'Large' ],
-			},
-			{
-				name: 'Style',
-				terms: [ 'Modern', 'Classic', 'Vintage' ],
-			},
-		];
-
 		await test.step( 'go to product editor -> Organization tab -> Click on `Add new`', async () => {
 			await page.goto(
 				`wp-admin/post.php?post=${ product.id }&action=edit`
@@ -152,7 +137,7 @@ test(
 			 */
 			await confirmGlobalAttributesLoaded( page );
 
-			for ( const term of newAttributes ) {
+			for ( const attribute of attributesData ) {
 				const attributeRowLocator = attributeRowsLocator.last();
 
 				const attributeComboboxLocator = attributeRowLocator
@@ -162,8 +147,10 @@ test(
 					.last();
 
 				// Create new (local) product attribute.
-				await attributeComboboxLocator.fill( term.name );
-				await page.locator( `text=Create "${ term.name }"` ).click();
+				await attributeComboboxLocator.fill( attribute.name );
+				await page
+					.locator( `text=Create "${ attribute.name }"` )
+					.click();
 
 				const FormTokenFieldLocator = attributeRowLocator.locator(
 					'td.woocommerce-new-attribute-modal__table-attribute-value-column'
@@ -176,8 +163,8 @@ test(
 					);
 
 				// Add terms to the attribute.
-				for ( const attributeTerm of term.terms ) {
-					await FormTokenFieldInputLocator.fill( attributeTerm );
+				for ( const term of attribute.terms ) {
+					await FormTokenFieldInputLocator.fill( term.name );
 					await FormTokenFieldInputLocator.press( 'Enter' );
 				}
 
@@ -200,7 +187,7 @@ test(
 			const attributeRowsLocator =
 				attributesListLocator.getByRole( 'listitem' );
 
-			for ( const attribute of newAttributes ) {
+			for ( const attribute of attributesData ) {
 				const attributeRowLocator = attributeRowsLocator.filter( {
 					has: page.getByText( attribute.name, { exact: true } ),
 				} );
@@ -211,14 +198,14 @@ test(
 					const termLocator = attributeRowLocator
 						.locator( `[aria-hidden="true"]` )
 						.filter( {
-							has: page.getByText( term ),
+							has: page.getByText( term.name ),
 						} );
 
 					// Verify the term is visible
 					await expect( termLocator ).toBeVisible();
 
 					// Verify the term text
-					await expect( termLocator ).toContainText( term );
+					await expect( termLocator ).toContainText( term.name );
 				}
 			}
 		} );
@@ -232,7 +219,7 @@ test(
 			await page.goto( product.permalink );
 
 			// Verify attributes in store frontend
-			for ( const attribute of newAttributes ) {
+			for ( const attribute of attributesData ) {
 				const item = page.getByRole( 'row' ).filter( {
 					has: page.getByText( attribute.name, { exact: true } ),
 				} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -193,19 +193,36 @@ test.only(
 				} );
 				await expect( attributeRowLocator ).toBeVisible();
 
-				for ( const term of attribute.terms ) {
+				// UI only shows 3 terms, so we need to check if the term is visible.
+				const shownTerms = attribute.terms.slice( 0, 3 ).entries();
+
+				// Check if there are more terms than three.
+				const moreThanThreeTerms = attribute.terms.length > 3;
+
+				for ( const [ index, term ] of shownTerms ) {
+					/*
+					 * Disabling the eslint rule because the text
+					 * is different when there are more than three terms.
+					 */
+					const termLabel =
+						// eslint-disable-next-line playwright/no-conditional-in-test
+						moreThanThreeTerms && index === 2
+							? '+ 3 more'
+							: term.name;
 					// Pick the term element/locator
 					const termLocator = attributeRowLocator
 						.locator( `[aria-hidden="true"]` )
 						.filter( {
-							has: page.getByText( term.name ),
+							has: page.getByText( termLabel, {
+								exact: true,
+							} ),
 						} );
 
 					// Verify the term is visible
 					await expect( termLocator ).toBeVisible();
 
 					// Verify the term text
-					await expect( termLocator ).toContainText( term.name );
+					await expect( termLocator ).toContainText( termLabel );
 				}
 			}
 		} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -6,7 +6,7 @@ const { updateProduct } = require( '../../../../utils/product-block-editor' );
 const { clickOnTab } = require( '../../../../utils/simple-products' );
 const attributesData = require( './fixtures/attributes' );
 const {
-	confirmGlobalAttributesLoaded,
+	waitForGlobalAttributesLoaded,
 } = require( './helpers/confirm-global-attributes-loaded' );
 
 async function waitForAttributeList( page ) {
@@ -135,7 +135,7 @@ test(
 			 * First, check the app loads the attributes,
 			 * based on the Spinner visibility.
 			 */
-			await confirmGlobalAttributesLoaded( page );
+			await waitForGlobalAttributesLoaded( page );
 
 			for ( const attribute of attributesData ) {
 				const attributeRowLocator = attributeRowsLocator.last();

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -4,6 +4,9 @@ const {
 const { expect } = require( '../../../../fixtures/fixtures' );
 const { updateProduct } = require( '../../../../utils/product-block-editor' );
 const { clickOnTab } = require( '../../../../utils/simple-products' );
+const {
+	confirmGlobalAttributesLoaded,
+} = require( './helpers/confirm-global-attributes-loaded' );
 
 async function waitForAttributeList( page ) {
 	// The list child is different in case there are no results versus when there already are some attributes, so we need to wait for either one to be visible.
@@ -147,13 +150,7 @@ test(
 			 * First, check the app loads the attributes,
 			 * based on the Spinner visibility.
 			 */
-			const spinnerLocator = attributeRowsLocator.locator(
-				'.components-spinner'
-			);
-			await spinnerLocator.waitFor( {
-				state: 'visible',
-			} );
-			await spinnerLocator.waitFor( { state: 'hidden' } );
+			await confirmGlobalAttributesLoaded( page );
 
 			for ( const term of newAttributes ) {
 				const attributeRowLocator = attributeRowsLocator.last();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR iterates over a couple of E2E tests related to the new Product Editor. The most relevant changes:

**Introduce `./fixtures` and`./data`
Basically, we want to be consistent with the testing data. The difference between fixtures and data is fixtures are used to create or manipulate that in the dB. `Data` are part of the app that, in this context, is not editable. For instance, the Tabs instances.

**introduce `./helpers`**
We want to define specific helper functions to address cases that repeat, among other tests. For instance, we added the `waitForGlobalAttributesLoaded` helper that checks if the global attributes have been loaded based on the Spinner element. (related to this [comment](https://github.com/woocommerce/woocommerce/pull/48871#discussion_r1655387623) )

**Make the tests stronger when**
* comparing the quantity string, for instance:

```
`${ termsLength } variations do not have prices. Variations that do not have prices will not be visible to customers.Set prices`
```

* were created more than three terms per attribute. It tests the `+3 More` label

<img width="361" alt="Screenshot 2024-06-27 at 12 19 38 PM" src="https://github.com/woocommerce/woocommerce/assets/77539/a307d5c2-9903-49d6-b19f-1b809abba451">

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


### Running E2E tests locally

```
cd plugins/woocommerce
```

Ensure Playwright is installed

```
npx playwright install
```

Ensure wp-env is running

```
pnpm env:start
```

Run the following tests

```cli
pnpm test:e2e-pw tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
```

<img width="392" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/ee5764b5-8087-45c4-895c-117cbe951fd6">

```cli
pnpm test:e2e-pw tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
```

<img width="415" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/cc283681-291a-4fc5-919c-6649c2bfa37f">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
