### PR TITLE
Fix fatal error in order reports when parent order doesn't exist for a refund. 

### DIFF
--- a/plugins/woocommerce/changelog/49006-fix-32202-fatal-error-when-parent-order-doesnt-exist
+++ b/plugins/woocommerce/changelog/49006-fix-32202-fatal-error-when-parent-order-doesnt-exist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error in order reports when parent order doesn't exist

--- a/plugins/woocommerce/src/Admin/API/Reports/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Controller.php
@@ -145,7 +145,7 @@ class Controller extends GenericController {
 	protected function get_order_number( $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		if ( ! $order instanceof \WC_Order && ! $order instanceof \WC_Order_Refund ) {
+		if ( ! $this->is_valid_order( $order ) ) {
 			return null;
 		}
 
@@ -153,7 +153,7 @@ class Controller extends GenericController {
 			$order = wc_get_order( $order->get_parent_id() );
 
 			// If the parent order doesn't exist, return null.
-			if ( ! $order instanceof \WC_Order && ! $order instanceof \WC_Order_Refund ) {
+			if ( ! $this->is_valid_order( $order ) ) {
 				return null;
 			}
 		}
@@ -166,6 +166,16 @@ class Controller extends GenericController {
 	}
 
 	/**
+	 * Whether the order is valid.
+	 *
+	 * @param bool|WC_Order|WC_Order_Refund $order Order object.
+	 * @return bool True if the order is valid, false otherwise.
+	 */
+	protected function is_valid_order( $order ) {
+		return $order instanceof \WC_Order || $order instanceof \WC_Order_Refund;
+	}
+
+	/**
 	 * Get the order total with the related currency formatting.
 	 * Returns the parent order total if the order is actually a refund.
 	 *
@@ -175,14 +185,14 @@ class Controller extends GenericController {
 	protected function get_total_formatted( $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		if ( ! $order instanceof \WC_Order && ! $order instanceof \WC_Order_Refund ) {
+		if ( ! $this->is_valid_order( $order ) ) {
 			return null;
 		}
 
 		if ( 'shop_order_refund' === $order->get_type() ) {
 			$order = wc_get_order( $order->get_parent_id() );
 
-			if ( ! $order instanceof \WC_Order && ! $order instanceof \WC_Order_Refund ) {
+			if ( ! $this->is_valid_order( $order ) ) {
 				return null;
 			}
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Controller.php
@@ -140,7 +140,7 @@ class Controller extends GenericController {
 	 * Returns the parent order number if the order is actually a refund.
 	 *
 	 * @param  int $order_id Order ID.
-	 * @return string
+	 * @return string|null The Order Number or null if the order doesn't exist.
 	 */
 	protected function get_order_number( $order_id ) {
 		$order = wc_get_order( $order_id );
@@ -151,6 +151,11 @@ class Controller extends GenericController {
 
 		if ( 'shop_order_refund' === $order->get_type() ) {
 			$order = wc_get_order( $order->get_parent_id() );
+
+			// If the parent order doesn't exist, return null.
+			if ( ! $order instanceof \WC_Order && ! $order instanceof \WC_Order_Refund ) {
+				return null;
+			}
 		}
 
 		if ( ! has_filter( 'woocommerce_order_number' ) ) {
@@ -165,7 +170,7 @@ class Controller extends GenericController {
 	 * Returns the parent order total if the order is actually a refund.
 	 *
 	 * @param  int $order_id Order ID.
-	 * @return string
+	 * @return string|null The Order Number or null if the order doesn't exist.
 	 */
 	protected function get_total_formatted( $order_id ) {
 		$order = wc_get_order( $order_id );
@@ -176,6 +181,10 @@ class Controller extends GenericController {
 
 		if ( 'shop_order_refund' === $order->get_type() ) {
 			$order = wc_get_order( $order->get_parent_id() );
+
+			if ( ! $order instanceof \WC_Order && ! $order instanceof \WC_Order_Refund ) {
+				return null;
+			}
 		}
 
 		return wp_strip_all_tags( html_entity_decode( $order->get_formatted_order_total() ), true );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
@@ -114,7 +114,8 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		// Since wp_delete_post($order->get_id()) & $order->delete() will delete the refund as well,
+		// Since $order->delete() will delete the refund as well and
+		// wp_delete_post($order->get_id()) can be prevented by the following filter: maybe_prevent_deletion_of_post (see https://github.com/woocommerce/woocommerce/blob/97a0d9b16006b089f7d1e98af19d61f6d71b621b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php#L916 )
 		// we need to update the post_parent to a non-existent order to simulate an orphaned refund.
 		wp_update_post(
 			array(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
@@ -92,6 +92,52 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'order', $order_report['_links'] );
 	}
 
+	public function test_get_reports_with_orphaned_refund() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 ); // $25 x 4.
+		$order->save();
+
+		$refund = wc_create_refund(
+			array(
+				'amount'   => 100,
+				'order_id' => $order->get_id(),
+			)
+		);
+
+		// Since wp_delete_post($order->get_id()) & $order->delete() will delete the refund as well,
+		// we need to update the post_parent to a non-existent order to simulate an orphaned refund.
+		wp_update_post(
+			array(
+				'ID'          => $refund->get_id(),
+				'post_parent' => '99999999',
+			)
+		);
+
+		WC_Helper_Queue::run_all_pending();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $reports ) );
+
+		$order_report  = $reports[0];
+		$refund_report = $reports[1];
+
+		$this->assertEquals( $order->get_id(), $order_report['order_id'] );
+		$this->assertEquals( $refund->get_id(), $refund_report['order_id'] );
+	}
+
 	/**
 	 * Test getting reports without valid permissions.
 	 *
@@ -242,7 +288,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $response_orders ) );
 		$order_ids = array_map(
-			function( $order ) {
+			function ( $order ) {
 				return $order['order_id'];
 			},
 			$response_orders
@@ -502,6 +548,5 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$second_order_from_response   = $response_orders[ $second_order->get_id() ];
 		$second_order_formatted_total = wp_strip_all_tags( html_entity_decode( $second_order->get_formatted_order_total() ), true );
 		$this->assertEquals( $second_order_from_response['total_formatted'], $second_order_formatted_total );
-
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/32202

This PR addresses the issue of retrieving order reports for orphaned refunds (refunds with non-existent parent orders). See this comment for more details: https://github.com/woocommerce/woocommerce/issues/32202#issuecomment-1072895998.

Generally, this scenario shouldn't occur because using `$order->delete()` will trash the `order` and the `refund` and `wp_delete_post($order->get_id())` will prevent it from becoming orphaned because of this filter: [maybe_prevent_deletion_of_post](https://github.com/woocommerce/woocommerce/blob/97a0d9b16006b089f7d1e98af19d61f6d71b621b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php#L916) . However, if an order is manually deleted from the database or the parent ID of a refund is updated to a non-existent order ID:

```
		wp_update_post(
			array(
				'ID'          => $refund->get_id(),
				'post_parent' => '99999999', <- Doesn't exist
			)
		);
```

The following endpoint will throw a fatal error: `GET wp-json/wc-analytics/reports/orders`, resulting in `Call to a member function get_id() on bool` as mentioned in the issue.

This PR adds a check to ensure that the parent order ID exists before proceeding. If it does not exist, the function will return `null`, which is the same value that was previously returned if the order was not found.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an order.
2. Create a refund for that order.
3. Get the ID of the refund created.

![image](https://github.com/woocommerce/woocommerce/assets/2488994/520c5fc3-5c32-457b-8a44-edaae02e312a)

4. Run `wp shell ` -> `wp_update_post( array( 'ID'  => YOUR_REFUND_ID, 'post_parent' => '99999999', ) );`
5. Go to Analytics -> Orders -> Select a Range that includes that order and the refund that you created.
6. See that the report is loaded correctly. If you checkout `trunk` you will see that you get a fatal error.
7. As the refund does not have a valid parent order, it will show as empty the field of `Order #`:

![image](https://github.com/woocommerce/woocommerce/assets/2488994/7bb42d05-0eb4-4ff1-8563-326064edd76c)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [X] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix fatal error in order reports when parent order doesn't exist

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
