### PR TITLE
 Fix sidebar attribute control in Products by Attribute block 

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/products-by-attribute/inspector-controls.tsx
@@ -61,7 +61,7 @@ export const ProductsByAttributeInspectorControls = (
 					selected={ attributes }
 					onChange={ ( value = [] ) => {
 						const result = value.map(
-							( { id, attr_slug: attributeSlug } ) => ( {
+							( { id, value: attributeSlug } ) => ( {
 								id,
 								attr_slug: attributeSlug,
 							} )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/products-by-attribute/products-by-attribute.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/products-by-attribute/products-by-attribute.block_theme.spec.ts
@@ -28,4 +28,28 @@ test.describe( `${ blockData.slug } Block`, () => {
 			blockLocatorFrontend.getByRole( 'listitem' )
 		).toHaveCount( 9 );
 	} );
+
+	test( 'can change attributes from the sidebar', async ( {
+		editor,
+		admin,
+		frontendUtils,
+		page
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.slug } );
+		const blockLocator = await editor.getBlockByName( blockData.slug );
+		await blockLocator.getByText( 'Color' ).click();
+		await blockLocator.getByText( 'Done' ).click();
+		await page.getByText( 'Filter by Product Attribute' ).click();
+		await page.getByText( 'Color' ).click();
+		await page.getByText( 'Size' ).click();
+		await expect( blockLocator.getByRole( 'listitem' ) ).toHaveCount( 1 );
+		await editor.publishAndVisitPost();
+		const blockLocatorFrontend = await frontendUtils.getBlockByName(
+			blockData.slug
+		);
+		await expect(
+			blockLocatorFrontend.getByRole( 'listitem' )
+		).toHaveCount( 1 );
+	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/products-by-attribute/products-by-attribute.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/products-by-attribute/products-by-attribute.block_theme.spec.ts
@@ -33,7 +33,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 		editor,
 		admin,
 		frontendUtils,
-		page
+		page,
 	} ) => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: blockData.slug } );

--- a/plugins/woocommerce/changelog/fix-48574-fix-product-by-attribute-sidebar-control
+++ b/plugins/woocommerce/changelog/fix-48574-fix-product-by-attribute-sidebar-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix sidebar attribute control in Products by Attribute block


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/48574.
Closes https://github.com/woocommerce/woocommerce/issues/42669.

This PR fixes the attribute control displayed in the sidebar when selecting the Products by Attribute block. Until now, selecting some attributes there would cause the block to display an error.

### How to test the changes in this Pull Request:

1. Add a Products by Attribute block to a new post.
2. Select an attribute and click on _Done_.
3. Now, in the sidebar, open the Filter by Product Attribute panel and change the selected attributes.
4. Verify the block is still rendered correctly.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
