### PR TITLE
Prevent high numbers from breaking currency inputs

### DIFF
--- a/packages/js/product-editor/changelog/fix-high-number-currency-round
+++ b/packages/js/product-editor/changelog/fix-high-number-currency-round
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent high numbers from breaking currency inputs
+
+

--- a/packages/js/product-editor/src/hooks/use-currency-input-props.ts
+++ b/packages/js/product-editor/src/hooks/use-currency-input-props.ts
@@ -27,6 +27,8 @@ type Props = {
 	onKeyUp?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
 };
 
+const CURRENCY_INPUT_MAX = 1_000_000_000_000_000_000.0;
+
 export const useCurrencyInputProps = ( {
 	value,
 	onChange,
@@ -72,7 +74,11 @@ export const useCurrencyInputProps = ( {
 		onChange( newValue: string ) {
 			const sanitizeValue = sanitizePrice( newValue );
 			if ( onChange ) {
-				onChange( sanitizeValue );
+				onChange(
+					Number( sanitizeValue ) <= CURRENCY_INPUT_MAX
+						? sanitizeValue
+						: String( CURRENCY_INPUT_MAX )
+				);
 			}
 		},
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Introduces a max limit for currency input, as the function imported from 'locutus/php/strings/number_format' breaks when presented with very high numbers, which turn into scientific notation (e.g. 1e+20).

Closes #48481 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add
3. Type in a high number in regular price (e.g. 999999999999999999999999999999999999999)
4. Press tab
5. Verify it is rounded to 1,000,000,000,000,000,000.00
6. Do the same for list price
7. Press tab and verify the same rounding occurs


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
