### PR TITLE
Remove performance tests from PR checks (leave on push to trunk)

### DIFF
--- a/plugins/woocommerce/changelog/ci-disable-perf-checks-for-prs
+++ b/plugins/woocommerce/changelog/ci-disable-perf-checks-for-prs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove performance tests from PR checks (leave on push to trunk)

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -533,7 +533,6 @@
 						"start": "env:perf"
 					},
 					"events": [
-						"pull_request",
 						"push"
 					]
 				},
@@ -553,7 +552,6 @@
 						"tests/metrics/**"
 					],
 					"events": [
-						"pull_request",
 						"push"
 					]
 				},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove the Performance K6 and Metrics tests from PR checks. They will still run on push to trunk.

### How to test the changes in this Pull Request:

Check CI, Performance K6 and Metrics tests jobs should not run.