### PR TITLE
Updated ignored jobs list for evaluation script

### DIFF
--- a/.github/workflows/scripts/evaluate-jobs-conclusions.js
+++ b/.github/workflows/scripts/evaluate-jobs-conclusions.js
@@ -3,7 +3,7 @@ const { REPOSITORY, RUN_ID, GITHUB_TOKEN, TEST_MODE } = process.env;
 const IGNORED_JOBS = [
 	/Evaluate Project Job Statuses/,
 	/Report results on Slack/,
-	/Publish reports/,
+	/Test reports/,
 	/Create issues for flaky tests/,
 ];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`Test reports` CI jobs have been renamed and were not included in the ignored jobs list of the evaluation scripts. This was making failing reporting jobs block PR merge when they shouldn't

### How to test the changes in this Pull Request:

Check CI. It should pass.