### PR TITLE
Place Printful behind a feature flag

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
@@ -132,10 +132,12 @@ export const SETUP_TASKLIST_PRODUCT_TYPES_FILTER =
 export const SETUP_TASKLIST_PRODUCTS_AFTER_FILTER =
 	'woocommerce_admin_task_products_after';
 
-addFilter(
-	SETUP_TASKLIST_PRODUCTS_AFTER_FILTER,
-	'woocommerce/task-lists/products-sponsored-placement',
-	( products ) => {
-		return [ ...products, PrintfulAdvertProductPlacement ];
-	}
-);
+if ( window.wcAdminFeatures && window.wcAdminFeatures.printful === true ) {
+	addFilter(
+		SETUP_TASKLIST_PRODUCTS_AFTER_FILTER,
+		'woocommerce/task-lists/products-sponsored-placement',
+		( products ) => {
+			return [ ...products, PrintfulAdvertProductPlacement ];
+		}
+	);
+}

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -43,6 +43,7 @@ declare global {
 			'onboarding-tasks': boolean;
 			'payment-gateway-suggestions': boolean;
 			'pattern-toolkit-full-composability': boolean;
+			printful: boolean;
 			'product-pre-publish-modal': boolean;
 			'product-custom-fields': boolean;
 			'remote-inbox-notifications': boolean;

--- a/plugins/woocommerce/changelog/update-printful-ff
+++ b/plugins/woocommerce/changelog/update-printful-ff
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add feature flag for Printful placement

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -25,6 +25,7 @@
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,
+		"printful": false,
 		"settings": false,
 		"shipping-label-banner": true,
 		"subscriptions": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -23,6 +23,7 @@
 		"payment-gateway-suggestions": true,
 		"product-pre-publish-modal": false,
 		"product-custom-fields": true,
+		"printful": false,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"settings": false,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This places the Printful placement behind a feature flag to allow it to be disabled in WooCommerce 9.1 and re-enabled in a future release.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Case 1: Flag disabled (default behavior)
1. Go to WooCommerce > Home
2. Click "Add products" task
3. See that Printful does NOT appear

<img width="1792" alt="printful off" src="https://github.com/woocommerce/woocommerce/assets/9312929/1b76c8d9-d7e5-4f1f-80c2-5e312805a799">

#### Case 2: Flag enabled
1. Using Beta Tester or similar, enable the feature flag. eg Tools > WCA Test Helper > Features
1. Go to WooCommerce > Home
1. Click "Add products" task
1. See that Printful appears

<img width="1792" alt="printful on" src="https://github.com/woocommerce/woocommerce/assets/9312929/86b194b5-c51b-46e0-9547-0a9a6a2bee4f">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
