### PR TITLE
CYS: not enable PTK features on WordPress 6.5

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
@@ -27,7 +27,7 @@ import {
 	SidebarNavigationContext,
 } from '../components/sidebar';
 import { SidebarNavigationScreenLogo } from './sidebar-navigation-screen-logo';
-import { isPatternToolkitFullComposabilityFeatureFlagEnabled } from '../utils/is-full-composability-enabled';
+import { isFullComposabilityFeatureAndAPIAvailable } from '../utils/is-full-composability-enabled';
 import { SidebarNavigationScreenHomepagePTK } from './sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk';
 
 const getComponentByPathParams = (
@@ -71,7 +71,7 @@ const getComponentByPathParams = (
 	}
 
 	if (
-		isPatternToolkitFullComposabilityFeatureFlagEnabled() &&
+		isFullComposabilityFeatureAndAPIAvailable() &&
 		params?.includes( '/customize-store/assembler-hub/homepage' )
 	) {
 		return (
@@ -82,7 +82,7 @@ const getComponentByPathParams = (
 	}
 
 	if (
-		! isPatternToolkitFullComposabilityFeatureFlagEnabled() &&
+		! isFullComposabilityFeatureAndAPIAvailable() &&
 		params === '/customize-store/assembler-hub/homepage'
 	) {
 		return (

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/is-full-composability-enabled.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/is-full-composability-enabled.ts
@@ -6,11 +6,11 @@ import {
 	// @ts-expect-error No types for this exist yet.
 } from '@wordpress/block-editor';
 
-export const isPatternToolkitFullComposabilityFeatureFlagEnabled = () => {
+const isPatternToolkitFullComposabilityFeatureFlagEnabled = () => {
 	return window.wcAdminFeatures[ 'pattern-toolkit-full-composability' ];
 };
 
-export const isGutenbergAPIAvailableForFullComposability = () => {
+const isGutenbergAPIAvailableForFullComposability = () => {
 	return [ BlockPopover ].every(
 		( api ) => api !== undefined && api !== null
 	);

--- a/plugins/woocommerce/changelog/49591-fix-wordpress-6-5-cys
+++ b/plugins/woocommerce/changelog/49591-fix-wordpress-6-5-cys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS: not enable PTK features on WordPress 6.5.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you have **WordPress 6.5 without Gutenberg enabled**.
2. Head over to WooCommerce > Home > Customize your store.
3. Click Desing your Homepage.
12. Ensure that PTK features aren't visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: not enable PTK features on WordPress 6.5.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
