### PR TITLE
Product rating - Inherit the color of the star when no ratings

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/product-rating/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-rating/style.scss
@@ -88,14 +88,15 @@ $line-height: 1.618;
 		/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
 		font-family: WooCommerce;
 		font-weight: 400;
-		-webkit-text-stroke: 2px var(--wp--preset--color--black, #000);
 		&::before {
 			content: "\53";
 			top: 0;
 			left: 0;
 			right: 0;
 			position: absolute;
-			color: transparent;
+			-webkit-text-stroke-color: inherit;
+			-webkit-text-stroke-width: 2px;
+			-webkit-text-fill-color: transparent;
 			white-space: nowrap;
 			text-align: center;
 		}

--- a/plugins/woocommerce/changelog/49678-fix-nostar-color
+++ b/plugins/woocommerce/changelog/49678-fix-nostar-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Product rating - Inherit the color of the star when no ratings


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes the empty star inherit the theme color instead of always being black.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store` and click `Start designing` or `Customize your store` to go to the assembler.
2. Click on `Design your store` and on the `Featured selling` category.
3. Insert the `Product Collection 3 Columns` pattern.
4. Check the review star (when the product has no reviews) is the same color as the `No review` text.
5. Go back and click on `Choose your color palette`.
6. Try different palettes and check the star and text are always the same color.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product rating - Inherit the color of the star when no ratings
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
