### PR TITLE
E2E: remove UI check when creating attribute global terms

### DIFF
--- a/plugins/woocommerce/changelog/update-e2e-checking-new-tokens
+++ b/plugins/woocommerce/changelog/update-e2e-checking-new-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+E2E: remove UI check when creating attribute global terms

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -64,7 +64,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 			'The block product editor is not being tested'
 		);
 
-		test( 'can create a variation option and publish the product', async ( {
+		test.only( 'can create a variation option and publish the product', async ( {
 			page,
 		} ) => {
 			await test.step( 'Load new product editor, disable tour', async () => {
@@ -164,17 +164,6 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 					);
 
 					/*
-					 * Check the option being added to the list,
-					 * by checking the token with validating state.
-					 */
-					const newValidatingTokenLocator =
-						FormTokenFieldLocator.locator( '.is-validating' );
-
-					await newValidatingTokenLocator.waitFor( {
-						state: 'visible',
-					} );
-
-					/*
 					 * Wait for the async POST request
 					 * that creates the new attribute term to finish.
 					 */
@@ -189,9 +178,6 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 						);
 					} );
 				}
-
-				// Wait for the last term to be validated/added
-				await expect( page.locator( '.is-validating' ) ).toBeHidden();
 
 				await page
 					.locator( '.woocommerce-new-attribute-modal__buttons' )

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -64,7 +64,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 			'The block product editor is not being tested'
 		);
 
-		test.only( 'can create a variation option and publish the product', async ( {
+		test( 'can create a variation option and publish the product', async ( {
 			page,
 		} ) => {
 			await test.step( 'Load new product editor, disable tour', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR tries to [mitigate this flaky E2E test](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-core-e2e-tests/tests/d8426828-b0c9-8438-8965-4d5b10ea5b0c?branch=all+branches) that checks the workflow when the user creates Product variations.

I've removed the UI code that checks the `is-validating` state of the term token label.
I think it should be enough just relying on the async request that the client performs to create the global-attribute term.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Running E2E tests locally

```
cd plugins/woocommerce
```

Ensure Playwright is installed

```
npx playwright install
```

Ensure wp-env is running

```
pnpm env:start
```

Run the following tests:

```cli
pnpm test:e2e-pw tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
```

<img width="771" alt="image" src="https://github.com/woocommerce/woocommerce/assets/77539/b4f0e78a-0e89-44b5-9ec5-5970642c5d83">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
