### PR TITLE
Fix specs evaluation logging constant control

### DIFF
--- a/plugins/woocommerce/changelog/fix-specs-evaluation-logging-constant-control
+++ b/plugins/woocommerce/changelog/fix-specs-evaluation-logging-constant-control
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: We fix the way we interpret the constant presence and its value when it comes to logging specs evaluation.
+
+

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluationLogger.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluationLogger.php
@@ -73,7 +73,7 @@ class EvaluationLogger {
 	 * Log the results.
 	 */
 	public function log() {
-		$should_log = false === defined( 'WC_ADMIN_DEBUG_RULE_EVALUATOR' ) || true !== constant( 'WC_ADMIN_DEBUG_RULE_EVALUATOR' );
+		$should_log = defined( 'WC_ADMIN_DEBUG_RULE_EVALUATOR' ) && true === constant( 'WC_ADMIN_DEBUG_RULE_EVALUATOR' );
 
 		/**
 		 * Filter to determine if the rule evaluator should log the results.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/49167, we've [messed up](https://github.com/woocommerce/woocommerce/pull/49167/commits/16f1bc09be02c431e4595f896299df5f8219bc29) the logical condition interpreting the `WC_ADMIN_DEBUG_RULE_EVALUATOR` constant's presence and it value when we introduced the filter for unit tests. We are fixing it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout the PR branch on your local environment
1. Go to `WooCommerce > Settings > Advanced > WooCommerce.com` and make sure `Marketplace suggestions > Show suggestions` is enabled.
1. Go to WooCommerce > Status > Logs and delete any logs that are related to suggestions, if any (especially `wc-payment-gateway-suggestions`)
1. Add this line to your local environment `wp-config.php`:
```
define( 'WC_ADMIN_DEBUG_RULE_EVALUATOR', true );
```
1. Go to `WooCommerce > Status > Logs`, and you should see a `wc-payment-gateway-suggestions` log file with log entries (there may be others like wc-shipping-partner-suggestions or wc-wcpay-promotions). Delete this log file.
1. In your local environment `wp-config.php`, change the `WC_ADMIN_DEBUG_RULE_EVALUATOR` constant to `false`
1. Go to `WooCommerce > Status > Logs` and the `wc-payment-gateway-suggestions` log file should be recreated with entries as the specs are re-evaluated. Delete this log file.
1. Delete the added line in your `wp-config.php` file.
2. Go to `WooCommerce > Status > Logs` and the `wc-payment-gateway-suggestions` log file should not be present.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
