### PR TITLE
Monorepo: don't optimize composer autoloading by default.

### DIFF
--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -61,7 +61,7 @@ jobs:
                   unzip -qq woocommerce.zip
                   rm woocommerce.zip
                   mv woocommerce woocommerce-dev
-                  zip -q -r "woocommerce-dev.zip" "woocommerce-dev/"
+                  zip -q -r -9 "woocommerce-dev.zip" "woocommerce-dev/"
                   rm -fR "$GITHUB_WORKSPACE/zips/woocommerce-dev"
 
                   # Plugin data is passed as a JSON object.

--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -56,7 +56,7 @@ jobs:
                   bash bin/build-zip.sh
 
                   mkdir "$GITHUB_WORKSPACE/zips"
-                  cp "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
+                  mv "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
                   cd "$GITHUB_WORKSPACE/zips"
                   unzip -qq woocommerce.zip
                   rm woocommerce.zip

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -66,7 +66,7 @@ jobs:
 
                   mkdir "$GITHUB_WORKSPACE/zips"
                   mkdir -p "$GITHUB_WORKSPACE/unzips/woocommerce"
-                  cp "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
+                  mv "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
                   cd "$GITHUB_WORKSPACE/zips"
                   unzip -qq woocommerce.zip
                   cp -r woocommerce "$GITHUB_WORKSPACE/unzips/woocommerce/woocommerce"

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -72,7 +72,7 @@ jobs:
                   cp -r woocommerce "$GITHUB_WORKSPACE/unzips/woocommerce/woocommerce"
                   rm woocommerce.zip
                   mv woocommerce woocommerce-dev
-                  zip -q -r "woocommerce-dev.zip" "woocommerce-dev/"
+                  zip -q -r -9 "woocommerce-dev.zip" "woocommerce-dev/"
                   rm -fR "$GITHUB_WORKSPACE/zips/woocommerce-dev"
                   # Plugin data is passed as a JSON object.
                   PLUGIN_DATA="{}"          

--- a/plugins/woocommerce/changelog/dev-speedup-deps-installation
+++ b/plugins/woocommerce/changelog/dev-speedup-deps-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Build: speedup dependencies installation by disabling composer optimize autoloading by default.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -40,7 +40,6 @@
 		"yoast/phpunit-polyfills": "^2.0"
 	},
 	"config": {
-		"optimize-autoloader": true,
 		"preferred-install": {
 			"woocommerce/action-scheduler": "dist"
 		},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Drop composer autoloading setting from composer file, in order to speedup deps installation for about 3 seconds (local dev. environment). The autoloading optimization still happens when building zip-file [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/bin/build-zip.sh#L25).

### How to test the changes in this Pull Request:

In WooCommerce plugin repository run `time composer install --quiet` (this branch vs trunk):

```log
# This branch
real    0m7,025s
user    0m6,206s
sys     0m1,347s

# Trunk
real    0m10,291s
user    0m8,638s
sys     0m1,010s
```
