### PR TITLE
Change when stock notif emails are triggered

### DIFF
--- a/plugins/woocommerce/changelog/fix-31664-stock-emails
+++ b/plugins/woocommerce/changelog/fix-31664-stock-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure low and no stock email notification routine is triggered whenever product stock changes

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -642,24 +642,22 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					// Fire actions to let 3rd parties know the stock is about to be changed.
 					if ( $product->is_type( 'variation' ) ) {
 						/**
-						* Action to signal that the value of 'stock_quantity' for a variation is about to change.
-						*
-						* @since 4.9
-						*
-						* @param WC_Product $product The variation whose stock is about to change.
-						* @param int|float  $value   The new stock value.
-						*/
-						do_action( 'woocommerce_variation_before_set_stock', $product, $value );
+						 * Action to signal that the value of 'stock_quantity' for a variation is about to change.
+						 *
+						 * @param WC_Product $product The variation whose stock is about to change.
+						 *
+						 * @since 4.9
+						 */
+						do_action( 'woocommerce_variation_before_set_stock', $product );
 					} else {
 						/**
-						* Action to signal that the value of 'stock_quantity' for a product is about to change.
-						*
-						* @since 4.9
-						*
-						* @param WC_Product $product The product whose stock is about to change.
-						* @param int|float  $value   The new stock value.
-						*/
-						do_action( 'woocommerce_product_before_set_stock', $product, $value );
+						 * Action to signal that the value of 'stock_quantity' for a product is about to change.
+						 *
+						 * @param WC_Product $product The product whose stock is about to change.
+						 *
+						 * @since 4.9
+						 */
+						do_action( 'woocommerce_product_before_set_stock', $product );
 					}
 					break;
 			}
@@ -734,12 +732,26 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( in_array( 'stock_quantity', $this->updated_props, true ) ) {
 			if ( $product->is_type( 'variation' ) ) {
-				// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
-				/** This action is documented in includes/wc-stock-functions.php */
+				/**
+				 * Action to signal that the value of 'stock_quantity' for a variation has changed.
+				 *
+				 * @since 3.0
+				 * @since 9.2 Added $stock parameter.
+				 *
+				 * @param WC_Product $product The variation whose stock has changed.
+				 * @param int|float  $stock   The new stock value.
+				 */
 				do_action( 'woocommerce_variation_set_stock', $product, $product->get_stock_quantity() );
 			} else {
-				// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
-				/** This action is documented in includes/wc-stock-functions.php */
+				/**
+				 * Action to signal that the value of 'stock_quantity' for a product has changed.
+				 *
+				 * @since 3.0
+				 * @since 9.2 Added $stock parameter.
+				 *
+				 * @param WC_Product $product The variation whose stock has changed.
+				 * @param int|float  $stock   The new stock value.
+				 */
 				do_action( 'woocommerce_product_set_stock', $product, $product->get_stock_quantity() );
 			}
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -734,24 +734,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( in_array( 'stock_quantity', $this->updated_props, true ) ) {
 			if ( $product->is_type( 'variation' ) ) {
-				/**
-				 * Action to signal that the value of 'stock_quantity' for a variation has changed.
-				 *
-				 * @since 3.0
-				 *
-				 * @param WC_Product $product The variation whose stock has changed.
-				 * @param int|float  $value   The new stock value.
-				 */
+				// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+				/** This action is documented in includes/wc-stock-functions.php */
 				do_action( 'woocommerce_variation_set_stock', $product, $product->get_stock_quantity() );
 			} else {
-				/**
-				 * Action to signal that the value of 'stock_quantity' for a product has changed.
-				 *
-				 * @since 3.0
-				 *
-				 * @param WC_Product $product The product whose stock has changed.
-				 * @param int|float  $value   The new stock value.
-				 */
+				// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+				/** This action is documented in includes/wc-stock-functions.php */
 				do_action( 'woocommerce_product_set_stock', $product, $product->get_stock_quantity() );
 			}
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -646,18 +646,20 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						*
 						* @since 4.9
 						*
-						* @param int $product The variation whose stock is about to change.
+						* @param WC_Product $product The variation whose stock is about to change.
+						* @param int|float  $value   The new stock value.
 						*/
-						do_action( 'woocommerce_variation_before_set_stock', $product );
+						do_action( 'woocommerce_variation_before_set_stock', $product, $value );
 					} else {
 						/**
 						* Action to signal that the value of 'stock_quantity' for a product is about to change.
 						*
 						* @since 4.9
 						*
-						* @param int $product The product whose stock is about to change.
+						* @param WC_Product $product The product whose stock is about to change.
+						* @param int|float  $value   The new stock value.
 						*/
-						do_action( 'woocommerce_product_before_set_stock', $product );
+						do_action( 'woocommerce_product_before_set_stock', $product, $value );
 					}
 					break;
 			}
@@ -732,16 +734,50 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( in_array( 'stock_quantity', $this->updated_props, true ) ) {
 			if ( $product->is_type( 'variation' ) ) {
-				do_action( 'woocommerce_variation_set_stock', $product );
+				/**
+				 * Action to signal that the value of 'stock_quantity' for a variation has changed.
+				 *
+				 * @since 3.0
+				 *
+				 * @param WC_Product $product The variation whose stock has changed.
+				 * @param int|float  $value   The new stock value.
+				 */
+				do_action( 'woocommerce_variation_set_stock', $product, $product->get_stock_quantity() );
 			} else {
-				do_action( 'woocommerce_product_set_stock', $product );
+				/**
+				 * Action to signal that the value of 'stock_quantity' for a product has changed.
+				 *
+				 * @since 3.0
+				 *
+				 * @param WC_Product $product The product whose stock has changed.
+				 * @param int|float  $value   The new stock value.
+				 */
+				do_action( 'woocommerce_product_set_stock', $product, $product->get_stock_quantity() );
 			}
 		}
 
 		if ( in_array( 'stock_status', $this->updated_props, true ) ) {
 			if ( $product->is_type( 'variation' ) ) {
+				/**
+				 * Action to signal that the `stock_status` for a variation has changed.
+				 *
+				 * @since 3.0
+				 *
+				 * @param int        $product_id   The ID of the variation.
+				 * @param string     $stock_status The new stock status of the variation.
+				 * @param WC_Product $product      The product object.
+				 */
 				do_action( 'woocommerce_variation_set_stock_status', $product->get_id(), $product->get_stock_status(), $product );
 			} else {
+				/**
+				 * Action to signal that the `stock_status` for a product has changed.
+				 *
+				 * @since 3.0
+				 *
+				 * @param int        $product_id   The ID of the product.
+				 * @param string     $stock_status The new stock status of the product.
+				 * @param WC_Product $product      The product object.
+				 */
 				do_action( 'woocommerce_product_set_stock_status', $product->get_id(), $product->get_stock_status(), $product );
 			}
 		}

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -65,20 +65,20 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 			 *
 			 * @since 3.0
 			 *
-			 * @param WC_Product $product  The variation whose stock has changed.
-			 * @param int|float  $quantity The new stock quantity value.
+			 * @param WC_Product $product The variation whose stock has changed.
+			 * @param int|float  $stock   The new stock value.
 			 */
-			do_action( 'woocommerce_variation_set_stock', $product_with_stock, $stock_quantity );
+			do_action( 'woocommerce_variation_set_stock', $product_with_stock, $new_stock );
 		} else {
 			/**
 			 * Action to signal that the value of 'stock_quantity' for a product has changed.
 			 *
 			 * @since 3.0
 			 *
-			 * @param WC_Product $product  The variation whose stock has changed.
-			 * @param int|float  $quantity The new stock quantity value.
+			 * @param WC_Product $product The variation whose stock has changed.
+			 * @param int|float  $stock   The new stock value.
 			 */
-			do_action( 'woocommerce_product_set_stock', $product_with_stock, $stock_quantity );
+			do_action( 'woocommerce_product_set_stock', $product_with_stock, $new_stock );
 		}
 
 		return $product_with_stock->get_stock_quantity();

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -287,8 +287,8 @@ function wc_trigger_stock_change_notifications( $order, $changes ) {
  * This functionality was moved out of `wc_trigger_stock_change_notifications` in order to decouple it from orders,
  * since stock quantity can also be updated in other ways.
  *
- * @param WC_Product $product
- * @param int|float  $stock_quantity
+ * @param WC_Product $product        The product whose stock level has changed.
+ * @param int|float  $stock_quantity The new quantity of stock.
  *
  * @return void
  */

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -257,7 +257,7 @@ function wc_trigger_stock_change_notifications( $order, $changes ) {
 			 *     @type WC_Product $product  The product that is on backorder.
 			 *     @type int        $order_id The ID of the order.
 			 *     @type int|float  $quantity The amount of product on backorder.
-			 * }s
+			 * }
 			 */
 			do_action(
 				'woocommerce_product_on_backorder',

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -42,8 +42,12 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 
 		// Fire actions to let 3rd parties know the stock is about to be changed.
 		if ( $product_with_stock->is_type( 'variation' ) ) {
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			/** This action is documented in includes/data-stores/class-wc-product-data-store-cpt.php */
 			do_action( 'woocommerce_variation_before_set_stock', $product_with_stock );
 		} else {
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			/** This action is documented in includes/data-stores/class-wc-product-data-store-cpt.php */
 			do_action( 'woocommerce_product_before_set_stock', $product_with_stock );
 		}
 
@@ -60,24 +64,12 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 
 		// Fire actions to let 3rd parties know the stock changed.
 		if ( $product_with_stock->is_type( 'variation' ) ) {
-			/**
-			 * Action to signal that the value of 'stock_quantity' for a variation has changed.
-			 *
-			 * @since 3.0
-			 *
-			 * @param WC_Product $product The variation whose stock has changed.
-			 * @param int|float  $stock   The new stock value.
-			 */
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			/** This action is documented in includes/data-stores/class-wc-product-data-store-cpt.php */
 			do_action( 'woocommerce_variation_set_stock', $product_with_stock, $new_stock );
 		} else {
-			/**
-			 * Action to signal that the value of 'stock_quantity' for a product has changed.
-			 *
-			 * @since 3.0
-			 *
-			 * @param WC_Product $product The variation whose stock has changed.
-			 * @param int|float  $stock   The new stock value.
-			 */
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			/** This action is documented in includes/data-stores/class-wc-product-data-store-cpt.php */
 			do_action( 'woocommerce_product_set_stock', $product_with_stock, $new_stock );
 		}
 

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -489,8 +489,11 @@ function wc_get_low_stock_amount( WC_Product $product ) {
 	$low_stock_amount = $product->get_low_stock_amount();
 
 	if ( '' === $low_stock_amount && $product->is_type( 'variation' ) ) {
-		$product          = wc_get_product( $product->get_parent_id() );
-		$low_stock_amount = $product->get_low_stock_amount();
+		$parent_product = wc_get_product( $product->get_parent_id() );
+
+		if ( $parent_product instanceof WC_Product ) {
+			$low_stock_amount = $parent_product->get_low_stock_amount();
+		}
 	}
 
 	if ( '' === $low_stock_amount ) {

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -60,9 +60,25 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 
 		// Fire actions to let 3rd parties know the stock changed.
 		if ( $product_with_stock->is_type( 'variation' ) ) {
-			do_action( 'woocommerce_variation_set_stock', $product_with_stock );
+			/**
+			 * Action to signal that the value of 'stock_quantity' for a variation has changed.
+			 *
+			 * @since 3.0
+			 *
+			 * @param WC_Product $product  The variation whose stock has changed.
+			 * @param int|float  $quantity The new stock quantity value.
+			 */
+			do_action( 'woocommerce_variation_set_stock', $product_with_stock, $stock_quantity );
 		} else {
-			do_action( 'woocommerce_product_set_stock', $product_with_stock );
+			/**
+			 * Action to signal that the value of 'stock_quantity' for a product has changed.
+			 *
+			 * @since 3.0
+			 *
+			 * @param WC_Product $product  The variation whose stock has changed.
+			 * @param int|float  $quantity The new stock quantity value.
+			 */
+			do_action( 'woocommerce_product_set_stock', $product_with_stock, $stock_quantity );
 		}
 
 		return $product_with_stock->get_stock_quantity();

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -371,7 +371,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		wc_update_product_stock( $product->get_id(), $initial_stock );
 
 		$action_fired = false;
-		$callback     = function() use ( &$action_fired ) {
+		$callback     = function () use ( &$action_fired ) {
 			$action_fired = true;
 		};
 		add_action( 'woocommerce_low_stock', $callback );
@@ -409,7 +409,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		wc_update_product_stock( $product->get_id(), $initial_stock );
 
 		$action_fired = false;
-		$callback     = function() use ( &$action_fired ) {
+		$callback     = function () use ( &$action_fired ) {
 			$action_fired = true;
 		};
 		add_action( 'woocommerce_no_stock', $callback );

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -357,4 +357,79 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertIsIntAndEquals( $site_wide_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 	}
 
+	/**
+	 * @testdox Test that the `woocommerce_low_stock` action fires when a product stock hits the low stock threshold.
+	 */
+	public function test_wc_update_product_stock_low_stock_action() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->save();
+
+		$low_stock_amount = wc_get_low_stock_amount( $product );
+		$initial_stock    = $low_stock_amount + 2;
+
+		wc_update_product_stock( $product->get_id(), $initial_stock );
+
+		$action_fired = false;
+		$callback     = function() use ( &$action_fired ) {
+			$action_fired = true;
+		};
+		add_action( 'woocommerce_low_stock', $callback );
+
+		// Test with `wc_update_product_stock`.
+		wc_update_product_stock( $product->get_id(), 1, 'decrease' );
+		$this->assertFalse( $action_fired );
+		wc_update_product_stock( $product->get_id(), 1, 'decrease' );
+		$this->assertTrue( $action_fired );
+
+		$action_fired = false;
+
+		// Test with the data store.
+		$product->set_stock_quantity( $initial_stock );
+		$product->save();
+		$this->assertFalse( $action_fired );
+		$product->set_stock_quantity( $low_stock_amount );
+		$product->save();
+		$this->assertTrue( $action_fired );
+
+		remove_action( 'woocommerce_low_stock', $callback );
+	}
+
+	/**
+	 * @testdox Test that the `woocommerce_no_stock` action fires when a product stock hits the no stock threshold.
+	 */
+	public function test_wc_update_product_stock_no_stock_action() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->save();
+
+		$no_stock_amount = get_option( 'woocommerce_notify_no_stock_amount', 0 );
+		$initial_stock   = $no_stock_amount + 2;
+
+		wc_update_product_stock( $product->get_id(), $initial_stock );
+
+		$action_fired = false;
+		$callback     = function() use ( &$action_fired ) {
+			$action_fired = true;
+		};
+		add_action( 'woocommerce_no_stock', $callback );
+
+		// Test with `wc_update_product_stock`.
+		wc_update_product_stock( $product->get_id(), 1, 'decrease' );
+		$this->assertFalse( $action_fired );
+		wc_update_product_stock( $product->get_id(), 1, 'decrease' );
+		$this->assertTrue( $action_fired );
+
+		$action_fired = false;
+
+		// Test with the data store.
+		$product->set_stock_quantity( $initial_stock );
+		$product->save();
+		$this->assertFalse( $action_fired );
+		$product->set_stock_quantity( $no_stock_amount );
+		$product->save();
+		$this->assertTrue( $action_fired );
+
+		remove_action( 'woocommerce_no_stock', $callback );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Moves the check for low/no stock to the point when a product's stock quantity is updated. This decouples the check from orders, since stock can also change in other contexts (such as updates via REST API).

**Open question:** When a product is out of stock, and back ordering is enabled, should an "out of stock" email get sent _every time_ a back order is made, or only the first time? We could potentially set a post meta flag when an "out of stock" email has already been sent (and clear the flag when the stock is changed back to a positive number).

Fixes #31664

### How to test the changes in this Pull Request:

1. Install a plugin like [WP Mail Logging](https://wordpress.org/plugins/wp-mail-logging/) on your test site so you can capture outgoing emails.
2. Create a product. Under Product data > Inventory, check the box for Stock management, and set the Quantity to 3. Under Allow backorders, select Allow, but notify customer.
3. Using cURL or your favorite API client, send a request like the following:
    ```
    curl --request POST \
      --url http://localhost:8888/wp-json/wc/v3/products/{product id} \
      --data '{
      "stock_quantity": 2
    }'
    ```
4. Check the mail log. There should be a message about the stock quantity for the product becoming "low" (this won't happen if you test on the trunk branch).
5. Send another request with `"stock_quantity": 1`. The same email should be sent again. Then send another with `"stock_quantity": 0`. This time the email should say the product is out of stock.
6. Now, with the product stock level at `0`, create a new order through the admin UI. Add the product, set the order status to On Hold, and save the order. Three new emails should be generated: a "new order" email, a "product backorder" email, and a "product out of stock" email. The product's stock level should now show as `-1`.
7. Note that if you set the product's stock level to a negative number through the API, a "product out of stock" email should be generated, but not the "product backorder", since the change is not associated with an order.