### PR TITLE
CYS - Fetch patterns from the private dotcom patterns category

### DIFF
--- a/plugins/woocommerce/changelog/49007-48603-fetch-dotcom-patterns
+++ b/plugins/woocommerce/changelog/49007-48603-fetch-dotcom-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Fetch patterns from the private dotcom patterns category instead of from the default source site.

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -34,6 +34,8 @@ use WP_Error;
  * @internal
  */
 class BlockPatterns {
+	const CATEGORIES_PREFIXES = [ '_woo_', '_dotcom_imported_' ];
+
 	/**
 	 * Path to the patterns' directory.
 	 *
@@ -166,10 +168,12 @@ class BlockPatterns {
 			function ( $pattern ) {
 				$pattern['categories'] = array_map(
 					function ( $category ) {
-						if ( strpos( $category['title'], '_woo_' ) !== false ) {
-							$parsed_category   = str_replace( '_woo_', '', $category['title'] );
-							$parsed_category   = str_replace( '_', ' ', $parsed_category );
-							$category['title'] = ucfirst( $parsed_category );
+						foreach ( self::CATEGORIES_PREFIXES as $prefix ) {
+							if ( strpos( $category['title'], $prefix ) !== false ) {
+								$parsed_category   = str_replace( $prefix, '', $category['title'] );
+								$parsed_category   = str_replace( '_', ' ', $parsed_category );
+								$category['title'] = ucfirst( $parsed_category );
+							}
 						}
 
 						return $category;

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -185,39 +185,31 @@ class PTKPatternsStore {
 
 		$this->flush_cached_patterns();
 
-		$dotcom_patterns = $this->ptk_client->fetch_patterns(
-			array(
-				'categories' => array( 'intro', 'about', 'services', 'testimonials' ),
-			)
-		);
-		if ( is_wp_error( $dotcom_patterns ) ) {
-			wc_get_logger()->warning(
-				sprintf(
-				// translators: %s is a generated error message.
-					__( 'Failed to get Dotcom patterns from the PTK: "%s"', 'woocommerce' ),
-					$dotcom_patterns->get_error_message()
-				),
-			);
-		}
-
-		$woo_patterns = $this->ptk_client->fetch_patterns(
+		$patterns = $this->ptk_client->fetch_patterns(
 			array(
 				'site'       => 'wooblockpatterns.wpcomstaging.com',
-				'categories' => array( '_woo_intro', '_woo_featured_selling', '_woo_about', '_woo_reviews', '_woo_social_media' ),
+				'categories' => array(
+					'_woo_intro',
+					'_woo_featured_selling',
+					'_woo_about',
+					'_woo_reviews',
+					'_woo_social_media',
+					'_dotcom_imported_intro',
+					'_dotcom_imported_about',
+					'_dotcom_imported_services',
+				),
 			)
 		);
-		if ( is_wp_error( $woo_patterns ) ) {
+		if ( is_wp_error( $patterns ) ) {
 			wc_get_logger()->warning(
 				sprintf(
 				// translators: %s is a generated error message.
 					__( 'Failed to get WooCommerce patterns from the PTK: "%s"', 'woocommerce' ),
-					$woo_patterns->get_error_message()
+					$patterns->get_error_message()
 				),
 			);
 			return;
 		}
-
-		$patterns = array_merge( $dotcom_patterns, $woo_patterns );
 
 		$patterns = $this->filter_patterns( $patterns, self::EXCLUDED_PATTERNS );
 		$patterns = $this->map_categories( $patterns );

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
@@ -134,7 +134,7 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 	public function test_fetch_patterns_should_not_set_the_patterns_cache_when_fetching_patterns_fails() {
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 		$this->ptk_client
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->once() )
 			->method( 'fetch_patterns' )
 			->willReturn( new WP_Error( 'error', 'Request failed.' ) );
 
@@ -156,14 +156,14 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 			),
 		);
 		$this->ptk_client
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->once() )
 			->method( 'fetch_patterns' )
 			->willReturn( $expected_patterns );
 		$this->pattern_store->fetch_patterns();
 
 		$patterns = get_transient( PTKPatternsStore::TRANSIENT_NAME );
 
-		$this->assertEquals( array_merge( $expected_patterns, $expected_patterns ), $patterns );
+		$this->assertEquals( $expected_patterns, $patterns );
 	}
 
 	/**
@@ -184,21 +184,13 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 		);
 
 		$this->ptk_client
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->once() )
 			->method( 'fetch_patterns' )
 			->willReturn( $api_patterns );
 
 		$this->pattern_store->fetch_patterns();
 
-		$patterns = get_transient( PTKPatternsStore::TRANSIENT_NAME );
-
-		$expected_patterns = array(
-			$api_patterns[0],
-			$api_patterns[0],
-		);
-
-		$this->assertEquals( $expected_patterns, $patterns );
-		$this->assertEquals( $expected_patterns, get_transient( PTKPatternsStore::TRANSIENT_NAME ) );
+		$this->assertEquals( array( $api_patterns[0] ), get_transient( PTKPatternsStore::TRANSIENT_NAME ) );
 	}
 
 	/**
@@ -233,7 +225,7 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 		);
 
 		$this->ptk_client
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->once() )
 			->method( 'fetch_patterns' )
 			->willReturnOnConsecutiveCalls(
 				$ptk_patterns,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR replaces the fetching of the Dotcom patterns from the original source site to the `wooblockpatterns.wpcomstaging.com` site.

Closes https://github.com/woocommerce/woocommerce/issues/48603

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have the `WooCommerce beta tester` plugin installed.
2. Head over to `Tools > WCA Test Helper > Features`.
3. Make sure you see the `pattern-toolkit-full-composability` on the list.
4. Enable it.
5. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`, **disable** `Allow usage of WooCommerce to be tracked`, and save.
6. On the same page, check the option again and Save.
7. Go to `wp-admin/tools.php?page=action-scheduler`, search for the `fetch_patterns` action, and make sure it was scheduled.
8. Click on `Run` under the action name if it is still pending and wait until is completed.
9. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store`, click on `Start designing` or `Customize your theme`.
10. In the assembler, click on `Design your homepage`.
11. Check you see the Dotcom and the Woo patterns in each category: there should be more than 3 patterns in `Intro`, more than 1 in `About`, and 16 in `Services`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Fetch patterns from the private dotcom patterns category instead of from the default source site.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
