### PR TITLE
CYS: Add `rel="noreferrer"` to External Fiverr Link

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
@@ -544,6 +544,7 @@ export const SidebarNavigationScreenLogo = ( {
 											href="https://www.fiverr.com/logo-maker/woo?afp=&cxd_token=917527_33214203&show_join=true"
 											target="_blank"
 											type="external"
+											rel="noreferrer"
 										/>
 									),
 								},

--- a/plugins/woocommerce/changelog/49314-update-cys-fiverr-logo-cta-link-attributes
+++ b/plugins/woocommerce/changelog/49314-update-cys-fiverr-logo-cta-link-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS: Add `rel="noreferrer"` to External Fiverr Link in sidebar of **Add your logo** screen.


### PR DESCRIPTION
This is a precautionary "best practice" to prevent the new page from accessing the original page’s `window` object.

See pb22l9-304-p2 (internal link) for additional context.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

~~Closes # .~~

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to **WooCommerce > Home > Customize your store**.
2. Click on **Customize your theme** (or **Start designing**).
3. Click on **Add your logo**.
4. Inspect the `Fiverr` link in the CTA text that appears below the logo upload input.
5. Confirm the `rel="noreferrer"` attribute is present on the `a` element.

![CleanShot 2024-07-09 at 15 42 25@2x](https://github.com/woocommerce/woocommerce/assets/481776/8ccf8507-ad26-43e7-a419-e29937085f55)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS: Add `rel="noreferrer"` to External Fiverr Link in sidebar of **Add your logo** screen.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
