### PR TITLE
Tooling: lint new php files for strict types directive (take 2).

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -11,7 +11,7 @@
 baseBranch=${1:-"trunk"}
 
 # Lint changed php-files to match code style.
-changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=dr -- '*.php')
+changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=d -- '*.php')
 if [[ -n $changedFiles ]]; then
     composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
 fi

--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -11,7 +11,7 @@
 baseBranch=${1:-"trunk"}
 
 # Lint changed php-files to match code style.
-changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=d -- '*.php')
+changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=dr -- '*.php')
 if [[ -n $changedFiles ]]; then
     composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
 fi

--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -10,12 +10,21 @@
 
 baseBranch=${1:-"trunk"}
 
+# Lint changed php-files to match code style.
 changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=d -- '*.php')
-
-# Only complete this if changed files are detected.
-if [[ -z $changedFiles ]]; then
-    echo "No changed files detected."
-    exit 0
+if [[ -n $changedFiles ]]; then
+    composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
 fi
 
-composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
+# Lint new (excl. renamed) php-files to contain strict types directive.
+newFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=dmr -- '*.php')
+if [[ -n $newFiles ]]; then
+	passingFiles=$(find $newFiles -type f -exec grep -xl --regexp='declare(\s*strict_types\s*=\s*1\s*);' /dev/null {} +)
+	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort))
+	if [[ -n violatingFiles ]]; then
+		redColoured='\033[0;31m'
+		printf "${redColoured}Following files are missing 'declare( strict_types = 1)' directive:\n"
+		printf "${redColoured}%s\n" $violatingFiles
+		exit 1
+	fi
+fi

--- a/plugins/woocommerce/changelog/add-41443-lint-strict-types-directive-for-new-files
+++ b/plugins/woocommerce/changelog/add-41443-lint-strict-types-directive-for-new-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Lint new PHP files for strict types directive


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Re-introduces the lining from https://github.com/woocommerce/woocommerce/pull/48779, but this time properly filtering out modified and deleted files `--diff-filter=dmr`: [here](https://github.com/woocommerce/woocommerce/actions/runs/9714625640/job/26814204022?pr=48946#step:4:27).

The test changes covering rename, delete, modify, add files:
![Screenshot from 2024-06-28 16-53-38](https://github.com/woocommerce/woocommerce/assets/1577185/5d3d191b-149a-4f2f-9973-e4079fa3f168)
results:
![Screenshot from 2024-06-28 16-53-12](https://github.com/woocommerce/woocommerce/assets/1577185/7d638694-eb9f-42ca-9e74-ca1165568355)

Testing: https://github.com/woocommerce/woocommerce/pull/48946 linting to fail mentioning only 2 files.
