### PR TITLE
Avoid reserving stock for draft orders under payment is attempted

### DIFF
--- a/plugins/woocommerce/changelog/update-remove-draft-order-stock-holds-44231
+++ b/plugins/woocommerce/changelog/update-remove-draft-order-stock-holds-44231
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Updated block checkout and Store API stock handling so stock is only reserved when attempting payment for an order.

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -10,6 +10,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
+
 /**
  * Update a product's stock amount.
  *
@@ -348,7 +350,8 @@ function wc_get_held_stock_quantity( WC_Product $product, $exclude_order_id = 0 
 		return 0;
 	}
 
-	return ( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->get_reserved_stock( $product, $exclude_order_id );
+	$reserve_stock = new ReserveStock();
+	return $reserve_stock->get_reserved_stock( $product, $exclude_order_id );
 }
 
 /**
@@ -374,7 +377,8 @@ function wc_reserve_stock_for_order( $order ) {
 	$order = $order instanceof WC_Order ? $order : wc_get_order( $order );
 
 	if ( $order ) {
-		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $order );
+		$reserve_stock = new ReserveStock();
+		$reserve_stock->reserve_stock_for_order( $order );
 	}
 }
 add_action( 'woocommerce_checkout_order_created', 'wc_reserve_stock_for_order' );
@@ -400,7 +404,8 @@ function wc_release_stock_for_order( $order ) {
 	$order = $order instanceof WC_Order ? $order : wc_get_order( $order );
 
 	if ( $order ) {
-		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->release_stock_for_order( $order );
+		$reserve_stock = new ReserveStock();
+		$reserve_stock->release_stock_for_order( $order );
 	}
 }
 add_action( 'woocommerce_checkout_order_exception', 'wc_release_stock_for_order' );

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -88,7 +88,7 @@ final class ReserveStock {
 		try {
 			$items = array_filter(
 				$order->get_items(),
-				function( $item ) {
+				function ( $item ) {
 					return $item->is_type( 'line_item' ) && $item->get_product() instanceof \WC_Product && $item->get_quantity() > 0;
 				}
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes how stock is reserved for draft orders on the block based checkout to prevent checkouts by other customers.

1. Upon checkout entry (when the draft order is created) no longer automatically reserves stock
2. Reserves stock when POSTing to `/checkout` with a valid order, valid customer data, and before payment. 
3. Core rules for stock being freed up are maintained; that is when the order is no longer pending or draft, or as soon as payment is complete.
4. Additionally, stock is freed up if an exception is thrown by the `/checkout` route. This could be due to payment error.

### Developer only testing

![Screenshot 2024-07-16 at 11 35 26](https://github.com/user-attachments/assets/6575403f-76a2-4c12-ac35-026d46304d73)

Make sure ^ this is defaulted to 60.

Developers can test the stock reservation process by:

1. Set up a product to be stock managed with backorders disabled. 
2. Add that product to cart and go to checkout
3. In the database, keep an eye on the `wp_wc_reserved_stock` table. On checkout entry there should be no new rows in `wp_wc_reserved_stock` for the current draft order.
4. Try to place the order using PayPal standard. PayPal standard makes the order pending so there is time to take payment. Once you hit paypal, `wp_wc_reserved_stock` should have a row reserving the stock for your order.
5. If you cancel and come back to checkout, then pay using BACS, the row in `wp_wc_reserved_stock` is removed after payment.

To test exception handling:

1. Edit the BACS payment method to simulate an error. Edit `/woocommerce-monorepo/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php` and add some code that will create an exception e.g. 

```
public function process_payment( $order_id ) {
	sleep(10); // Simulate a slow payment gateway
	throw new Exception( 'oops' );
```

2. When you place order the row will appear in `wp_wc_reserved_stock` table
3. Once processing fails, the row should disappear from `wp_wc_reserved_stock` table

Closes #44231

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a product to be stock managed with backorders disabled and 5 qty in stock
2. Open up 2 browsers and in both, add 5 qty of the product to your cart
3. Go to checkout in both browsers. There should be no stock errors shown in either window.
4. Place an order in browser # 1. Order will go through.
5. Place an order in browser # 2. The order will not go through. Notice will state that there is not enough stock remaining. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
