### PR TITLE
CYS - Fix marking the CYS task as completed only by accessing the Intro page

### DIFF
--- a/plugins/woocommerce/changelog/49374-fix-intro-page-when-reloading
+++ b/plugins/woocommerce/changelog/49374-fix-intro-page-when-reloading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Fix marking the CYS task as completed only by accessing the Intro page.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Jetpack_Gutenberg;
+use WP_Post;
 
 /**
  * Customize Your Store Task
@@ -32,15 +33,15 @@ class CustomizeStore extends Task {
 	/**
 	 * Mark the CYS task as complete whenever the user updates their global styles.
 	 *
-	 * @param int      $post_id Post ID.
-	 * @param \WP_Post $post Post object.
-	 * @param bool     $update Whether this is an existing post being updated.
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post Post object.
+	 * @param bool    $update Whether this is an existing post being updated.
 	 *
 	 * @return void
 	 */
 	public function mark_task_as_complete( $post_id, $post, $update ) {
-		if ( $post instanceof \WP_Post ) {
-			$is_cys_complete = '{"version": 2, "isGlobalStylesUserThemeJSON": true }' !== $post->post_content || in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true );
+		if ( $post instanceof WP_Post ) {
+			$is_cys_complete = $this->has_custom_global_styles( $post ) || $this->has_custom_template( $post );
 
 			if ( $is_cys_complete ) {
 				update_option( 'woocommerce_admin_customize_store_completed', 'yes' );
@@ -259,5 +260,34 @@ class CustomizeStore extends Task {
 				body { overflow: hidden; }
 			</style>';
 		}
+	}
+
+	/**
+	 * Checks if the post has custom global styles stored (if it is different from the default global styles).
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return bool
+	 */
+	private function has_custom_global_styles( WP_Post $post ) {
+		$required_keys = array( 'version', 'isGlobalStylesUserThemeJSON' );
+
+		$json_post_content = json_decode( $post->post_content, true );
+		if ( is_null( $json_post_content ) ) {
+			return false;
+		}
+
+		$post_content_keys = array_keys( $json_post_content );
+
+		return ! empty( array_diff( $post_content_keys, $required_keys ) ) || ! empty( array_diff( $required_keys, $post_content_keys ) );
+	}
+
+	/**
+	 * Checks if the post is a template or a template part.
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return bool Whether the post is a template or a template part.
+	 */
+	private function has_custom_template( WP_Post $post ) {
+		return in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true );
 	}
 }


### PR DESCRIPTION
This PR improves the conditions to check if the "customize store" task should be marked as completed.

Before, we were relying on a JSON string to check if the global styles were the default, but that string had a hardcoded version. Since the version has changed this was failing. We are now checking that the global style JSON only has two keys: `version` and `isGlobalStylesUserThemeJSON`, regardless of their values.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have the `WooCommerce Beta Tester` plugin installed and activated.
3. Under `Tools > WCA Test Helper > Tools` click on `Reset Customize Your Store`.
4. Access `WooCommerce > Home` and make sure the CYS task is not marked as complete:

<img width="755" alt="Screenshot 2024-03-21 at 16 02 51" src="https://github.com/woocommerce/woocommerce/assets/15730971/1312aa68-04db-46ac-95c8-ba582403fda4">

5. Click on `Customize your store`.
6. Refresh the page and make sure you see the exact same page.
7. Access `WooCommerce > Home` and make sure the CYS task is not marked as complete.

9. Make sure you have the TT4 theme enabled (or any other block theme).
10. Head over to `Appearance > Editor > Styles` and change to a different style combination.
11. Go back to `WooCommerce > Home` and ensure the task is now marked as complete.
12. Under `Tools > WCA Test Helper > Tools`, click on `Reset Customize Your Store` again.
13. Access `WooCommerce > Home` one more time and make sure the CYS task is not marked as complete anymore:

<img width="755" alt="Screenshot 2024-03-21 at 16 02 51" src="https://github.com/woocommerce/woocommerce/assets/15730971/1312aa68-04db-46ac-95c8-ba582403fda4">

14. Head over to `Appearance > Editor > Templates` and select one template, e.g. Product Catalog, and modify it
15. Go back to `WooCommerce > Home` and ensure the task is now marked as complete:

<img width="1871" alt="Screenshot 2024-03-21 at 16 08 59" src="https://github.com/woocommerce/woocommerce/assets/15730971/f3c10891-cf47-4a34-8e9c-13f1c2c464c5">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Fix marking the CYS task as completed only by accessing the Intro page.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
