### PR TITLE
Product Editor: Fix crash and issues with variations (that will cause problems with React 18)

### DIFF
--- a/packages/js/block-templates/changelog/fix-create-variations-crash-react-18
+++ b/packages/js/block-templates/changelog/fix-create-variations-crash-react-18
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only attempt to fetch layout template in useLayoutTemplate when layout template id is provided.

--- a/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
+++ b/packages/js/block-templates/src/hooks/use-layout-template/use-layout-template.ts
@@ -49,11 +49,11 @@ export const useLayoutTemplate = ( layoutTemplateId: string | null ) => {
 		// To prevent this, we pass `__invalid-template-id` as the ID when there is no layout template ID.
 		// A request will still be triggered, but it will return no results.
 		layoutTemplateId || '__invalid-template-id',
-		// Only perform the query if we have a layout template ID; otherwise, just return null.
+		// Only perform the query if the layout template entity is registered and we have a layout template ID; otherwise, just return null.
 		// Note: Until we are using @woocommerce/core-data 6.24.0 (Gutenberg 17.2),
 		// the REST API requests will still be triggered even when the query is disabled due to a regression.
 		// See: https://github.com/WordPress/gutenberg/pull/56108
-		{ enabled: isEntityRegistered }
+		{ enabled: isEntityRegistered && !! layoutTemplateId }
 	);
 
 	return { layoutTemplate, isResolving };

--- a/packages/js/product-editor/changelog/fix-create-variations-crash-react-18
+++ b/packages/js/product-editor/changelog/fix-create-variations-crash-react-18
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Addressed issues causing variations tab to crash when generating variations with React 18.

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -47,7 +47,7 @@ export function TabBlockEdit( {
 
 		const timeoutId = setTimeout( setCanRenderChildren, 300, true );
 		return () => clearTimeout( timeoutId );
-	}, [ context.selectedTab, id ] );
+	}, [ context.selectedTab, id, setAttributes ] );
 
 	return (
 		<div { ...blockProps }>

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import { createElement, useEffect, useState } from '@wordpress/element';
@@ -61,7 +62,20 @@ export function TabBlockEdit( {
 				role="tabpanel"
 				className={ classes }
 			>
-				<ErrorBoundary>
+				<ErrorBoundary
+					errorMessage={ __(
+						'An error occurred while loading this tab. Make sure any unsaved changes are saved and then try reloading the page to see if the error recurs.',
+						'woocommerce'
+					) }
+					onError={ ( error, errorInfo ) => {
+						// eslint-disable-next-line no-console
+						console.error(
+							`Error caught while loading tab '${ id }'`,
+							error,
+							errorInfo
+						);
+					} }
+				>
 					{ canRenderChildren && (
 						/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 						/* @ts-ignore Content only template locking does exist for this property. */

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -70,7 +70,7 @@ export function TabBlockEdit( {
 					onError={ ( error, errorInfo ) => {
 						// eslint-disable-next-line no-console
 						console.error(
-							`Error caught while loading tab '${ id }'`,
+							`Error caught in tab '${ id }'`,
 							error,
 							errorInfo
 						);

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import type { BlockAttributes } from '@wordpress/blocks';
 import { useWooBlockProps } from '@woocommerce/block-templates';
+import { __experimentalErrorBoundary as ErrorBoundary } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -60,11 +61,13 @@ export function TabBlockEdit( {
 				role="tabpanel"
 				className={ classes }
 			>
-				{ canRenderChildren && (
-					/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-					/* @ts-ignore Content only template locking does exist for this property. */
-					<InnerBlocks templateLock="contentOnly" />
-				) }
+				<ErrorBoundary>
+					{ canRenderChildren && (
+						/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+						/* @ts-ignore Content only template locking does exist for this property. */
+						<InnerBlocks templateLock="contentOnly" />
+					) }
+				</ErrorBoundary>
 			</div>
 		</div>
 	);

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -64,7 +64,7 @@ export function TabBlockEdit( {
 			>
 				<ErrorBoundary
 					errorMessage={ __(
-						'An error occurred while loading this tab. Make sure any unsaved changes are saved and then try reloading the page to see if the error recurs.',
+						'An unexpected error occurred in this tab. Make sure any unsaved changes are saved and then try reloading the page to see if the error recurs.',
 						'woocommerce'
 					) }
 					onError={ ( error, errorInfo ) => {

--- a/packages/js/product-editor/src/blocks/generic/tab/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/tab/editor.scss
@@ -4,7 +4,7 @@
 	}
 
 	.woocommerce-error-boundary {
-		margin-top: 64px;
+		margin-top: $gap-largest;
 	}
 }
 

--- a/packages/js/product-editor/src/blocks/generic/tab/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/tab/editor.scss
@@ -2,6 +2,10 @@
 	&:not(.is-selected) {
 		display: none;
 	}
+
+	.woocommerce-error-boundary {
+		margin-top: 64px;
+	}
 }
 
 // Remove the Gutenberg selected outline.

--- a/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.scss
+++ b/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.scss
@@ -7,7 +7,15 @@
 	}
 }
 
-.woocommerce-attribute-list-item {
+.woocommerce-list-item {
+	&.woocommerce-attribute-list-item {
+		&__actions {
+
+		}
+	}
+}
+
+.woocommerce-list-item.woocommerce-attribute-list-item {
 	display: grid;
 	background: none;
 	border: none;
@@ -15,7 +23,9 @@
 	grid-template-columns: 1fr 2fr 16 * $grid-unit;
 	min-height: 9 * $grid-unit;
 	padding: $grid-unit + $grid-unit-05 0;
+}
 
+.woocommerce-attribute-list-item {
 	&:not(:last-child) {
 		border-bottom: 1px solid $gray-200;
 	}

--- a/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.scss
+++ b/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.scss
@@ -7,14 +7,6 @@
 	}
 }
 
-.woocommerce-list-item {
-	&.woocommerce-attribute-list-item {
-		&__actions {
-
-		}
-	}
-}
-
 .woocommerce-list-item.woocommerce-attribute-list-item {
 	display: grid;
 	background: none;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is a follow up of #49058, which didn't actually fix the problem with the variations tab crashing when variations are generated with React 18.

This PR is a second attempt at fixing the crash. 

This PR is still using the React 17 compatibility mode (`render` vs `createRoot`) --  -- the switch to React 18 for WC Admin is in #48785. **_To run these changes in React 18 mode, see the draft PR #49216 that includes the changes from #48785._**

The change made to prevent the crash when generating variations is honestly more of a workaround than a proper fix. An `ErrorBoundary` was added to the tabs, and that suppresses the error (it is never shown because the tabs re-render before it does). I think that underlying issue causing the error will be addressed when #49014 is addressed.

Without this fix, in the general case of an error in the processing of the tabs (outside of a scenario where the tabs then re-render and correct themselves), the entire tab block (including the tab buttons in the header) are not shown, and the generic block error is shown:

<img width="1118" alt="Screenshot 2024-07-08 at 16 40 06" src="https://github.com/woocommerce/woocommerce/assets/2098816/81df6f1e-990b-4cd0-a59b-475fade5febf">

It also makes the following related changes:

- `useLayoutTemplate` is changed to only fetch layout template when an id is provided, preventing the following error from appearing in the dev console when generating variations:

```
Failed to load resource: the server responded with a status of 404 () https://[HOST]/wp-json/wc/v3/layout-templates/__invalid-template-id?_locale=user
```

- The variation options list styling was made more specific, to prevent the following issue when running with React 18:

<img width="1118" alt="Screenshot 2024-07-07 at 08 28 43" src="https://github.com/woocommerce/woocommerce/assets/2098816/6d932695-8143-4f9a-b239-91f573acc020">


Closes #48933.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. On the `Variations` tab, click `Add Options` and add some variation options.
3. Verify that the variations are added correctly and the selected tab remains `Variations` (note, the loading state showing is a known issue and will be addressed separately; see #49014)
4. Verify that no `Failed to load resource` error was logged in the browser dev console (see above)
5. Verify that the variation options list styling is correct (like below, not above)

<img width="1118" alt="Screenshot 2024-07-08 at 16 23 28" src="https://github.com/woocommerce/woocommerce/assets/2098816/ff700037-22e8-4c7d-a6e3-7f9872dbdf2d">

6. Install a [test version of the Gutenberg plugin](https://github.com/user-attachments/files/16160002/gutenberg.zip) that forces a crash in the inner block processing of the product editor tabs (don't use this test version of the Gutenberg plugin for anything else... it has hardcoded errors!).
7. Go to **Products** > **Add New**
8. Verify that an error message is shown in each tab and that the tab buttons remain visible.

<img width="1118" alt="Screenshot 2024-07-08 at 16 30 52" src="https://github.com/woocommerce/woocommerce/assets/2098816/09a80ce8-1ff5-4fcb-a14d-b06830d09d5f">

_Note: This is just to verify that the `ErrorBoundary` put in place looks okay in case it actually ever is shown. It does *not* show when the error causing the crash when generating variations under React 18 happens, because the tabs re-render again before actually shown._


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
