### PR TITLE
Product Editor: disable Add button when no terms or options when creating variations

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-disable-add-button-when-no-attributes
+++ b/packages/js/product-editor/changelog/update-product-editor-disable-add-button-when-no-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Editor: disable `Add` button when no terms or options when creating variations

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -461,7 +461,6 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 							);
 						}
 					} }
-					onInputChange={ console.log }
 					__experimentalExpandOnFocus={ true }
 					__experimentalAutoSelectFirstMatch={ true }
 					__experimentalShowHowTo={ true }

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -461,6 +461,7 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 							);
 						}
 					} }
+					onInputChange={ console.log }
 					__experimentalExpandOnFocus={ true }
 					__experimentalAutoSelectFirstMatch={ true }
 					__experimentalShowHowTo={ true }

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -317,11 +317,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 						index: number,
 						attribute?: EnhancedProductAttribute
 					) {
-						/*
-						 * For local (Product) attributes, the field name suffix
-						 * to set the attribute terms is 'options',
-						 * for global attributes, the field name suffix is 'terms'.
-						 */
 						const attributeTermPropName =
 							attribute && isGlobalAttribute( attribute )
 								? 'terms'
@@ -473,6 +468,10 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 											: ''
 									}
 								>
+									{ /*
+									 * we need to wrap the button in a div to make the tooltip work,
+									 * since when the button is disabled, the tooltip is not shown.
+									 */ }
 									<div>
 										<Button
 											variant="primary"

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -25,6 +25,7 @@ import { TRACKS_SOURCE } from '../../constants';
 import { AttributeTableRow } from './attribute-table-row';
 import type { EnhancedProductAttribute } from '../../hooks/use-product-attributes';
 import type { AttributesComboboxControlItem } from '../attribute-combobox-field/types';
+import { isAttributeFilledOut } from './utils';
 
 type NewAttributeModalProps = {
 	title?: string;
@@ -111,13 +112,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		onAddAnother();
 	};
 
-	const hasTermsOrOptions = ( attribute: EnhancedProductAttribute ) => {
-		return (
-			( attribute.terms && attribute.terms.length > 0 ) ||
-			( attribute.options && attribute.options.length > 0 )
-		);
-	};
-
 	/**
 	 * By convention, a global attribute has an ID different from 0.
 	 *
@@ -142,16 +136,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		return isGlobalAttribute( attribute )
 			? mapTermsToOptions( attribute.terms )
 			: attribute.options;
-	};
-
-	const isAttributeFilledOut = (
-		attribute: EnhancedProductAttribute | null
-	): attribute is EnhancedProductAttribute => {
-		return (
-			attribute !== null &&
-			attribute.name.length > 0 &&
-			hasTermsOrOptions( attribute )
-		);
 	};
 
 	const getVisibleOrTrue = ( attribute: EnhancedProductAttribute ) =>

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -15,7 +15,7 @@ import {
 	type ProductAttributeTerm,
 	type ProductAttribute,
 } from '@woocommerce/data';
-import { Button, Modal, Notice } from '@wordpress/components';
+import { Button, Modal, Notice, Tooltip } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -475,16 +475,30 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 								>
 									{ cancelLabel }
 								</Button>
-								<Button
-									variant="primary"
-									label={ addAccessibleLabel }
-									disabled={ isAddButtonDisabled }
-									onClick={ () =>
-										onAddingAttributes( values )
+								<Tooltip
+									text={
+										isAddButtonDisabled
+											? __(
+													'Add at least one attribute and one value. Press Enter to select.',
+													'woocommerce'
+											  )
+											: ''
 									}
 								>
-									{ addLabel }
-								</Button>
+									<div>
+										<Button
+											variant="primary"
+											label={ addAccessibleLabel }
+											showTooltip={ true }
+											disabled={ isAddButtonDisabled }
+											onClick={ () =>
+												onAddingAttributes( values )
+											}
+										>
+											{ addLabel }
+										</Button>
+									</div>
+								</Tooltip>
 							</div>
 						</Modal>
 					);

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -112,12 +112,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		onAddAnother();
 	};
 
-	/**
-	 * By convention, a global attribute has an ID different from 0.
-	 *
-	 * @param {EnhancedProductAttribute} attribute - The attribute to check.
-	 * @return {boolean}                             True if the attribute is global, false it's local.
-	 */
 	const isGlobalAttribute = (
 		attribute: EnhancedProductAttribute
 	): boolean => {

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -224,13 +224,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					setValue: ( name: string, value: any ) => void;
 				} ) => {
-					/*
-					 * Handle if the Add button is disabled.
-					 * - attributes should be not empty array
-					 * - attributes should not be an array of null or undefined
-					 * - It should be at least one term or option in the attribute
-					 */
-					const isAddButtonDisabled = ! values.attributes.some(
+					const isAddButtonDisabled = ! values.attributes.every(
 						( attr ) => isAttributeFilledOut( attr )
 					);
 

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -246,6 +246,16 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					setValue: ( name: string, value: any ) => void;
 				} ) => {
+					/*
+					 * Handle if the Add button is disabled.
+					 * - attributes should be not empty array
+					 * - attributes should not be an array of null or undefined
+					 * - It should be at least one term or option in the attribute
+					 */
+					const isAddButtonDisabled = ! values.attributes.some(
+						( attr ) => isAttributeFilledOut( attr )
+					);
+
 					/**
 					 * Select the attribute in the form field.
 					 * If the attribute does not exist, create it.
@@ -484,12 +494,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 								<Button
 									isPrimary
 									label={ addAccessibleLabel }
-									disabled={
-										values.attributes.length === 1 &&
-										( values.attributes[ 0 ] === null ||
-											values.attributes[ 0 ] ===
-												undefined )
-									}
+									disabled={ isAddButtonDisabled }
 									onClick={ () =>
 										onAddingAttributes( values )
 									}

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -118,7 +118,15 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		);
 	};
 
-	const isGlobalAttribute = ( attribute: EnhancedProductAttribute ) => {
+	/**
+	 * By convention, a global attribute has an ID different from 0.
+	 *
+	 * @param {EnhancedProductAttribute} attribute - The attribute to check.
+	 * @return {boolean}                             True if the attribute is global, false it's local.
+	 */
+	const isGlobalAttribute = (
+		attribute: EnhancedProductAttribute
+	): boolean => {
 		return attribute.id !== 0;
 	};
 
@@ -328,13 +336,14 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 						attribute?: EnhancedProductAttribute
 					) {
 						/*
-						 * By convention, it's a global attribute if the attribute ID is 0.
-						 * For global attributes, the field name suffix
+						 * For local (Product) attributes, the field name suffix
 						 * to set the attribute terms is 'options',
-						 * for local attributes, the field name suffix is 'terms'.
+						 * for global attributes, the field name suffix is 'terms'.
 						 */
 						const attributeTermPropName =
-							attribute?.id === 0 ? 'options' : 'terms';
+							attribute && isGlobalAttribute( attribute )
+								? 'terms'
+								: 'options';
 
 						const fieldName = `attributes[${ index }].${ attributeTermPropName }`;
 

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -492,7 +492,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 									{ cancelLabel }
 								</Button>
 								<Button
-									isPrimary
+									variant="primary"
 									label={ addAccessibleLabel }
 									disabled={ isAddButtonDisabled }
 									onClick={ () =>

--- a/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
+++ b/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
@@ -198,3 +198,136 @@ describe( 'hasTermsOrOptions', () => {
 		expect( hasTermsOrOptions( attribute as any ) ).toBe( false );
 	} );
 } );
+
+describe( 'isAttributeFilledOut', () => {
+	it( 'should return true if the attribute has a name and local terms (options)', () => {
+		const attribute: EnhancedProductAttribute = {
+			name: 'Color',
+			id: 123,
+			slug: 'color',
+			position: 0,
+			visible: true,
+			variation: true,
+			options: [ 'Beige', 'black', 'Blue' ],
+		};
+
+		expect( isAttributeFilledOut( attribute ) ).toBe( true );
+	} );
+
+	it( 'should return true if the attribute has a name and global terms', () => {
+		const terms: ProductAttributeTerm[] = [
+			{
+				id: 1,
+				name: 'red',
+				slug: 'red',
+				description: 'red color',
+				count: 1,
+				menu_order: 0,
+			},
+			{
+				id: 2,
+				name: 'blue',
+				slug: 'blue',
+				description: 'blue color',
+				count: 1,
+				menu_order: 1,
+			},
+			{
+				id: 3,
+				name: 'green',
+				slug: 'green',
+				description: 'green color',
+				count: 1,
+				menu_order: 2,
+			},
+		];
+
+		const attribute: EnhancedProductAttribute = {
+			name: 'Color',
+			id: 123,
+			slug: 'color',
+			position: 0,
+			visible: true,
+			variation: true,
+			terms,
+			options: [],
+		};
+
+		expect( isAttributeFilledOut( attribute ) ).toBe( true );
+	} );
+
+	it( 'should return true if the attribute has a name and both local terms and global terms', () => {
+		const terms: ProductAttributeTerm[] = [
+			{
+				id: 1,
+				name: 'red',
+				slug: 'red',
+				description: 'red color',
+				count: 1,
+				menu_order: 0,
+			},
+			{
+				id: 2,
+				name: 'blue',
+				slug: 'blue',
+				description: 'blue color',
+				count: 1,
+				menu_order: 1,
+			},
+			{
+				id: 3,
+				name: 'green',
+				slug: 'green',
+				description: 'green color',
+				count: 1,
+				menu_order: 2,
+			},
+		];
+
+		const attribute: EnhancedProductAttribute = {
+			name: 'Color',
+			id: 123,
+			slug: 'color',
+			position: 0,
+			visible: true,
+			variation: true,
+			terms,
+			options: [ 'Beige', 'black', 'Blue' ],
+		};
+
+		expect( isAttributeFilledOut( attribute ) ).toBe( true );
+	} );
+
+	it( 'should return false if the attribute has a name but no terms or options', () => {
+		const attribute: EnhancedProductAttribute = {
+			name: 'Empty',
+			id: 999,
+			slug: 'empty',
+			position: 0,
+			visible: true,
+			variation: true,
+			options: [],
+		};
+
+		expect( isAttributeFilledOut( attribute ) ).toBe( false );
+	} );
+
+	it( 'should return false if the attribute is null', () => {
+		const attribute = null;
+		expect( isAttributeFilledOut( attribute as any ) ).toBe( false );
+	} );
+
+	it( 'should return false if the attribute has no name', () => {
+		const attribute: EnhancedProductAttribute = {
+			name: '',
+			id: 123,
+			slug: 'color',
+			position: 0,
+			visible: true,
+			variation: true,
+			options: [ 'Beige', 'black', 'Blue' ],
+		};
+
+		expect( isAttributeFilledOut( attribute ) ).toBe( false );
+	} );
+} );

--- a/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
+++ b/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
@@ -85,7 +85,7 @@ describe( 'hasTermsOrOptions', () => {
 	it( 'should return true if the attribute has local terms (options)', () => {
 		const attribute: EnhancedProductAttribute = {
 			name: 'Color',
-			id: 123,
+			id: 0,
 			slug: 'color',
 			position: 0,
 			visible: true,
@@ -126,55 +126,13 @@ describe( 'hasTermsOrOptions', () => {
 
 		const attribute: EnhancedProductAttribute = {
 			name: 'Color',
-			id: 0,
-			slug: 'color',
-			position: 0,
-			visible: true,
-			variation: true,
-			terms,
-			options: [],
-		};
-
-		expect( hasTermsOrOptions( attribute ) ).toBe( true );
-	} );
-
-	it( 'should return true if the attribute has both local terms and global terms', () => {
-		const terms: ProductAttributeTerm[] = [
-			{
-				id: 1,
-				name: 'red',
-				slug: 'red',
-				description: 'red color',
-				count: 1,
-				menu_order: 0,
-			},
-			{
-				id: 2,
-				name: 'blue',
-				slug: 'blue',
-				description: 'blue color',
-				count: 1,
-				menu_order: 1,
-			},
-			{
-				id: 3,
-				name: 'green',
-				slug: 'green',
-				description: 'green color',
-				count: 1,
-				menu_order: 2,
-			},
-		];
-
-		const attribute: EnhancedProductAttribute = {
-			name: 'Color',
 			id: 123,
 			slug: 'color',
 			position: 0,
 			visible: true,
 			variation: true,
 			terms,
-			options: [ 'Beige', 'black', 'Blue' ],
+			options: [],
 		};
 
 		expect( hasTermsOrOptions( attribute ) ).toBe( true );
@@ -195,7 +153,7 @@ describe( 'hasTermsOrOptions', () => {
 
 	it( 'should return false if the attribute is null', () => {
 		const attribute = null;
-		expect( hasTermsOrOptions( attribute as any ) ).toBe( false ); // eslint-disable-line @typescript-eslint/no-explicit-any
+		expect( hasTermsOrOptions( attribute ) ).toBe( false );
 	} );
 } );
 
@@ -203,7 +161,7 @@ describe( 'isAttributeFilledOut', () => {
 	it( 'should return true if the attribute has a name and local terms (options)', () => {
 		const attribute: EnhancedProductAttribute = {
 			name: 'Color',
-			id: 123,
+			id: 0,
 			slug: 'color',
 			position: 0,
 			visible: true,
@@ -251,48 +209,6 @@ describe( 'isAttributeFilledOut', () => {
 			variation: true,
 			terms,
 			options: [],
-		};
-
-		expect( isAttributeFilledOut( attribute ) ).toBe( true );
-	} );
-
-	it( 'should return true if the attribute has a name and both local terms and global terms', () => {
-		const terms: ProductAttributeTerm[] = [
-			{
-				id: 1,
-				name: 'red',
-				slug: 'red',
-				description: 'red color',
-				count: 1,
-				menu_order: 0,
-			},
-			{
-				id: 2,
-				name: 'blue',
-				slug: 'blue',
-				description: 'blue color',
-				count: 1,
-				menu_order: 1,
-			},
-			{
-				id: 3,
-				name: 'green',
-				slug: 'green',
-				description: 'green color',
-				count: 1,
-				menu_order: 2,
-			},
-		];
-
-		const attribute: EnhancedProductAttribute = {
-			name: 'Color',
-			id: 0,
-			slug: 'color',
-			position: 0,
-			visible: true,
-			variation: true,
-			terms,
-			options: [ 'Beige', 'black', 'Blue' ],
 		};
 
 		expect( isAttributeFilledOut( attribute ) ).toBe( true );

--- a/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
+++ b/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
@@ -195,7 +195,7 @@ describe( 'hasTermsOrOptions', () => {
 
 	it( 'should return false if the attribute is null', () => {
 		const attribute = null;
-		expect( hasTermsOrOptions( attribute as any ) ).toBe( false );
+		expect( hasTermsOrOptions( attribute as any ) ).toBe( false ); // eslint-disable-line @typescript-eslint/no-explicit-any
 	} );
 } );
 
@@ -314,7 +314,7 @@ describe( 'isAttributeFilledOut', () => {
 
 	it( 'should return false if the attribute is null', () => {
 		const attribute = null;
-		expect( isAttributeFilledOut( attribute as any ) ).toBe( false );
+		expect( isAttributeFilledOut( attribute as any ) ).toBe( false ); // eslint-disable-line @typescript-eslint/no-explicit-any
 	} );
 
 	it( 'should return false if the attribute has no name', () => {

--- a/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
+++ b/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
@@ -1,15 +1,21 @@
 /**
  * External dependencies
  */
-import { ProductProductAttribute } from '@woocommerce/data';
+import {
+	ProductAttributeTerm,
+	ProductProductAttribute,
+} from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import {
 	getAttributeKey,
+	hasTermsOrOptions,
+	isAttributeFilledOut,
 	reorderSortableProductAttributePositions,
 } from '../utils';
+import { EnhancedProductAttribute } from '../../../hooks/use-product-attributes';
 
 const attributeList: Record< number | string, ProductProductAttribute > = {
 	15: {
@@ -72,5 +78,123 @@ describe( 'getAttributeKey', () => {
 	it( 'should return the attribute key', () => {
 		expect( getAttributeKey( attributeList[ '15' ] ) ).toEqual( 15 );
 		expect( getAttributeKey( attributeList.Quality ) ).toEqual( 'Quality' );
+	} );
+} );
+
+describe( 'hasTermsOrOptions', () => {
+	it( 'should return true if the attribute has local terms (options)', () => {
+		const attribute: EnhancedProductAttribute = {
+			name: 'Color',
+			id: 123,
+			slug: 'color',
+			position: 0,
+			visible: true,
+			variation: true,
+			options: [ 'Beige', 'black', 'Blue' ],
+		};
+
+		expect( hasTermsOrOptions( attribute ) ).toBe( true );
+	} );
+
+	it( 'should return true if the attribute has global terms', () => {
+		const terms: ProductAttributeTerm[] = [
+			{
+				id: 1,
+				name: 'red',
+				slug: 'red',
+				description: 'red color',
+				count: 1,
+				menu_order: 0,
+			},
+			{
+				id: 2,
+				name: 'blue',
+				slug: 'blue',
+				description: 'blue color',
+				count: 1,
+				menu_order: 1,
+			},
+			{
+				id: 3,
+				name: 'green',
+				slug: 'green',
+				description: 'green color',
+				count: 1,
+				menu_order: 2,
+			},
+		];
+
+		const attribute: EnhancedProductAttribute = {
+			name: 'Color',
+			id: 123,
+			slug: 'color',
+			position: 0,
+			visible: true,
+			variation: true,
+			terms,
+			options: [],
+		};
+
+		expect( hasTermsOrOptions( attribute ) ).toBe( true );
+	} );
+
+	it( 'should return true if the attribute has both local terms and global terms', () => {
+		const terms: ProductAttributeTerm[] = [
+			{
+				id: 1,
+				name: 'red',
+				slug: 'red',
+				description: 'red color',
+				count: 1,
+				menu_order: 0,
+			},
+			{
+				id: 2,
+				name: 'blue',
+				slug: 'blue',
+				description: 'blue color',
+				count: 1,
+				menu_order: 1,
+			},
+			{
+				id: 3,
+				name: 'green',
+				slug: 'green',
+				description: 'green color',
+				count: 1,
+				menu_order: 2,
+			},
+		];
+
+		const attribute: EnhancedProductAttribute = {
+			name: 'Color',
+			id: 123,
+			slug: 'color',
+			position: 0,
+			visible: true,
+			variation: true,
+			terms,
+			options: [ 'Beige', 'black', 'Blue' ],
+		};
+
+		expect( hasTermsOrOptions( attribute ) ).toBe( true );
+	} );
+
+	it( 'should return false if the attribute has neither terms nor options', () => {
+		const attribute: EnhancedProductAttribute = {
+			name: 'Empty',
+			id: 999,
+			slug: 'empty',
+			position: 0,
+			visible: true,
+			variation: true,
+			options: [],
+		};
+		expect( hasTermsOrOptions( attribute ) ).toBe( false );
+	} );
+
+	it( 'should return false if the attribute is null', () => {
+		const attribute = null;
+		expect( hasTermsOrOptions( attribute as any ) ).toBe( false );
 	} );
 } );

--- a/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
+++ b/packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
@@ -126,7 +126,7 @@ describe( 'hasTermsOrOptions', () => {
 
 		const attribute: EnhancedProductAttribute = {
 			name: 'Color',
-			id: 123,
+			id: 0,
 			slug: 'color',
 			position: 0,
 			visible: true,
@@ -286,7 +286,7 @@ describe( 'isAttributeFilledOut', () => {
 
 		const attribute: EnhancedProductAttribute = {
 			name: 'Color',
-			id: 123,
+			id: 0,
 			slug: 'color',
 			position: 0,
 			visible: true,
@@ -314,13 +314,13 @@ describe( 'isAttributeFilledOut', () => {
 
 	it( 'should return false if the attribute is null', () => {
 		const attribute = null;
-		expect( isAttributeFilledOut( attribute as any ) ).toBe( false ); // eslint-disable-line @typescript-eslint/no-explicit-any
+		expect( isAttributeFilledOut( attribute ) ).toBe( false );
 	} );
 
 	it( 'should return false if the attribute has no name', () => {
 		const attribute: EnhancedProductAttribute = {
 			name: '',
-			id: 123,
+			id: 0,
 			slug: 'color',
 			position: 0,
 			visible: true,

--- a/packages/js/product-editor/src/components/attribute-control/utils.ts
+++ b/packages/js/product-editor/src/components/attribute-control/utils.ts
@@ -62,13 +62,8 @@ export function reorderSortableProductAttributePositions(
  * @return {boolean} True if the attribute has terms or options, false otherwise.
  */
 export const hasTermsOrOptions = (
-	attribute: EnhancedProductAttribute
-): boolean => {
-	return !! (
-		( attribute?.terms && attribute.terms.length > 0 ) ||
-		( attribute?.options && attribute.options.length > 0 )
-	);
-};
+	attribute: EnhancedProductAttribute | null
+): boolean => !! ( attribute?.terms?.length || attribute?.options?.length );
 
 /**
  * Checks if the given attribute is filled out,
@@ -79,10 +74,5 @@ export const hasTermsOrOptions = (
  */
 export const isAttributeFilledOut = (
 	attribute: EnhancedProductAttribute | null
-): attribute is EnhancedProductAttribute => {
-	return (
-		attribute !== null &&
-		attribute.name.length > 0 &&
-		hasTermsOrOptions( attribute )
-	);
-};
+): attribute is EnhancedProductAttribute =>
+	!! attribute?.name.length && hasTermsOrOptions( attribute );

--- a/packages/js/product-editor/src/components/attribute-control/utils.ts
+++ b/packages/js/product-editor/src/components/attribute-control/utils.ts
@@ -4,6 +4,11 @@
 import type { ProductProductAttribute } from '@woocommerce/data';
 
 /**
+ * Internal dependencies
+ */
+import type { EnhancedProductAttribute } from '../../hooks/use-product-attributes';
+
+/**
  * Returns the attribute key. The key will be the `id` or the `name` when the id is 0.
  *
  * @param { ProductProductAttribute } attribute product attribute.
@@ -48,3 +53,36 @@ export function reorderSortableProductAttributePositions(
 		}
 	);
 }
+
+/**
+ * Checks if the given attribute has
+ * either terms (global attributes) or options (local attributes).
+ *
+ * @param {EnhancedProductAttribute} attribute - The attribute to check.
+ * @return {boolean} True if the attribute has terms or options, false otherwise.
+ */
+export const hasTermsOrOptions = (
+	attribute: EnhancedProductAttribute
+): boolean => {
+	return (
+		( attribute.terms && attribute.terms.length > 0 ) ||
+		( attribute.options && attribute.options.length > 0 )
+	);
+};
+
+/**
+ * Checks if the given attribute is filled out,
+ * meaning it has a name and either terms or options.
+ *
+ * @param {EnhancedProductAttribute | null} attribute - The attribute to check.
+ * @return {attribute is EnhancedProductAttribute} - True if the attribute is filled out, otherwise false.
+ */
+export const isAttributeFilledOut = (
+	attribute: EnhancedProductAttribute | null
+): attribute is EnhancedProductAttribute => {
+	return (
+		attribute !== null &&
+		attribute.name.length > 0 &&
+		hasTermsOrOptions( attribute )
+	);
+};

--- a/packages/js/product-editor/src/components/attribute-control/utils.ts
+++ b/packages/js/product-editor/src/components/attribute-control/utils.ts
@@ -64,9 +64,9 @@ export function reorderSortableProductAttributePositions(
 export const hasTermsOrOptions = (
 	attribute: EnhancedProductAttribute
 ): boolean => {
-	return (
-		( attribute.terms && attribute.terms.length > 0 ) ||
-		( attribute.options && attribute.options.length > 0 )
+	return !! (
+		( attribute?.terms && attribute.terms.length > 0 ) ||
+		( attribute?.options && attribute.options.length > 0 )
 	);
 };
 

--- a/plugins/woocommerce/changelog/update-e2e-check-add-button-when-creating-new-global-attribute-terms
+++ b/plugins/woocommerce/changelog/update-e2e-check-add-button-when-creating-new-global-attribute-terms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+E2E: check the `Add` button when creating product variations in the new Product Editor

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -120,6 +120,11 @@ test(
 				.isVisible();
 
 			await page.waitForLoadState( 'domcontentloaded' );
+
+			// Confirm the Add button is disabled
+			await expect(
+				page.getByRole( 'button', { name: 'Add attributes' } )
+			).toBeDisabled();
 		} );
 
 		await test.step( 'create local attributes with terms', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -173,6 +173,11 @@ test(
 				await page.getByLabel( 'Add another attribute' ).click();
 			}
 
+			// Since there are no more attributes to add, the button should be enabled.
+			await expect(
+				page.getByRole( 'button', { name: 'Add attributes' } )
+			).toBeEnabled();
+
 			// Add the product attributes
 			await page
 				.getByRole( 'button', { name: 'Add attributes' } )

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -131,10 +131,7 @@ test(
 				'.woocommerce-new-attribute-modal__table-row'
 			);
 
-			/*
-			 * First, check the app loads the attributes,
-			 * based on the Spinner visibility.
-			 */
+			// First, check the app loads the attributes,
 			await waitForGlobalAttributesLoaded( page );
 
 			for ( const attribute of attributesData ) {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -170,19 +170,32 @@ test(
 					await FormTokenFieldInputLocator.press( 'Enter' );
 				}
 
+				// Terms accepted, so the Add button should be enabled.
+				await expect(
+					page.getByRole( 'button', { name: 'Add attributes' } )
+				).toBeEnabled();
+
 				await page.getByLabel( 'Add another attribute' ).click();
+
+				// Attribute no defined, so the Add button should be disabled.
+				await expect(
+					page.getByRole( 'button', { name: 'Add attributes' } )
+				).toBeDisabled();
 			}
-
-			// Since there are no more attributes to add, the button should be enabled.
-			await expect(
-				page.getByRole( 'button', { name: 'Add attributes' } )
-			).toBeEnabled();
-
-			// Add the product attributes
-			await page
-				.getByRole( 'button', { name: 'Add attributes' } )
-				.click();
 		} );
+
+		// Remove the last row, as it was added by the last click on "Add another attribute".
+		await page
+			.getByRole( 'button', { name: 'Remove attribute' } )
+			.last()
+			.click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Add attributes' } )
+		).toBeEnabled();
+
+		// Add the product attributes
+		await page.getByRole( 'button', { name: 'Add attributes' } ).click();
 
 		await test.step( 'verify attributes in product editor', async () => {
 			// Locate the main attributes list element


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves the UX when creating Product variations or adding (local) product attributes.
In short, the `Add` button will be enabled only when there is at least one term among all attributes.

Relevant changes

* Move `isAttributeFilledOut` and `hasTermsOrOptions`  helper functions to the utils file
* Document
* Added unit tests
* Disable/enable `Add` button depending on the terms definition

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### UI/UX

1. Enable the new Product Editor
2. Go to Variations or Organization tabs
3. Add `Variation options` or `Attributes` depending on the chosen tab
4. Confirm the `Add` button won't be enabled when there is not any term


https://github.com/woocommerce/woocommerce/assets/77539/dd946f98-f74a-4215-9d87-733f6f9a85d7

5. Confirm the UI shows a tooltip when button is disabled:

<img width="439" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/5efc874f-0450-49de-bb10-8ccae94b2e9e">

### Unit tests

```cli
pnpm --filter=./packages/js/product-editor run test:js packages/js/product-editor/src/components/attribute-control/test/utils.spec.ts
```

<img width="772" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/14b13933-0395-4704-b346-8209aa99b9df">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
