### PR TITLE
Product Collection: Fix alignment of the first item in Grid layout for WP 6.6

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/block.json
@@ -24,9 +24,6 @@
 		"html": false,
 		"align": [ "wide", "full" ],
 		"anchor": true,
-		"__experimentalLayout": {
-			"allowEditing": false
-		},
 		"color": {
 			"gradients": true,
 			"link": true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
@@ -306,7 +306,8 @@ const ProductTemplateEdit = (
 		className: clsx(
 			__unstableLayoutClassNames,
 			'wc-block-product-template',
-			customClassName
+			customClassName,
+			{ [ `is-product-collection-layout-${ layoutType }` ]: layoutType }
 		),
 	} );
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/style.scss
@@ -37,7 +37,7 @@ $min-product-width: 150px;
 		@include break-small {
 			@for $i from 2 through 6 {
 				&.is-flex-container.columns-#{ $i } > li {
-					width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));
+					width: calc((100% / #{$i}) - 1.25em + (1.25em / #{$i}));
 				}
 			}
 		}
@@ -48,12 +48,18 @@ $min-product-width: 150px;
 		grid-gap: $grid-gap;
 
 		@for $i from 2 through 6 {
-			$gap-count: calc(#{ $i } - 1);
-			$total-gap-width: calc(#{ $gap-count } * #{ $grid-gap });
-			$max-product-width: calc((100% - #{ $total-gap-width }) / #{ $i });
+			$gap-count: calc(#{$i} - 1);
+			$total-gap-width: calc(#{$gap-count} * #{$grid-gap});
+			$max-product-width: calc((100% - #{$total-gap-width}) / #{$i});
 
 			&.columns-#{ $i } {
-				grid-template-columns: repeat(auto-fill, minmax(max(#{ $min-product-width }, #{ $max-product-width }), 1fr));
+				grid-template-columns: repeat(
+					auto-fill,
+					minmax(
+						max(#{$min-product-width}, #{$max-product-width}),
+						1fr
+					)
+				);
 			}
 		}
 
@@ -71,3 +77,9 @@ $min-product-width: 150px;
 	margin-top: 0;
 }
 
+/**
+ * Stack layout
+ */
+.is-product-collection-layout-list .wc-block-product:not(:last-child) {
+	margin-bottom: 1.2rem;
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/style.scss
@@ -27,7 +27,7 @@ $min-product-width: 150px;
 		flex-wrap: wrap;
 		gap: 1.25em;
 
-		> li {
+		>li {
 			margin: 0;
 			width: 100%;
 			// Below style is required to override high-specificity Storefront styles
@@ -36,7 +36,7 @@ $min-product-width: 150px;
 
 		@include break-small {
 			@for $i from 2 through 6 {
-				&.is-flex-container.columns-#{ $i } > li {
+				&.is-flex-container.columns-#{ $i }>li {
 					width: calc((100% / #{$i}) - 1.25em + (1.25em / #{$i}));
 				}
 			}
@@ -53,17 +53,11 @@ $min-product-width: 150px;
 			$max-product-width: calc((100% - #{$total-gap-width}) / #{$i});
 
 			&.columns-#{ $i } {
-				grid-template-columns: repeat(
-					auto-fill,
-					minmax(
-						max(#{$min-product-width}, #{$max-product-width}),
-						1fr
-					)
-				);
+				grid-template-columns: repeat(auto-fill, minmax(max(#{$min-product-width}, #{$max-product-width}), 1fr));
 			}
 		}
 
-		> li {
+		>li {
 			margin-block-start: 0;
 		}
 	}

--- a/plugins/woocommerce/changelog/49096-fix-remove-experimental-layout-from-product-template
+++ b/plugins/woocommerce/changelog/49096-fix-remove-experimental-layout-from-product-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Product Collection: Fix alignment of the first item in Grid layout for WP 6.6

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
@@ -48,6 +48,8 @@ class ProductTemplate extends AbstractBlock {
 
 		$classnames = '';
 		if ( isset( $block->context['displayLayout'] ) && isset( $block->context['query'] ) ) {
+			$classnames = 'is-product-collection-layout-' . $block->context['displayLayout']['type'] . ' ';
+
 			if ( isset( $block->context['displayLayout']['type'] ) && 'flex' === $block->context['displayLayout']['type'] ) {
 				if ( isset( $block->context['displayLayout']['shrinkColumns'] ) && $block->context['displayLayout']['shrinkColumns'] ) {
 					$classnames = "wc-block-product-template__responsive columns-{$block->context['displayLayout']['columns']}";
@@ -56,6 +58,7 @@ class ProductTemplate extends AbstractBlock {
 				}
 			}
 		}
+
 		if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 			$classnames .= ' has-link-color';
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Background**

[Here](https://github.com/woocommerce/woocommerce/blob/1687d462fb6c3a07b0b6abbf4938146f8e628c32/plugins/woocommerce-blocks/assets/js/blocks/product-template/block.json#L27-L29), we are using `__experimentalLayout`. Therefore, When layout is `flex`, it will add [is-layout-flex](https://github.com/WordPress/gutenberg/blob/08b77b34d1d32b4d2c0a4489ebf4314e1f297074/lib/block-supports/layout.php#L138) class. Similarly, for `grid` it will add `is-layout-grid` class.
```
"__experimentalLayout": {
	"allowEditing": false
},
```

**Changes made in this PR**

In WordPress 6.6, there is some changes to `is-layout-flex` and `is-layout-grid` classes. As you can see in screenshot below, alignment of 1st item in Grid layout is not correct.
![image](https://github.com/woocommerce/woocommerce/assets/16707866/c9e83fed-ac49-4e65-9773-c729a72e6723)


This PR fixes the alignment by removing `__experimentalLayout` from block.json file. This is responsible for adding `is-layout-flex` and `is-layout-grid` classes.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Pre-requisite:** Make sure you are using WordPress 6.6

1. Add Product Collection block to a new post.
2. Choose any Collection
3. Verify that the alignment of the first item in Grid layout is correct.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/woocommerce/woocommerce/assets/16707866/c9e83fed-ac49-4e65-9773-c729a72e6723) | ![image](https://github.com/woocommerce/woocommerce/assets/16707866/746595b3-dc24-40df-a686-d90d623a7139) |

4. As this PR changes how "Stack" and "Grid" layout works, please do some smoke testing to make sure that both layouts are working as expected. Test on Editor as well as on Frontend.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Collection: Fix alignment of the first item in Grid layout for WP 6.6

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
