### PR TITLE
Add some robots.txt rules

### DIFF
--- a/plugins/woocommerce/changelog/add-robots-txt
+++ b/plugins/woocommerce/changelog/add-robots-txt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add some robots.txt rules about directories created by WooCommerce

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1053,7 +1053,7 @@ final class WooCommerce {
 	public function robots_txt( $output ) {
 		$path = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
 
-		$lines       = explode( PHP_EOL, $output );
+		$lines       = preg_split( '/\r\n|\r|\n/', $output );
 		$agent_index = array_search( 'User-agent: *', $lines, true );
 
 		if ( false !== $agent_index ) {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -308,7 +308,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_installed', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 
-		add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
+		self::add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
 		add_filter( 'wp_plugin_dependencies_slug', array( $this, 'convert_woocommerce_slug' ) );
 
 		// These classes set up hooks on instantiation.
@@ -1050,7 +1050,7 @@ final class WooCommerce {
 	 *
 	 * @return string
 	 */
-	public function robots_txt( $output ) {
+	private function robots_txt( $output ) {
 		$path = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
 
 		$lines       = preg_split( '/\r\n|\r|\n/', $output );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -308,6 +308,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_installed', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 
+		add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
 		add_filter( 'wp_plugin_dependencies_slug', array( $this, 'convert_woocommerce_slug' ) );
 
 		// These classes set up hooks on instantiation.
@@ -1036,6 +1037,43 @@ final class WooCommerce {
 			$this->session = new $session_class();
 			$this->session->init();
 		}
+	}
+
+	/**
+	 * Tell bots not to index some WooCommerce-created directories.
+	 *
+	 * We try to detect the default "User-agent: *" added by WordPress and add our rules to that group, because
+	 * it's possible that some bots will only interpret the first group of rules if there are multiple groups with
+	 * the same user agent.
+	 *
+	 * @param string $output The contents that WordPress will output in a robots.txt file.
+	 *
+	 * @return string
+	 */
+	public function robots_txt( $output ) {
+		$path = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
+
+		$lines       = explode( PHP_EOL, $output );
+		$agent_index = array_search( 'User-agent: *', $lines );
+
+		if ( false !== $agent_index ) {
+			$above = array_slice( $lines, 0, $agent_index + 1 );
+			$below = array_slice( $lines, $agent_index + 1 );
+		} else {
+			$above = $lines;
+			$below = array();
+
+			$above[] = '';
+			$above[] = 'User-agent: *';
+		}
+
+		$above[] = "Disallow: $path/wp-content/uploads/wc-logs/";
+		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_transient_files/";
+		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_uploads/";
+
+		$lines = array_merge( $above, $below );
+
+		return implode( PHP_EOL, $lines );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1054,7 +1054,7 @@ final class WooCommerce {
 		$path = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
 
 		$lines       = explode( PHP_EOL, $output );
-		$agent_index = array_search( 'User-agent: *', $lines );
+		$agent_index = array_search( 'User-agent: *', $lines, true );
 
 		if ( false !== $agent_index ) {
 			$above = array_slice( $lines, 0, $agent_index + 1 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce creates some subdirectories within the WordPress uploads directory. This adds some rules
to the robots.txt file generated by WordPress that tells bots not to index these subdirectories.

Additional context: https://github.com/Automattic/woocommerce/issues/79

### How to test the changes in this Pull Request:

1. With this branch checked out, view the robots.txt file for your test site, e.g. `http://localhost:8888/robots.txt`
2. Switch to trunk and check the file again to make sure what we're adding here isn't breaking or replacing any other rules added by WordPress or other plugins.
3. If you want, try installing some other SEO plugin that adds its own robots.txt rules, and make sure what we're doing here plays nicely with that.