### PR TITLE
BlockTemplatesController: move all hooks into methods instead of being inline

### DIFF
--- a/plugins/woocommerce/changelog/update-BlockTemplatesController-inline-methods
+++ b/plugins/woocommerce/changelog/update-BlockTemplatesController-inline-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: BlockTemplatesController: move all hooks into methods instead of being inline
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -28,71 +28,9 @@ class BlockTemplatesController {
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'taxonomy_template_hierarchy', array( $this, 'add_archive_product_to_eligible_for_fallback_templates' ), 10, 1 );
-
-		// By default, the Template Part Block only supports template parts that are in the current theme directory.
-		// This render_callback wrapper allows us to add support for plugin-housed template parts.
-		add_filter(
-			'block_type_metadata_settings',
-			function ( $settings, $metadata ) {
-				if (
-					isset( $metadata['name'], $settings['render_callback'] ) &&
-					'core/template-part' === $metadata['name'] &&
-					in_array( $settings['render_callback'], array( 'render_block_core_template_part', 'gutenberg_render_block_core_template_part' ), true )
-				) {
-					$settings['render_callback'] = array( $this, 'render_woocommerce_template_part' );
-				}
-				return $settings;
-			},
-			10,
-			2
-		);
-
-		// Prevents shortcodes in templates having their HTML content broken by wpautop.
-		// @see https://core.trac.wordpress.org/ticket/58366 for more info.
-		add_filter(
-			'block_type_metadata_settings',
-			function ( $settings, $metadata ) {
-				if (
-					isset( $metadata['name'], $settings['render_callback'] ) &&
-					'core/shortcode' === $metadata['name']
-				) {
-					$settings['original_render_callback'] = $settings['render_callback'];
-					$settings['render_callback']          = function ( $attributes, $content ) use ( $settings ) {
-						// The shortcode has already been rendered, so look for the cart/checkout HTML.
-						if ( strstr( $content, 'woocommerce-cart-form' ) || strstr( $content, 'wc-empty-cart-message' ) || strstr( $content, 'woocommerce-checkout-form' ) ) {
-							// Return early before wpautop runs again.
-							return $content;
-						}
-
-						$render_callback = $settings['original_render_callback'];
-
-						return $render_callback( $attributes, $content );
-					};
-				}
-				return $settings;
-			},
-			10,
-			2
-		);
-
-		// Prevents the pages that are assigned as cart/checkout from showing the "template" selector in the page-editor.
-		// We want to avoid this flow and point users towards the site editor instead.
-		add_action(
-			'current_screen',
-			function () {
-				if ( ! is_admin() ) {
-					return;
-				}
-
-				$current_screen = get_current_screen();
-
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				if ( $current_screen && 'page' === $current_screen->id && ! empty( $_GET['post'] ) && in_array( absint( $_GET['post'] ), array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ) ), true ) ) {
-					wp_add_inline_style( 'wc-blocks-editor-style', '.edit-post-post-template { display: none; }' );
-				}
-			},
-			10
-		);
+		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
+		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
+		add_action( 'current_screen', array( $this, 'hide_template_selector_in_cart_checkout_pages' ), 10 );
 	}
 
 	/**
@@ -206,6 +144,73 @@ class BlockTemplatesController {
 		}
 
 		return $template_hierarchy;
+	}
+
+	/**
+	 * By default, the Template Part Block only supports template parts that are in the current theme directory.
+	 * This render_callback wrapper allows us to add support for plugin-housed template parts.
+	 *
+	 * @param array $settings Array of determined settings for registering a block type.
+	 * @param array $metadata     Metadata provided for registering a block type.
+	 */
+	public function add_plugin_templates_parts_support( $settings, $metadata ) {
+		if (
+			isset( $metadata['name'], $settings['render_callback'] ) &&
+			'core/template-part' === $metadata['name'] &&
+			in_array( $settings['render_callback'], array( 'render_block_core_template_part', 'gutenberg_render_block_core_template_part' ), true )
+		) {
+			$settings['render_callback'] = array( $this, 'render_woocommerce_template_part' );
+		}
+		return $settings;
+	}
+
+
+	/**
+	 * Prevents shortcodes in templates having their HTML content broken by wpautop.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/58366 for more info.
+	 *
+	 * @param array $settings Array of determined settings for registering a block type.
+	 * @param array $metadata     Metadata provided for registering a block type.
+	 */
+	public function prevent_shortcodes_html_breakage( $settings, $metadata ) {
+		if (
+				isset( $metadata['name'], $settings['render_callback'] ) &&
+				'core/shortcode' === $metadata['name']
+			) {
+			$settings['original_render_callback'] = $settings['render_callback'];
+			$settings['render_callback']          = function ( $attributes, $content ) use ( $settings ) {
+				// The shortcode has already been rendered, so look for the cart/checkout HTML.
+				if ( strstr( $content, 'woocommerce-cart-form' ) || strstr( $content, 'wc-empty-cart-message' ) || strstr( $content, 'woocommerce-checkout-form' ) ) {
+					// Return early before wpautop runs again.
+					return $content;
+				}
+
+				$render_callback = $settings['original_render_callback'];
+
+				return $render_callback( $attributes, $content );
+			};
+		}
+		return $settings;
+	}
+
+	/**
+	 * Prevents the pages that are assigned as Cart/Checkout from showing the "template" selector in the page-editor.
+	 * We want to avoid this flow and point users towards the Site Editor instead.
+	 *
+	 * @return void
+	 */
+	public function hide_template_selector_in_cart_checkout_pages() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$current_screen = get_current_screen();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $current_screen && 'page' === $current_screen->id && ! empty( $_GET['post'] ) && in_array( absint( $_GET['post'] ), array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ) ), true ) ) {
+			wp_add_inline_style( 'wc-blocks-editor-style', '.edit-post-post-template { display: none; }' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Based on this comment: https://github.com/woocommerce/woocommerce/pull/48905#discussion_r1658637599, we would like to move all filters/actions in `BlockTemplatesController` to their own methods, instead of being inline, to keep it consistent within the same class.

### How to test the changes in this Pull Request:

This PR doesn't change any functionality, so testing is about making sure there are no regressions:

1. In the admin, go to Appearance > Editor > Templates > Page: Checkout and verify the Checkout header is rendered correctly.
2. Go to the Checkout page in the frontend and verify the Checkout header is also rendered there.
3. ~In the admin, go to Pages > Cart and verify there is no template selector in the _Page_ sidebar. Check the same for the Checkout page.~ (This is currently broken in `trunk`, I opened an issue here: https://github.com/woocommerce/woocommerce/issues/49190)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
