### PR TITLE
Open corresponding page when previewing WooCommerce block templates

### DIFF
--- a/plugins/woocommerce/changelog/fix-47877-redirect-to-shop-page
+++ b/plugins/woocommerce/changelog/fix-47877-redirect-to-shop-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Site Editor: redirect to corresponding page when previewing WooCommerce template.

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -510,6 +510,12 @@ class BlockTemplatesController {
 			return;
 		}
 
+
+		if ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-view-template' ) ) {
+			return;
+		}
+
+
 		$referer = wp_parse_url( wp_get_referer() );
 
 		if (
@@ -538,7 +544,8 @@ class BlockTemplatesController {
 		$page_url = $this->get_woocommerce_page_by_template_slug( $template_slug );
 
 		if ( $page_url ) {
-			wp_safe_redirect( $page_url );
+
+			wp_safe_redirect( wp_nonce_url( $page_url, 'woocommerce-preview-block-template' ) );
 			exit;
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -510,12 +510,6 @@ class BlockTemplatesController {
 			return;
 		}
 
-
-		if ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-view-template' ) ) {
-			return;
-		}
-
-
 		$referer = wp_parse_url( wp_get_referer() );
 
 		if (
@@ -544,8 +538,7 @@ class BlockTemplatesController {
 		$page_url = $this->get_woocommerce_page_by_template_slug( $template_slug );
 
 		if ( $page_url ) {
-
-			wp_safe_redirect( wp_nonce_url( $page_url, 'woocommerce-preview-block-template' ) );
+			wp_safe_redirect( $page_url );
 			exit;
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -524,6 +524,10 @@ class BlockTemplatesController {
 
 		wp_parse_str( $referer['query'], $query );
 
+		if ( empty( $query['postId'] ) || empty( $query['postType'] ) ) {
+			return;
+		}
+
 		$query = wp_parse_args( $query, array(
 			'postId'   => '',
 			'postType' => '',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47877.

This PR add a workaround to redirect admins to correct page when previewing WooCommerce template from Site Editor.

Currently, when click on the View Site button, the home page is always open regardless of current template. That link is fixed to home URL and can't be filtered/extended by themes/plugins. This PR doesn't modify that link, but redirect the admins based on the template information in the URL obtained from the referrer.

Currently, only three static templates is supported (Product Catalog, Cart, and Checkout). But we can add support to the dynamic ones like product category too.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the Product Catalog at Appearance > Site Editor > Templates > Product Catalog.
2. Click on the View site button in the header > preview dropdown.
3. See the Shop page is opened.
4. Repeat the steps above for Cart and Checkout pages.
5. Note for Checkout page, if there is no product added to the cart, users will be redirected one more time to the cart page.
6. Ensure there is no redirect loop.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
