### PR TITLE
Disable Metrics job in CI

### DIFF
--- a/plugins/woocommerce/changelog/ci-disable-metrics-job
+++ b/plugins/woocommerce/changelog/ci-disable-metrics-job
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -572,7 +572,7 @@
 						"tests/metrics/**"
 					],
 					"events": [
-						"push"
+						"disabled"
 					]
 				},
 				{


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Metrics job has been broken for a while now and it takes over 20m to eventually fail. It also creates notifications noise.

This PR disables it until it gets fixed.

### How to test the changes in this Pull Request:

Check CI. Make sure the Metrics job is not among the running jobs. To be also checked after merge.