### PR TITLE
[WooCommerce Analytics] Adapt Order Report CSV Export structure to the one used in the client side.

### DIFF
--- a/plugins/woocommerce/changelog/tweak-export-csv-data
+++ b/plugins/woocommerce/changelog/tweak-export-csv-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Equalize data in Order export with data in Client side CSV export

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -530,7 +530,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'products'        => __( 'Product(s)', 'woocommerce' ),
 			'num_items_sold'  => __( 'Items sold', 'woocommerce' ),
 			'coupons'         => __( 'Coupon(s)', 'woocommerce' ),
-			'total_formatted' => __( 'Net Sales', 'woocommerce' ),
+			'net_total' 	  => __( 'Net Sales', 'woocommerce' ),
 			'attribution'     => __( 'Attribution', 'woocommerce' ),
 		);
 
@@ -562,7 +562,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'products'        => isset( $item['extended_info']['products'] ) ? $this->get_products( $item['extended_info']['products'] ) : null,
 			'num_items_sold'  => $item['num_items_sold'],
 			'coupons'         => isset( $item['extended_info']['coupons'] ) ? $this->get_coupons( $item['extended_info']['coupons'] ) : null,
-			'total_formatted' => $item['total_formatted'],
+			'net_total' 	  => $item['net_total'],
 			'attribution'     => $item['extended_info']['attribution']['origin'],
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -524,14 +524,13 @@ class Controller extends ReportsController implements ExportableInterface {
 		$export_columns = array(
 			'date_created'    => __( 'Date', 'woocommerce' ),
 			'order_number'    => __( 'Order #', 'woocommerce' ),
-			'total_formatted' => __( 'N. Revenue (formatted)', 'woocommerce' ),
 			'status'          => __( 'Status', 'woocommerce' ),
 			'customer_name'   => __( 'Customer', 'woocommerce' ),
 			'customer_type'   => __( 'Customer type', 'woocommerce' ),
 			'products'        => __( 'Product(s)', 'woocommerce' ),
 			'num_items_sold'  => __( 'Items sold', 'woocommerce' ),
 			'coupons'         => __( 'Coupon(s)', 'woocommerce' ),
-			'net_total'       => __( 'N. Revenue', 'woocommerce' ),
+			'total_formatted' => __( 'Net Sales', 'woocommerce' ),
 			'attribution'     => __( 'Attribution', 'woocommerce' ),
 		);
 
@@ -555,16 +554,15 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function prepare_item_for_export( $item ) {
 		$export_item = array(
-			'date_created'    => $item['date_created'],
+			'date_created'    => $item['date'],
 			'order_number'    => $item['order_number'],
-			'total_formatted' => $item['total_formatted'],
 			'status'          => $item['status'],
 			'customer_name'   => isset( $item['extended_info']['customer'] ) ? $this->get_customer_name( $item['extended_info']['customer'] ) : null,
 			'customer_type'   => $item['customer_type'],
 			'products'        => isset( $item['extended_info']['products'] ) ? $this->get_products( $item['extended_info']['products'] ) : null,
 			'num_items_sold'  => $item['num_items_sold'],
 			'coupons'         => isset( $item['extended_info']['coupons'] ) ? $this->get_coupons( $item['extended_info']['coupons'] ) : null,
-			'net_total'       => $item['net_total'],
+			'total_formatted' => $item['total_formatted'],
 			'attribution'     => $item['extended_info']['attribution']['origin'],
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46643 

This PR equalizes the structure of the Order CSV Reports when generated by email with the one generated by client side using csv-export package. In particular:

- Change the date created to date to match the local date instead of GMT date as it does in client-side version.
- Remove total_formatted (as is not offered in the client side version)
- Change the label for  N. Revenue to Net Sales as it does on the client-side.

⚠️  Notice the name of the files is different. I think this is ok and no need to be changed. The email-based report uses some ID to batch the report creation for large stores. The user can always change the name when saving the file.
 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this PR. It would be useful to have also [WC Smooth Generator ](https://github.com/woocommerce/wc-smooth-generator)
2. Generate minimum 26 orders 
3. Go to Analytics - Orders
4. In the report show only 50 per page and click download. Save the file
5. Now select only 25 per page. A file link will be emailed to you. (this is handled [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/ReportExporter.php#L207) ) 
6. Check the file by email matches in contents with the file downloaded by client side.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
