### PR TITLE
Ensure local state is not overwritten by server when using `extensionCartUpdate`

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -225,6 +225,9 @@ const CheckoutProcessor = () => {
 
 	// Redirect when checkout is complete and there is a redirect url.
 	useEffect( () => {
+		window.localStorage.removeItem(
+			'WOOCOMMERCE_CHECKOUT_IS_CUSTOMER_DATA_DIRTY'
+		);
 		if ( currentRedirectUrl.current ) {
 			window.location.href = currentRedirectUrl.current;
 		}

--- a/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
@@ -1,12 +1,8 @@
 /**
  * External dependencies
  */
-import { debounce, pick } from '@woocommerce/base-utils';
-import {
-	CartBillingAddress,
-	CartShippingAddress,
-	BillingAddressShippingAddress,
-} from '@woocommerce/types';
+import { debounce } from '@woocommerce/base-utils';
+import { CartBillingAddress, CartShippingAddress } from '@woocommerce/types';
 import { select, dispatch } from '@wordpress/data';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -134,25 +130,11 @@ const updateCustomerData = (): void => {
 		return;
 	}
 
-	// Find valid data from the list of dirtyProps and prepare to push to the server.
-	const customerDataToUpdate = {} as Partial< BillingAddressShippingAddress >;
-
-	if ( localState.dirtyProps.billingAddress.length ) {
-		customerDataToUpdate.billing_address = pick(
-			localState.customerData.billingAddress,
-			localState.dirtyProps.billingAddress
-		);
-	}
-
-	if ( localState.dirtyProps.shippingAddress.length ) {
-		customerDataToUpdate.shipping_address = pick(
-			localState.customerData.shippingAddress,
-			localState.dirtyProps.shippingAddress
-		);
-	}
-
 	dispatch( STORE_KEY )
-		.updateCustomerData( customerDataToUpdate )
+		.updateCustomerData( {
+			billing_address: localState.customerData.billingAddress,
+			shipping_address: localState.customerData.shippingAddress,
+		} )
 		.then( () => {
 			localState.dirtyProps.billingAddress = [];
 			localState.dirtyProps.shippingAddress = [];

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -66,9 +66,9 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 					},
 				},
 			};
-			setIsCustomerDataDirty(
-				getIsCustomerDataDirty() || billingAddressChanged
-			);
+			if ( billingAddressChanged ) {
+				setIsCustomerDataDirty( true );
+			}
 			break;
 		case types.SET_SHIPPING_ADDRESS:
 			const shippingAddressChanged = Object.keys(
@@ -89,9 +89,9 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 					},
 				},
 			};
-			setIsCustomerDataDirty(
-				getIsCustomerDataDirty() || shippingAddressChanged
-			);
+			if ( shippingAddressChanged ) {
+				setIsCustomerDataDirty( true );
+			}
 			break;
 
 		case types.REMOVING_COUPON:

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -9,7 +9,7 @@ import type { Reducer } from 'redux';
 import { ACTION_TYPES as types } from './action-types';
 import { defaultCartState, CartState } from './default-state';
 import { EMPTY_CART_ERRORS } from '../constants';
-import { getIsCustomerDataDirty, setIsCustomerDataDirty } from './utils';
+import { setIsCustomerDataDirty } from './utils';
 
 /**
  * Reducer for receiving items related to the cart.

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -58,12 +58,6 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 			} );
 			state = {
 				...state,
-				metaData: {
-					...state.metaData,
-					isCustomerDataDirty:
-						state.metaData.isCustomerDataDirty ||
-						billingAddressChanged,
-				},
 				cartData: {
 					...state.cartData,
 					billingAddress: {
@@ -87,9 +81,6 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 			} );
 			state = {
 				...state,
-				metaData: {
-					...state.metaData,
-				},
 				cartData: {
 					...state.cartData,
 					shippingAddress: {

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import type { Reducer } from 'redux';
-import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -59,7 +59,9 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 				...state,
 				metaData: {
 					...state.metaData,
-					isCustomerDataDirty: state.metaData.isCustomerDataDirty || billingAddressChanged,
+					isCustomerDataDirty:
+						state.metaData.isCustomerDataDirty ||
+						billingAddressChanged,
 				},
 				cartData: {
 					...state.cartData,

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -59,7 +59,7 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 				...state,
 				metaData: {
 					...state.metaData,
-					isCustomerDataDirty: billingAddressChanged,
+					isCustomerDataDirty: state.metaData.isCustomerDataDirty || billingAddressChanged,
 				},
 				cartData: {
 					...state.cartData,

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -48,14 +48,19 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 			}
 			break;
 		case types.SET_BILLING_ADDRESS:
+			const billingAddressChanged = Object.keys(
+				action.billingAddress
+			).some( ( key ) => {
+				return (
+					action.billingAddress[ key ] !==
+					state.cartData.billingAddress?.[ key ]
+				);
+			} );
 			state = {
 				...state,
 				metaData: {
 					...state.metaData,
-					isCustomerDataDirty: ! isShallowEqual(
-						action.billingAddress,
-						state.cartData.billingAddress
-					),
+					isCustomerDataDirty: billingAddressChanged,
 				},
 				cartData: {
 					...state.cartData,
@@ -67,14 +72,19 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 			};
 			break;
 		case types.SET_SHIPPING_ADDRESS:
+			const shippingAddressChanged = Object.keys(
+				action.shippingAddress
+			).some( ( key ) => {
+				return (
+					action.shippingAddress[ key ] !==
+					state.cartData.shippingAddress?.[ key ]
+				);
+			} );
 			state = {
 				...state,
 				metaData: {
 					...state.metaData,
-					isCustomerDataDirty: ! isShallowEqual(
-						action.shippingAddress,
-						state.cartData.shippingAddress
-					),
+					isCustomerDataDirty: shippingAddressChanged,
 				},
 				cartData: {
 					...state.cartData,

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -9,6 +9,7 @@ import type { Reducer } from 'redux';
 import { ACTION_TYPES as types } from './action-types';
 import { defaultCartState, CartState } from './default-state';
 import { EMPTY_CART_ERRORS } from '../constants';
+import { getIsCustomerDataDirty, setIsCustomerDataDirty } from './utils';
 
 /**
  * Reducer for receiving items related to the cart.
@@ -71,6 +72,9 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 					},
 				},
 			};
+			setIsCustomerDataDirty(
+				getIsCustomerDataDirty() || billingAddressChanged
+			);
 			break;
 		case types.SET_SHIPPING_ADDRESS:
 			const shippingAddressChanged = Object.keys(
@@ -85,7 +89,6 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 				...state,
 				metaData: {
 					...state.metaData,
-					isCustomerDataDirty: shippingAddressChanged,
 				},
 				cartData: {
 					...state.cartData,
@@ -95,6 +98,9 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 					},
 				},
 			};
+			setIsCustomerDataDirty(
+				getIsCustomerDataDirty() || shippingAddressChanged
+			);
 			break;
 
 		case types.REMOVING_COUPON:

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Reducer } from 'redux';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -49,6 +50,13 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 		case types.SET_BILLING_ADDRESS:
 			state = {
 				...state,
+				metaData: {
+					...state.metaData,
+					isCustomerDataDirty: ! isShallowEqual(
+						action.billingAddress,
+						state.cartData.billingAddress
+					),
+				},
 				cartData: {
 					...state.cartData,
 					billingAddress: {
@@ -61,6 +69,13 @@ const reducer: Reducer< CartState > = ( state = defaultCartState, action ) => {
 		case types.SET_SHIPPING_ADDRESS:
 			state = {
 				...state,
+				metaData: {
+					...state.metaData,
+					isCustomerDataDirty: ! isShallowEqual(
+						action.shippingAddress,
+						state.cartData.shippingAddress
+					),
+				},
 				cartData: {
 					...state.cartData,
 					shippingAddress: {

--- a/plugins/woocommerce-blocks/assets/js/data/cart/test/push-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/test/push-changes.ts
@@ -130,12 +130,30 @@ describe( 'pushChanges', () => {
 		// Push these changes to the server, the `updateCustomerData` mock is set to reject (in the original mock at the top of the file), to simulate a server error.
 		pushChanges( false );
 
-		// Check that the mock was called with only the updated data.
+		// Check that the mock was called with full address data.
 		await expect( updateCustomerDataMock ).toHaveBeenCalledWith( {
-			shipping_address: {
+			billingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
+				city: 'New York',
+				state: 'NY',
+				postcode: '10001',
+				country: 'US',
+				email: 'john.doe@mail.com',
+				phone: '555-555-5555',
+			},
+			shippingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
 				city: 'Houston',
 				state: 'TX',
 				postcode: 'ABCDEF',
+				country: 'US',
+				phone: '555-555-5555',
 			},
 		} );
 
@@ -177,10 +195,28 @@ describe( 'pushChanges', () => {
 		// to the server because the previous push failed when they were originally changed.
 		pushChanges( false );
 		await expect( updateCustomerDataMock ).toHaveBeenLastCalledWith( {
-			shipping_address: {
+			billingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
+				city: 'New York',
+				state: 'NY',
+				postcode: '10001',
+				country: 'US',
+				email: 'john.doe@mail.com',
+				phone: '555-555-5555',
+			},
+			shippingAddress: {
+				first_name: 'John',
+				last_name: 'Doe',
+				address_1: '123 Main St',
+				address_2: '',
 				city: 'Houston',
 				state: 'TX',
 				postcode: '77058',
+				country: 'US',
+				phone: '555-555-5555',
 			},
 		} );
 	} );

--- a/plugins/woocommerce-blocks/assets/js/data/cart/test/push-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/test/push-changes.ts
@@ -132,7 +132,7 @@ describe( 'pushChanges', () => {
 
 		// Check that the mock was called with full address data.
 		await expect( updateCustomerDataMock ).toHaveBeenCalledWith( {
-			billingAddress: {
+			billing_address: {
 				first_name: 'John',
 				last_name: 'Doe',
 				address_1: '123 Main St',
@@ -144,7 +144,7 @@ describe( 'pushChanges', () => {
 				email: 'john.doe@mail.com',
 				phone: '555-555-5555',
 			},
-			shippingAddress: {
+			shipping_address: {
 				first_name: 'John',
 				last_name: 'Doe',
 				address_1: '123 Main St',
@@ -195,7 +195,7 @@ describe( 'pushChanges', () => {
 		// to the server because the previous push failed when they were originally changed.
 		pushChanges( false );
 		await expect( updateCustomerDataMock ).toHaveBeenLastCalledWith( {
-			billingAddress: {
+			billing_address: {
 				first_name: 'John',
 				last_name: 'Doe',
 				address_1: '123 Main St',
@@ -207,7 +207,7 @@ describe( 'pushChanges', () => {
 				email: 'john.doe@mail.com',
 				phone: '555-555-5555',
 			},
-			shippingAddress: {
+			shipping_address: {
 				first_name: 'John',
 				last_name: 'Doe',
 				address_1: '123 Main St',

--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -92,7 +92,9 @@ export const applyExtensionCartUpdate =
 	( args: ExtensionCartUpdateArgs ) =>
 	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
-			const { response } = await apiFetchWithHeaders( {
+			const { response } = await apiFetchWithHeaders< {
+				response: CartResponse;
+			} >( {
 				path: '/wc/store/v1/cart/extensions',
 				method: 'POST',
 				data: { namespace: args.namespace, data: args.data },
@@ -115,7 +117,7 @@ export const applyExtensionCartUpdate =
 			}
 			dispatch.receiveCart( response );
 		} catch ( error ) {
-			dispatch.receiveError( error );
+			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
 			return Promise.reject( error );
 		}
 	};
@@ -390,7 +392,9 @@ export const updateCustomerData =
 	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
 			dispatch.updatingCustomerData( true );
-			const { response } = await apiFetchWithHeaders( {
+			const { response } = await apiFetchWithHeaders< {
+				response: CartResponse;
+			} >( {
 				path: '/wc/store/v1/cart/update-customer',
 				method: 'POST',
 				data: customerData,
@@ -404,7 +408,7 @@ export const updateCustomerData =
 			setIsCustomerDataDirty( false );
 			return response;
 		} catch ( error ) {
-			dispatch.receiveError( error );
+			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
 			setIsCustomerDataDirty( true );
 			return Promise.reject( error );
 		} finally {

--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -24,6 +24,7 @@ import { notifyQuantityChanges } from './notify-quantity-changes';
 import { notifyCartErrors } from './notify-errors';
 import { CartDispatchFromMap, CartSelectFromMap } from './index';
 import { apiFetchWithHeaders } from '../shared-controls';
+import { getIsCustomerDataDirty, setIsCustomerDataDirty } from './utils';
 
 /**
  * A thunk used in updating the store with the cart items retrieved from a request. This also notifies the shopper
@@ -91,18 +92,30 @@ export const applyExtensionCartUpdate =
 	( args: ExtensionCartUpdateArgs ) =>
 	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
-			const { response } = await apiFetchWithHeaders< {
-				response: CartResponse;
-			} >( {
+			const { response } = await apiFetchWithHeaders( {
 				path: '/wc/store/v1/cart/extensions',
 				method: 'POST',
 				data: { namespace: args.namespace, data: args.data },
 				cache: 'no-store',
 			} );
+			if ( args.overwriteDirtyCustomerData === true ) {
+				dispatch.receiveCart( response );
+				return response;
+			}
+			if ( getIsCustomerDataDirty() ) {
+				// If the customer data is dirty, we don't want to overwrite it with the response.
+				// Remove shipping and billing address from the response and then receive the cart.
+				const {
+					shipping_address: _,
+					billing_address: __,
+					...responseWithoutShippingOrBilling
+				} = response;
+				dispatch.receiveCart( responseWithoutShippingOrBilling );
+				return response;
+			}
 			dispatch.receiveCart( response );
-			return response;
 		} catch ( error ) {
-			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
+			dispatch.receiveError( error );
 			return Promise.reject( error );
 		}
 	};
@@ -377,9 +390,7 @@ export const updateCustomerData =
 	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
 			dispatch.updatingCustomerData( true );
-			const { response } = await apiFetchWithHeaders< {
-				response: CartResponse;
-			} >( {
+			const { response } = await apiFetchWithHeaders( {
 				path: '/wc/store/v1/cart/update-customer',
 				method: 'POST',
 				data: customerData,
@@ -390,9 +401,11 @@ export const updateCustomerData =
 			} else {
 				dispatch.receiveCart( response );
 			}
+			setIsCustomerDataDirty( false );
 			return response;
 		} catch ( error ) {
-			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
+			dispatch.receiveError( error );
+			setIsCustomerDataDirty( true );
 			return Promise.reject( error );
 		} finally {
 			dispatch.updatingCustomerData( false );

--- a/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { select } from '@wordpress/data';
-import { camelCaseKeys } from '@woocommerce/base-utils';
+import { camelCaseKeys, debounce } from '@woocommerce/base-utils';
 import { isEmail } from '@wordpress/url';
 import {
 	CartBillingAddress,
@@ -131,9 +131,12 @@ export const getIsCustomerDataDirty = () => {
 /**
  * Sets a flag in localStorage to indicate whether the customer data has been modified.
  */
-export const setIsCustomerDataDirty = ( isCustomerDataDirty: boolean ) => {
-	window.localStorage.setItem(
-		'WOOCOMMERCE_CHECKOUT_IS_CUSTOMER_DATA_DIRTY',
-		isCustomerDataDirty ? 'true' : 'false'
-	);
-};
+export const setIsCustomerDataDirty = debounce(
+	( isCustomerDataDirty: boolean ) => {
+		window.localStorage.setItem(
+			'WOOCOMMERCE_CHECKOUT_IS_CUSTOMER_DATA_DIRTY',
+			isCustomerDataDirty ? 'true' : 'false'
+		);
+	},
+	300
+);

--- a/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
@@ -123,7 +123,7 @@ export const validateDirtyProps = ( dirtyProps: {
 export const getIsCustomerDataDirty = () => {
 	return (
 		window.localStorage.getItem(
-			'woocommerce_checkout_is_customer_data_dirty'
+			'WOOCOMMERCE_CHECKOUT_IS_CUSTOMER_DATA_DIRTY'
 		) === 'true'
 	);
 };
@@ -133,7 +133,7 @@ export const getIsCustomerDataDirty = () => {
  */
 export const setIsCustomerDataDirty = ( isCustomerDataDirty: boolean ) => {
 	window.localStorage.setItem(
-		'woocommerce_checkout_is_customer_data_dirty',
+		'WOOCOMMERCE_CHECKOUT_IS_CUSTOMER_DATA_DIRTY',
 		isCustomerDataDirty ? 'true' : 'false'
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
@@ -116,3 +116,24 @@ export const validateDirtyProps = ( dirtyProps: {
 
 	return invalidProps.length === 0;
 };
+
+/**
+ * Gets the localStorage flag to indicate whether the customer data is dirty.
+ */
+export const getIsCustomerDataDirty = () => {
+	return (
+		window.localStorage.getItem(
+			'woocommerce_checkout_is_customer_data_dirty'
+		) === 'true'
+	);
+};
+
+/**
+ * Sets a flag in localStorage to indicate whether the customer data has been modified.
+ */
+export const setIsCustomerDataDirty = ( isCustomerDataDirty: boolean ) => {
+	window.localStorage.setItem(
+		'woocommerce_checkout_is_customer_data_dirty',
+		isCustomerDataDirty ? 'true' : 'false'
+	);
+};

--- a/plugins/woocommerce-blocks/assets/js/types/type-defs/cart.ts
+++ b/plugins/woocommerce-blocks/assets/js/types/type-defs/cart.ts
@@ -211,6 +211,7 @@ export interface CartMeta {
 export interface ExtensionCartUpdateArgs {
 	data: Record< string, unknown >;
 	namespace: string;
+	overwriteDirtyCustomerData?: undefined | boolean;
 }
 
 export interface BillingAddressShippingAddress {

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/cart.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/cart.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD024 -->
 # Cart Store (`wc/store/cart`) <!-- omit in toc -->
 
 > 💡 What's the difference between the Cart Store and the Checkout Store?
@@ -372,7 +373,7 @@ This action is used to send POSTs request to the /cart/extensions endpoint with 
     -   _data_ `object`: The data to send to the endpoint with the following keys:
         -   _key_ `string`: The key of the extension.
         -   _value_ `string`: The value of the extension.
-	-   _overwriteDirtyCustomerData_ `boolean`: Whether to overwrite the customer data in the client with the data returned from the server, even if it is dirty (i.e. it hasn't been pushed to the server yet).
+    -   _overwriteDirtyCustomerData_ `boolean`: Whether to overwrite the customer data in the client with the data returned from the server, even if it is dirty (i.e. it hasn't been pushed to the server yet).
 
 
 #### _Example_ <!-- omit in toc -->

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/cart.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/cart.md
@@ -372,6 +372,7 @@ This action is used to send POSTs request to the /cart/extensions endpoint with 
     -   _data_ `object`: The data to send to the endpoint with the following keys:
         -   _key_ `string`: The key of the extension.
         -   _value_ `string`: The value of the extension.
+	-   _overwriteDirtyCustomerData_ `boolean`: Whether to overwrite the customer data in the client with the data returned from the server, even if it is dirty (i.e. it hasn't been pushed to the server yet).
 
 
 #### _Example_ <!-- omit in toc -->

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD024 -->
 # Updating the cart with the Store API <!-- omit in toc -->
 
 ## Table of Contents <!-- omit in toc -->

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD024 -->
 # Updating the cart with the Store API <!-- omit in toc -->
 
 ## Table of Contents <!-- omit in toc -->

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
@@ -123,10 +123,11 @@ If you try to register again, under the same namespace, the previously registere
 
 `extensionCartUpdate`: Used to signal that you want your registered callback to be executed, and to pass data to the callback. It takes an object as its only argument.
 
-| Attribute   | Type     | Required | Description                                                                                                                                                      |
-| ----------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `namespace` | `string` | Yes      | The namespace of your extension. This is used to determine which extension's callbacks should be executed.                                                       |
-| `data`      | `Object` | No       | The data you want to pass to your callback. Anything in the `data` key will be passed as the first (and only) argument to your callback as an associative array. |
+| Attribute   | Type      | Required | Description                                                                                                                                                      |
+| ----------- |-----------|----------| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `namespace` | `string`  | Yes      | The namespace of your extension. This is used to determine which extension's callbacks should be executed.                                                       |
+| `data`      | `Object`  | No       | The data you want to pass to your callback. Anything in the `data` key will be passed as the first (and only) argument to your callback as an associative array. |
+| `overwriteDirtyCustomerData`      | `boolean` | No       | Whether to overwrite the customer data in the client with the data returned from the server, even if it is dirty (i.e. it hasn't been pushed to the server yet). |
 
 ## Putting it all together
 

--- a/plugins/woocommerce-blocks/tests/e2e/plugins/extension-cart-update.php
+++ b/plugins/woocommerce-blocks/tests/e2e/plugins/extension-cart-update.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Blocks Test extensionCartUpdate
+ * Description: Adds an extensionCartUpdate endpoint.
+ * Plugin URI: https://github.com/woocommerce/woocommerce
+ * Author: WooCommerce
+ *
+ * @package woocommerce-blocks-test-extension-cart-update
+ */
+
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\StoreApi;
+
+add_action(
+	'woocommerce_init',
+	function () {
+		$extend = StoreApi::container()->get( ExtendSchema::class );
+		if (
+			is_callable(
+				array(
+					$extend,
+					'register_update_callback',
+				)
+			)
+		) {
+			$extend->register_update_callback(
+				array(
+					'namespace' => 'woocommerce-blocks-test-extension-cart-update',
+					'callback'  => function ( $data ) {},
+				)
+			);
+		}
+	}
+);

--- a/plugins/woocommerce-blocks/tests/e2e/plugins/extension-cart-update.php
+++ b/plugins/woocommerce-blocks/tests/e2e/plugins/extension-cart-update.php
@@ -26,7 +26,12 @@ add_action(
 			$extend->register_update_callback(
 				array(
 					'namespace' => 'woocommerce-blocks-test-extension-cart-update',
-					'callback'  => function ( $data ) {},
+					'callback'  => function ( $data ) {
+						if ( ! empty( $data['test-name-change'] ) ) {
+							WC()->cart->get_customer()->set_shipping_first_name( 'Mr. Test' );
+							WC()->cart->get_customer()->save();
+						}
+					},
 				)
 			);
 		}

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -82,11 +82,6 @@ test.describe( 'Shopper → Extensibility', () => {
 		} ) => {
 			await checkoutPageObject.fillInCheckoutWithTestData();
 			await checkoutPageObject.page.waitForFunction( () => {
-				console.log(
-					window.wp.data
-						.select( 'wc/store/cart' )
-						.isCustomerDataDirty()
-				);
 				return (
 					window.wp.data
 						.select( 'wc/store/cart' )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { expect, test as base, guestFile } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { REGULAR_PRICED_PRODUCT_NAME } from './constants';
+import { CheckoutPage } from './checkout.page';
+
+const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
+	checkoutPageObject: async ( { page }, use ) => {
+		const pageObject = new CheckoutPage( {
+			page,
+		} );
+		await use( pageObject );
+	},
+} );
+
+test.describe( 'Shopper → Account (guest user)', () => {
+	test.use( { storageState: guestFile } );
+
+	test.beforeEach( async ( { requestUtils, frontendUtils } ) => {
+		await requestUtils.rest( {
+			method: 'PUT',
+			path: 'wc/v3/settings/account/woocommerce_enable_guest_checkout',
+			data: { value: 'yes' },
+		} );
+		await requestUtils.rest( {
+			method: 'PUT',
+			path: 'wc/v3/settings/account/woocommerce_enable_checkout_login_reminder',
+			data: { value: 'yes' },
+		} );
+		await requestUtils.activatePlugin(
+			'woocommerce-blocks-test-extensioncartupdate'
+		);
+
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+		await frontendUtils.goToCheckout();
+	} );
+
+	test( 'Shopper can use extensionCartUpdate without the unpushed data being overwritten', async ( {
+		checkoutPageObject,
+	} ) => {
+		await checkoutPageObject.page
+			.getByLabel( 'Country/Region' )
+			.fill( 'United Kingdom (UK)' );
+		await checkoutPageObject.page.getByLabel( 'Country/Region' ).blur();
+
+		await checkoutPageObject.page.evaluate(
+			"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update' } )"
+		);
+		await expect(
+			checkoutPageObject.page.getByLabel( 'Country/Region' )
+		).toHaveValue( 'United Kingdom (UK)' );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -77,5 +77,28 @@ test.describe( 'Shopper → Extensibility', () => {
 				checkoutPageObject.page.getByLabel( 'Country/Region' )
 			).toHaveValue( 'United States (US)' );
 		} );
+		test( 'Cart data can be modified by extensions', async ( {
+			checkoutPageObject,
+		} ) => {
+			await checkoutPageObject.fillInCheckoutWithTestData();
+			await checkoutPageObject.page.waitForFunction( () => {
+				console.log(
+					window.wp.data
+						.select( 'wc/store/cart' )
+						.isCustomerDataDirty()
+				);
+				return (
+					window.wp.data
+						.select( 'wc/store/cart' )
+						.isCustomerDataDirty() === false
+				);
+			} );
+			await checkoutPageObject.page.evaluate(
+				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', data: { 'test-name-change': true } } )"
+			);
+			await expect(
+				checkoutPageObject.page.getByLabel( 'First name' )
+			).toHaveValue( 'Mr. Test' );
+		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -67,15 +67,15 @@ test.describe( 'Shopper → Extensibility', () => {
 			// overwriteDirtyCustomerData: true so overwriting is possible, but since the address pushed it should not
 			// be overwritten.
 			await checkoutPageObject.fillInCheckoutWithTestData();
-			await checkoutPageObject.page
-				.getByLabel( 'Country/Region' )
-				.fill( 'United States (US)' );
+			await expect(
+				checkoutPageObject.page.getByLabel( 'Country/Region' )
+			).toHaveValue( 'United States (US)' );
 			await checkoutPageObject.page.evaluate(
 				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: true } )"
 			);
-			await checkoutPageObject.page
-				.getByLabel( 'Country/Region' )
-				.fill( 'United States (US)' );
+			await expect(
+				checkoutPageObject.page.getByLabel( 'Country/Region' )
+			).toHaveValue( 'United States (US)' );
 		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -84,7 +84,7 @@ test.describe( 'Shopper → Extensibility', () => {
 			await checkoutPageObject.page.waitForFunction( () => {
 				return (
 					window.localStorage.getItem(
-						'woocommerce_checkout_is_customer_data_dirty'
+						'WOOCOMMERCE_CHECKOUT_IS_CUSTOMER_DATA_DIRTY'
 					) === 'false'
 				);
 			} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -83,9 +83,9 @@ test.describe( 'Shopper → Extensibility', () => {
 			await checkoutPageObject.fillInCheckoutWithTestData();
 			await checkoutPageObject.page.waitForFunction( () => {
 				return (
-					window.wp.data
-						.select( 'wc/store/cart' )
-						.isCustomerDataDirty() === false
+					window.localStorage.getItem(
+						'woocommerce_checkout_is_customer_data_dirty'
+					) === 'false'
 				);
 			} );
 			await checkoutPageObject.page.evaluate(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -47,7 +47,7 @@ test.describe( 'Shopper → Extensibility', () => {
 			// First test by only partially filling in the address form.
 			await checkoutPageObject.page
 				.getByLabel( 'Country/Region' )
-				.fill( 'United Kingdom (UK)' );
+				.selectOption( 'United Kingdom (UK)' );
 			await checkoutPageObject.page.getByLabel( 'Country/Region' ).blur();
 
 			await checkoutPageObject.page.evaluate(
@@ -55,13 +55,13 @@ test.describe( 'Shopper → Extensibility', () => {
 			);
 			await expect(
 				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).toHaveValue( 'United Kingdom (UK)' );
+			).toHaveValue( 'GB' );
 			await checkoutPageObject.page.evaluate(
 				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: true } )"
 			);
 			await expect(
 				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).not.toHaveValue( 'United Kingdom (UK)' );
+			).not.toHaveValue( 'GB' );
 
 			// Next fully test the address form (so it pushes), then run extensionCartUpdate with
 			// overwriteDirtyCustomerData: true so overwriting is possible, but since the address pushed it should not
@@ -69,13 +69,13 @@ test.describe( 'Shopper → Extensibility', () => {
 			await checkoutPageObject.fillInCheckoutWithTestData();
 			await expect(
 				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).toHaveValue( 'United States (US)' );
+			).toHaveValue( 'US' );
 			await checkoutPageObject.page.evaluate(
 				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: true } )"
 			);
 			await expect(
 				checkoutPageObject.page.getByLabel( 'Country/Region' )
-			).toHaveValue( 'United States (US)' );
+			).toHaveValue( 'US' );
 		} );
 		test( 'Cart data can be modified by extensions', async ( {
 			checkoutPageObject,

--- a/plugins/woocommerce/changelog/try-ecu-ignore-empty
+++ b/plugins/woocommerce/changelog/try-ecu-ignore-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure local state is not overwritten by server when using `extensionCartUpdate`


### PR DESCRIPTION
### Changes proposed in this Pull Request:

~~Add new property to the `wc/store/cart` data store. The new property is in the `metaData` object and is called `isCustomerDataDirty`. This will track whether an address change is pending (i.e. not pushed to the server yet). When a request to update customer data completes, `isCustomerDataDirty` is set to false.~~

- When the shipping or billing addresses are updated, add a flag to `localStorage` to mark whether the addresses are dirty (i.e. not synced with server yet).
- When the address is pushed, set this flag to false.
- **Push entire address object when updating customer, not just dirty keys.** - This is required because if you change the address in tab A, then only new changes in tab B are synced, problematic when country is changed and things like State and Postcode are synced and "invalid".
- Add some e2e tests for `extensionCartUpdate` - may not completely cover its functionality but covers this use-case.
- Add new arg to `extensionCartUpdate` called `overwriteDirtyCustomerData` - this can be used by extensions if they don't care about overwriting pending data. This defaults to `false`.
- Update documentation to reflect new args

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49203

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Developer only testing

1. Install the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin. Add a new snippet containing the following:

```php
use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
use Automattic\WooCommerce\StoreApi\StoreApi;

add_action(
	'woocommerce_init',
	function () {
		$extend = StoreApi::container()->get( ExtendSchema::class );
		if (
			is_callable(
				array(
					$extend,
					'register_update_callback',
				)
			)
		) {
			$extend->register_update_callback(
				array(
					'namespace' => 'woocommerce-blocks-test-extension-cart-update',
					'callback'  => function ( $data ) {
						if ( ! empty( $data['test-name-change'] ) ) {
							WC()->cart->get_customer()->set_shipping_first_name( 'Mr. Test' );
							WC()->cart->get_customer()->save();
						}
					},
				)
			);
		}
	}
);
```
2. In an incognito session, add an item to your cart and go to the Checkout block. **Be sure not to fill in any data unless the test instructions say so**.
3. Enter the following into your JS console: `wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', data: { 'test-name-change': true } } )`
4. Check the name on your Shipping Address, it should be `Mr. Test`.
5. Change the name to something else. Repeat step 3 and 4.
6. Change the country and repeat step 3.
7. Ensure the country has not reset or changed.
8. Change the name again, fill the rest of your details and check out. 
9. Re-add an item to your cart and go to the Checkout block. Change country again.
10. Repeat step 3. Ensure the name changes to `Mr. Test`.

##### In multiple tabs

Open two tabs, follow the instructions in order from top to bottom.

| Tab A | Tab B |
| ------ | ----- |
| Add an item to your cart and go to the Checkout page  |  |
| Set the country to UK, fill in a full address (example address: 566 Chiswick High Road, London, United Kingdom, W4 5YE) | |
| | Go to the Checkout page |
| | Change the country from UK to US, do not fill anything else in. |
| | Enter the following into your JS console: `wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', data: { 'test-name-change': true } } )`. Ensure the country is still US and has not reverted to UK. The name you entered should not change at this point. |
| | Fill a full US address (example address: 2401 Utah Avenue, South Seattle, Washington, 98134). Set the name to `Should change`. |
| | Enter the following into your JS console: `wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', data: { 'test-name-change': true } } )`. The name should update to 'Mr. Test' |
| Reload the page, ensure the address entered in Tab B shows here. | |

#### Regression testing

1. Add an item to your cart and ensure you can check out successfully.
2. Test with WC EU VAT Number and/or WC Points and Rewards. Ensure these plugins work correctly in the Checkout block.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
