### PR TITLE
E2E: enable reporting slow blocks test.

### DIFF
--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -376,7 +376,7 @@
 				},
 				{
 					"name": "Blocks e2e - trigger for Blocks e2e tests in @woocommerce/plugin-woocommerce",
-					"testType": "e2e",
+					"testType": "test:php",
 					"command": "test:e2e:fake",
 					"changes": [
 						"tests/e2e/**"

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -376,7 +376,7 @@
 				},
 				{
 					"name": "Blocks e2e - trigger for Blocks e2e tests in @woocommerce/plugin-woocommerce",
-					"testType": "unit:php",
+					"testType": "e2e",
 					"command": "test:e2e:fake",
 					"changes": [
 						"tests/e2e/**"

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -376,7 +376,7 @@
 				},
 				{
 					"name": "Blocks e2e - trigger for Blocks e2e tests in @woocommerce/plugin-woocommerce",
-					"testType": "test:php",
+					"testType": "unit:php",
 					"command": "test:e2e:fake",
 					"changes": [
 						"tests/e2e/**"

--- a/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
@@ -16,12 +16,10 @@ const config: PlaywrightTestConfig = {
 	),
 	testDir: './tests',
 	retries: CI ? 2 : 0,
-	// We're running our tests in serial, so we only need one worker.
 	workers: 1,
+	reportSlowTests: { max: 5, threshold: 30 * 1000 }, // 30 seconds threshold
 	fullyParallel: false,
 	forbidOnly: !! CI,
-	// Don't report slow test "files", as we're running our tests in serial.
-	reportSlowTests: null,
 	reporter: process.env.CI
 		? [
 				[ 'github' ],

--- a/plugins/woocommerce/changelog/update-report-slow-blocks-e2e-tests
+++ b/plugins/woocommerce/changelog/update-report-slow-blocks-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E: enable slow tests reporting for blocks E2E tests.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enables slow E2E tests reporting for blocks E2E tests - enables us to review and identify slow tests.