### PR TITLE
[e2e tests] Add Allure reporter to Blocks e2e tests

### DIFF
--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -194,6 +194,7 @@
 		"@wordpress/prettier-config": "1.4.0",
 		"@wordpress/scripts": "24.6.0",
 		"@wordpress/stylelint-config": "^21.36.0",
+		"allure-playwright": "^2.9.2",
 		"autoprefixer": "10.4.14",
 		"axios": "0.27.2",
 		"babel-jest": "^29.7.0",

--- a/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
@@ -23,7 +23,17 @@ const config: PlaywrightTestConfig = {
 	// Don't report slow test "files", as we're running our tests in serial.
 	reportSlowTests: null,
 	reporter: process.env.CI
-		? [ [ 'github' ], [ 'list' ], [ './flaky-tests-reporter.ts' ] ]
+		? [
+				[ 'github' ],
+				[ 'list' ],
+				[ './flaky-tests-reporter.ts' ],
+				[
+					'allure-playwright',
+					{
+						outputFolder: `${ __dirname }/artifacts/test-results/allure-results`,
+					},
+				],
+		  ]
 		: 'list',
 	use: {
 		baseURL: BASE_URL,

--- a/plugins/woocommerce/changelog/e2e-add-allure-to-blocks-e2e
+++ b/plugins/woocommerce/changelog/e2e-add-allure-to-blocks-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add Allure to Blocks e2e tests

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -605,7 +605,8 @@
 					],
 					"report": {
 						"resultsBlobName": "blocks-e2e-report",
-						"resultsPath": "../woocommerce-blocks/tests/e2e/artifacts/test-results"
+						"resultsPath": "../woocommerce-blocks/tests/e2e/artifacts/test-results",
+						"allure": true
 					}
 				},
 				{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4260,6 +4260,9 @@ importers:
       '@wordpress/stylelint-config':
         specifier: ^21.36.0
         version: 21.36.0(postcss@8.4.32)(stylelint@14.16.1)
+      allure-playwright:
+        specifier: ^2.9.2
+        version: 2.9.2
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.32)
@@ -21630,7 +21633,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      react: 18.2.0
+      react: ^17.0.2
 
   react-number-format@4.9.3:
     resolution: {integrity: sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some context: p1719928788444249-slack-C03CPM3UXDJ

Add Allure report for Blocks e2e tests and include the reports in the tests reports [dashboard](https://woocommerce.github.io/woocommerce-test-reports).
The allure reporter was only configured to run in CI.

### How to test the changes in this Pull Request:

Check CI for this PR:
- should be green
- there should be a job named `Test reports - blocks-e2e-report` running successfully. 
- after the above job ran there should only be one artifact left named `blocks-e2e-report-attempt-n` 

Check the dashboard:
- there should be a report named `blocks-e2e-report` for this PR in the [list of PRs](https://woocommerce.github.io/woocommerce-test-reports/#/pr). You can also the [direct url to the PR reports](https://woocommerce.github.io/woocommerce-test-reports/#/pr/49228). 
- clicking the report name ([blocks-e2e-report](https://a8c-woo-test-reports.s3.amazonaws.com/reports/pull_request/49228/core-e2e-report/index.html)) will open the Allure report.

