### PR TITLE
CYS: improve copy no blocks placeholder

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/hooks/block-placeholder/use-add-no-blocks-placeholder.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/hooks/block-placeholder/use-add-no-blocks-placeholder.ts
@@ -50,19 +50,30 @@ export const useAddNoBlocksPlaceholder = ( {
 						url: NoBlocks,
 						align: 'center',
 					} ),
-					createBlock( 'core/paragraph', {
-						align: 'center',
-						fontFamily: 'inter',
-						style: {
-							color: {
-								text: '#000000',
+					createBlock(
+						'core/group',
+						{
+							layout: {
+								type: 'constrained',
+								contentSize: '350px',
 							},
 						},
-						content: __(
-							'Unlock your creativity and populate your homepage by adding as many patterns as you like.',
-							'woocommerce'
-						),
-					} ),
+						[
+							createBlock( 'core/paragraph', {
+								align: 'center',
+								fontFamily: 'inter',
+								style: {
+									color: {
+										text: '#000000',
+									},
+								},
+								content: __(
+									'Add one or more of our homepage patterns to create a page that welcomes shoppers.',
+									'woocommerce'
+								),
+							} ),
+						]
+					),
 				]
 			);
 			insertBlock( noBlocksBlock, 1 );

--- a/plugins/woocommerce/changelog/49030-48683-cys-improve-copyux-when-the-user-cant-save-due-block-placeholder
+++ b/plugins/woocommerce/changelog/49030-48683-cys-improve-copyux-when-the-user-cant-save-due-block-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+CYS: improve copy no blocks placeholder.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the copy for the no-block placeholder. The button will be added in the next iteration. I created an issue and put it in the backlog: https://github.com/woocommerce/woocommerce/issues/49033


| Before | After | Mockup |
|--------|--------|--------|
|![image](https://github.com/woocommerce/woocommerce/assets/4463174/61525421-bf0c-4192-ac13-cafdf176b5d2)  |![image](https://github.com/woocommerce/woocommerce/assets/4463174/5eaa5185-6ed6-404b-9009-2050e7946954)|![image](https://github.com/woocommerce/woocommerce/assets/4463174/0570643d-d1f9-4bd3-adea-b16ebe1e1df1)| 


Closes #48683.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled
2. Make sure you have the WooCommerce beta tester plugin installed
3. Head over to Tools > WCA Test Helper > Features
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
7. Click on Design Your Homepage.
8. Start to delete all the blocks by clicking on the bin on the Toolbar.
9. Ensure that when only the header and the footer are visible, a placeholder appears:
![image](https://github.com/woocommerce/woocommerce/assets/4463174/5eaa5185-6ed6-404b-9009-2050e7946954)
10. Add a new pattern.
11. Ensure that the placeholder disappears.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: improve copy no blocks placeholder.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
