### PR TITLE
Prevent product editor styles loading on non wc-admin pages

### DIFF
--- a/packages/js/product-editor/changelog/49170-fix-49169
+++ b/packages/js/product-editor/changelog/49170-fix-49169
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent product editor styles loading on non wc-admin pages

--- a/packages/js/product-editor/src/components/editor/style.scss
+++ b/packages/js/product-editor/src/components/editor/style.scss
@@ -1,1 +1,4 @@
-@import '@wordpress/interface/src/style.scss';
+@import "@wordpress/interface/src/components/complementary-area-header/style.scss";
+@import "@wordpress/interface/src/components/complementary-area/style.scss";
+@import "@wordpress/interface/src/components/interface-skeleton/style.scss";
+@import "@wordpress/interface/src/components/pinned-items/style.scss";

--- a/plugins/woocommerce/changelog/49170-fix-49169
+++ b/plugins/woocommerce/changelog/49170-fix-49169
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent product editor styles loading on non wc-admin pages

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -116,9 +116,10 @@ class Init {
 	 * Enqueue styles needed for the rich text editor.
 	 */
 	public function enqueue_styles() {
-		if ( ! PageController::is_admin_or_embed_page() ) {
+		if ( ! PageController::is_admin_page() ) {
 			return;
 		}
+		wp_enqueue_style( 'wc-product-editor' );
 		wp_enqueue_style( 'wp-edit-blocks' );
 		wp_enqueue_style( 'wp-format-library' );
 		wp_enqueue_editor();
@@ -134,7 +135,7 @@ class Init {
 	 * Dequeue conflicting styles.
 	 */
 	public function dequeue_conflicting_styles() {
-		if ( ! PageController::is_admin_or_embed_page() ) {
+		if ( ! PageController::is_admin_page() ) {
 			return;
 		}
 		// Dequeing this to avoid conflicts, until we remove the 'woocommerce-page' class.

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -373,7 +373,7 @@ class WCAdminAssets {
 			),
 			array(
 				'handle'       => WC_ADMIN_APP,
-				'dependencies' => array( 'wc-components', 'wc-admin-layout', 'wc-customer-effort-score', 'wc-product-editor', 'wp-components', 'wc-experimental' ),
+				'dependencies' => array( 'wc-components', 'wc-admin-layout', 'wc-customer-effort-score', 'wp-components', 'wc-experimental' ),
 			),
 			array(
 				'handle' => 'wc-onboarding',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR prevents product editor styles from loading on embed pages and also removes fullscreen styles that were being loaded by the interface skeleton package.  Need someone from @woocommerce/mothra to confirm that:

* We don't use product editor styles on embed pages
* Fullscreen is not an option in the product editor

Closes #49169 .

#### Before
<img width="1157" alt="Screenshot 2024-07-04 at 2 39 19 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/03742659-7d65-47eb-8f65-0688065f35fd">


#### After
<img width="1157" alt="Screenshot 2024-07-04 at 2 38 29 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/7e094d41-be7d-42e2-b96c-7b9edb9fbb67">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and build Gutenberg - https://github.com/WordPress/gutenberg/
2. Navigate to any Woo page
3. Notice the admin and menu bar appear on every page, including the product editor
4. Navigate to the product editor from other WC Admin pages and verify the editor styles are still loaded correctly

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Prevent product editor styles loading on non wc-admin pages

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
