### PR TITLE
CYS: fix toolbar position after the site preview resizes

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/toolbar.tsx
@@ -165,7 +165,7 @@ export const Toolbar = () => {
 
 				return new window.DOMRect(
 					rect?.left + 10,
-					Math.max( top + 90, 110 ),
+					Math.max( top + 70 + rect.top, 100 ),
 					width,
 					height
 				);

--- a/plugins/woocommerce/changelog/49028-49024-cys-block-toolbar-isnt-in-the-right-position-when-the-user-resize-the-viewport
+++ b/plugins/woocommerce/changelog/49028-49024-cys-block-toolbar-isnt-in-the-right-position-when-the-user-resize-the-viewport
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS: fix toolbar position after the site preview resizes


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/woocommerce/woocommerce/assets/4463174/db1c9f68-b897-40b2-aa18-cafce8bc8dd7" /> | <video src="https://github.com/woocommerce/woocommerce/assets/4463174/18ef983f-030f-4d74-bb7f-8915e2a9d113" /> |  

Closes #49024.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled
2. Make sure you have the WooCommerce beta tester plugin installed
3. Head over to Tools > WCA Test Helper > Features
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on `Design your homepage`.
8. Focus on a pattern in the site preview.
9. Ensure that the Block Toolbar is rendered in the right position.
10. Resize the site preview.
11. Ensure that the Block Toolbar is rendered in the right position.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: fix toolbar position after the site preview resizes

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>