### PR TITLE
Revert "Set stock quantity value as 0 by default"

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -74,7 +74,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		'tax_status'         => 'taxable',
 		'tax_class'          => '',
 		'manage_stock'       => false,
-		'stock_quantity'     => 0,
+		'stock_quantity'     => null,
 		'stock_status'       => 'instock',
 		'backorders'         => 'no',
 		'low_stock_amount'   => '',
@@ -358,10 +358,10 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * Returns number of items available for sale.
 	 *
 	 * @param  string $context What the value is for. Valid values are view and edit.
-	 * @return int
+	 * @return int|null
 	 */
 	public function get_stock_quantity( $context = 'view' ) {
-		return $this->get_prop( 'stock_quantity', $context ) ?? 0;
+		return $this->get_prop( 'stock_quantity', $context );
 	}
 
 	/**
@@ -966,7 +966,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param float|null $quantity Stock quantity.
 	 */
 	public function set_stock_quantity( $quantity ) {
-		$this->set_prop( 'stock_quantity', '' !== $quantity ? wc_stock_amount( $quantity ) : 0 );
+		$this->set_prop( 'stock_quantity', '' !== $quantity ? wc_stock_amount( $quantity ) : null );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -197,7 +197,7 @@ class WC_Meta_Box_Product_Data {
 		if ( ! empty( $file_urls ) ) {
 			$file_url_size = count( $file_urls );
 
-			for ( $i = 0; $i < $file_url_size; $i++ ) {
+			for ( $i = 0; $i < $file_url_size; $i ++ ) {
 				if ( ! empty( $file_urls[ $i ] ) ) {
 					$downloads[] = array(
 						'name'        => wc_clean( $file_names[ $i ] ),
@@ -332,7 +332,7 @@ class WC_Meta_Box_Product_Data {
 		$classname    = WC_Product_Factory::get_product_classname( $post_id, $product_type ? $product_type : 'simple' );
 		$product      = new $classname( $post_id );
 		$attributes   = self::prepare_attributes();
-		$stock        = 0;
+		$stock        = null;
 
 		// Handle stock changes.
 		if ( isset( $_POST['_stock'] ) ) {
@@ -483,7 +483,7 @@ class WC_Meta_Box_Product_Data {
 				}
 				$variation_id = absint( $_POST['variable_post_id'][ $i ] );
 				$variation    = wc_get_product_object( 'variation', $variation_id );
-				$stock        = 0;
+				$stock        = null;
 
 				// Handle stock changes.
 				if ( isset( $_POST['variable_stock'], $_POST['variable_stock'][ $i ] ) ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -56,7 +56,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			woocommerce_wp_text_input(
 				array(
 					'id'                => '_stock',
-					'value'             => wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ),
+					'value'             => wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ?? 1 ),
 					'label'             => __( 'Quantity', 'woocommerce' ),
 					'desc_tip'          => true,
 					'description'       => __( 'Stock quantity. If this is a variable product this value will be used to control stock for all variations, unless you define stock at variation level.', 'woocommerce' ),
@@ -71,10 +71,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ) ) . '" />';
 
 			$backorder_args = array(
-				'id'      => '_backorders',
-				'value'   => $product_object->get_backorders( 'edit' ),
-				'label'   => __( 'Allow backorders?', 'woocommerce' ),
-				'options' => wc_get_product_backorder_options(),
+				'id'          => '_backorders',
+				'value'       => $product_object->get_backorders( 'edit' ),
+				'label'       => __( 'Allow backorders?', 'woocommerce' ),
+				'options'     => wc_get_product_backorder_options(),
 			);
 
 			/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1640,7 +1640,7 @@ CREATE TABLE {$wpdb->prefix}wc_product_meta_lookup (
   `min_price` decimal(19,4) NULL default NULL,
   `max_price` decimal(19,4) NULL default NULL,
   `onsale` tinyint(1) NULL default 0,
-  `stock_quantity` double NULL default 0,
+  `stock_quantity` double NULL default NULL,
   `stock_status` varchar(100) NULL default 'instock',
   `rating_count` bigint(20) NULL default 0,
   `average_rating` decimal(3,2) NULL default 0.00,

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -329,7 +329,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * Returns number of items available for sale.
 	 *
 	 * @param  string $context What the value is for. Valid values are view and edit.
-	 * @return int
+	 * @return int|null
 	 */
 	public function get_stock_quantity( $context = 'view' ) {
 		$value = $this->get_prop( 'stock_quantity', $context );
@@ -338,7 +338,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 		if ( 'view' === $context && 'parent' === $this->get_manage_stock() ) {
 			$value = apply_filters( $this->get_hook_prefix() . 'stock_quantity', $this->parent_data['stock_quantity'], $this );
 		}
-		return $value ?? 0;
+		return $value;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1243,7 +1243,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			do_action( 'product_variation_linked', $variation_id );
 
-			++$count;
+			$count ++;
 
 			if ( $limit > 0 && $count >= $limit ) {
 				break;
@@ -1399,12 +1399,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * Uses locking to update the quantity. If the lock is not acquired, change is lost.
 	 *
 	 * @since  3.0.0 this supports set, increase and decrease.
-	 * @param  int       $product_id_with_stock Product ID.
-	 * @param  int|float $stock_quantity Stock quantity.
-	 * @param  string    $operation Set, increase and decrease.
+	 * @param  int            $product_id_with_stock Product ID.
+	 * @param  int|float|null $stock_quantity Stock quantity.
+	 * @param  string         $operation Set, increase and decrease.
 	 * @return int|float New stock level.
 	 */
-	public function update_product_stock( $product_id_with_stock, $stock_quantity = 0, $operation = 'set' ) {
+	public function update_product_stock( $product_id_with_stock, $stock_quantity = null, $operation = 'set' ) {
 		global $wpdb;
 
 		// Ensures a row exists to update.
@@ -2110,7 +2110,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( 'wc_product_meta_lookup' === $table ) {
 			$price_meta   = (array) get_post_meta( $id, '_price', false );
 			$manage_stock = get_post_meta( $id, '_manage_stock', true );
-			$stock        = 'yes' === $manage_stock ? wc_stock_amount( get_post_meta( $id, '_stock', true ) ) : 0;
+			$stock        = 'yes' === $manage_stock ? wc_stock_amount( get_post_meta( $id, '_stock', true ) ) : null;
 			$price        = wc_format_decimal( get_post_meta( $id, '_price', true ) );
 			$sale_price   = wc_format_decimal( get_post_meta( $id, '_sale_price', true ) );
 			return array(

--- a/plugins/woocommerce/includes/interfaces/class-wc-product-data-store-interface.php
+++ b/plugins/woocommerce/includes/interfaces/class-wc-product-data-store-interface.php
@@ -96,11 +96,11 @@ interface WC_Product_Data_Store_Interface {
 	 *
 	 * Uses queries rather than update_post_meta so we can do this in one query (to avoid stock issues).
 	 *
-	 * @param int    $product_id_with_stock Product ID.
-	 * @param int    $stock_quantity Stock quantity to update to.
-	 * @param string $operation Either set, increase or decrease.
+	 * @param int      $product_id_with_stock Product ID.
+	 * @param int|null $stock_quantity Stock quantity to update to.
+	 * @param string   $operation Either set, increase or decrease.
 	 */
-	public function update_product_stock( $product_id_with_stock, $stock_quantity = 0, $operation = 'set' );
+	public function update_product_stock( $product_id_with_stock, $stock_quantity = null, $operation = 'set' );
 
 	/**
 	 * Update a product's sale count directly.

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
  * @param  int|null       $stock_quantity Stock quantity.
  * @param  string         $operation      Type of operation, allows 'set', 'increase' and 'decrease'.
  * @param  bool           $updating       If true, the product object won't be saved here as it will be updated later.
- * @return bool|int
+ * @return bool|int|null
  */
 function wc_update_product_stock( $product, $stock_quantity = null, $operation = 'set', $updating = false ) {
 	if ( ! is_a( $product, 'WC_Product' ) ) {

--- a/plugins/woocommerce/tests/api-core-tests/tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/orders/orders.test.js
@@ -1,5 +1,7 @@
 const { test, expect } = require( '@playwright/test' );
 const { order } = require( '../../data' );
+const { API_BASE_URL } = process.env;
+const shouldSkip = API_BASE_URL != undefined;
 
 /**
  * Billing properties to update.
@@ -46,6 +48,312 @@ test.describe.serial( 'Orders API tests', () => {
 	let orderId, sampleData;
 
 	test.beforeAll( async ( { request } ) => {
+		// create Sample Data function
+		const createSampleData = async () => {
+			const testProductData = await productsTestSetupCreateSampleData();
+
+			const orderedProducts = {
+				pocketHoodie: testProductData.simpleProducts.find(
+					( p ) => p.name === 'Hoodie with Pocket oxo'
+				),
+				sunglasses: testProductData.simpleProducts.find(
+					( p ) => p.name === 'Sunglasses oxo'
+				),
+				beanie: testProductData.simpleProducts.find(
+					( p ) => p.name === 'Beanie oxo'
+				),
+				blueVneck:
+					testProductData.variableProducts.vneckVariations.find(
+						( p ) => p.sku === 'woo-vneck-tee-blue'
+					),
+				pennant: testProductData.externalProducts[ 0 ],
+			};
+
+			const johnAddress = {
+				first_name: 'John',
+				last_name: 'Doe',
+				company: 'Automattic',
+				country: 'US',
+				address_1: '60 29th Street',
+				address_2: '#343',
+				city: 'San Francisco',
+				state: 'CA',
+				postcode: '94110',
+				phone: '123456789',
+			};
+			const tinaAddress = {
+				first_name: 'Tina',
+				last_name: 'Clark',
+				company: 'Automattic',
+				country: 'US',
+				address_1: 'Oxford Ave',
+				address_2: '',
+				city: 'Buffalo',
+				state: 'NY',
+				postcode: '14201',
+				phone: '123456789',
+			};
+			const guestShippingAddress = {
+				first_name: 'Ano',
+				last_name: 'Nymous',
+				company: '',
+				country: 'US',
+				address_1: '0 Incognito St',
+				address_2: '',
+				city: 'Erie',
+				state: 'PA',
+				postcode: '16515',
+				phone: '123456789',
+			};
+			const guestBillingAddress = {
+				first_name: 'Ben',
+				last_name: 'Efactor',
+				company: '',
+				country: 'US',
+				address_1: '200 W University Avenue',
+				address_2: '',
+				city: 'Gainesville',
+				state: 'FL',
+				postcode: '32601',
+				phone: '123456789',
+				email: 'ben.efactor@email.net',
+			};
+
+			const john = await request.post( '/wp-json/wc/v3/customers', {
+				data: {
+					first_name: 'John',
+					last_name: 'Doe',
+					username: 'john.doe',
+					email: 'john.doe@example.com',
+					billing: {
+						...johnAddress,
+						email: 'john.doe@example.com',
+					},
+					shipping: johnAddress,
+				},
+			} );
+			const johnJSON = await john.json();
+
+			const tina = await request.post( '/wp-json/wc/v3/customers', {
+				data: {
+					first_name: 'Tina',
+					last_name: 'Clark',
+					username: 'tina.clark',
+					email: 'tina.clark@example.com',
+					billing: {
+						...tinaAddress,
+						email: 'tina.clark@example.com',
+					},
+					shipping: tinaAddress,
+				},
+			} );
+			const tinaJSON = await tina.json();
+
+			const orderBaseData = {
+				payment_method: 'cod',
+				payment_method_title: 'Cash on Delivery',
+				status: 'processing',
+				set_paid: false,
+				currency: 'USD',
+				customer_id: 0,
+			};
+
+			const orders = [];
+			// Have "John" order all products.
+			Object.values( orderedProducts ).forEach( async ( product ) => {
+				const order = await request.post( '/wp-json/wc/v3/orders', {
+					data: {
+						...orderBaseData,
+						customer_id: johnJSON.id,
+						billing: {
+							...johnAddress,
+							email: 'john.doe@example.com',
+						},
+						shipping: johnAddress,
+						line_items: [
+							{
+								product_id: product.id,
+								quantity: 1,
+							},
+						],
+					},
+				} );
+				const orderJSON = await order.json();
+
+				orders.push( orderJSON );
+			} );
+
+			// Have "Tina" order some sunglasses and make a child order.
+			// This somewhat resembles a subscription renewal, but we're just testing the `parent` field.
+			const order2 = await request.post( '/wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					status: 'completed',
+					set_paid: true,
+					customer_id: tinaJSON.id,
+					billing: {
+						...tinaAddress,
+						email: 'tina.clark@example.com',
+					},
+					shipping: tinaAddress,
+					line_items: [
+						{
+							product_id: orderedProducts.sunglasses.id,
+							quantity: 1,
+						},
+					],
+				},
+			} );
+			const order2JSON = await order2.json();
+
+			orders.push( order2JSON );
+
+			// create child order by referencing a parent_id
+			const order3 = await request.post( '/wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					parent_id: order2JSON.id,
+					customer_id: tinaJSON.id,
+					billing: {
+						...tinaAddress,
+						email: 'tina.clark@example.com',
+					},
+					shipping: tinaAddress,
+					line_items: [
+						{
+							product_id: orderedProducts.sunglasses.id,
+							quantity: 1,
+						},
+					],
+				},
+			} );
+			const order3JSON = await order3.json();
+
+			orders.push( order3JSON );
+
+			// Guest order.
+			const guestOrder = await request.post( '/wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					billing: guestBillingAddress,
+					shipping: guestShippingAddress,
+					line_items: [
+						{
+							product_id: orderedProducts.pennant.id,
+							quantity: 2,
+						},
+						{
+							product_id: orderedProducts.beanie.id,
+							quantity: 1,
+						},
+					],
+				},
+			} );
+			const guestOrderJSON = await guestOrder.json();
+
+			// Create an order with all possible numerical fields (taxes, fees, refunds, etc).
+			await request.put(
+				'/wp-json/wc/v3/settings/general/woocommerce_calc_taxes',
+				{
+					data: {
+						value: 'yes',
+					},
+				}
+			);
+
+			await request.post( '/wp-json/wc/v3/taxes', {
+				data: {
+					country: '*',
+					state: '*',
+					postcode: '*',
+					city: '*',
+					name: 'Tax',
+					rate: '5.5',
+					shipping: true,
+				},
+			} );
+
+			const coupon = await request.post( '/wp-json/wc/v3/coupons', {
+				data: {
+					code: 'save5',
+					amount: '5',
+				},
+			} );
+			const couponJSON = await coupon.json();
+
+			const order4 = await request.post( '/wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					line_items: [
+						{
+							product_id: orderedProducts.blueVneck.id,
+							quantity: 1,
+						},
+					],
+					coupon_lines: [
+						{
+							code: 'save5',
+						},
+					],
+					shipping_lines: [
+						{
+							method_id: 'flat_rate',
+							total: '5.00',
+						},
+					],
+					fee_lines: [
+						{
+							total: '1.00',
+							name: 'Test Fee',
+						},
+					],
+				},
+			} );
+			const order4JSON = await order4.json();
+
+			await request.post(
+				`/wp-json/wc/v3/orders/${ order4JSON.id }/refunds`,
+				{
+					data: {
+						api_refund: false, // Prevent an actual refund request (fails with CoD),
+						line_items: [
+							{
+								id: order4JSON.line_items[ 0 ].id,
+								quantity: 1,
+								refund_total: order4JSON.line_items[ 0 ].total,
+								refund_tax: [
+									{
+										id: order4JSON.line_items[ 0 ]
+											.taxes[ 0 ].id,
+										refund_total:
+											order4JSON.line_items[ 0 ]
+												.total_tax,
+									},
+								],
+							},
+						],
+					},
+				}
+			);
+			orders.push( order4JSON );
+
+			return {
+				customers: {
+					johnJSON,
+					tinaJSON,
+				},
+				orders,
+				precisionOrder: order4JSON,
+				hierarchicalOrders: {
+					parent: order2JSON,
+					child: order3JSON,
+				},
+				guestOrderJSON,
+				testProductData,
+				couponJSON,
+			};
+		};
+
 		const createSampleCategories = async () => {
 			const clothing = await request.post(
 				'/wp-json/wc/v3/products/categories',
@@ -282,7 +590,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -355,7 +663,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -434,7 +742,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -510,7 +818,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -575,7 +883,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -648,7 +956,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -721,7 +1029,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -786,7 +1094,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -863,7 +1171,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: 'reduced-rate',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -932,7 +1240,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1005,7 +1313,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1070,7 +1378,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1147,7 +1455,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1220,7 +1528,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1312,7 +1620,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1403,7 +1711,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1488,7 +1796,7 @@ test.describe.serial( 'Orders API tests', () => {
 					tax_status: 'taxable',
 					tax_class: '',
 					manage_stock: false,
-					stock_quantity: 0,
+					stock_quantity: null,
 					backorders: 'no',
 					backorders_allowed: false,
 					backordered: false,
@@ -1574,7 +1882,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1620,7 +1928,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1666,7 +1974,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1712,7 +2020,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1773,7 +2081,7 @@ test.describe.serial( 'Orders API tests', () => {
 					tax_status: 'taxable',
 					tax_class: '',
 					manage_stock: false,
-					stock_quantity: 0,
+					stock_quantity: null,
 					backorders: 'no',
 					backorders_allowed: false,
 					backordered: false,
@@ -1850,7 +2158,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1891,7 +2199,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1932,7 +2240,7 @@ test.describe.serial( 'Orders API tests', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -2084,7 +2392,7 @@ test.describe.serial( 'Orders API tests', () => {
 				( p ) => p.name === 'T-Shirt oxo'
 			);
 
-			const order1 = await request.post( '/wp-json/wc/v3/orders', {
+			const order = await request.post( '/wp-json/wc/v3/orders', {
 				data: {
 					set_paid: true,
 					status: 'completed',
@@ -2104,7 +2412,7 @@ test.describe.serial( 'Orders API tests', () => {
 					],
 				},
 			} );
-			const orderJSON = await order1.json();
+			const orderJSON = await order.json();
 
 			return [ orderJSON ];
 		};
@@ -2164,316 +2472,11 @@ test.describe.serial( 'Orders API tests', () => {
 			};
 		};
 
-		// create Sample Data function
-		const createSampleData = async () => {
-			const testProductData = await productsTestSetupCreateSampleData();
-			const orderedProducts = {
-				pocketHoodie: testProductData.simpleProducts.find(
-					( p ) => p.name === 'Hoodie with Pocket oxo'
-				),
-				sunglasses: testProductData.simpleProducts.find(
-					( p ) => p.name === 'Sunglasses oxo'
-				),
-				beanie: testProductData.simpleProducts.find(
-					( p ) => p.name === 'Beanie oxo'
-				),
-				blueVneck:
-					testProductData.variableProducts.vneckVariations.find(
-						( p ) => p.sku === 'woo-vneck-tee-blue'
-					),
-				pennant: testProductData.externalProducts[ 0 ],
-			};
-
-			const johnAddress = {
-				first_name: 'John',
-				last_name: 'Doe',
-				company: 'Automattic',
-				country: 'US',
-				address_1: '60 29th Street',
-				address_2: '#343',
-				city: 'San Francisco',
-				state: 'CA',
-				postcode: '94110',
-				phone: '123456789',
-			};
-			const tinaAddress = {
-				first_name: 'Tina',
-				last_name: 'Clark',
-				company: 'Automattic',
-				country: 'US',
-				address_1: 'Oxford Ave',
-				address_2: '',
-				city: 'Buffalo',
-				state: 'NY',
-				postcode: '14201',
-				phone: '123456789',
-			};
-			const guestShippingAddress = {
-				first_name: 'Ano',
-				last_name: 'Nymous',
-				company: '',
-				country: 'US',
-				address_1: '0 Incognito St',
-				address_2: '',
-				city: 'Erie',
-				state: 'PA',
-				postcode: '16515',
-				phone: '123456789',
-			};
-			const guestBillingAddress = {
-				first_name: 'Ben',
-				last_name: 'Efactor',
-				company: '',
-				country: 'US',
-				address_1: '200 W University Avenue',
-				address_2: '',
-				city: 'Gainesville',
-				state: 'FL',
-				postcode: '32601',
-				phone: '123456789',
-				email: 'ben.efactor@email.net',
-			};
-
-			const john = await request.post( '/wp-json/wc/v3/customers', {
-				data: {
-					first_name: 'John',
-					last_name: 'Doe',
-					username: 'john.doe',
-					email: 'john.doe@example.com',
-					billing: {
-						...johnAddress,
-						email: 'john.doe@example.com',
-					},
-					shipping: johnAddress,
-				},
-			} );
-			const johnJSON = await john.json();
-
-			const tina = await request.post( '/wp-json/wc/v3/customers', {
-				data: {
-					first_name: 'Tina',
-					last_name: 'Clark',
-					username: 'tina.clark',
-					email: 'tina.clark@example.com',
-					billing: {
-						...tinaAddress,
-						email: 'tina.clark@example.com',
-					},
-					shipping: tinaAddress,
-				},
-			} );
-			const tinaJSON = await tina.json();
-
-			const orderBaseData = {
-				payment_method: 'cod',
-				payment_method_title: 'Cash on Delivery',
-				status: 'processing',
-				set_paid: false,
-				currency: 'USD',
-				customer_id: 0,
-			};
-
-			const orders = [];
-			// Have "John" order all products.
-			Object.values( orderedProducts ).forEach( async ( product ) => {
-				const order2 = await request.post( '/wp-json/wc/v3/orders', {
-					data: {
-						...orderBaseData,
-						customer_id: johnJSON.id,
-						billing: {
-							...johnAddress,
-							email: 'john.doe@example.com',
-						},
-						shipping: johnAddress,
-						line_items: [
-							{
-								product_id: product.id,
-								quantity: 1,
-							},
-						],
-					},
-				} );
-				const orderJSON = await order2.json();
-
-				orders.push( orderJSON );
-			} );
-
-			// Have "Tina" order some sunglasses and make a child order.
-			// This somewhat resembles a subscription renewal, but we're just testing the `parent` field.
-			const order2 = await request.post( '/wp-json/wc/v3/orders', {
-				data: {
-					...orderBaseData,
-					status: 'completed',
-					set_paid: true,
-					customer_id: tinaJSON.id,
-					billing: {
-						...tinaAddress,
-						email: 'tina.clark@example.com',
-					},
-					shipping: tinaAddress,
-					line_items: [
-						{
-							product_id: orderedProducts.sunglasses.id,
-							quantity: 1,
-						},
-					],
-				},
-			} );
-			const order2JSON = await order2.json();
-
-			orders.push( order2JSON );
-
-			// create child order by referencing a parent_id
-			const order3 = await request.post( '/wp-json/wc/v3/orders', {
-				data: {
-					...orderBaseData,
-					parent_id: order2JSON.id,
-					customer_id: tinaJSON.id,
-					billing: {
-						...tinaAddress,
-						email: 'tina.clark@example.com',
-					},
-					shipping: tinaAddress,
-					line_items: [
-						{
-							product_id: orderedProducts.sunglasses.id,
-							quantity: 1,
-						},
-					],
-				},
-			} );
-			const order3JSON = await order3.json();
-
-			orders.push( order3JSON );
-
-			// Guest order.
-			const guestOrder = await request.post( '/wp-json/wc/v3/orders', {
-				data: {
-					...orderBaseData,
-					billing: guestBillingAddress,
-					shipping: guestShippingAddress,
-					line_items: [
-						{
-							product_id: orderedProducts.pennant.id,
-							quantity: 2,
-						},
-						{
-							product_id: orderedProducts.beanie.id,
-							quantity: 1,
-						},
-					],
-				},
-			} );
-			const guestOrderJSON = await guestOrder.json();
-
-			// Create an order with all possible numerical fields (taxes, fees, refunds, etc).
-			await request.put(
-				'/wp-json/wc/v3/settings/general/woocommerce_calc_taxes',
-				{
-					data: {
-						value: 'yes',
-					},
-				}
-			);
-
-			await request.post( '/wp-json/wc/v3/taxes', {
-				data: {
-					country: '*',
-					state: '*',
-					postcode: '*',
-					city: '*',
-					name: 'Tax',
-					rate: '5.5',
-					shipping: true,
-				},
-			} );
-
-			const coupon = await request.post( '/wp-json/wc/v3/coupons', {
-				data: {
-					code: 'save5',
-					amount: '5',
-				},
-			} );
-			const couponJSON = await coupon.json();
-
-			const order4 = await request.post( '/wp-json/wc/v3/orders', {
-				data: {
-					...orderBaseData,
-					line_items: [
-						{
-							product_id: orderedProducts.blueVneck.id,
-							quantity: 1,
-						},
-					],
-					coupon_lines: [
-						{
-							code: 'save5',
-						},
-					],
-					shipping_lines: [
-						{
-							method_id: 'flat_rate',
-							total: '5.00',
-						},
-					],
-					fee_lines: [
-						{
-							total: '1.00',
-							name: 'Test Fee',
-						},
-					],
-				},
-			} );
-			const order4JSON = await order4.json();
-
-			await request.post(
-				`/wp-json/wc/v3/orders/${ order4JSON.id }/refunds`,
-				{
-					data: {
-						api_refund: false, // Prevent an actual refund request (fails with CoD),
-						line_items: [
-							{
-								id: order4JSON.line_items[ 0 ].id,
-								quantity: 1,
-								refund_total: order4JSON.line_items[ 0 ].total,
-								refund_tax: [
-									{
-										id: order4JSON.line_items[ 0 ]
-											.taxes[ 0 ].id,
-										refund_total:
-											order4JSON.line_items[ 0 ]
-												.total_tax,
-									},
-								],
-							},
-						],
-					},
-				}
-			);
-			orders.push( order4JSON );
-
-			return {
-				customers: {
-					johnJSON,
-					tinaJSON,
-				},
-				orders,
-				precisionOrder: order4JSON,
-				hierarchicalOrders: {
-					parent: order2JSON,
-					child: order3JSON,
-				},
-				guestOrderJSON,
-				testProductData,
-				couponJSON,
-			};
-		};
-
 		sampleData = await createSampleData();
 	}, 100000 );
 
 	test.afterAll( async ( { request } ) => {
-		const productsTestSetupDeleteSampleData = async ( _sampleData ) => {
+		const productsTestSetupDeleteSampleData = async ( sampleData ) => {
 			const {
 				categories,
 				attributes,
@@ -2486,7 +2489,7 @@ test.describe.serial( 'Orders API tests', () => {
 				variableProducts,
 				hierarchicalProducts,
 				orders,
-			} = _sampleData;
+			} = sampleData;
 
 			const productIds = []
 				.concat( simpleProducts.map( ( p ) => p.id ) )
@@ -2501,8 +2504,8 @@ test.describe.serial( 'Orders API tests', () => {
 					hierarchicalProducts.childJSON.id,
 				] );
 
-			for ( const _order of orders ) {
-				await request.delete( `/wp-json/wc/v3/orders/${ _order.id }`, {
+			for ( const order of orders ) {
+				await request.delete( `/wp-json/wc/v3/orders/${ order.id }`, {
 					data: {
 						force: true,
 					},
@@ -2583,22 +2586,22 @@ test.describe.serial( 'Orders API tests', () => {
 			}
 		};
 
-		const deleteSampleData = async ( _sampleData ) => {
+		const deleteSampleData = async ( sampleData ) => {
 			await productsTestSetupDeleteSampleData(
-				_sampleData.testProductData
+				sampleData.testProductData
 			);
 
-			for ( const _order of _sampleData.orders.concat( [
-				_sampleData.guestOrderJSON,
+			for ( const order of sampleData.orders.concat( [
+				sampleData.guestOrderJSON,
 			] ) ) {
-				await request.delete( `/wp-json/wc/v3/orders/${ _order.id }`, {
+				await request.delete( `/wp-json/wc/v3/orders/${ order.id }`, {
 					data: {
 						force: true,
 					},
 				} );
 			}
 
-			for ( const customer of Object.values( _sampleData.customers ) ) {
+			for ( const customer of Object.values( sampleData.customers ) ) {
 				await request.delete(
 					`/wp-json/wc/v3/customers/${ customer.id }`,
 					{
@@ -2778,7 +2781,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const allOrdersJSON = await allOrders.json();
 
 			expect( allOrders.status() ).toEqual( 200 );
-			const allOrdersIds = allOrdersJSON.map( ( _order ) => _order.id );
+			const allOrdersIds = allOrdersJSON.map( ( order ) => order.id );
 			expect( allOrdersIds ).toHaveLength( ORDERS_COUNT );
 
 			const ordersToFilter = [
@@ -2936,8 +2939,8 @@ test.describe.serial( 'Orders API tests', () => {
 
 			expect( result1.status() ).toEqual( 200 );
 			expect( result1JSON ).toHaveLength( 5 );
-			result1JSON.forEach( ( _order ) =>
-				expect( _order ).toEqual(
+			result1JSON.forEach( ( order ) =>
+				expect( order ).toEqual(
 					expect.objectContaining( {
 						customer_id: sampleData.customers.johnJSON.id,
 					} )
@@ -2954,8 +2957,8 @@ test.describe.serial( 'Orders API tests', () => {
 
 			expect( result2.status() ).toEqual( 200 );
 			expect( result2JSON ).toHaveLength( 3 );
-			result2JSON.forEach( ( _order ) =>
-				expect( _order ).toEqual(
+			result2JSON.forEach( ( order ) =>
+				expect( order ).toEqual(
 					expect.objectContaining( {
 						customer_id: 0,
 					} )
@@ -2976,8 +2979,8 @@ test.describe.serial( 'Orders API tests', () => {
 
 			expect( result1.status() ).toEqual( 200 );
 			expect( result1JSON ).toHaveLength( 2 );
-			result1JSON.forEach( ( _order ) =>
-				expect( _order ).toEqual(
+			result1JSON.forEach( ( order ) =>
+				expect( order ).toEqual(
 					expect.objectContaining( {
 						line_items: expect.arrayContaining( [
 							expect.objectContaining( {
@@ -2999,36 +3002,36 @@ test.describe.serial( 'Orders API tests', () => {
 				);
 			};
 
-			const verifyOrderPrecision = ( _order, dp ) => {
-				expectPrecisionToMatch( _order.discount_total, dp );
-				expectPrecisionToMatch( _order.discount_tax, dp );
-				expectPrecisionToMatch( _order.shipping_total, dp );
-				expectPrecisionToMatch( _order.shipping_tax, dp );
-				expectPrecisionToMatch( _order.cart_tax, dp );
-				expectPrecisionToMatch( _order.total, dp );
-				expectPrecisionToMatch( _order.total_tax, dp );
+			const verifyOrderPrecision = ( order, dp ) => {
+				expectPrecisionToMatch( order.discount_total, dp );
+				expectPrecisionToMatch( order.discount_tax, dp );
+				expectPrecisionToMatch( order.shipping_total, dp );
+				expectPrecisionToMatch( order.shipping_tax, dp );
+				expectPrecisionToMatch( order.cart_tax, dp );
+				expectPrecisionToMatch( order.total, dp );
+				expectPrecisionToMatch( order.total_tax, dp );
 
-				_order.line_items.forEach( ( lineItem ) => {
+				order.line_items.forEach( ( lineItem ) => {
 					expectPrecisionToMatch( lineItem.total, dp );
 					expectPrecisionToMatch( lineItem.total_tax, dp );
 				} );
 
-				_order.tax_lines.forEach( ( taxLine ) => {
+				order.tax_lines.forEach( ( taxLine ) => {
 					expectPrecisionToMatch( taxLine.tax_total, dp );
 					expectPrecisionToMatch( taxLine.shipping_tax_total, dp );
 				} );
 
-				_order.shipping_lines.forEach( ( shippingLine ) => {
+				order.shipping_lines.forEach( ( shippingLine ) => {
 					expectPrecisionToMatch( shippingLine.total, dp );
 					expectPrecisionToMatch( shippingLine.total_tax, dp );
 				} );
 
-				_order.fee_lines.forEach( ( feeLine ) => {
+				order.fee_lines.forEach( ( feeLine ) => {
 					expectPrecisionToMatch( feeLine.total, dp );
 					expectPrecisionToMatch( feeLine.total_tax, dp );
 				} );
 
-				_order.refunds.forEach( ( refund ) => {
+				order.refunds.forEach( ( refund ) => {
 					expectPrecisionToMatch( refund.total, dp );
 				} );
 			};
@@ -3086,8 +3089,8 @@ test.describe.serial( 'Orders API tests', () => {
 
 			expect( result1.status() ).toEqual( 200 );
 			expect( result1JSON.length ).toBeGreaterThanOrEqual( 1 );
-			result1JSON.forEach( ( _order ) =>
-				expect( _order.billing.email ).toContain( 'example.com' )
+			result1JSON.forEach( ( order ) =>
+				expect( order.billing.email ).toContain( 'example.com' )
 			);
 
 			// Test billing address.
@@ -3128,8 +3131,8 @@ test.describe.serial( 'Orders API tests', () => {
 
 			expect( result4.status() ).toEqual( 200 );
 			expect( result4JSON.length ).toBeGreaterThanOrEqual( 1 );
-			result4JSON.forEach( ( _order ) =>
-				expect( _order.billing.last_name ).toEqual( 'Doe' )
+			result4JSON.forEach( ( order ) =>
+				expect( order.billing.last_name ).toEqual( 'Doe' )
 			);
 
 			// Test order item name.
@@ -3142,8 +3145,8 @@ test.describe.serial( 'Orders API tests', () => {
 
 			expect( result5.status() ).toEqual( 200 );
 			expect( result5JSON ).toHaveLength( 2 );
-			result5JSON.forEach( ( _order ) =>
-				expect( _order ).toEqual(
+			result5JSON.forEach( ( order ) =>
+				expect( order ).toEqual(
 					expect.objectContaining( {
 						line_items: expect.arrayContaining( [
 							expect.objectContaining( {

--- a/plugins/woocommerce/tests/api-core-tests/tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/products/product-list.test.js
@@ -15,6 +15,56 @@ test.describe( 'Products API tests: List All Products', () => {
 	let sampleData;
 
 	test.beforeAll( async ( { request } ) => {
+		const createSampleData = async () => {
+			const categories = await createSampleCategories();
+
+			const attributes = await createSampleAttributes();
+
+			const tags = await createSampleTags();
+
+			const shippingClasses = await createSampleShippingClasses();
+
+			const taxClasses = await createSampleTaxClasses();
+
+			const simpleProducts = await createSampleSimpleProducts(
+				categories,
+				attributes,
+				tags
+			);
+			const externalProducts = await createSampleExternalProducts(
+				categories
+			);
+			const groupedProducts = await createSampleGroupedProduct(
+				categories
+			);
+			const variableProducts = await createSampleVariableProducts(
+				categories,
+				attributes
+			);
+			const hierarchicalProducts =
+				await createSampleHierarchicalProducts();
+
+			const reviewIds = await createSampleProductReviews(
+				simpleProducts
+			);
+			const orders = await createSampleProductOrders( simpleProducts );
+
+			return {
+				categories,
+				attributes,
+				tags,
+				shippingClasses,
+				taxClasses,
+				simpleProducts,
+				externalProducts,
+				groupedProducts,
+				variableProducts,
+				hierarchicalProducts,
+				reviewIds,
+				orders,
+			};
+		};
+
 		const createSampleCategories = async () => {
 			const clothing = await request.post(
 				'/wp-json/wc/v3/products/categories',
@@ -250,7 +300,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -323,7 +373,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -402,7 +452,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -478,7 +528,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -543,7 +593,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -616,7 +666,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -689,7 +739,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -754,7 +804,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -831,7 +881,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: 'reduced-rate',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -900,7 +950,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -973,7 +1023,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1038,7 +1088,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1115,7 +1165,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1188,7 +1238,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1280,7 +1330,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1371,7 +1421,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								backorders: 'no',
 								backorders_allowed: false,
 								backordered: false,
@@ -1456,7 +1506,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					tax_status: 'taxable',
 					tax_class: '',
 					manage_stock: false,
-					stock_quantity: 0,
+					stock_quantity: null,
 					backorders: 'no',
 					backorders_allowed: false,
 					backordered: false,
@@ -1542,7 +1592,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1588,7 +1638,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1634,7 +1684,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1680,7 +1730,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1741,7 +1791,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					tax_status: 'taxable',
 					tax_class: '',
 					manage_stock: false,
-					stock_quantity: 0,
+					stock_quantity: null,
 					backorders: 'no',
 					backorders_allowed: false,
 					backordered: false,
@@ -1818,7 +1868,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1859,7 +1909,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -1900,7 +1950,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								tax_status: 'taxable',
 								tax_class: '',
 								manage_stock: false,
-								stock_quantity: 0,
+								stock_quantity: null,
 								stock_status: 'instock',
 								backorders: 'no',
 								backorders_allowed: false,
@@ -2072,61 +2122,11 @@ test.describe( 'Products API tests: List All Products', () => {
 			return [ orderJSON ];
 		};
 
-		const createSampleData = async () => {
-			const categories = await createSampleCategories();
-
-			const attributes = await createSampleAttributes();
-
-			const tags = await createSampleTags();
-
-			const shippingClasses = await createSampleShippingClasses();
-
-			const taxClasses = await createSampleTaxClasses();
-
-			const simpleProducts = await createSampleSimpleProducts(
-				categories,
-				attributes,
-				tags
-			);
-			const externalProducts = await createSampleExternalProducts(
-				categories
-			);
-			const groupedProducts = await createSampleGroupedProduct(
-				categories
-			);
-			const variableProducts = await createSampleVariableProducts(
-				categories,
-				attributes
-			);
-			const hierarchicalProducts =
-				await createSampleHierarchicalProducts();
-
-			const reviewIds = await createSampleProductReviews(
-				simpleProducts
-			);
-			const orders = await createSampleProductOrders( simpleProducts );
-
-			return {
-				categories,
-				attributes,
-				tags,
-				shippingClasses,
-				taxClasses,
-				simpleProducts,
-				externalProducts,
-				groupedProducts,
-				variableProducts,
-				hierarchicalProducts,
-				reviewIds,
-				orders,
-			};
-		};
-
 		sampleData = await createSampleData();
 	}, 10000 );
 
 	test.afterAll( async ( { request } ) => {
-		const deleteSampleData = async ( _sampleData ) => {
+		const deleteSampleData = async ( sampleData ) => {
 			const {
 				categories,
 				attributes,
@@ -2139,7 +2139,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				variableProducts,
 				hierarchicalProducts,
 				orders,
-			} = _sampleData;
+			} = sampleData;
 
 			const productIds = []
 				.concat( simpleProducts.map( ( p ) => p.id ) )

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
@@ -135,7 +135,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$product->set_stock_quantity( 5 );
 		$product->set_stock_status( 'instock' );
 		$product->save();
-		$this->assertEquals( 0, $product->get_stock_quantity() );
+		$this->assertEquals( '', $product->get_stock_quantity() );
 		$this->assertEquals( 'instock', $product->get_stock_status() );
 		$product->set_stock_status( 'outofstock' );
 		$product->save();

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/functions.php
@@ -917,11 +917,14 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: test_wc_update_product_stock_should_return_old_value_if_not_managing_stock.
+	 * Test: test_wc_update_product_stock_should_return_null_if_not_managing_stock.
 	 */
-	public function test_wc_update_product_stock_should_return_old_value_if_not_managing_stock() {
+	public function test_wc_update_product_stock_should_return_null_if_not_managing_stock() {
 		$product = WC_Helper_Product::create_simple_product();
-		$this->assertEquals( 0, wc_update_product_stock( $product, 3 ) );
+		$product->set_stock_quantity( 5 );
+		$product->save();
+
+		$this->assertNull( wc_update_product_stock( $product, 3 ) );
 	}
 
 	/**
@@ -1308,4 +1311,5 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 100, $price_shop );
 	}
+
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
@@ -37,7 +37,7 @@ class WC_Tests_Product_Variable extends WC_Unit_Test_Case {
 		$product->set_stock_quantity( 5 );
 		$product->set_stock_status( 'instock' );
 		$product->save();
-		$this->assertEquals( 0, $product->get_stock_quantity() );
+		$this->assertEquals( '', $product->get_stock_quantity() );
 		$this->assertEquals( 'outofstock', $product->get_stock_status() );
 
 		$product->set_manage_stock( true );


### PR DESCRIPTION
Reverts woocommerce/woocommerce#48448 (commit 0652c2eb4fa00c1f2ea990d675aee8aba069ee97).

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The PR https://github.com/woocommerce/woocommerce/pull/48448 set stock quantity to 0 by default. However, the change had bigger implications than we thought. It initially breaks some use cases for Product Bundles and potentially could break backward compatibility. This is why we decided to revert the change.

More context here (p1719342549204909-slack-C01DT6U03HC)

With the changes reverted here, you will see again:
- Set the stock quantity to 1 by default in the UI.
- It's possible to set the stock quantity to `null`.
- `get_stock_quantity` can return `null` again.

⚠️ This is not a simple revert. There are a few changes in the original PR that are necessary due to the linter. A simple revert won't be accepted because the original files need to be updated to pass the linter checks before modifying them.

You can check [this issue](https://github.com/woocommerce/woocommerce/issues/39475) if you want additional details.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch.
2. Go to Products > Add New > Inventory.
3. Check `Track stock quantity for this product`.
4. Verify that `Quantity` is 1.
5. Create a product and confirm that the stock management works well.
6. Try a few extensions that interact with the stock quantity like `WooCommerce Product Bundles` and `WooCommerce Back in Stock Notifications`. If you remember more extensions, please test them.
7. Perform some smoke tests. Verify that the Stock status works as expected and that the available stock matches what it should. Create multiple orders from the product page, and very everything works ok.
8. Enable the new product editor under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
9. Go to Products > Add New > Inventory.
10. Press `Track inventory`.
11. Verify the `Available stock` is 1.
12. Make more smoke tests.
13. Test with variable products as well.
14. Go to `/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory` and disable `Manage stock`.
15. Create a few orders and verify everything works as expected.
16. Re-enable the `Manage stock` option. Everything should work well.
17. Since this affects multiple areas, please test any other use case you can think of.

<!-- End testing instructions -->