### PR TITLE
Pin wp-env core version to 6.5

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -1,4 +1,5 @@
 {
+	"core": "WordPress/WordPress#6.5",
 	"phpVersion": "7.4",
 	"plugins": [
 		"."

--- a/plugins/woocommerce/changelog/e2e-pin-wp-env-core-version-6.5
+++ b/plugins/woocommerce/changelog/e2e-pin-wp-env-core-version-6.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Tests: pin wp-env core version to 6.5 (temporary until tests are fixed to pass with 6.6)

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -233,7 +233,8 @@
 						"patterns/**/*.php",
 						"src/**/*.php",
 						"templates/**/*.php",
-						"tests/e2e-pw/**"
+						"tests/e2e-pw/**",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:test"

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -233,8 +233,7 @@
 						"patterns/**/*.php",
 						"src/**/*.php",
 						"templates/**/*.php",
-						"tests/e2e-pw/**",
-						".wp-env.json"
+						"tests/e2e-pw/**"
 					],
 					"testEnv": {
 						"start": "env:test"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some e2e tests are failing with WP6.6. Until they get fixed, pinning the version in wp-env config should unblock PRs.

### How to test the changes in this Pull Request:

Check CI. All tests need to pass.