### PR TITLE
Change Tooltip component to render Popover as inline

### DIFF
--- a/packages/js/components/changelog/update-tooltip-inline
+++ b/packages/js/components/changelog/update-tooltip-inline
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change Tooltip component to render Popover as inline

--- a/packages/js/components/src/tooltip/style.scss
+++ b/packages/js/components/src/tooltip/style.scss
@@ -8,19 +8,19 @@
 
     &__text .components-popover__content {
         font-size: $default-font-size;
+		font-weight: normal;
         padding: $gap;
+		text-transform: none;
 		/* Allow tooltip to be wider than the default of `fit-content`
 		 * from the Popover component, but limit it to a reasonable
 		 * maximum width.
 		 */
 		width: auto;
         max-width: 300px;
-    }
-
-	&__text {
 		a {
 			white-space: nowrap;
+			text-decoration: underline;
 		}
-	}
+    }
 }
 

--- a/packages/js/components/src/tooltip/tooltip.tsx
+++ b/packages/js/components/src/tooltip/tooltip.tsx
@@ -73,6 +73,8 @@ export const Tooltip: React.FC< TooltipProps > = ( {
 					<Popover
 						focusOnMount="container"
 						position={ position }
+						// @ts-expect-error this prop does exist
+						inline
 						className="woocommerce-tooltip__text"
 						onFocusOutside={ ( event: FocusEvent ) => {
 							if (


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This aims to improve the experience with screen readers by rendering the tooltip's popovers as inline, so that they are part of the hierarchy in a way that makes sense.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Check all the "?" icons on all tabs for regressions in behavior and looks, compared to before this change

OPTIONAL: test with VoiceOver, verify that it's possible to continue navigating the tree by pressing right from inside the popover.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
