### PR TITLE
Fix logo picker e2e tests with flaky wait for response

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-wait-for-response-logo-picker-test
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-wait-for-response-logo-picker-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: Fix flaky logo picker waiting for response tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
@@ -69,12 +69,15 @@ export class LogoPickerPage {
 	}
 
 	async saveLogoSettings( assemblerLocator ) {
-		await assemblerLocator.locator( '[aria-label="Back"]' ).click();
 		const waitForLogoResponse = this.page.waitForResponse(
 			( response ) =>
 				response.url().includes( 'wp-json/wp/v2/settings' ) &&
 				response.status() === 200
 		);
+		await assemblerLocator.locator( '[aria-label="Back"]' ).click();
+		await assemblerLocator
+			.getByRole( 'button', { name: 'Save', exact: true } )
+			.waitFor();
 		await Promise.all( [
 			waitForLogoResponse,
 			assemblerLocator.getByText( 'Save' ).click(),

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
@@ -75,14 +75,8 @@ export class LogoPickerPage {
 				response.url().includes( 'wp-json/wp/v2/settings' ) &&
 				response.status() === 200
 		);
-		const waitForHeaderResponse = this.page.waitForResponse(
-			( response ) =>
-				response.url().includes( '//header' ) &&
-				response.status() === 200
-		);
 		return await Promise.all( [
 			waitForLogoResponse,
-			waitForHeaderResponse,
 			assemblerLocator.getByText( 'Save' ).click(),
 		] );
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
@@ -75,9 +75,10 @@ export class LogoPickerPage {
 				response.url().includes( 'wp-json/wp/v2/settings' ) &&
 				response.status() === 200
 		);
-		return await Promise.all( [
+		await Promise.all( [
 			waitForLogoResponse,
 			assemblerLocator.getByText( 'Save' ).click(),
 		] );
+		await assemblerLocator.getByText( 'Your store looks great!' ).waitFor();
 	}
 }

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -188,6 +188,7 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 	} );
 
 	test( 'Enabling the "use as site icon" option should set the image as the site icon', async ( {
+		page,
 		assemblerPageObject,
 		logoPickerPageObject,
 	} ) => {
@@ -197,12 +198,16 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 		await emptyLogoPicker.click();
 		await logoPickerPageObject.pickImage( assembler );
 		await assembler.getByText( 'Use as site icon' ).click();
+		await logoPickerPageObject.saveLogoSettings( assembler );
 
-		const [ logoResponse ] = await logoPickerPageObject.saveLogoSettings(
-			assembler
-		);
-
-		expect( logoResponse.ok() ).toBeTruthy();
+		// alternative way to verify new site icon on the site
+		// verifying site icon shown in the new tab is impossible in headless mode
+		const date = new Date();
+		await expect(
+			page.goto(
+				`/wp-content/uploads/${ date.getFullYear() }/${ date.getMonth() }/image-03-100x100.png`
+			)
+		).toBeTruthy();
 	} );
 
 	test( 'The selected image should be visible on the frontend', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -188,15 +188,9 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 	} );
 
 	test( 'Enabling the "use as site icon" option should set the image as the site icon', async ( {
-		page,
 		assemblerPageObject,
 		logoPickerPageObject,
 	} ) => {
-		const waitForHeaderResponse = page.waitForResponse(
-			( response ) =>
-				response.url().includes( '//header' ) &&
-				response.status() === 200
-		);
 		const assembler = await assemblerPageObject.getAssembler();
 		const emptyLogoPicker =
 			logoPickerPageObject.getEmptyLogoPickerLocator( assembler );
@@ -208,8 +202,6 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 			assembler
 		);
 
-		await waitForHeaderResponse;
-
 		expect( logoResponse.ok() ).toBeTruthy();
 	} );
 
@@ -219,11 +211,6 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 		logoPickerPageObject,
 		assemblerPageObject,
 	} ) => {
-		const waitForHeaderResponse = page.waitForResponse(
-			( response ) =>
-				response.url().includes( '//header' ) &&
-				response.status() === 200
-		);
 		const assembler = await assemblerPageObject.getAssembler();
 		const emptyLogoPicker =
 			logoPickerPageObject.getEmptyLogoPickerLocator( assembler );
@@ -231,8 +218,6 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 		await emptyLogoPicker.click();
 		await logoPickerPageObject.pickImage( assembler );
 		await logoPickerPageObject.saveLogoSettings( assembler );
-
-		await waitForHeaderResponse;
 
 		await page.goto( baseURL );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -188,9 +188,15 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 	} );
 
 	test( 'Enabling the "use as site icon" option should set the image as the site icon', async ( {
+		page,
 		assemblerPageObject,
 		logoPickerPageObject,
 	} ) => {
+		const waitForHeaderResponse = page.waitForResponse(
+			( response ) =>
+				response.url().includes( '//header' ) &&
+				response.status() === 200
+		);
 		const assembler = await assemblerPageObject.getAssembler();
 		const emptyLogoPicker =
 			logoPickerPageObject.getEmptyLogoPickerLocator( assembler );
@@ -202,6 +208,8 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 			assembler
 		);
 
+		await waitForHeaderResponse;
+
 		expect( logoResponse.ok() ).toBeTruthy();
 	} );
 
@@ -211,6 +219,11 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 		logoPickerPageObject,
 		assemblerPageObject,
 	} ) => {
+		const waitForHeaderResponse = page.waitForResponse(
+			( response ) =>
+				response.url().includes( '//header' ) &&
+				response.status() === 200
+		);
 		const assembler = await assemblerPageObject.getAssembler();
 		const emptyLogoPicker =
 			logoPickerPageObject.getEmptyLogoPickerLocator( assembler );
@@ -218,6 +231,8 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 		await emptyLogoPicker.click();
 		await logoPickerPageObject.pickImage( assembler );
 		await logoPickerPageObject.saveLogoSettings( assembler );
+
+		await waitForHeaderResponse;
 
 		await page.goto( baseURL );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49079

This should solve 2 very flaky instances:
- https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-core-e2e-tests/tests/018fa08c-e763-7f7f-b5b6-05b572e9e6df?branch=all+branches
- https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-core-e2e-tests/tests/018fa08c-e764-7224-af64-5c09ced977ee?branch=all+branches

We never properly tested the new site icon so far, and this one was also very flaky.
I changed the logic to somehow properly test if the site icon has been generated if applied previously, as it needs to generate a 100x100 png file in the uploads folder.

First I tried to verify the site icon in the response with the following:

```
const responsePromise = page.waitForResponse('**/image-03-100x100.png');
// reload page to ensure siteicon is applied
await page.reload();
await responsePromise;
```

However, that was impossible to assert in the headless mode because the new site icon (favicon) renders the new tab only in non-headless mode.
That's why I ended up verifying the generated 100x100 png file in the uploads folder, as that's what the functionality `Use as site icon` does.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

```
pnpm test:e2e-pw tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
