### PR TITLE
Blocks E2E: Fix DB snapshot removal step in setup script

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/bin/test-env-setup.sh
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/test-env-setup.sh
@@ -7,7 +7,7 @@ head_dir=$(cd "$(dirname "$script_dir")" && cd ../../.. && pwd)
 relative_path=${script_dir#$head_dir/}
 
 # Remove the database snapshot if it exists.
-wp-env run tests-cli -- rm blocks_e2e.sql 2> /dev/null
+wp-env run tests-cli -- rm -f blocks_e2e.sql
 # Run the main script in the container for better performance.
 wp-env run tests-cli -- bash wp-content/plugins/woocommerce/blocks-bin/playwright/scripts/index.sh
 # Disable the LYS Coming Soon banner.

--- a/plugins/woocommerce-blocks/tests/e2e/bin/test-env-setup.sh
+++ b/plugins/woocommerce-blocks/tests/e2e/bin/test-env-setup.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# Extract the relative path from the plugin root to this script directory.
-# By doing so, we can run this script from anywhere.
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-head_dir=$(cd "$(dirname "$script_dir")" && cd ../../.. && pwd)
-relative_path=${script_dir#$head_dir/}
-
 # Remove the database snapshot if it exists.
 wp-env run tests-cli -- rm -f blocks_e2e.sql
 # Run the main script in the container for better performance.

--- a/plugins/woocommerce/changelog/49677-fix-e2e-db-snapshot-removal-step
+++ b/plugins/woocommerce/changelog/49677-fix-e2e-db-snapshot-removal-step
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Blocks E2E: Fix DB snapshot removal step in setup script.


### PR DESCRIPTION
### Proposed changes

Originally reported in Slack by @samueljseay: p1721116681569559/1720653992.840819-slack-C02FL3X7KR6

This PR fixes an issue where the E2E setup invoked by `pnpm env:start` (or `pnpm env:restart`) fails at the DB snapshot removal if it doesn't exist. 

Additionally, this PR removes some unused lines from the setup script.

### How to test

The simplest way to test it is to run the `pnpm env:restart` twice if the snapshot currently exists. The first run removes the snapshot, so the second run would normally fail against `trunk` and succeed against this branch. If you start from a clean env, however, running `pnpm env:start` (once) should be enough to make the script fail. 😄 


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Blocks E2E: Fix DB snapshot removal step in setup script.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>