### PR TITLE
Hide username checkbox if using block checkout

### DIFF
--- a/plugins/woocommerce/changelog/update-hide-username-setting-for-block-checkout-49184
+++ b/plugins/woocommerce/changelog/update-hide-username-setting-for-block-checkout-49184
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Hide account creation options not relevent to block checkout when using block checkout.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -239,20 +239,22 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 			),
 		);
 
-		// Hide username setting when using the block based checkout.
+		// Change settings when using the block based checkout.
 		if ( CartCheckoutUtils::is_checkout_block_default() ) {
+			$account_settings = array_filter(
+				$account_settings,
+				function ( $setting ) {
+					return 'woocommerce_registration_generate_username' !== $setting['id'];
+				},
+			);
 			$account_settings = array_map(
 				function ( $setting ) {
-					switch ( $setting['id'] ) {
-						case 'woocommerce_registration_generate_username':
-							return array();
-						case 'woocommerce_registration_generate_password':
-							unset( $setting['checkboxgroup'] );
-							break;
+					if ( 'woocommerce_registration_generate_password' === $setting['id'] ) {
+						unset( $setting['checkboxgroup'] );
 					}
 					return $setting;
 				},
-				$account_settings,
+				$account_settings
 			);
 		}
 
@@ -297,7 +299,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					});
 				}
 
-				checkboxes.forEach(cb => cb.addEventListener('change', updateInputs));
+				checkboxes.forEach(cb => cb && cb.addEventListener('change', updateInputs));
 				updateInputs(); // Initial state
 			});
 		</script>

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -241,11 +241,18 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 
 		// Hide username setting when using the block based checkout.
 		if ( CartCheckoutUtils::is_checkout_block_default() ) {
-			$account_settings = array_filter(
-				$account_settings,
+			$account_settings = array_map(
 				function ( $setting ) {
-					return 'woocommerce_registration_generate_password' !== $setting['id'];
-				}
+					switch ( $setting['id'] ) {
+						case 'woocommerce_registration_generate_username':
+							return array();
+						case 'woocommerce_registration_generate_password':
+							unset( $setting['checkboxgroup'] );
+							break;
+					}
+					return $setting;
+				},
+				$account_settings,
 			);
 		}
 
@@ -282,6 +289,9 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				function updateInputs() {
 					const isChecked = checkboxes.some(cb => cb && cb.checked);
 					inputs.forEach(input => {
+						if ( ! input ) {
+							return;
+						}
 						input.disabled = !isChecked;
 						input.closest('td').classList.toggle("disabled", !isChecked);
 					});

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -11,6 +11,8 @@ if ( class_exists( 'WC_Settings_Accounts', false ) ) {
 	return new WC_Settings_Accounts();
 }
 
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+
 /**
  * WC_Settings_Accounts.
  */
@@ -236,6 +238,16 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'id'   => 'personal_data_retention',
 			),
 		);
+
+		// Hide username setting when using the block based checkout.
+		if ( CartCheckoutUtils::is_checkout_block_default() ) {
+			$account_settings = array_filter(
+				$account_settings,
+				function ( $setting ) {
+					return 'woocommerce_registration_generate_password' !== $setting['id'];
+				}
+			);
+		}
 
 		/**
 		 * Filter account settings.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If the main checkout is block based, this hides the "Use email address as account login (recommended)" setting. This is because the block based checkout does not yet support a username field.

![Screenshot 2024-07-11 at 12 39 03](https://github.com/woocommerce/woocommerce/assets/90977/d645693d-c806-4cf9-9398-2685f04fe85e)

Closes #49184

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure you're using the block based checkout
2. Go to WooCommerce > Settings > Accounts and Privacy
3. You should not see the setting that reads "Use email address as account login (recommended)"
4. Go to WooCommerce > Settings > Advanced
5. Change the checkout page to some other page that does not contain block based checkout
6. Go to WooCommerce > Settings > Accounts and Privacy
7. The setting "Use email address as account login (recommended)" is now visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
