### PR TITLE
Check if parent product exists when creating attribute lookup data for variations

### DIFF
--- a/plugins/woocommerce/changelog/pr-49474
+++ b/plugins/woocommerce/changelog/pr-49474
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check if parent product exists when creating attribute lookup data for variations

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -431,9 +431,14 @@ class LookupDataStore {
 	 * Create all the necessary lookup data for a given variation.
 	 *
 	 * @param \WC_Product_Variation $variation The variation to create entries for.
+	 * @throws \Exception Can't retrieve the details of the parent product.
 	 */
 	private function create_data_for_variation( \WC_Product_Variation $variation ) {
 		$main_product = WC()->call_function( 'wc_get_product', $variation->get_parent_id() );
+		if ( false === $main_product ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new \Exception( "The product is a variation, and the retrieval of data for the parent product (id {$variation->get_parent_id()}) failed." );
+		}
 
 		$product_attributes_data   = $this->get_attribute_taxonomies( $main_product );
 		$variation_attributes_data = array_filter(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Check if the parent product actually exists before creating the data for a variation in the product attributes lokup table. If it doesn't, throw an exception, which will be catched in the same class and then a log entry will be written and the process will finish in an orderly manner. Without this fix, an unhandled fatal error is generated instead.

The original issue didn't affect full table regenerations (via tools UI or via `wp wc palt regenerate`), because in this case existing variable products are queried for available variations and then these are processed; thus orphan variations are automatically skipped.

This (both the original issue and the fix) applies only when the optimized table regeneration implemented in https://github.com/woocommerce/woocommerce/pull/47700 is disabled.

Closes #33730.

### How to test the changes in this Pull Request:

Create a variable product with one variation defined by a global attribute, and take note of the variation id. Then turn the variation into an orphan: `wp db query "update wp_posts set post_parent=0 where id=<variation id>"` followed by `wp eval "clean_post_cache(<variation id>);"`.

Now run `wp wc palt regenerate_for_product <variation id> --disable-db-optimization`. Without this fix you would have got a fatal error, with this fix you'll get _Error: Lookup data regeneration failed. See the WooCommerce logs (source is palt-updates) for details_, and if you got to the logs you'll see an entry in the _palt_updates_ file with the message _"Lookup data creation (not optimized) failed for product &lt;variation id&gt;: The product is a variation, and the retrieval of data for the parent product (id 0) failed"_.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
