### PR TITLE
Product Editor: Fix tab switching when variations are generated

### DIFF
--- a/packages/js/product-editor/changelog/fix-create-variations-tab-switch
+++ b/packages/js/product-editor/changelog/fix-create-variations-tab-switch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a React 18 concurrency-related issue with tab switching.

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -5,12 +5,14 @@ import {
 	createElement,
 	StrictMode,
 	Fragment,
+	useCallback,
 	useState,
 } from '@wordpress/element';
 import {
 	LayoutContextProvider,
 	useExtendLayout,
 } from '@woocommerce/admin-layout';
+import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 import { useSelect } from '@wordpress/data';
 import { Popover } from '@wordpress/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -39,7 +41,13 @@ import { PrepublishPanel } from '../prepublish-panel/prepublish-panel';
 
 export function Editor( { productId, postType = 'product' }: EditorProps ) {
 	const [ isEditorLoading, setIsEditorLoading ] = useState( true );
-	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
+
+	const query = getQuery() as Record< string, string >;
+	const selectedTab = query.tab || null;
+
+	const setSelectedTab = useCallback( ( tabId: string ) => {
+		navigateTo( { url: getNewPath( { tab: tabId } ) } );
+	}, [] );
 
 	const updatedLayoutContext = useExtendLayout( 'product-block-editor' );
 

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -278,7 +278,7 @@ export function Header( {
 					<MoreMenu />
 				</div>
 			</div>
-			<Tabs onChange={ onTabSelect } />
+			<Tabs selected={ selectedTab } onChange={ onTabSelect } />
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/header/types.ts
+++ b/packages/js/product-editor/src/components/header/types.ts
@@ -1,7 +1,7 @@
 export type HeaderProps = {
-	onTabSelect: ( tabId: string | null ) => void;
+	onTabSelect: ( tabId: string ) => void;
 	productType?: string;
-	selectedTab?: string | null;
+	selectedTab: string | null;
 };
 
 export interface Image {

--- a/packages/js/product-editor/src/components/tabs/test/tabs.spec.tsx
+++ b/packages/js/product-editor/src/components/tabs/test/tabs.spec.tsx
@@ -3,9 +3,8 @@
  */
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import { getQuery, navigateTo } from '@woocommerce/navigation';
 import { SlotFillProvider } from '@wordpress/components';
-import { useState, createElement } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 import { select } from '@wordpress/data';
 
@@ -13,10 +12,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { Tabs } from '../';
-import {
-	TabBlockEdit as Tab,
-	TabBlockAttributes,
-} from '../../../blocks/generic/tab/edit';
+import { TabBlockEdit as Tab } from '../../../blocks/generic/tab/edit';
 import { TRACKS_SOURCE } from '../../../constants';
 
 jest.mock( '@woocommerce/block-templates', () => ( {

--- a/packages/js/product-editor/src/components/tabs/test/tabs.spec.tsx
+++ b/packages/js/product-editor/src/components/tabs/test/tabs.spec.tsx
@@ -50,8 +50,13 @@ const blockProps = {
 	isSelected: false,
 };
 
-function MockTabs( { onChange = jest.fn() } ) {
-	const [ selected, setSelected ] = useState< string | null >( null );
+function MockTabs( {
+	selected = null,
+	onChange = jest.fn(),
+}: {
+	selected?: string | null;
+	onChange?: ( tabId: string ) => void;
+} ) {
 	const mockContext = {
 		editedProduct: null,
 		postId: 1,
@@ -59,24 +64,9 @@ function MockTabs( { onChange = jest.fn() } ) {
 		selectedTab: selected,
 	};
 
-	function getAttributes( id: string ) {
-		return function setAttributes( {
-			isSelected,
-		}: Partial< TabBlockAttributes > ) {
-			if ( isSelected ) {
-				setSelected( id );
-			}
-		};
-	}
-
 	return (
 		<SlotFillProvider>
-			<Tabs
-				onChange={ ( tabId ) => {
-					setSelected( tabId );
-					onChange( tabId );
-				} }
-			/>
+			<Tabs selected={ selected } onChange={ onChange } />
 			<Tab
 				{ ...blockProps }
 				attributes={ {
@@ -85,11 +75,8 @@ function MockTabs( { onChange = jest.fn() } ) {
 					order: 1,
 					isSelected: selected === 'test1',
 				} }
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore editedProduct is not used, so we can just ignore the fact that our context doesn't have it
 				context={ mockContext }
 				name="test1"
-				setAttributes={ getAttributes( 'test1' ) }
 			/>
 			<Tab
 				{ ...blockProps }
@@ -99,11 +86,8 @@ function MockTabs( { onChange = jest.fn() } ) {
 					order: 2,
 					isSelected: selected === 'test2',
 				} }
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore editedProduct is not used, so we can just ignore the fact that our context doesn't have it
 				context={ mockContext }
 				name="test2"
-				setAttributes={ getAttributes( 'test2' ) }
 			/>
 			<Tab
 				{ ...blockProps }
@@ -113,11 +97,8 @@ function MockTabs( { onChange = jest.fn() } ) {
 					order: 3,
 					isSelected: selected === 'test3',
 				} }
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore editedProduct is not used, so we can just ignore the fact that our context doesn't have it
 				context={ mockContext }
 				name="test3"
-				setAttributes={ getAttributes( 'test3' ) }
 			/>
 		</SlotFillProvider>
 	);
@@ -126,9 +107,6 @@ function MockTabs( { onChange = jest.fn() } ) {
 describe( 'Tabs', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		( getQuery as jest.Mock ).mockReturnValue( {
-			tab: null,
-		} );
 	} );
 
 	it( 'should render tab buttons added to the slot', () => {
@@ -138,93 +116,46 @@ describe( 'Tabs', () => {
 		expect( screen.queryByText( 'Test button 2' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should set the first tab as active initially', async () => {
-		render( <MockTabs /> );
+	it( 'should call onChange with the first tab if no selection set', async () => {
+		const mockOnChange = jest.fn();
+
+		render( <MockTabs onChange={ mockOnChange } /> );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( 'test1' );
+	} );
+
+	it( 'should set the selected tab active', async () => {
+		const mockOnChange = jest.fn();
+
+		render( <MockTabs selected={ 'test2' } onChange={ mockOnChange } /> );
 
 		expect( screen.queryByText( 'Test button 1' ) ).toHaveAttribute(
 			'aria-selected',
-			'true'
+			'false'
 		);
 
 		expect( screen.queryByText( 'Test button 2' ) ).toHaveAttribute(
 			'aria-selected',
-			'false'
+			'true'
 		);
+
+		expect( mockOnChange ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should navigate to a new URL when a tab is clicked', () => {
-		render( <MockTabs /> );
+	it( 'should call the onChange prop when changing', async () => {
+		const mockOnChange = jest.fn();
 
-		const button = screen.getByText( 'Test button 2' );
+		render( <MockTabs selected={ 'test2' } onChange={ mockOnChange } /> );
+
+		const button = screen.getByText( 'Test button 1' );
 		fireEvent.click( button );
 
-		expect( navigateTo ).toHaveBeenLastCalledWith( {
-			url: 'admin.php?page=wc-admin&tab=test2',
-		} );
-	} );
-
-	it( 'should select the tab provided in the URL initially', () => {
-		( getQuery as jest.Mock ).mockReturnValue( {
-			tab: 'test2',
-		} );
-
-		render( <MockTabs /> );
-
-		expect( screen.getByText( 'Test button 2' ) ).toHaveAttribute(
-			'aria-selected',
-			'true'
-		);
-	} );
-
-	it( 'should select the tab provided on URL change', () => {
-		const { rerender } = render( <MockTabs /> );
-
-		( getQuery as jest.Mock ).mockReturnValue( {
-			tab: 'test3',
-		} );
-
-		rerender( <MockTabs /> );
-
-		expect( screen.getByText( 'Test button 3' ) ).toHaveAttribute(
-			'aria-selected',
-			'true'
-		);
-	} );
-
-	it( 'should call the onChange props when changing', async () => {
-		const mockOnChange = jest.fn();
-		const { rerender } = render( <MockTabs onChange={ mockOnChange } /> );
-
 		expect( mockOnChange ).toHaveBeenCalledWith( 'test1' );
-
-		( getQuery as jest.Mock ).mockReturnValue( {
-			tab: 'test2',
-		} );
-
-		rerender( <MockTabs onChange={ mockOnChange } /> );
-
-		expect( mockOnChange ).toHaveBeenCalledWith( 'test2' );
-	} );
-
-	it( 'should add a class to the initially selected tab panel', async () => {
-		render( <MockTabs /> );
-
-		const panel1 = screen.getByRole( 'tabpanel', {
-			name: 'Test button 1',
-		} );
-		const panel2 = screen.getByRole( 'tabpanel', {
-			name: 'Test button 2',
-		} );
-
-		expect( panel1.classList ).toContain( 'is-selected' );
-		expect( panel2.classList ).not.toContain( 'is-selected' );
 	} );
 
 	it( 'should add a class to the newly selected tab panel', async () => {
-		const { rerender } = render( <MockTabs /> );
+		const { rerender } = render( <MockTabs selected={ 'test2' } /> );
 
-		const button = screen.getByText( 'Test button 2' );
-		fireEvent.click( button );
 		const panel1 = screen.getByRole( 'tabpanel', {
 			name: 'Test button 1',
 		} );
@@ -232,14 +163,13 @@ describe( 'Tabs', () => {
 			name: 'Test button 2',
 		} );
 
-		( getQuery as jest.Mock ).mockReturnValue( {
-			tab: 'test2',
-		} );
-
-		rerender( <MockTabs /> );
-
 		expect( panel1.classList ).not.toContain( 'is-selected' );
 		expect( panel2.classList ).toContain( 'is-selected' );
+
+		rerender( <MockTabs selected={ 'test1' } /> );
+
+		expect( panel1.classList ).toContain( 'is-selected' );
+		expect( panel2.classList ).not.toContain( 'is-selected' );
 	} );
 
 	it( 'should trigger wcadmin_product_tab_click track event when tab is clicked', async () => {
@@ -252,6 +182,7 @@ describe( 'Tabs', () => {
 
 		const button = screen.getByText( 'Test button 2' );
 		fireEvent.click( button );
+
 		expect( recordEvent ).toBeCalledWith( 'product_tab_click', {
 			product_tab: 'test2',
 			product_type: 'simple',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a concurrency/batching state issue switching tabs in React 18. This PR is still using the React 17 compatibility mode (`render` vs `createRoot`) -- the switch to React 18 for WC Admin is in #48785. To run these changes in React 18 mode, see the draft PR #49117 that includes the changes from #48785.

The state handling of the selected tab was moved from the `Tabs` component to the `Editor` component, as it is a simpler flow and avoids setting state and making callback within `useEffect` in `Tabs`.

The unit tests for `Tabs` were undated and simplified accordingly.

One functional change is that now if no `tab` query param is provided in the URL, the URL route is updated to include the `tab` query param. This seems reasonable and makes the handling of the selected tab and the `tab` query param more consistent.

This PR does not address the separate issue of the loading state appearing when generating variations (see #49014).

Closes #48933.

#### Before (tab switches when variations are generated)

https://github.com/woocommerce/woocommerce/assets/2098816/2db8b502-c467-48ee-b708-2f075efecad2

#### After (tab does not switch when variations are generated)

https://github.com/woocommerce/woocommerce/assets/2098816/06ec8ff5-88cd-4db8-92eb-ed2e0374f290

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. Verify the `General` tab is selected by default and fields appear correctly.
3. Switch tabs and verify things work properly.
4. On the `Variations` tab, click `Add Options` and add some variation options.
5. Verify that the variations are added correctly and the selected tab remains `Variations` (note, the loading state showing is a known issue and will be addressed separately; see #49014)
6. Reload the page and verify that the selected tab remains `Variations`.
7. Click `Edit` on a variation in the list and verify the variation shows properly in the editor.
8. Verify switching between tabs on the variation works.
9. Verify switching between variations using the footer navigation works.
10. Click on `Main product` to return to the main product.
11. Verify the `Variations` tab is selected and that things work.
12. Change the `tab` query param in the page URL from `variations` to `shipping` and verify that the page loads with the `Shipping` tab selected. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
