### PR TITLE
Testing: fix metrics job on push to trunk

### DIFF
--- a/.github/workflows/scripts/run-metrics.sh
+++ b/.github/workflows/scripts/run-metrics.sh
@@ -25,7 +25,7 @@ elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
 
 	echo "Publish results to CodeVitals"
 	COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
-    pnpm --filter="compare-perf" run log $CODEVITALS_PROJECT_TOKEN trunk $GITHUB_SHA 19f3d0884617d7ecdcf37664f648a51e2987cada $COMMITTED_AT
+    pnpm --filter="compare-perf" run log $CODEVITALS_PROJECT_TOKEN trunk $GITHUB_SHA 19f3d0884617d7ecdcf37664f648a51e2987cada $COMMITTED_AT "$GITHUB_WORKSPACE/artifacts"
 else
   	echo "Unsupported event: $GITHUB_EVENT_NAME"
 fi

--- a/.github/workflows/scripts/run-metrics.sh
+++ b/.github/workflows/scripts/run-metrics.sh
@@ -25,7 +25,7 @@ elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
 
 	echo "Publish results to CodeVitals"
 	COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
-    pnpm --filter="compare-perf" run log $CODEVITALS_PROJECT_TOKEN trunk $GITHUB_SHA 19f3d0884617d7ecdcf37664f648a51e2987cada $COMMITTED_AT "$GITHUB_WORKSPACE/artifacts"
+    pnpm --filter="compare-perf" run log $CODEVITALS_PROJECT_TOKEN trunk $GITHUB_SHA 19f3d0884617d7ecdcf37664f648a51e2987cada $COMMITTED_AT
 else
   	echo "Unsupported event: $GITHUB_EVENT_NAME"
 fi

--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -15,14 +15,11 @@ const resultsFiles = [
 		metricsPrefix: 'product-editor-',
 	},
 ];
+const ARTIFACTS_PATH =
+	process.env.WP_ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
 
 const performanceResults = resultsFiles.map( ( { file } ) =>
-	JSON.parse(
-		fs.readFileSync(
-			path.join( process.env.WP_ARTIFACTS_PATH, file ),
-			'utf8'
-		)
-	)
+	JSON.parse( fs.readFileSync( path.join( ARTIFACTS_PATH, file ), 'utf8' ) )
 );
 
 const data = new TextEncoder().encode(

--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -3,7 +3,8 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const https = require( 'https' );
-const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
+const [ token, branch, hash, baseHash, timestamp, artifacts_path ] =
+	process.argv.slice( 2 );
 
 const resultsFiles = [
 	{
@@ -17,12 +18,7 @@ const resultsFiles = [
 ];
 
 const performanceResults = resultsFiles.map( ( { file } ) =>
-	JSON.parse(
-		fs.readFileSync(
-			path.join( process.env.WP_ARTIFACTS_PATH, file ),
-			'utf8'
-		)
-	)
+	JSON.parse( fs.readFileSync( path.join( artifacts_path, file ), 'utf8' ) )
 );
 
 const data = new TextEncoder().encode(

--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -3,8 +3,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const https = require( 'https' );
-const [ token, branch, hash, baseHash, timestamp, artifacts_path ] =
-	process.argv.slice( 2 );
+const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
 
 const resultsFiles = [
 	{
@@ -18,7 +17,12 @@ const resultsFiles = [
 ];
 
 const performanceResults = resultsFiles.map( ( { file } ) =>
-	JSON.parse( fs.readFileSync( path.join( artifacts_path, file ), 'utf8' ) )
+	JSON.parse(
+		fs.readFileSync(
+			path.join( process.env.WP_ARTIFACTS_PATH, file ),
+			'utf8'
+		)
+	)
 );
 
 const data = new TextEncoder().encode(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes path resolution for prior generated reports (similar to reports genration).

Closes #48493.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Checkout this branch, build project if needed, and execute locally (takes time, in my case I intentionally fake token to not upload local results; if script fails on posting results remotely we are good):

```
pnpm --filter='@woocommerce/plugin-woocommerce' test:metrics:ci
```
with some changes introduced to run-metrics.sh

```
#!/bin/bash

set -eo pipefail

GITHUB_EVENT_NAME='push'
GITHUB_SHA=$(git rev-parse HEAD)
CODEVITALS_PROJECT_TOKEN='...'
```
