### PR TITLE
[WooCommerce Analytics] Fix: Show variations only for the selected product's variations

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-reports
+++ b/plugins/woocommerce/changelog/fix-variation-reports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show variations only for the selected product's variations

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -39,6 +39,8 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	protected $param_mapping = array(
 		'variations' => 'variation_includes',
+		'products'   => 'product_includes',
+		'categories' => 'category_includes'
 	);
 
 	/**
@@ -381,6 +383,17 @@ class Controller extends ReportsController implements ExportableInterface {
 			'type'              => 'boolean',
 			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['products']        = array(
+			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce' ),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'integer',
+			),
+
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -40,7 +40,7 @@ class Controller extends ReportsController implements ExportableInterface {
 	protected $param_mapping = array(
 		'variations' => 'variation_includes',
 		'products'   => 'product_includes',
-		'categories' => 'category_includes'
+		'categories' => 'category_includes',
 	);
 
 	/**
@@ -384,8 +384,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-
-		$params['products']        = array(
+		$params['products']           = array(
 			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -393,7 +392,6 @@ class Controller extends ReportsController implements ExportableInterface {
 			'items'             => array(
 				'type' => 'integer',
 			),
-
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -40,7 +40,6 @@ class Controller extends ReportsController implements ExportableInterface {
 	protected $param_mapping = array(
 		'variations' => 'variation_includes',
 		'products'   => 'product_includes',
-		'categories' => 'category_includes',
 	);
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -384,7 +384,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['products']           = array(
+		$params['products']            = array(
 			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #43110 

Fixes a bug that showed up all the product variations instead of the selected one


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a store, make sure that you have orders for multiple variable products (say Variable Product 1, Variable Product 2)
2. Go to Analytics > Products, and filter only the report for "Variable Product 1".
2. You will notice that variations of Variable Product 2 is also showing under the "Variations" section.
3. Checkout this PR and refresh the page
4. Now just the variations for the selected product are shown.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
