### PR TITLE
Add clear button to `Categories` dropdown

### DIFF
--- a/packages/js/components/changelog/dev-36283_add_clear_button_to_dropdown
+++ b/packages/js/components/changelog/dev-36283_add_clear_button_to_dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add clear button to SelectTree #49036

--- a/packages/js/components/src/experimental-select-control/suffix-icon.tsx
+++ b/packages/js/components/src/experimental-select-control/suffix-icon.tsx
@@ -3,14 +3,21 @@
  */
 import { createElement } from 'react';
 import { Icon } from '@wordpress/icons';
+import classNames from 'classnames';
 
 type SuffixIconProps = {
 	icon: JSX.Element;
+	className?: string;
 };
 
-export const SuffixIcon = ( { icon }: SuffixIconProps ) => {
+export const SuffixIcon = ( { className = '', icon }: SuffixIconProps ) => {
 	return (
-		<div className="woocommerce-experimental-select-control__suffix-icon">
+		<div
+			className={ classNames(
+				'woocommerce-experimental-select-control__suffix-icon',
+				className
+			) }
+		>
 			<Icon icon={ icon } size={ 24 } />
 		</div>
 	);

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.scss
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.scss
@@ -11,8 +11,10 @@
 	}
 	&__suffix, &__suffix-items {
 		display: flex;
+		align-items: center;
 		button {
-			padding-right: 0;
+			height: $gap-large;
+			padding: 0 $gap-smallest;
 		}
 	}
 	&__icon-clear {

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.scss
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.scss
@@ -9,6 +9,19 @@
 	&__input:disabled {
 		background-color: $gray-100;
 	}
+	&__suffix, &__suffix-items {
+		display: flex;
+		button {
+			padding-right: 0;
+		}
+	}
+	&__icon-clear {
+		padding-right: 0;
+		svg {
+			fill: $gray-700;
+			cursor: pointer;
+		}
+	}
 }
 
 .woocommerce-experimental-select-tree-control__dropdown {

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -28,7 +28,7 @@ interface SelectTreeProps extends TreeControlProps {
 	label: string | JSX.Element;
 	onInputChange?: ( value: string | undefined ) => void;
 	initialInputValue?: string | undefined;
-	isClearButtonVisible?: boolean;
+	isClearingAllowed?: boolean;
 	onClear?: () => void;
 }
 
@@ -40,7 +40,7 @@ export const SelectTree = function SelectTree( {
 	initialInputValue,
 	onInputChange,
 	shouldShowCreateButton,
-	isClearButtonVisible = false,
+	isClearingAllowed = false,
 	onClear = () => {},
 	...props
 }: SelectTreeProps ) {
@@ -156,8 +156,8 @@ export const SelectTree = function SelectTree( {
 		value: inputValue,
 	};
 
-	const handleOnClear = () => {
-		if ( isClearButtonVisible ) {
+	const handleClear = () => {
+		if ( isClearingAllowed ) {
 			onClear();
 		}
 	};
@@ -195,8 +195,8 @@ export const SelectTree = function SelectTree( {
 							inputProps={ inputProps }
 							suffix={
 								<div className="woocommerce-experimental-select-control__suffix-items">
-									{ isClearButtonVisible && isOpen && (
-										<Button onClick={ handleOnClear }>
+									{ isClearingAllowed && isOpen && (
+										<Button onClick={ handleClear }>
 											<SuffixIcon
 												className="woocommerce-experimental-select-control__icon-clear"
 												icon={ closeSmall }

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { chevronDown, chevronUp } from '@wordpress/icons';
+import { chevronDown, chevronUp, closeSmall } from '@wordpress/icons';
 import classNames from 'classnames';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
-import { BaseControl, TextControl } from '@wordpress/components';
+import { BaseControl, Button, TextControl } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -28,6 +28,8 @@ interface SelectTreeProps extends TreeControlProps {
 	label: string | JSX.Element;
 	onInputChange?: ( value: string | undefined ) => void;
 	initialInputValue?: string | undefined;
+	isClearButtonVisible?: boolean;
+	onClear?: () => void;
 }
 
 export const SelectTree = function SelectTree( {
@@ -38,6 +40,8 @@ export const SelectTree = function SelectTree( {
 	initialInputValue,
 	onInputChange,
 	shouldShowCreateButton,
+	isClearButtonVisible = false,
+	onClear = () => {},
 	...props
 }: SelectTreeProps ) {
 	const linkedTree = useLinkedTree( items );
@@ -152,6 +156,12 @@ export const SelectTree = function SelectTree( {
 		value: inputValue,
 	};
 
+	const handleOnClear = () => {
+		if ( isClearButtonVisible ) {
+			onClear();
+		}
+	};
+
 	return (
 		<div
 			id={ selectTreeInstanceId }
@@ -184,9 +194,21 @@ export const SelectTree = function SelectTree( {
 							} }
 							inputProps={ inputProps }
 							suffix={
-								<SuffixIcon
-									icon={ isOpen ? chevronUp : chevronDown }
-								/>
+								<div className="woocommerce-experimental-select-control__suffix-items">
+									{ isClearButtonVisible && isOpen && (
+										<Button onClick={ handleOnClear }>
+											<SuffixIcon
+												className="woocommerce-experimental-select-control__icon-clear"
+												icon={ closeSmall }
+											/>
+										</Button>
+									) }
+									<SuffixIcon
+										icon={
+											isOpen ? chevronUp : chevronDown
+										}
+									/>
+								</div>
 							}
 						>
 							<SelectedItems

--- a/packages/js/product-editor/changelog/dev-36283_add_clear_button_to_dropdown
+++ b/packages/js/product-editor/changelog/dev-36283_add_clear_button_to_dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add clear button to Categories dropdown #49036

--- a/packages/js/product-editor/src/blocks/generic/taxonomy/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/taxonomy/edit.tsx
@@ -103,6 +103,10 @@ export function Edit( {
 		value: String( taxonomy.id ),
 	} ) );
 
+	function onClear() {
+		setSelectedEntries( [] );
+	}
+
 	return (
 		<div { ...blockProps }>
 			<>
@@ -175,6 +179,10 @@ export function Edit( {
 							);
 						}
 					} }
+					onClear={ onClear }
+					isClearButtonVisible={
+						( selectedEntries || [] ).length > 0
+					}
 				></SelectTreeControl>
 				{ showCreateNewModal && (
 					<CreateTaxonomyModal

--- a/packages/js/product-editor/src/blocks/generic/taxonomy/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/taxonomy/edit.tsx
@@ -103,7 +103,7 @@ export function Edit( {
 		value: String( taxonomy.id ),
 	} ) );
 
-	function onClear() {
+	function handleClear() {
 		setSelectedEntries( [] );
 	}
 
@@ -179,10 +179,8 @@ export function Edit( {
 							);
 						}
 					} }
-					onClear={ onClear }
-					isClearButtonVisible={
-						( selectedEntries || [] ).length > 0
-					}
+					onClear={ handleClear }
+					isClearingAllowed={ ( selectedEntries || [] ).length > 0 }
 				></SelectTreeControl>
 				{ showCreateNewModal && (
 					<CreateTaxonomyModal


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a clear button to the `Categories` dropdown.

![Screen Recording on 2024-07-02 at 03-36-46](https://github.com/woocommerce/woocommerce/assets/1314156/536c5b01-ee55-4b4e-82f7-a2a9e1c051da)

Closes #36283.

**Acceptance criteria**

- [ ] There's an `X` button visible in the search field when there's at least 1 item added.
- [ ] The icon for the button is `close-small` from the Gutenberg library (color `gutenberg-700`).
- [ ] The `X` button is visible when the search field is opened (both resting and focused).
- [ ] Clicking the `X` button removes all added items (chips).
- [ ] When there's any text input (when the user is searching or creating a new item), clicking the `X` button will clear the previously added items but not the currently edited text.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to `Products` > `Add New` > `Organization`.
3. Press the categories dropdown and create a couple of Categories.
4. Verify that pressing the `x` (clear button) removes all the selected Categories.

![Screenshot 2024-07-02 at 3 43 42 PM](https://github.com/woocommerce/woocommerce/assets/1314156/668ad5cb-684b-4733-addb-f90525a5a427)

5. The clear button shouldn't be visible when there isn't any Category selected.
6. The clear button shouldn't be visible when the dropdown is not extended.
7. The clear button shouldn't delete the input content, only the selected categories.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
