### PR TITLE
CYS - Bring back footer and header borders on hover and selected patterns

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/style.scss
@@ -43,10 +43,9 @@
 		&.is-added {
 			.auto-block-preview__container,
 			.block-editor-block-preview__container {
-				// WIP: This is a temporary CSS. Replace red with the actual color.
 				box-shadow: 0 0 0 1.5px #fff,
-					0 0 0 3.5px var(--gutenberg-gray-900, #1e1e1e);
-				border-color: var(--gutenberg-gray-900, #1e1e1e);
+					0 0 0 3.5px var(--wp-admin-theme-color, #3858e9);
+				border-color: var(--wp-admin-theme-color);
 				border-radius: 4px;
 				&::after {
 					outline: none;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -495,7 +495,7 @@ body.woocommerce-assembler {
 			.auto-block-preview__container,
 			.block-editor-block-preview__container {
 				box-shadow: 0 0 0 1.5px #fff,
-				0 0 0 3.5px var(--wp-admin-theme-color, #3858e9);
+					0 0 0 3.5px var(--wp-admin-theme-color, #3858e9);
 				border-color: var(--wp-admin-theme-color);
 				border-radius: 4px;
 				&::after {
@@ -508,7 +508,7 @@ body.woocommerce-assembler {
 			.auto-block-preview__container,
 			.block-editor-block-preview__container {
 				box-shadow: 0 0 0 1.5px #fff,
-				0 0 0 3.5px var(--wp-admin-theme-color, #3858e9);
+					0 0 0 3.5px var(--wp-admin-theme-color, #3858e9);
 				border-color: var(--wp-admin-theme-color);
 				border-radius: 4px;
 				&::after {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -485,6 +485,38 @@ body.woocommerce-assembler {
 	}
 
 	/* Layout sidebar */
+	.block-editor-block-patterns-list__item {
+		.auto-block-preview__container,
+		.block-editor-block-preview__container {
+			border: none;
+		}
+
+		&.is-selected {
+			.auto-block-preview__container,
+			.block-editor-block-preview__container {
+				box-shadow: 0 0 0 1.5px #fff,
+				0 0 0 3.5px var(--gutenberg-gray-900, #1e1e1e);
+				border-color: var(--gutenberg-gray-900, #1e1e1e);
+				border-radius: 4px;
+				&::after {
+					outline: none;
+				}
+			}
+		}
+
+		&:hover {
+			.auto-block-preview__container,
+			.block-editor-block-preview__container {
+				box-shadow: 0 0 0 1.5px #fff,
+				0 0 0 3.5px var(--wp-admin-theme-color, #3858e9);
+				border-color: var(--wp-admin-theme-color);
+				border-radius: 4px;
+				&::after {
+					outline: none;
+				}
+			}
+		}
+	}
 
 	.block-editor-block-preview__content {
 		height: 100%;
@@ -505,6 +537,7 @@ body.woocommerce-assembler {
 
 		.block-editor-block-patterns-list {
 			width: 324px;
+			overflow-y: unset;
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -495,8 +495,8 @@ body.woocommerce-assembler {
 			.auto-block-preview__container,
 			.block-editor-block-preview__container {
 				box-shadow: 0 0 0 1.5px #fff,
-				0 0 0 3.5px var(--gutenberg-gray-900, #1e1e1e);
-				border-color: var(--gutenberg-gray-900, #1e1e1e);
+				0 0 0 3.5px var(--wp-admin-theme-color, #3858e9);
+				border-color: var(--wp-admin-theme-color);
 				border-radius: 4px;
 				&::after {
 					outline: none;

--- a/plugins/woocommerce/changelog/49299-fix-cys-header-footer-borders
+++ b/plugins/woocommerce/changelog/49299-fix-cys-header-footer-borders
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Add borders to footer and header patterns on the assembler.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a bug introduced in this PR https://github.com/woocommerce/woocommerce/pull/49206 where the border of header and footer patterns were removed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have the last version of Gutenberg enabled.
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list and enable it.
5. Head over to `WooCommerce > Home > Customize your store` and go to the assembler.
6. Click `Choose your header`.
7. Check when hovering headers are marked in a blue border and clicking on a different header marks it with the blue border.
8. Go back and do the same test on the `Choose your footer` section.
9. Go to `wp-admin/profile.php?wp_http_referer=%2Fwp-admin%2Fusers.php`, change the admin color scheme, and save.
10. Go to `wp-admin/admin.php?page=wc-admin&customizing=true&path=%2Fcustomize-store%2Fassembler-hub%2Fhomepage%2Fintro` and check the border color on patterns matches the color scheme.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Add borders to footer and header patterns on the assembler.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
