### PR TITLE
CYS - Fix assembler styling issues

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/style.scss
@@ -29,6 +29,7 @@
 	}
 
 	.block-editor-block-patterns-list {
+		margin-top: 22px;
 		overflow-y: unset;
 		height: unset;
 	}

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -101,6 +101,7 @@ body.woocommerce-assembler {
 	.edit-site-layout__sidebar-region {
 		width: 380px;
 		z-index: 3;
+		background-color: #fafafa;
 	}
 
 	.edit-site-layout__sidebar {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -449,6 +449,8 @@ body.woocommerce-assembler {
 	.woocommerce-customize-store_sidebar-patterns-upgrade-notice {
 		color: #1e1e1e;
 		padding: 0 0 40px;
+		margin-top: 48px;
+		font-size: 11px;
 
 		h4 {
 			text-transform: uppercase;

--- a/plugins/woocommerce/changelog/49232-fix-css-issues-cys
+++ b/plugins/woocommerce/changelog/49232-fix-css-issues-cys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Fix CSS spacing issues in the assembler.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list and enable it.
5. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and uncheck `Allow usage of WooCommerce to be tracked`.
6. Go to `WooCommerce > Home > Customize your store` and go to the assembler.
7. On the assembler, click on `Design your homepage`.
8. Check the spacing between the section description and the list of patterns matches this:
<img width="363" alt="Screenshot 2024-07-08 at 14 46 51" src="https://github.com/woocommerce/woocommerce/assets/186112/dfda3ad5-be4e-4a3d-aae3-b9f012500332">

9. Check the `Want more patterns` title font size is 11px and the margin top matches this:
<img width="380" alt="Screenshot 2024-07-08 at 14 47 41" src="https://github.com/woocommerce/woocommerce/assets/186112/13983a01-9409-4f93-82df-daed3bc6aafd">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Fix CSS spacing issues in the assembler.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
