### PR TITLE
Monorepo: set strict mode for WooCommerce plugin linting script.

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -eo pipefail
+
 # Lint branch
 #
 # Runs phpcs-changed, comparing the current branch to its "base" or "parent" branch.

--- a/plugins/woocommerce/changelog/fix-woocommerce-plugin-linting
+++ b/plugins/woocommerce/changelog/fix-woocommerce-plugin-linting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: set strict mode for linting script.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Set strict mode for lining script in WooCommerce plugin.
