### PR TITLE
Fix strict_types=1 check in lint-branch.sh

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -21,7 +21,7 @@ newFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --
 if [[ -n $newFiles ]]; then
 	passingFiles=$(find $newFiles -type f -exec grep -xl --regexp='declare(\s*strict_types\s*=\s*1\s*);' /dev/null {} +)
 	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort))
-	if [[ -n violatingFiles ]]; then
+	if [[ -n $violatingFiles ]]; then
 		redColoured='\033[0;31m'
 		printf "${redColoured}Following files are missing 'declare( strict_types = 1)' directive:\n"
 		printf "${redColoured}%s\n" $violatingFiles

--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -23,7 +23,7 @@ if [[ -n $newFiles ]]; then
 	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort))
 	if [[ -n $violatingFiles ]]; then
 		redColoured='\033[0;31m'
-		printf "${redColoured}Following files are missing 'declare( strict_types = 1)' directive:\n"
+		printf "${redColoured}Following files are missing 'declare( strict_types = 1 )' directive:\n"
 		printf "${redColoured}%s\n" $violatingFiles
 		exit 1
 	fi

--- a/plugins/woocommerce/changelog/fix-lint-branch-strict_types
+++ b/plugins/woocommerce/changelog/fix-lint-branch-strict_types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix strict_types=1 check in lint-branch.sh
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The job that is checking for `declare( strict_types=1 )` to be in new PHP files was failing in https://github.com/woocommerce/woocommerce/pull/48905, even though all new PHP files in that PR do have `declare( strict_types=1 )`.

I think it was because of a small typo in the script, which should be fixed in this PR.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
