### PR TITLE
[blocks e2e] Update config for retries and trace retention

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
@@ -15,7 +15,7 @@ const config: PlaywrightTestConfig = {
 		new URL( 'global-setup.ts', 'file:' + __filename ).href
 	),
 	testDir: './tests',
-	retries: CI ? 2 : 0,
+	retries: CI ? 1 : 0,
 	workers: 1,
 	reportSlowTests: { max: 5, threshold: 30 * 1000 }, // 30 seconds threshold
 	fullyParallel: false,
@@ -36,7 +36,10 @@ const config: PlaywrightTestConfig = {
 	use: {
 		baseURL: BASE_URL,
 		screenshot: 'only-on-failure',
-		trace: 'retain-on-failure',
+		trace:
+			/^https?:\/\/localhost/.test( BASE_URL ) || ! CI
+				? 'retain-on-first-failure'
+				: 'off',
 		video: 'on-first-retry',
 		viewport: { width: 1280, height: 720 },
 		storageState: STORAGE_STATE_PATH,

--- a/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ import { PlaywrightTestConfig, defineConfig, devices } from '@playwright/test';
 const { CI, DEFAULT_TIMEOUT_OVERRIDE } = process.env;
 
 const config: PlaywrightTestConfig = {
-	maxFailures: 0,
+	maxFailures: CI ? 30 : 0,
 	timeout: parseInt( DEFAULT_TIMEOUT_OVERRIDE || '', 10 ) || 100_000, // Defaults to 100s.
 	outputDir: `${ __dirname }/artifacts/test-results`,
 	globalSetup: fileURLToPath(

--- a/plugins/woocommerce/changelog/e2e-update-blocks-e2e-artifacts-and-retries
+++ b/plugins/woocommerce/changelog/e2e-update-blocks-e2e-artifacts-and-retries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow up of https://github.com/woocommerce/woocommerce/pull/49148
Updates the retries from 2 to 1 in CI and the trace retention.
It should save some CI checks execution time and reduce the artifacts size which can get pretty big with many failures.

### How to test the changes in this Pull Request:

Check CI. Blocks e2e tests run successfully.
