### PR TITLE
Add missing dependencies to generate variation script in classic product form

### DIFF
--- a/plugins/woocommerce/changelog/fix-48576_generating_variation_dependency
+++ b/plugins/woocommerce/changelog/fix-48576_generating_variation_dependency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add missing script dependencies to product variation generation script.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -276,7 +276,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
 				wp_enqueue_media();
 				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), $version );
-				wp_register_script( 'wc-admin-variation-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product-variation' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'serializejson', 'media-models', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), $version );
+				wp_register_script( 'wc-admin-variation-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product-variation' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'serializejson', 'media-models', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal', 'wp-data', 'wp-notices' ), $version );
 
 				wp_enqueue_script( 'wc-admin-product-meta-boxes' );
 				wp_enqueue_script( 'wc-admin-variation-meta-boxes' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds the WP data and notices dependency to the `wc-admin-variation-meta-boxes` script as they are being used within the file: https://github.com/woocommerce/woocommerce/blob/5b412c46f03165916f91b86ba6283dca49a3538d/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js#L1126
This worked fine previously as there is another script on the page already loading the data and notice package.

**Note:** I couldn't specifically reproduce this on `trunk` but was able to with WooCommerce 9.1.2. It could be that we are loading some new scripts now that do include the above dependencies, but I think in either case it be good to add them.

Closes #48576 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the latest WooCommerce version ( 9.1.2 ) **don't** install the WooCommerce Beta tester as this prevents the bug from happening.
2. Add the following code to e.g. `functions.php` to remove the Marketing feature using [woocommerce_admin_features](https://wp-kama.com/plugin/woocommerce/hook/woocommerce_admin_features) filter ( you can use Code Snippets for this: https://wordpress.org/plugins/code-snippets/ ):
```
add_filter('woocommerce_admin_features', 'ospiotr_remove_marketing_woo_admin');

function ospiotr_remove_marketing_woo_admin($features)
{
$features = array_diff($features, ['marketing']);
return $features;
}
```
3. Add a new user with role Shop Manager
4. Log in as the user with role Shop Manager
5. Go to Add a new product: `wp-admin/post-new.php?post_type=product`
6. Set the product type to Variable Product
7. Click on the Attributes tab
8. Add existing or new attribute and attribute values
9. Make sure “used for variations” is checked
10. click on Save attributes
11. click on the Variations tab
12. click on the Generate variations button and hit ok on the confirmation popup
13. Witness the unlimited loading and a console error ( if you save the product and refresh the variations are generated, this only happens for the actual success notice ).
14. Load this branch
15. Now follow steps 5 to 12 again with the shop manager user.
16. Notice how there is no console error this time and the generated variations show up correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
