### PR TITLE
Clean up core profiler jetpack copy experiment

### DIFF
--- a/plugins/woocommerce/changelog/update-core-profiler-clean-up-jetpack-copy-experiment
+++ b/plugins/woocommerce/changelog/update-core-profiler-clean-up-jetpack-copy-experiment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove Jetpack copy experiment from core profiler

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -97,37 +97,6 @@ class OnboardingFreeExtensions extends WC_REST_Data_Controller {
 			}
 		}
 
-		$extensions = $this->replace_jetpack_with_jetpack_boost_for_treatment( $extensions );
-
 		return new WP_REST_Response( $extensions );
-	}
-
-	private function replace_jetpack_with_jetpack_boost_for_treatment( array $extensions ) {
-		$is_treatment = \WooCommerce\Admin\Experimental_Abtest::in_treatment( 'woocommerce_jetpack_copy' );
-
-		if ( ! $is_treatment ) {
-			return $extensions;
-		}
-
-		$has_core_profiler = array_search( 'obw/core-profiler', array_column( $extensions, 'key' ) );
-
-		if ( $has_core_profiler === false ) {
-			return $extensions;
-		}
-
-		$has_jetpack = array_search( 'jetpack', array_column( $extensions[ $has_core_profiler ]['plugins'], 'key' ) );
-
-		if ( $has_jetpack === false ) {
-			return $extensions;
-		}
-
-		$jetpack                  = &$extensions[ $has_core_profiler ]['plugins'][ $has_jetpack ];
-		$jetpack->key             = 'jetpack-boost';
-		$jetpack->name            = 'Jetpack Boost';
-		$jetpack->label           = __( 'Optimize store performance with Jetpack Boost', 'woocommerce' );
-		$jetpack->description     = __( 'Speed up your store and improve your SEO with performance-boosting tools from Jetpack. Learn more', 'woocommerce' );
-		$jetpack->learn_more_link = 'https://jetpack.com/boost/';
-
-		return $extensions;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Internal reference: p1720576993579959-slack-C01SFMVEYAK

Jetpack copy experiment implemented in https://github.com/woocommerce/woocommerce/pull/39799 is no longer needed. This PR removes the experiment request code.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
 
1. In a fresh store, go to onboarding wizard and continue until the plugins step
2. Observe Jetpack plugin's title is `Boost content creation with Jetpack AI Assistant`

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/1a021740-8c58-49af-aebd-c83c599a429f">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>