### PR TITLE
Change the custom field name component to be an autocomplete

### DIFF
--- a/packages/js/product-editor/changelog/add-46919
+++ b/packages/js/product-editor/changelog/add-46919
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Change the custom field name component to be an autocomplete

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -1,14 +1,8 @@
 /**
  * External dependencies
  */
-import { Button, ComboboxControl, Modal } from '@wordpress/components';
-import {
-	createElement,
-	useState,
-	useRef,
-	useEffect,
-	useCallback,
-} from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
+import { createElement, useState, useRef, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { recordEvent } from '@woocommerce/tracks';
@@ -26,31 +20,14 @@ import {
 	type ValidationErrors,
 } from '../utils/validations';
 import type { Metadata } from '../../../types';
+import { CustomFieldNameControl } from '../custom-field-name-control';
 import type { CreateModalProps } from './types';
-import { select } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
-import { useAsyncFilter } from '@woocommerce/components';
-import { useDebounce } from '@wordpress/compose';
 
 const DEFAULT_CUSTOM_FIELD = {
 	id: 1,
 	key: '',
 	value: '',
 } satisfies Metadata< string >;
-
-async function searchCustomFieldNames( search?: string ) {
-	return apiFetch< string[] >( {
-		path: addQueryArgs( '/wc/v3/products/custom-fields/names', {
-			search,
-		} ),
-	} ).then( ( data ) =>
-		( data ?? [] ).map( ( customFieldName ) => ( {
-			value: customFieldName,
-			label: customFieldName,
-		} ) )
-	);
-}
 
 export function CreateModal( {
 	values,
@@ -60,16 +37,6 @@ export function CreateModal( {
 }: CreateModalProps ) {
 	const [ customFields, setCustomFields ] = useState< Metadata< string >[] >(
 		[ DEFAULT_CUSTOM_FIELD ]
-	);
-	const [ customFieldNames, setCustomFieldNames ] = useState<
-		ComboboxControl.Props[ 'options' ]
-	>( [] );
-
-	const handleFilterValueChange = useDebounce(
-		useCallback( function onFilterValueChange( search: string ) {
-			searchCustomFieldNames( search ).then( setCustomFieldNames );
-		}, [] ),
-		250
 	);
 
 	const [ validationError, setValidationError ] =
@@ -259,7 +226,8 @@ export function CreateModal( {
 					{ customFields.map( ( customField ) => (
 						<div key={ customField.id } role="row">
 							<div role="cell">
-								<ComboboxControl
+								<CustomFieldNameControl
+									ref={ getRef( customField, 'key' ) }
 									label={ __( 'Name', 'woocommerce' ) }
 									hideLabelFromVision
 									allowReset={ false }
@@ -267,16 +235,12 @@ export function CreateModal( {
 										customField,
 										'key'
 									) }
-									options={ customFieldNames }
 									value={ customField.key }
 									onChange={ changeHandler(
 										customField,
 										'key'
 									) }
 									onBlur={ blurHandler( customField, 'key' ) }
-									onFilterValueChange={
-										handleFilterValueChange
-									}
 									className={ classNames(
 										'woocommerce-product-text-control',
 										{
@@ -287,21 +251,6 @@ export function CreateModal( {
 										}
 									) }
 								/>
-								{ /* <TextControl
-									ref={ getRef( customField, 'key' ) }
-									label={ '' }
-									aria-label={ __( 'Name', 'woocommerce' ) }
-									error={ getValidationError(
-										customField,
-										'key'
-									) }
-									value={ customField.key }
-									onChange={ changeHandler(
-										customField,
-										'key'
-									) }
-									onBlur={ blurHandler( customField, 'key' ) }
-								/> */ }
 							</div>
 							<div role="cell">
 								<TextControl

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -242,7 +242,6 @@ export function CreateModal( {
 									) }
 									onBlur={ blurHandler( customField, 'key' ) }
 									className={ classNames(
-										'woocommerce-product-text-control',
 										{
 											'has-error': getValidationError(
 												customField,

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/create-modal.tsx
@@ -241,14 +241,12 @@ export function CreateModal( {
 										'key'
 									) }
 									onBlur={ blurHandler( customField, 'key' ) }
-									className={ classNames(
-										{
-											'has-error': getValidationError(
-												customField,
-												'key'
-											),
-										}
-									) }
+									className={ classNames( {
+										'has-error': getValidationError(
+											customField,
+											'key'
+										),
+									} ) }
 								/>
 							</div>
 							<div role="cell">

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
@@ -33,6 +33,10 @@
 
 				.components-input-base {
 					gap: 0;
+
+					.components-input-control__input {
+						height: 36px;
+					}
 				}
 			}
 

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -11,7 +11,6 @@ import {
 	useCallback,
 	useEffect,
 	useLayoutEffect,
-	useMemo,
 	useRef,
 	useState,
 } from '@wordpress/element';
@@ -74,7 +73,6 @@ export const CustomFieldNameControl = forwardRef(
 			value,
 			onChange,
 			onBlur,
-			...props
 		}: CustomFieldNameControlProps,
 		ref: ForwardedRef< HTMLInputElement >
 	) {
@@ -109,83 +107,6 @@ export const CustomFieldNameControl = forwardRef(
 				}
 			},
 			[ id, ref ]
-		);
-
-		const { attrs, events } = useMemo(
-			function splitAttrsAndEvents() {
-				return Object.entries( props ).reduce<
-					Record< string, Record< string, unknown > >
-				>(
-					( current, [ propName, propValue ] ) => {
-						if ( propValue !== undefined ) {
-							if ( propName.startsWith( 'on' ) ) {
-								const eventName = propName
-									.substring( 2 )
-									.toLowerCase();
-								current.events[ eventName ] =
-									propValue as never;
-							} else {
-								current.attrs[ propName ] = propValue as never;
-							}
-						}
-
-						return current;
-					},
-					{ attrs: {}, events: {} }
-				);
-			},
-			[ props ]
-		);
-
-		useEffect(
-			/**
-			 * The Combobox component does not expose any attribute
-			 * of the internal native input element removing the ability
-			 * to set attribute's values like name important in the
-			 * context of form submission
-			 */
-			function initializeAttrs() {
-				Object.entries( attrs ).forEach(
-					( [ propName, propValue ] ) => {
-						comboboxRef.current?.setAttribute(
-							propName,
-							`${ propValue }`
-						);
-					}
-				);
-			},
-			[ attrs ]
-		);
-
-		useEffect(
-			/**
-			 * The Combobox component does not expose any event
-			 * of the internal native input element removing the ability
-			 * to focus the element and other things related also to
-			 * validations
-			 */
-			function initializeEvents() {
-				Object.entries( events ).forEach(
-					( [ propName, propValue ] ) => {
-						comboboxRef.current?.addEventListener(
-							propName,
-							propValue as () => void
-						);
-					}
-				);
-
-				return () => {
-					Object.entries( events ).forEach(
-						( [ propName, propValue ] ) => {
-							comboboxRef.current?.removeEventListener(
-								propName,
-								propValue as () => void
-							);
-						}
-					);
-				};
-			},
-			[ events ]
 		);
 
 		const handleFilterValueChange = useDebounce(

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -11,6 +11,7 @@ import {
 	useCallback,
 	useEffect,
 	useLayoutEffect,
+	useMemo,
 	useRef,
 	useState,
 } from '@wordpress/element';
@@ -86,6 +87,28 @@ export const CustomFieldNameControl = forwardRef(
 			ComboboxControl.Props[ 'options' ]
 		>( [] );
 
+		const options = useMemo(
+			/**
+			 * Prepend the selected value as an option to let
+			 * the Combobox know which option is the selected
+			 * one even when an async request is being performed
+			 *
+			 * @return The combobox options.
+			 */
+			function prependSelectedValueAsOption() {
+				if ( value ) {
+					const isExisting = customFieldNames.some(
+						( customFieldName ) => customFieldName.value === value
+					);
+					if ( ! isExisting ) {
+						return [ { label: value, value }, ...customFieldNames ];
+					}
+				}
+				return customFieldNames;
+			},
+			[ customFieldNames, value ]
+		);
+
 		useLayoutEffect(
 			/**
 			 * The Combobox component does not expose the ref to the
@@ -130,6 +153,7 @@ export const CustomFieldNameControl = forwardRef(
 				 * on bluring
 				 */
 				function handleBlur( event: FocusEvent ) {
+					setCustomFieldNames( [] );
 					if ( inputElementRef.current ) {
 						inputElementRef.current.value = value;
 					}
@@ -156,7 +180,7 @@ export const CustomFieldNameControl = forwardRef(
 				label={ label }
 				messages={ messages }
 				value={ value }
-				options={ customFieldNames }
+				options={ options }
 				onChange={ onChange }
 				onFilterValueChange={ handleFilterValueChange }
 				className={ classNames(

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -25,10 +25,10 @@ import type { ComboboxControlOption } from '../../attribute-combobox-field/types
 import type { CustomFieldNameControlProps } from './types';
 
 /**
- * Since the Combobox does not support an arbitrary value, the 
+ * Since the Combobox does not support an arbitrary value, the
  * way to make it behave as an autocomplete, is by converting
  * the arbitrary value into an option so it can be selected as
- * a valid value.
+ * a valid value
  *
  * @param search The seraching criteria.
  * @return The list of filtered custom field names as a Promise.
@@ -58,9 +58,9 @@ async function searchCustomFieldNames( search?: string ) {
 
 /**
  * This is a wrapper + a work around the Combobox to
- * expose important properties and events from the 
- * internal input element that are required when 
- * validating the field in the context of a form.
+ * expose important properties and events from the
+ * internal input element that are required when
+ * validating the field in the context of a form
  */
 export const CustomFieldNameControl = forwardRef(
 	function ForwardedCustomFieldNameControl(
@@ -93,7 +93,7 @@ export const CustomFieldNameControl = forwardRef(
 			 * The Combobox component does not expose the ref to the
 			 * internal native input element removing the ability to
 			 * focus the element when validating it in the context
-			 * of a form.
+			 * of a form
 			 */
 			function initializeRefs() {
 				comboboxRef.current = document.querySelector(
@@ -142,7 +142,7 @@ export const CustomFieldNameControl = forwardRef(
 			 * The Combobox component does not expose any attribute
 			 * of the internal native input element removing the ability
 			 * to set attribute's values like name important in the
-			 * context of form submission. 
+			 * context of form submission
 			 */
 			function initializeAttrs() {
 				Object.entries( attrs ).forEach(
@@ -162,7 +162,7 @@ export const CustomFieldNameControl = forwardRef(
 			 * The Combobox component does not expose any event
 			 * of the internal native input element removing the ability
 			 * to focus the element and other things related also to
-			 * validations. 
+			 * validations
 			 */
 			function initializeEvents() {
 				Object.entries( events ).forEach(
@@ -206,7 +206,7 @@ export const CustomFieldNameControl = forwardRef(
 				 * The Combobox component clear the value of its internal
 				 * input control when losing the focus, even when the
 				 * selected value is set, afecting the validation behavior
-				 * on bluring. 
+				 * on bluring
 				 */
 				function handleBlur( event: FocusEvent ) {
 					if ( comboboxRef.current ) {

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -76,7 +76,7 @@ export const CustomFieldNameControl = forwardRef(
 		}: CustomFieldNameControlProps,
 		ref: ForwardedRef< HTMLInputElement >
 	) {
-		const comboboxRef = useRef< HTMLInputElement >();
+		const inputElementRef = useRef< HTMLInputElement >();
 		const id = useInstanceId(
 			CustomFieldNameControl,
 			'woocommerce-custom-field-name'
@@ -94,15 +94,15 @@ export const CustomFieldNameControl = forwardRef(
 			 * of a form
 			 */
 			function initializeRefs() {
-				comboboxRef.current = document.querySelector(
+				inputElementRef.current = document.querySelector(
 					`.${ id } [role="combobox"]`
 				) as HTMLInputElement;
 
 				if ( ref ) {
 					if ( typeof ref === 'function' ) {
-						ref( comboboxRef.current );
+						ref( inputElementRef.current );
 					} else {
-						ref.current = comboboxRef.current;
+						ref.current = inputElementRef.current;
 					}
 				}
 			},
@@ -130,16 +130,16 @@ export const CustomFieldNameControl = forwardRef(
 				 * on bluring
 				 */
 				function handleBlur( event: FocusEvent ) {
-					if ( comboboxRef.current ) {
-						comboboxRef.current.value = value;
+					if ( inputElementRef.current ) {
+						inputElementRef.current.value = value;
 					}
 					onBlur?.( event as never );
 				}
 
-				comboboxRef.current?.addEventListener( 'blur', handleBlur );
+				inputElementRef.current?.addEventListener( 'blur', handleBlur );
 
 				return () => {
-					comboboxRef.current?.removeEventListener(
+					inputElementRef.current?.removeEventListener(
 						'blur',
 						handleBlur
 					);

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import type { Ref } from 'react';
+import { ComboboxControl } from '@wordpress/components';
+import {
+	createElement,
+	forwardRef,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { CustomFieldNameControlProps } from './types';
+import { useInstanceId } from '@wordpress/compose';
+import classNames from 'classnames';
+
+export const CustomFieldNameControl = forwardRef(
+	function ForwardedCustomFieldNameControl(
+		{
+			allowReset,
+			className,
+			help,
+			hideLabelFromVision,
+			label,
+			messages,
+			value,
+			options,
+			onChange,
+			onFilterValueChange,
+			...props
+		}: CustomFieldNameControlProps,
+		ref: Ref< HTMLInputElement >
+	) {
+		const comboboxRef = useRef< HTMLInputElement >();
+		const id = useInstanceId(
+			CustomFieldNameControl,
+			'woocommerce-custom-field-name'
+		);
+
+		useLayoutEffect(
+			function initializeRefs() {
+				comboboxRef.current = document.querySelector(
+					`.${ id } [role="combobox"]`
+				) as HTMLInputElement;
+
+				if ( typeof ref === 'function' ) {
+					ref( comboboxRef.current );
+				}
+			},
+			[ id ]
+		);
+
+		const {
+			attrs,
+			events,
+		}: Record< string, Record< string, unknown > > = useMemo(
+			function splitAttrsAndEvents() {
+				return Object.entries( props ).reduce(
+					( current, [ key, value ] ) => {
+						if ( value !== undefined ) {
+							if ( key.startsWith( 'on' ) ) {
+								const eventName = key
+									.substring( 2 )
+									.toLowerCase();
+								current.events[ eventName ] = value as never;
+							} else {
+								current.attrs[ key ] = value as never;
+							}
+						}
+
+						return current;
+					},
+					{ attrs: {}, events: {} } as Record<
+						string,
+						Record< string, unknown >
+					>
+				);
+			},
+			[ props ]
+		);
+
+		useEffect(
+			function initializeAttrs() {
+				Object.entries( attrs ).forEach( ( [ key, value ] ) => {
+					comboboxRef.current?.setAttribute( key, `${ value }` );
+				} );
+			},
+			[ attrs ]
+		);
+
+		useEffect(
+			function initializeEvents() {
+				console.log( events );
+				Object.entries( events ).forEach( ( [ key, value ] ) => {
+					comboboxRef.current?.addEventListener(
+						key,
+						value as () => void
+					);
+				} );
+
+				return () => {
+					Object.entries( events ).forEach( ( [ key, value ] ) => {
+						comboboxRef.current?.removeEventListener(
+							key,
+							value as () => void
+						);
+					} );
+				};
+			},
+			[ events ]
+		);
+
+		return (
+			<ComboboxControl
+				allowReset={ allowReset }
+				help={ help }
+				hideLabelFromVision={ hideLabelFromVision }
+				label={ label }
+				messages={ messages }
+				value={ value }
+				options={ options }
+				onChange={ onChange }
+				onFilterValueChange={ onFilterValueChange }
+				className={ classNames( id, className ) }
+			/>
+		);
+	}
+);

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -15,7 +15,6 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 
@@ -31,7 +30,7 @@ async function searchCustomFieldNames( search?: string ) {
 			search,
 		} ),
 	} ).then( ( customFieldNames = [] ) => {
-		let options: ComboboxControlOption[] = [];
+		const options: ComboboxControlOption[] = [];
 
 		if ( search && customFieldNames.indexOf( search ) === -1 ) {
 			options.push( { value: search, label: search } );
@@ -88,7 +87,7 @@ export const CustomFieldNameControl = forwardRef(
 					}
 				}
 			},
-			[ id ]
+			[ id, ref ]
 		);
 
 		const { attrs, events } = useMemo(
@@ -96,15 +95,16 @@ export const CustomFieldNameControl = forwardRef(
 				return Object.entries( props ).reduce<
 					Record< string, Record< string, unknown > >
 				>(
-					( current, [ key, value ] ) => {
-						if ( value !== undefined ) {
-							if ( key.startsWith( 'on' ) ) {
-								const eventName = key
+					( current, [ propName, propValue ] ) => {
+						if ( propValue !== undefined ) {
+							if ( propName.startsWith( 'on' ) ) {
+								const eventName = propName
 									.substring( 2 )
 									.toLowerCase();
-								current.events[ eventName ] = value as never;
+								current.events[ eventName ] =
+									propValue as never;
 							} else {
-								current.attrs[ key ] = value as never;
+								current.attrs[ propName ] = propValue as never;
 							}
 						}
 
@@ -118,29 +118,38 @@ export const CustomFieldNameControl = forwardRef(
 
 		useEffect(
 			function initializeAttrs() {
-				Object.entries( attrs ).forEach( ( [ key, value ] ) => {
-					comboboxRef.current?.setAttribute( key, `${ value }` );
-				} );
+				Object.entries( attrs ).forEach(
+					( [ propName, propValue ] ) => {
+						comboboxRef.current?.setAttribute(
+							propName,
+							`${ propValue }`
+						);
+					}
+				);
 			},
 			[ attrs ]
 		);
 
 		useEffect(
 			function initializeEvents() {
-				Object.entries( events ).forEach( ( [ key, value ] ) => {
-					comboboxRef.current?.addEventListener(
-						key,
-						value as () => void
-					);
-				} );
+				Object.entries( events ).forEach(
+					( [ propName, propValue ] ) => {
+						comboboxRef.current?.addEventListener(
+							propName,
+							propValue as () => void
+						);
+					}
+				);
 
 				return () => {
-					Object.entries( events ).forEach( ( [ key, value ] ) => {
-						comboboxRef.current?.removeEventListener(
-							key,
-							value as () => void
-						);
-					} );
+					Object.entries( events ).forEach(
+						( [ propName, propValue ] ) => {
+							comboboxRef.current?.removeEventListener(
+								propName,
+								propValue as () => void
+							);
+						}
+					);
 				};
 			},
 			[ events ]

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -24,6 +24,15 @@ import classNames from 'classnames';
 import type { ComboboxControlOption } from '../../attribute-combobox-field/types';
 import type { CustomFieldNameControlProps } from './types';
 
+/**
+ * Since the Combobox does not support an arbitrary value, the 
+ * way to make it behave as an autocomplete, is by converting
+ * the arbitrary value into an option so it can be selected as
+ * a valid value.
+ *
+ * @param search The seraching criteria.
+ * @return The list of filtered custom field names as a Promise.
+ */
 async function searchCustomFieldNames( search?: string ) {
 	return apiFetch< string[] >( {
 		path: addQueryArgs( '/wc/v3/products/custom-fields/names', {
@@ -47,6 +56,12 @@ async function searchCustomFieldNames( search?: string ) {
 	} );
 }
 
+/**
+ * This is a wrapper + a work around the Combobox to
+ * expose important properties and events from the 
+ * internal input element that are required when 
+ * validating the field in the context of a form.
+ */
 export const CustomFieldNameControl = forwardRef(
 	function ForwardedCustomFieldNameControl(
 		{
@@ -74,6 +89,12 @@ export const CustomFieldNameControl = forwardRef(
 		>( [] );
 
 		useLayoutEffect(
+			/**
+			 * The Combobox component does not expose the ref to the
+			 * internal native input element removing the ability to
+			 * focus the element when validating it in the context
+			 * of a form.
+			 */
 			function initializeRefs() {
 				comboboxRef.current = document.querySelector(
 					`.${ id } [role="combobox"]`
@@ -117,6 +138,12 @@ export const CustomFieldNameControl = forwardRef(
 		);
 
 		useEffect(
+			/**
+			 * The Combobox component does not expose any attribute
+			 * of the internal native input element removing the ability
+			 * to set attribute's values like name important in the
+			 * context of form submission. 
+			 */
 			function initializeAttrs() {
 				Object.entries( attrs ).forEach(
 					( [ propName, propValue ] ) => {
@@ -131,6 +158,12 @@ export const CustomFieldNameControl = forwardRef(
 		);
 
 		useEffect(
+			/**
+			 * The Combobox component does not expose any event
+			 * of the internal native input element removing the ability
+			 * to focus the element and other things related also to
+			 * validations. 
+			 */
 			function initializeEvents() {
 				Object.entries( events ).forEach(
 					( [ propName, propValue ] ) => {
@@ -169,6 +202,12 @@ export const CustomFieldNameControl = forwardRef(
 
 		useEffect(
 			function overrideBlur() {
+				/**
+				 * The Combobox component clear the value of its internal
+				 * input control when losing the focus, even when the
+				 * selected value is set, afecting the validation behavior
+				 * on bluring. 
+				 */
 				function handleBlur( event: FocusEvent ) {
 					if ( comboboxRef.current ) {
 						comboboxRef.current.value = value;

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/custom-field-name-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Ref } from 'react';
+import type { ForwardedRef } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { ComboboxControl } from '@wordpress/components';
 import { useDebounce, useInstanceId } from '@wordpress/compose';
@@ -22,8 +22,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import type { ComboboxControlOption } from '../../attribute-combobox-field/types';
 import type { CustomFieldNameControlProps } from './types';
-import { ComboboxControlOption } from '../../attribute-combobox-field/types';
 
 async function searchCustomFieldNames( search?: string ) {
 	return apiFetch< string[] >( {
@@ -62,7 +62,7 @@ export const CustomFieldNameControl = forwardRef(
 			onBlur,
 			...props
 		}: CustomFieldNameControlProps,
-		ref: Ref< HTMLInputElement >
+		ref: ForwardedRef< HTMLInputElement >
 	) {
 		const comboboxRef = useRef< HTMLInputElement >();
 		const id = useInstanceId(
@@ -80,8 +80,12 @@ export const CustomFieldNameControl = forwardRef(
 					`.${ id } [role="combobox"]`
 				) as HTMLInputElement;
 
-				if ( typeof ref === 'function' ) {
-					ref( comboboxRef.current );
+				if ( ref ) {
+					if ( typeof ref === 'function' ) {
+						ref( comboboxRef.current );
+					} else {
+						ref.current = comboboxRef.current;
+					}
 				}
 			},
 			[ id ]

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/index.ts
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/index.ts
@@ -1,0 +1,2 @@
+export * from './custom-field-name-control';
+export * from './types';

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/style.scss
@@ -14,10 +14,17 @@
 		position: relative;
 		border: none;
 
+		&:focus-within {
+			> .components-flex {
+				border-color: var(--wp-admin-theme-color);
+				box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
+			}
+		}
+
 		> .components-flex {
 			height: 36px;
-			border: 1px solid var(--wp-admin-theme-color);
-			box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
+			border: 1px solid $gray-600;
+			box-shadow: none;
 			border-radius: 2px;
 		}
 

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/style.scss
@@ -1,0 +1,36 @@
+.woocommerce-custom-field-name-control {
+	background-color: #fff;
+
+	&.has-error {
+		.components-combobox-control__suggestions-container {
+			> .components-flex,
+			> .components-form-token-field__suggestions-list {
+				border-color: $studio-red-50;
+			}
+		}
+	}
+
+	.components-combobox-control__suggestions-container {
+		position: relative;
+		border: none;
+
+		> .components-flex {
+			height: 36px;
+			border: 1px solid var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
+			border-radius: 2px;
+		}
+
+		> .components-form-token-field__suggestions-list {
+			position: absolute;
+			z-index: 1;
+			background-color: #fff;
+			border: 1px solid var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
+			outline: 2px solid #0000;
+			top: calc(100% - 1px);
+			border-bottom-left-radius: 2px;
+			border-bottom-right-radius: 2px;
+		}
+	}
+}

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/style.scss
@@ -3,6 +3,7 @@
 
 	&.has-error {
 		.components-combobox-control__suggestions-container {
+			&:focus-within > .components-flex,
 			> .components-flex,
 			> .components-form-token-field__suggestions-list {
 				border-color: $studio-red-50;

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/types.ts
@@ -3,7 +3,10 @@
  */
 import { ComboboxControl } from '@wordpress/components';
 
-export type CustomFieldNameControlProps = ComboboxControl.Props &
+export type CustomFieldNameControlProps = Omit<
+	ComboboxControl.Props,
+	'options' | 'onFilterValueChange'
+> &
 	Omit<
 		React.DetailedHTMLProps<
 			React.InputHTMLAttributes< HTMLInputElement >,

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/types.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { ComboboxControl } from '@wordpress/components';
+
+export type CustomFieldNameControlProps = ComboboxControl.Props &
+	Omit<
+		React.DetailedHTMLProps<
+			React.InputHTMLAttributes< HTMLInputElement >,
+			HTMLInputElement
+		>,
+		'className' | 'value' | 'onChange'
+	>;

--- a/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/types.ts
+++ b/packages/js/product-editor/src/components/custom-fields/custom-field-name-control/types.ts
@@ -7,10 +7,10 @@ export type CustomFieldNameControlProps = Omit<
 	ComboboxControl.Props,
 	'options' | 'onFilterValueChange'
 > &
-	Omit<
+	Pick<
 		React.DetailedHTMLProps<
 			React.InputHTMLAttributes< HTMLInputElement >,
 			HTMLInputElement
 		>,
-		'className' | 'value' | 'onChange'
+		'onBlur'
 	>;

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -114,7 +114,7 @@ export function EditModal( {
 				value={ customField.key }
 				onChange={ changeHandler( 'key' ) }
 				onBlur={ blurHandler( 'key' ) }
-				className={ classNames( 'woocommerce-product-text-control', {
+				className={ classNames( {
 					'has-error': validationError?.key,
 				} ) }
 			/>

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/edit-modal.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Button, Modal } from '@wordpress/components';
-import { createElement, useState, useRef } from '@wordpress/element';
+import { createElement, useState, useRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import classNames from 'classnames';
@@ -15,6 +15,7 @@ import { TRACKS_SOURCE } from '../../../constants';
 import { TextControl } from '../../text-control';
 import type { Metadata } from '../../../types';
 import { type ValidationError, validate } from '../utils/validations';
+import { CustomFieldNameControl } from '../custom-field-name-control';
 import type { EditModalProps } from './types';
 
 export function EditModal( {
@@ -31,6 +32,10 @@ export function EditModal( {
 	const keyInputRef = useRef< HTMLInputElement >( null );
 	const valueInputRef = useRef< HTMLInputElement >( null );
 
+	useEffect( function focusNameInputOnMount() {
+		keyInputRef.current?.focus();
+	}, [] );
+
 	function renderTitle() {
 		return sprintf(
 			/* translators: %s: the name of the custom field */
@@ -40,7 +45,7 @@ export function EditModal( {
 	}
 
 	function changeHandler( prop: keyof Metadata< string > ) {
-		return function handleChange( value: string ) {
+		return function handleChange( value: string | null ) {
 			setCustomField( ( current ) => ( {
 				...current,
 				[ prop ]: value,
@@ -101,13 +106,17 @@ export function EditModal( {
 				props.className
 			) }
 		>
-			<TextControl
+			<CustomFieldNameControl
 				ref={ keyInputRef }
 				label={ __( 'Name', 'woocommerce' ) }
-				error={ validationError?.key }
+				allowReset={ false }
+				help={ validationError?.key }
 				value={ customField.key }
 				onChange={ changeHandler( 'key' ) }
 				onBlur={ blurHandler( 'key' ) }
+				className={ classNames( 'woocommerce-product-text-control', {
+					'has-error': validationError?.key,
+				} ) }
 			/>
 
 			<TextControl

--- a/packages/js/product-editor/src/components/custom-fields/edit-modal/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/edit-modal/style.scss
@@ -9,6 +9,12 @@
 
 	.components-base-control {
 		width: 100%;
+
+		.components-input-base {
+			.components-input-control__input {
+				height: 36px;
+			}
+		}
 	}
 
 	.components-modal__content {

--- a/packages/js/product-editor/src/components/custom-fields/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/style.scss
@@ -1,5 +1,6 @@
 @import "./create-modal/style.scss";
 @import "./edit-modal/style.scss";
+@import "./custom-field-name-control/style.scss";
 
 .woocommerce-product-custom-fields {
 	&__table {

--- a/plugins/woocommerce/changelog/add-46919
+++ b/plugins/woocommerce/changelog/add-46919
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add $wpdb->esc_like to the search criteria when searching for a product custom field name

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -81,7 +81,7 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 			WHERE posts.post_type = %s AND post_metas.meta_key NOT LIKE %s AND post_metas.meta_key LIKE %s",
 			$this->post_type,
 			$wpdb->esc_like( '_' ) . '%',
-			"%{$search}%"
+			'%' . $wpdb->esc_like( $search ) . '%'
 		);
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already and $order is a static value.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46919

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure `product-custom-fields` feature toggle is on under the under the `WooCommerce Admin Test Helper` plugin features tab.
3. Go to `Products > Add new` and click the `Organization` tab
4. Switch on the `Show custom fields` toggle.
5. The `Custom fields` section should be shown.
6. Click `Add new` button.
7. From the `Add custom fields` modal, the custom field name should now be an autocomplete, from there should be possible to create a new name or find and existing one.
8. The same as 7 should be possible when editing the custom field in its own edition modal.
9. Validations should remains as before this PR.
10. Note that the behavior of the autocomplete is based on the [ComboboxControl](https://wordpress.github.io/gutenberg/?path=/docs/components-comboboxcontrol--docs) from core.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
