### PR TITLE
Use default cursor for everything in select and tree components

### DIFF
--- a/packages/js/components/changelog/tweak-select-tree
+++ b/packages/js/components/changelog/tweak-select-tree
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Use default cursor for everything in select and tree components
+
+

--- a/packages/js/components/src/experimental-select-control/selected-items.scss
+++ b/packages/js/components/src/experimental-select-control/selected-items.scss
@@ -17,5 +17,8 @@
 
     .woocommerce-tag {
         margin: 0;
+		.woocommerce-tag__remove {
+			cursor: default;
+		}
     }
 }

--- a/packages/js/components/src/experimental-tree-control/tree-item.scss
+++ b/packages/js/components/src/experimental-tree-control/tree-item.scss
@@ -44,6 +44,7 @@ $control-size: $gap-large;
 		svg.components-checkbox-control__checked,
 		svg.components-checkbox-control__indeterminate,
 		.components-checkbox-control__input[type='checkbox'] {
+			cursor: default;
 			&:focus {
 				outline: none;
 				box-shadow: none;
@@ -56,6 +57,7 @@ $control-size: $gap-large;
 		align-items: center;
 
 		.components-button {
+			cursor: default;
 			padding: 0;
 			height: $control-size;
 			width: $control-size;

--- a/packages/js/components/src/experimental-tree-control/tree.scss
+++ b/packages/js/components/src/experimental-tree-control/tree.scss
@@ -14,6 +14,7 @@
 	}
 	&__button {
 		width: 100%;
+		cursor: default;
 		&:hover,
 		&:focus-within {
 			outline: 1.5px solid var( --wp-admin-theme-color );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This tweaks CSS for the Select and Tree components.

I didn't remove the cursor when hovering over the input field, as mentioned in the original issue, because I think it would make the user experience worse.

Closes #38229 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Go to the Organization Tab
4. Using the cursor, navigate the combo box and verify that the checkboxes, the remove buttons, and the create new button show the default cursor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
