### PR TITLE
Fix variation name in WC Analytics Variations report

### DIFF
--- a/plugins/woocommerce-admin/client/lib/async-requests/index.js
+++ b/plugins/woocommerce-admin/client/lib/async-requests/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { identity } from 'lodash';
@@ -106,7 +107,19 @@ export function getVariationName( { attributes, name } ) {
 	}
 
 	const attributeList = ( attributes || [] )
-		.map( ( { option } ) => option )
+		.map( ( { name: attributeName, option } ) => {
+			if ( ! option ) {
+				attributeName =
+					attributeName.charAt( 0 ).toUpperCase() +
+					attributeName.slice( 1 );
+				option = sprintf(
+					// translators: %s: the attribute name.
+					__( 'Any %s', 'woocommerce' ),
+					attributeName
+				);
+			}
+			return option;
+		} )
 		.join( ', ' );
 
 	return attributeList ? name + separator + attributeList : name;

--- a/plugins/woocommerce/changelog/fix-33159-variation-name-in-analytics-variations-report
+++ b/plugins/woocommerce/changelog/fix-33159-variation-name-in-analytics-variations-report
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variation name in analytics variations report


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33159.

The issue is, for example, if a variable product has a variation which its attribute has `Any [attribute_name]` like the below image:

<img width="771" alt="Screenshot 2024-07-12 at 15 37 44" src="https://github.com/user-attachments/assets/fed9b540-bc66-4c56-9d67-543d93c34429">
<br/><br/>

In the `WC Analytics > Variations` report, the variations report API `/wc-analytics/reports/variations` will respond:

<img width="648" alt="Screenshot 2024-07-12 at 15 41 23" src="https://github.com/user-attachments/assets/bd2566d1-c3cf-46e3-b395-a31d5494cd6e">
<br/><br/>

So the `Product / Variation title` in the WC Analytics > Variations report will display: `Hoodie - Green, , S`

<img width="1053" alt="Screenshot 2024-07-12 at 15 45 46" src="https://github.com/user-attachments/assets/e1e2bf2a-7ef6-412d-9af8-c5973f29f03a">
<br/><br/>

This PR fixes the issue by adding `Any [attribute_name]` to the variation product name if the attribute is empty.

<img width="1062" alt="Screenshot 2024-07-12 at 15 54 42" src="https://github.com/user-attachments/assets/f002e9ca-4ce7-4151-928f-d066d4b67191">
<br/><br/>

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Do not checkout this PR yet
2. Add a variable product with 3 attributes
3. Create some variations, set one of the attribute as `Any [attribute_name]`. E.g. `Any Color`
4. Place an order with the variation product with any option for the attribute created above
5. Go to `Analytics > Variations`, see the Product / Variation title display incorrectly
6. Checkout the branch `fix/33159-variation-name-in-analytics-variations-report`
7. Run `pnpm install` and `pnpm build`
8. Go to `Analytics > Variations`, see the Product / Variation title display correctly
9. Repeat step 4 to place some orders like that
10. Go to `Analytics > Variations`, see the Product / Variation title display correctly

Note that in the original issue #33159, the reproduction step is to have a variation product with specific attributes, place an order, then change one of the variation product attribute to `Any ...`. And it seems to me that they expect the `Product / Variation title` in `Analytics > Variations` would remain unchanged. But to me it makes more sense to display `Any ...` in the product title as that is the correct product variation.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
