### PR TITLE
Blocks: Update wp-env config to use production WP

### DIFF
--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.6.zip",
+	"core": "https://wordpress.org/wordpress-6.6.1.zip",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.6.1.zip",
+	"core": null,
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.6-RC2.zip",
+	"core": "https://wordpress.org/wordpress-6.6.zip",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -49,7 +49,7 @@ test.describe( 'Single Product template', () => {
 		await admin.visitSiteEditor( {
 			postType: testData.templateType,
 		} );
-		await editor.revertTemplateCreation( testData.templateName );
+		await editor.revertTemplate( { templateName: testData.templateName } );
 		await page.goto( testData.permalink );
 
 		// Verify the edits are no longer visible.

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/single-product-template.block_theme_with_templates.spec.ts
@@ -53,7 +53,7 @@ test.describe( 'Single Product Template', () => {
 		await admin.visitSiteEditor( {
 			postType: testData.templateType,
 		} );
-		await editor.revertTemplateCustomizations( {
+		await editor.revertTemplate( {
 			templateName: testData.templateName,
 		} );
 		await page.goto( testData.permalink );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -58,7 +58,7 @@ test.describe( 'Template customization', () => {
 				await admin.visitSiteEditor( {
 					postType: testData.templateType,
 				} );
-				await editor.revertTemplateCustomizations( {
+				await editor.revertTemplate( {
 					templateName: testData.templateName,
 				} );
 				await testData.visitPage( { frontendUtils, page } );
@@ -97,7 +97,7 @@ test.describe( 'Template customization', () => {
 					await admin.visitSiteEditor( {
 						postType: testData.templateType,
 					} );
-					await editor.revertTemplateCustomizations( {
+					await editor.revertTemplate( {
 						templateName:
 							testData.fallbackTemplate?.templateName || '',
 					} );
@@ -180,7 +180,7 @@ test.describe( 'Template customization', () => {
 					postType: testData.templateType,
 				} );
 
-				await editor.revertTemplateCustomizations( {
+				await editor.revertTemplate( {
 					templateName: testData.templateName,
 				} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -67,7 +67,7 @@ test.describe( 'Template customization', () => {
 				await admin.visitSiteEditor( {
 					postType: testData.templateType,
 				} );
-				await editor.revertTemplateCustomizations( {
+				await editor.revertTemplate( {
 					templateName: testData.templateName,
 				} );
 				await testData.visitPage( { frontendUtils, page } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
@@ -90,9 +90,8 @@ test.describe( 'Template part customization', () => {
 			await admin.visitSiteEditor( {
 				postType: 'wp_template_part',
 			} );
-			await editor.revertTemplateCustomizations( {
+			await editor.revertTemplate( {
 				templateName,
-				templateType: 'wp_template_part',
 			} );
 			await testUtils.openMiniCart();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
@@ -89,9 +89,8 @@ test.describe( 'Template part customization', () => {
 			await admin.visitSiteEditor( {
 				postType: 'wp_template_part',
 			} );
-			await editor.revertTemplateCustomizations( {
+			await editor.revertTemplate( {
 				templateName,
-				templateType: 'wp_template_part',
 			} );
 			await testUtils.openMiniCart();
 			await expect( page.getByText( userText ) ).toBeHidden();
@@ -158,9 +157,8 @@ test.describe( 'Template part customization', () => {
 				postType: 'wp_template_part',
 			} );
 
-			await editor.revertTemplateCustomizations( {
+			await editor.revertTemplate( {
 				templateName,
-				templateType: 'wp_template_part',
 			} );
 
 			await testUtils.openMiniCart();

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Editor as CoreEditor } from '@wordpress/e2e-test-utils-playwright';
-import { expect } from '@woocommerce/e2e-utils';
 
 export class Editor extends CoreEditor {
 	async getBlockByName( name: string ) {
@@ -72,54 +71,20 @@ export class Editor extends CoreEditor {
 		}
 	}
 
-	async revertTemplateCreation( templateName: string ) {
+	async revertTemplate( { templateName }: { templateName: string } ) {
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
+		await this.page.getByLabel( templateName, { exact: true } ).click();
 
-		const deletedNotice = this.page
+		await this.page.getByLabel( 'Actions' ).click();
+		await this.page
+			.getByRole( 'menuitem', { name: /Reset|Delete/ } )
+			.click();
+		await this.page.getByRole( 'button', { name: /Reset|Delete/ } ).click();
+
+		await this.page
 			.getByLabel( 'Dismiss this notice' )
-			.getByText( `"${ templateName }" deleted.` );
-
-		// Wait until search has finished.
-		const searchResults = this.page.getByLabel( 'Actions' );
-		const initialSearchResultsCount = await searchResults.count();
-		await expect
-			.poll( async () => await searchResults.count() )
-			.toBeLessThan( initialSearchResultsCount );
-
-		await searchResults.first().click();
-		await this.page.getByRole( 'menuitem', { name: 'Delete' } ).click();
-		await this.page.getByRole( 'button', { name: 'Delete' } ).click();
-
-		await expect( deletedNotice ).toBeVisible();
-	}
-
-	async revertTemplateCustomizations( {
-		templateName,
-	}: {
-		templateName: string;
-	} ) {
-		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
-
-		const resetNotice = this.page
-			.getByLabel( 'Dismiss this notice' )
-			.getByText( `"${ templateName }" reset.` );
-		const savedButton = this.page.getByRole( 'button', {
-			name: 'Saved',
-		} );
-
-		// Wait until search has finished.
-		const searchResults = this.page.getByLabel( 'Actions' );
-		const initialSearchResultsCount = await searchResults.count();
-		await expect
-			.poll( async () => await searchResults.count() )
-			.toBeLessThan( initialSearchResultsCount );
-
-		await searchResults.first().click();
-		await this.page.getByRole( 'menuitem', { name: 'Reset' } ).click();
-		await this.page.getByRole( 'button', { name: 'Reset' } ).click();
-
-		await expect( resetNotice ).toBeVisible();
-		await expect( savedButton ).toBeVisible();
+			.getByText( /reset|deleted/ )
+			.waitFor();
 	}
 
 	async publishAndVisitPost() {

--- a/plugins/woocommerce/changelog/update-blocks-wp-env-core-.6
+++ b/plugins/woocommerce/changelog/update-blocks-wp-env-core-.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update WP version to 6.6 in Blocks wp-env config.

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -306,19 +306,26 @@ test.describe( 'Store owner can complete the core profiler', () => {
 			).toBeVisible();
 			// confirm that the optional plugins are present
 			await expect(
-				page.getByText( 'Pinterest for WooCommerce', { exact: true } )
+				page.locator( '.plugin-title', {
+					hasText: 'Pinterest for WooCommerce',
+				} )
+			).toBeVisible();
+			await expect(
+				page.locator( '.plugin-title', {
+					hasText: /Google for WooCommerce|Google Listings & Ads/,
+				} )
 			).toBeVisible();
 
 			await expect(
-				page
-					.getByRole( 'cell', {
-						name: 'Google for WooCommerce Get',
-					} )
-					.getByRole( 'strong' )
-			).toBeVisible();
-
-			await expect( page.getByText( 'MailPoet' ) ).toBeHidden();
-			await expect( page.getByText( 'Jetpack' ) ).toBeHidden();
+				page.locator( '.plugin-title', {
+					hasText: 'MailPoet',
+				} )
+			).toBeHidden();
+			await expect(
+				page.locator( '.plugin-title', {
+					hasText: 'Jetpack',
+				} )
+			).toBeHidden();
 		} );
 
 		await test.step( 'Confirm that information from core profiler saved', async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since the 6.6 has been released, let's remove the hardcoded RC from the Blocks wp-env config.

### How to test the changes in this Pull Request:

CI should be green. 