### PR TITLE
Fix deprecated get_option notice when viewing Analytics > Orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-option-notice-analytics-orders
+++ b/plugins/woocommerce/changelog/fix-option-notice-analytics-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix get_options deprecated notice when viewing Analytics > Orders

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -202,6 +202,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_product_tour_modal_hidden',
 			'woocommerce_block_product_tour_shown',
 			'woocommerce_revenue_report_date_tour_shown',
+			'woocommerce_orders_report_date_tour_shown',
 			'woocommerce_show_prepublish_checks_enabled',
 			'woocommerce_date_type',
 			'date_format',

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -9,6 +9,11 @@ const test = baseTest.extend( {
 			woocommerce_task_list_reminder_bar_hidden: 'yes',
 		} );
 
+		// Disable the orders report date tour
+		await wcAdminApi.post( 'options', {
+			woocommerce_orders_report_date_tour_shown: 'yes',
+		} );
+
 		// Disable the revenue report date tour
 		await wcAdminApi.post( 'options', {
 			woocommerce_revenue_report_date_tour_shown: 'yes',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When viewing Analytics > Orders a deprecated message is shown/logged. The reason this happens is because we switched to using a whitelist for allowed options, since WC 6.3. The option `woocommerce_orders_report_date_tour_shown` was not included in this whitelist, which is what this PR changes.

We can observe the requests for options by viewing the API requests when visiting Analytics > Orders. There we can see the request to: `https://domain.test/wp-json/wc-admin/options?options=woocommerce_task_list_reminder_bar_hidden%2Cwoocommerce_orders_report_date_tour_shown%2Cwoocommerce_date_type&_locale=user`

The only option that was missing from the whitelist was `woocommerce_orders_report_date_tour_shown`. I also checked all the other Analytics pages to ensure they aren't loading any options that weren't whitelisted.

Closes #47026 
Closes #37592

### How to test the changes in this Pull Request:

1. Start with testing before checking out this PR to confirm the error is logged
2. Configure site to log deprecations notices:
```
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', true );
```
3. In the DB table wp_options set the option `woocommerce_orders_report_date_tour_shown` to `no` (only needed if previously viewed)
4. Visit the page Analytics > Orders and click on the `Got it` to acknowledge the notice
![image](https://github.com/woocommerce/woocommerce/assets/11388669/ba46333b-a718-4fba-aa80-c89a5cfb142a)
5. Check the log file `wp-content/debug.log` and confirm we see both deprecation messages for `get_options` and `update_options`
```
[03-Jul-2024 10:02:53 UTC] The Automattic\WooCommerce\Admin\API\Options::get_options function is deprecated since version 6.3.
[03-Jul-2024 10:02:53 UTC] The Automattic\WooCommerce\Admin\API\Options::get_options function is deprecated since version 6.3.
[03-Jul-2024 10:03:13 UTC] The Automattic\WooCommerce\Admin\API\Options::update_options function is deprecated since version 6.3.
[03-Jul-2024 10:03:13 UTC] The Automattic\WooCommerce\Admin\API\Options::update_options function is deprecated since version 6.3.
[03-Jul-2024 10:03:13 UTC] The Automattic\WooCommerce\Admin\API\Options::update_options function is deprecated since version 6.3.
[03-Jul-2024 10:03:13 UTC] The Automattic\WooCommerce\Admin\API\Options::update_options function is deprecated since version 6.3.
```
6. Checkout this PR and repeat steps 3 to 5, this time we shouldn't see any warnings for either `get_options` or `update_options`
7. Check all additional pages in Analytics and confirm we don't get warnings for any other page.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
