### PR TITLE
Fix flaky shopper checkout block creating user with custom password e2e test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-shopper-checkout-block
+++ b/plugins/woocommerce/changelog/e2e-fix-shopper-checkout-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix shopper checkout block test

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -229,18 +229,10 @@ test.describe(
 			await api.get( 'customers' ).then( async ( response ) => {
 				for ( let i = 0; i < response.data.length; i++ ) {
 					if (
-						response.data[ i ].billing.email === newAccountEmail
-					) {
-						await api.delete(
-							`customers/${ response.data[ i ].id }`,
-							{
-								force: true,
-							}
-						);
-					}
-					if (
-						response.data[ i ].billing.email ===
-						newAccountEmailWithCustomPassword
+						[
+							newAccountEmail,
+							newAccountEmailWithCustomPassword,
+						].includes( response.data[ i ].billing.email )
 					) {
 						await api.delete(
 							`customers/${ response.data[ i ].id }`,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -135,22 +135,6 @@ test.describe(
 			await api.put( 'payment_gateways/cod', {
 				enabled: true,
 			} );
-			// make sure there's no pre-existing customer that has the same email we're going to use for account creation
-			const { data: customersList } = await api.get( 'customers', {
-				email: newAccountEmail,
-			} );
-
-			if ( customersList && customersList.length ) {
-				const customerId = customersList[ 0 ].id;
-
-				console.log(
-					`Customer with email ${ newAccountEmail } exists! Deleting it before starting test...`
-				);
-
-				await api.delete( `customers/${ customerId }`, {
-					force: true,
-				} );
-			}
 			// make sure our customer user has a pre-defined billing/shipping address
 			await api.put( `customers/2`, {
 				shipping: {
@@ -281,6 +265,22 @@ test.describe(
 					},
 				],
 			} );
+			// make sure there's no pre-existing customer that has the same email we're going to use for account creation
+			const { data: customersList } = await api.get( 'customers', {
+				email: newAccountEmail,
+			} );
+
+			if ( customersList && customersList.length ) {
+				const customerId = customersList[ 0 ].id;
+
+				console.log(
+					`Customer with email ${ newAccountEmail } exists! Deleting it before starting test...`
+				);
+
+				await api.delete( `customers/${ customerId }`, {
+					force: true,
+				} );
+			}
 		} );
 
 		test( 'can see empty checkout block page', async ( {
@@ -929,7 +929,7 @@ test.describe(
 			);
 		} );
 
-		test( 'can create an account during checkout with custom password', async ( {
+		test.only( 'can create an account during checkout with custom password', async ( {
 			page,
 			testPage,
 			baseURL,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -18,7 +18,12 @@ const {
 const { getOrderIdFromUrl } = require( '../../utils/order' );
 
 const guestEmail = 'checkout-guest@example.com';
-const newAccountEmail = 'marge-test-account@example.com';
+const newAccountEmail = `marge-${ new Date()
+	.getTime()
+	.toString() }@woocommercecoree2etestsuite.com`;
+const newAccountEmailWithCustomPassword = `homer-${ new Date()
+	.getTime()
+	.toString() }@woocommercecoree2etestsuite.com`;
 const newAccountCustomPassword = 'supersecurepassword123';
 
 const simpleProductName = 'Very Simple Product';
@@ -233,6 +238,17 @@ test.describe(
 							}
 						);
 					}
+					if (
+						response.data[ i ].billing.email ===
+						newAccountEmailWithCustomPassword
+					) {
+						await api.delete(
+							`customers/${ response.data[ i ].id }`,
+							{
+								force: true,
+							}
+						);
+					}
 				}
 			} );
 		} );
@@ -265,22 +281,6 @@ test.describe(
 					},
 				],
 			} );
-			// make sure there's no pre-existing customer that has the same email we're going to use for account creation
-			const { data: customersList } = await api.get( 'customers', {
-				email: newAccountEmail,
-			} );
-
-			if ( customersList && customersList.length ) {
-				const customerId = customersList[ 0 ].id;
-
-				console.log(
-					`Customer with email ${ newAccountEmail } exists! Deleting it before starting test...`
-				);
-
-				await api.delete( `customers/${ customerId }`, {
-					force: true,
-				} );
-			}
 		} );
 
 		test( 'can see empty checkout block page', async ( {
@@ -981,9 +981,11 @@ test.describe(
 
 			// For flakiness, sometimes the email address is not filled
 			await page.getByLabel( 'Email address' ).click();
-			await page.getByLabel( 'Email address' ).fill( newAccountEmail );
+			await page
+				.getByLabel( 'Email address' )
+				.fill( newAccountEmailWithCustomPassword );
 			await expect( page.getByLabel( 'Email address' ) ).toHaveValue(
-				newAccountEmail
+				newAccountEmailWithCustomPassword
 			);
 
 			// fill shipping address and check cash on delivery method
@@ -1020,7 +1022,9 @@ test.describe(
 
 			// Log in again.
 			await page.goto( '/my-account/' );
-			await page.locator( '#username' ).fill( newAccountEmail );
+			await page
+				.locator( '#username' )
+				.fill( newAccountEmailWithCustomPassword );
 			await page.locator( '#password' ).fill( newAccountCustomPassword );
 			await page.locator( 'text=Log in' ).click();
 			await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -929,7 +929,7 @@ test.describe(
 			);
 		} );
 
-		test.only( 'can create an account during checkout with custom password', async ( {
+		test( 'can create an account during checkout with custom password', async ( {
 			page,
 			testPage,
 			baseURL,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48827
Very flaky instance: https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-core-e2e-tests/tests/bb68dde6-9b7f-88a5-9fbe-6b28f5574c42?branch=all+branches

Looks like it was missing deleting existing user if created during test, now with beforeEach we don't need to think about it for every new test we add.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

```
pnpm test:e2e-pw tests/e2e-pw/tests/shopper/checkout-block.spec.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
