### PR TITLE
Fix e2e-guidelines.md syntax

### DIFF
--- a/plugins/woocommerce-blocks/docs/contributors/e2e-guidelines.md
+++ b/plugins/woocommerce-blocks/docs/contributors/e2e-guidelines.md
@@ -14,8 +14,10 @@ pnpm --filter='@woocommerce/plugin-woocommerce' watch:build
 
 Next, run the following command from the [`woocommerce-blocks` plugin folder](../../../woocommerce-blocks/) to start a `wp-env` instance and install all the testing products, languages, etc.:
 
-````shell
+```sh
 cd plugins/woocommerce-blocks/
+pnpm env:start
+```
 
 > [!TIP]
 > If you want to start/stop the environment without running the whole setup, use the native `wp-env` commands directly, e.g. `npx wp-env start` and `npx wp-env stop`.
@@ -26,9 +28,9 @@ The testing environment should now be ready under [localhost:8889](http://localh
 
 Occasionally, you'll need to reset the environment, e.g., when testing products have been updated. To do that, run the following command and go make yourself some coffee:
 
-```shell
+```sh
 pnpm env:restart
-````
+```
 
 ## Running and debugging tests
 
@@ -37,7 +39,7 @@ pnpm env:restart
 
 Here is a basic set of commands to quickly start running and debugging the tests. For full documentation, see the official Playwright guide on [Running and Debugging Tests](https://playwright.dev/docs/running-tests).
 
-```shell
+```sh
 # Run all available tests.
 pnpm test:e2e
 
@@ -76,7 +78,7 @@ When a test fails in CI, a failure artifact is zipped and uploaded to the Summar
 
 Once you download and extract that zip, you'll see dedicated folders for the failed test artifacts. In CI, we retry running a failed test twice before considering it a failure, so there can be up to three folders per failed test. Each of those folders should contain a Playwright trace zip file and a screenshot from the failure moment. On the first retry, we also record the entire test, so the first retry folder should contain a video recording as well. To view a trace, head to the [Playwright Trace Viewer](https://trace.playwright.dev) page and drag and drop the trace zip file there, or run it from the command line:
 
-```shell
+```sh
 npx playwright show-trace <path-to-the-trace>
 ```
 

--- a/plugins/woocommerce/changelog/49018-fix-block-e2e-readme
+++ b/plugins/woocommerce/changelog/49018-fix-block-e2e-readme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix broken syntax in e2e-guidelines.md.


### PR DESCRIPTION
### Proposed changes

Revert some [accidental changes](https://github.com/woocommerce/woocommerce/commit/921e86e6abd5a26b8addfed6fa56108e5311b6f7#diff-d0089ed526edb7907e7eb6094434053eabe45618905b0d49bca9cc4ce7b259f7) from https://github.com/woocommerce/woocommerce/pull/48429 that broke the md syntax in the Blocks E2E readme doc.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix broken syntax in e2e-guidelines.md.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

