### PR TITLE
Put product filters overlay template part behind feature flag

### DIFF
--- a/plugins/woocommerce/changelog/49564-hide-filters-overlay
+++ b/plugins/woocommerce/changelog/49564-hide-filters-overlay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Hide product filters overlay template part experimental feature from public release

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
@@ -59,10 +59,13 @@ class BlockTemplatesRegistry {
 		}
 		if ( BlockTemplateUtils::supports_block_templates( 'wp_template_part' ) ) {
 			$template_parts = array(
-				MiniCartTemplate::SLUG              => new MiniCartTemplate(),
-				CheckoutHeaderTemplate::SLUG        => new CheckoutHeaderTemplate(),
-				ProductFiltersOverlayTemplate::SLUG => new ProductFiltersOverlayTemplate(),
+				MiniCartTemplate::SLUG       => new MiniCartTemplate(),
+				CheckoutHeaderTemplate::SLUG => new CheckoutHeaderTemplate(),
 			);
+
+			if ( Features::is_enabled( 'experimental-blocks' ) ) {
+				$template_parts[ ProductFiltersOverlayTemplate::SLUG ] = new ProductFiltersOverlayTemplate();
+			}
 		} else {
 			$template_parts = array();
 		}

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -316,8 +316,11 @@ class BlockTemplateUtils {
 		$wp_template_part_filenames = array(
 			'checkout-header.html',
 			'mini-cart.html',
-			'product-filters-overlay.html',
 		);
+
+		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			$wp_template_part_filenames[] = 'product-filters-overlay.html';
+		}
 
 		/*
 		* This may return the blockified directory for wp_templates.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR hides an experimental feature `Product Filters Overlay Template Part` behind a feature flag.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Test by developers only.**

Prereq:
- Ensure you have the WooCommerce Beta Tester plugin installed

1. Go to Tools->WCA Test Helper->Features and enable `experimental-blocks`
2. Go to Site Editor->Patterns->Template Parts and ensure you see the `Filters Overlay` template part in the list.
3. Go to Tools->WCA Test Helper->Features and disable `experimental-blocks`
4. Go to Site Editor->Patterns->Template Parts and ensure you no longer see the `Filters Overlay` template part in the list.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Hide product filters overlay template part experimental feature from public release
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
