### PR TITLE
Add srcset to Single Product gallery thumbnail images

### DIFF
--- a/plugins/woocommerce/changelog/fix-48431-blurry-thumbnail-images
+++ b/plugins/woocommerce/changelog/fix-48431-blurry-thumbnail-images
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make Single Product gallery thumbnail images sharper by defining a srcset

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -255,6 +255,7 @@
                 item = $('<img/>', {
                   onload: 'this.width = this.naturalWidth; this.height = this.naturalHeight',
                   src: slide.attr('data-thumb'),
+                  srcset: slide.attr('data-thumb-srcset'),
                   alt: slide.attr('alt')
                 })
               }

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1608,6 +1608,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $main_image ? 'woocommerce_single' : $thumbnail_size );
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
+	$thumbnail_srcset  = wp_get_attachment_image_srcset( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
 	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
 	$image             = wp_get_attachment_image(
@@ -1631,7 +1632,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 		)
 	);
 
-	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" data-thumb-srcset="' . esc_attr( $thumbnail_srcset ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 }
 
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes #48431.

This PR adds a `srcset` attribute to thumbnail images displayed in the Single Product page for products that have multiple images or variable products with different images for each variation.

### How to test the changes in this Pull Request:

1. Create a product with several images.
2. Visit the product in the frontend.
3. Verify the thumbnail images aren't blurred. If you aren't sure, you can open your browser devtools (<kbd>F12</kbd>), inspect the image and verify it has a `srcset` attribute.

Before | After
--- | ---
![Captura de pantalla de 2024-07-03 17-48-18](https://github.com/woocommerce/woocommerce/assets/3616980/c4471d86-6a7c-451f-b278-3d976b2b106c) | ![Captura de pantalla de 2024-07-03 17-48-33](https://github.com/woocommerce/woocommerce/assets/3616980/462fe780-ef7c-4683-b6ba-c7323bd7804f)

_(Note: you might to open the PRs in a new tab to see the difference)_

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
