### PR TITLE
Revert "Monorepo: don't optimize composer autoloading by default. (#48971)"

### DIFF
--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -56,12 +56,12 @@ jobs:
                   bash bin/build-zip.sh
 
                   mkdir "$GITHUB_WORKSPACE/zips"
-                  mv "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
+                  cp "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
                   cd "$GITHUB_WORKSPACE/zips"
                   unzip -qq woocommerce.zip
                   rm woocommerce.zip
                   mv woocommerce woocommerce-dev
-                  zip -q -r -9 "woocommerce-dev.zip" "woocommerce-dev/"
+                  zip -q -r "woocommerce-dev.zip" "woocommerce-dev/"
                   rm -fR "$GITHUB_WORKSPACE/zips/woocommerce-dev"
 
                   # Plugin data is passed as a JSON object.

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -66,13 +66,13 @@ jobs:
 
                   mkdir "$GITHUB_WORKSPACE/zips"
                   mkdir -p "$GITHUB_WORKSPACE/unzips/woocommerce"
-                  mv "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
+                  cp "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
                   cd "$GITHUB_WORKSPACE/zips"
                   unzip -qq woocommerce.zip
                   cp -r woocommerce "$GITHUB_WORKSPACE/unzips/woocommerce/woocommerce"
                   rm woocommerce.zip
                   mv woocommerce woocommerce-dev
-                  zip -q -r -9 "woocommerce-dev.zip" "woocommerce-dev/"
+                  zip -q -r "woocommerce-dev.zip" "woocommerce-dev/"
                   rm -fR "$GITHUB_WORKSPACE/zips/woocommerce-dev"
                   # Plugin data is passed as a JSON object.
                   PLUGIN_DATA="{}"          

--- a/plugins/woocommerce/changelog/dev-speedup-deps-installation
+++ b/plugins/woocommerce/changelog/dev-speedup-deps-installation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Build: speedup dependencies installation by disabling composer optimize autoloading by default.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -40,6 +40,7 @@
 		"yoast/phpunit-polyfills": "^2.0"
 	},
 	"config": {
+		"optimize-autoloader": true,
 		"preferred-install": {
 			"woocommerce/action-scheduler": "dist"
 		},


### PR DESCRIPTION
This reverts commit 76b1bd4ae75b17072b34f754c443d71fdb1f0b17.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Revert changes from https://github.com/woocommerce/woocommerce/pull/48971, which surfaced autoloading-related issues.
