### PR TITLE
Fix shortcode cart shipping calculator placeholder

### DIFF
--- a/plugins/woocommerce/changelog/fix-placeholder-display-25152
+++ b/plugins/woocommerce/changelog/fix-placeholder-display-25152
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed placeholders in the classic cart shipping calculator to update with country selection.

--- a/plugins/woocommerce/client/legacy/js/frontend/address-i18n.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-i18n.js
@@ -41,9 +41,9 @@ jQuery( function( $ ) {
 				thislocale = locale['default'];
 			}
 
-			var $postcodefield = thisform.find( '#billing_postcode_field, #shipping_postcode_field' ),
-				$cityfield     = thisform.find( '#billing_city_field, #shipping_city_field' ),
-				$statefield    = thisform.find( '#billing_state_field, #shipping_state_field' );
+			var $postcodefield = thisform.find( '#billing_postcode_field, #shipping_postcode_field, #calc_shipping_postcode_field' ),
+				$cityfield     = thisform.find( '#billing_city_field, #shipping_city_field, #calc_shipping_city_field' ),
+				$statefield    = thisform.find( '#billing_state_field, #shipping_state_field, #calc_shipping_state_field' );
 
 			if ( ! $postcodefield.attr( 'data-o_class' ) ) {
 				$postcodefield.attr( 'data-o_class', $postcodefield.attr( 'class' ) );
@@ -74,7 +74,7 @@ jQuery( function( $ ) {
 				if (
 					typeof fieldLocale.placeholder === 'undefined' &&
 					typeof fieldLocale.label !== 'undefined' &&
-					! field.find( 'label' ).length
+					! field.find( 'label:not(.screen-reader-text)' ).length
 				) {
 					field.find( ':input' ).attr( 'placeholder', fieldLocale.label );
 					field.find( ':input' ).attr( 'data-placeholder', fieldLocale.label );

--- a/plugins/woocommerce/client/legacy/js/frontend/country-select.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/country-select.js
@@ -104,12 +104,15 @@ jQuery( function( $ ) {
 			placeholder   = $statebox.attr( 'placeholder' ) || $statebox.attr( 'data-placeholder' ) || '',
 			$newstate;
 
+		if ( placeholder === wc_country_select_params.i18n_select_state_text ) {
+			placeholder = '';
+		}
+
 		if ( states[ country ] ) {
 			if ( $.isEmptyObject( states[ country ] ) ) {
 				$newstate = $( '<input type="hidden" />' )
 					.prop( 'id', input_id )
 					.prop( 'name', input_name )
-					.prop( 'placeholder', placeholder )
 					.attr( 'data-input-classes', input_classes )
 					.addClass( 'hidden ' + input_classes );
 				$parent.hide().find( '.select2-container' ).remove();
@@ -154,8 +157,8 @@ jQuery( function( $ ) {
 				$newstate = $( '<input type="text" />' )
 					.prop( 'id', input_id )
 					.prop( 'name', input_name )
-					.prop('placeholder', placeholder)
-					.attr('data-input-classes', input_classes )
+					.prop( 'placeholder', placeholder )
+					.attr( 'data-input-classes', input_classes )
 					.addClass( 'input-text  ' + input_classes );
 				$parent.show().find( '.select2-container' ).remove();
 				$statebox.replaceWith( $newstate );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There were a few issues with the legacy shipping calculator related to #25152 which should be resolved by this PR. That is:

- After switching from a country with states (US) to one without (UK) "select an option" would remain as the placeholder on classic checkout
- The shipping calculator would have blank or incorrect placeholders depending on the selected country

These issues are fixed by updating the localisation JS to handle calculator fields which have different IDs.

Closes #25152

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the classic cart
2. Open the shipping calculator
3. Select US country
4. Ensure the state field has a placeholder "state"
5. Switch to the United Kingdom
6. Ensure the state field has a placeholder "county"
7. Test some other combinations and each time make sure placeholders update
8. Go to Classic Checkout
9. Repeat the above tests but this time ensure the field Labels update
10. Switch from US to UK and ensure the state field placeholder is cleared (does not read "select an option".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
