### PR TITLE
Revert "CI: lint strict types directive for new files (#48779)"

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -10,21 +10,12 @@
 
 baseBranch=${1:-"trunk"}
 
-# Lint changed php-files to match code style.
 changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=d -- '*.php')
-if [[ -n $changedFiles ]]; then
-    composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
+
+# Only complete this if changed files are detected.
+if [[ -z $changedFiles ]]; then
+    echo "No changed files detected."
+    exit 0
 fi
 
-# Lint new (excl. renamed) php-files to contain strict types directive.
-newFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=r -- '*.php')
-if [[ -n $newFiles ]]; then
-	passingFiles=$(find $newFiles -type f -exec grep -xl --regexp='declare(\s*strict_types\s*=\s*1\s*);' /dev/null {} +)
-	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort))
-	if [[ -n violatingFiles ]]; then
-		redColoured='\033[0;31m'
-		printf "${redColoured}Following files are missing 'declare( strict_types = 1)' directive:\n"
-		printf "${redColoured}%s\n" $violatingFiles
-		exit 1
-	fi
-fi
+composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles

--- a/plugins/woocommerce/changelog/add-41443-lint-strict-types-directive-for-new-files
+++ b/plugins/woocommerce/changelog/add-41443-lint-strict-types-directive-for-new-files
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Lint new PHP files for strict types directive


### PR DESCRIPTION
This reverts commit 66ae029f708e70c64865029edc9ef70472266340.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reverts https://github.com/woocommerce/woocommerce/pull/48779, which needs a bit more work (falsely recognizes modified files as new ones).

### How to test the changes in this Pull Request:

- CI checks shall pass