### PR TITLE
Change case for CLIRunner namespace to meet autoloader expectations

### DIFF
--- a/plugins/woocommerce/changelog/tweak-psr-namespaces
+++ b/plugins/woocommerce/changelog/tweak-psr-namespaces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Change CLIRunner namespace for better PSR compatibility.

--- a/plugins/woocommerce/includes/class-wc-cli.php
+++ b/plugins/woocommerce/includes/class-wc-cli.php
@@ -6,7 +6,7 @@
  * @version 3.0.0
  */
 
-use Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner as CustomOrdersTableCLIRunner;
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\CLIRunner as CustomOrdersTableCLIRunner;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\CLIRunner as ProductAttributesLookupCLIRunner;
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable;
+namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Database\Migrations;
  * Base class for implementing migrations from the standard WordPress meta table
  * to custom structured tables.
  *
- * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
+ * @package Automattic\WooCommerce\Database\Migrations
  */
 abstract class MetaToCustomTableMigrator extends TableMigrator {
 

--- a/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Database\Migrations;
  * Base class for implementing migrations from the standard WordPress meta table
  * to custom meta (key-value pairs) tables.
  *
- * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
+ * @package Automattic\WooCommerce\Database\Migrations
  */
 abstract class MetaToMetaTableMigrator extends TableMigrator {
 

--- a/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Database\Migrations;
  * Base class for implementing WP posts to order tables migrations handlers.
  * It mainly contains methods to deal with error handling.
  *
- * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
+ * @package Automattic\WooCommerce\Database\Migrations
  */
 abstract class TableMigrator {
 

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -24,7 +24,7 @@ namespace Automattic\WooCommerce\Internal\BatchProcessing;
 /**
  * Class BatchProcessingController
  *
- * @package Automattic\WooCommerce\Internal\Updates.
+ * @package Automattic\WooCommerce\Internal\BatchProcessing.
  */
 class BatchProcessingController {
 	/*

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessorInterface.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessorInterface.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce\Internal\BatchProcessing;
 /**
  * Interface BatchProcessorInterface
  *
- * @package Automattic\WooCommerce\DataBase
+ * @package Automattic\WooCommerce\Internal\BatchProcessing
  */
 interface BatchProcessorInterface {
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -548,7 +548,7 @@ class CustomOrdersTableController {
 			$compatibility_info = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
 			$sync_complete      = 0 === $this->data_synchronizer->get_current_orders_pending_sync_count();
 			$disabled           = array();
-			// Changing something here? You might also want to look at `enable|disable` functions in Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner.
+			// Changing something here? You might also want to look at `enable|disable` functions in Automattic\WooCommerce\Database\Migrations\CustomOrderTable\CLIRunner.
 			$incompatible_plugins = $this->plugin_util->get_items_considered_incompatible( 'custom_order_tables', $compatibility_info );
 			$incompatible_plugins = array_diff( $incompatible_plugins, $this->plugin_util->get_plugins_excluded_from_compatibility_ui() );
 			if ( count( $incompatible_plugins ) > 0 ) {

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/COTMigrationServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/COTMigrationServiceProvider.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
-use Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner;
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\CLIRunner;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Caches\OrderCacheController;
-use Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner;
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\CLIRunner;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableRefundDataStore;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR just changes the namespace for `CLIRunner` from Automattic\WooCommerce\Data**B**ase\Migrations\CustomOrderTable to Automattic\WooCommerce\Data**b**ase\Migrations\CustomOrderTable for better compliance with our autoloader. Namespaces are case-insensitive in PHP so this shouldn't have any serious consequences for anything, and it fixes a warning Composer is currently throwing for this file.

Similarly, a few `@package` docblock tags are renamed for consistency with the namespace and folder structure.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out `trunk` and run `composer dump-autoload -o`. You'll see a few warnings (related to code in `tests/`) and then one for `CLIRunner`:
   > Class Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner located in ./src/Database/Migrations/CustomOrderTable/CLIRunner.php does not comply with psr-4 autoloading standard. Skipping.
1. Check out this branch and repeat the above. No warnings should appear for `CLIRunner`.
1. Run some smoke tests if desired, though this change makes no functional changes.

Related: p1720602736490069-slack-C0E1AV8T0

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>