### PR TITLE
Enable Classic Template tests in the frontend and the Product Attribute template

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -28,13 +28,11 @@ const templates = [
 		slug: 'single-product',
 		path: '/product/single/',
 	},
-	// This test is disabled because archives are disabled for attributes by
-	// default. This can be uncommented when this is toggled on.
-	//{
-	//	title: 'Product Attribute',
-	//	slug: 'taxonomy-product_attribute',
-	//	path: '/product-attribute/color/',
-	//},
+	{
+		title: 'Product Attribute',
+		slug: 'taxonomy-product_attribute',
+		path: '/product-attribute/color/',
+	},
 	{
 		title: 'Product Category',
 		slug: 'taxonomy-product_cat',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -26,17 +26,17 @@ const templates = [
 	{
 		title: 'Single Product',
 		slug: 'single-product',
-		path: '/product/single/',
+		path: '/product/hoodie',
 	},
 	{
 		title: 'Product Attribute',
 		slug: 'taxonomy-product_attribute',
-		path: '/product-attribute/color/',
+		path: '/color/blue',
 	},
 	{
 		title: 'Product Category',
 		slug: 'taxonomy-product_cat',
-		path: '/product-category/music/',
+		path: '/product-category/clothing',
 	},
 	{
 		title: 'Product Tag',
@@ -51,7 +51,7 @@ const templates = [
 	{
 		title: 'Product Search Results',
 		slug: 'product-search-results',
-		path: '/?s=s&post_type=product',
+		path: '/?s=shirt&post_type=product',
 	},
 ];
 
@@ -279,6 +279,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		test( `is rendered on ${ template.title } template`, async ( {
 			admin,
 			editor,
+			page,
 		} ) => {
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//${ template.slug }`,
@@ -291,38 +292,10 @@ test.describe( `${ blockData.name } Block `, () => {
 			);
 
 			await expect( block ).toBeVisible();
-		} );
-
-		// These tests consistently fail due to the default content of the
-		// page--potentially the classic block is not being used after
-		// another test runs. Reenable this when we have a solution for
-		// this.
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip( `is rendered on ${ template.title } template - frontend side`, async ( {
-			admin,
-			editor,
-			page,
-		} ) => {
-			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ template.slug }`,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
-
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Hello World' },
-			} );
-
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
 
 			await page.goto( template.path );
 
-			await expect(
-				page.getByText( 'Hello World' ).first()
-			).toBeVisible();
+			await expect( page.locator( 'div[data-template]' ) ).toBeVisible();
 		} );
 	}
 } );

--- a/plugins/woocommerce/changelog/fix-classic-template-tests-product-attribute-template
+++ b/plugins/woocommerce/changelog/fix-classic-template-tests-product-attribute-template
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Enable Classic Template tests in the frontend and the Product Attribute template
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes two changes:

1. Re-enables the Classic Template block tests in the Product Attribute template. Product Attribute archives are now enabled by default, so there is no reason to keep them disabled.
2. Replaces the test that was testing the block rendered in the frontend with a check inside the same test that checked the editor. I don't think they need to be two separate tests for each template.

### How to test the changes in this Pull Request:

1. Verify e2e tests are passing and make sure code changes make sense.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
