### PR TITLE
Add daily checks for core e2e with PHP 8.1, WP latest-1 and HPOS disabled

### DIFF
--- a/plugins/woocommerce/changelog/ci-add-new-daily-checks
+++ b/plugins/woocommerce/changelog/ci-add-new-daily-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add daily checks for core e2e with PHP 8.1 and WP latest-1

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -379,7 +379,7 @@
 						"--shard=5/5"
 					],
 					"events": [
-						"push",
+						"daily-checks",
 						"release-checks"
 					],
 					"changes": [
@@ -422,6 +422,7 @@
 						}
 					},
 					"events": [
+						"daily-checks",
 						"release-checks"
 					],
 					"report": {
@@ -449,6 +450,7 @@
 						}
 					},
 					"events": [
+						"daily-checks",
 						"release-checks"
 					],
 					"report": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated the CI event config for some Core e2e jobs:
- e2e with PHP 8.1 - added in the daily-checks 
- e2e with WP latest-1 - added in the daily-checks 
- e2e with HPOS disabled - removed from push to trunk, added to daily-checks

### How to test the changes in this Pull Request:

Check the config changes. See [this daily run](https://github.com/woocommerce/woocommerce/actions/runs/9711476302) (cancelled to save on runners time, but the jobs started running - enough to validate this PR).