### PR TITLE
CYS: move `sidebar-navigation-screen-homepage-ptk` to the right folder

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
@@ -12,7 +12,7 @@ import { memo, useCallback, useContext } from '@wordpress/element';
 import { SidebarNavigationScreenColorPalette } from './sidebar-navigation-screen-color-palette';
 import { SidebarNavigationScreenFooter } from './sidebar-navigation-screen-footer';
 import { SidebarNavigationScreenHeader } from './sidebar-navigation-screen-header';
-import { SidebarNavigationScreenHomepage } from './sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage';
+import { SidebarNavigationScreenHomepage } from './sidebar-navigation-screen-homepage';
 import { SidebarNavigationScreenMain } from './sidebar-navigation-screen-main';
 import { SidebarNavigationScreenTypography } from './sidebar-navigation-screen-typography';
 // import { SidebarNavigationScreenPages } from './sidebar-navigation-screen-pages';
@@ -28,7 +28,7 @@ import {
 } from '../components/sidebar';
 import { SidebarNavigationScreenLogo } from './sidebar-navigation-screen-logo';
 import { isPatternToolkitFullComposabilityFeatureFlagEnabled } from '../utils/is-full-composability-enabled';
-import { SidebarNavigationScreenHomepagePTK } from './sidebar-navigation-screen-homepage-ptk';
+import { SidebarNavigationScreenHomepagePTK } from './sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk';
 
 const getComponentByPathParams = (
 	params: string,

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
@@ -32,20 +32,21 @@ import SidebarNavigationItem from '@wordpress/edit-site/build-module/components/
  * Internal dependencies
  */
 import { ADMIN_URL } from '~/utils/admin-settings';
-import { SidebarNavigationScreen } from './sidebar-navigation-screen';
+import { SidebarNavigationScreen } from '../sidebar-navigation-screen';
 
 import { trackEvent } from '~/customize-store/tracking';
-import { CustomizeStoreContext } from '..';
+import { CustomizeStoreContext } from '../..';
 import { Link } from '@woocommerce/components';
-import { PATTERN_CATEGORIES } from './pattern-screen/categories';
+import { PATTERN_CATEGORIES } from '../pattern-screen/categories';
 import { capitalize } from 'lodash';
 import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';
 import { useSelect } from '@wordpress/data';
 import { useNetworkStatus } from '~/utils/react-hooks/use-network-status';
 import { isIframe, sendMessageToParent } from '~/customize-store/utils';
-import { useEditorBlocks } from '../hooks/use-editor-blocks';
-import { isTrackingAllowed } from '../utils/is-tracking-allowed';
+import { useEditorBlocks } from '../../hooks/use-editor-blocks';
+import { isTrackingAllowed } from '../../utils/is-tracking-allowed';
 import clsx from 'clsx';
+import './style.scss';
 
 const isActiveElement = ( path: string | undefined, category: string ) => {
 	if ( path?.includes( category ) ) {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage.tsx
@@ -30,13 +30,13 @@ import interpolateComponents from '@automattic/interpolate-components';
 /**
  * Internal dependencies
  */
-import { SidebarNavigationScreen } from '../sidebar-navigation-screen';
+import { SidebarNavigationScreen } from './sidebar-navigation-screen';
 import { ADMIN_URL } from '~/utils/admin-settings';
-import { useEditorBlocks } from '../../hooks/use-editor-blocks';
-import { useHomeTemplates } from '../../hooks/use-home-templates';
+import { useEditorBlocks } from '../hooks/use-editor-blocks';
+import { useHomeTemplates } from '../hooks/use-home-templates';
 import { BlockInstance } from '@wordpress/blocks';
-import { useSelectedPattern } from '../../hooks/use-selected-pattern';
-import { useEditorScroll } from '../../hooks/use-editor-scroll';
+import { useSelectedPattern } from '../hooks/use-selected-pattern';
+import { useEditorScroll } from '../hooks/use-editor-scroll';
 import { FlowType } from '~/customize-store/types';
 import { CustomizeStoreContext } from '~/customize-store/assembler-hub';
 import { select, useSelect } from '@wordpress/data';
@@ -45,12 +45,11 @@ import { trackEvent } from '~/customize-store/tracking';
 import {
 	PRODUCT_HERO_PATTERN_BUTTON_STYLE,
 	findButtonBlockInsideCoverBlockProductHeroPatternAndUpdate,
-} from '../../utils/hero-pattern';
+} from '../utils/hero-pattern';
 import { useNetworkStatus } from '~/utils/react-hooks/use-network-status';
 import { isIframe, sendMessageToParent } from '~/customize-store/utils';
-import { isTrackingAllowed } from '../../utils/is-tracking-allowed';
-import './style.scss';
-import { useIsActiveNewNeutralVariation } from '../../hooks/use-is-active-new-neutral-variation';
+import { isTrackingAllowed } from '../utils/is-tracking-allowed';
+import { useIsActiveNewNeutralVariation } from '../hooks/use-is-active-new-neutral-variation';
 
 export const SidebarNavigationScreenHomepage = ( {
 	onNavigateBackClick,

--- a/plugins/woocommerce/changelog/49541-fix-cys-filename-sidebar
+++ b/plugins/woocommerce/changelog/49541-fix-cys-filename-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This PR moves the file `sidebar-navigation-screen-homepage-ptk` to the right folder.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR moves the file `sidebar-navigation-screen-homepage-ptk` to the right folder.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:




1. Ensure that you have the last version of Gutenberg enabled
2. Make sure you have the WooCommerce beta tester plugin installed.
3. Head over to Tools > WCA Test Helper > Features.
4. Make sure you see the `pattern-toolkit-full-composability` on the list.
5. Enable it.
6. Head over to WooCommerce > Home > Customize your store.
11. Click Desing your Homepage.
12. Do a smoke test.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR moves the file `sidebar-navigation-screen-homepage-ptk` to the right folder.




</details>
