### PR TITLE
Remove duplicate title in coming soon dev docs

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -358,7 +358,7 @@
           "post_title": "Integrating with coming soon mode",
           "tags": "how-to, coming-soon",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/integrating-coming-soon-mode.md",
-          "hash": "eea34a5e37ceb5448f859d3bb350b6716e4c843a1477bfa5b9a7c369ed837f78",
+          "hash": "d702df70aff95e040624ffc6f9c8383ef98df2616a508e8ba2b031a9743de7e5",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/integrating-coming-soon-mode.md",
           "id": "787743efb6ef0ad509b17735eaf58b2a9a08afbc"
         },
@@ -1367,5 +1367,5 @@
       "categories": []
     }
   ],
-  "hash": "f28ecd23ddeca12c13736f3708c95e0bf8918cca5431abbeb066a9950745bc1e"
+  "hash": "cf89b5c07e5b7a9007eb4afe021b02ddce4611c81a863b0a431ae57491a3b37f"
 }

--- a/docs/extension-development/integrating-coming-soon-mode.md
+++ b/docs/extension-development/integrating-coming-soon-mode.md
@@ -3,8 +3,6 @@ post_title: Integrating with coming soon mode
 tags: how-to, coming-soon
 ---
 
-# Integrating with coming soon mode
-
 This guide provides examples for third-party developers and hosting providers on how to integrate their systems with WooCommerce's coming soon mode. For more details, please read the [developer blog post](https://developer.woocommerce.com/2024/06/18/introducing-coming-soon-mode/).
 
 ## Introduction


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes duplicate heading in https://developer.woocommerce.com/docs/integrating-with-coming-soon-mode/

<img width="1288" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/2cec2599-23fb-4b99-9bf2-1c3f519510fa">

### How to test the changes in this Pull Request:

1. Check code, we only intend to remove the heading in markdown content

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Remove duplicate header in developer docs markdown for coming soon docs
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
