### PR TITLE
Add tests to verify Featured Product/Category image editor works

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/featured-category/featured-category.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/featured-category/featured-category.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { expect, test } from '@woocommerce/e2e-utils';
+import { test, expect, wpCLI } from '@woocommerce/e2e-utils';
 
 const blockData = {
 	slug: 'woocommerce/featured-category',
@@ -26,6 +26,41 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await expect( blockLocatorFrontend.getByText( 'Music' ) ).toBeVisible();
 		await expect(
 			blockLocatorFrontend.getByText( 'Shop now' )
+		).toBeVisible();
+	} );
+
+	test( 'image can be edited', async ( { editor, admin } ) => {
+		await test.step( 'Create a product category with an image', async () => {
+			// Get the id of the image associated to the Cap product (for example).
+			const productCliOutput = await wpCLI(
+				`post list --post_type=product --title=Cap --field=ID`
+			);
+			const productId = productCliOutput.stdout.match( /\d+/g )?.pop();
+			const mediaCliOutput = await wpCLI(
+				`post meta get ${ productId } _thumbnail_id`
+			);
+			const mediaId = mediaCliOutput.stdout.match( /\d+/g )?.pop();
+
+			// Create a product category with that image.
+			const categoryCliOutput = await wpCLI(
+				`wc product_cat create --name="Test Category" --slug="test-category" --image='{ "id": ${ mediaId } }' --user=1`
+			);
+			const categoryId = categoryCliOutput.stdout.match( /\d+/g )?.pop();
+			await wpCLI(
+				`wc product update ${ productId } --categories='[ { "id": ${ categoryId } } ]' --user=1`
+			);
+		} );
+
+		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.slug } );
+		const blockLocator = await editor.getBlockByName( blockData.slug );
+		await blockLocator.getByText( 'Test Category' ).click();
+		await blockLocator.getByText( 'Done' ).click();
+		await editor.page.getByLabel( 'Edit category image' ).click();
+		await editor.page.getByLabel( 'Rotate' ).click();
+		await editor.page.getByRole( 'button', { name: 'Apply' } ).click();
+		await expect(
+			editor.page.locator( 'img[alt="Test Category"][src*="-edited"]' )
 		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/featured-product/featured-product.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/featured-product/featured-product.block_theme.spec.ts
@@ -28,4 +28,18 @@ test.describe( `${ blockData.slug } Block`, () => {
 			blockLocatorFrontend.getByText( 'Shop now' )
 		).toBeVisible();
 	} );
+
+	test( 'image can be edited', async ( { editor, admin } ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.slug } );
+		const blockLocator = await editor.getBlockByName( blockData.slug );
+		await blockLocator.getByText( 'Album' ).click();
+		await blockLocator.getByText( 'Done' ).click();
+		await editor.page.getByLabel( 'Edit product image' ).click();
+		await editor.page.getByLabel( 'Rotate' ).click();
+		await editor.page.getByRole( 'button', { name: 'Apply' } ).click();
+		await expect(
+			editor.page.locator( 'img[alt="Album"][src*="-edited"]' )
+		).toBeVisible();
+	} );
 } );

--- a/plugins/woocommerce/changelog/fix-42396-featured-product-category-image-editor-tests
+++ b/plugins/woocommerce/changelog/fix-42396-featured-product-category-image-editor-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add tests to verify Featured Product/Category image editor works
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds some tests to verify the image editor of the Featured Product and Featured Category blocks works properly. They would have caught issues like https://github.com/woocommerce/woocommerce-blocks/issues/9100.

Closes https://github.com/woocommerce/woocommerce/issues/42396.

### How to test the changes in this Pull Request:

_(No need to test when testing the release)_

1. Verify e2e tests pass.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
