### PR TITLE
[testing workflows] Add new workflow to trigger any jobs in ci.yml on demand

### DIFF
--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -13,5 +13,5 @@ jobs:
     name: 'Run tests'
     uses: ./.github/workflows/ci.yml
     with:
-      trigger: ${{ github.event.inputs.trigger }}
+      trigger: ${{ inputs.trigger }}
     secrets: inherit

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -1,0 +1,17 @@
+name: 'On demand tests run'
+
+on:
+  workflow_dispatch:
+    inputs:
+      trigger:
+        description: 'Event name. It will be used to filter the jobs to run in ci.yml. It can be anything, as long as the job you want to run has this event configured in the `events` list. Example: daily-checks, pull_request, on-demand, etc.'
+        required: true
+        default: ''
+
+jobs:
+  run-tests:
+    name: 'Run tests'
+    uses: ./.github/workflows/ci.yml
+    with:
+      trigger: ${{ github.event.inputs.trigger }}
+    secrets: inherit

--- a/plugins/woocommerce/changelog/ci-add-manual-trigger-workflow
+++ b/plugins/woocommerce/changelog/ci-add-manual-trigger-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add new CI workflow to trigger tests on demand.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -593,7 +593,8 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"daily-checks"
+						"daily-checks",
+						"on-demand"
 					],
 					"report": {
 						"resultsBlobName": "default-pressable-core-e2e",
@@ -608,7 +609,8 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"daily-checks"
+						"daily-checks",
+						"on-demand"
 					],
 					"report": {
 						"resultsBlobName": "default-wpcom-core-e2e",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a new workflow that can be manually triggered on demand that calls the ci.yml workflow with a value that will filter the jobs to run.
Also configured 2 jobs with the "on-demand" event, that can be used to test this.

### How to test the changes in this Pull Request:

The workflow needs to be merged first, and we can test from trunk.
