### PR TITLE
Allow returning to input on selectTree when pressing escape

### DIFF
--- a/packages/js/components/changelog/update-escape-select-control
+++ b/packages/js/components/changelog/update-escape-select-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Allow returning to input on selectTree when pressing escape

--- a/packages/js/components/src/experimental-select-tree-control/select-tree-menu.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree-menu.tsx
@@ -42,6 +42,7 @@ export const SelectTreeMenu = ( {
 	items,
 	treeRef: ref,
 	onClose = () => {},
+	onEscape,
 	shouldShowCreateButton,
 	...props
 }: MenuProps ) => {
@@ -135,6 +136,7 @@ export const SelectTreeMenu = ( {
 									shouldShowCreateButton={
 										shouldShowCreateButton
 									}
+									onEscape={ onEscape }
 									style={ {
 										width: boundingRect?.width,
 									} }

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -245,7 +245,10 @@ export const SelectTree = function SelectTree( {
 				isOpen={ isOpen }
 				items={ linkedTree }
 				shouldShowCreateButton={ shouldShowCreateButton }
-				onEscape={ focusOnInput }
+				onEscape={ () => {
+					focusOnInput();
+					setIsOpen( false );
+				} }
 				onClose={ () => {
 					setIsOpen( false );
 				} }

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -245,6 +245,7 @@ export const SelectTree = function SelectTree( {
 				isOpen={ isOpen }
 				items={ linkedTree }
 				shouldShowCreateButton={ shouldShowCreateButton }
+				onEscape={ focusOnInput }
 				onClose={ () => {
 					setIsOpen( false );
 				} }

--- a/packages/js/components/src/experimental-tree-control/tree-item.tsx
+++ b/packages/js/components/src/experimental-tree-control/tree-item.tsx
@@ -33,6 +33,15 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 		ref,
 	} );
 
+	function handleEscapePress(
+		event: React.KeyboardEvent< HTMLInputElement >
+	) {
+		if ( event.key === 'Escape' && props.onEscape ) {
+			event.preventDefault();
+			props.onEscape();
+		}
+	}
+
 	return (
 		<li
 			{ ...treeItemProps }
@@ -58,15 +67,7 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 							}
 							checked={ selection.checkedStatus === 'checked' }
 							onChange={ selection.onSelectChild }
-							onKeyDown={ ( event ) => {
-								if (
-									event.key === 'Escape' &&
-									props.onEscape
-								) {
-									event.preventDefault();
-									props.onEscape();
-								}
-							} }
+							onKeyDown={ handleEscapePress }
 							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 							// @ts-ignore __nextHasNoMarginBottom is a valid prop
 							__nextHasNoMarginBottom={ true }
@@ -79,15 +80,7 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 							onChange={ ( event ) =>
 								selection.onSelectChild( event.target.checked )
 							}
-							onKeyDown={ ( event ) => {
-								if (
-									event.key === 'Escape' &&
-									props.onEscape
-								) {
-									event.preventDefault();
-									props.onEscape();
-								}
-							} }
+							onKeyDown={ handleEscapePress }
 						/>
 					) }
 

--- a/packages/js/components/src/experimental-tree-control/tree-item.tsx
+++ b/packages/js/components/src/experimental-tree-control/tree-item.tsx
@@ -58,6 +58,15 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 							}
 							checked={ selection.checkedStatus === 'checked' }
 							onChange={ selection.onSelectChild }
+							onKeyDown={ ( event ) => {
+								if (
+									event.key === 'Escape' &&
+									props.onEscape
+								) {
+									event.preventDefault();
+									props.onEscape();
+								}
+							} }
 							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 							// @ts-ignore __nextHasNoMarginBottom is a valid prop
 							__nextHasNoMarginBottom={ true }

--- a/packages/js/components/src/experimental-tree-control/tree-item.tsx
+++ b/packages/js/components/src/experimental-tree-control/tree-item.tsx
@@ -79,6 +79,15 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 							onChange={ ( event ) =>
 								selection.onSelectChild( event.target.checked )
 							}
+							onKeyDown={ ( event ) => {
+								if (
+									event.key === 'Escape' &&
+									props.onEscape
+								) {
+									event.preventDefault();
+									props.onEscape();
+								}
+							} }
 						/>
 					) }
 

--- a/packages/js/components/src/experimental-tree-control/tree.tsx
+++ b/packages/js/components/src/experimental-tree-control/tree.tsx
@@ -59,6 +59,7 @@ export const Tree = forwardRef( function ForwardedTree(
 										) as HTMLButtonElement
 								 )?.focus();
 							} }
+							onEscape={ props.onEscape }
 						/>
 					) ) }
 				</ol>
@@ -94,6 +95,9 @@ export const Tree = forwardRef( function ForwardedTree(
 									)
 									?.focus();
 							}
+						} else if ( event.key === 'Escape' && props.onEscape ) {
+							event.preventDefault();
+							props.onEscape();
 						}
 					} }
 				>

--- a/packages/js/components/src/experimental-tree-control/types.ts
+++ b/packages/js/components/src/experimental-tree-control/types.ts
@@ -76,6 +76,10 @@ type BaseTreeProps = {
 	 * Called when the create button is clicked to help closing any related popover.
 	 */
 	onTreeBlur?(): void;
+	/**
+	 * Called when the escape key is pressed.
+	 */
+	onEscape?(): void;
 };
 
 export type TreeProps = BaseTreeProps &

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21630,7 +21630,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      react: ^17.0.2
+      react: 18.2.0
 
   react-number-format@4.9.3:
     resolution: {integrity: sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This implements a behavior similar to FormTokenField in SelectTree, which is closing the menu and returning to the input when pressing esc. Reference: https://wordpress.github.io/gutenberg/?path=/docs/components-formtokenfield--docs

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Go to the Organization tab
4. In the categories field, navigate through the existing categories using the keyboard up/down keys, and press the Esc button. 
5. It should change the focus to the input and close the menu


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
