### PR TITLE
Fix Blocks e2e environment setup in release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,9 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.ref_name }}
           ARTIFACT_NAME: ${{ github.ref_name == 'nightly' && 'woocommerce-trunk-nightly.zip' || 'woocommerce.zip' }}
+          WP_ENV_CONFIG_PATH: ${{ matrix.projectPath }}
         working-directory: ${{ matrix.projectPath }}
-        run: node ./tests/e2e-pw/bin/override-wp-env-plugins.js
+        run: node ./github/workflows/scripts/override-wp-env-plugins.js
 
       - name: 'Start Test Environment'
         id: 'prepare-test-environment'

--- a/.github/workflows/scripts/override-wp-env-plugins.js
+++ b/.github/workflows/scripts/override-wp-env-plugins.js
@@ -1,6 +1,7 @@
+/* eslint-disable no-console */
 const fs = require( 'fs' );
 
-const { RELEASE_TAG, ARTIFACT_NAME } = process.env;
+const { RELEASE_TAG, ARTIFACT_NAME, WP_ENV_CONFIG_PATH } = process.env;
 
 if ( ! RELEASE_TAG ) {
 	console.error( 'Please set the RELEASE_TAG environment variable!' );
@@ -12,9 +13,12 @@ if ( ! ARTIFACT_NAME ) {
 	process.exit( 1 );
 }
 
+if ( ! WP_ENV_CONFIG_PATH ) {
+	console.error( 'Please set the WP_ENV_CONFIG_PATH environment variable!' );
+	process.exit( 1 );
+}
+
 const artifactUrl = `https://github.com/woocommerce/woocommerce/releases/download/${ RELEASE_TAG }/${ ARTIFACT_NAME }`;
-// https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip
-// https://github.com/woocommerce/woocommerce/releases/download/9.0.0-beta.2/woocommerce.zip
 
 const testEnvPlugins = {
 	env: {
@@ -23,7 +27,7 @@ const testEnvPlugins = {
 		},
 	},
 };
-const data = fs.readFileSync( '.wp-env.json', 'utf8' );
+const data = fs.readFileSync( `${ WP_ENV_CONFIG_PATH }/.wp-env.json`, 'utf8' );
 const wpEnvConfig = JSON.parse( data );
 testEnvPlugins.env.tests.plugins = wpEnvConfig.env.tests.plugins;
 
@@ -34,6 +38,6 @@ if ( currentDirEntry !== -1 ) {
 }
 
 fs.writeFileSync(
-	'.wp-env.override.json',
+	`${ WP_ENV_CONFIG_PATH }/.wp-env.override.json`,
 	JSON.stringify( testEnvPlugins, null, 2 )
 );

--- a/plugins/woocommerce/changelog/ci-release-checks-override-wp-env-for-blocks-tests
+++ b/plugins/woocommerce/changelog/ci-release-checks-override-wp-env-for-blocks-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -286,7 +286,6 @@
 					"changes": [],
 					"events": [
 						"daily-checks",
-						"nightly-checks",
 						"release-checks"
 					],
 					"testEnv": {
@@ -601,7 +600,8 @@
 					"events": [
 						"pull_request",
 						"push",
-						"release-checks"
+						"release-checks",
+						"nightly-checks"
 					],
 					"report": {
 						"resultsBlobName": "blocks-e2e-report",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/49277

When running the tests in CI for a release, the wp-env config is updated to include the release asset. The script doing that was part of core e2e tests and was only updating the core wp-env config.
This PR moves the script into `.github` folder and updates it to take a wp-env config path, so that a file in any path within the monorepo can be updated.

### How to test the changes in this Pull Request:

Make sure the code makes sense.
CI works as expected for PR.
To be tested after merge. We can update the nigthly release to trigger the tests.