### PR TITLE
[testing workflows] Include wp-env config file in the tests jobs changes list

### DIFF
--- a/plugins/woocommerce/changelog/ci-include-wp-env-config-in-changes-list
+++ b/plugins/woocommerce/changelog/ci-include-wp-env-config-in-changes-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI config: update changes lists to include wp-env config

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -117,7 +117,8 @@
 						"templates/**/*.php",
 						"tests/php/**/*.php",
 						"tests/legacy/unit-tests/**/*.php",
-						"tests/unit-tests/**/*.php"
+						"tests/unit-tests/**/*.php",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:test",
@@ -145,7 +146,8 @@
 						"templates/**/*.php",
 						"tests/php/**/*.php",
 						"tests/legacy/unit-tests/**/*.php",
-						"tests/unit-tests/**/*.php"
+						"tests/unit-tests/**/*.php",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:test",
@@ -172,7 +174,8 @@
 						"templates/**/*.php",
 						"tests/php/**/*.php",
 						"tests/legacy/unit-tests/**/*.php",
-						"tests/unit-tests/**/*.php"
+						"tests/unit-tests/**/*.php",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:test",
@@ -200,7 +203,8 @@
 						"templates/**/*.php",
 						"tests/php/**/*.php",
 						"tests/legacy/unit-tests/**/*.php",
-						"tests/unit-tests/**/*.php"
+						"tests/unit-tests/**/*.php",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:test",
@@ -233,7 +237,8 @@
 						"patterns/**/*.php",
 						"src/**/*.php",
 						"templates/**/*.php",
-						"tests/e2e-pw/**"
+						"tests/e2e-pw/**",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:test"
@@ -371,16 +376,7 @@
 						"daily-checks",
 						"release-checks"
 					],
-					"changes": [
-						"client/admin/config/*.json",
-						"composer.json",
-						"composer.lock",
-						"includes/**/*.php",
-						"patterns/**/*.php",
-						"src/**/*.php",
-						"templates/**/*.php",
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -463,7 +459,8 @@
 						"src/**/*.php",
 						"templates/**/*.php",
 						"tests/api-core-tests/**",
-						"tests/e2e-pw/bin/**"
+						"tests/e2e-pw/bin/**",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:test"
@@ -492,7 +489,8 @@
 						"src/**/*.php",
 						"templates/**/*.php",
 						"tests/api-core-tests/**",
-						"tests/e2e-pw/bin/**"
+						"tests/e2e-pw/bin/**",
+						".wp-env.json"
 					],
 					"events": [
 						"push"
@@ -522,7 +520,8 @@
 						"patterns/**/*.php",
 						"src/**/*.php",
 						"templates/**/*.php",
-						"tests/performance/**"
+						"tests/performance/**",
+						".wp-env.json"
 					],
 					"testEnv": {
 						"start": "env:perf"
@@ -545,7 +544,8 @@
 						"src/**/*.php",
 						"templates/**/*.php",
 						"templates/**/*.html",
-						"tests/metrics/**"
+						"tests/metrics/**",
+						".wp-env.json"
 					],
 					"events": [
 						"disabled"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates to .wp-env.json config file should trigger the tests that are using the environment these file is configuring.

### How to test the changes in this Pull Request:

Check CI. Should be green.