### PR TITLE
Update Fiverr CTA to Reflect the Latest Copy in Figma

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
@@ -535,7 +535,7 @@ export const SidebarNavigationScreenLogo = ( {
 						<p>
 							{ interpolateComponents( {
 								mixedString: __(
-									'Get a custom logo designed by a professional on {{link}}Fiverr{{/link}}.',
+									'Build your brand by creating a memorable logo using {{link}}Fiverr{{/link}}.',
 									'woocommerce'
 								),
 								components: {

--- a/plugins/woocommerce/changelog/48987-update-cys-fiverr-logo-maker-cta-copy
+++ b/plugins/woocommerce/changelog/48987-update-cys-fiverr-logo-maker-cta-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS: Update verbiage in the CTA to our Fiverr Logo Maker landing page.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updates the copy for the CTA to our Fiverr logo maker WooCommerce landing page in the sidebar navigation on the logo view.

For context, see p1719849853044929/1717705169.110299-slack-C053716F2H2 (internal link).

~Closes # .~

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to WooCommerce > Home > Customize your store.
2. Click on Customize your theme (or Use the store designer).
3. Click on Add your logo.
4. Confirm the **UPDATED** Fiverr CTA text appears below the logo upload input (see screenshot below).
5. Click on the Fiverr link in the text and confirm the [Woo-branded Fiverr logo maker landing page](https://www.fiverr.com/logo-maker/woo?afp=&cxd_token=917527_33214203&show_join=true) opens in a new tab.

| Before | After |
|--------|--------|
|  ![CleanShot 2024-06-13 at 22 21 37](https://github.com/woocommerce/woocommerce/assets/481776/e1bb368a-6e22-4341-bf5c-bfd592af3237) | ![CleanShot 2024-07-01 at 12 36 31](https://github.com/woocommerce/woocommerce/assets/481776/85f7708c-71d0-4e2f-a952-2a183b6fb258) | 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: Update verbiage in the CTA to our Fiverr Logo Maker landing page. 

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>