### PR TITLE
Remove the matrix.testEnv condition from the build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           pull-playwright-cache: ${{ matrix.testEnv.shouldCreate && matrix.testType == 'e2e' }}
 
       - uses: './.github/actions/setup-woocommerce-monorepo'
-        if: ${{ github.ref_type != 'tag' &&  matrix.testEnv.shouldCreate }}
+        if: ${{ github.ref_type != 'tag' }}
         name: 'Build project'
         id: 'build-project'
         with:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

#49017 introduced the matrix.testEnv.should created in the build step run condition. However,  some of the JS tests for packages require a build and do not create an environment.

### How to test the changes in this Pull Request:

CI green.
