### PR TITLE
Prevent error on Cart Shipping Calculator when using Additional Checkout Fields API

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
@@ -73,7 +73,13 @@ const ShippingCalculatorAddress = ( {
 					const isAddressValid = validateSubmit();
 
 					if ( isAddressValid ) {
-						return onUpdate( address );
+						const addressToSubmit = {};
+						addressFields.forEach( ( key ) => {
+							if ( typeof address[ key ] !== 'undefined' ) {
+								addressToSubmit[ key ] = address[ key ];
+							}
+						} );
+						return onUpdate( addressToSubmit );
 					}
 				} }
 				type="submit"

--- a/plugins/woocommerce/changelog/fix-shipping-calculator-custom-fields
+++ b/plugins/woocommerce/changelog/fix-shipping-calculator-custom-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a warning showing when using the Shipping Address Calculator in combination with the additional checkout fields API

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -172,6 +172,13 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		// correct format, and finally the second validation step is to ensure the correctly-formatted values
 		// match what we expect (postcode etc.).
 		foreach ( $address as $key => $value ) {
+
+			// Only run specific validation on properties that are defined in the schema and present in the address.
+			// This is for partial address pushes when only part of a customer address is sent.
+			// Full schema address validation still happens later, so empty, required values are disallowed.
+			if ( empty( $schema[ $key ] ) || empty( $address[ $key ] ) ) {
+				continue;
+			}
 			if ( is_wp_error( rest_validate_value_from_schema( $value, $schema[ $key ], $key ) ) ) {
 				$errors->add(
 					'invalid_' . $key,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a check to the beginning of `AbstractAddressSchema`'s `validate_callback`  method.

In this method, the flow of validation goes: 

1. Validate the fields against the schema
2. Sanitize the fields
3. Revalidate the fields following sanitization to check they haven't been changed from what we were expecting.

On step 3, we check if the schema key exists and if the field has a value, otherwise we skip validating it. This is to prevent errors where partial address pushes fail because of "invalid" required values that were not sent as part of the partial push.

This check should be repeated in step 1 as well.

I also made it so only the values edited in the form in the shipping calculator are sent to the update-customer endpoint.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49682 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet:
```php
add_action(
	'woocommerce_blocks_loaded',
	function() {
		woocommerce_register_additional_checkout_field(
			array(
				'id'             => 'plugin-namespace/road-type',
				'label'          => __( 'Road type', 'woo-gutenberg-products-block' ),
				'optionalLabel'  => __( 'Road type (optional)', 'woo-gutenberg-products-block' ),
				'autocomplete'   => 'road-type',
				'required'       => 'true',
				'autocapitalize' => 'characters',
				'location'       => 'address',
				'type'           => 'select',
				'options'        => array(
					array(
						'value' => 'alleyway',
						'label' => __( 'Alleyway', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'avenue',
						'label' => __( 'Avenue', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'boulevard',
						'label' => __( 'Boulevard', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'cul-de-sac',
						'label' => __( 'Cul-de-sac', 'woo-gutenberg-products-block' ),
					),
					array(
						'value' => 'street',
						'label' => __( 'Street', 'woo-gutenberg-products-block' ),
					),
				),
			)
		);


		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'plugin-namespace/test-required-text-field',
				'label'    => __( 'Test field', 'woocommerce' ),
				'location' => 'address',
				'required' => true,
				'type'     => 'text',
			)
		);
	}
);
```
2. Go to `WooCommerce -> Settings -> Shipping -> Shipping Settings -> Enable the shipping calculator on the cart` and check the box.
3. Add an item to your cart and go to the Cart block.
4. In the sidebar, interact with the shipping calculator and change your address multiple times. Ensure no error is shown.
5. Go to the Checkout and fill in the address form. Purposely leave "Test field" blank.
6. Try to check out. Ensure an error shows about "Test field" being required.
7. Fill it in and verify checking out works OK.

#### Developer testing
1. Using the snippet above, test with Store API.
2. Ensure partial address pushes both including and excluding the fields defined above work.
3. Try checking out with invalid values for the keys defined above.
4. Try checking out with invalid core values, e.g. `first_name: ''`
5. Ensure you can't check out without completing all require fields with valid values.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
