### PR TITLE
[Product Collection] Fix collection chooser button text alignment for WP 6.6

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/editor.scss
@@ -24,6 +24,7 @@ $max-button-width: calc((100% - #{$total-gap-width}) / #{$max-columns});
 
 	.components-button.wc-blocks-product-collection__collection-button {
 		margin: 0;
+		justify-content: start;
 	}
 }
 

--- a/plugins/woocommerce/changelog/49088-fix-collection-chooser-button-text-alignment
+++ b/plugins/woocommerce/changelog/49088-fix-collection-chooser-button-text-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Product Collection: Fix collection chooser button text alignment for WP 6.6


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Note:** This is reproducible on WordPress 6.6

While testing on WordPress 6.6, I noticed that the text in the collection chooser button is not aligned to the left. The text is centered, but it should be aligned to the left. This PR fixes the alignment of the collection chooser button text.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/woocommerce/woocommerce/assets/16707866/135fd536-07f8-4e6a-b123-74811bf0357a) | ![image](https://github.com/woocommerce/woocommerce/assets/16707866/a52dc676-5f94-4ce0-b25e-fa35739a89f5) |

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Pre-requisite:** WordPress 6.6

1. Add Product Collection block to a new post
2. Reduce the width of browser window such that only one column is shown for collections
3. Verify that the text in the collection chooser button is aligned to the left

| Before | After |
| ------ | ----- |
| ![image](https://github.com/woocommerce/woocommerce/assets/16707866/135fd536-07f8-4e6a-b123-74811bf0357a) | ![image](https://github.com/woocommerce/woocommerce/assets/16707866/a52dc676-5f94-4ce0-b25e-fa35739a89f5) |

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Collection: Fix collection chooser button text alignment for WP 6.6

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
