### PR TITLE
Exclude simple products from variations reports by default

### DIFF
--- a/plugins/woocommerce/changelog/49244-fix-37940-remove-simple-products-from-variation-report
+++ b/plugins/woocommerce/changelog/49244-fix-37940-remove-simple-products-from-variation-report
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Prevent non-variation products from being included in variations reports by default.
+Exclude simple products from variations reports by default.

--- a/plugins/woocommerce/changelog/49244-fix-37940-remove-simple-products-from-variation-report
+++ b/plugins/woocommerce/changelog/49244-fix-37940-remove-simple-products-from-variation-report
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent non-variation products from being included in variations reports by default.

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
@@ -179,10 +179,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		if ( $included_variations ) {
 			$this->subquery->add_sql_clause( 'where', "AND {$order_product_lookup_table}.variation_id IN ({$included_variations})" );
-		} elseif ( ! $included_products ) {
-			if ( $this->should_exclude_simple_products( $query_args ) ) {
-				$this->subquery->add_sql_clause( 'where', "AND {$order_product_lookup_table}.variation_id != 0" );
-			}
+		} elseif ( $this->should_exclude_simple_products( $query_args ) ) {
+			$this->subquery->add_sql_clause( 'where', "AND {$order_product_lookup_table}.variation_id != 0" );
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-variations.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-variations.php
@@ -89,6 +89,37 @@ class WC_Admin_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test to confirm that simple products are excluded from the variations reports by default
+	 *
+	 * @since x.x.x
+	 */
+	public function test_simple_products_excluded_from_variations_reports_by_default() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$simple_product = WC_Helper_Product::create_simple_product();
+
+		$order = WC_Helper_Order::create_order( 1, $simple_product );
+		$order->set_status( 'completed' );
+		$order->set_total( 15 );
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'product_includes' => $simple_product->get_id(),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 0, count( $reports ) );
+	}
+
+	/**
 	 * Test getting reports with the `variations` param.
 	 *
 	 * @since 3.5.0

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-variations.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-variations.php
@@ -90,8 +90,6 @@ class WC_Admin_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Test to confirm that simple products are excluded from the variations reports by default
-	 *
-	 * @since x.x.x
 	 */
 	public function test_simple_products_excluded_from_variations_reports_by_default() {
 		wp_set_current_user( $this->user );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Prior to this PR, the variations reports may include simple products despite the [should_exclude_simple_products](https://github.com/woocommerce/woocommerce/blob/d6c80a501c4461287494dd662396c20e11301a4e/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php#L301) method returning `true`.

The where clause in the query that excludes simple products was conditionally added if the request did not include a list of supplied products. This PR removes that condition so that we exclude simple products by default.

Closes #37940

### How to test the changes in this Pull Request:

1. Don't check out this branch
2. Create a simple product and assign it to a new category `Variations Category`
3. Place an order for that product
4. Go to `Analytics > Variations` and add a filter for `Variations Category`
5. Confirm that the simple product appears in the product table at the bottom
6. Checkout `fix/37940-remove-simple-products-from-variation-report`
7. Clear the analytics cache
8. Go back to `Analytics > Variations` and add the filter again
9. Confirm the product is no longer included in the product table 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Exclude simple products from variations reports by default.

</details>
<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
