### PR TITLE
Fix toggling of permission details in downloadable product permissions metabox (order screen)

### DIFF
--- a/plugins/woocommerce/changelog/fix-downloadable-product-metabox-toggle
+++ b/plugins/woocommerce/changelog/fix-downloadable-product-metabox-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent download permissions metabox from being toggled when toggling individual permission details.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1435,6 +1435,12 @@ jQuery( function ( $ ) {
 				.on( 'click', '#copy-download-link', this.copy_link )
 				.on( 'aftercopy', '#copy-download-link', this.copy_success )
 				.on( 'aftercopyfailure', '#copy-download-link', this.copy_fail );
+
+			// Work around WP's callback for '.handlediv' hiding the containing WP metabox instead of just the WC one.
+			$( '.order_download_permissions .wc-metabox .handlediv' ).on( 'click', function( e ) {
+				e.stopImmediatePropagation();
+				$( this ).closest( 'h3' ).trigger( 'click' );
+			} );
 		},
 
 		grant_access: function() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In the *Downloadable product permissions* metabox (order edit screen) we have some arrows with the `handlediv` class tied to each individual download permission, but the use of this class also means wp-admin toggles the full metabox (instead of just the permission) when clicked.

This PR prevents the click event from bubbling up to WP so that only the individual permission is toggled.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure to build WC so that the legacy assets are built and linked. `pnpm --filter='@woocommerce/plugin-woocommerce' build` should do the trick.
1. If your site doesn't have any download products, first create one in WC > Products.
2. Go to WC > Orders and create a new order.
3. Scroll down to the *Downloadable product permissions* metabox and use the input field to search for a downloadable product. Select it and click **Grant access**.
4. Confirm that clicking the arrow symbol only toggles details for a particular download permission and the metabox as a whole remains visible.
5. Refresh the page.
6. Scroll down again to the *Downloadable product permissions* metabox and confirm once again that clicking the arrow symbols only toggles permission details, and not the whole metabox.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
