### PR TITLE
Fix product editor block template dependency conflict

### DIFF
--- a/packages/js/create-product-editor-block/changelog/fix-product-editor-block-template
+++ b/packages/js/create-product-editor-block/changelog/fix-product-editor-block-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add ajv-keywords package to fix dependency conflict.

--- a/packages/js/create-product-editor-block/index.js
+++ b/packages/js/create-product-editor-block/index.js
@@ -34,6 +34,7 @@ module.exports = {
 			'@wordpress/stylelint-config',
 			'eslint-import-resolver-typescript',
 			'@woocommerce/product-editor',
+			'ajv-keywords@^3.5.2', // Adding ajv-keywords to fix a depedency issue caused by legacy-peer-deps = true.
 		],
 		customScripts: {
 			postinstall: 'composer install',

--- a/packages/js/create-product-editor-block/index.js
+++ b/packages/js/create-product-editor-block/index.js
@@ -34,7 +34,7 @@ module.exports = {
 			'@wordpress/stylelint-config',
 			'eslint-import-resolver-typescript',
 			'@woocommerce/product-editor',
-			'ajv-keywords@^3.5.2', // Adding ajv-keywords to fix a depedency issue caused by legacy-peer-deps = true.
+			'ajv-keywords@^3.5.2', // Adding ajv-keywords to fix a dependency issue caused by legacy-peer-deps = true.
 		],
 		customScripts: {
 			postinstall: 'composer install',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently when running `npx @wordpress/create-block --template @woocommerce/create-product-editor-block` it fails when running `npm start` because it installs a newer version of `ajv-keywords`. I believe this is happening because we make use of `legacy-peer-deps = true`, which is necessary as the product-editor package still relies on React 17.
To fix this, I locked the `ajv-keywords` version by adding it as a dependency.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `npx @wordpress/create-block --template @woocommerce/create-product-editor-block` in any directory and notice how it fails on the last step ( the `npm start` command ). Note: you can just press enter for all the default values.
2. Run `npx @wordpress/create-block --template path/to/monorepo/packages/js/create-product-editor-block` in any directory
3. This should finish successfully, now go to the created directory ( `example-product-editor-block` if default value used ) and run `npm start`, it should build successfully.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
