### PR TITLE
CYS: fix: Assembler follows admin color schema

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/iframe.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/iframe.jsx
@@ -39,6 +39,8 @@ function Iframe( {
 } ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
 
+	const [ bodyClasses, setBodyClasses ] = useState( [] );
+
 	const { resolvedAssets } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 
@@ -53,6 +55,28 @@ function Iframe( {
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
 			setIframeDocument( node.contentDocument );
+		};
+		function onLoad() {
+			const { contentDocument, ownerDocument } = node;
+			const { documentElement } = contentDocument;
+
+			documentElement.classList.add( 'block-editor-iframe__html' );
+
+			setBodyClasses(
+				Array.from( ownerDocument?.body.classList ).filter(
+					( name ) =>
+						name.startsWith( 'admin-color-' ) ||
+						name.startsWith( 'post-type-' ) ||
+						name === 'wp-embed-responsive'
+				)
+			);
+		}
+
+		node.addEventListener( 'load', onLoad );
+
+		return () => {
+			delete node._load;
+			node.removeEventListener( 'load', onLoad );
 		};
 	}, [] );
 
@@ -125,7 +149,8 @@ function Iframe( {
 							ref={ bodyRef }
 							className={ clsx(
 								'block-editor-iframe__body',
-								'editor-styles-wrapper'
+								'editor-styles-wrapper',
+								...bodyClasses
 							) }
 						>
 							{ contentResizeListener }

--- a/plugins/woocommerce/changelog/49159-fix-match-admin-color-schema
+++ b/plugins/woocommerce/changelog/49159-fix-match-admin-color-schema
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS: fix: Assembler follows admin color schema.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR allows Assembler to follow admin color schema.

| Before | After |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce/assets/4463174/429576e1-4161-4fea-9149-68a16b98ee52)| ![image](https://github.com/woocommerce/woocommerce/assets/4463174/9dd82cd5-061d-4538-8e64-ca5c50c5a764)| 


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Visit `/wp-admin/profile.php`
7. Click on `Sunrise`.
8. Save.
10. Head over to WooCommerce > Home > Customize your store.
11. Click Desing your Homepage.
12.  Hover the first pattern in the Site Preview.
13. Compare the border color with the Site Editor one. Ensure that they are equal.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: fix: Assembler follows admin color schema.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
