### PR TITLE
Allow rendering the quantity in cart when the quantity is not editable

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -286,27 +286,27 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 						/>
 
 						<div className="wc-block-cart-item__quantity">
-							{ ! soldIndividually &&
-								!! quantityLimits.editable && (
-									<QuantitySelector
-										disabled={ isPendingDelete }
-										quantity={ quantity }
-										minimum={ quantityLimits.minimum }
-										maximum={ quantityLimits.maximum }
-										step={ quantityLimits.multiple_of }
-										onChange={ ( newQuantity ) => {
-											setItemQuantity( newQuantity );
-											dispatchStoreEvent(
-												'cart-set-item-quantity',
-												{
-													product: lineItem,
-													quantity: newQuantity,
-												}
-											);
-										} }
-										itemName={ name }
-									/>
-								) }
+							{ ! soldIndividually && (
+								<QuantitySelector
+									disabled={ isPendingDelete }
+									editable={ quantityLimits.editable }
+									quantity={ quantity }
+									minimum={ quantityLimits.minimum }
+									maximum={ quantityLimits.maximum }
+									step={ quantityLimits.multiple_of }
+									onChange={ ( newQuantity ) => {
+										setItemQuantity( newQuantity );
+										dispatchStoreEvent(
+											'cart-set-item-quantity',
+											{
+												product: lineItem,
+												quantity: newQuantity,
+											}
+										);
+									} }
+									itemName={ name }
+								/>
+							) }
 							{ showRemoveItemLink && (
 								<button
 									className="wc-block-cart-item__remove-link"

--- a/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/index.tsx
@@ -50,6 +50,10 @@ export interface QuantitySelectorProps {
 	 * Whether the component should be interactable or not
 	 */
 	disabled: boolean;
+	/**
+	 * Whether the component should be editable or not
+	 */
+	editable: boolean;
 }
 
 const QuantitySelector = ( {
@@ -61,6 +65,7 @@ const QuantitySelector = ( {
 	step = 1,
 	itemName = '',
 	disabled,
+	editable,
 }: QuantitySelectorProps ): JSX.Element => {
 	const classes = clsx( 'wc-block-components-quantity-selector', className );
 
@@ -158,6 +163,7 @@ const QuantitySelector = ( {
 				ref={ inputRef }
 				className="wc-block-components-quantity-selector__input"
 				disabled={ disabled }
+				readOnly={ ! editable }
 				type="number"
 				step={ step }
 				min={ minimum }
@@ -184,54 +190,64 @@ const QuantitySelector = ( {
 					itemName
 				) }
 			/>
-			<button
-				ref={ decreaseButtonRef }
-				aria-label={ sprintf(
-					/* translators: %s refers to the item name in the cart. */
-					__( 'Reduce quantity of %s', 'woocommerce' ),
-					itemName
-				) }
-				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
-				disabled={ ! canDecrease }
-				onClick={ () => {
-					const newQuantity = quantity - step;
-					onChange( newQuantity );
-					speak(
-						sprintf(
-							/* translators: %s refers to the item's new quantity in the cart. */
-							__( 'Quantity reduced to %s.', 'woocommerce' ),
-							newQuantity
-						)
-					);
-					normalizeQuantity( newQuantity );
-				} }
-			>
-				&#65293;
-			</button>
-			<button
-				ref={ increaseButtonRef }
-				aria-label={ sprintf(
-					/* translators: %s refers to the item's name in the cart. */
-					__( 'Increase quantity of %s', 'woocommerce' ),
-					itemName
-				) }
-				disabled={ ! canIncrease }
-				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
-				onClick={ () => {
-					const newQuantity = quantity + step;
-					onChange( newQuantity );
-					speak(
-						sprintf(
-							/* translators: %s refers to the item's new quantity in the cart. */
-							__( 'Quantity increased to %s.', 'woocommerce' ),
-							newQuantity
-						)
-					);
-					normalizeQuantity( newQuantity );
-				} }
-			>
-				&#65291;
-			</button>
+			{ editable && (
+				<>
+					<button
+						ref={ decreaseButtonRef }
+						aria-label={ sprintf(
+							/* translators: %s refers to the item name in the cart. */
+							__( 'Reduce quantity of %s', 'woocommerce' ),
+							itemName
+						) }
+						className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+						disabled={ ! canDecrease }
+						onClick={ () => {
+							const newQuantity = quantity - step;
+							onChange( newQuantity );
+							speak(
+								sprintf(
+									/* translators: %s refers to the item's new quantity in the cart. */
+									__(
+										'Quantity reduced to %s.',
+										'woocommerce'
+									),
+									newQuantity
+								)
+							);
+							normalizeQuantity( newQuantity );
+						} }
+					>
+						&#65293;
+					</button>
+					<button
+						ref={ increaseButtonRef }
+						aria-label={ sprintf(
+							/* translators: %s refers to the item's name in the cart. */
+							__( 'Increase quantity of %s', 'woocommerce' ),
+							itemName
+						) }
+						disabled={ ! canIncrease }
+						className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+						onClick={ () => {
+							const newQuantity = quantity + step;
+							onChange( newQuantity );
+							speak(
+								sprintf(
+									/* translators: %s refers to the item's new quantity in the cart. */
+									__(
+										'Quantity increased to %s.',
+										'woocommerce'
+									),
+									newQuantity
+								)
+							);
+							normalizeQuantity( newQuantity );
+						} }
+					>
+						&#65291;
+					</button>
+				</>
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/index.tsx
@@ -47,11 +47,11 @@ export interface QuantitySelectorProps {
 	 */
 	itemName?: string;
 	/**
-	 * Whether the component should be interactable or not
+	 * Whether the component should be interactable
 	 */
 	disabled: boolean;
 	/**
-	 * Whether the component should be editable or not
+	 * Whether the component should be editable
 	 */
 	editable: boolean;
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/test/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/test/index.tsx
@@ -18,7 +18,7 @@ const defaults = {
 
 describe( 'QuantitySelector', () => {
 	it( 'The quantity step buttons are rendered when the quantity is editable', () => {
-		render( <QuantitySelector { ...defaults } /> );
+		const { rerender } = render( <QuantitySelector { ...defaults } /> );
 
 		expect(
 			screen.getByLabelText(
@@ -28,10 +28,8 @@ describe( 'QuantitySelector', () => {
 		expect(
 			screen.getByLabelText( `Reduce quantity of ${ defaults.itemName }` )
 		).toBeInTheDocument();
-	} );
 
-	it( 'The quantity step buttons are not rendered when the quantity is not editable', () => {
-		render( <QuantitySelector { ...defaults } editable={ false } /> );
+		rerender( <QuantitySelector { ...defaults } editable={ false } /> );
 
 		expect(
 			screen.queryByLabelText(

--- a/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/test/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/quantity-selector/test/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import QuantitySelector, { QuantitySelectorProps } from '../index';
+
+const defaults = {
+	disabled: false,
+	editable: true,
+	itemName: 'product',
+	maximum: 9999,
+	onChange: () => void 0,
+} as QuantitySelectorProps;
+
+describe( 'QuantitySelector', () => {
+	it( 'The quantity step buttons are rendered when the quantity is editable', () => {
+		render( <QuantitySelector { ...defaults } /> );
+
+		expect(
+			screen.getByLabelText(
+				`Increase quantity of ${ defaults.itemName }`
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.getByLabelText( `Reduce quantity of ${ defaults.itemName }` )
+		).toBeInTheDocument();
+	} );
+
+	it( 'The quantity step buttons are not rendered when the quantity is not editable', () => {
+		render( <QuantitySelector { ...defaults } editable={ false } /> );
+
+		expect(
+			screen.queryByLabelText(
+				`Increase quantity of ${ defaults.itemName }`
+			)
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(
+				`Reduce quantity of ${ defaults.itemName }`
+			)
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-49423-allow-rendering-the-quantity-in-cart-when-the-quantity-is-not-editable
+++ b/plugins/woocommerce/changelog/fix-49423-allow-rendering-the-quantity-in-cart-when-the-quantity-is-not-editable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+allows the quantity selector on block cart page to render as readonly when editable is false


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #49423

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

_N.B. Ensure to use Block Cart and Checkout pages for this test._

1. create a test plugin or otherwise add the following code snippet
```
add_filter( 'woocommerce_store_api_product_quantity_editable', '__return_false' );
```
2. add a product to store (if one doesn't already exist)
3. navigate to the store front and add the product to cart
4. navigate to block cart page

**Result**: quantity should be rendered without the +/- quantity change buttons, as well as being readonly so that the customer cannot edit the quantity.

![image](https://github.com/user-attachments/assets/293ebe8e-25a7-4f0d-834a-30c6d2eae964)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>
allows the quantity selector on block cart page to render as readonly when editable is false
<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
