### PR TITLE
Track the newly installed version in wp_options

### DIFF
--- a/plugins/woocommerce/changelog/add-initial-install-option-value
+++ b/plugins/woocommerce/changelog/add-initial-install-option-value
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add the initially installed WooCommerce version to the wp_options table

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -272,7 +272,7 @@ class WC_Install {
 	 *
 	 * @var string
 	 */
-	const INITIAL_INSTALL_VERSION_OPTION = 'woocommerce_initial_install_version';
+	const INITIAL_INSTALLED_VERSION = 'woocommerce_initial_installed_version';
 
 	/**
 	 * Option name used to uniquely identify installations of WooCommerce.
@@ -324,7 +324,7 @@ class WC_Install {
 			 *
 			 * @since 9.2.0
 			 */
-			add_option( self::INITIAL_INSTALL_VERSION_OPTION, WC()->version );
+			add_option( self::INITIAL_INSTALLED_VERSION, WC()->version, '', false );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -318,7 +318,7 @@ class WC_Install {
 			do_action_deprecated( 'woocommerce_admin_newly_installed', array(), '6.5.0', 'woocommerce_newly_installed' );
 
 			update_option( self::NEWLY_INSTALLED_OPTION, 'no' );
-			update_option( self::INITIAL_INSTALL_VERSION_OPTION, WC()->version );
+			add_option( self::INITIAL_INSTALL_VERSION_OPTION, WC()->version );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -268,6 +268,13 @@ class WC_Install {
 	const NEWLY_INSTALLED_OPTION = 'woocommerce_newly_installed';
 
 	/**
+	 * Option name used to track new installation versions of WooCommerce.
+	 *
+	 * @var string
+	 */
+	const INITIAL_INSTALL_VERSION_OPTION = 'woocommerce_initial_install_version';
+
+	/**
 	 * Option name used to uniquely identify installations of WooCommerce.
 	 *
 	 * @var string
@@ -311,6 +318,7 @@ class WC_Install {
 			do_action_deprecated( 'woocommerce_admin_newly_installed', array(), '6.5.0', 'woocommerce_newly_installed' );
 
 			update_option( self::NEWLY_INSTALLED_OPTION, 'no' );
+			update_option( self::INITIAL_INSTALL_VERSION_OPTION, WC()->version );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -318,6 +318,12 @@ class WC_Install {
 			do_action_deprecated( 'woocommerce_admin_newly_installed', array(), '6.5.0', 'woocommerce_newly_installed' );
 
 			update_option( self::NEWLY_INSTALLED_OPTION, 'no' );
+
+			/**
+			 * This option is used to track the initial version of WooCommerce that was installed.
+			 *
+			 * @since 9.2.0
+			 */
 			add_option( self::INITIAL_INSTALL_VERSION_OPTION, WC()->version );
 		}
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -187,6 +187,7 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 
 		$this->assertTrue( 1 === did_action( 'woocommerce_newly_installed' ) );
 		$this->assertEquals( get_option( WC_Install::NEWLY_INSTALLED_OPTION ), 'no' );
+		$this->assetEquals( get_option( WC_Install::NEWLY_INSTALLED_OPTION ), WC()->version );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -13,6 +13,19 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	const VERSION_OPTION = 'woocommerce_admin_version';
 
 	/**
+	 * @var null|string Initial installed version number.
+	 */
+	protected static $initial_installed_version_number = null;
+
+	/**
+	 * Setup
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::$initial_installed_version_number = WC()->version;
+	}
+
+	/**
 	 * Integration test for database table creation.
 	 *
 	 * @group database
@@ -187,7 +200,7 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 
 		$this->assertTrue( 1 === did_action( 'woocommerce_newly_installed' ) );
 		$this->assertEquals( get_option( WC_Install::NEWLY_INSTALLED_OPTION ), 'no' );
-		$this->assetEquals( get_option( WC_Install::NEWLY_INSTALLED_OPTION ), WC()->version );
+		$this->assertEquals( get_option( WC_Install::INITIAL_INSTALLED_VERSION ), self::$initial_installed_version_number );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is inspired by a problem encountered with WooCommerce's hooked blocks. Where we need to manage the insertion of hooked blocks in WooCommerce for both new and existing sites:

1. New sites: Automatically insert all current hooked blocks.
2. Existing sites: Don't insert any new hooked blocks.
3. Future updates: Only insert hooked blocks that were available at the time of the site's installation.

A potential solution is to assign version numbers to each hooked block. This would allow us to insert only the blocks that match the site's installation version, ensuring consistency across updates.

Similar logic may want to be used in other features and projects. That's because we introduce changes based on WooCommerce updates (ie. when the version increases), not based on installation dates or timestamps.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce on a fresh site and look up `woocommerce_initial_installed_version ` in the `wp_options` table for the installed version.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
