### PR TITLE
Store API: Reduced number of recalculations on Store API cart routes

### DIFF
--- a/plugins/woocommerce/changelog/update-47296-store-api-calculation-handling
+++ b/plugins/woocommerce/changelog/update-47296-store-api-calculation-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Reduced number of recalculations on Store API cart routes

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -106,6 +106,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 		add_action( 'woocommerce_add_to_cart', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_applied_coupon', array( $this, 'calculate_totals' ), 20, 0 );
+		add_action( 'woocommerce_removed_coupon', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_cart_item_removed', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_cart_item_restored', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_check_cart_items', array( $this, 'check_cart_items' ), 1 );
@@ -715,7 +716,6 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		return $return;
-
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -105,7 +105,6 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 */
 	public function get_response( \WP_REST_Request $request ) {
 		$this->load_cart_session( $request );
-		$this->cart_controller->calculate_totals();
 
 		$response    = null;
 		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
@@ -332,13 +331,11 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_Error WP Error object.
 	 */
 	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
-
 		$additional_data['status'] = $http_status_code;
 
 		// If there was a conflict, return the cart so the client can resolve it.
 		if ( 409 === $http_status_code ) {
-			$cart                    = $this->cart_controller->get_cart_instance();
-			$additional_data['cart'] = $this->cart_schema->get_item_response( $cart );
+			$additional_data['cart'] = $this->cart_schema->get_item_response( $this->cart_controller->get_cart_for_response() );
 		}
 
 		return new \WP_Error( $error_code, $error_message, $additional_data );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractRoute.php
@@ -6,8 +6,6 @@ use Automattic\WooCommerce\StoreApi\Routes\RouteInterface;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Exceptions\InvalidCartException;
 use Automattic\WooCommerce\StoreApi\Schemas\v1\AbstractSchema;
-use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
-use Automattic\WooCommerce\Blocks\Package;
 use WP_Error;
 
 /**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
@@ -56,6 +56,6 @@ class Cart extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		return rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_instance() ) );
+		return rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -95,10 +95,8 @@ class CartAddItem extends AbstractCartRoute {
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		// Do not allow key to be specified during creation.
 		if ( ! empty( $request['key'] ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_item_exists', __( 'Cannot create an existing cart item.', 'woocommerce' ), 400 );
+			throw new RouteException( 'woocommerce_rest_cart_item_exists', esc_html__( 'Cannot create an existing cart item.', 'woocommerce' ), 400 );
 		}
-
-		$cart = $this->cart_controller->get_cart_instance();
 
 		/**
 		 * Filters cart item data sent via the API before it is passed to the cart controller.
@@ -128,7 +126,7 @@ class CartAddItem extends AbstractCartRoute {
 
 		$this->cart_controller->add_to_cart( $add_to_cart_data );
 
-		$response = rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		$response = rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );
 		$response->set_status( 201 );
 		return $response;
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php
@@ -64,7 +64,7 @@ class CartApplyCoupon extends AbstractCartRoute {
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		if ( ! wc_coupons_enabled() ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_disabled', esc_html__( 'Coupons are disabled.', 'woocommerce' ), 404 );
 		}
 
 		$coupon_code = wc_format_coupon_code( wp_unslash( $request['code'] ) );
@@ -72,10 +72,9 @@ class CartApplyCoupon extends AbstractCartRoute {
 		try {
 			$this->cart_controller->apply_coupon( $coupon_code );
 		} catch ( \WC_REST_Exception $e ) {
-			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
+			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
-		$cart = $this->cart_controller->get_cart_instance();
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCouponsByCode.php
@@ -79,7 +79,7 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
 		if ( ! $this->cart_controller->has_coupon( $request['code'] ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', esc_html__( 'Coupon does not exist in the cart.', 'woocommerce' ), 404 );
 		}
 
 		return $this->prepare_item_for_response( $request['code'], $request );
@@ -94,13 +94,11 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 */
 	protected function get_route_delete_response( \WP_REST_Request $request ) {
 		if ( ! $this->cart_controller->has_coupon( $request['code'] ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', esc_html__( 'Coupon does not exist in the cart.', 'woocommerce' ), 404 );
 		}
 
 		$cart = $this->cart_controller->get_cart_instance();
-
 		$cart->remove_coupon( $request['code'] );
-		$cart->calculate_totals();
 
 		return new \WP_REST_Response( null, 204 );
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveCoupon.php
@@ -64,24 +64,24 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		if ( ! wc_coupons_enabled() ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_disabled', esc_html__( 'Coupons are disabled.', 'woocommerce' ), 404 );
 		}
 
 		$cart        = $this->cart_controller->get_cart_instance();
 		$coupon_code = wc_format_coupon_code( $request['code'] );
 		$coupon      = new \WC_Coupon( $coupon_code );
+		$discounts   = new \WC_Discounts( $cart );
 
-		if ( $coupon->get_code() !== $coupon_code || ! $coupon->is_valid() ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_error', __( 'Invalid coupon code.', 'woocommerce' ), 400 );
+		if ( $coupon->get_code() !== $coupon_code || is_wp_error( $discounts->is_coupon_valid( $coupon ) ) ) {
+			throw new RouteException( 'woocommerce_rest_cart_coupon_error', esc_html__( 'Invalid coupon code.', 'woocommerce' ), 400 );
 		}
 
 		if ( ! $this->cart_controller->has_coupon( $coupon_code ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon cannot be removed because it is not already applied to the cart.', 'woocommerce' ), 409 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', esc_html__( 'Coupon cannot be removed because it is not already applied to the cart.', 'woocommerce' ), 409 );
 		}
 
 		$cart = $this->cart_controller->get_cart_instance();
 		$cart->remove_coupon( $coupon_code );
-		$cart->calculate_totals();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -70,11 +70,11 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		if ( ! wc_shipping_enabled() ) {
-			throw new RouteException( 'woocommerce_rest_shipping_disabled', __( 'Shipping is disabled.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_shipping_disabled', esc_html__( 'Shipping is disabled.', 'woocommerce' ), 404 );
 		}
 
 		if ( ! isset( $request['rate_id'] ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_missing_rate_id', __( 'Invalid Rate ID.', 'woocommerce' ), 400 );
+			throw new RouteException( 'woocommerce_rest_cart_missing_rate_id', esc_html__( 'Invalid Rate ID.', 'woocommerce' ), 400 );
 		}
 
 		$cart       = $this->cart_controller->get_cart_instance();
@@ -90,7 +90,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 				}
 			}
 		} catch ( \WC_Rest_Exception $e ) {
-			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
+			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
 		/**
@@ -107,7 +107,6 @@ class CartSelectShippingRate extends AbstractCartRoute {
 		 */
 		do_action( 'woocommerce_store_api_cart_select_shipping_rate', $package_id, $rate_id, $request );
 
-		$cart->calculate_shipping();
 		$cart->calculate_totals();
 
 		return rest_ensure_response( $this->cart_schema->get_item_response( $cart ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -2,7 +2,6 @@
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
-use Automattic\WooCommerce\StoreApi\Utilities\ValidationUtils;
 
 /**
  * CartUpdateCustomer class.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -121,7 +121,6 @@ class Checkout extends AbstractCartRoute {
 	 */
 	public function get_response( \WP_REST_Request $request ) {
 		$this->load_cart_session( $request );
-		$this->cart_controller->calculate_totals();
 
 		$response    = null;
 		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -12,7 +12,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\ArrayUtils;
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\StoreApi\Utilities\NoticeHandler;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
-use Automattic\WooCommerce\Blocks\Package;
 use WP_Error;
 
 /**
@@ -27,20 +26,40 @@ class CartController {
 	 * Makes the cart and sessions available to a route by loading them from core.
 	 */
 	public function load_cart() {
-		if ( ! did_action( 'woocommerce_load_cart_from_session' ) && function_exists( 'wc_load_cart' ) ) {
-			wc_load_cart();
+		if ( did_action( 'woocommerce_load_cart_from_session' ) ) {
+			return;
 		}
+
+		// Initialize the cart.
+		wc_load_cart();
+
+		// Load cart from session.
+		$cart = $this->get_cart_instance();
+		$cart->get_cart();
 	}
 
 	/**
-	 * Recalculates the cart totals.
+	 * Gets the latest cart instance, and ensures totals have been calculated before returning.
+	 *
+	 * @return \WC_Cart
+	 */
+	public function get_cart_for_response() {
+		return did_action( 'woocommerce_after_calculate_totals' ) ? $this->get_cart_instance() : $this->calculate_totals();
+	}
+
+	/**
+	 * Recalculates the cart totals and returns the updated cart instance.
+	 *
+	 * @since 9.2.0 Calculate shipping was removed here because it's called already by calculate_totals.
+	 *
+	 * @return \WC_Cart
 	 */
 	public function calculate_totals() {
 		$cart = $this->get_cart_instance();
 		$cart->get_cart();
 		$cart->calculate_fees();
-		$cart->calculate_shipping();
 		$cart->calculate_totals();
+		return $cart;
 	}
 
 	/**
@@ -188,19 +207,19 @@ class CartController {
 		$cart_item = $this->get_cart_item( $item_id );
 
 		if ( empty( $cart_item ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woocommerce' ), 409 );
+			throw new RouteException( 'woocommerce_rest_cart_invalid_key', esc_html__( 'Cart item does not exist.', 'woocommerce' ), 409 );
 		}
 
 		$product = $cart_item['data'];
 
 		if ( ! $product instanceof \WC_Product ) {
-			throw new RouteException( 'woocommerce_rest_cart_invalid_product', __( 'Cart item is invalid.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_invalid_product', esc_html__( 'Cart item is invalid.', 'woocommerce' ), 404 );
 		}
 
 		$quantity_validation = ( new QuantityLimits() )->validate_cart_item_quantity( $quantity, $cart_item );
 
 		if ( is_wp_error( $quantity_validation ) ) {
-			throw new RouteException( $quantity_validation->get_error_code(), $quantity_validation->get_error_message(), 400 );
+			throw new RouteException( $quantity_validation->get_error_code(), $quantity_validation->get_error_message(), 400 ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
 		$cart = $this->get_cart_instance();
@@ -725,7 +744,7 @@ class CartController {
 		$cart = wc()->cart;
 
 		if ( ! $cart || ! $cart instanceof \WC_Cart ) {
-			throw new RouteException( 'woocommerce_rest_cart_error', __( 'Unable to retrieve cart.', 'woocommerce' ), 500 );
+			throw new RouteException( 'woocommerce_rest_cart_error', esc_html__( 'Unable to retrieve cart.', 'woocommerce' ), 500 );
 		}
 
 		return $cart;
@@ -824,7 +843,7 @@ class CartController {
 
 		// Add extra package data to array.
 		$packages = array_map(
-			function( $key, $package, $index ) {
+			function ( $key, $package, $index ) {
 				$package['package_id']   = isset( $package['package_id'] ) ? $package['package_id'] : $key;
 				$package['package_name'] = isset( $package['package_name'] ) ? $package['package_name'] : $this->get_package_name( $package, $index );
 				return $package;
@@ -909,7 +928,7 @@ class CartController {
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
 					/* translators: %s coupon code */
-					__( '"%s" is an invalid coupon code.', 'woocommerce' ),
+					esc_html__( '"%s" is an invalid coupon code.', 'woocommerce' ),
 					esc_html( $coupon_code )
 				),
 				400
@@ -921,7 +940,7 @@ class CartController {
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
 					/* translators: %s coupon code */
-					__( 'Coupon code "%s" has already been applied.', 'woocommerce' ),
+					esc_html__( 'Coupon code "%s" has already been applied.', 'woocommerce' ),
 					esc_html( $coupon_code )
 				),
 				400
@@ -942,7 +961,7 @@ class CartController {
 
 		// Prevents new coupons being added if individual use coupons are already in the cart.
 		$individual_use_coupons = $this->get_cart_coupons(
-			function( $code ) {
+			function ( $code ) {
 				$coupon = new \WC_Coupon( $code );
 				return $coupon->get_individual_use();
 			}
@@ -969,8 +988,8 @@ class CartController {
 					'woocommerce_rest_cart_coupon_error',
 					sprintf(
 						/* translators: %s: coupon code */
-						__( '"%s" has already been applied and cannot be used in conjunction with other coupons.', 'woocommerce' ),
-						$code
+						esc_html__( '"%s" has already been applied and cannot be used in conjunction with other coupons.', 'woocommerce' ),
+						esc_html( $code )
 					),
 					400
 				);

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -100,7 +100,6 @@ class OrderController {
 
 		// Ensure cart is current.
 		if ( $update_totals ) {
-			wc()->cart->calculate_shipping();
 			wc()->cart->calculate_totals();
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is an attempt to reduce the number of calculations that are run on Store API cart endpoints by:

- Loading only cart item data when hitting the API
- Recalculating before returning the response, but not before generation
- Avoiding duplicate shipping calculation calls (since the main calculation method handles it)

Most events such as adding items or removing coupons trigger a recalculation automatically so there is no need to do it manually from Store API.

Closes #47296

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Test suites should cover API routes. You should test the full checkout flow to spot regressions, taking note of displayed totals when adding and removing items from cart, applying coupons, and changing shipping methods.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
