### PR TITLE
Do not run `BatchProcessingController`'s cleanup after a premature shutdown

### DIFF
--- a/plugins/woocommerce/changelog/fix-49229
+++ b/plugins/woocommerce/changelog/fix-49229
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent BatchProcessingController from cleaning up processors after a premature shutdown.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -537,7 +537,11 @@ class BatchProcessingController {
 			return;
 		}
 
-		if ( as_has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
+		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
+		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action') ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+
+		if ( call_user_func( $has_scheduled_action, self::WATCHDOG_ACTION_NAME ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -528,6 +528,15 @@ class BatchProcessingController {
 	 * @since 9.1.0
 	 */
 	private function remove_or_retry_failed_processors(): void {
+		if ( ! did_action( 'wp_loaded' ) ) {
+			return;
+		}
+
+		$last_error = error_get_last();
+		if ( ! is_null( $last_error ) && in_array( $last_error['type'], array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ), true ) ) {
+			return;
+		}
+
 		if ( as_has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
`BatchProcessingController` has a small routine hooked onto `shutdown` that attempts to re-schedule (or mark as failed) background processors that failed due to a fatal error or some abnormal circumstance.

That logic shouldn't be problematic, but the fact that we're running it during a `shutdown` means it's also executed when script execution has been halted (by an error or just an `exit/die` statement) **before** WooCommerce or even Action-Scheduler have been initialized. Given our reliance on A-S functions being available, this produces further fatal errors.

This PR makes sure we only run this function if WP has reached a stage where AS and WC should be available, and also if no fatal error is the source of the script being halted.

Closes #49229.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. (Optional) To confirm _when_ the cleanup routine is actually being executed, add the following to line 539 in `[...]/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php`:
   ```php
   error_log( 'Running BatchProcessingController cleanup routine...' );
   ```
1. Using a suitable location (such as a .php file in `wp-content/mu-plugins`) activate all 
of the following snippets. Make sure to comment out (as necessary) the other snippets. You should only have one active at a given time.

   ```php
   <?php
   // Snippet 1. Stops execution before A-S has been initialized. Should prevent the cleanup routine from running.
   add_action( 'plugins_loaded', 'wp_die', 0 );
   
   // Snippet 2. Stops execution before A-S has been initialized. Should prevent the cleanup routine from running.
   add_action( 'init', function() { as_has_scheduled_action( 'zzz' ); }, 0 );
   
   // Snippet 3. Stops execution after A-S has been initialized. Should not prevent the cleanup routine from running.
   add_action( 'wp_loaded', 'wp_die', 999 );
   
   // Snippet 4. Produces a fatal error. Should prevent the cleanup routine from running.
   add_action( 'wp_loaded', function() { 1 / 0; }, 999 );
   
   // Snippet 5. Produces a warning. Won't prevent the cleanup routine from running.
   add_action( 'wp_loaded', function() { $a = (object) array(); $a->x; }, 999 );
   ```
3. Make sure that no fatal errors are logged in relation to `BatchProcessingController` or A-S.
4. (Optional) Repeat the above on `trunk`, where any of the 3 first snippets will produce errors related to `BatchProcessingController`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
