### PR TITLE
CYS - Fix size of the "no logo" title to match the "logo" title size

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -342,6 +342,7 @@ body.woocommerce-assembler {
 		padding-top: 32px;
 		border-top: 1px solid var(--gutenberg-gray-700, #dcdcde);
 		color: var(--gutenberg-gray-900, #1e1e1e);
+		font-size: 11px;
 
 		p {
 			margin-top: 6px;

--- a/plugins/woocommerce/changelog/49231-fix-logo-title-font-size
+++ b/plugins/woocommerce/changelog/49231-fix-logo-title-font-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Fix the font size of the "DON'T HAVE A LOGO YET?" title.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the size of the `DON'T HAVE A LOGO YET?` title to 11px.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list and enable it.
5. Go to `WooCommerce > Home > Customize your store` and go to the assembler.
6. Click on `Add your logo`.
7. Check the `DON'T HAVE A LOGO YET?` title has a font size of 11px and it's the same size of the `LOGO` title above.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Fix the font size of the "DON'T HAVE A LOGO YET?" title.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
