### PR TITLE
ensure DISABLE_HPOS logs valid value

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-hpos-log
+++ b/plugins/woocommerce/changelog/dev-e2e-hpos-log
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: ensure DISABLE_HPOS logs valid value
+
+

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -185,7 +185,7 @@ module.exports = async ( config ) => {
 	// (if a value for DISABLE_HPOS was set)
 	// This was always being set to 'yes' after login in wp-env so this step ensures the
 	// correct value is set before we begin our tests
-	console.log( `DISABLE_HPOS: ${ DISABLE_HPOS }` );
+	console.log( `DISABLE_HPOS: ${ DISABLE_HPOS || '0' }` );
 
 	const api = new wcApi( {
 		url: baseURL,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When running `pnpm test:e2e-pw` without specifying a value for `DISABLE_HPOS` the log output is

```
DISABLE_HPOS: undefined
```

This PR updates the message to log `0` when `DISABLE_HPOS` does not have a value.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. run `pnpm env:restart && pnpm test:e2e-pw`
2. Note the message is now `DISABLE_HPOS: 0`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
