### PR TITLE
CYS: fix not template set correctly

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/data/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/data/actions.ts
@@ -259,8 +259,8 @@ export const updateTemplate = async ( {
 	homepageTemplateId: keyof typeof HOMEPAGE_TEMPLATES;
 } ) => {
 	if ( isFullComposabilityFeatureAndAPIAvailable() ) {
-		updateTemplatePTK();
+		await updateTemplatePTK();
 	} else {
-		updateTemplatePrePTK( { homepageTemplateId } );
+		await updateTemplatePrePTK( { homepageTemplateId } );
 	}
 };

--- a/plugins/woocommerce/changelog/49113-fix-missing-await
+++ b/plugins/woocommerce/changelog/49113-fix-missing-await
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: fix not template set correctly.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In some cases, the template isn't set correctly due to the missing the `await`. 

⚠️ Before approving this PR, ensure that you're able to reproduce the issue.


https://github.com/woocommerce/woocommerce/assets/4463174/9f6da667-d463-469c-a89e-3122753d4427



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Ensure that you have the browser dev tools closed.
4. Install [ the Transient Manager plugin](https://wordpress.org/plugins/transients-manager/)
5. Head over to Tools > WCA Test Helper > Features.
6. Make sure you see the `pattern-toolkit-full-composability` on the list.
7.  Head over to Tools > WCA Test Helper > Tools > Resets Customize Your Store changes.
8. Head over to Transient.
9. Click delete all.
10. Head over to WooCommerce > Home > Customize your store.
11. Ensure that the site preview looks doesn't have the default TT4 template

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: fix not template set correctly.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>