### PR TITLE
CI: bug-fix for linting missing strict types directive in new php files.

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -21,7 +21,7 @@ newFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --
 if [[ -n $newFiles ]]; then
 	passingFiles=$(find $newFiles -type f -exec grep -xl --regexp='declare(\s*strict_types\s*=\s*1\s*);' /dev/null {} +)
 	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort))
-	if [[ -n violatingFiles ]]; then
+	if [[ -n "$violatingFiles" ]]; then
 		redColoured='\033[0;31m'
 		printf "${redColoured}Following files are missing 'declare( strict_types = 1)' directive:\n"
 		printf "${redColoured}%s\n" $violatingFiles

--- a/plugins/woocommerce/changelog/dev-fix-validating-strict-types-directive
+++ b/plugins/woocommerce/changelog/dev-fix-validating-strict-types-directive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: buffix for linting missing strict types directive.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The linting was introduced in https://github.com/woocommerce/woocommerce/pull/48943, and this PR fixes complaining about valid changes.
