### PR TITLE
Update WC blocks wp-env to use WP 6.6 RC1

### DIFF
--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.6-RC1.zip",
+	"core": "https://wordpress.org/wordpress-6.6-RC2.zip",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.6-beta3.zip",
+	"core": "https://wordpress.org/wordpress-6.6-RC1.zip",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/assets/js/base/utils/render-frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/render-frontend.tsx
@@ -17,7 +17,6 @@ type BlockProps<
 	attributes?: TAttribute;
 };
 
-// Temporary change to code to make CI run.
 type BlockType<
 	TProps extends Record< string, unknown >,
 	TAttribute extends Record< string, unknown >

--- a/plugins/woocommerce-blocks/assets/js/base/utils/render-frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/render-frontend.tsx
@@ -17,6 +17,7 @@ type BlockProps<
 	attributes?: TAttribute;
 };
 
+// Temporary change to code to make CI run.
 type BlockType<
 	TProps extends Record< string, unknown >,
 	TAttribute extends Record< string, unknown >

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -358,6 +358,7 @@
 					"name": "JavaScript",
 					"command": "test:js",
 					"changes": [
+						".wp-env.json",
 						"webpack.config.js",
 						"babel.config.js",
 						"tsconfig.json",

--- a/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -255,7 +255,9 @@ test.describe( `${ blockData.name } Block `, () => {
 		const resetNotice = editor.page
 			.getByLabel( 'Dismiss this notice' )
 			.getByText( `"Single Product" reset.` );
-		const searchResults = editor.page.getByLabel( 'Actions' );
+		const searchResults = editor.page.getByLabel( 'Actions', {
+			exact: true,
+		} );
 		await expect.poll( async () => await searchResults.count() ).toBe( 1 );
 		await searchResults.first().click();
 		await editor.page.getByRole( 'menuitem', { name: 'Reset' } ).click();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
@@ -62,7 +62,9 @@ for ( const template of templates ) {
 				attributes: { content: userText },
 			} );
 
-			await page.getByRole( 'button', { name: 'Save' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Save', exact: true } )
+				.click();
 
 			await page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -55,7 +55,6 @@ test.describe( 'Single Product Template', () => {
 		} );
 		await editor.revertTemplateCustomizations( {
 			templateName: testData.templateName,
-			templateType: testData.templateType,
 		} );
 		await page.goto( testData.permalink );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -61,7 +61,6 @@ test.describe( 'Template customization', () => {
 				} );
 				await editor.revertTemplateCustomizations( {
 					templateName: testData.templateName,
-					templateType: testData.templateType,
 				} );
 				await testData.visitPage( { frontendUtils, page } );
 				await expect( page.getByText( userText ) ).toHaveCount( 0 );
@@ -102,7 +101,6 @@ test.describe( 'Template customization', () => {
 					await editor.revertTemplateCustomizations( {
 						templateName:
 							testData.fallbackTemplate?.templateName || '',
-						templateType: 'wp_template',
 					} );
 					await testData.visitPage( { frontendUtils, page } );
 					await expect(
@@ -185,7 +183,6 @@ test.describe( 'Template customization', () => {
 
 				await editor.revertTemplateCustomizations( {
 					templateName: testData.templateName,
-					templateType: testData.templateType,
 				} );
 
 				await testData.visitPage( { frontendUtils, page } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -69,7 +69,6 @@ test.describe( 'Template customization', () => {
 				} );
 				await editor.revertTemplateCustomizations( {
 					templateName: testData.templateName,
-					templateType: testData.templateType,
 				} );
 				await testData.visitPage( { frontendUtils, page } );
 

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -95,10 +95,8 @@ export class Editor extends CoreEditor {
 
 	async revertTemplateCustomizations( {
 		templateName,
-		templateType,
 	}: {
 		templateName: string;
-		templateType: 'wp_template' | 'wp_template_part';
 	} ) {
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
 

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -104,11 +104,7 @@ export class Editor extends CoreEditor {
 
 		const resetNotice = this.page
 			.getByLabel( 'Dismiss this notice' )
-			.getByText(
-				templateType === 'wp_template'
-					? `"${ templateName }" reset.`
-					: `"${ templateName }" deleted.`
-			);
+			.getByText( `"${ templateName }" reset.` );
 		const savedButton = this.page.getByRole( 'button', {
 			name: 'Saved',
 		} );

--- a/plugins/woocommerce/changelog/49037-update-e2e-wp-version
+++ b/plugins/woocommerce/changelog/49037-update-e2e-wp-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This is a monorepo-facing change that updates E2E tests in our CI.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Update WC blocks wp-env to use WP 6.6 RC1

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Not much to test here, just ensure E2E tests are passing

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is a monorepo-facing change that updates E2E tests in our CI.
</details>
