### PR TITLE
Monorepo: fix linting script (side-effects from enabling strict mode earlier

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -23,7 +23,7 @@ fi
 newFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only --diff-filter=dmr -- '*.php')
 if [[ -n $newFiles ]]; then
 	passingFiles=$(find $newFiles -type f -exec grep -xl --regexp='declare(\s*strict_types\s*=\s*1\s*);' /dev/null {} +)
-	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort))
+	violatingFiles=$(grep -vxf <(printf "%s\n" $passingFiles | sort) <(printf "%s\n" $newFiles | sort) || echo '')
 	if [[ -n "$violatingFiles" ]]; then
 		redColoured='\033[0;31m'
 		printf "${redColoured}Following files are missing 'declare( strict_types = 1)' directive:\n"

--- a/plugins/woocommerce/changelog/fix-linting-script
+++ b/plugins/woocommerce/changelog/fix-linting-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: fix side-effects of setting strict mode for linting script.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/49366 we enabled strict mode for lining script. A side-eefect was discovered in p1720711141326699-slack-C02FL3X7KR6 which we are addressing here.