### PR TITLE
Monorepo: tweak CodeSniffer rules conflicting with strict types declaration requirements

### DIFF
--- a/plugins/woocommerce/changelog/fix-codesniffer-tweaks-conflicting-rules
+++ b/plugins/woocommerce/changelog/fix-codesniffer-tweaks-conflicting-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updated CodeSniffer configuration to address conflicting rules.

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -112,6 +112,7 @@
 	</rule>
 
 	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
+		<exclude-pattern>includes/</exclude-pattern>
 		<exclude-pattern>src/</exclude-pattern>
 		<exclude-pattern>tests/php/</exclude-pattern>
 		<exclude-pattern>patterns</exclude-pattern>
@@ -119,16 +120,8 @@
 	<rule ref="Squiz.Commenting.FileComment.SpacingAfterComment">
 		<exclude-pattern>patterns</exclude-pattern>
 	</rule>
-	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<exclude-pattern>src/</exclude-pattern>
-		<exclude-pattern>tests/php/</exclude-pattern>
-	</rule>
 
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
-		<exclude-pattern>tests/php/</exclude-pattern>
-	</rule>
-
-	<rule ref="Squiz.Commenting.FileComment.Missing">
 		<exclude-pattern>tests/php/</exclude-pattern>
 	</rule>
 

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -112,13 +112,17 @@
 	</rule>
 
 	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
-		<exclude-pattern>includes/</exclude-pattern>
 		<exclude-pattern>src/</exclude-pattern>
 		<exclude-pattern>tests/php/</exclude-pattern>
 		<exclude-pattern>patterns</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment.SpacingAfterComment">
 		<exclude-pattern>patterns</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>includes/</exclude-pattern>
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/php/</exclude-pattern>
 	</rule>
 
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Disables `Squiz.Commenting.FileComment.Missing` rule for `includes` directory, due to conflict with strict declaration directive checks (p1720169993151589-slack-C03CPM3UXDJ).